### PR TITLE
Update Pinned Block Number in Mainnet Forking guide

### DIFF
--- a/docs/hardhat-network/guides/mainnet-forking.md
+++ b/docs/hardhat-network/guides/mainnet-forking.md
@@ -46,7 +46,7 @@ networks: {
   hardhat: {
     forking: {
       url: "https://eth-mainnet.alchemyapi.io/v2/<key>",
-      blockNumber: 14393928
+      blockNumber: 14390000
     }
   }
 }
@@ -55,7 +55,7 @@ networks: {
 If you are using the `node` task, you can also specify a block number with the `--fork-block-number` flag:
 
 ```
-npx hardhat node --fork https://eth-mainnet.alchemyapi.io/v2/<key> --fork-block-number 14393928
+npx hardhat node --fork https://eth-mainnet.alchemyapi.io/v2/<key> --fork-block-number 14390000
 ```
 
 ## Customizing Hardhat Network's behavior
@@ -80,7 +80,7 @@ await network.provider.request({
     {
       forking: {
         jsonRpcUrl: "https://eth-mainnet.alchemyapi.io/v2/<key>",
-        blockNumber: 14393928,
+        blockNumber: 14390000,
       },
     },
   ],

--- a/docs/hardhat-network/guides/mainnet-forking.md
+++ b/docs/hardhat-network/guides/mainnet-forking.md
@@ -46,7 +46,7 @@ networks: {
   hardhat: {
     forking: {
       url: "https://eth-mainnet.alchemyapi.io/v2/<key>",
-      blockNumber: 11095000
+      blockNumber: 14393928
     }
   }
 }
@@ -55,7 +55,7 @@ networks: {
 If you are using the `node` task, you can also specify a block number with the `--fork-block-number` flag:
 
 ```
-npx hardhat node --fork https://eth-mainnet.alchemyapi.io/v2/<key> --fork-block-number 11095000
+npx hardhat node --fork https://eth-mainnet.alchemyapi.io/v2/<key> --fork-block-number 14393928
 ```
 
 ## Customizing Hardhat Network's behavior
@@ -80,7 +80,7 @@ await network.provider.request({
     {
       forking: {
         jsonRpcUrl: "https://eth-mainnet.alchemyapi.io/v2/<key>",
-        blockNumber: 11095000,
+        blockNumber: 14393928,
       },
     },
   ],


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This PR changes the value of the pinned block in the mainnet forking guide from 11095000 to 14393928. I chose 14393928 because it was the block when I made the change.

closes #2330 
