### PR TITLE
add Cronos ChainID 25 support to hardhat verify

### DIFF
--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -205,4 +205,11 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://explorer.pops.one",
     },
   },
+  cronos: {
+    chainId: 25,
+    urls: {
+      apiURL: "https://api.cronoscan.com/api",
+      browserURL: "https://cronoscan.com",
+    },
+  },
 };


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
I added Cronos support to my local project to get verification going and thought I'd add it to upstream

In my local version I had to edit the types.ts file too, as suggested here:
https://github.com/NomicFoundation/hardhat/commit/e04944c6c4a69a52b09f83fce759dcb9cbb32777#diff-450405d52fcde8250684aaf117939e95485b9cf7a80259e0bee6a0f4f3f1e6c5

but that has since been changed to be less strict it seems here so isn't needed in this PR:
https://github.com/NomicFoundation/hardhat/commit/17e95b239e7e53ae46e2f41dde545c3f6a406975