### PR TITLE
Fixes help printing of optional task parameters

### DIFF
--- a/.changeset/lazy-islands-cheat.md
+++ b/.changeset/lazy-islands-cheat.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix a bug when formatting optional params in the help messages.

--- a/packages/hardhat-core/src/internal/cli/HelpPrinter.ts
+++ b/packages/hardhat-core/src/internal/cli/HelpPrinter.ts
@@ -112,11 +112,11 @@ export class HelpPrinter {
 
     for (const name of Object.keys(paramDefinitions).sort()) {
       const definition = paramDefinitions[name];
-      const { defaultValue, isFlag } = definition;
+      const { isFlag, isOptional } = definition;
 
       paramsList += " ";
 
-      if (defaultValue !== undefined) {
+      if (isOptional) {
         paramsList += "[";
       }
 
@@ -126,7 +126,7 @@ export class HelpPrinter {
         paramsList += ` ${this._getParamValueDescription(definition)}`;
       }
 
-      if (defaultValue !== undefined) {
+      if (isOptional) {
         paramsList += "]";
       }
     }
@@ -140,11 +140,11 @@ export class HelpPrinter {
     let paramsList = "";
 
     for (const definition of positionalParamDefinitions) {
-      const { defaultValue, isVariadic, name } = definition;
+      const { isOptional, isVariadic, name } = definition;
 
       paramsList += " ";
 
-      if (defaultValue !== undefined) {
+      if (isOptional) {
         paramsList += "[";
       }
 
@@ -154,7 +154,7 @@ export class HelpPrinter {
 
       paramsList += name;
 
-      if (defaultValue !== undefined) {
+      if (isOptional) {
         paramsList += "]";
       }
     }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
The task parameters marked as optional are not always rendered as such in the printed help. This is a trifle but irksome nonetheless.

For the following `hardhat.config.js`:

```js
task("accounts", "Prints the list of accounts")
  .addParam("name")
  .addParam("param", undefined, "arg")
  .addOptionalParam("key")
  .addOptionalParam("value", undefined, "0x")
  .addOptionalVariadicPositionalParam("items")
  .setAction(async (taskArgs, hre) => console.log([1, 2, 3, 4, 5]));

/**
 * @type import('hardhat/config').HardhatUserConfig
 */
module.exports = {
  solidity: "0.8.4",
};
```

Running `hh accounts --help` yields:

```sh
$ hh accounts --help
Hardhat version 2.9.3

Usage: hardhat [GLOBAL OPTIONS] accounts --key <STRING> --name <STRING> [--param <STRING>] [--value <STRING>] ...items

OPTIONS:

  --key   
  --name  
  --param (default: "arg")
  --value (default: "0x")

POSITIONAL ARGUMENTS:

  items 

accounts: Prints the list of accounts

For global options help run: hardhat help
```

instead of:

```sh
$ hh accounts --help
Hardhat version 2.9.3

Usage: hardhat [GLOBAL OPTIONS] accounts [--key <STRING>] --name <STRING> [--param <STRING>] [--value <STRING>] [...items]

OPTIONS:

  --key   
  --name  
  --param (default: "arg")
  --value (default: "0x")

POSITIONAL ARGUMENTS:

  items 

accounts: Prints the list of accounts

For global options help run: hardhat help
```

Note that in the first output example, `key` and `items` are not enclosed in brackets even though they are optional.

This pull request fixes the `HelpPrinter` class so they are enclosed as shown in the second output example.