### PR TITLE
Align `@types/mocha` with `mocha`'s version

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/shelljs": "^0.8.6",
     "@typescript-eslint/eslint-plugin": "4.29.2",

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -63,7 +63,7 @@
     "@types/fs-extra": "^5.1.0",
     "@types/glob": "^7.1.1",
     "@types/lodash": "^4.14.123",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@types/node-fetch": "^2.3.7",
     "@types/qs": "^6.5.3",

--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -57,6 +57,10 @@ subtask(TASK_TEST_RUN_MOCHA_TESTS)
       mocha.run(resolve);
     });
 
+    // [@types/mocha@7.0.2](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3dce8b667f77c414b123be249d1ea6e98804ea4f/types/mocha/index.d.ts)
+    // is missing the definition of `dispose`, which is actually implemented
+    // https://github.com/mochajs/mocha/blob/v7.2.0/lib/mocha.js#L575
+    // @ts-ignore
     mocha.dispose();
 
     return testFailures;

--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -60,7 +60,7 @@ subtask(TASK_TEST_RUN_MOCHA_TESTS)
     // [@types/mocha@7.0.2](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3dce8b667f77c414b123be249d1ea6e98804ea4f/types/mocha/index.d.ts)
     // is missing the definition of `dispose`, which is actually implemented
     // https://github.com/mochajs/mocha/blob/v7.2.0/lib/mocha.js#L575
-    // @ts-ignore
+    // @ts-expect-error
     mocha.dispose();
 
     return testFailures;

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -70,7 +70,7 @@ const ADVANCED_TYPESCRIPT_SAMPLE_PROJECT_DEPENDENCIES: Dependencies = {
   "@typescript-eslint/parser": "^4.29.1",
   "@types/chai": "^4.2.21",
   "@types/node": "^12.0.0",
-  "@types/mocha": "^9.0.0",
+  "@types/mocha": "^7.0.2",
   "ts-node": "^10.1.0",
   typechain: "^5.1.2", // a workaround. see https://github.com/nomiclabs/hardhat/issues/1672#issuecomment-894497156
   typescript: "^4.5.2",

--- a/packages/hardhat-docker/package.json
+++ b/packages/hardhat-docker/package.json
@@ -31,7 +31,7 @@
     "@types/chai": "^4.2.0",
     "@types/dockerode": "^2.5.19",
     "@types/fs-extra": "^5.1.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node-fetch": "^2.3.7",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",

--- a/packages/hardhat-ethers/package.json
+++ b/packages/hardhat-ethers/package.json
@@ -38,7 +38,7 @@
   ],
   "devDependencies": {
     "@types/chai": "^4.2.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-etherscan/package.json
+++ b/packages/hardhat-etherscan/package.json
@@ -48,7 +48,7 @@
     "@types/cbor": "^5.0.1",
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node-fetch": "^2.3.7",
     "@types/node": "^12.0.0",
     "@types/semver": "^6.0.2",

--- a/packages/hardhat-ganache/package.json
+++ b/packages/hardhat-ganache/package.json
@@ -40,7 +40,7 @@
     "@types/chai": "^4.2.0",
     "@types/debug": "^4.1.4",
     "@types/fs-extra": "^5.1.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-shorthand/package.json
+++ b/packages/hardhat-shorthand/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-solhint/package.json
+++ b/packages/hardhat-solhint/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-solpp/package.json
+++ b/packages/hardhat-solpp/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-truffle4/package.json
+++ b/packages/hardhat-truffle4/package.json
@@ -42,7 +42,7 @@
     "@nomiclabs/hardhat-web3-legacy": "^2.0.0",
     "@types/fs-extra": "^5.1.0",
     "@types/glob": "^7.1.1",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-truffle5/package.json
+++ b/packages/hardhat-truffle5/package.json
@@ -42,7 +42,7 @@
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@types/fs-extra": "^5.1.0",
     "@types/glob": "^7.1.1",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-vyper/package.json
+++ b/packages/hardhat-vyper/package.json
@@ -40,7 +40,7 @@
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
     "@types/glob": "^7.1.1",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-waffle/package.json
+++ b/packages/hardhat-waffle/package.json
@@ -34,7 +34,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-web3-legacy/package.json
+++ b/packages/hardhat-web3-legacy/package.json
@@ -33,7 +33,7 @@
   ],
   "devDependencies": {
     "@types/chai": "^4.2.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-web3/package.json
+++ b/packages/hardhat-web3/package.json
@@ -33,7 +33,7 @@
   ],
   "devDependencies": {
     "@types/chai": "^4.2.0",
-    "@types/mocha": "^9.0.0",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,10 +2147,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/mocha@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.0.0.tgz#3205bcd15ada9bc681ac20bef64e9e6df88fd297"
-  integrity sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==
+"@types/mocha@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-7.0.2.tgz#b17f16cf933597e10d6d78eae3251e692ce8b0ce"
+  integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
 
 "@types/node-fetch@^2.3.7", "@types/node-fetch@^2.5.5":
   version "2.5.11"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

In https://github.com/nomiclabs/hardhat/pull/2140, `@types/mocha` has been updated to `^9.0.0`, yet hardhat still uses `mocha` v7.

This PR aligns `@types/mocha` version with `mocha`'s.

Note that the type definition provided by [`@types/mocha@7.0.2`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3dce8b667f77c414b123be249d1ea6e98804ea4f/types/mocha/index.d.ts) is not 100% accurate, e.g. it's missing the [`dispose()` function](https://github.com/mochajs/mocha/blob/v7.2.0/lib/mocha.js#L575), but I think it's still better than using `@types/mocha@9.0.0`. 

Of course, the ideal solution would be to upgrade `mocha` to v9 ;)