### PR TITLE
[etherscan-verify] Add support for custom chains/explorer paths

### DIFF
--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -176,7 +176,7 @@ module.exports = {
         aurora: "api-key",
         auroraTestnet: "api-key",
     },
-    // If hardhat doesn't know about the chain's explorer api you can add it here 
+    // If hardhat doesn't know about the chain's explorer api you can add it here
     extendChainConfig: {
       localhost: {
           chainId: 31337,

--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -175,6 +175,16 @@ module.exports = {
         sokol: "api-key",
         aurora: "api-key",
         auroraTestnet: "api-key",
+    },
+    // If hardhat doesn't know about the chain's explorer api you can add it here 
+    extendChainConfig: {
+      localhost: {
+          chainId: 31337,
+          urls: {
+            apiURL: "https://localhost/api",
+            browserURL: "https://localhost",
+          },
+      }
     }
   }
 };

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -1,4 +1,4 @@
-import { ChainConfig, EtherscanConfig} from "./types";
+import { ChainConfig, EtherscanConfig } from "./types";
 
 // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids
 const chainConfig: ChainConfig = {
@@ -201,8 +201,8 @@ const chainConfig: ChainConfig = {
 };
 
 export const getChainConfig = (config: EtherscanConfig) => {
-    return {
-      ...chainConfig,
-      ...config.extendChainConfig
-    };
-}
+  return {
+    ...chainConfig,
+    ...config.extendChainConfig,
+  };
+};

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -1,7 +1,7 @@
-import { ChainConfig } from "./types";
+import { ChainConfig, EtherscanConfig} from "./types";
 
 // See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids
-export const chainConfig: ChainConfig = {
+const chainConfig: ChainConfig = {
   mainnet: {
     chainId: 1,
     urls: {
@@ -199,3 +199,10 @@ export const chainConfig: ChainConfig = {
     },
   },
 };
+
+export const getChainConfig = (config: EtherscanConfig) => {
+    return {
+      ...chainConfig,
+      ...config.extendChainConfig
+    };
+}

--- a/packages/hardhat-etherscan/src/config.ts
+++ b/packages/hardhat-etherscan/src/config.ts
@@ -1,6 +1,6 @@
 import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import { ConfigExtender } from "hardhat/types";
-import { chainConfig } from "./ChainConfig";
+import { getChainConfig } from "./ChainConfig";
 import { EtherscanConfig } from "./types";
 import { pluginName } from "./constants";
 
@@ -13,7 +13,7 @@ const verifyAllowedChains = (etherscanConfig: EtherscanConfig): string[] => {
     return [];
   }
 
-  const allowed = Object.keys(chainConfig);
+  const allowed = Object.keys(getChainConfig(etherscanConfig));
   const actual = Object.keys(etherscanConfig.apiKey);
 
   return actual.filter((chain: string) => !allowed.includes(chain));

--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -45,7 +45,7 @@ import {
   toCheckStatusRequest,
   toVerifyRequest,
 } from "./etherscan/EtherscanVerifyContractRequest";
-import { chainConfig } from "./ChainConfig";
+import { getChainConfig } from "./ChainConfig";
 import {
   getEtherscanEndpoints,
   retrieveContractBytecode,
@@ -593,8 +593,8 @@ See https://etherscan.io/solcversions for more information.`
   }
 );
 
-subtask(TASK_VERIFY_GET_ETHERSCAN_ENDPOINT).setAction(async (_, { network }) =>
-  getEtherscanEndpoints(network.provider, network.name, chainConfig)
+subtask(TASK_VERIFY_GET_ETHERSCAN_ENDPOINT).setAction(async (_, { network, config }) =>
+  getEtherscanEndpoints(network.provider, network.name, getChainConfig(config.etherscan))
 );
 
 subtask(TASK_VERIFY_GET_CONTRACT_INFORMATION)

--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -593,8 +593,13 @@ See https://etherscan.io/solcversions for more information.`
   }
 );
 
