### PR TITLE
Fix fork tests when gas prices are high

### DIFF
--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -71,6 +71,10 @@ describe("Debug module", function () {
           const impersonatedAddress =
             "0xC014BA5EC014ba5ec014Ba5EC014ba5Ec014bA5E";
 
+          await this.provider.send("hardhat_setNextBlockBaseFeePerGas", [
+            "0x0",
+          ]);
+
           await this.provider.send("eth_sendTransaction", [
             {
               from: DEFAULT_ACCOUNTS_ADDRESSES[0],

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -123,6 +123,10 @@ describe("Hardhat module", function () {
           const impersonatedAddress =
             "0xC014BA5EC014ba5ec014Ba5EC014ba5Ec014bA5E";
 
+          await this.provider.send("hardhat_setNextBlockBaseFeePerGas", [
+            "0x0",
+          ]);
+
           await this.provider.send("eth_sendTransaction", [
             {
               from: DEFAULT_ACCOUNTS_ADDRESSES[0],


### PR DESCRIPTION
There are a couple of tests that fail with an "insufficient balance" error when the fork provider is used. This happens when gas prices are high (as they are right now).

This PR fixes this by just setting the base fee to 0 in those tests.