### PR TITLE
Force empty Uncles for forked-nodes

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/fork/rpcToBlockData.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/fork/rpcToBlockData.ts
@@ -1,4 +1,5 @@
 import { BlockData } from "@ethereumjs/block";
+import { KECCAK256_RLP_ARRAY } from "ethereumjs-util";
 
 import { RpcBlockWithTransactions } from "../../../core/jsonrpc/types/output/block";
 
@@ -8,7 +9,8 @@ export function rpcToBlockData(rpcBlock: RpcBlockWithTransactions): BlockData {
   return {
     header: {
       parentHash: rpcBlock.parentHash,
-      uncleHash: rpcBlock.sha3Uncles,
+      // We don't implement uncles - set the hash as the hash of an empty array
+      uncleHash: KECCAK256_RLP_ARRAY,
       coinbase: rpcBlock.miner,
       stateRoot: rpcBlock.stateRoot,
       transactionsTrie: rpcBlock.transactionsRoot,

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkBlockchain.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkBlockchain.ts
@@ -1,7 +1,7 @@
 import { Block } from "@ethereumjs/block";
 import Common from "@ethereumjs/common";
 import { assert } from "chai";
-import { BN, bufferToHex, toBuffer, zeros } from "ethereumjs-util";
+import { BN, bufferToHex, rlphash, toBuffer, zeros } from "ethereumjs-util";
 
 import { JsonRpcClient } from "../../../../../src/internal/hardhat-network/jsonrpc/client";
 import { ForkBlockchain } from "../../../../../src/internal/hardhat-network/provider/fork/ForkBlockchain";
@@ -134,6 +134,17 @@ describe("ForkBlockchain", () => {
       await fb.addBlock(block);
       const savedBlock = await fb.getBlock(block.hash());
       assert.equal(savedBlock, block);
+    });
+
+    it("has the correct uncles hash", async () => {
+      // Block 13327133 on mainnet had 1 uncle
+      const block = await fb.getBlock(13327133);
+      if (block === null) {
+        assert.fail("no block returned");
+      }
+      // Compute the expected uncle hash
+      const uncleHash = rlphash(block.uncleHeaders.map((u) => u.serialize()));
+      assert.equal(bufferToHex(block.header.uncleHash), bufferToHex(uncleHash));
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

<!-- Add a description of your PR here -->
There is an issue with the forked-node, when handling blocks with uncles. It seems that the list of uncles is omitted since the methods to find the uncles are not implemented (IIUC), however the hash passed to the RPC responses is the actual real header uncles hash. If the real block had uncles, some libraries would expect the uncles list to be not-empty (cf. [geth](https://github.com/ethereum/go-ethereum/blob/f2491c5ed77b9554bd979a426db741a99acf6fa4/ethclient/ethclient.go#L121-L123))

This PR fixes this by ensuring we always respond with the uncles hash set as the hash of an empty list.