### PR TITLE
HttpProxy envs while interacting with networks

### DIFF
--- a/config/typescript/@types/proxy/index.d.ts
+++ b/config/typescript/@types/proxy/index.d.ts
@@ -1,0 +1,1 @@
+declare module "proxy";

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -35,6 +35,8 @@ As general rule, you can target any network configured in the `hardhat.config.js
 
 `npx hardhat run --network <your-network> scripts/deploy.js`
 
+If you are behind an HTTP proxy, you may need to set the `HTTP_PROXY` or `HTTPS_PROXY` environment variable to the URL of your proxy.
+
 ### Truffle migrations support
 
 You can use Hardhat alongside Truffle if you want to use its migration system. Your contracts written using Hardhat will just work with Truffle.

--- a/packages/hardhat-core/test/internal/core/providers/http.ts
+++ b/packages/hardhat-core/test/internal/core/providers/http.ts
@@ -30,13 +30,14 @@ describe("HttpProvider", function () {
   });
 
   describe("Simple Request - HttpProxyAgent", function () {
-    const url = INFURA_URL;
+    const rpcUrl = INFURA_URL;
+
     let env: typeof process.env;
     let proxy: any;
     let proxyPort: number;
     const simpleRequest = {
       method: "eth_getTransactionCount",
-      params: ["0x0000000000000000000000000000000000000000"],
+      params: ["0x0000000000000000000000000000000000000000", "latest"],
     };
 
     before(function (done) {
@@ -47,54 +48,62 @@ describe("HttpProvider", function () {
         done();
       });
     });
+
     describe("Simple Request without PROXY env", function () {
-      it("Request is successfull", async function () {
-        if (url === undefined) {
+      it("Request is successful", async function () {
+        if (rpcUrl === undefined) {
           this.skip();
-          return;
         }
-        const provider = new HttpProvider(url, "Test");
+
+        const provider = new HttpProvider(rpcUrl, "Test");
         assert.isOk(await provider.request(simpleRequest));
       });
     });
+
     describe("Simple Request with HTTPS_PROXY env", function () {
       before(function () {
         // Save the Environment Settings and Set
         env = process.env;
         process.env.HTTPS_PROXY = `http://127.0.0.1:${proxyPort}`;
       });
