### PR TITLE
Fix reverted with custom error

### DIFF
--- a/.changeset/thick-masks-hammer.md
+++ b/.changeset/thick-masks-hammer.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-chai-matchers": patch
+---
+
+Fix an error in revertedWithCustomError's argument matching

--- a/packages/hardhat-chai-matchers/test/fixture-projects/hardhat-project/contracts/Matchers.sol
+++ b/packages/hardhat-chai-matchers/test/fixture-projects/hardhat-project/contracts/Matchers.sol
@@ -14,7 +14,7 @@ contract Matchers {
   error SomeCustomError();
   error AnotherCustomError();
   error CustomErrorWithInt(int);
-  error CustomErrorWithUint(uint);
+  error CustomErrorWithUint(uint nameToForceEthersToUseAnArrayLikeWithNamedProperties);
   error CustomErrorWithUintAndString(uint, string);
   error CustomErrorWithPair(Pair);
 

--- a/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
@@ -371,7 +371,7 @@ describe("INTEGRATION: Reverted with custom error", function () {
             .withArgs(() => false)
         ).to.be.rejectedWith(
           AssertionError,
-          "The predicate for custom error argument #1 returned false"
+          "The predicate for custom error argument with index 0 returned false"
         );
 
         await expect(matchers.revertWithCustomErrorWithUint(1))
@@ -384,7 +384,7 @@ describe("INTEGRATION: Reverted with custom error", function () {
             .withArgs(anyUint)
         ).to.be.rejectedWith(
           AssertionError,
-          "The predicate for custom error argument #1 threw an AssertionError: anyUint expected its argument to be an unsigned integer, but it was negative, with value -1"
+          "The predicate for custom error argument with index 0 threw an AssertionError: anyUint expected its argument to be an unsigned integer, but it was negative, with value -1"
         );
       });
     });


### PR DESCRIPTION
This PR introduces a fix to `revertedWithCustomError().withArgs()`.

As we were using ethers' array-like structures, and with an `as any` 🚨, we were incorrectly iterating the actual errors (i.e. by name and index), leading to always comparing them with `undefined`.

This PR converts the array-like into an actual array first. I also checked that this pattern isn't present in the other matchers.

Thanks @pcaversaccio for reporting it!