### PR TITLE
Improve GitHub actions

### DIFF
--- a/.github/workflows/comment-on-linter-error.yml
+++ b/.github/workflows/comment-on-linter-error.yml
@@ -1,0 +1,43 @@
+name: Comment on lint failure
+
+on:
+  pull_request_target:
+    branches:
+      - $default-branch
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  comment_on_lint_failure:
+    name: Comment on lint failure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: yarn
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Build
+        run: yarn build
+      - name: lint
+        run: yarn lint
+      - name: Check dependency versions
+        run: node scripts/check-dependencies.js
+      - uses: actions/github-script@v6
+        name: Comment on failure
+        if: ${{ failure() }}
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Thanks for submitting this PR!\n\nUnfortunately, it has some linter errors. We'd really appreciate if you fix them.\n\nYou can try running `yarn lint:fix` in the root of the repository."
+            })

--- a/.github/workflows/comment-on-linter-error.yml
+++ b/.github/workflows/comment-on-linter-error.yml
@@ -39,5 +39,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "Thanks for submitting this PR!\n\nUnfortunately, it has some linter errors. We'd really appreciate if you fix them.\n\nYou can try running `yarn lint:fix` in the root of the repository."
+              body: "Thanks for submitting this PR!\nUnfortunately, it has some linter errors, so we can't merge it yet. Can you please fix them?\nRunning yarn `lint:fix` in the root of the repository may fix them automatically."
             })

--- a/.github/workflows/stale-issues-and-prs.yml
+++ b/.github/workflows/stale-issues-and-prs.yml
@@ -19,3 +19,5 @@ jobs:
           close-pr-message: "This PR was closed because it has been stalled for 7 days with no activity."
           days-before-stale: 30
           days-before-close: 7
+          exempt-issue-labels: not-stale
+          exempt-pr-labels: not-stale


### PR DESCRIPTION
This PR adds two small improvements to our Github actions setup:

1. If you label something as `not-stale`, it won't be autoclosed.
2. It creates a new workflow that comments when the linter fails, including when the PR was submitted by external contributors.