-      it("Request is successfull", async function () {
-        if (url === undefined) {
+
+      it("Request is successful", async function () {
+        if (rpcUrl === undefined) {
           this.skip();
-          return;
         }
-        const provider = new HttpProvider(url, "Test");
+
+        const provider = new HttpProvider(rpcUrl, "Test");
         assert.isOk(await provider.request(simpleRequest));
       });
+
       after(function () {
         // restoring everything back to the environment
         process.env = env;
       });
     });
+
     describe("Simple Request with HTTP_PROXY env", function () {
       before(function () {
         // Save the Environment Settings and Set
         env = process.env;
         process.env.HTTP_PROXY = `http://127.0.0.1:${proxyPort}`;
       });
-      it("Request is successfull", async function () {
-        if (url === undefined) {
+
+      it("Request is successful", async function () {
+        if (rpcUrl === undefined) {
           this.skip();
-          return;
         }
-        const provider = new HttpProvider(url, "Test");
+
+        const provider = new HttpProvider(rpcUrl, "Test");
         assert.isOk(await provider.request(simpleRequest));
       });
+
       after(function () {
         // restoring everything back to the environment
         process.env = env;
       });
     });
+
     after(function (done) {
       // Shutdown Proxy Server
       proxy.once("close", function () {

--- a/packages/hardhat-core/test/internal/core/providers/http.ts
+++ b/packages/hardhat-core/test/internal/core/providers/http.ts
@@ -1,5 +1,10 @@
+import { assert } from "chai";
+// @ts-ignore
+// eslint-disable-next-line  import/no-extraneous-dependencies
+import Proxy from "proxy";
+
 import { HttpProvider } from "../../../../src/internal/core/providers/http";
-import { ALCHEMY_URL } from "../../../setup";
+import { ALCHEMY_URL, INFURA_URL } from "../../../setup";
 
 describe("HttpProvider", function () {
   describe("429 Too many requests - retries", function () {
@@ -23,6 +28,81 @@ describe("HttpProvider", function () {
       }
 
       await Promise.all(requests);
+    });
+  });
+
+  describe("Simple Request - HttpProxyAgent", function () {
+    const url = INFURA_URL;
+    let env: typeof process.env;
+    let proxy: any;
+    let proxyPort: number;
+    const simpleRequest = {
+      method: "eth_getTransactionCount",
+      params: ["0x0000000000000000000000000000000000000000"],
+    };
+
+    before(function (done) {
+      // Setup Proxy Server
+      proxy = new Proxy();
+      proxy.listen(function () {
+        proxyPort = proxy.address().port;
+        done();
+      });
+    });
+    describe("Simple Request without PROXY env", function () {
+      it("Request is successfull", async function () {
+        if (url === undefined) {
+          this.skip();
+          return;
+        }
+        const provider = new HttpProvider(url, "Test");
+       assert.isOk(await provider.request(simpleRequest));
+      });
+    });
+    describe("Simple Request with HTTPS_PROXY env", function () {
+      before(function () {
+        // Save the Environment Settings and Set
+        env = process.env;
+        process.env.HTTPS_PROXY = `http://127.0.0.1:${proxyPort}`;
+      });
+      it("Request is successfull", async function () {
+        if (url === undefined) {
+          this.skip();
+          return;
+        }
+        const provider = new HttpProvider(url, "Test");
+        assert.isOk(await provider.request(simpleRequest));
+      });
+      after(function () {
+        // restoring everything back to the environment
+        process.env = env;
+      });
+    });
+    describe("Simple Request with HTTP_PROXY env", function () {
+      before(function () {
+        // Save the Environment Settings and Set
+        env = process.env;
+        process.env.HTTP_PROXY = `http://127.0.0.1:${proxyPort}`;
+      });
+      it("Request is successfull", async function () {
+        if (url === undefined) {
+          this.skip();
+          return;
+        }
+        const provider = new HttpProvider(url, "Test");
+        assert.isOk(await provider.request(simpleRequest));
+      });
+      after(function () {
+        // restoring everything back to the environment
+        process.env = env;
+      });
+    });
+    after(function (done) {
+      // Shutdown Proxy Server
+      proxy.once("close", function () {
+        done();
+      });
+      proxy.close();
     });
   });
 });

--- a/packages/hardhat-core/test/internal/core/providers/http.ts
+++ b/packages/hardhat-core/test/internal/core/providers/http.ts
@@ -1,6 +1,4 @@
 import { assert } from "chai";
-// @ts-ignore
-// eslint-disable-next-line  import/no-extraneous-dependencies
 import Proxy from "proxy";
 
 import { HttpProvider } from "../../../../src/internal/core/providers/http";
@@ -56,7 +54,7 @@ describe("HttpProvider", function () {
           return;
         }
         const provider = new HttpProvider(url, "Test");
-       assert.isOk(await provider.request(simpleRequest));
+        assert.isOk(await provider.request(simpleRequest));
       });
     });
     describe("Simple Request with HTTPS_PROXY env", function () {

--- a/packages/hardhat-core/test/internal/util/download.ts
+++ b/packages/hardhat-core/test/internal/util/download.ts
@@ -1,8 +1,6 @@
 import { assert } from "chai";
 import fsExtra from "fs-extra";
 import path from "path";
-// @ts-ignore
-// eslint-disable-next-line  import/no-extraneous-dependencies
 import Proxy from "proxy";
 
 import { download } from "../../../src/internal/util/download";


### PR DESCRIPTION
- [X] Because this PR includes a **new feature**, it uses the `development` branch as its base branch.

---

Being behind a Corporate HttpProxy, I'd like to add the feature to deploy/interact with networks by using standard environment variables : HTTPS_PROXY or HTTP_PROXY .

Linked to #1978 
