### PR TITLE
Added the Unlock Hardhat plugin

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -379,7 +379,7 @@ module.exports.communityPlugins = [
     description: "Hardhat plugin for Uniswap V3 deployment",
     tags: ["uniswap", "testing", "local deployment"],
   },
-   {
+  {
     name: "@unlock-protocol/hardhat-plugin",
     author: "Unlock Inc",
     authorUrl: "http://unlock-protocol.com/",

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -379,6 +379,13 @@ module.exports.communityPlugins = [
     description: "Hardhat plugin for Uniswap V3 deployment",
     tags: ["uniswap", "testing", "local deployment"],
   },
+   {
+    name: "@unlock-protocol/hardhat-plugin",
+    author: "Unlock Inc",
+    authorUrl: "http://unlock-protocol.com/",
+    description: "Hardhat plugin for Unlock Protocol deployments.",
+    tags: ["unlock", "nft", "memberships", "udt", "testing", "deployment"],
+  },
   {
     name: "hardhat-deploy-tenderly",
     author: "Ronan Sandford",


### PR DESCRIPTION
We created a hardhat plugin to make it easy for devs to build on top of unlock by deploying contracts!
We use this internally ourselves :)

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.
---

Adding the Unlock Hardhat plugin to the list of community plugins.