### PR TITLE
Allow --version flag to be used when not in a Hardhat project directory

### DIFF
--- a/.changeset/sixty-trainers-help.md
+++ b/.changeset/sixty-trainers-help.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Allow --version flag to be used when not in a Hardhat project directory

--- a/packages/e2e/test/index.ts
+++ b/packages/e2e/test/index.ts
@@ -9,6 +9,8 @@ import { useFixture } from "./helpers";
 
 const hardhatBinary = path.join("node_modules", ".bin", "hardhat");
 
+const versionRegExp = /^\d+\.\d+\.\d+\n$/;
+
 describe("e2e tests", function () {
   before(function () {
     shell.set("-e"); // Ensure that shell failures will induce test failures
@@ -16,6 +18,12 @@ describe("e2e tests", function () {
 
   describe("basic-project", function () {
     useFixture("basic-project");
+
+    it("should print the hardhat version", function () {
+      const { code, stdout } = shell.exec(`${hardhatBinary} --version`);
+      assert.equal(code, 0);
+      assert.match(stdout, versionRegExp);
+    });
 
     it("should compile", function () {
       // hh clean
@@ -211,6 +219,27 @@ describe("e2e tests", function () {
           shell.exec(suggestedCommand);
         });
       }
+    });
+  });
+
+  describe("no project", function () {
+    useFixture("empty");
+
+    it("should print the hardhat version", function () {
+      const { code, stdout } = shell.exec(`${hardhatBinary} --version`);
+      assert.equal(code, 0);
+      assert.match(stdout, versionRegExp);
+    });
+
+    it(`should print an error message if you try to compile`, function () {
+      shell.set("+e");
+      const { code, stderr } = shell.exec(`${hardhatBinary} compile`);
+      shell.set("-e");
+      assert.equal(code, 1);
+      assert.match(
+        stderr,
+        /^Error HH1: You are not inside a Hardhat project\.\n/
+      );
     });
   });
 });

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -94,6 +94,12 @@ async function main() {
 
     showStackTraces = hardhatArguments.showStackTraces;
 
+    // --version is a special case
+    if (hardhatArguments.version) {
+      await printVersionMessage(packageJson);
+      return;
+    }
+
     if (hardhatArguments.config === undefined && !isCwdInsideProject()) {
       if (
         process.stdout.isTTY === true ||
@@ -116,12 +122,6 @@ async function main() {
       if (process.platform === "win32") {
         throw new HardhatError(ERRORS.GENERAL.NOT_INSIDE_PROJECT_ON_WINDOWS);
       }
-    }
-
-    // --version is a special case
-    if (hardhatArguments.version) {
-      await printVersionMessage(packageJson);
-      return;
     }
 
     if (!isHardhatInstalledLocallyOrLinked()) {


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

If you run hardhat --version and are not in a HardHat project directory, you will be prompted to create a new project, if your terminal is interactive.

This change moves the --version flag processing earlier in the main function so that it doesn't require you to be in a HardHat project directory to check the version.

