### PR TITLE
pending block should include logsBloom

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/output.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/output.ts
@@ -170,7 +170,7 @@ export function getRpcBlock(
     nonce: pending ? null : bufferToRpcData(block.header.nonce, 8),
     mixHash: pending ? null : bufferToRpcData(block.header.mixHash, 32),
     sha3Uncles: bufferToRpcData(block.header.uncleHash),
-    logsBloom: pending ? null : bufferToRpcData(block.header.bloom),
+    logsBloom: bufferToRpcData(block.header.bloom),
     transactionsRoot: bufferToRpcData(block.header.transactionsTrie),
     stateRoot: bufferToRpcData(block.header.stateRoot),
     receiptsRoot: bufferToRpcData(block.header.receiptTrie),

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByNumber.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByNumber.ts
@@ -103,6 +103,7 @@ describe("Eth module", function () {
             ["pending", false]
           );
 
+          assert.isNotEmpty(block.logsBloom);
           assert.equal(block.transactions.length, 1);
           assert.equal(block.parentHash, firstBlock.hash);
           assert.include(block.transactions as string[], txHash);


### PR DESCRIPTION
- [x ] Because this PR includes a **bug fix**, relevant tests have been included.


Based on https://github.com/ethereumproject/go-ethereum/pull/216 logsBloom should be included in the pending block response.