### PR TITLE
Fix incorrect desktop social urls

### DIFF
--- a/docs/src/components/ui/DesktopMenu.tsx
+++ b/docs/src/components/ui/DesktopMenu.tsx
@@ -379,7 +379,7 @@ const DesktopMenu = ({
               <SocialLink
                 target="_blank"
                 rel="noreferrer"
-                href={social.name}
+                href={social.href}
                 aria-label={social.name}
               >
                 <Icon />


### PR DESCRIPTION
Fixes incorrect social URLs in the header on desktop due to the `.name` prop being used in the `href={}`.
