### PR TITLE
[Toolbox] Disable typechain override for js projects

### DIFF
--- a/packages/hardhat-toolbox/src/index.ts
+++ b/packages/hardhat-toolbox/src/index.ts
@@ -32,4 +32,10 @@ extendConfig((config, userConfig) => {
   if (gasReporterConfig?.currency === undefined) {
     configAsAny.gasReporter.currency = "USD";
   }
+
+  // We don't generate types for js projects
+  if (userConfig?.typechain?.dontOverrideCompile === undefined) {
+    config.typechain.dontOverrideCompile =
+      config.paths.configFile.endsWith(".js");
+  }
 });


### PR DESCRIPTION
Moving this logic from `@typechain/hardhat` into the toolbox. See https://github.com/dethcrypto/TypeChain/issues/722