### PR TITLE
properPrivateKey, properAddress, and hexEquals chai matchers

### DIFF
--- a/packages/hardhat-chai-matchers/src/hardhatChaiMatchers.ts
+++ b/packages/hardhat-chai-matchers/src/hardhatChaiMatchers.ts
@@ -2,6 +2,9 @@ import "./types";
 import { supportBigNumber } from "./bigNumber";
 import { supportEmit } from "./emit";
 import { supportReverted } from "./reverted";
+import { supportHexEqual } from "./hexEqual";
+import { supportProperAddress } from "./properAddress";
+import { supportProperPrivateKey } from "./properPrivateKey";
 
 export function hardhatChaiMatchers(
   chai: Chai.ChaiStatic,
@@ -10,4 +13,7 @@ export function hardhatChaiMatchers(
   supportBigNumber(chai.Assertion, utils);
   supportEmit(chai.Assertion);
   supportReverted(chai.Assertion);
+  supportHexEqual(chai.Assertion);
+  supportProperAddress(chai.Assertion);
+  supportProperPrivateKey(chai.Assertion);
 }

--- a/packages/hardhat-chai-matchers/src/hexEqual.ts
+++ b/packages/hardhat-chai-matchers/src/hexEqual.ts
@@ -1,0 +1,25 @@
+export function supportHexEqual(Assertion: Chai.AssertionStatic) {
+  Assertion.addMethod("hexEqual", function (this: any, other: string) {
+    const subject = this._obj;
+    const isNegated = this.__flags.negate === true;
+    const isHex = (a: string) => /^0x[0-9a-fA-F]*$/.test(a);
+    for (const element of [subject, other]) {
+      if (!isHex(element)) {
+        this.assert(
+          isNegated,
+          `Expected "${subject}" to be a hex string equal to "${other}", but "${element}" is not a valid hex string`,
+          `Expected "${subject}" not to be a hex string equal to "${other}", but "${element}" is not a valid hex string`
+        );
+      }
+    }
+    const extractNumeric = (hex: string) => hex.replace(/^0x0*/, "");
+    this.assert(
+      extractNumeric(subject.toLowerCase()) ===
+        extractNumeric(other.toLowerCase()),
+      `Expected "${subject}" to be a hex string equal equal to "${other}"`,
+      `Expected "${subject}" not to a hex string equal be equal to "${other}", but it was`,
+      `Hex string representing the same number as ${other}`,
+      subject
+    );
+  });
+}

--- a/packages/hardhat-chai-matchers/src/hexEqual.ts
+++ b/packages/hardhat-chai-matchers/src/hexEqual.ts
@@ -2,16 +2,20 @@ export function supportHexEqual(Assertion: Chai.AssertionStatic) {
   Assertion.addMethod("hexEqual", function (this: any, other: string) {
     const subject = this._obj;
     const isNegated = this.__flags.negate === true;
+
+    // check that both values are proper hex strings
     const isHex = (a: string) => /^0x[0-9a-fA-F]*$/.test(a);
     for (const element of [subject, other]) {
       if (!isHex(element)) {
         this.assert(
-          isNegated,
+          isNegated, // trick to make this assertion always fail
           `Expected "${subject}" to be a hex string equal to "${other}", but "${element}" is not a valid hex string`,
           `Expected "${subject}" not to be a hex string equal to "${other}", but "${element}" is not a valid hex string`
         );
       }
     }
+
+    // compare values
     const extractNumeric = (hex: string) => hex.replace(/^0x0*/, "");
     this.assert(
       extractNumeric(subject.toLowerCase()) ===

--- a/packages/hardhat-chai-matchers/src/hexEqual.ts
+++ b/packages/hardhat-chai-matchers/src/hexEqual.ts
@@ -16,8 +16,8 @@ export function supportHexEqual(Assertion: Chai.AssertionStatic) {
     this.assert(
       extractNumeric(subject.toLowerCase()) ===
         extractNumeric(other.toLowerCase()),
-      `Expected "${subject}" to be a hex string equal equal to "${other}"`,
-      `Expected "${subject}" not to a hex string equal be equal to "${other}", but it was`,
+      `Expected "${subject}" to be a hex string equal to "${other}"`,
+      `Expected "${subject}" not to be a hex string equal to "${other}", but it was`,
       `Hex string representing the same number as ${other}`,
       subject
     );

--- a/packages/hardhat-chai-matchers/src/properAddress.ts
+++ b/packages/hardhat-chai-matchers/src/properAddress.ts
@@ -1,0 +1,12 @@
+export function supportProperAddress(Assertion: Chai.AssertionStatic) {
+  Assertion.addProperty("properAddress", function (this: any) {
+    const subject = this._obj;
+    this.assert(
+      /^0x[0-9-a-fA-F]{40}$/.test(subject),
+      `Expected "${subject}" to be a proper address`,
+      `Expected "${subject}" not to be a proper address`,
+      "proper address (eg.: 0x1234567890123456789012345678901234567890)",
+      subject
+    );
+  });
+}

--- a/packages/hardhat-chai-matchers/src/properPrivateKey.ts
+++ b/packages/hardhat-chai-matchers/src/properPrivateKey.ts
@@ -1,0 +1,12 @@
+export function supportProperPrivateKey(Assertion: Chai.AssertionStatic) {
+  Assertion.addProperty("properPrivateKey", function (this: any) {
+    const subject = this._obj;
+    this.assert(
+      /^0x[0-9-a-fA-F]{64}$/.test(subject),
+      `Expected "${subject}" to be a proper private key`,
+      `Expected "${subject}" not to be a proper private key`,
+      "proper address (eg.: 0x1234567890123456789012345678901234567890)",
+      subject
+    );
+  });
+}

--- a/packages/hardhat-chai-matchers/src/properPrivateKey.ts
+++ b/packages/hardhat-chai-matchers/src/properPrivateKey.ts
@@ -5,7 +5,7 @@ export function supportProperPrivateKey(Assertion: Chai.AssertionStatic) {
       /^0x[0-9-a-fA-F]{64}$/.test(subject),
       `Expected "${subject}" to be a proper private key`,
       `Expected "${subject}" not to be a proper private key`,
-      "proper address (eg.: 0x1234567890123456789012345678901234567890)",
+      "proper private key (eg.: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80)",
       subject
     );
   });

--- a/packages/hardhat-chai-matchers/src/types.ts
+++ b/packages/hardhat-chai-matchers/src/types.ts
@@ -6,6 +6,9 @@ declare namespace Chai {
       TypeComparison {
     emit(contract: any, eventName: string): EmitAssertion;
     reverted: AsyncAssertion;
+    hexEqual(other: string): void;
+    properPrivateKey: void;
+    properAddress: void;
   }
 
   interface NumericComparison {

--- a/packages/hardhat-chai-matchers/test/hexEqual.ts
+++ b/packages/hardhat-chai-matchers/test/hexEqual.ts
@@ -1,0 +1,63 @@
+import { AssertionError, expect } from "chai";
+
+describe("UNIT: hexEqual", () => {
+  it("0xAB equals 0xab", () => {
+    expect("0xAB").to.hexEqual("0xab");
+  });
+
+  it("0xAB does not equal 0xabc", () => {
+    expect("0xAB").to.not.hexEqual("0xabc");
+  });
+
+  it("0x0010ab equals 0x000010ab", () => {
+    expect("0x0010ab").to.hexEqual("0x000010ab");
+  });
+
+  it("0x0000010AB does not equal 0x0010abc", () => {
+    expect("0x0000010AB").to.not.hexEqual("0x0010abc");
+  });
+
+  it("0x edge case", () => {
+    expect("0x").to.hexEqual("0x000000");
+  });
+
+  it("abc is not a hex string", () => {
+    expect(() => expect("abc").to.hexEqual("0xabc")).to.throw(
+      AssertionError,
+      'Expected "abc" to be a hex string equal to "0xabc", but "abc" is not a valid hex string'
+    );
+    expect(() => expect("0xabc").to.hexEqual("abc")).to.throw(
+      AssertionError,
+      'Expected "0xabc" to be a hex string equal to "abc", but "abc" is not a valid hex string'
+    );
+    expect(() => expect("abc").to.not.hexEqual("0xabc")).to.throw(
+      AssertionError,
+      'Expected "abc" not to be a hex string equal to "0xabc", but "abc" is not a valid hex string'
+    );
+    expect(() => expect("0xabc").to.not.hexEqual("abc")).to.throw(
+      AssertionError,
+      'Expected "0xabc" not to be a hex string equal to "abc", but "abc" is not a valid hex string'
+    );
+  });
+
+  it("xyz is not a hex string", () => {
+    expect(() => expect("xyz").to.hexEqual("0x1A4")).to.throw(
+      AssertionError,
+      'Expected "xyz" to be a hex string equal to "0x1A4", but "xyz" is not a valid hex string'
+    );
+  });
+
+  it("0xyz is not a hex string", () => {
+    expect(() => expect("0xyz").to.hexEqual("0x1A4")).to.throw(
+      AssertionError,
+      'Expected "0xyz" to be a hex string equal to "0x1A4", but "0xyz" is not a valid hex string'
+    );
+  });
+
+  it("empty string is not a hex string", () => {
+    expect(() => expect("").to.hexEqual("0x0")).to.throw(
+      AssertionError,
+      'Expected "" to be a hex string equal to "0x0", but "" is not a valid hex string'
+    );
+  });
+});

--- a/packages/hardhat-chai-matchers/test/hexEqual.ts
+++ b/packages/hardhat-chai-matchers/test/hexEqual.ts
@@ -1,5 +1,7 @@
 import { AssertionError, expect } from "chai";
 
+import "../src";
+
 describe("UNIT: hexEqual", () => {
   it("0xAB equals 0xab", () => {
     expect("0xAB").to.hexEqual("0xab");
@@ -58,6 +60,20 @@ describe("UNIT: hexEqual", () => {
     expect(() => expect("").to.hexEqual("0x0")).to.throw(
       AssertionError,
       'Expected "" to be a hex string equal to "0x0", but "" is not a valid hex string'
+    );
+  });
+
+  it("correct error when strings are not equal", async function () {
+    expect(() => expect("0xa").to.hexEqual("0xb")).to.throw(
+      AssertionError,
+      'Expected "0xa" to be a hex string equal to "0xb"'
+    );
+  });
+
+  it("correct error when strings are equal but expected not to", async function () {
+    expect(() => expect("0xa").not.to.hexEqual("0xa")).to.throw(
+      AssertionError,
+      'Expected "0xa" not to be a hex string equal to "0xa", but it was'
     );
   });
 });

--- a/packages/hardhat-chai-matchers/test/properAddress.ts
+++ b/packages/hardhat-chai-matchers/test/properAddress.ts
@@ -2,29 +2,19 @@ import { expect, AssertionError } from "chai";
 
 import "../src";
 
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
 describe("Proper address", () => {
   it("Expect to be proper address", async () => {
-    expect(
-      () =>
-        expect("0x28FAA621c3348823D6c6548981a19716bcDc740e").to.be.properAddress
-    ).to.not.throw();
-    expect(
-      () =>
-        expect("0x846C66cf71C43f80403B51fE3906B3599D63336f").to.be.properAddress
-    ).to.not.throw();
+    expect("0x28FAA621c3348823D6c6548981a19716bcDc740e").to.be.properAddress;
+    expect("0x846C66cf71C43f80403B51fE3906B3599D63336f").to.be.properAddress;
   });
 
   it("Expect not to be proper address", async () => {
-    expect(
-      () =>
-        expect("0x28FAA621c3348823D6c6548981a19716bcDc740").to.not.be
-          .properAddress
-    ).to.not.throw();
-    expect(
-      () =>
-        expect("0x846C66cf71C43f80403B51fE3906B3599D63336g").to.not.be
-          .properAddress
-    ).to.not.throw();
+    expect("28FAA621c3348823D6c6548981a19716bcDc740e").not.to.be.properAddress;
+    expect("0x28FAA621c3348823D6c6548981a19716bcDc740").to.not.be.properAddress;
+    expect("0x846C66cf71C43f80403B51fE3906B3599D63336g").to.not.be
+      .properAddress;
   });
 
   it("Expect to throw if invalid address", async () => {

--- a/packages/hardhat-chai-matchers/test/properAddress.ts
+++ b/packages/hardhat-chai-matchers/test/properAddress.ts
@@ -1,0 +1,50 @@
+import { expect, AssertionError } from "chai";
+
+import "../src";
+
+describe("Proper address", () => {
+  it("Expect to be proper address", async () => {
+    expect(
+      () =>
+        expect("0x28FAA621c3348823D6c6548981a19716bcDc740e").to.be.properAddress
+    ).to.not.throw();
+    expect(
+      () =>
+        expect("0x846C66cf71C43f80403B51fE3906B3599D63336f").to.be.properAddress
+    ).to.not.throw();
+  });
+
+  it("Expect not to be proper address", async () => {
+    expect(
+      () =>
+        expect("0x28FAA621c3348823D6c6548981a19716bcDc740").to.not.be
+          .properAddress
+    ).to.not.throw();
+    expect(
+      () =>
+        expect("0x846C66cf71C43f80403B51fE3906B3599D63336g").to.not.be
+          .properAddress
+    ).to.not.throw();
+  });
+
+  it("Expect to throw if invalid address", async () => {
+    expect(
+      () =>
+        expect("0x28FAA621c3348823D6c6548981a19716bcDc740").to.be.properAddress
+    ).to.throw(
+      AssertionError,
+      'Expected "0x28FAA621c3348823D6c6548981a19716bcDc740" to be a proper address'
+    );
+  });
+
+  it("Expect to throw if negation with proper address)", async () => {
+    expect(
+      () =>
+        expect("0x28FAA621c3348823D6c6548981a19716bcDc740e").not.to.be
+          .properAddress
+    ).to.throw(
+      AssertionError,
+      'Expected "0x28FAA621c3348823D6c6548981a19716bcDc740e" not to be a proper address'
+    );
+  });
+});

--- a/packages/hardhat-chai-matchers/test/properPrivateKey.ts
+++ b/packages/hardhat-chai-matchers/test/properPrivateKey.ts
@@ -2,34 +2,21 @@ import { expect, AssertionError } from "chai";
 
 import "../src";
 
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
 describe("Proper private", () => {
   it("Expect to be proper private", async () => {
-    expect(
-      () =>
-        expect(
-          "0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7c5"
-        ).to.be.properPrivateKey
-    ).to.not.throw();
-    expect(
-      () =>
-        expect(
-          "0x03c909455dcef4e1e981a21ffb14c1c51214906ce19e8e7541921b758221b5ae"
-        ).to.be.properPrivateKey
-    ).to.not.throw();
+    expect("0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7c5")
+      .to.be.properPrivateKey;
+    expect("0x03c909455dcef4e1e981a21ffb14c1c51214906ce19e8e7541921b758221b5ae")
+      .to.be.properPrivateKey;
   });
 
   it("Expect not to be proper private", async () => {
-    expect(
-      () =>
-        expect("0x28FAA621c3348823D6c6548981a19716bcDc740").to.not.be
-          .properPrivateKey
-    ).to.not.throw();
-    expect(
-      () =>
-        expect(
-          "0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7cw"
-        ).to.not.be.properPrivateKey
-    ).to.not.throw();
+    expect("0x28FAA621c3348823D6c6548981a19716bcDc740").to.not.be
+      .properPrivateKey;
+    expect("0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7cw")
+      .to.not.be.properPrivateKey;
   });
 
   it("Expect to throw if invalid private", async () => {

--- a/packages/hardhat-chai-matchers/test/properPrivateKey.ts
+++ b/packages/hardhat-chai-matchers/test/properPrivateKey.ts
@@ -4,22 +4,22 @@ import "../src";
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
-describe("Proper private", () => {
-  it("Expect to be proper private", async () => {
+describe("Proper private key", () => {
+  it("Expect to be proper private key", async () => {
     expect("0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7c5")
       .to.be.properPrivateKey;
     expect("0x03c909455dcef4e1e981a21ffb14c1c51214906ce19e8e7541921b758221b5ae")
       .to.be.properPrivateKey;
   });
 
-  it("Expect not to be proper private", async () => {
+  it("Expect not to be proper private key", async () => {
     expect("0x28FAA621c3348823D6c6548981a19716bcDc740").to.not.be
       .properPrivateKey;
     expect("0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7cw")
       .to.not.be.properPrivateKey;
   });
 
-  it("Expect to throw if invalid private", async () => {
+  it("Expect to throw if invalid private key", async () => {
     expect(
       () =>
         expect(
@@ -31,7 +31,7 @@ describe("Proper private", () => {
     );
   });
 
-  it("Expect to throw if negation with proper private)", async () => {
+  it("Expect to throw if negation with proper private key)", async () => {
     expect(
       () =>
         expect(

--- a/packages/hardhat-chai-matchers/test/properPrivateKey.ts
+++ b/packages/hardhat-chai-matchers/test/properPrivateKey.ts
@@ -1,0 +1,58 @@
+import { expect, AssertionError } from "chai";
+
+import "../src";
+
+describe("Proper private", () => {
+  it("Expect to be proper private", async () => {
+    expect(
+      () =>
+        expect(
+          "0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7c5"
+        ).to.be.properPrivateKey
+    ).to.not.throw();
+    expect(
+      () =>
+        expect(
+          "0x03c909455dcef4e1e981a21ffb14c1c51214906ce19e8e7541921b758221b5ae"
+        ).to.be.properPrivateKey
+    ).to.not.throw();
+  });
+
+  it("Expect not to be proper private", async () => {
+    expect(
+      () =>
+        expect("0x28FAA621c3348823D6c6548981a19716bcDc740").to.not.be
+          .properPrivateKey
+    ).to.not.throw();
+    expect(
+      () =>
+        expect(
+          "0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7cw"
+        ).to.not.be.properPrivateKey
+    ).to.not.throw();
+  });
+
+  it("Expect to throw if invalid private", async () => {
+    expect(
+      () =>
+        expect(
+          "0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7c"
+        ).to.be.properPrivateKey
+    ).to.throw(
+      AssertionError,
+      'Expected "0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7c" to be a proper private key'
+    );
+  });
+
+  it("Expect to throw if negation with proper private)", async () => {
+    expect(
+      () =>
+        expect(
+          "0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7c5"
+        ).not.to.be.properPrivateKey
+    ).to.throw(
+      AssertionError,
+      'Expected "0x706618637b8ca922f6290ce1ecd4c31247e9ab75cf0530a0ac95c0332173d7c5" not to be a proper private key'
+    );
+  });
+});


### PR DESCRIPTION
Fixes HH-499