### PR TITLE
Fix slow tests

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -55,8 +55,8 @@
     "console.sol"
   ],
   "devDependencies": {
-    "@types/bn.js": "^5.1.0",
     "@nomiclabs/eslint-plugin-hardhat-internal-rules": "^1.0.0",
+    "@types/bn.js": "^5.1.0",
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^7.1.3",
     "@types/ci-info": "^2.0.0",
@@ -142,7 +142,7 @@
     "stacktrace-parser": "^0.1.10",
     "true-case-path": "^2.2.1",
     "tsort": "0.0.1",
-    "undici": "^4.14.1",
+    "undici": "^5.4.0",
     "uuid": "^8.3.2",
     "ws": "^7.4.6"
   },

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -126,7 +126,14 @@ export function useProvider({
     delete (this as any).hardhatNetworkProvider;
 
     if (this.server !== undefined) {
+      // close server and fail if it takes too long
+      const beforeClose = Date.now();
       await this.server.close();
+      const afterClose = Date.now();
+      if (afterClose - beforeClose > 1000) {
+        throw new Error("Closing the server took more than 1 second");
+      }
+
       delete this.server;
       delete this.serverInfo;
     }

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
@@ -871,7 +871,7 @@ describe("Evm module", function () {
             });
 
             it("should allow disabling interval mining", async function () {
-              const interval = 1000;
+              const interval = 100;
               const initialBlock = await getBlockNumber();
               await this.provider.send("evm_setIntervalMining", [interval]);
 
@@ -891,7 +891,7 @@ describe("Evm module", function () {
             });
 
             it("should mine block with transaction after the interval", async function () {
-              const interval = 1000;
+              const interval = 100;
               const txHash = await this.provider.send("eth_sendTransaction", [
                 {
                   from: DEFAULT_ACCOUNTS_ADDRESSES[1],

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
@@ -1383,6 +1383,7 @@ describe("Evm module", function () {
           });
 
           afterEach(async function () {
+            await this.provider.send("evm_setIntervalMining", [0]);
             sinonClock.restore();
           });
 
@@ -1405,7 +1406,7 @@ describe("Evm module", function () {
               rpcQuantityToNumber(firstBlock.timestamp) + 100
             );
 
-            sinonClock.tick(20 * 1000);
+            await sinonClock.tickAsync(20 * 1000);
 
             await this.provider.send("evm_revert", [snapshotId]);
             const afterRevertBlock = await mineEmptyBlock();
@@ -1419,10 +1420,6 @@ describe("Evm module", function () {
           });
 
           describe("when interval mining is enabled", () => {
-            afterEach(async function () {
-              await this.provider.send("evm_setIntervalMining", [0]);
-            });
-
             it("should handle race condition", async function () {
               const interval = 5000;
               const initialBlock = await getBlockNumber();

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -1317,7 +1317,8 @@ describe("Hardhat module", function () {
             });
           });
 
-          afterEach(() => {
+          afterEach(async function () {
+            await this.provider.send("evm_setIntervalMining", [0]);
             sinonClock.restore();
           });
 

--- a/packages/hardhat-docker/package.json
+++ b/packages/hardhat-docker/package.json
@@ -50,6 +50,6 @@
   "dependencies": {
     "dockerode": "^2.5.8",
     "fs-extra": "^7.0.1",
-    "undici": "^4.14.1"
+    "undici": "^5.4.0"
   }
 }

--- a/packages/hardhat-etherscan/package.json
+++ b/packages/hardhat-etherscan/package.json
@@ -41,7 +41,7 @@
     "debug": "^4.1.1",
     "fs-extra": "^7.0.1",
     "semver": "^6.3.0",
-    "undici": "^4.14.1"
+    "undici": "^5.4.0"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10364,10 +10364,10 @@ underscore@^1.8.3:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.3.tgz#54bc95f7648c5557897e5e968d0f76bc062c34ee"
   integrity sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==
 
-undici@^4.14.1:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-4.16.0.tgz#469bb87b3b918818d3d7843d91a1d08da357d5ff"
-  integrity sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==
+undici@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.4.0.tgz#c474fae02743d4788b96118d46008a24195024d2"
+  integrity sha512-A1SRXysDg7J+mVP46jF+9cKANw0kptqSFZ8tGyL+HBiv0K1spjxPX8Z4EGu+Eu6pjClJUBdnUPlxrOafR668/g==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
For some reason (which I believe is related to some interaction between sinon an undici), some tests were taking a long time while the server was being closed. This was adding more than 30 seconds to the total time of the test run.

Upgrading undici, plus some other minor changes, fixed it.

Since this is not the first time this happens, I also added a check that fails if the server takes more than one second to close.