### PR TITLE
Fix HARDHAT_TESTS_SOLC_PATH handling

### DIFF
--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
@@ -96,7 +96,7 @@ function getCompilersDownloadDir() {
 
 function getCompilerDownloadPath(compilerPath: string) {
   const compilersDir = getCompilersDownloadDir();
-  return path.join(compilersDir, compilerPath);
+  return path.resolve(compilersDir, compilerPath);
 }
 
 export async function downloadSolc(compilerPath: string): Promise<void> {
@@ -111,11 +111,15 @@ export async function downloadSolc(compilerPath: string): Promise<void> {
 }
 
 async function getSolc(compilerPath: string): Promise<any> {
-  await downloadSolc(compilerPath);
-  let absoluteCompilerPath = compilerPath;
-  if (!path.isAbsolute(absoluteCompilerPath)) {
-    absoluteCompilerPath = getCompilerDownloadPath(compilerPath);
+  const isAbsolutePath = path.isAbsolute(compilerPath);
+
+  if (!isAbsolutePath) {
+    await downloadSolc(compilerPath);
   }
+
+  const absoluteCompilerPath = isAbsolutePath
+    ? compilerPath
+    : getCompilerDownloadPath(compilerPath);
 
   return solcWrapper(loadCompilerSources(absoluteCompilerPath));
 }

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -772,6 +772,11 @@ describe("Stack traces", function () {
       process.exit(1);
     }
 
+    if (!path.isAbsolute(customSolcPath)) {
+      console.error("HARDHAT_TESTS_SOLC_PATH has to be an absolute path");
+      process.exit(1);
+    }
+
     describe.only(`Use compiler at ${customSolcPath} with version ${customSolcVersion}`, function () {
       const compilerOptions = {
         solidityVersion: customSolcVersion,


### PR DESCRIPTION
Closes #1969.

@cameel to simplify things, I made it so that _only_ absolute paths can be used for this variable. That way we know that we shouldn't try to download the compiler in those cases.