### PR TITLE
fix chainlink fund link consumer npm package link

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -250,6 +250,7 @@ module.exports.communityPlugins = [
   {
     name: "hardhat-fund-link",
     author: "Applied Blockchain",
+    npmPackage: "@appliedblockchain/chainlink-plugins-fund-link",
     authorUrl: "https://github.com/appliedblockchain",
     description: "Transfers Link token amount between accounts.",
     tags: ["Chainlink", "Link"],


### PR DESCRIPTION
The chainlink fund link plugin URL is redirecting the user to an existing page. This PR fixes the package name on npm modules.
