### PR TITLE
Add document to run client with localhost network when forking

### DIFF
--- a/docs/hardhat-network/guides/mainnet-forking.md
+++ b/docs/hardhat-network/guides/mainnet-forking.md
@@ -28,6 +28,12 @@ networks: {
 
 By accessing any state that exists on mainnet, Hardhat Network will pull the data and expose it transparently as if it was available locally.
 
+(Note: run hardhat console or hardhat test with localhost network parameter to connect to the forked network:
+
+```
+  npx hardhat console --network localhost
+```
+
 ## Pinning a block
 
 Hardhat Network will by default fork from the latest mainnet block. While this might be practical depending on the context, to set up a test suite that depends on forking we recommend forking from a specific block number.


### PR DESCRIPTION
When running "hardhat node" with fork, a user will need to use --network localhost for the 'hardhat console' or 'hardhat test' client to connect to the forked network properly.  E.g.

  npx hardhat console --network localhost

Without this option is not specified, the behavior is strange.  E.g. eth_getCode won't return deployed contract, even when the contract is actually deployed to the local network.

It took me a whole day to figure this out - hope this is documented so that others won't have to

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
