### PR TITLE
Add hardhat-hethers to community plugins

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -422,6 +422,13 @@ module.exports.communityPlugins = [
     description: "Automatically expose internal Solidity functions for testing",
     tags: ["Solidity", "Testing"],
   },
+  {
+    name: "hardhat-hethers",
+    author: "LimeChain",
+    authorUrl: "https://github.com/LimeChain/hardhat-hethers",
+    description: "Injects hethers into the Hardhat Runtime Environment",
+    tags: ["Hedera", "hethers"],
+  },
 ];
 
 module.exports.officialPlugins = [


### PR DESCRIPTION
Add [hardhat-hethers](https://github.com/LimeChain/hardhat-hethers) to the list of community plugins. It injects [hethers](https://github.com/hashgraph/hethers.js) into the `hre` object and enables testing of Hedera smart contracts.