### PR TITLE
Fixing case issue that doesn't match code

### DIFF
--- a/docs/tutorial/testing-contracts.md
+++ b/docs/tutorial/testing-contracts.md
@@ -198,7 +198,7 @@ describe("Token contract", function () {
       // `require` will evaluate false and revert the transaction.
       await expect(
         hardhatToken.connect(addr1).transfer(owner.address, 1)
-      ).to.be.revertedWith("Not enough tokens");
+      ).to.be.revertedWith("not enough tokens");
 
       // Owner balance shouldn't have changed.
       expect(await hardhatToken.balanceOf(owner.address)).to.equal(


### PR DESCRIPTION
- [x] Because this PR includes a **documentation change**, it uses the `master` branch as its base branch.

Fixing the casing of 'Not'->'not' in the test so it matches the contract