### PR TITLE
Add OneLedger mainnet and testnet for smart contract verification

### DIFF
--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -175,6 +175,8 @@ module.exports = {
         sokol: "api-key",
         aurora: "api-key",
         auroraTestnet: "api-key",
+        oneledger: "api-key",
+        frankenstein: "api-key",
     }
   }
 };

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -198,4 +198,18 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://testnet.aurorascan.dev",
     },
   },
+  oneledger: {
+    chainId: 311752642,
+    urls: {
+      apiURL: "https://mainnet-explorer.oneledger.network/api",
+      browserURL: "https://mainnet-explorer.oneledger.network",
+    },
+  },
+  frankenstein: {
+    chainId: 4216137055,
+    urls: {
+      apiURL: "https://frankenstein-explorer.oneledger.network/api",
+      browserURL: "https://frankenstein-explorer.oneledger.network",
+    },
+  },
 };

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -36,7 +36,10 @@ type Chain =
   | "sokol"
   // aurora
   | "aurora"
-  | "auroraTestnet";
+  | "auroraTestnet"
+  // oneledger
+  | "oneledger"
+  | "frankenstein";
 
 export type ChainConfig = {
   [Network in Chain]: EtherscanChainConfig;


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## What does this PR introduce?

Add support for OneLedger mainnet and test network, by adding the OneLedger chain specifications under`ChainConfig.ts.

This is to enable to verify contracts deployed on OneLedger via the command:
`npx hardhat verify --network oneledger DEPLOYED_CONTRACT_ADDRESS`