-subtask(TASK_VERIFY_GET_ETHERSCAN_ENDPOINT).setAction(async (_, { network, config }) =>
-  getEtherscanEndpoints(network.provider, network.name, getChainConfig(config.etherscan))
+subtask(TASK_VERIFY_GET_ETHERSCAN_ENDPOINT).setAction(
+  async (_, { network, config }) =>
+    getEtherscanEndpoints(
+      network.provider,
+      network.name,
+      getChainConfig(config.etherscan)
+    )
 );
 
 subtask(TASK_VERIFY_GET_CONTRACT_INFORMATION)

--- a/packages/hardhat-etherscan/src/network/prober.ts
+++ b/packages/hardhat-etherscan/src/network/prober.ts
@@ -22,7 +22,7 @@ export async function getEtherscanEndpoints(
   const chainIdsToNames = new Map(
     entries(chainConfig).map(([chainName, config]) => [
       config.chainId,
-      chainName,
+      chainName.toString(),
     ])
   );
 

--- a/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
@@ -1,10 +1,10 @@
 import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import { pluginName } from "./constants";
-import { chainConfig } from "./ChainConfig";
+import { getChainConfig } from "./ChainConfig";
 import { EtherscanConfig, ChainConfig } from "./types";
 
-const isNetworkKey = (network: string): network is keyof ChainConfig => {
-  return network in chainConfig;
+const isNetworkKey = (network: string, config: EtherscanConfig): boolean => {
+  return network in getChainConfig(config);
 };
 
 export const resolveEtherscanApiKey = (
@@ -21,7 +21,7 @@ export const resolveEtherscanApiKey = (
 
   const apiKeys = etherscan.apiKey;
 
-  if (!isNetworkKey(network)) {
+  if (!isNetworkKey(network, etherscan)) {
     throw new NomicLabsHardhatPluginError(
       pluginName,
       `Unrecognized network: ${network}`

--- a/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/src/resolveEtherscanApiKey.ts
@@ -1,7 +1,7 @@
 import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import { pluginName } from "./constants";
 import { getChainConfig } from "./ChainConfig";
-import { EtherscanConfig, ChainConfig } from "./types";
+import { EtherscanConfig} from "./types";
 
 const isNetworkKey = (network: string, config: EtherscanConfig): boolean => {
   return network in getChainConfig(config);

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -1,14 +1,14 @@
-export type ChainConfig = {
-  [chain : string]: EtherscanChainConfig;
-};
+export interface ChainConfig {
+  [chain: string]: EtherscanChainConfig;
+}
 
-type EtherscanApiKeys = {
-  [chain : string]: string;
-};
+interface EtherscanApiKeys {
+  [chain: string]: string;
+}
 
 export interface EtherscanConfig {
   apiKey?: string | EtherscanApiKeys;
-  extendChainConfig? : { [chain: string] : EtherscanChainConfig }
+  extendChainConfig?: { [chain: string]: EtherscanChainConfig };
 }
 
 export interface EtherscanURLs {

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -1,53 +1,14 @@
-type Chain =
-  | "mainnet"
-  | "ropsten"
-  | "rinkeby"
-  | "goerli"
-  | "kovan"
-  // binance smart chain
-  | "bsc"
-  | "bscTestnet"
-  // huobi eco chain
-  | "heco"
-  | "hecoTestnet"
-  // fantom mainnet
-  | "opera"
-  | "ftmTestnet"
-  // optimistim
-  | "optimisticEthereum"
-  | "optimisticKovan"
-  // polygon
-  | "polygon"
-  | "polygonMumbai"
-  // arbitrum
-  | "arbitrumOne"
-  | "arbitrumTestnet"
-  // avalanche
-  | "avalanche"
-  | "avalancheFujiTestnet"
-  // moonbeam
-  | "moonbeam"
-  | "moonriver"
-  | "moonbaseAlpha"
-  | "harmony"
-  | "harmonyTest"
-  // xdai
-  | "xdai"
-  | "sokol"
-  // aurora
-  | "aurora"
-  | "auroraTestnet";
-
 export type ChainConfig = {
-  [Network in Chain]: EtherscanChainConfig;
+  [chain : string]: EtherscanChainConfig;
 };
 
 type EtherscanApiKeys = {
-  [Network in Chain]?: string;
+  [chain : string]: string;
 };
 
 export interface EtherscanConfig {
   apiKey?: string | EtherscanApiKeys;
+  extendChainConfig? : { [chain: string] : EtherscanChainConfig }
 }
 
 export interface EtherscanURLs {
@@ -55,12 +16,12 @@ export interface EtherscanURLs {
   browserURL: string;
 }
 
-interface EtherscanChainConfig {
+export interface EtherscanChainConfig {
   chainId: number;
   urls: EtherscanURLs;
 }
 
 export interface EtherscanNetworkEntry {
-  network: Chain;
+  network: string;
   urls: EtherscanURLs;
 }

--- a/packages/hardhat-etherscan/test/unit/ChainConfig.ts
+++ b/packages/hardhat-etherscan/test/unit/ChainConfig.ts
@@ -1,9 +1,9 @@
 import { assert } from "chai";
-import { chainConfig } from "../../src/ChainConfig";
+import { getChainConfig } from "../../src/ChainConfig";
 
 describe("Chain Config", () => {
   it("should have no duplicate chain ids", () => {
-    const chainIds: number[] = Object.values(chainConfig).map(
+    const chainIds: number[] = Object.values(getChainConfig({})).map(
       (config) => config.chainId
     );
 

--- a/packages/hardhat-etherscan/test/unit/etherscanConfigExtender.ts
+++ b/packages/hardhat-etherscan/test/unit/etherscanConfigExtender.ts
@@ -64,4 +64,39 @@ describe("Config extension", () => {
       etherscanConfigExtender(resolvedConfig, invalidEtherscanConfig);
     }, 'Etherscan API token "newhotness" is for an unsupported network');
   });
+
+  it("should provide custom network", () => {
+    const resolvedConfig = {} as HardhatConfig;
+    etherscanConfigExtender(resolvedConfig, {
+      etherscan: { apiKey: { localhost: "example_token" }, 
+            extendChainConfig: {
+              localhost: {
+                chainId: 31337,
+                urls: {
+                  apiURL: "https://localhost/api",
+                  browserURL: "https://localhost",
+                },
+              }
+            } },
+    });
+  });
+
+  it("should not provide custom network without api key", () => {
+    assert.throws(() => {
+      const resolvedConfig = {} as HardhatConfig;
+      etherscanConfigExtender(resolvedConfig, {
+        etherscan: { apiKey: { wrong_network: "example_token" }, 
+              extendChainConfig: {
+                localhost: {
+                  chainId: 31337,
+                  urls: {
+                    apiURL: "https://localhost/api",
+                    browserURL: "https://localhost",
+                  },
+                }
+              } },
+      });
+    });
+  });
+
 });

--- a/packages/hardhat-etherscan/test/unit/etherscanConfigExtender.ts
+++ b/packages/hardhat-etherscan/test/unit/etherscanConfigExtender.ts
@@ -68,16 +68,18 @@ describe("Config extension", () => {
   it("should provide custom network", () => {
     const resolvedConfig = {} as HardhatConfig;
     etherscanConfigExtender(resolvedConfig, {
-      etherscan: { apiKey: { localhost: "example_token" }, 
-            extendChainConfig: {
-              localhost: {
-                chainId: 31337,
-                urls: {
-                  apiURL: "https://localhost/api",
-                  browserURL: "https://localhost",
-                },
-              }
-            } },
+      etherscan: {
+        apiKey: { localhost: "example_token" },
+        extendChainConfig: {
+          localhost: {
+            chainId: 31337,
+            urls: {
+              apiURL: "https://localhost/api",
+              browserURL: "https://localhost",
+            },
+          },
+        },
+      },
     });
   });
 
@@ -85,18 +87,19 @@ describe("Config extension", () => {
     assert.throws(() => {
       const resolvedConfig = {} as HardhatConfig;
       etherscanConfigExtender(resolvedConfig, {
-        etherscan: { apiKey: { wrong_network: "example_token" }, 
-              extendChainConfig: {
-                localhost: {
-                  chainId: 31337,
-                  urls: {
-                    apiURL: "https://localhost/api",
-                    browserURL: "https://localhost",
-                  },
-                }
-              } },
+        etherscan: {
+          apiKey: { wrong_network: "example_token" },
+          extendChainConfig: {
+            localhost: {
+              chainId: 31337,
+              urls: {
+                apiURL: "https://localhost/api",
+                browserURL: "https://localhost",
+              },
+            },
+          },
+        },
       });
     });
   });
-
 });

--- a/packages/hardhat-etherscan/test/unit/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/test/unit/resolveEtherscanApiKey.ts
@@ -67,7 +67,7 @@ describe("Etherscan API Key resolution", () => {
     it("should throw if network subkey is undefined", () => {
       assert.throws(
         () =>
-        // @ts-expect-error
+          // @ts-expect-error
           resolveEtherscanApiKey({ apiKey: { rinkeby: undefined } }, "rinkeby"),
         /Please provide an Etherscan API token via hardhat config./
       );
@@ -89,20 +89,23 @@ describe("Etherscan API Key resolution", () => {
 
     it("should resolve custom network", () => {
       assert.equal(
-        resolveEtherscanApiKey({ apiKey: { localhost: "testtoken" }, 
-          extendChainConfig: {
-            localhost: {
-              chainId: 31337,
-              urls: {
-                apiURL: "https://localhost/api",
-                browserURL: "https://localhost",
+        resolveEtherscanApiKey(
+          {
+            apiKey: { localhost: "testtoken" },
+            extendChainConfig: {
+              localhost: {
+                chainId: 31337,
+                urls: {
+                  apiURL: "https://localhost/api",
+                  browserURL: "https://localhost",
+                },
               },
-            }
-          }} 
-        , "localhost"),
+            },
+          },
+          "localhost"
+        ),
         "testtoken"
       );
     });
-  
   });
 });

--- a/packages/hardhat-etherscan/test/unit/resolveEtherscanApiKey.ts
+++ b/packages/hardhat-etherscan/test/unit/resolveEtherscanApiKey.ts
@@ -39,7 +39,6 @@ describe("Etherscan API Key resolution", () => {
     it("should throw if api key is for unrecognized network", () => {
       assert.throws(() =>
         resolveEtherscanApiKey(
-          // @ts-expect-error
           { apiKey: { newthing: "testtoken" } },
           "newthing"
         )
@@ -68,6 +67,7 @@ describe("Etherscan API Key resolution", () => {
     it("should throw if network subkey is undefined", () => {
       assert.throws(
         () =>
+        // @ts-expect-error
           resolveEtherscanApiKey({ apiKey: { rinkeby: undefined } }, "rinkeby"),
         /Please provide an Etherscan API token via hardhat config./
       );
@@ -82,10 +82,27 @@ describe("Etherscan API Key resolution", () => {
 
     it("should throw if network subkey is not a supported network", () => {
       assert.throws(
-        // @ts-expect-error
         () => resolveEtherscanApiKey({ apiKey: { boom: "" } }, "boom"),
         "Unrecognized network: boom"
       );
     });
+
+    it("should resolve custom network", () => {
+      assert.equal(
+        resolveEtherscanApiKey({ apiKey: { localhost: "testtoken" }, 
+          extendChainConfig: {
+            localhost: {
+              chainId: 31337,
+              urls: {
+                apiURL: "https://localhost/api",
+                browserURL: "https://localhost",
+              },
+            }
+          }} 
+        , "localhost"),
+        "testtoken"
+      );
+    });
+  
   });
 });


### PR DESCRIPTION
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team. (Issues #2385, #2173) (Existing PR #2177, which seems to be stale).
---

This PR adds support for custom chains without having to modify ChainConfig.ts. Specifically, it adds support for custom explorers, which were previously required to be hardcoded.

It removes the type constraint for Chain and Network, because it was too constraining (the type system can't know about all the possible chains, and I'm not sure what value it adds to constrain the type).

The PR adds an optional element to the hardhat Etherscan config:

```typescript
    // If hardhat doesn't know about the chain's explorer api you can add it here 
    {
    extendChainConfig: {
      localhost: {
          chainId: 31337,
          urls: {
            apiURL: "https://localhost/api",
            browserURL: "https://localhost",
          },
      }
}
```
