### PR TITLE
advanced-ts: fix eslint plugin breaking ts imports

### DIFF
--- a/packages/hardhat-core/sample-projects/advanced-ts/.eslintrc.js
+++ b/packages/hardhat-core/sample-projects/advanced-ts/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
   extends: [
     "standard",
     "plugin:prettier/recommended",
-    "plugin:node/recommended",
+    "plugin:@typescript-eslint/recommended",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

fixes https://github.com/NomicFoundation/hardhat/issues/2266

in the typescript starter it is using `plugin:node/recommended` for eslint which breaks every import done across files (see linked issue). this is strange considering typescript projects are already installing the ts-eslint rules.

some in the thread suggested removing the rules entirely but i have found that replacing them with the `@typescript-eslint/recommended` is a drop-in replacement. 
