### PR TITLE
gas-providers.ts - fix klaytn rpc

### DIFF
--- a/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
+++ b/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
@@ -312,11 +312,16 @@ export class GanacheGasMultiplierProvider extends MultipliedGasEstimationProvide
 
   private async _isGanache(): Promise<boolean> {
     if (this._cachedIsGanache === undefined) {
-      const clientVersion = (await this._wrappedProvider.request({
-        method: "web3_clientVersion",
-      })) as string;
+      try {
+        const clientVersion = (await this._wrappedProvider.request({
+          method: "web3_clientVersion",
+        })) as string;
 
-      this._cachedIsGanache = clientVersion.includes("TestRPC");
+        this._cachedIsGanache = clientVersion.includes("TestRPC");
+      } catch (error) {
+        /* There is no "web3_clientVersion" method in Klaytn RPC */
+        this._cachedIsGanache = false;
+      }
     }
 
     return this._cachedIsGanache;


### PR DESCRIPTION
https://github.com/nomiclabs/hardhat/issues/1953

There is no "web3_clientVersion" method in Klaytn RPC. Added exception handling code.
