### PR TITLE
Fix hardhat org links

### DIFF
--- a/docs/redirects.config.js
+++ b/docs/redirects.config.js
@@ -61,6 +61,11 @@ const customRedirects = [
     destination: "/hardhat-network/docs/metamask-issue",
     permanent: false
   },
+  {
+    source: "/migrate-from-waffle",
+    destination: "/hardhat-chai-matchers/docs/migrate-from-waffle",
+    permanent: false
+  },
 
   // top-level projects URLs
   {

--- a/docs/redirects.config.js
+++ b/docs/redirects.config.js
@@ -20,6 +20,16 @@ const customRedirects = [
     destination: "/hardhat-runner/docs/config",
     permanent: false
   },
+  {
+    source: "/plugins",
+    destination: "/hardhat-runner/plugins",
+    permanent: false
+  },
+  {
+    source: "/getting-started",
+    destination: "/hardhat-runner/docs/getting-started#overview",
+    permanent: false
+  },
   { source: "/links/stack-traces", destination: "/", permanent: false },
   {
     source: "/reportbug",
@@ -146,11 +156,6 @@ const customRedirects = [
     permanent: false
   },
   {
-    source: "/getting-started",
-    destination: "/hardhat-runner/docs/getting-started#overview",
-    permanent: false
-  },
-  {
     source: "/hardhat-network/guides/mainnet-forking",
     destination: "/hardhat-network/docs/guides/forking-other-networks",
     permanent: false
@@ -187,12 +192,7 @@ const customRedirects = [
   },
   {
     source: "/reference/solidity-support",
-    destination: "hardhat-runner/docs/reference/solidity-support",
-    permanent: false
-  },
-  {
-    source: "/plugins",
-    destination: "/hardhat-runner/plugins",
+    destination: "/hardhat-runner/docs/reference/solidity-support",
     permanent: false
   },
   {

--- a/docs/redirects.config.js
+++ b/docs/redirects.config.js
@@ -27,6 +27,11 @@ const customRedirects = [
     permanent: false
   },
   {
+    source: "/report-bug",
+    destination: "https://github.com/nomiclabs/hardhat/issues/new",
+    permanent: false
+  },
+  {
     source: "/console-log",
     destination: "/hardhat-network/#console.log",
     permanent: false

--- a/docs/redirects.config.js
+++ b/docs/redirects.config.js
@@ -66,6 +66,11 @@ const customRedirects = [
     destination: "/hardhat-chai-matchers/docs/migrate-from-waffle",
     permanent: false
   },
+  {
+    source: "/custom-hardfork-history",
+    destination: "/hardhat-network/docs/guides/forking-other-networks.html#using-a-custom-hardfork-history",
+    permanent: false
+  },
 
   // top-level projects URLs
   {

--- a/docs/redirects.config.js
+++ b/docs/redirects.config.js
@@ -198,7 +198,7 @@ const customRedirects = [
   },
   {
     source: "/guides/:slug(waffle-testing|truffle-testing|truffle-migration|ganache-tests)",
-    destination: "/other-guides/:slug",
+    destination: "/hardhat-runner/docs/other-guides/:slug",
     permanent: false
   },
   {

--- a/packages/hardhat-chai-matchers/src/internal/checkIfWaffleIsInstalled.ts
+++ b/packages/hardhat-chai-matchers/src/internal/checkIfWaffleIsInstalled.ts
@@ -4,13 +4,11 @@ export function checkIfWaffleIsInstalled() {
   try {
     require.resolve("ethereum-waffle");
 
-    // TODO: add "Learn how to do it in https://hardhat.org/migrate-from-waffle"
-    // at the end of the message after the guide is written (issue HH-726).
     console.warn(
       chalk.yellow(
         `You have both ethereum-waffle and @nomicfoundation/hardhat-chai-matchers installed. They don't work correctly together, so please make sure you only use one.
 
-We recommend you migrate to @nomicfoundation/hardhat-chai-matchers. `
+We recommend you migrate to @nomicfoundation/hardhat-chai-matchers. Learn how to do it here: https://hardhat.org/migrate-from-waffle`
       )
     );
   } catch {}

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -307,7 +307,7 @@ async function main() {
     } else {
       if (!isHardhatError) {
         console.error(
-          `If you think this is a bug in Hardhat, please report it here: https://hardhat.org/reportbug`
+          `If you think this is a bug in Hardhat, please report it here: https://hardhat.org/report-bug`
         );
       }
 

--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -291,7 +291,7 @@ function checkUnsupportedSolidityConfig(resolvedConfig: HardhatConfig) {
           unsupportedVersions.length === 1 ? "is" : "are"
         } not fully supported yet. You can still use Hardhat, but some features, like stack traces, might not work correctly.
 
-Learn more at https://hardhat.org/reference/solidity-support
+Learn more at https://hardhat.org/hardhat-runner/docs/reference/solidity-support
 `
       )
     );

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -245,7 +245,7 @@ Either try using a new directory name, or remove the conflicting files.`,
       title: "Selected network doesn't exist",
       description: `You are trying to run Hardhat with a nonexistent network.
 
-Read the [documentation](https://hardhat.org/config/#networks-configuration) to learn how to define custom networks.`,
+Read the [documentation](https://hardhat.org/hardhat-runner/docs/config#networks-configuration) to learn how to define custom networks.`,
       shouldBeReported: false,
     },
     INVALID_GLOBAL_CHAIN_ID: {
@@ -305,7 +305,7 @@ Please make sure that your Ethereum node has unlocked accounts.`,
       title: "Invalid HD path",
       description: `An invalid HD/BIP32 derivation path was provided in your config.  
       
-Read the [documentation](https://hardhat.org/config/#hd-wallet-config) to learn how to define HD accounts correctly.`,
+Read the [documentation](https://hardhat.org/hardhat-runner/docs/config#hd-wallet-config) to learn how to define HD accounts correctly.`,
       shouldBeReported: false,
     },
     INVALID_RPC_QUANTITY_VALUE: {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/logger.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/logger.ts
@@ -496,7 +496,7 @@ export class ModulesLogger {
       this.printEmptyLine();
 
       this._print(
-        "If you think this is a bug in Hardhat, please report it here: https://hardhat.org/reportbug"
+        "If you think this is a bug in Hardhat, please report it here: https://hardhat.org/report-bug"
       );
     });
   }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -2532,7 +2532,7 @@ Hardhat Network's forking functionality only works with blocks from at least spu
       throw new InternalError(
         `No known hardfork for execution on historical block ${blockNumber.toString()} (relative to fork block number ${
           this._forkBlockNumber
-        }). The node was not configured with a hardfork activation history.  See http://hardhat.org/hardhat-network/docs/guides/forking-other-networks.html#using-a-custom-hardfork-history`
+        }). The node was not configured with a hardfork activation history.  See http://hardhat.org/custom-hardfork-history`
       );
     }
 

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -104,7 +104,7 @@ module.exports = {};
 
 And then run `npx hardhat blockNumber` to try it.
 
-Read the documentation on the [Hardhat Runtime Environment](https://hardhat.org/advanced/hardhat-runtime-environment.html) to learn how to access the HRE in different ways to use ethers.js from anywhere the HRE is accessible.
+Read the documentation on the [Hardhat Runtime Environment](https://hardhat.org/hardhat-runner/docs/advanced/hardhat-runtime-environment) to learn how to access the HRE in different ways to use ethers.js from anywhere the HRE is accessible.
 
 ### Library linking
 

--- a/packages/hardhat-ethers/src/internal/helpers.ts
+++ b/packages/hardhat-ethers/src/internal/helpers.ts
@@ -268,7 +268,7 @@ Remove one of them and review your library links before proceeding.`
       `The contract ${artifact.contractName} is missing links for the following libraries:
 ${missingLibraries}
 
-Learn more about linking contracts at https://hardhat.org/plugins/nomiclabs-hardhat-ethers.html#library-linking
+Learn more about linking contracts at https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-ethers#library-linking
 `
     );
   }

--- a/packages/hardhat-etherscan/src/solc/libraries.ts
+++ b/packages/hardhat-etherscan/src/solc/libraries.ts
@@ -78,7 +78,7 @@ ${missingLibraryNames}`;
     if (missingLibraries.length === undetectableLibraries.length) {
       message += `
 
-Visit https://hardhat.org/plugins/nomiclabs-hardhat-etherscan.html#libraries-with-undetectable-addresses to learn how to solve this.`;
+Visit https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-etherscan#libraries-with-undetectable-addresses to learn how to solve this.`;
     } else {
       message += `
 

--- a/packages/hardhat-shorthand/README.md
+++ b/packages/hardhat-shorthand/README.md
@@ -4,7 +4,7 @@
 
 `hardhat-shorthand` is an NPM package that installs a globally accessible binary called `hh` that runs the project's locally installed `hardhat` and supports shell autocompletion for tasks.
 
-Check [the guide](https://hardhat.org/guides/shorthand.html) to learn more.
+Check [the guide](https://hardhat.org/hardhat-runner/docs/guides/command-line-completion) to learn more.
 
 ## Installation
 

--- a/packages/hardhat-truffle5/README.md
+++ b/packages/hardhat-truffle5/README.md
@@ -42,4 +42,4 @@ An instance of [`TruffleEnvironmentArtifacts`](https://github.com/nomiclabs/hard
 
 There are no additional steps you need to take for this plugin to work. Install it, run `npx hardhat test` and your Truffle tests should run with no need to make any modifications.
 
-Take a look at the [testing guide](https://hardhat.org/guides/truffle-testing.html) for a tutorial using it.
+Take a look at the [testing guide](https://hardhat.org/hardhat-runner/docs/other-guides/truffle-testing) for a tutorial using it.

--- a/packages/hardhat-waffle/README.md
+++ b/packages/hardhat-waffle/README.md
@@ -69,4 +69,4 @@ const { deployContract } = waffle;
 
 Also, you don't need to call `chai.use` in order to use [Waffle's Chai matchers](https://ethereum-waffle.readthedocs.io/en/latest/matchers.html).
 
-Note that by default, Hardhat saves its compilation output into `artifacts/` instead of `build/`. You can either use that directory in your tests, or [customize your Hardhat config](https://hardhat.org/config/#path-configuration).
+Note that by default, Hardhat saves its compilation output into `artifacts/` instead of `build/`. You can either use that directory in your tests, or [customize your Hardhat config](https://hardhat.org/hardhat-runner/docs/config#path-configuration).

--- a/packages/hardhat-web3/README.md
+++ b/packages/hardhat-web3/README.md
@@ -54,4 +54,4 @@ module.exports = {};
 
 And then run `npx hardhat accounts` to try it.
 
-Read the documentation on the [Hardhat Runtime Environment](https://hardhat.org/advanced/hardhat-runtime-environment.html) to learn how to access the HRE in different ways to use Web3.js from anywhere the HRE is accessible.
+Read the documentation on the [Hardhat Runtime Environment](https://hardhat.org/hardhat-runner/docs/advanced/hardhat-runtime-environment) to learn how to access the HRE in different ways to use Web3.js from anywhere the HRE is accessible.


### PR DESCRIPTION
Closes HH-795.

I tried to update all URLs that were causing a redirect _except_ for shortlinks. To be consistent with this approach, I moved some redirects to the shortlinks section of `redirects.config.js`

I also added a new `/report-bug` shortlink and updated the `/reportbug` usages. This is just for aesthetics/consistency.