### PR TITLE
Upgrade the target in the sample project's tsconfig

### DIFF
--- a/packages/hardhat-core/sample-projects/typescript/tsconfig.json
+++ b/packages/hardhat-core/sample-projects/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2020",
     "module": "commonjs",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This PR upgrades the `target` in the sample project's tsconfig to `es2020`, which means users can take advantage of bigint literals (e.g. `1n`) without changing their config.

This `target` is fully supported by Node 14+, as you can see [here](https://github.com/tsconfig/bases/blob/main/bases/node14.json).

We still support Node 12, but we are dropping its support at the end of the month, so the risk of this going wrong is tiny.