### PR TITLE
Fix OOM during parallel compilation

### DIFF
--- a/.changeset/slow-pianos-double.md
+++ b/.changeset/slow-pianos-double.md
@@ -1,0 +1,6 @@
+---
+"hardhat": patch
+---
+
+- Fixed a potential OOM error during parallel compilation
+- Added a `--concurrency` param to the compile task

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -411,7 +411,8 @@ module.exports.communityPlugins = [
     name: "hardhat-network-metadata",
     author: "Focal Labs Inc.",
     authorUrl: "https://github.com/krruzic/hardhat-network-metadata",
-    description: "Hardhat plugin to allow adding any extra data to your network configuration",
+    description:
+      "Hardhat plugin to allow adding any extra data to your network configuration",
     tags: ["Metadata", "Testing", "Tasks", "Config"],
   },
 ];

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -104,6 +104,8 @@ const log = debug("hardhat:core:tasks:compile");
 
 const COMPILE_TASK_FIRST_SOLC_VERSION_SUPPORTED = "0.4.11";
 
+const DEFAULT_CONCURRENCY_LEVEL = Math.max(os.cpus().length - 1, 1);
+
 /**
  * Returns a list of absolute paths to all the solidity files in the project.
  * This list doesn't include dependencies, for example solidity files inside
@@ -364,14 +366,17 @@ subtask(TASK_COMPILE_SOLIDITY_LOG_NOTHING_TO_COMPILE)
 subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOBS)
   .addParam("compilationJobs", undefined, undefined, types.any)
   .addParam("quiet", undefined, undefined, types.boolean)
+  .addParam("concurrency", undefined, DEFAULT_CONCURRENCY_LEVEL, types.int)
   .setAction(
     async (
       {
         compilationJobs,
         quiet,
+        concurrency,
       }: {
         compilationJobs: CompilationJob[];
         quiet: boolean;
+        concurrency: number;
       },
       { run }
     ): Promise<{ artifactsEmittedPerJob: ArtifactsEmittedPerJob }> => {
@@ -380,8 +385,6 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOBS)
         await run(TASK_COMPILE_SOLIDITY_LOG_NOTHING_TO_COMPILE, { quiet });
         return { artifactsEmittedPerJob: [] };
       }
-
-      const { default: pMap } = await import("p-map");
 
       log(`Compiling ${compilationJobs.length} jobs`);
 
@@ -423,7 +426,8 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOBS)
         });
       }
 
-      const pMapOptions = { concurrency: os.cpus().length, stopOnError: false };
+      const { default: pMap } = await import("p-map");
+      const pMapOptions = { concurrency, stopOnError: false };
       try {
         const artifactsEmittedPerJob: ArtifactsEmittedPerJob = await pMap(
           compilationJobs,
@@ -1288,9 +1292,14 @@ subtask(TASK_COMPILE_SOLIDITY_LOG_COMPILATION_RESULT)
 subtask(TASK_COMPILE_SOLIDITY)
   .addParam("force", undefined, undefined, types.boolean)
   .addParam("quiet", undefined, undefined, types.boolean)
+  .addParam("concurrency", undefined, DEFAULT_CONCURRENCY_LEVEL, types.int)
   .setAction(
     async (
-      { force, quiet }: { force: boolean; quiet: boolean },
+      {
+        force,
+        quiet,
+        concurrency,
+      }: { force: boolean; quiet: boolean; concurrency: number },
       { artifacts, config, run }
     ) => {
       const sourcePaths: string[] = await run(
@@ -1349,6 +1358,7 @@ subtask(TASK_COMPILE_SOLIDITY)
         {
           compilationJobs: mergedCompilationJobs,
           quiet,
+          concurrency,
         }
       );
 
@@ -1411,6 +1421,12 @@ subtask(TASK_COMPILE_GET_COMPILATION_TASKS, async (): Promise<string[]> => {
 task(TASK_COMPILE, "Compiles the entire project, building all artifacts")
   .addFlag("force", "Force compilation ignoring cache")
   .addFlag("quiet", "Makes the compilation process less verbose")
+  .addParam(
+    "concurrency",
+    "Number of compilation jobs executed in parallel. Defaults to the number of CPU cores - 1",
+    DEFAULT_CONCURRENCY_LEVEL,
+    types.int
+  )
   .setAction(async (compilationArgs: any, { run }) => {
     const compilationTasks: string[] = await run(
       TASK_COMPILE_GET_COMPILATION_TASKS

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -425,24 +425,22 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOBS)
 
       const pMapOptions = { concurrency: os.cpus().length, stopOnError: false };
       try {
-        const results = await pMap(
+        const artifactsEmittedPerJob: ArtifactsEmittedPerJob = await pMap(
           compilationJobs,
-          (compilationJob, compilationJobIndex) => {
-            return run(TASK_COMPILE_SOLIDITY_COMPILE_JOB, {
+          async (compilationJob, compilationJobIndex) => {
+            const result = await run(TASK_COMPILE_SOLIDITY_COMPILE_JOB, {
               compilationJob,
               compilationJobs,
               compilationJobIndex,
               quiet,
             });
+
+            return {
+              compilationJob: result.compilationJob,
+              artifactsEmittedPerFile: result.artifactsEmittedPerFile,
+            };
           },
           pMapOptions
-        );
-
-        const artifactsEmittedPerJob: ArtifactsEmittedPerJob = results.map(
-          ({ compilationJob, artifactsEmittedPerFile }) => ({
-            compilationJob,
-            artifactsEmittedPerFile,
-          })
         );
 
         return { artifactsEmittedPerJob };

--- a/packages/hardhat-core/test/internal/cli/autocomplete.ts
+++ b/packages/hardhat-core/test/internal/cli/autocomplete.ts
@@ -118,6 +118,11 @@ const quietParam = {
   description: "Makes the compilation process less verbose",
   name: "--quiet",
 };
+const concurrencyParam = {
+  description:
+    "Number of compilation jobs executed in parallel. Defaults to the number of CPU cores - 1",
+  name: "--concurrency",
+};
 
 describe("autocomplete", function () {
   if (os.type() === "Windows_NT") {
@@ -181,6 +186,7 @@ describe("autocomplete", function () {
         ...coreParams,
         forceParam,
         quietParam,
+        concurrencyParam,
       ]);
     });
 
@@ -194,6 +200,7 @@ describe("autocomplete", function () {
       expect(suggestions).same.deep.members([
         ...coreParamsWithoutVerbose,
         forceParam,
+        concurrencyParam,
       ]);
     });
 


### PR DESCRIPTION
Projects with a huge number of contracts like OZ's [contract-wizard](https://github.com/OpenZeppelin/contracts-wizard) can get an OOM error during compilation. This PR fixes that problem, by reducing the potential size of the array that accumulates the compilation results to what it was in v2.8.4.

Even with that change, it's still possible to get an OOM if the concurrency level is high and the available memory is not enough. This happens because multiple compilation results are present at the same time, and they may not fit in the available memory. In that case, the workaround is to increase the memory or to reduce the concurrency level. To make the latter option possible, this PR adds a `--concurrency` param to the compile task.