### PR TITLE
Remove incorrect sinon-chai reference from hardhat-chai-matchers

### DIFF
--- a/packages/hardhat-chai-matchers/src/tsconfig.json
+++ b/packages/hardhat-chai-matchers/src/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../",
     "rootDirs": ["."],
-    "composite": true
+    "composite": true,
+    "types": ["node", "chai"]
   },
   "include": ["./**/*.ts"],
   "exclude": [],

--- a/packages/hardhat-chai-matchers/src/types.ts
+++ b/packages/hardhat-chai-matchers/src/types.ts
@@ -1,5 +1,3 @@
-declare module "deep-eql";
-
 // eslint-disable-next-line @typescript-eslint/no-namespace, @typescript-eslint/no-unused-vars
 declare namespace Chai {
   interface Assertion


### PR DESCRIPTION
This PR deserves a thorough explanation:

As reported in #2836, `hardhat-chai-matchers` was incorrectly adding a `/// <reference types="sinon-chai" />`. This was surprising, as we don't use Sinon in that package.

What happened is that tsc loads all the typing packages from the `typeRoots` you declare by default. In our case, those are set to `<repo>/node_modules/@types` and `<repo>/config/typescript/@types`. Inside the main `@types` we have both `chai` and `chai-sinon`, and given how the Chai overload is written (not a declare module construct), it needs to load both.

I fixed it by explicitly telling tsc to only load `@types/node` and `@types/chai`.