### PR TITLE
Fix passing options and depth when inspecting a lazyObject

### DIFF
--- a/.changeset/chilled-cycles-smile.md
+++ b/.changeset/chilled-cycles-smile.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix passing options and depth when inspecting a lazyObject or lazyFunction

--- a/packages/hardhat-core/src/internal/util/lazy.ts
+++ b/packages/hardhat-core/src/internal/util/lazy.ts
@@ -1,4 +1,4 @@
-import { InspectOptions } from "util";
+import util, { InspectOptions } from "util";
 
 import { HardhatError } from "../core/errors";
 import { ERRORS } from "../core/errors-list";
@@ -39,7 +39,10 @@ export function lazyObject<T extends object>(objectCreator: () => T): T {
       [inspect](
         depth: number,
         options: InspectOptions,
-        inspectFn: (object: any, options: InspectOptions) => string
+        inspectFn: (
+          object: any,
+          options: InspectOptions
+        ) => string = util.inspect
       ) {
         const realTarget = getRealTarget();
         const newOptions = { ...options, depth };
@@ -72,7 +75,10 @@ export function lazyFunction<T extends Function>(functionCreator: () => T): T {
       (dummyTarget as any)[inspect] = function (
         depth: number,
         options: InspectOptions,
-        inspectFn: (object: any, options: InspectOptions) => string
+        inspectFn: (
+          object: any,
+          options: InspectOptions
+        ) => string = util.inspect
       ) {
         const realTarget = getRealTarget();
         const newOptions = { ...options, depth };

--- a/packages/hardhat-core/src/internal/util/lazy.ts
+++ b/packages/hardhat-core/src/internal/util/lazy.ts
@@ -1,4 +1,4 @@
-import util from "util";
+import { InspectOptions } from "util";
 
 import { HardhatError } from "../core/errors";
 import { ERRORS } from "../core/errors-list";
@@ -36,9 +36,14 @@ export function lazyObject<T extends object>(objectCreator: () => T): T {
   return createLazyProxy(
     objectCreator,
     (getRealTarget) => ({
-      [inspect]() {
+      [inspect](
+        depth: number,
+        options: InspectOptions,
+        inspectFn: (object: any, options: InspectOptions) => string
+      ) {
         const realTarget = getRealTarget();
-        return util.inspect(realTarget);
+        const newOptions = { ...options, depth };
+        return inspectFn(realTarget, newOptions);
       },
     }),
     (object) => {
@@ -64,9 +69,14 @@ export function lazyFunction<T extends Function>(functionCreator: () => T): T {
     (getRealTarget) => {
       function dummyTarget() {}
 
-      (dummyTarget as any)[inspect] = function () {
+      (dummyTarget as any)[inspect] = function (
+        depth: number,
+        options: InspectOptions,
+        inspectFn: (object: any, options: InspectOptions) => string
+      ) {
         const realTarget = getRealTarget();
-        return util.inspect(realTarget);
+        const newOptions = { ...options, depth };
+        return inspectFn(realTarget, newOptions);
       };
 
       return dummyTarget;


### PR DESCRIPTION
...or lazyFunction

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

<!-- Add a description of your PR here -->

Hi! This PR changes the way we call `util.inspect` in lazy objects and functions:
- The current state is that `util.inspect` is called without any additional arguments.
- From [node docs](https://nodejs.org/api/util.html#custom-inspection-functions-on-objects), the custom inspect function is called with three arguments `(depth, options, inspect)` so we can use these when calling inspect on the real object/function.
- In this PR we pass those options, including the depth, to the inspect call. This avoids losing any options but most importantly avoids losing the depth, which would otherwise make us recurse infinitely if we had a lazyObject within a circular object.
- Because of this, I believe this fixes #1473.