### PR TITLE
Fix smart contract compilation when the downloaded solc is for WASM platform.

### DIFF
--- a/.changeset/hungry-yaks-enjoy.md
+++ b/.changeset/hungry-yaks-enjoy.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix a bug preventing to run the solcjs compiler.

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -590,6 +590,8 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD)
             log("Native solc binary doesn't work, using solcjs instead");
             nativeBinaryFailed = true;
           }
+        } else {
+          platform = CompilerPlatform.WASM;
         }
       }
 


### PR DESCRIPTION
When the downloaded solidity compiler is the WASM version (because there is no available native compiler for the selected platform) it is still run as a native compiler, because of the missing else statement that set the correct platform.

Closes #2554 and fixes #2329 and #2004 as well.
