### PR TITLE
Temporary fix to #2380

### DIFF
--- a/.changeset/sour-phones-develop.md
+++ b/.changeset/sour-phones-develop.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix a bug that made Hardhat Network hang when connecting MetaMask (#2380)

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -411,7 +411,8 @@ module.exports.communityPlugins = [
     name: "hardhat-network-metadata",
     author: "Focal Labs Inc.",
     authorUrl: "https://github.com/krruzic/hardhat-network-metadata",
-    description: "Hardhat plugin to allow adding any extra data to your network configuration",
+    description:
+      "Hardhat plugin to allow adding any extra data to your network configuration",
     tags: ["Metadata", "Testing", "Tasks", "Config"],
   },
 ];

--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
@@ -244,7 +244,7 @@ export class JsonRpcClient {
         gasUsedRatio: t.array(t.number),
         reward: optional(t.array(t.array(rpcQuantity))),
       }),
-      (res) => res.oldestBlock.add(blockCount)
+      (res) => res.oldestBlock.addn(res.baseFeePerGas.length)
     );
   }
 

--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
@@ -20,7 +20,8 @@ import { rpcTransactionReceipt } from "../../core/jsonrpc/types/output/receipt";
 import { rpcTransaction } from "../../core/jsonrpc/types/output/transaction";
 import { HttpProvider } from "../../core/providers/http";
 import { createNonCryptographicHashBasedIdentifier } from "../../util/hash";
-import { nullable } from "../../util/io-ts";
+import { nullable, optional } from "../../util/io-ts";
+import { FeeHistory } from "../provider/node-types";
 
 export class JsonRpcClient {
   private _cache: Map<string, any> = new Map();
@@ -219,6 +220,32 @@ export class JsonRpcClient {
       transactionCount: results[1],
       balance: results[2],
     };
+  }
+
+  // This is part of a temporary fix to https://github.com/NomicFoundation/hardhat/issues/2380
+  // This method caches each request instead of caching each block's fee info individually, which is not ideal
+  public async getFeeHistory(
+    blockCount: BN,
+    newestBlock: BN | "pending",
+    rewardPercentiles: number[]
+  ): Promise<FeeHistory> {
+    return this._perform(
+      "eth_feeHistory",
+      [
+        numberToRpcQuantity(blockCount),
+        newestBlock === "pending"
+          ? "pending"
+          : numberToRpcQuantity(newestBlock),
+        rewardPercentiles,
+      ],
+      t.type({
+        oldestBlock: rpcQuantity,
+        baseFeePerGas: t.array(rpcQuantity),
+        gasUsedRatio: t.array(t.number),
+        reward: optional(t.array(t.array(rpcQuantity))),
+      }),
+      (res) => res.oldestBlock.add(blockCount)
+    );
   }
 
   private async _perform<T>(


### PR DESCRIPTION
This is a quick fix to #2380. This is not the ideal fix because the fee history is cached per-request instead of per-block, which leads to lots of cache misses. Also, if the remote network can't answer an `eth_feeHistory` we fail, but we could do something better in that case.