### PR TITLE
Add `.reverted` matcher

### DIFF
--- a/packages/hardhat-chai-matchers/src/reverted.ts
+++ b/packages/hardhat-chai-matchers/src/reverted.ts
@@ -1,31 +1,106 @@
+import { AssertionError } from "chai";
+
 export function supportReverted(Assertion: Chai.AssertionStatic) {
   Assertion.addProperty("reverted", function (this: any) {
-    const promise = this._obj;
+    const subject: unknown = this._obj;
 
-    const onSuccess = (_value: any) => {
-      this.assert(
-        false,
-        `Expected transaction to be reverted`,
-        `Expected transaction NOT to be reverted`,
-        "Transaction reverted.",
-        "Transaction NOT reverted."
-      );
+    // Check if the received value can be linked to a transaction, and then
+    // get the receipt of that transaction and check its status.
+    //
+    // If the value doesn't correspond to a transaction, then the `reverted`
+    // assertions is false.
+    const onSuccess = (value: unknown) => {
+      if (isTransactionResponse(value) || typeof value === "string") {
+        const hash = typeof value === "string" ? value : value.hash;
+
+        if (!isValidTransactionHash(hash)) {
+          return Promise.reject(
+            new AssertionError(
+              `Expected a valid transaction hash, but got '${hash}'`
+            )
+          );
+        }
+
+        return getTransactionReceipt(hash).then((receipt) => {
+          this.assert(
+            receipt.status === 0,
+            "Expected transaction to be reverted",
+            "Expected transaction NOT to be reverted"
+          );
+        });
+      } else if (isTransactionReceipt(value)) {
+        const receipt = value;
+
+        this.assert(
+          receipt.status === 0,
+          "Expected transaction to be reverted",
+          "Expected transaction NOT to be reverted"
+        );
+      } else {
+        // If the subject of the assertion is not connected to a transaction
+        // (hash, receipt, etc.), then the assertion fails.
+        // Since we use `false` here, this means that `.not.to.be.reverted`
+        // assertions will pass instead of always throwing a validation error.
+        // This allows users to do things like:
+        //   `expect(c.callStatic.f()).to.not.be.reverted
+        this.assert(
+          false,
+          "Expected transaction to be reverted",
+          "Expected transaction NOT to be reverted"
+        );
+      }
     };
 
     const onError = (error: any) => {
+      if (!(error instanceof Error)) {
+        throw new AssertionError("Expected an Error object");
+      }
+
       this.assert(
         true,
-        `Expected transaction to be reverted`,
-        `Expected transaction NOT to be reverted`,
-        "Transaction reverted.",
-        error
+        "Expected transaction to be reverted",
+        "Expected transaction NOT to be reverted"
       );
     };
 
-    const derivedPromise = promise.then(onSuccess, onError);
+    // we use `Promise.resolve(subject)` so we can process both values and
+    // promises of values in the same way
+    const derivedPromise = Promise.resolve(subject).then(onSuccess, onError);
 
     this.then = derivedPromise.then.bind(derivedPromise);
     this.catch = derivedPromise.catch.bind(derivedPromise);
+
     return this;
   });
+}
+
+async function getTransactionReceipt(hash: string) {
+  const hre = await import("hardhat");
+
+  return hre.ethers.provider.getTransactionReceipt(hash);
+}
+
+function isTransactionResponse(x: unknown): x is { hash: string } {
+  if (typeof x === "object" && x !== null) {
+    return "hash" in x;
+  }
+
+  return false;
+}
+
+function isTransactionReceipt(x: unknown): x is { status: number } {
+  if (typeof x === "object" && x !== null && "status" in x) {
+    const status = (x as any).status;
+
+    // this means we only support ethers's receipts for now; adding support for
+    // raw receipts, where the status is an hexadecimal string, should be easy
+    // and we can do it if there's demand for that
+    return typeof status === "number";
+  }
+
+  return false;
+}
+
+function isValidTransactionHash(x: string): boolean {
+  return /0x[0-9a-fA-F]{64}/.test(x);
 }

--- a/packages/hardhat-chai-matchers/test/fixture-projects/hardhat-project/contracts/Matchers.sol
+++ b/packages/hardhat-chai-matchers/test/fixture-projects/hardhat-project/contracts/Matchers.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: UNLICENSED
+
 pragma solidity ^0.8.0;
 
 contract Matchers {
@@ -7,7 +9,16 @@ contract Matchers {
     x++;
   }
 
+  function succeedsView() public view returns (uint) {
+    return x;
+  }
+
   function revertsWithoutReasonString() public {
+    x++;
+    require(false);
+  }
+
+  function revertsWithoutReasonStringView() public pure {
     require(false);
   }
 }

--- a/packages/hardhat-chai-matchers/test/reverted.ts
+++ b/packages/hardhat-chai-matchers/test/reverted.ts
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { AssertionError, expect } from "chai";
 import { useEnvironment, useEnvironmentWithNode } from "./helpers";
 
 import "../src";
@@ -17,36 +17,279 @@ describe("INTEGRATION: Reverted", function () {
   });
 
   function runTests() {
-    const deployMatchers = async (hre: any) => {
-      return (await hre.ethers.getContractFactory("Matchers")).deploy();
+    // deploy Matchers contract before each test
+    let matchers: any;
+    beforeEach("deploy matchers contract", async function () {
+      const Matchers = await this.hre.ethers.getContractFactory("Matchers");
+      matchers = await Matchers.deploy();
+    });
+
+    // helpers
+    const expectAssertionError = async (x: Promise<void>, message: string) => {
+      return expect(x).to.be.eventually.rejectedWith(AssertionError, message);
     };
 
-    it("should pass if transaction reverts", async function () {
-      const matchers = await deployMatchers(this.hre);
+    const mineSuccessfulTransaction = async (hre: any) => {
+      await hre.network.provider.send("evm_setAutomine", [false]);
 
-      await expect(matchers.revertsWithoutReasonString()).to.be.reverted;
+      const [signer] = await hre.ethers.getSigners();
+      const tx = await signer.sendTransaction({ to: signer.address });
+
+      await hre.network.provider.send("hardhat_mine", []);
+      await hre.network.provider.send("evm_setAutomine", [true]);
+
+      return tx;
+    };
+
+    const mineRevertedTransaction = async (hre: any) => {
+      await hre.network.provider.send("evm_setAutomine", [false]);
+
+      const tx = await matchers.revertsWithoutReasonString({
+        gasLimit: 1_000_000,
+      });
+
+      await hre.network.provider.send("hardhat_mine", []);
+      await hre.network.provider.send("evm_setAutomine", [true]);
+
+      return tx;
+    };
+
+    describe("with a string as its subject", function () {
+      it("hash of a successful transaction", async function () {
+        const { hash } = await mineSuccessfulTransaction(this.hre);
+
+        await expectAssertionError(
+          expect(hash).to.be.reverted,
+          "Expected transaction to be reverted"
+        );
+        await expect(hash).to.not.be.reverted;
+      });
+
+      it("hash of a reverted transaction", async function () {
+        const { hash } = await mineRevertedTransaction(this.hre);
+
+        await expect(hash).to.be.reverted;
+        await expectAssertionError(
+          expect(hash).to.not.be.reverted,
+          "Expected transaction NOT to be reverted"
+        );
+      });
+
+      it("invalid string", async function () {
+        await expectAssertionError(
+          expect("0x123").to.be.reverted,
+          "Expected a valid transaction hash, but got '0x123'"
+        );
+
+        await expectAssertionError(
+          expect("0x123").to.not.be.reverted,
+          "Expected a valid transaction hash, but got '0x123'"
+        );
+      });
+
+      it("promise of a hash of a successful transaction", async function () {
+        const { hash } = await mineSuccessfulTransaction(this.hre);
+
+        await expectAssertionError(
+          expect(Promise.resolve(hash)).to.be.reverted,
+          "Expected transaction to be reverted"
+        );
+        await expect(Promise.resolve(hash)).to.not.be.reverted;
+      });
+
+      it("promise of a hash of a reverted transaction", async function () {
+        const { hash } = await mineRevertedTransaction(this.hre);
+
+        await expect(Promise.resolve(hash)).to.be.reverted;
+        await expectAssertionError(
+          expect(Promise.resolve(hash)).to.not.be.reverted,
+          "Expected transaction NOT to be reverted"
+        );
+      });
+
+      it("promise of an invalid string", async function () {
+        await expectAssertionError(
+          expect(Promise.resolve("0x123")).to.be.reverted,
+          "Expected a valid transaction hash, but got '0x123'"
+        );
+
+        await expectAssertionError(
+          expect(Promise.resolve("0x123")).to.not.be.reverted,
+          "Expected a valid transaction hash, but got '0x123'"
+        );
+      });
     });
 
-    it("should fail if transaction succeeds", async function () {
-      const matchers = await deployMatchers(this.hre);
+    describe("with a TxResponse as its subject", function () {
+      it("TxResponse of a successful transaction", async function () {
+        const tx = await mineSuccessfulTransaction(this.hre);
 
-      await expect(expect(matchers.succeeds()).to.be.reverted).to.be.eventually
-        .rejected;
+        await expectAssertionError(
+          expect(tx).to.be.reverted,
+          "Expected transaction to be reverted"
+        );
+        await expect(tx).to.not.be.reverted;
+      });
+
+      it("TxResponse of a reverted transaction", async function () {
+        const tx = await mineRevertedTransaction(this.hre);
+
+        await expect(tx).to.be.reverted;
+        await expectAssertionError(
+          expect(tx).to.not.be.reverted,
+          "Expected transaction NOT to be reverted"
+        );
+      });
+
+      it("promise of a TxResponse of a successful transaction", async function () {
+        const tx = await mineSuccessfulTransaction(this.hre);
+
+        await expectAssertionError(
+          expect(Promise.resolve(tx)).to.be.reverted,
+          "Expected transaction to be reverted"
+        );
+        await expect(Promise.resolve(tx)).to.not.be.reverted;
+      });
+
+      it("promise of a TxResponse of a reverted transaction", async function () {
+        const tx = await mineRevertedTransaction(this.hre);
+
+        await expect(Promise.resolve(tx)).to.be.reverted;
+        await expectAssertionError(
+          expect(Promise.resolve(tx)).to.not.be.reverted,
+          "Expected transaction NOT to be reverted"
+        );
+      });
     });
 
-    describe("negated", function () {
-      it("should pass if transaction succeeds", async function () {
-        const matchers = await deployMatchers(this.hre);
+    describe("with a TxReceipt as its subject", function () {
+      it("TxReceipt of a successful transaction", async function () {
+        const tx = await mineSuccessfulTransaction(this.hre);
+        const receipt = await tx.wait();
 
+        await expectAssertionError(
+          expect(receipt).to.be.reverted,
+          "Expected transaction to be reverted"
+        );
+        await expect(receipt).to.not.be.reverted;
+      });
+
+      it("TxReceipt of a reverted transaction", async function () {
+        const tx = await mineRevertedTransaction(this.hre);
+        const receipt = await this.hre.ethers.provider.waitForTransaction(
+          tx.hash
+        ); // tx.wait rejects, so we use provider.waitForTransaction
+
+        await expect(receipt).to.be.reverted;
+        await expectAssertionError(
+          expect(receipt).to.not.be.reverted,
+          "Expected transaction NOT to be reverted"
+        );
+      });
+
+      it("promise of a TxReceipt of a successful transaction", async function () {
+        const tx = await mineSuccessfulTransaction(this.hre);
+        const receipt = await tx.wait();
+
+        await expectAssertionError(
+          expect(Promise.resolve(receipt)).to.be.reverted,
+          "Expected transaction to be reverted"
+        );
+        await expect(Promise.resolve(receipt)).to.not.be.reverted;
+      });
+
+      it("promise of a TxReceipt of a reverted transaction", async function () {
+        const tx = await mineRevertedTransaction(this.hre);
+        const receipt = await this.hre.ethers.provider.waitForTransaction(
+          tx.hash
+        ); // tx.wait rejects, so we use provider.waitForTransaction
+
+        await expect(Promise.resolve(receipt)).to.be.reverted;
+        await expectAssertionError(
+          expect(Promise.resolve(receipt)).to.not.be.reverted,
+          "Expected transaction NOT to be reverted"
+        );
+      });
+    });
+
+    describe("calling a contract method that succeeds", function () {
+      it("a write method that succeeds", async function () {
+        await expectAssertionError(
+          expect(matchers.succeeds()).to.be.reverted,
+          "Expected transaction to be reverted"
+        );
         await expect(matchers.succeeds()).to.not.be.reverted;
       });
 
-      it("should fail if transaction reverts", async function () {
-        const matchers = await deployMatchers(this.hre);
+      it("a view method that succeeds", async function () {
+        await expectAssertionError(
+          expect(matchers.succeedsView()).to.be.reverted,
+          "Expected transaction to be reverted"
+        );
+        await expect(matchers.succeedsView()).to.not.be.reverted;
+      });
 
-        await expect(
-          expect(matchers.revertsWithoutReasonString()).to.not.be.reverted
-        ).to.be.eventually.rejected;
+      it("a gas estimation that succeeds", async function () {
+        await expectAssertionError(
+          expect(matchers.estimateGas.succeeds()).to.be.reverted,
+          "Expected transaction to be reverted"
+        );
+        await expect(matchers.estimateGas.succeeds()).to.not.be.reverted;
+      });
+
+      it("a static call of a write method that succeeds", async function () {
+        await expectAssertionError(
+          expect(matchers.callStatic.succeeds()).to.be.reverted,
+          "Expected transaction to be reverted"
+        );
+        await expect(matchers.callStatic.succeeds()).to.not.be.reverted;
+      });
+    });
+
+    describe("calling a contract method that reverts", function () {
+      it("a write method that reverts", async function () {
+        await expect(matchers.revertsWithoutReasonString()).to.be.reverted;
+        await expectAssertionError(
+          expect(matchers.revertsWithoutReasonString()).to.not.be.reverted,
+          "Expected transaction NOT to be reverted"
+        );
+      });
+
+      it("a view method that reverts", async function () {
+        await expect(matchers.revertsWithoutReasonStringView()).to.be.reverted;
+        await expectAssertionError(
+          expect(matchers.revertsWithoutReasonStringView()).to.not.be.reverted,
+          "Expected transaction NOT to be reverted"
+        );
+      });
+
+      it("a gas estimation that succeeds", async function () {
+        await expect(matchers.estimateGas.revertsWithoutReasonString()).to.be
+          .reverted;
+        await expectAssertionError(
+          expect(matchers.estimateGas.revertsWithoutReasonString()).to.not.be
+            .reverted,
+          "Expected transaction NOT to be reverted"
+        );
+      });
+
+      it("a static call of a write method that succeeds", async function () {
+        await expect(matchers.callStatic.revertsWithoutReasonString()).to.be
+          .reverted;
+        await expectAssertionError(
+          expect(matchers.callStatic.revertsWithoutReasonString()).to.not.be
+            .reverted,
+          "Expected transaction NOT to be reverted"
+        );
+      });
+    });
+
+    describe("invalid rejection values", function () {
+      it("non-errors", async function () {
+        await expectAssertionError(
+          expect(Promise.reject({})).to.be.reverted,
+          "Expected an Error object"
+        );
       });
     });
   }

--- a/packages/hardhat-chai-matchers/tsconfig.json
+++ b/packages/hardhat-chai-matchers/tsconfig.json
@@ -7,6 +7,9 @@
   "references": [
     {
       "path": "../hardhat-core/src"
+    },
+    {
+      "path": "../hardhat-ethers"
     }
   ]
 }


### PR DESCRIPTION
I tested this with Uniswap V3's repo (after commenting out the `.to.emit` and `.revertedWith` assertions) and it worked fine. Coverage of the `src/matchers.ts` file is 100%. I also did some "manual mutation testing" to be sure that the tests are correct.

Reviewing the diff probably doesn't make sense. I suggest just reading the `src/reverted.ts` and `test/reverted.ts` files from scratch.