### PR TITLE
Fix problem with CI not running all core tests

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -32,8 +32,8 @@
     "prettier": "prettier \"**/*.{js,md,json}\"",
     "test": "mocha --recursive \"test/**/*.ts\"",
     "test:except-tracing": "mocha --recursive \"test/**/*.ts\" --invert --grep \"Stack traces\"",
-    "test:tracing": "mocha --recursive \"test/internal/hardhat-network/{helpers,stack-traces}/*.ts\"",
-    "test:forking": "mocha --recursive \"test/internal/hardhat-network/{helpers,jsonrpc,provider}/*.ts\"",
+    "test:tracing": "mocha --recursive \"test/internal/hardhat-network/{helpers,stack-traces}/**/*.ts\"",
+    "test:forking": "mocha --recursive \"test/internal/hardhat-network/{helpers,jsonrpc,provider}/**/*.ts\"",
     "build": "tsc --build .",
     "clean": "rimraf builtin-tasks internal types utils *.d.ts *.map *.js build-test tsconfig.tsbuildinfo test/internal/hardhat-network/provider/.hardhat_node_test_cache"
   },

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
@@ -128,6 +128,12 @@ describe("Evm module", function () {
         });
 
         it("should accept a hex string param", async function () {
+          const originalOffset = parseInt(
+            await this.provider.send("evm_increaseTime", [
+              numberToRpcQuantity(0),
+            ]),
+            10
+          );
           const offset1 = 123;
           const offset2 = 1000;
           const totalOffset1 = parseInt(
@@ -142,8 +148,8 @@ describe("Evm module", function () {
             ]),
             10
           );
-          assert.strictEqual(totalOffset1, offset1);
-          assert.strictEqual(totalOffset2, offset1 + offset2);
+          assert.strictEqual(totalOffset1, originalOffset + offset1);
+          assert.strictEqual(totalOffset2, originalOffset + offset1 + offset2);
         });
       });
 


### PR DESCRIPTION
Note that CI runs for this PR show that, for the forking test Action, 1856+35+1 (passing+pending+failing) tests were run, whereas, for [a recent run without this change](https://github.com/NomicFoundation/hardhat/runs/5517403119?check_suite_focus=true), only 404+2 tests were run.

The problem seems to be that our usage of `mocha --recursive "test/internal/hardhat-network/{helpers,jsonrpc,provider}/*.ts"` was not picking up the tests in the subdirectories of `provider` because the glob pattern was only resolving to `.ts` files and not to any folder names, so there was nothing for `--recursive` to act upon. (Thinking further, I suspect that using `--recursive` has no effect when used alongside `.../*.ts`, since no folders will be targeted.)