### PR TITLE
don't allow own package name in solidity file import

### DIFF
--- a/.changeset/silly-geese-fold.md
+++ b/.changeset/silly-geese-fold.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+A better error is show if a Solidity file makes an import throug its own package name.

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -809,6 +809,16 @@ Hardhat's compiler is case sensitive to ensure projects are portable across diff
 Try installing the library using npm.`,
       shouldBeReported: false,
     },
+    INCLUDES_OWN_PACKAGE_NAME: {
+      number: 412,
+      message:
+        "Invalid import %imported% from %from%. Trying to import file using the own package's name.",
+      title: "Invalid import: includes own package's name",
+      description: `A Solidity file is trying to import another using its own package name. That is most likely caused by an existing symlink for the package in your node modules created.
+
+Import the file directly without referencing the package's name.`,
+      shouldBeReported: false,
+    },
   },
   SOLC: {
     INVALID_VERSION: {

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -814,9 +814,9 @@ Try installing the library using npm.`,
       message:
         "Invalid import %imported% from %from%. Trying to import file using the own package's name.",
       title: "Invalid import: includes own package's name",
-      description: `A Solidity file is trying to import another using its own package name. That is most likely caused by an existing symlink for the package in your node modules created.
+      description: `A Solidity file is trying to import another using its own package name. This is most likely caused by an existing symlink for the package in your node_modules.
 
-Import the file directly without referencing the package's name.`,
+Use a relative import instead of referencing the package's name.`,
       shouldBeReported: false,
     },
   },

--- a/packages/hardhat-core/src/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/src/internal/solidity/resolver.ts
@@ -8,6 +8,7 @@ import {
   ResolvedFile as IResolvedFile,
 } from "../../types/builtin-tasks";
 import {
+  includesOwnPackageName,
   isAbsolutePathSourceName,
   isLocalSourceName,
   normalizeSourceName,
@@ -123,6 +124,15 @@ export class Resolver {
 
     if (isAbsolutePathSourceName(imported)) {
       throw new HardhatError(ERRORS.RESOLVER.INVALID_IMPORT_ABSOLUTE_PATH, {
+        from: from.sourceName,
+        imported,
+      });
+    }
+
+    // Edge-case where an import can contain the current package's name in monorepos.
+    // The path can be resolved because there's a symlink in the node modules.
+    if (await includesOwnPackageName(imported)) {
+      throw new HardhatError(ERRORS.RESOLVER.INCLUDES_OWN_PACKAGE_NAME, {
         from: from.sourceName,
         imported,
       });

--- a/packages/hardhat-core/src/internal/util/packageInfo.ts
+++ b/packages/hardhat-core/src/internal/util/packageInfo.ts
@@ -24,6 +24,15 @@ export function findClosestPackageJson(file: string): string | null {
   return findup.sync("package.json", { cwd: path.dirname(file) });
 }
 
+export async function getPackageName(file: string): Promise<string> {
+  const packageJsonPath = findClosestPackageJson(file);
+  if (packageJsonPath !== null && packageJsonPath !== "") {
+    const packageJson: PackageJson = await fsExtra.readJSON(packageJsonPath);
+    return packageJson.name;
+  }
+  return "";
+}
+
 export async function getPackageJson(): Promise<PackageJson> {
   const root = getPackageRoot();
   return fsExtra.readJSON(path.join(root, "package.json"));

--- a/packages/hardhat-core/src/utils/source-names.ts
+++ b/packages/hardhat-core/src/utils/source-names.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { HardhatError } from "../internal/core/errors";
 import { ERRORS } from "../internal/core/errors-list";
 import { FileNotFoundError, getFileTrueCase } from "../internal/util/fs-utils";
+import { getPackageName } from "../internal/util/packageInfo";
 
 const NODE_MODULES = "node_modules";
 
@@ -227,4 +228,18 @@ async function getSourceNameTrueCase(
     // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
     throw error;
   }
+}
+
+/**
+ * This function returns true if the sourceName contains the current package's name
+ * as a substring
+ */
+export async function includesOwnPackageName(
+  sourceName: string
+): Promise<boolean> {
+  const packageName = await getPackageName(sourceName);
+  if (packageName !== "") {
+    return sourceName.startsWith(`${packageName}/`);
+  }
+  return false;
 }

--- a/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/package.json
+++ b/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "project-with-hardhat-directory",
+  "version": "1.0.0"
+}

--- a/packages/hardhat-core/test/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/test/internal/solidity/resolver.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 import * as fsExtra from "fs-extra";
 import path from "path";
+import sinon from "sinon";
 
 import { TASK_COMPILE } from "../../../src/builtin-tasks/task-names";
 import { ERRORS } from "../../../src/internal/core/errors-list";
@@ -9,6 +10,8 @@ import {
   ResolvedFile,
   Resolver,
 } from "../../../src/internal/solidity/resolver";
+import * as packageInfo from "../../../src/internal/util/packageInfo";
+import * as sourceNames from "../../../src/utils/source-names";
 import { LibraryInfo } from "../../../src/types/builtin-tasks";
 import { useEnvironment } from "../../helpers/environment";
 import { expectHardhatErrorAsync } from "../../helpers/errors";
@@ -364,6 +367,15 @@ describe("Resolver", function () {
           () => resolver.resolveImport(localFrom, "/asd"),
           ERRORS.RESOLVER.INVALID_IMPORT_ABSOLUTE_PATH
         );
+      });
+
+      it("shouldn't let you import something that starts with the own package name", async function () {
+        sinon.stub(packageInfo, "getPackageName").resolves("myPackageName");
+        await expectHardhatErrorAsync(
+          () => resolver.resolveImport(localFrom, "myPackageName/src/file"),
+          ERRORS.RESOLVER.INCLUDES_OWN_PACKAGE_NAME
+        );
+        sinon.restore();
       });
     });
 

