### PR TITLE
Moved the signer assignment to the before function

### DIFF
--- a/docs/tutorial/testing-contracts.md
+++ b/docs/tutorial/testing-contracts.md
@@ -143,12 +143,18 @@ describe("Token contract", function () {
   let addr2;
   let addrs;
 
-  // `beforeEach` will run before each test, re-deploying the contract every
-  // time. It receives a callback, which can be async.
-  beforeEach(async function () {
-    // Get the ContractFactory and Signers here.
-    Token = await ethers.getContractFactory("Token");
+  // `before` will run once before all tests in the suite. It receives a
+  // callback, which can be async.
+  before(async () => {
+    // Get the signers here.
     [owner, addr1, addr2, ...addrs] = await ethers.getSigners();
+  });
+
+  // `beforeEach` will run before each test, re-deploying the contract every
+  // time.
+  beforeEach(async function () {
+    // Get the ContractFactory here.
+    Token = await ethers.getContractFactory("Token");
 
     // To deploy our contract, we just have to call Token.deploy() and await
     // for it to be deployed(), which happens once its transaction has been


### PR DESCRIPTION
It seems more logical to assign the signer once with the before() function instead of reassigning over and over before every test case.

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
