### PR TITLE
Update hardhat-etherscan Aurora changeset

### DIFF
--- a/.changeset/shaggy-hotels-wave.md
+++ b/.changeset/shaggy-hotels-wave.md
@@ -1,6 +1,5 @@
 ---
-"@nomiclabs/hardhat-ethers": patch
 "@nomiclabs/hardhat-etherscan": patch
 ---
 
-Add support for the Aurora network to `@nomiclabs/hardhat-etherscan`
+Add support for the Aurora network to `@nomiclabs/hardhat-etherscan` (thanks @baboobhaiya!)


### PR DESCRIPTION
The changeset bumped `hardhat-ethers` too for some reason. I also added a mention to the PR's author.