### PR TITLE
Adding support for AuroraScan

### DIFF
--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -162,6 +162,9 @@ module.exports = {
         // avalanche
         avalanche: "YOUR_SNOWTRACE_API_KEY",
         avalancheFujiTestnet: "YOUR_SNOWTRACE_API_KEY",
+        // aurora
+        aurora: "YOUR_AURORASCAN_API_KEY",
+        auroraTestnet: "YOUR_AURORASCAN_API_KEY",
         // moonbeam
         moonbeam: "YOUR_MOONBEAM_MOONSCAN_API_KEY"
         moonriver: "YOUR_MOONRIVER_MOONSCAN_API_KEY",

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -170,4 +170,18 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://blockscout.com/poa/sokol",
     },
   },
+  aurora: {
+    chainId: 1313161554,
+    urls: {
+      apiURL: "https://api.aurorascan.dev/api",
+      browserURL: "https://aurorascan.dev",
+    },
+  },
+  auroraTestnet: {
+    chainId: 1313161555,
+    urls: {
+      apiURL: "https://api-testnet.aurora.dev/api",
+      browserURL: "https://testnet.aurorascan.dev",
+    },
+  },
 };

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -25,6 +25,9 @@ type Chain =
   // avalanche
   | "avalanche"
   | "avalancheFujiTestnet"
+  // aurora
+  | "aurora"
+  | "auroraTestnet"
   // moonbeam
   | "moonbeam"
   | "moonriver"


### PR DESCRIPTION
This adds support for verifying Aurora smart contracts on AuroraScan.

Official RPC endpoints:

https://mainnet.aurora.dev/
https://testnet.aurora.dev/

Deposit to `0x4444c3F7D7d3153Dc0773C31ae10cf9B5495d4Bb` has been made.