### PR TITLE
Fix newHeads subscription

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -2018,8 +2018,14 @@ Hardhat Network's forking functionality only works with blocks from at least spu
 
   private async _runInPendingBlockContext<T>(action: () => Promise<T>) {
     const snapshotId = await this.takeSnapshot();
+    const [blockTimestamp] = this._calculateTimestampAndOffset();
+    const needsTimestampIncrease =
+      await this._timestampClashesWithPreviousBlockOne(blockTimestamp);
+    if (needsTimestampIncrease) {
+      blockTimestamp.iaddn(1);
+    }
     try {
-      await this.mineBlock();
+      await this._mineBlockWithPendingTxs(blockTimestamp);
       return await action();
     } finally {
       await this.revertToSnapshot(snapshotId);

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/subscribe.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/subscribe.ts
@@ -102,6 +102,30 @@ describe("Eth module", function () {
           assert.lengthOf(getResults().messageResults, 3);
         });
 
+        it("Sends newHeads events only on new blocks", async function () {
+          const filterId = await this.provider.send("eth_subscribe", [
+            "newHeads",
+          ]);
+
+          const getResults = createFilterResultsGetter(this.provider, filterId);
+
+          await this.provider.send("evm_mine", []);
+          await this.provider.send("evm_mine", []);
+          await this.provider.send("evm_mine", []);
+          await this.provider.send("eth_getTransactionCount", [
+            "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+            "pending",
+          ]);
+          await this.provider.send("eth_getBlockByNumber", ["pending", false]);
+
+          assert.isTrue(
+            await this.provider.send("eth_unsubscribe", [filterId])
+          );
+
+          assert.lengthOf(getResults().notificationsResults, 3);
+          assert.lengthOf(getResults().messageResults, 3);
+        });
+
         it("Supports newPendingTransactions subscribe", async function () {
           const filterId = await this.provider.send("eth_subscribe", [
             "newPendingTransactions",


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

<!-- Add a description of your PR here -->
So it seems that the `newHeads` subscription actually receives some events when there is a call to a `pending` block, for example in `getTransactionsCount`. This is because it mines a new pending block to then run an action on this block, before reverting it. But when the pending block is mined, it emits a new-block event to the subscribers, which doesn't really make sense.

~So this PR fixes that, by adding a `bool` argument to the `mineBlock` method so the caller can choose if the method should notify subscribers or not.~

So here there's a bit of code duplication between `mineBlock` and `_runInPendingBlockContext`, regarding the next block timestamp computation ; but I couldn't find a better way to do this.