### PR TITLE
Fix: dark mode ordered list text color

### DIFF
--- a/docs/.vuepress/theme/styles/theme-dark-hc.styl
+++ b/docs/.vuepress/theme/styles/theme-dark-hc.styl
@@ -141,7 +141,7 @@
                 border-left-color: rgba(240, 141, 73, 1);
             }
         }
-        ul {
+        ul, ol {
             li {
                 color: $text;
                 code {

--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -146,7 +146,7 @@
                 border-left-color: rgba(240, 141, 73, 1);
             }
         }
-        ul {
+        ul, ol {
             li {
                 color: $text;
                 code {


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Added `ol` to the dark mode `.page` CSS.

Fixes the issue #2288 
![image](https://user-images.githubusercontent.com/29498872/150631169-3e476394-7069-4321-bf0f-2b8d26f21209.png)
