### PR TITLE
Keep the baseFeePerGas constant in reserved blocks

### DIFF
--- a/.changeset/popular-parents-nail.md
+++ b/.changeset/popular-parents-nail.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed a problem with `hardhat_mine` when used with `solidity-coverage`.

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/BlockchainBase.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/BlockchainBase.ts
@@ -86,14 +86,16 @@ export abstract class BlockchainBase {
     count: BN,
     interval: BN,
     previousBlockStateRoot: Buffer,
-    previousBlockTotalDifficulty: BN
+    previousBlockTotalDifficulty: BN,
+    previousBlockBaseFeePerGas: BN | undefined
   ) {
     this._data.reserveBlocks(
       this.getLatestBlockNumber().addn(1),
       count,
       interval,
       previousBlockStateRoot,
-      previousBlockTotalDifficulty
+      previousBlockTotalDifficulty,
+      previousBlockBaseFeePerGas
     );
   }
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/BlockchainData.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/BlockchainData.ts
@@ -15,6 +15,7 @@ interface Reservation {
   interval: BN;
   previousBlockStateRoot: Buffer;
   previousBlockTotalDifficulty: BN;
+  previousBlockBaseFeePerGas: BN | undefined;
 }
 
 export class BlockchainData {
@@ -33,7 +34,8 @@ export class BlockchainData {
     count: BN,
     interval: BN,
     previousBlockStateRoot: Buffer,
-    previousBlockTotalDifficulty: BN
+    previousBlockTotalDifficulty: BN,
+    previousBlockBaseFeePerGas: BN | undefined
   ) {
     const reservation: Reservation = {
       first,
@@ -41,6 +43,7 @@ export class BlockchainData {
       interval,
       previousBlockStateRoot,
       previousBlockTotalDifficulty,
+      previousBlockBaseFeePerGas,
     };
     this._blockReservations.push(reservation);
   }
@@ -217,6 +220,7 @@ export class BlockchainData {
           header: {
             number: blockNumber,
             stateRoot: oldReservation.previousBlockStateRoot,
+            baseFeePerGas: oldReservation.previousBlockBaseFeePerGas,
             timestamp,
           },
         },

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/HardhatBlockchain.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/HardhatBlockchain.ts
@@ -36,13 +36,15 @@ export class HardhatBlockchain
     count: BN,
     interval: BN,
     previousBlockStateRoot: Buffer,
-    previousBlockTotalDifficulty: BN
+    previousBlockTotalDifficulty: BN,
+    previousBlockBaseFeePerGas: BN | undefined
   ) {
     super.reserveBlocks(
       count,
       interval,
       previousBlockStateRoot,
-      previousBlockTotalDifficulty
+      previousBlockTotalDifficulty,
+      previousBlockBaseFeePerGas
     );
     this._length = this._length + count.toNumber();
   }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/fork/ForkBlockchain.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/fork/ForkBlockchain.ts
@@ -97,13 +97,15 @@ export class ForkBlockchain
     count: BN,
     interval: BN,
     previousBlockStateRoot: Buffer,
-    previousBlockTotalDifficulty: BN
+    previousBlockTotalDifficulty: BN,
+    previousBlockBaseFeePerGas: BN | undefined
   ) {
     super.reserveBlocks(
       count,
       interval,
       previousBlockStateRoot,
-      previousBlockTotalDifficulty
+      previousBlockTotalDifficulty,
+      previousBlockBaseFeePerGas
     );
     this._latestBlockNumber = this._latestBlockNumber.add(count);
   }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -563,7 +563,8 @@ Hardhat Network's forking functionality only works with blocks from at least spu
       remainingBlockCount.subn(1),
       interval,
       await this._stateManager.getStateRoot(),
-      await this.getBlockTotalDifficulty(latestBlock)
+      await this.getBlockTotalDifficulty(latestBlock),
+      (await this.getLatestBlock()).header.baseFeePerGas
     );
 
     await mineBlock();

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/types/HardhatBlockchainInterface.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/types/HardhatBlockchainInterface.ts
@@ -11,7 +11,8 @@ export interface HardhatBlockchainInterface extends BlockchainInterface {
     count: BN,
     interval: BN,
     previousBlockStateRoot: Buffer,
-    previousBlockTotalDifficulty: BN
+    previousBlockTotalDifficulty: BN,
+    previousBlockBaseFeePerGas: BN | undefined
   ): void;
   deleteLaterBlocks(block: Block): void;
   getBlockByTransactionHash(transactionHash: Buffer): Promise<Block | null>;


### PR DESCRIPTION
Closes #2467

`solidity-coverage` sets the initial base fee per gas to 1. This value is kept at that level as long as no block uses more than 50% of the available gas.

Since `hardhat_mine` mines empty blocks, it should never increase the base fee per gas, but reserved blocks were defaulting to a base fee of 7. This PR fixes that by using the base fee per gas of the latest block in the reserved blocks.

Of course, this is not correct, but neither was the previous behavior.