### PR TITLE
Update plugins.js to add Hardhat Metadata Plugin

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -407,6 +407,13 @@ module.exports.communityPlugins = [
     description: "Hardhat plugin to sync your compiled contract with Laika",
     tags: ["Tasks", "Laika"],
   },
+  {
+    name: "hardhat-network-metadata",
+    author: "Focal Labs Inc.",
+    authorUrl: "https://github.com/krruzic/hardhat-network-metadata",
+    description: "Hardhat plugin to allow adding any extra data to your network configuration",
+    tags: ["Metadata", "Testing", "Tasks", "Config"],
+  },
 ];
 
 module.exports.officialPlugins = [


### PR DESCRIPTION
add  plugin hardhat-network-metadata. This plugin allows you to add an extra field `metadata` within a network config like so:
```js
{ ...,
  metadata: { 
    anything: "goes here", 
    seriously: 1224233, 
    literallyWhateverYouWant: { a: 1 }
   }
}
```
