### PR TITLE
Adds config for arbitrum

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/reorgs-protection.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/reorgs-protection.ts
@@ -35,6 +35,11 @@ export function getLargestPossibleReorg(networkId: number): number | undefined {
   if (networkId === 100) {
     return 38;
   }
+
+  // arbitrum
+  if (networkId === 42161) {
+    return 15
+  }
 }
 
 export const FALLBACK_MAX_REORG = 30;


### PR DESCRIPTION
Some arbitrum providers such as alchemy only support forking from 20 blocks back. The default of 30 means forking for this chain fails. 


