### PR TITLE
Use absolute paths for test task arguments

### DIFF
--- a/.changeset/red-lobsters-work.md
+++ b/.changeset/red-lobsters-work.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+The test task now works correctly when a test file starts with `./` (fixes #2220).

--- a/packages/e2e/test/index.ts
+++ b/packages/e2e/test/index.ts
@@ -66,6 +66,24 @@ describe("e2e tests", function () {
       const { code: hhCleanCode2 } = shell.exec(`${hardhatBinary} clean`);
       assert.equal(hhCleanCode2, 0);
     });
+
+    it("the test task should accept test files", async function () {
+      // hh clean
+      const { code: hhCleanCode1 } = shell.exec(`${hardhatBinary} clean`);
+      assert.equal(hhCleanCode1, 0);
+
+      // hh test without ./
+      const { code: testRunCode1 } = shell.exec(
+        `${hardhatBinary} test test/simple.js`
+      );
+      assert.equal(testRunCode1, 0);
+
+      // hh test with ./
+      const { code: testRunCode2 } = shell.exec(
+        `${hardhatBinary} test ./test/simple.js`
+      );
+      assert.equal(testRunCode2, 0);
+    });
   });
 
   describe("sample projects", function () {

--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -26,7 +26,11 @@ subtask(TASK_TEST_GET_TEST_FILES)
   )
   .setAction(async ({ testFiles }: { testFiles: string[] }, { config }) => {
     if (testFiles.length !== 0) {
-      return testFiles;
+      const testFilesAbsolutePaths = testFiles.map((x) =>
+        path.resolve(process.cwd(), x)
+      );
+
+      return testFilesAbsolutePaths;
     }
 
     const jsFiles = await glob(path.join(config.paths.tests, "**/*.js"));


### PR DESCRIPTION
Related to #2220.

The `mocha.dispose()` call seems to throw when the test task is used like this:

```
hh test ./test/test.js
```

But this works:

```
hh test test/test.js
```

Converting the arguments to absolute paths (relative to `process.cwd()`) fixes the issue.
