### PR TITLE
Use a low keepAlive in the tests http provider

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/server.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/server.ts
@@ -3,6 +3,7 @@ import type WsT from "ws";
 import debug from "debug";
 import http, { Server } from "http";
 import { AddressInfo } from "net";
+import { Client } from "undici";
 
 import {
   EIP1193Provider,
@@ -43,9 +44,20 @@ export class JsonRpcServer implements IJsonRpcServer {
   }
 
   public getProvider = (name = "json-rpc"): EIP1193Provider => {
-    const { address, port } = this._httpServer.address() as AddressInfo; // TCP sockets return AddressInfo
+    const { address, port } = this._httpServer.address() as AddressInfo;
 
-    return new HttpProvider(`http://${address}:${port}/`, name);
+    const dispatcher = new Client(`http://${address}:${port}/`, {
+      keepAliveTimeout: 10,
+      keepAliveMaxTimeout: 10,
+    });
+
+    return new HttpProvider(
+      `http://${address}:${port}/`,
+      name,
+      {},
+      20000,
+      dispatcher
+    );
   };
 
   public listen = (): Promise<{ address: string; port: number }> => {


### PR DESCRIPTION
If we use the default timeouts, the tests that use the http provider have to wait 4 seconds for the server to close, because it attempts a graceful shutdown and it still has open connections.