### PR TITLE
Add Sepolia to Hardhat Etherscan

### DIFF
--- a/.changeset/gentle-points-provide.md
+++ b/.changeset/gentle-points-provide.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-etherscan": patch
+---
+
+Add support for Sepolia (Thanks @pcaversaccio!)

--- a/packages/hardhat-etherscan/README.md
+++ b/packages/hardhat-etherscan/README.md
@@ -141,6 +141,7 @@ module.exports = {
         rinkeby: "YOUR_ETHERSCAN_API_KEY",
         goerli: "YOUR_ETHERSCAN_API_KEY",
         kovan: "YOUR_ETHERSCAN_API_KEY",
+        sepolia: "YOUR_ETHERSCAN_API_KEY",
         // binance smart chain
         bsc: "YOUR_BSCSCAN_API_KEY",
         bscTestnet: "YOUR_BSCSCAN_API_KEY",

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -51,6 +51,13 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://kovan.etherscan.io",
     },
   },
+  sepolia: {
+    chainId: 11155111,
+    urls: {
+      apiURL: "https://api-sepolia.etherscan.io",
+      browserURL: "https://sepolia.etherscan.io",
+    },
+  },
   bsc: {
     chainId: 56,
     urls: {

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -54,7 +54,7 @@ export const chainConfig: ChainConfig = {
   sepolia: {
     chainId: 11155111,
     urls: {
-      apiURL: "https://api-sepolia.etherscan.io",
+      apiURL: "https://api-sepolia.etherscan.io/api",
       browserURL: "https://sepolia.etherscan.io",
     },
   },

--- a/packages/hardhat-etherscan/src/types.ts
+++ b/packages/hardhat-etherscan/src/types.ts
@@ -4,6 +4,7 @@ type Chain =
   | "rinkeby"
   | "goerli"
   | "kovan"
+  | "sepolia"
   // binance smart chain
   | "bsc"
   | "bscTestnet"


### PR DESCRIPTION

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This PR adds Sepolia, the new Ethereum test network, to the `hardhat-etherscan` plugin. 
- RPC for Sepolia: https://nunki.htznr.fault.dev/rpc.
- 0.242069 ETH has been sent to [`0x4444c3F7D7d3153Dc0773C31ae10cf9B5495d4Bb`](https://sepolia.etherscan.io/address/0x4444c3F7D7d3153Dc0773C31ae10cf9B5495d4Bb).
