### PR TITLE
Improve debug_traceTransaction and add opcodes filter

### DIFF
--- a/.changeset/smooth-dryers-clean.md
+++ b/.changeset/smooth-dryers-clean.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Improve debug_traceTransaction memory usage and add opcodes filter to reduce rpc response size for debugging complex transactions.

--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/input/debugTraceTransaction.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/input/debugTraceTransaction.ts
@@ -8,6 +8,7 @@ export const rpcDebugTracingConfig = optionalOrNullable(
       disableStorage: optionalOrNullable(t.boolean),
       disableMemory: optionalOrNullable(t.boolean),
       disableStack: optionalOrNullable(t.boolean),
+      opcodes: optionalOrNullable(t.array(t.string)),
     },
     "RpcDebugTracingConfig"
   )

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-debug-tracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-debug-tracer.ts
@@ -163,9 +163,12 @@ export class VMDebugTracer {
       topLevelMessage.to
     );
 
-    const rpcStructLogs = flattenDeep(nestedStructLogs).map((v) =>
-      this._structLogToRpcStructLog(v)
-    );
+    const rpcStructLogs = flattenDeep(nestedStructLogs)
+      .filter(
+        (structLog) =>
+          !this._config?.opcodes || this._config.opcodes.includes(structLog.op)
+      )
+      .map((v) => this._structLogToRpcStructLog(v));
 
     // geth does this for some reason
     if (result.execResult.exceptionError?.error === "out of gas") {


### PR DESCRIPTION
When it comes to memory consumption, the debug_traceTransaction goes brrrrr. For complex enough DeFi transactions, the RPC response is huge as well. This is particularly a show stopper for [hardhat-tracer](https://github.com/zemse/hardhat-tracer).

This PR does the following:
- Keeps data in StructLogs in Buffer format while in internal use, and only converts them into hex strings when exporting to RpcStructLog. So if user has disabled any of the memory, stack, or storage, that Buffer data is not exported to hex string. This is just about 50% memory savings, which is not as significant as the opcodes filter in the next point.
- Adds an opcode filter that can be optionally passed by the user, which prevents exporting struct logs that are not needed. This considerably reduces memory consumption, i.e. at first, memory is allocated when hardhat generates rpc response and then again it is allocated at the receiving end in the same machine. As an example use case of this feature, hardhat-tracer plugin only needs certain opcodes (related to calls, storage, and events) in the struct logs in order to function and a related issue (#2510) may also benefit from this feature.

Sorry for not discussing this first, I was just trying to find cause of the problem and did not know what to do, and ended up with almost the changes in this PR, so I finally thought to just proceed and create a PR. Please let me know any changes that are needed. Finally thanks for creating Hardhat, it's an extremely amazing tool! (ik a thanks is not at all enough but still).