### PR TITLE
Remove gas field from abi

### DIFF
--- a/packages/hardhat-vyper/src/util.ts
+++ b/packages/hardhat-vyper/src/util.ts
@@ -56,6 +56,14 @@ function ensureHexPrefix(hex: string) {
   return `${/^0x/i.test(hex) ? "" : "0x"}${hex}`;
 }
 
+/** Earlier versions of vyper have an gas estimate which is often
+ * incorrect (https://github.com/vyperlang/vyper/issues/2151)*/
+function removeGasEstimate(abi: string[]): string[] {
+  return JSON.parse(JSON.stringify(abi), (key, value) => {
+    if (key !== "gas") return value;
+  });
+}
+
 /** Vyper contract names are taken from their file names, so we can convert directly */
 function pathToContractName(file: string) {
   const sourceName = path.basename(file);
@@ -72,7 +80,7 @@ export function getArtifactFromVyperOutput(
     _format: ARTIFACT_FORMAT_VERSION,
     contractName,
     sourceName,
-    abi: output.abi,
+    abi: removeGasEstimate(output.abi),
     bytecode: ensureHexPrefix(output.bytecode),
     deployedBytecode: ensureHexPrefix(output.bytecode_runtime),
     linkReferences: {},

--- a/packages/hardhat-vyper/test/fixture-projects/generates-gas-field/contracts/A.vy
+++ b/packages/hardhat-vyper/test/fixture-projects/generates-gas-field/contracts/A.vy
@@ -1,0 +1,5 @@
+# @version 0.2.12
+
+@external
+def test() -> int128:
+  return 42

--- a/packages/hardhat-vyper/test/fixture-projects/generates-gas-field/hardhat.config.js
+++ b/packages/hardhat-vyper/test/fixture-projects/generates-gas-field/hardhat.config.js
@@ -1,0 +1,5 @@
+require("../../../src/index");
+
+module.exports = {
+  vyper: "0.2.12",
+};

--- a/packages/hardhat-vyper/test/tests.ts
+++ b/packages/hardhat-vyper/test/tests.ts
@@ -93,4 +93,18 @@ describe("Vyper plugin", function () {
       }, "The Vyper version pragma statement in this file doesn't match any of the configured compilers in your config.");
     });
   });
+
+  describe("project produces abi without gas field", function () {
+    useFixtureProject("generates-gas-field");
+    useEnvironment();
+
+    it("Should remove the gas field", async function () {
+      await this.env.run(TASK_COMPILE);
+
+      assert.isUndefined(
+        JSON.parse(JSON.stringify(this.env.artifacts.readArtifactSync("A").abi))
+          .gas
+      );
+    });
+  });
 });


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

Earlier Versions of Vyper generate a gas field in the ABI. This gas estimate is often [incorrect](https://github.com/vyperlang/vyper/issues/2151) and produces invalid typechain objects (see https://github.com/NomicFoundation/hardhat/issues/1696, https://github.com/dethcrypto/TypeChain/pull/711)
