### PR TITLE
Add LUKSO L14 in networks available to verify contracts via `hardhat verify`

### DIFF
--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -198,4 +198,11 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://testnet.aurorascan.dev",
     },
   },
+  luksoL14: {
+    chainId: 22,
+    urls: {
+      apiURL: "https://blockscout.com/lukso/l14/api",
+      browserURL: "https://blockscout.com/lukso/l14",
+    },
+  },
 };

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -36,7 +36,9 @@ type Chain =
   | "sokol"
   // aurora
   | "aurora"
-  | "auroraTestnet";
+  | "auroraTestnet"
+  // LUKSO L14
+  | "luksoL14";
 
 export type ChainConfig = {
   [Network in Chain]: EtherscanChainConfig;


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team. 
|-> **I have created issue #2598**
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

# What does this PR introduce?

Add support for LUKSO L14 test network, by adding the L14 chain specifications under`ChainConfig.ts.

This is to enable to verify contracts deployed on L14 via the command:

```
npx hardhat verify --network luksoL14 DEPLOYED_CONTRACT_ADDRESS_ON_L14
```

## Issue reference

#2598 
