### PR TITLE
Make eth_getStorageAt spec-compliant

### DIFF
--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/base-types.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/base-types.ts
@@ -29,6 +29,41 @@ export const rpcHash = new t.Type<Buffer>(
   t.identity
 );
 
+export const rpcStorageSlot = new t.Type<BN>(
+  "Storage slot",
+  BN.isBN,
+  validateStorageSlot,
+  t.identity
+);
+
+function validateStorageSlot(u: unknown, c: t.Context): t.Validation<BN> {
+  if (typeof u !== "string") {
+    return t.failure(
+      u,
+      c,
+      `Storage slot argument must be a string, got '${u}'`
+    );
+  }
+
+  if (u.match(/^0x(?:[0-9a-fA-F]*)*$/) === null) {
+    return t.failure(
+      u,
+      c,
+      `Storage slot argument must be a valid hexadecimal, got '${u}'`
+    );
+  }
+
+  if (u.length !== 66) {
+    return t.failure(
+      u,
+      c,
+      `Storage slot argument must have a length of 66 (32 bytes), but '${u}' has a length of ${u.length}`
+    );
+  }
+
+  return t.success(new BN(toBuffer(u)));
+}
+
 export const rpcAddress = new t.Type<Buffer>(
   "ADDRESS",
   (v): v is Buffer => Buffer.isBuffer(v) && v.length === ADDRESS_LENGTH_BYTES,
@@ -86,6 +121,15 @@ export function numberToRpcQuantity(n: number | BN): string {
   );
 
   return `0x${n.toString(16)}`;
+}
+
+export function numberToRpcStorageSlot(n: number | BN): string {
+  assertHardhatInvariant(
+    typeof n === "number" || BN.isBN(n),
+    "Expected number"
+  );
+
+  return `0x${n.toString(16).padStart(64, "0")}`;
 }
 
 /**

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts
@@ -26,6 +26,7 @@ import {
   rpcFloat,
   rpcHash,
   rpcQuantity,
+  rpcStorageSlot,
 } from "../../../core/jsonrpc/types/base-types";
 import {
   optionalRpcNewBlockTag,
@@ -688,7 +689,7 @@ export class EthModule {
     return validateParams(
       params,
       rpcAddress,
-      rpcQuantity,
+      rpcStorageSlot,
       optionalRpcNewBlockTag
     );
   }

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getStorageAt.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getStorageAt.ts
@@ -1,7 +1,11 @@
 import { assert } from "chai";
 
-import { numberToRpcQuantity } from "../../../../../../../src/internal/core/jsonrpc/types/base-types";
+import {
+  numberToRpcQuantity,
+  numberToRpcStorageSlot,
+} from "../../../../../../../src/internal/core/jsonrpc/types/base-types";
 import { workaroundWindowsCiFailures } from "../../../../../../utils/workaround-windows-ci-failures";
+import { assertInvalidArgumentsError } from "../../../../helpers/assertions";
 import { EXAMPLE_CONTRACT } from "../../../../helpers/contracts";
 import { setCWD } from "../../../../helpers/cwd";
 import {
@@ -39,7 +43,7 @@ describe("Eth module", function () {
               assert.strictEqual(
                 await this.provider.send("eth_getStorageAt", [
                   exampleContract,
-                  numberToRpcQuantity(3),
+                  numberToRpcStorageSlot(3),
                 ]),
                 "0x0000000000000000000000000000000000000000000000000000000000000000"
               );
@@ -47,7 +51,7 @@ describe("Eth module", function () {
               assert.strictEqual(
                 await this.provider.send("eth_getStorageAt", [
                   exampleContract,
-                  numberToRpcQuantity(4),
+                  numberToRpcStorageSlot(4),
                 ]),
                 "0x0000000000000000000000000000000000000000000000000000000000000000"
               );
@@ -55,7 +59,7 @@ describe("Eth module", function () {
               assert.strictEqual(
                 await this.provider.send("eth_getStorageAt", [
                   DEFAULT_ACCOUNTS_ADDRESSES[0],
-                  numberToRpcQuantity(0),
+                  numberToRpcStorageSlot(0),
                 ]),
                 "0x0000000000000000000000000000000000000000000000000000000000000000"
               );
@@ -74,7 +78,7 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     exampleContract,
-                    numberToRpcQuantity(2),
+                    numberToRpcStorageSlot(2),
                     numberToRpcQuantity(firstBlock),
                   ]),
                   "0x0000000000000000000000000000000000000000000000000000000000000000"
@@ -83,7 +87,7 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     exampleContract,
-                    numberToRpcQuantity(2),
+                    numberToRpcStorageSlot(2),
                   ]),
                   "0x1234567890123456789012345678901234567890123456789012345678901234"
                 );
@@ -91,7 +95,7 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     exampleContract,
-                    numberToRpcQuantity(2),
+                    numberToRpcStorageSlot(2),
                     "latest",
                   ]),
                   "0x1234567890123456789012345678901234567890123456789012345678901234"
@@ -126,7 +130,7 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     contractAddress,
-                    numberToRpcQuantity(2),
+                    numberToRpcStorageSlot(2),
                   ]),
                   "0x0000000000000000000000000000000000000000000000000000000000000000"
                 );
@@ -134,7 +138,7 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     contractAddress,
-                    numberToRpcQuantity(2),
+                    numberToRpcStorageSlot(2),
                     "pending",
                   ]),
                   "0x1234567890123456789012345678901234567890123456789012345678901234"
@@ -150,7 +154,7 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     exampleContract,
-                    numberToRpcQuantity(2),
+                    numberToRpcStorageSlot(2),
                     "latest",
                   ]),
                   "0x1234567890123456789012345678901234567890123456789012345678901234"
@@ -159,7 +163,7 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     exampleContract,
-                    numberToRpcQuantity(2),
+                    numberToRpcStorageSlot(2),
                     "earliest",
                   ]),
                   "0x0000000000000000000000000000000000000000000000000000000000000000"
@@ -192,7 +196,7 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     exampleContract,
-                    numberToRpcQuantity(0),
+                    numberToRpcStorageSlot(0),
                     numberToRpcQuantity(firstBlock + 1),
                   ]),
                   "0x0000000000000000000000000000000000000000000000000000000000000000"
@@ -201,7 +205,7 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     exampleContract,
-                    numberToRpcQuantity(0),
+                    numberToRpcStorageSlot(0),
                   ]),
                   "0x000000000000000000000000000000000000000000000000000000000000007b"
                 );
@@ -220,7 +224,7 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     exampleContract,
-                    numberToRpcQuantity(0),
+                    numberToRpcStorageSlot(0),
                     numberToRpcQuantity(firstBlock + 2),
                   ]),
                   "0x000000000000000000000000000000000000000000000000000000000000007b"
@@ -229,12 +233,71 @@ describe("Eth module", function () {
                 assert.strictEqual(
                   await this.provider.send("eth_getStorageAt", [
                     exampleContract,
-                    numberToRpcQuantity(0),
+                    numberToRpcStorageSlot(0),
                   ]),
                   "0x000000000000000000000000000000000000000000000000000000000000007c"
                 );
               });
             });
+          });
+        });
+
+        describe("validation", function () {
+          it("should accept valid storage slot arguments", async function () {
+            assert.strictEqual(
+              await this.provider.send("eth_getStorageAt", [
+                "0x0101010101010101010101010101010101010101",
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+              ]),
+              "0x0000000000000000000000000000000000000000000000000000000000000000"
+            );
+
+            assert.strictEqual(
+              await this.provider.send("eth_getStorageAt", [
+                "0x0101010101010101010101010101010101010101",
+                "0xcd39aa866fd639607c7241f617cf83f33c646551f3d205f2905c5abacca2db85",
+              ]),
+              "0x0000000000000000000000000000000000000000000000000000000000000000"
+            );
+          });
+
+          it("should not accept plain numbers", async function () {
+            await assertInvalidArgumentsError(
+              this.provider,
+              "eth_getStorageAt",
+              ["0x0101010101010101010101010101010101010101", 0],
+              "Storage slot argument must be a string, got '0'"
+            );
+          });
+
+          it("should not accept invalid hex strings", async function () {
+            await assertInvalidArgumentsError(
+              this.provider,
+              "eth_getStorageAt",
+              ["0x0101010101010101010101010101010101010101", "0xABCDEFG"],
+              "Storage slot argument must be a valid hexadecimal, got '0xABCDEFG'"
+            );
+          });
+
+          it("should not accept hex strings that are too short", async function () {
+            await assertInvalidArgumentsError(
+              this.provider,
+              "eth_getStorageAt",
+              ["0x0101010101010101010101010101010101010101", "0x0"],
+              "Storage slot argument must have a length of 66 (32 bytes), but '0x0' has a length of 3"
+            );
+          });
+
+          it("should not accept hex strings that are too long", async function () {
+            await assertInvalidArgumentsError(
+              this.provider,
+              "eth_getStorageAt",
+              [
+                "0x0101010101010101010101010101010101010101",
+                "0x00000000000000000000000000000000000000000000000000000000000000000",
+              ],
+              "Storage slot argument must have a length of 66 (32 bytes), but '0x00000000000000000000000000000000000000000000000000000000000000000' has a length of 67"
+            );
           });
         });
       });


### PR DESCRIPTION
According to [the spec](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/execution-apis/assembled-spec/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false), the storage slot in `eth_getStorageAt` **should** have a length of 66 (0x + 32 bytes).

While this is technically a bug fix, it will probably break things for many people. There are two solutions:

- To use `helpers.getStorageAt`, since the network helpers will be released along with this change (or soon enough).
- To use `ethers.utils.hexZeroPad(storageSlot, 32)` around the value to make it valid