### PR TITLE
fix: don't override grep options in test task

### DIFF
--- a/.changeset/quick-moons-report.md
+++ b/.changeset/quick-moons-report.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+- Fix a bug that would override mocha grep options within the test task

--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -72,11 +72,11 @@ subtask(TASK_TEST_RUN_MOCHA_TESTS)
     ) => {
       const { default: Mocha } = await import("mocha");
 
-      const mochaConfig: MochaOptions = {
-        ...config.mocha,
-        grep: taskArgs.grep,
-      };
+      const mochaConfig: MochaOptions = { ...config.mocha };
 
+      if (taskArgs.grep) {
+        mochaConfig.grep = taskArgs.grep;
+      }
       if (taskArgs.bail) {
         mochaConfig.bail = true;
       }

--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -74,7 +74,7 @@ subtask(TASK_TEST_RUN_MOCHA_TESTS)
 
       const mochaConfig: MochaOptions = { ...config.mocha };
 
-      if (taskArgs.grep) {
+      if (taskArgs.grep !== undefined) {
         mochaConfig.grep = taskArgs.grep;
       }
       if (taskArgs.bail) {


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
Fixes a bug in the `test` task that would override the `grep` options in the config file. 

Fixes #2459