--- a/packages/hardhat-core/test/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/test/internal/solidity/resolver.ts
@@ -11,7 +11,6 @@ import {
   Resolver,
 } from "../../../src/internal/solidity/resolver";
 import * as packageInfo from "../../../src/internal/util/packageInfo";
-import * as sourceNames from "../../../src/utils/source-names";
 import { LibraryInfo } from "../../../src/types/builtin-tasks";
 import { useEnvironment } from "../../helpers/environment";
 import { expectHardhatErrorAsync } from "../../helpers/errors";

--- a/packages/hardhat-core/test/utils/source-names.ts
+++ b/packages/hardhat-core/test/utils/source-names.ts
@@ -1,8 +1,11 @@
 import { assert } from "chai";
 import path from "path";
+import sinon from "sinon";
 
 import { ERRORS } from "../../src/internal/core/errors-list";
+import * as packageInfo from "../../src/internal/util/packageInfo";
 import {
+  includesOwnPackageName,
   isAbsolutePathSourceName,
   isLocalSourceName,
   localPathToSourceName,
@@ -213,6 +216,26 @@ describe("Source names utilities", function () {
       assert.equal(replaceBackslashes("\\a"), "/a");
       assert.equal(replaceBackslashes("\\\\a"), "//a");
       assert.equal(replaceBackslashes("/\\\\a"), "///a");
+    });
+  });
+
+  describe("includesOwnPackageName", function () {
+    before(() => {
+      sinon.stub(packageInfo, "getPackageName").resolves("myPackageName");
+    });
+
+    after(() => {
+      sinon.restore();
+    });
+
+    it("Should return true if parsed string starts with the package name", async function () {
+      assert.isTrue(await includesOwnPackageName("myPackageName/src/file"));
+    });
+
+    it("Should return false if the parsed string doesn't start with the package name", async function () {
+      assert.isFalse(
+        await includesOwnPackageName("differentPackageName/src/file")
+      );
     });
   });
 });


### PR DESCRIPTION
Verifies that a solidity file import doesn't contain the own package's name. See the linked issue for further details.

The PR is still missing tests. I wanted some feedback before I spend more time on it.

close #1500 

Closes HH-763