### PR TITLE
removed recompilation from verify task

### DIFF
--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -230,9 +230,6 @@ Possible causes are:
     throw new NomicLabsHardhatPluginError(pluginName, message);
   }
 
-  // Make sure that contract artifacts are up-to-date.
-  await run(TASK_COMPILE);
-
   const contractInformation: ExtendedContractInformation = await run(
     TASK_VERIFY_GET_CONTRACT_INFORMATION,
     {


### PR DESCRIPTION
This PR is in reference to issue #1117 

I don't believe we should be recompiling just for contract verification, and should instead be using the existing artifacts, however I'm a bit worried changing this now would be a breaking change.

Regardless, I'm opening the PR with this change, and so we have a good place to discuss alternative solutions.

-----

The core problem being fixed (refer to linked issue for reproduction steps from @fvictorio) is that when we change the contract name (or presumably make any change to the contract), the verification pipeline recompiles **only that contract** and not `console.sol`.
This results in the existing artifact debug file for `console.sol` pointing to the old hash of the `contracts/Greeter.sol:Greeter` build-info and not the newly recompiled `contracts/Greeter.sol:Foo` hash and causing the error from the original issue.