### PR TITLE
Adding warning for current and future users of Hardhat

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -130,7 +130,7 @@ $ npx hardhat accounts
 
 ::: warning
 
-The account addresses above are deterministic: they are the same for _all_ Hardhat users. Accordingly, the private keys for these addresses are well known, so there are probably bots monitoring these addresses on mainnet, waiting to withdraw any funds sent to them. Therefore, _do not send mainnet Ether to these addresses_. If you add any of these accounts to a wallet (eg Metamask), be very careful to avoid sending any mainnet Ether to it: consider naming the account something like "Hardhat - Unsafe".
+_Do not send mainnet Ether to the addresses above._ Those addresses are deterministic: they are the same for _all_ Hardhat users. Accordingly, the private keys for these addresses are well known, so there are probably bots monitoring those addresses on mainnet, waiting to withdraw any funds sent to them. If you add any of these accounts to a wallet (eg Metamask), be very careful to avoid sending any mainnet Ether to them: consider naming the account something like "Hardhat - Unsafe" in order to prevent any mistakes.
 
 :::
 

--- a/docs/hardhat-network/README.md
+++ b/docs/hardhat-network/README.md
@@ -48,7 +48,7 @@ If you want to connect Hardhat to this node, you just need to run using `--netwo
 
 ::: warning
 
-The account addresses and private keys shown in the output of `hardhat node` are deterministic: they are the same for _all_ Hardhat users. Accordingly, those private keys are well known, so there are probably bots monitoring these addresses on mainnet, waiting to withdraw any funds sent to them. Therefore, _do not send mainnet Ether to these addresses_. If you add any of these accounts to a wallet (eg Metamask), be very careful to avoid sending any mainnet Ether to it: consider naming the account something like "Hardhat - Unsafe".
+_Do not send mainnet Ether to the account addresses shown by `hardhat node`_. Those addresses and private keys are deterministic: they are the same for _all_ Hardhat users. Accordingly, those private keys are well known, so there are probably bots monitoring these addresses on mainnet, waiting to withdraw any funds sent to them. If you add any of those accounts to a wallet (eg Metamask), be very careful to avoid sending any mainnet Ether to them: consider naming the account something like "Hardhat - Unsafe" in order to prevent any mistakes.
 
 :::
 


### PR DESCRIPTION
This has been seen that the current accounts in Hardhat are the same across EVERY user. We are adding warnings for the users while they go through the HH documentation. I guess the aptest place is where people generate them or see them the first time in the documentation.

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **documentation change**, its branch was created from the `website` branch, and this PR uses the `website` branch as its base branch.
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
