### PR TITLE
dotenv 10.0.0 doesn't load my .env file properly

### DIFF
--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -47,7 +47,7 @@ const BASIC_SAMPLE_PROJECT_DEPENDENCIES: Dependencies = {
 const ADVANCED_SAMPLE_PROJECT_DEPENDENCIES: Dependencies = {
   ...BASIC_SAMPLE_PROJECT_DEPENDENCIES,
   "@nomiclabs/hardhat-etherscan": "^3.0.0",
-  dotenv: "^10.0.0",
+  dotenv: "^16.0.0",
   eslint: "^7.29.0",
   "eslint-config-prettier": "^8.3.0",
   "eslint-config-standard": "^16.0.3",


### PR DESCRIPTION
dotenv was not loading my `.env` file properly, and only updating it to the latest version fixed it.

I haven't figured out the root cause of the problem though.
This stackoverflow answer (https://stackoverflow.com/a/70037859/4971151) suggests using
```
require('dotenv').config({path:__dirname+'/.env'})
```
instead of the `require('dotenv').config()` that hardhat is using, but I haven't gotten any problems with dotenv 16 so far, so seems like a cleaner approach.

my `tsconfig.json` file is
```
{
  "compilerOptions": {
    "declaration": true,
    "esModuleInterop": true,
    "forceConsistentCasingInFileNames": true,
    "module": "commonjs",
    "outDir": "dist",
    "resolveJsonModule": true,
    "strict": true,
    "target": "es2019"
  },
  "include": ["./scripts", "./test", "./typechain", "./deploy", "./lib"],
  "files": ["./hardhat.config.ts"]
}
```

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
