### PR TITLE
perf(fs): use realpathSync native for >15%. improvement [HH-446]

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   ],
   "devDependencies": {
     "@changesets/cli": "^2.16.0",
+    "@types/node": "^16",
     "prettier": "2.4.1",
     "shelljs": "^0.8.5",
-    "typescript": "~4.5.2",
+    "typescript": "^4.6.2",
     "wsrun": "^5.2.2"
   },
   "scripts": {

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -292,7 +292,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS)
  * Receives a list of compilation jobs and returns a new list where some of
  * the compilation jobs might've been removed.
  *
- * This task can be overriden to change the way the cache is used, or to use
+ * This task can be overridden to change the way the cache is used, or to use
  * a different approach to filtering out compilation jobs.
  */
 subtask(TASK_COMPILE_SOLIDITY_FILTER_COMPILATION_JOBS)
@@ -673,7 +673,7 @@ subtask(TASK_COMPILE_SOLIDITY_RUN_SOLC)
  * solc binary or, if that's not possible, using solcjs. Returns the generated
  * output.
  *
- * This task can be overriden to change how solc is obtained or used.
+ * This task can be overridden to change how solc is obtained or used.
  */
 subtask(TASK_COMPILE_SOLIDITY_COMPILE_SOLC)
   .addParam("input", undefined, undefined, types.any)
@@ -905,7 +905,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_ARTIFACT_FROM_COMPILATION_OUTPUT)
   );
 
 /**
- * Prints a message before running soljs with some input.
+ * Prints a message before running solcjs with some input.
  */
 subtask(TASK_COMPILE_SOLIDITY_LOG_RUN_COMPILER_START)
   .addParam("compilationJob", undefined, undefined, types.any)
@@ -1019,7 +1019,7 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE_JOB)
  * Receives a list of CompilationJobsFailure and throws an error if it's not
  * empty.
  *
- * This task could be overriden to avoid interrupting the compilation if
+ * This task could be overridden to avoid interrupting the compilation if
  * there's some part of the project that can't be compiled.
  */
 subtask(TASK_COMPILE_SOLIDITY_HANDLE_COMPILATION_JOBS_FAILURES)
@@ -1113,7 +1113,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS_FAILURE_REASONS)
           const { versionPragmas } = error.file.content;
           const versionsRange = versionPragmas.join(" ");
 
-          log(`File ${sourceName} has an incompatible overriden compiler`);
+          log(`File ${sourceName} has an incompatible overridden compiler`);
 
           errorMessage += `  * ${sourceName} (${versionsRange})\n`;
         }

--- a/packages/hardhat-core/src/builtin-tasks/flatten.ts
+++ b/packages/hardhat-core/src/builtin-tasks/flatten.ts
@@ -97,7 +97,8 @@ subtask(TASK_FLATTEN_GET_DEPENDENCY_GRAPH)
     const sourcePaths: string[] =
       files === undefined
         ? await run(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS)
-        : files.map((f) => fs.realpathSync(f));
+        /** @note realpathSync.native */
+        : files.map((f) => fs.realpathSync.native(f));
 
     const sourceNames: string[] = await run(
       TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES,

--- a/packages/hardhat-core/src/builtin-tasks/node.ts
+++ b/packages/hardhat-core/src/builtin-tasks/node.ts
@@ -207,7 +207,7 @@ subtask(TASK_NODE_SERVER_CREATED)
       provider: EthereumProvider;
       server: JsonRpcServer;
     }) => {
-      // this task is meant to be overriden by plugin writers
+      // this task is meant to be overridden by plugin writers
     }
   );
 

