### PR TITLE
fix: close node watcher after task

### DIFF
--- a/.changeset/four-foxes-sleep.md
+++ b/.changeset/four-foxes-sleep.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Updates `node` task to terminate when the server closes.

--- a/packages/hardhat-core/src/builtin-tasks/node.ts
+++ b/packages/hardhat-core/src/builtin-tasks/node.ts
@@ -29,7 +29,7 @@ import {
   TASK_NODE_SERVER_CREATED,
   TASK_NODE_SERVER_READY,
 } from "./task-names";
-import { watchCompilerOutput } from "./utils/watch";
+import { watchCompilerOutput, Watcher } from "./utils/watch";
 
 const log = debug("hardhat:core:tasks:node");
 
@@ -333,8 +333,9 @@ task(TASK_NODE, "Starts a JSON-RPC server on top of Hardhat Network")
 
         const { port: actualPort, address } = await server.listen();
 
+        let watcher: Watcher | undefined;
         try {
-          await watchCompilerOutput(provider, config.paths);
+          watcher = await watchCompilerOutput(provider, config.paths);
         } catch (error) {
           console.warn(
             chalk.yellow(
@@ -360,6 +361,7 @@ task(TASK_NODE, "Starts a JSON-RPC server on top of Hardhat Network")
         });
 
         await server.waitUntilClosed();
+        await watcher?.close();
       } catch (error) {
         if (HardhatError.isHardhatError(error)) {
           throw error;

--- a/packages/hardhat-core/src/builtin-tasks/utils/watch.ts
+++ b/packages/hardhat-core/src/builtin-tasks/utils/watch.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import { FSWatcher } from "chokidar";
 import debug from "debug";
 import fsExtra from "fs-extra";
 import * as path from "path";
@@ -9,10 +10,12 @@ import { EIP1193Provider, ProjectPathsConfig } from "../../types";
 
 const log = debug("hardhat:core:compilation-watcher");
 
+export type Watcher = FSWatcher;
+
 export async function watchCompilerOutput(
   provider: EIP1193Provider,
   paths: ProjectPathsConfig
-) {
+): Promise<Watcher> {
   const chokidar = await import("chokidar");
 
   const buildInfoDir = path.join(paths.artifacts, BUILD_INFO_DIR_NAME);
@@ -49,7 +52,7 @@ export async function watchCompilerOutput(
 
   log(`Watching changes on '${buildInfoDir}'`);
 
-  chokidar
+  return chokidar
     .watch(buildInfoDir, {
       ignoreInitial: true,
       awaitWriteFinish: {

--- a/packages/hardhat-core/test/builtin-tasks/node.ts
+++ b/packages/hardhat-core/test/builtin-tasks/node.ts
@@ -1,0 +1,20 @@
+import {
+  TASK_NODE,
+  TASK_NODE_SERVER_READY,
+} from "../../src/builtin-tasks/task-names";
+import { useEnvironment } from "../helpers/environment";
+import { useFixtureProject } from "../helpers/project";
+
+describe("node task", () => {
+  useFixtureProject("default-config-project");
+  useEnvironment();
+
+  it("should terminate", async function () {
+    this.env.tasks[TASK_NODE_SERVER_READY].setAction(async ({ server }) => {
+      server.close();
+    });
+
+    await this.env.run(TASK_NODE);
+    // NB: If a file watcher persists past this test, then mocha will fail to exit cleanly.
+  });
+});


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [X] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

Fixes the `node` task by closing the `chokidar` file watcher after the server has closed.

This prevents programmatic usages of the `node` task from hanging. For example, a test (eg `mocha`, `jest`) may run the `node` task for mainnet forking and terminate the server when the tests complete, but the test framework will hang because `chokidar` will not allow the process to quit.

I've included a test to show that the `node` task terminates. The test will still pass without these changes, but (as described) the test framework will hang despite the test passing. I could find no way to make the test fail, as the `chokidar` watcher is a not exposed in the current state of the code.