### PR TITLE
Support predicate in .withArgs()

### DIFF
--- a/packages/hardhat-chai-matchers/package.json
+++ b/packages/hardhat-chai-matchers/package.json
@@ -9,7 +9,8 @@
   "types": "dist/src/index.d.ts",
   "exports": {
     ".": "./dist/src/index.js",
-    "./panic": "./dist/src/reverted/panic.js"
+    "./panic": "./dist/src/reverted/panic.js",
+    "./withArgs": "./dist/src/withArgs.js"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-chai-matchers/scripts/check-subpath-exports.js
+++ b/packages/hardhat-chai-matchers/scripts/check-subpath-exports.js
@@ -8,3 +8,10 @@ const assert = require("assert");
 const { PANIC_CODES } = require("@nomicfoundation/hardhat-chai-matchers/panic");
 
 assert(PANIC_CODES !== undefined);
+
+const {
+  anyUint,
+  anyValue,
+} = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
+assert(anyUint !== undefined);
+assert(anyValue !== undefined);

--- a/packages/hardhat-chai-matchers/src/emit.ts
+++ b/packages/hardhat-chai-matchers/src/emit.ts
@@ -112,7 +112,27 @@ function assertArgsArraysEqual(
     actualArgs.length
   );
   for (let index = 0; index < expectedArgs.length; index++) {
-    if (expectedArgs[index] instanceof Uint8Array) {
+    if (typeof expectedArgs[index] === "function") {
+      const errorPrefix = `The predicate for event argument #${index + 1}`;
+      try {
+        context.assert(
+          expectedArgs[index](actualArgs[index]),
+          `${errorPrefix} returned false`
+          // no need for a negated message, since we disallow mixing .not. with
+          // .withArgs
+        );
+      } catch (e) {
+        if (e instanceof AssertionError) {
+          context.assert(
+            false,
+            `${errorPrefix} threw an AssertionError: ${e.message}`
+            // no need for a negated message, since we disallow mixing .not. with
+            // .withArgs
+          );
+        }
+        throw e;
+      }
+    } else if (expectedArgs[index] instanceof Uint8Array) {
       new Assertion(actualArgs[index]).equal(
         utils.hexlify(expectedArgs[index])
       );

--- a/packages/hardhat-chai-matchers/src/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/src/reverted/revertedWithCustomError.ts
@@ -1,3 +1,5 @@
+import { AssertionError } from "chai";
+
 import { decodeReturnData, getReturnDataFromError } from "./utils";
 
 export const REVERTED_WITH_CUSTOM_ERROR_CALLED = "customErrorAssertionCalled";
@@ -160,7 +162,29 @@ export async function revertedWithCustomErrorWithArgs(
 
   for (const [i, actualArg] of Object.entries(actualArgs) as any) {
     const expectedArg = expectedArgs[i];
-    if (Array.isArray(expectedArg)) {
+    if (typeof expectedArg === "function") {
+      const errorPrefix = `The user-defined predicate for custom error argument #${
+        parseInt(i, 10) + 1
+      }`;
+      try {
+        context.assert(
+          expectedArg(actualArg),
+          `${errorPrefix} returned false`
+          // no need for a negated message, since we disallow mixing .not. with
+          // .withArgs
+        );
+      } catch (e) {
+        if (e instanceof AssertionError) {
+          context.assert(
+            false,
+            `${errorPrefix} threw an AssertionError: ${e.message}`
+            // no need for a negated message, since we disallow mixing .not. with
+            // .withArgs
+          );
+        }
+        throw e;
+      }
+    } else if (Array.isArray(expectedArg)) {
       // we use [...x] here to convert the array-like values used by ethers to
       // represent structs into proper arrays
       new Assertion([...actualArg]).to.deep.equal([...expectedArg]);

--- a/packages/hardhat-chai-matchers/src/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/src/reverted/revertedWithCustomError.ts
@@ -163,7 +163,7 @@ export async function revertedWithCustomErrorWithArgs(
   for (const [i, actualArg] of Object.entries(actualArgs) as any) {
     const expectedArg = expectedArgs[i];
     if (typeof expectedArg === "function") {
-      const errorPrefix = `The user-defined predicate for custom error argument #${
+      const errorPrefix = `The predicate for custom error argument #${
         parseInt(i, 10) + 1
       }`;
       try {

--- a/packages/hardhat-chai-matchers/src/withArgs.ts
+++ b/packages/hardhat-chai-matchers/src/withArgs.ts
@@ -1,8 +1,38 @@
+import { AssertionError } from "chai";
+
+import { isBigNumber, normalizeToBigInt } from "hardhat/common";
+
 import { emitWithArgs, EMIT_CALLED } from "./emit";
 import {
   revertedWithCustomErrorWithArgs,
   REVERTED_WITH_CUSTOM_ERROR_CALLED,
 } from "./reverted/revertedWithCustomError";
+
+export function anyValue(): boolean {
+  return true;
+}
+
+export function anyUint(i: any): boolean {
+  if (typeof i === "number") {
+    if (i < 0) {
+      throw new AssertionError(
+        `anyUint expected its argument to be an unsigned integer, but it was negative, with value ${i}`
+      );
+    }
+    return true;
+  } else if (isBigNumber(i)) {
+    const bigInt = normalizeToBigInt(i);
+    if (bigInt < 0) {
+      throw new AssertionError(
+        `anyUint expected its argument to be an unsigned integer, but it was negative, with value ${bigInt}`
+      );
+    }
+    return true;
+  }
+  throw new AssertionError(
+    `anyUint expected its argument to be an integer, but its type was '${typeof i}'`
+  );
+}
 
 export function supportWithArgs(
   Assertion: Chai.AssertionStatic,

--- a/packages/hardhat-chai-matchers/src/withArgs.ts
+++ b/packages/hardhat-chai-matchers/src/withArgs.ts
@@ -8,10 +8,22 @@ import {
   REVERTED_WITH_CUSTOM_ERROR_CALLED,
 } from "./reverted/revertedWithCustomError";
 
+/**
+ * A predicate for use with .withArgs(...), to induce chai to accept any value
+ * as a positive match with the argument.
+ *
+ * Example: expect(contract.emitInt()).to.emit(contract, "Int").withArgs(anyValue)
+ */
 export function anyValue(): boolean {
   return true;
 }
 
+/**
+ * A predicate for use with .withArgs(...), to induce chai to accept any
+ * unsigned integer as a positive match with the argument.
+ *
+ * Example: expect(contract.emitUint()).to.emit(contract, "Uint").withArgs(anyUint)
+ */
 export function anyUint(i: any): boolean {
   if (typeof i === "number") {
     if (i < 0) {

--- a/packages/hardhat-chai-matchers/test/fixture-projects/hardhat-project/contracts/Events.sol
+++ b/packages/hardhat-chai-matchers/test/fixture-projects/hardhat-project/contracts/Events.sol
@@ -8,6 +8,7 @@ contract Events {
 
   event WithoutArgs();
   event WithUintArg(uint u);
+  event WithIntArg(int i);
   event WithTwoUintArgs(uint u, uint v);
   event WithStringArg(string s);
   event WithTwoStringArgs(string s, string t);
@@ -32,6 +33,10 @@ contract Events {
 
   function emitUint(uint u) public {
     emit WithUintArg(u);
+  }
+
+  function emitInt(int i) public {
+    emit WithIntArg(i);
   }
 
   function emitUintTwice(uint u, uint v) public {

--- a/packages/hardhat-chai-matchers/test/fixture-projects/hardhat-project/contracts/Matchers.sol
+++ b/packages/hardhat-chai-matchers/test/fixture-projects/hardhat-project/contracts/Matchers.sol
@@ -13,6 +13,7 @@ contract Matchers {
 
   error SomeCustomError();
   error AnotherCustomError();
+  error CustomErrorWithInt(int);
   error CustomErrorWithUint(uint);
   error CustomErrorWithUintAndString(uint, string);
   error CustomErrorWithPair(Pair);
@@ -90,6 +91,15 @@ contract Matchers {
 
   function revertWithCustomErrorWithUintView(uint n) public pure {
     revert CustomErrorWithUint(n);
+  }
+
+  function revertWithCustomErrorWithInt(int i) public {
+    x++;
+    revert CustomErrorWithInt(i);
+  }
+
+  function revertWithCustomErrorWithIntView(int i) public {
+    revert CustomErrorWithInt(i);
   }
 
   function revertWithCustomErrorWithUintAndString(uint n, string memory s) public {

--- a/packages/hardhat-chai-matchers/test/fixture-projects/hardhat-project/contracts/Matchers.sol
+++ b/packages/hardhat-chai-matchers/test/fixture-projects/hardhat-project/contracts/Matchers.sol
@@ -98,7 +98,7 @@ contract Matchers {
     revert CustomErrorWithInt(i);
   }
 
-  function revertWithCustomErrorWithIntView(int i) public {
+  function revertWithCustomErrorWithIntView(int i) public pure {
     revert CustomErrorWithInt(i);
   }
 

--- a/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
@@ -369,7 +369,7 @@ describe("INTEGRATION: Reverted with custom error", function () {
             .withArgs(() => false)
         ).to.be.rejectedWith(
           AssertionError,
-          "The user-defined predicate for custom error argument #1 returned false"
+          "The predicate for custom error argument #1 returned false"
         );
 
         await expect(matchers.revertWithCustomErrorWithUint(1))
@@ -382,7 +382,7 @@ describe("INTEGRATION: Reverted with custom error", function () {
             .withArgs(anyUint)
         ).to.be.rejectedWith(
           AssertionError,
-          "The user-defined predicate for custom error argument #1 threw an AssertionError: anyUint expected its argument to be an unsigned integer, but it was negative, with value -1"
+          "The predicate for custom error argument #1 threw an AssertionError: anyUint expected its argument to be an unsigned integer, but it was negative, with value -1"
         );
       });
     });

--- a/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
@@ -10,6 +10,7 @@ import {
 } from "../helpers";
 
 import "../../src";
+import { anyUint, anyValue } from "../../src/withArgs";
 
 describe("INTEGRATION: Reverted with custom error", function () {
   describe("with the in-process hardhat network", function () {
@@ -264,6 +265,17 @@ describe("INTEGRATION: Reverted with custom error", function () {
             )
             .withArgs(1, "bar")
         ).to.be.rejectedWith(AssertionError, "expected 'foo' to equal 'bar'");
+
+        await expect(
+          expect(matchers.revertWithCustomErrorWithUintAndString(1, "foo"))
+            .to.be.revertedWithCustomError(
+              matchers,
+              "CustomErrorWithUintAndString"
+            )
+            .withArgs(() => {
+              throw new Error("user-defined error");
+            }, "foo")
+        ).to.be.rejectedWith(Error, "user-defined error");
       });
 
       it("should check the length of the args", async function () {
@@ -344,6 +356,34 @@ describe("INTEGRATION: Reverted with custom error", function () {
         await expect(matchers.revertWithCustomErrorWithPair(1, 2))
           .to.be.revertedWithCustomError(matchers, "CustomErrorWithPair")
           .withArgs([BigInt(1), BigNumber.from(2)]);
+      });
+
+      it("should work with predicates", async function () {
+        await expect(matchers.revertWithCustomErrorWithUint(1))
+          .to.be.revertedWithCustomError(matchers, "CustomErrorWithUint")
+          .withArgs(anyValue);
+
+        await expect(
+          expect(matchers.revertWithCustomErrorWithUint(1))
+            .to.be.revertedWithCustomError(matchers, "CustomErrorWithUint")
+            .withArgs(() => false)
+        ).to.be.rejectedWith(
+          AssertionError,
+          "The user-defined predicate for custom error argument #1 returned false"
+        );
+
+        await expect(matchers.revertWithCustomErrorWithUint(1))
+          .to.be.revertedWithCustomError(matchers, "CustomErrorWithUint")
+          .withArgs(anyUint);
+
+        await expect(
+          expect(matchers.revertWithCustomErrorWithInt(-1))
+            .to.be.revertedWithCustomError(matchers, "CustomErrorWithInt")
+            .withArgs(anyUint)
+        ).to.be.rejectedWith(
+          AssertionError,
+          "The user-defined predicate for custom error argument #1 threw an AssertionError: anyUint expected its argument to be an unsigned integer, but it was negative, with value -1"
+        );
       });
     });
 


### PR DESCRIPTION
- [x] Support predicate arguments
- [x] Support at least one built-in predicate matcher, like anyArg(), anyValue(), etc. (source: https://linear.app/nomic-foundation/issue/HH-542#comment-de529709)