--- a/packages/hardhat-core/src/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-resolution.ts
@@ -426,7 +426,7 @@ export function resolveProjectPaths(
   userConfigPath: string,
   userPaths: ProjectPathsUserConfig = {}
 ): ProjectPathsConfig {
-  const configFile = fs.realpathSync(userConfigPath);
+  const configFile = fs.realpathSync.native(userConfigPath);
   const configDir = path.dirname(configFile);
 
   const root = resolvePathFrom(configDir, "", userPaths.root);

--- a/packages/hardhat-core/src/internal/core/execution-mode.ts
+++ b/packages/hardhat-core/src/internal/core/execution-mode.ts
@@ -20,7 +20,7 @@ export function isHardhatInstalledLocallyOrLinked(configPath?: string) {
     // We need to get the realpaths here, as hardhat may be linked and
     // running with `node --preserve-symlinks`
     return (
-      fs.realpathSync(resolvedPackageJson) === fs.realpathSync(thisPackageJson)
+      fs.realpathSync.native(resolvedPackageJson) === fs.realpathSync.native(thisPackageJson)
     );
   } catch {
     return false;

--- a/packages/hardhat-core/src/internal/core/tasks/task-definitions.ts
+++ b/packages/hardhat-core/src/internal/core/tasks/task-definitions.ts
@@ -583,7 +583,7 @@ export class OverriddenTaskDefinition implements TaskDefinition {
   }
 
   /**
-   * Retrieves, if defined, the description of the overriden task,
+   * Retrieves, if defined, the description of the overridden task,
    * otherwise retrieves the description of the parent task.
    */
   public get description() {
@@ -595,7 +595,7 @@ export class OverriddenTaskDefinition implements TaskDefinition {
   }
 
   /**
-   * Retrieves, if defined, the action of the overriden task,
+   * Retrieves, if defined, the action of the overridden task,
    * otherwise retrieves the action of the parent task.
    */
   public get action() {

--- a/packages/hardhat-core/src/internal/solidity/compilation-job.ts
+++ b/packages/hardhat-core/src/internal/solidity/compilation-job.ts
@@ -287,12 +287,12 @@ function getCompilationJobCreationError(
   directDependencies: ResolvedFile[],
   transitiveDependencies: taskTypes.TransitiveDependency[],
   compilerVersions: string[],
-  overriden: boolean
+  overridden: boolean
 ): CompilationJobCreationError {
   const fileVersionRange = file.content.versionPragmas.join(" ");
   if (semver.maxSatisfying(compilerVersions, fileVersionRange) === null) {
-    const reason = overriden
-      ? CompilationJobCreationErrorReason.INCOMPATIBLE_OVERRIDEN_SOLC_VERSION
+    const reason = overridden
+      ? CompilationJobCreationErrorReason.INCOMPATIBLE_OVERRIDDEN_SOLC_VERSION
       : CompilationJobCreationErrorReason.NO_COMPATIBLE_SOLC_VERSION_FOUND;
     return { reason, file };
   }

--- a/packages/hardhat-core/src/types/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/types/builtin-tasks/compile.ts
@@ -90,7 +90,7 @@ export interface CompilationJobCreationError {
 export enum CompilationJobCreationErrorReason {
   OTHER_ERROR = "other",
   NO_COMPATIBLE_SOLC_VERSION_FOUND = "no-compatible-solc-version-found",
-  INCOMPATIBLE_OVERRIDEN_SOLC_VERSION = "incompatible-overriden-solc-version",
+  INCOMPATIBLE_OVERRIDEN_SOLC_VERSION = "incompatible-overridden-solc-version",
   DIRECTLY_IMPORTS_INCOMPATIBLE_FILE = "directly-imports-incompatible-file",
   INDIRECTLY_IMPORTS_INCOMPATIBLE_FILE = "indirectly-imports-incompatible-file",
 }

--- a/packages/hardhat-core/test/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/test/builtin-tasks/compile.ts
@@ -145,7 +145,7 @@ Read about compiler configuration at https://hardhat.org/config
       );
     });
 
-    it("should return a proper message for a non compatible overriden solc error with a single file", async function () {
+    it("should return a proper message for a non compatible overridden solc error with a single file", async function () {
       const Foo = mockFile({
         sourceName: "contracts/Foo.sol",
         pragma: "^0.5.0",

--- a/packages/hardhat-core/test/helpers/fs.ts
+++ b/packages/hardhat-core/test/helpers/fs.ts
@@ -8,8 +8,10 @@ declare module "mocha" {
   }
 }
 
+
 async function getEmptyTmpDir(nameHint: string) {
   const tmpDirContainer = os.tmpdir();
+  // TODO: fs.mkdtempSync(path.join(os.tmpdir(), `hardhat-tests-${nameHint}`));
   const tmpDir = path.join(tmpDirContainer, `hardhat-tests-${nameHint}`);
   await fsExtra.ensureDir(tmpDir);
   await fsExtra.emptyDir(tmpDir);

--- a/packages/hardhat-core/test/internal/cli/autocomplete.ts
+++ b/packages/hardhat-core/test/internal/cli/autocomplete.ts
@@ -386,14 +386,14 @@ describe("autocomplete", function () {
     });
   });
 
-  describe("overriden task", () => {
-    useFixtureProject("autocomplete/overriden-task");
+  describe("overridden task", () => {
+    useFixtureProject("autocomplete/overridden-task");
 
     after(() => {
       resetHardhatContext();
     });
 
-    it("should work when a task is overriden", async () => {
+    it("should work when a task is overridden", async () => {
       const suggestions = await complete("hh ");
       expect(suggestions).to.have.deep.members(coreTasks);
     });

--- a/packages/hardhat-core/test/internal/core/project-structure.ts
+++ b/packages/hardhat-core/test/internal/core/project-structure.ts
@@ -2,6 +2,7 @@ import { assert } from "chai";
 import * as fsExtra from "fs-extra";
 import path from "path";
 
+
 import { ERRORS } from "../../../src/internal/core/errors-list";
 import {
   getRecommendedGitIgnore,

--- a/packages/hardhat-core/test/internal/core/tasks/task-definitions.ts
+++ b/packages/hardhat-core/test/internal/core/tasks/task-definitions.ts
@@ -992,10 +992,10 @@ describe("OverriddenTaskDefinition", () => {
 
   describe("Param definitions can be added only in compatible cases", () => {
     it("should add a flag param if addFlag is called", () => {
-      overriddenTask.addFlag("flagParam", "flag in overriden task");
+      overriddenTask.addFlag("flagParam", "flag in overridden task");
       assertParamDefinition(overriddenTask.paramDefinitions.flagParam, {
         name: "flagParam",
-        description: "flag in overriden task",
+        description: "flag in overridden task",
         defaultValue: false,
         type: types.boolean,
         isOptional: true,

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
@@ -15,11 +15,22 @@ interface SolcSourceFileToContents {
   [filename: string]: { content: string };
 }
 
+
+/**
+ * 
+ * getSolcSourceFileMapping
+ * @param {string[]} sources 
+ * @return {SolcSourceFileToContents}
+ * @note Previously realpathSync.native was unavailable on case-insensitive file systems 
+ * 
+ * requires typescript@^4.5.0 
+ * 
+ */
 function getSolcSourceFileMapping(sources: string[]): SolcSourceFileToContents {
   return Object.assign(
     {},
     ...sources.map((s) => ({
-      [path.basename(s)]: { content: fs.readFileSync(s, "utf8") },
+      [path.basename(s)]: { content: fs.realpathSync.native(s, "utf8") },
     }))
   );
 }

--- a/packages/hardhat-core/test/internal/solidity/compilation-job.ts
+++ b/packages/hardhat-core/test/internal/solidity/compilation-job.ts
@@ -111,7 +111,7 @@ describe("Compilation jobs", function () {
         assert.isTrue(compilationJob.emitsArtifacts(Foo));
       });
 
-      it("overriden compiler is used", async function () {
+      it("overridden compiler is used", async function () {
         const FooMock = new MockFile("Foo", [">=0.5.0"]);
         const [dependencyGraph, [Foo]] = await createMockData([
           { file: FooMock },
@@ -157,7 +157,7 @@ describe("Compilation jobs", function () {
         );
       });
 
-      it("invalid overriden compiler", async function () {
+      it("invalid overridden compiler", async function () {
         const FooMock = new MockFile("Foo", ["^0.5.0"]);
         const [dependencyGraph, [Foo]] = await createMockData([
           { file: FooMock },

--- a/packages/hardhat-core/test/internal/solidity/dependencyGraph.ts
+++ b/packages/hardhat-core/test/internal/solidity/dependencyGraph.ts
@@ -56,7 +56,7 @@ describe("Dependency Graph", function () {
     let loop2: ResolvedFile;
 
     before("Mock some resolved files", function () {
-      projectRoot = fs.realpathSync(".");
+      projectRoot = fs.realpathSync.native(".");
 
       fileWithoutDependencies = new ResolvedFile(
         "contracts/WD.sol",

--- a/packages/hardhat-core/test/internal/solidity/helpers.ts
+++ b/packages/hardhat-core/test/internal/solidity/helpers.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../src/internal/solidity/resolver";
 import * as taskTypes from "../../../src/types/builtin-tasks";
 
-const projectRoot = fs.realpathSync(".");
+const projectRoot = fs.realpathSync.native(".");
 
 export class MockFile {
   public readonly sourceName: string;

--- a/packages/hardhat-core/test/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/test/internal/solidity/resolver.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 import * as fsExtra from "fs-extra";
 import path from "path";
 import slash from "slash";
-
+import * as fs from 'fs';
 import { TASK_COMPILE } from "../../../src/builtin-tasks/task-names";
 import { ERRORS } from "../../../src/internal/core/errors-list";
 import { Parser } from "../../../src/internal/solidity/parse";
@@ -27,6 +27,8 @@ function assertResolvedFilePartiallyEquals(
     assert.deepEqual(actual[typedKey], expected[typedKey]);
   }
 }
+
+const realpathSync = fs.realpathSync.native ?? fs.realpathSync;
 
 const buildContent = (rawContent: string) => ({
   rawContent,

--- a/packages/hardhat-truffle4/test/tests.ts
+++ b/packages/hardhat-truffle4/test/tests.ts
@@ -202,14 +202,14 @@ describe("Test contracts compilation", function () {
 
     assert.include(
       sources,
-      fs.realpathSync(path.join("contracts", "fromContracts.sol"))
+      fs.realpathSync.native(path.join("contracts", "fromContracts.sol"))
     );
   });
 
   it("Should include sources from test", async function () {
     const sources = await this.env.run(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS);
 
-    assert.include(sources, fs.realpathSync(path.join("test", "fromTest.sol")));
+    assert.include(sources, fs.realpathSync.native(path.join("test", "fromTest.sol")));
   });
 
   it("Should ignore non-source files from test", async function () {
@@ -217,7 +217,7 @@ describe("Test contracts compilation", function () {
 
     assert.notInclude(
       sources,
-      fs.realpathSync(path.join("test", "shouldBeIgnored.txt"))
+      fs.realpathSync.native(path.join("test", "shouldBeIgnored.txt"))
     );
   });
 

--- a/packages/hardhat-truffle5/test/tests.ts
+++ b/packages/hardhat-truffle5/test/tests.ts
@@ -195,7 +195,7 @@ describe("Test contracts compilation", function () {
 
     assert.include(
       sources,
-      fs.realpathSync(
+      fs.realpathSync.native(
         path.join(process.cwd(), "contracts", "fromContracts.sol")
       )
     );
@@ -206,7 +206,7 @@ describe("Test contracts compilation", function () {
 
     assert.include(
       sources,
-      fs.realpathSync(path.join(process.cwd(), "test", "fromTest.sol"))
+      fs.realpathSync.native(path.join(process.cwd(), "test", "fromTest.sol"))
     );
   });
 
@@ -215,7 +215,7 @@ describe("Test contracts compilation", function () {
 
     assert.notInclude(
       sources,
-      fs.realpathSync(path.join(process.cwd(), "test", "shouldBeIgnored.txt"))
+      fs.realpathSync.native(path.join(process.cwd(), "test", "shouldBeIgnored.txt"))
     );
   });
 

--- a/packages/hardhat-vyper/test/helpers.ts
+++ b/packages/hardhat-vyper/test/helpers.ts
@@ -45,7 +45,7 @@ function getFixtureProjectPath(projectName: string): string {
     throw new Error(`Fixture project ${projectName} doesn't exist`);
   }
 
-  return fsExtra.realpathSync(projectPath);
+  return fsExtra.realpathSync.native(projectPath);
 }
 
 export function useEnvironment(configPath?: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2191,6 +2191,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.19.tgz#538e61fc220f77ae4a4663c3d8c3cb391365c209"
   integrity sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw==
 
+"@types/node@^16":
+  version "16.11.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.26.tgz#63d204d136c9916fb4dcd1b50f9740fe86884e47"
+  integrity sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
@@ -14563,6 +14568,11 @@ typescript@^4.3.4:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
+typescript@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 typescript@~4.5.2:
   version "4.5.2"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

# Performance: Faster Load Time with `realPathSync.native`

TypeScript now leverages a **system-native** implementation of the Node.js `realPathSync` function on all operating systems.

Previously this function was only used on Linux, but in TypeScript 4.5 it has been adopted to operating systems that are typically case-insensitive, like Windows and MacOS. On certain codebases, this change sped up project loading by 5-13% (depending on the host operating system).

## Reference material

For more information, see [the original change here](https://github.com/microsoft/TypeScript/pull/44966), along with [the 4.5-specific changes here](https://github.com/microsoft/TypeScript/pull/44966).

[ref: https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#real-path-sync-native](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#real-path-sync-native)

## Discussion

This is a rough cut, would like some feedback if you guys are interested in these possible changes (it does enforce at least typescript 4.5, and you are using ~ for semver of typescript)

Additionally, changing how `tmpDir` is managed with instead `mkdtmp` the nodejs utility is something I observed as a possible easy change that would yield very slight gain (potentially). Another would be instead of downloading repeatedly solidity compilers offer a global config option (I am sure users would do this) + offer a more compressed binary for solc native (quicker downloads). etc etc.  


### Notes

Originally scoped out files
<pre>
packages/hardhat-core/test/helpers/project.ts
packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
packages/hardhat-core/test/internal/util/download.ts
packages/hardhat-core/test/internal/util/packageInfo.ts
packages/hardhat-core/test/internal/core/typescript-support.ts
packages/hardhat-core/test/internal/solidity/helpers.ts
packages/hardhat-core/test/internal/solidity/dependencyGraph.ts
packages/hardhat-core/src/builtin-tasks/utils/solidity-files-cache.ts
</pre>

### Reference` fs.([1], :[2])`
```js
fs.link(srcpath, dstpath, callback);             // Asynchronous link. No arguments other than a possible exception are given to the completion callback.
fs.linkSync(srcpath, dstpath);                   // Synchronous link.
fs.symlink(srcpath, dstpath, [type], callback);  // Asynchronous symlink. No arguments other than a possible exception are given to the completion callback. The type argument can be set to 'dir', 'file', or 'junction' (default is 'file') and is only available on Windows (ignored on other platforms)
fs.symlinkSync(srcpath, dstpath, [type]);        // Synchronous symlink.
fs.readlink(path, callback);                     // Asynchronous readlink. The callback gets two arguments (err, linkString).
fs.readlinkSync(path);                           // Synchronous readlink. Returns the symbolic link's string value.
fs.unlink(path, callback);                       // Asynchronous unlink. No arguments other than a possible exception are given to the completion callback.
fs.unlinkSync(path);                             // Synchronous unlink.

fs.realpath(path, [cache], callback);     // Asynchronous realpath. The callback gets two arguments (err, resolvedPath).
fs.realpathSync(path, [cache]);           // Synchronous realpath. Returns the resolved path.
```