### PR TITLE
hardhat/etherscan: support Metis network

### DIFF
--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -175,6 +175,9 @@ module.exports = {
         sokol: "api-key",
         aurora: "api-key",
         auroraTestnet: "api-key",
+        // metis
+        metisStardust: "api-key",
+        metisAndromeda: "api-key",
     }
   }
 };

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -198,4 +198,18 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://testnet.aurorascan.dev",
     },
   },
+  metisStardust: {
+    chainId: 588,
+    urls: {
+      apiURL: "https://stardust-explorer.metis.io/api",
+      browserURL: "https://stardust-explorer.metis.io",
+    },
+  },
+  metisAndromeda: {
+    chainId: 1088,
+    urls: {
+      apiURL: "https://andromeda-explorer.metis.io/api",
+      browserURL: "https://andromeda-explorer.metis.io",
+    },
+  },
 };

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -36,7 +36,9 @@ type Chain =
   | "sokol"
   // aurora
   | "aurora"
-  | "auroraTestnet";
+  | "auroraTestnet"
+  | "metisAndromeda"
+  | "metisStardust";
 
 export type ChainConfig = {
   [Network in Chain]: EtherscanChainConfig;


### PR DESCRIPTION
Reference: https://docs.metis.io/building-on-metis/connection-details