### PR TITLE
website: "other hardhat components", not "projects"

### DIFF
--- a/docs/redirects.config.js
+++ b/docs/redirects.config.js
@@ -62,7 +62,7 @@ const customRedirects = [
     permanent: false
   },
 
-  // top-level projects URLs
+  // top-level component URLs
   {
     source: "/hardhat-runner",
     destination: "/hardhat-runner/docs/getting-started#overview",

--- a/docs/src/content/docs-landing/index.md
+++ b/docs/src/content/docs-landing/index.md
@@ -6,11 +6,11 @@ If you want to quickly start using it you can follow [this guide.](/hardhat-runn
 
 If you prefer a step-by-step tutorial, you can find it [here.](/tutorial)
 
-## Browse by project
+## Browse by component
 
 :::tip
 
-If you are in doubt about which project you are looking for, you can start [here.](/hardhat-runner)
+If you are in doubt about which component you are looking for, you can start [here.](/hardhat-runner)
 
 :::
 

--- a/docs/src/content/hardhat-chai-matchers/docs/other-components/_dirinfo.yaml
+++ b/docs/src/content/hardhat-chai-matchers/docs/other-components/_dirinfo.yaml
@@ -1,11 +1,11 @@
 section-type: group
-section-title: Other Hardhat projects
+section-title: Other Hardhat components
 order:
   - href: /../../../hardhat-runner/docs
     title: Hardhat Runner
   - href: /../../../hardhat-network/docs
     title: Hardhat Network
-  - href: /../../../hardhat-chai-matchers/docs
-    title: Hardhat Chai Matchers
+  - href: /../../../hardhat-vscode/docs
+    title: Hardhat VSCode
   - href: /../../../hardhat-network-helpers/docs
     title: Hardhat Network Helpers

--- a/docs/src/content/hardhat-network-helpers/docs/other-components/_dirinfo.yaml
+++ b/docs/src/content/hardhat-network-helpers/docs/other-components/_dirinfo.yaml
@@ -1,11 +1,11 @@
 section-type: group
-section-title: Other Hardhat projects
+section-title: Other Hardhat components
 order:
   - href: /../../../hardhat-runner/docs
     title: Hardhat Runner
+  - href: /../../../hardhat-network/docs
+    title: Hardhat Network
   - href: /../../../hardhat-vscode/docs
     title: Hardhat VSCode
   - href: /../../../hardhat-chai-matchers/docs
     title: Hardhat Chai Matchers
-  - href: /../../../hardhat-network-helpers/docs
-    title: Hardhat Network Helpers

--- a/docs/src/content/hardhat-network/docs/other-components/_dirinfo.yaml
+++ b/docs/src/content/hardhat-network/docs/other-components/_dirinfo.yaml
@@ -1,11 +1,11 @@
 section-type: group
-section-title: Other Hardhat projects
+section-title: Other Hardhat components
 order:
   - href: /../../../hardhat-runner/docs
     title: Hardhat Runner
-  - href: /../../../hardhat-network/docs
-    title: Hardhat Network
   - href: /../../../hardhat-vscode/docs
     title: Hardhat VSCode
+  - href: /../../../hardhat-chai-matchers/docs
+    title: Hardhat Chai Matchers
   - href: /../../../hardhat-network-helpers/docs
     title: Hardhat Network Helpers

--- a/docs/src/content/hardhat-runner/docs/other-components/_dirinfo.yaml
+++ b/docs/src/content/hardhat-runner/docs/other-components/_dirinfo.yaml
@@ -1,11 +1,11 @@
 section-type: group
-section-title: Other Hardhat projects
+section-title: Other Hardhat components
 order:
-  - href: /../../../hardhat-runner/docs
-    title: Hardhat Runner
   - href: /../../../hardhat-network/docs
     title: Hardhat Network
   - href: /../../../hardhat-vscode/docs
     title: Hardhat VSCode
   - href: /../../../hardhat-chai-matchers/docs
     title: Hardhat Chai Matchers
+  - href: /../../../hardhat-network-helpers/docs
+    title: Hardhat Network Helpers

--- a/docs/src/content/hardhat-vscode/docs/other-components/_dirinfo.yaml
+++ b/docs/src/content/hardhat-vscode/docs/other-components/_dirinfo.yaml
@@ -1,10 +1,10 @@
 section-type: group
-section-title: Other Hardhat projects
+section-title: Other Hardhat components
 order:
+  - href: /../../../hardhat-runner/docs
+    title: Hardhat Runner
   - href: /../../../hardhat-network/docs
     title: Hardhat Network
-  - href: /../../../hardhat-vscode/docs
-    title: Hardhat VSCode
   - href: /../../../hardhat-chai-matchers/docs
     title: Hardhat Chai Matchers
   - href: /../../../hardhat-network-helpers/docs

--- a/docs/src/content/layouts.yaml
+++ b/docs/src/content/layouts.yaml
@@ -10,7 +10,7 @@ hardhat-runner:
     - hardhat-runner/docs/troubleshooting
     - hardhat-runner/docs/reference
     - hardhat-runner/plugins
-    - hardhat-runner/docs/other-projects
+    - hardhat-runner/docs/other-components
     # hidden
     - hardhat-runner/docs/errors
     - hardhat-runner/docs/other-guides
@@ -20,7 +20,7 @@ hardhat-network:
   folders:
     - hardhat-network
     - hardhat-network/docs
-    - hardhat-network/docs/other-projects
+    - hardhat-network/docs/other-components
     # hidden
     - hardhat-network/docs/metamask-issue
 
@@ -29,21 +29,21 @@ hardhat-vscode:
   folders:
     - hardhat-vscode
     - hardhat-vscode/docs
-    - hardhat-vscode/docs/other-projects
+    - hardhat-vscode/docs/other-components
 
 hardhat-chai-matchers:
   title: Hardhat Chai Matchers
   folders:
     - hardhat-chai-matchers
     - hardhat-chai-matchers/docs
-    - hardhat-chai-matchers/docs/other-projects
+    - hardhat-chai-matchers/docs/other-components
 
 hardhat-network-helpers:
   title: Hardhat Network Helpers
   folders:
     - hardhat-network-helpers
     - hardhat-network-helpers/docs
-    - hardhat-network-helpers/docs/other-projects
+    - hardhat-network-helpers/docs/other-components
 
 hidden:
   title: hidden


### PR DESCRIPTION
For https://linear.app/nomic-foundation/issue/HH-861/use-hardhat-component-instead-of-hardhat-project-in-the-docs