### PR TITLE
Update deployment guide: wait for deployment confirmation

### DIFF
--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -9,10 +9,10 @@ async function main() {
   // We get the contract to deploy
   const Greeter = await ethers.getContractFactory("Greeter");
   const greeter = await Greeter.deploy("Hello, Hardhat!");
-  console.log("Greeter is deploying to:", greeter.address);
-  
+
   await greeter.deployed();
-  console.log("Deployment confirmed");
+
+  console.log("Greeter deployed to:", greeter.address);
 }
 
 main()

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -9,8 +9,10 @@ async function main() {
   // We get the contract to deploy
   const Greeter = await ethers.getContractFactory("Greeter");
   const greeter = await Greeter.deploy("Hello, Hardhat!");
-
-  console.log("Greeter deployed to:", greeter.address);
+  console.log("Greeter is deploying to:", greeter.address);
+  
+  await greeter.deployed();
+  console.log("Deployment confirmed");
 }
 
 main()


### PR DESCRIPTION
Makes use of the `deployed` method in the deployment guide so that users are aware of the method used to wait for contract deployment confirmation.
