### PR TITLE
Add `reset` helper

### DIFF
--- a/docs/src/content/hardhat-network-helpers/docs/reference.md
+++ b/docs/src/content/hardhat-network-helpers/docs/reference.md
@@ -268,3 +268,11 @@ it("test", async function () {
   // use token and exchanges contracts
 })
 ```
+
+## Other helpers
+
+### `reset()`
+
+Resets the Hardhat Network to its initial configured state.
+
+If you want to reset a forked network to a non-forked state, or a non-forked network to a forked state, use the low-level [`hardhat_reset`](/hardhat-network/docs/reference#hardhat_reset) JSON-RPC method instead.

--- a/docs/src/content/hardhat-network/docs/guides/forking-other-networks.md
+++ b/docs/src/content/hardhat-network/docs/guides/forking-other-networks.md
@@ -88,32 +88,15 @@ Once you've got local instances of mainnet protocols, setting them in the specif
 
 ## Resetting the fork
 
-You can manipulate forking during runtime to reset back to a fresh forked state, fork from another block number or disable forking by calling `hardhat_reset`:
+You can reset the network to its initial state with the [`reset`](</hardhat-network-helpers/docs/reference#reset()>) network helper:
 
-```ts
-await network.provider.request({
-  method: "hardhat_reset",
-  params: [
-    {
-      forking: {
-        jsonRpcUrl: "https://eth-mainnet.alchemyapi.io/v2/<key>",
-        blockNumber: 14390000,
-      },
-    },
-  ],
-});
+```js
+const helpers = require("@nomicfoundation/hardhat-network-helpers");
+
+await helpers.reset();
 ```
 
-You can disable forking by passing empty params:
-
-```ts
-await network.provider.request({
-  method: "hardhat_reset",
-  params: [],
-});
-```
-
-This will reset Hardhat Network, starting a new instance in the state described [here](../reference/#initial-state).
+If you want to reset it to a state different to the one in the config, use the low-level [`hardhat_reset`](/hardhat-network/docs/reference#hardhat_reset) JSON-RPC method instead.
 
 ## Using a custom hardfork history
 

--- a/docs/src/content/hardhat-network/docs/reference/index.md
+++ b/docs/src/content/hardhat-network/docs/reference/index.md
@@ -417,7 +417,32 @@ Also note that blocks created via `hardhat_mine` may not trigger new-block event
 
 #### `hardhat_reset`
 
-See the [Mainnet Forking guide](./guides/forking-other-networks.md#resetting-the-fork)
+You can manipulate forking during runtime to reset back to a fresh forked state, fork from another block number or disable forking by calling `hardhat_reset`:
+
+```ts
+await network.provider.request({
+  method: "hardhat_reset",
+  params: [
+    {
+      forking: {
+        jsonRpcUrl: "https://eth-mainnet.alchemyapi.io/v2/<key>",
+        blockNumber: 14390000,
+      },
+    },
+  ],
+});
+```
+
+You can disable forking by passing empty params:
+
+```ts
+await network.provider.request({
+  method: "hardhat_reset",
+  params: [],
+});
+```
+
+This will reset Hardhat Network, starting a new instance in the state described [here](../reference/#initial-state).
 
 #### `hardhat_setBalance`
 

--- a/packages/hardhat-core/test/internal-exports.ts
+++ b/packages/hardhat-core/test/internal-exports.ts
@@ -1,0 +1,7 @@
+// Our own packages might use internal stuff. This file tests that those things
+// are available to prevent moving them.
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// used by the `reset` hardhat network helper
+import { RpcForkConfig } from "../src/internal/core/jsonrpc/types/input/hardhat-network";

--- a/packages/hardhat-network-helpers/package.json
+++ b/packages/hardhat-network-helpers/package.json
@@ -42,6 +42,7 @@
     "@types/chai": "^4.2.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "^12.0.0",
+    "@types/sinon": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",
@@ -55,6 +56,7 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
+    "sinon": "^9.0.0",
     "ts-node": "^8.1.0",
     "typescript": "~4.5.2"
   },

--- a/packages/hardhat-network-helpers/src/helpers/reset.ts
+++ b/packages/hardhat-network-helpers/src/helpers/reset.ts
@@ -1,0 +1,46 @@
+import type {
+  EIP1193Provider,
+  HardhatNetworkForkingConfig,
+} from "hardhat/types";
+import { RpcForkConfig } from "hardhat/internal/core/jsonrpc/types/input/hardhat-network";
+
+import { getHardhatProvider } from "../utils";
+
+/**
+ * Resets the Hardhat Network to its initial configured state.
+ *
+ * If you want to reset a forked network to a non-forked state, or a non-forked
+ * network to a forked state, use the low-level `hardhat_reset` JSON-RPC method
+ * instead.
+ */
+export async function reset(): Promise<void> {
+  const hre = await import("hardhat");
+  const provider = await getHardhatProvider();
+
+  const forkingConfig = hre.config.networks.hardhat.forking;
+
+  return resetInternal(provider, forkingConfig);
+}
+
+export async function resetInternal(
+  provider: EIP1193Provider,
+  forkingConfig: HardhatNetworkForkingConfig | undefined
+) {
+  if (forkingConfig === undefined || !forkingConfig.enabled) {
+    await provider.request({
+      method: "hardhat_reset",
+      params: [],
+    });
+  } else {
+    const rpcForkConfig: RpcForkConfig = {
+      jsonRpcUrl: forkingConfig.url,
+      blockNumber: forkingConfig.blockNumber,
+      httpHeaders: forkingConfig.httpHeaders,
+    };
+
+    await provider.request({
+      method: "hardhat_reset",
+      params: [{ forking: rpcForkConfig }],
+    });
+  }
+}

--- a/packages/hardhat-network-helpers/src/index.ts
+++ b/packages/hardhat-network-helpers/src/index.ts
@@ -15,4 +15,4 @@ export { setStorageAt } from "./helpers/setStorageAt";
 export { setNextBlockBaseFeePerGas } from "./helpers/setNextBlockBaseFeePerGas";
 export { stopImpersonatingAccount } from "./helpers/stopImpersonatingAccount";
 export { takeSnapshot, SnapshotRestorer } from "./helpers/takeSnapshot";
-export { reset } from "./helpers/reset";
+export { resetFork, resetWithoutFork } from "./helpers/reset";

--- a/packages/hardhat-network-helpers/src/index.ts
+++ b/packages/hardhat-network-helpers/src/index.ts
@@ -15,3 +15,4 @@ export { setStorageAt } from "./helpers/setStorageAt";
 export { setNextBlockBaseFeePerGas } from "./helpers/setNextBlockBaseFeePerGas";
 export { stopImpersonatingAccount } from "./helpers/stopImpersonatingAccount";
 export { takeSnapshot, SnapshotRestorer } from "./helpers/takeSnapshot";
+export { reset } from "./helpers/reset";

--- a/packages/hardhat-network-helpers/test/helpers/reset.ts
+++ b/packages/hardhat-network-helpers/test/helpers/reset.ts
@@ -1,0 +1,174 @@
+import { assert } from "chai";
+import sinon from "sinon";
+
+import * as hh from "../../src";
+import { resetInternal } from "../../src/helpers/reset";
+import { useEnvironment } from "../test-utils";
+
+describe("reset", function () {
+  describe("integration", function () {
+    useEnvironment("simple");
+
+    it("should reset the non-forked network", async function () {
+      assert.equal(await hh.time.latestBlock(), 0);
+      await hh.mine();
+      assert.equal(await hh.time.latestBlock(), 1);
+      await hh.reset();
+      assert.equal(await hh.time.latestBlock(), 0);
+    });
+  });
+
+  describe("unit", function () {
+    it("no forking config", async function () {
+      const mockProvider = {
+        request: sinon.spy(),
+      };
+
+      await resetInternal(mockProvider as any, undefined);
+
+      assert.isTrue(
+        mockProvider.request.calledOnceWith({
+          method: "hardhat_reset",
+          params: [],
+        })
+      );
+    });
+
+    it("disabled forking", async function () {
+      const mockProvider = {
+        request: sinon.spy(),
+      };
+
+      await resetInternal(mockProvider as any, {
+        enabled: false,
+        url: "node-url",
+        httpHeaders: {},
+      });
+
+      assert.isTrue(
+        mockProvider.request.calledOnceWith({
+          method: "hardhat_reset",
+          params: [],
+        })
+      );
+    });
+
+    it("forking without block number", async function () {
+      const mockProvider = {
+        request: sinon.spy(),
+      };
+
+      await resetInternal(mockProvider as any, {
+        enabled: true,
+        url: "node-url",
+        httpHeaders: {},
+      });
+
+      assert.isTrue(
+        mockProvider.request.calledOnceWith({
+          method: "hardhat_reset",
+          params: [
+            {
+              forking: {
+                jsonRpcUrl: "node-url",
+                blockNumber: undefined,
+                httpHeaders: {},
+              },
+            },
+          ],
+        })
+      );
+    });
+
+    it("forking with block number", async function () {
+      const mockProvider = {
+        request: sinon.spy(),
+      };
+
+      await resetInternal(mockProvider as any, {
+        enabled: true,
+        url: "node-url",
+        blockNumber: 12345,
+        httpHeaders: {},
+      });
+
+      assert.isTrue(
+        mockProvider.request.calledOnceWith({
+          method: "hardhat_reset",
+          params: [
+            {
+              forking: {
+                jsonRpcUrl: "node-url",
+                blockNumber: 12345,
+                httpHeaders: {},
+              },
+            },
+          ],
+        })
+      );
+    });
+
+    it("forking without block number and http headers", async function () {
+      const mockProvider = {
+        request: sinon.spy(),
+      };
+
+      await resetInternal(mockProvider as any, {
+        enabled: true,
+        url: "node-url",
+        httpHeaders: {
+          Authorization: "Basic foobar",
+        },
+      });
+
+      assert.isTrue(
+        mockProvider.request.calledOnceWith({
+          method: "hardhat_reset",
+          params: [
+            {
+              forking: {
+                jsonRpcUrl: "node-url",
+                blockNumber: undefined,
+                httpHeaders: {
+                  Authorization: "Basic foobar",
+                },
+              },
+            },
+          ],
+        })
+      );
+    });
+
+    it("forking with block number and http headers", async function () {
+      const mockProvider = {
+        request: sinon.spy(),
+      };
+
+      await resetInternal(mockProvider as any, {
+        enabled: true,
+        url: "node-url",
+        blockNumber: 12345,
+        httpHeaders: {
+          Authorization: "Basic foobar",
+        },
+      });
+
+      assert.isTrue(
+        mockProvider.request.calledOnceWith({
+          method: "hardhat_reset",
+          params: [
+            {
+              forking: {
+                jsonRpcUrl: "node-url",
+                blockNumber: 12345,
+                httpHeaders: {
+                  Authorization: "Basic foobar",
+                },
+              },
+            },
+          ],
+        })
+      );
+    });
+  });
+});

--- a/packages/hardhat-network-helpers/test/setup.ts
+++ b/packages/hardhat-network-helpers/test/setup.ts
@@ -2,3 +2,16 @@ import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 
 chai.use(chaiAsPromised);
+
+function getEnv(key: string): string | undefined {
+  const variable = process.env[key];
+  if (variable === undefined || variable === "") {
+    return undefined;
+  }
+
+  const trimmed = variable.trim();
+
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
+export const ALCHEMY_URL = getEnv("ALCHEMY_URL");


### PR DESCRIPTION
Add a `reset` helper without any parameters that resets the network to its initial configured state.

I'm nor sure about one aspect of this helper: if you didn't specify a block number in your config, then `helpers.reset()` will reset the network to the current safe block number, which will probably be different to the initial one. In other words, the behavior is just like killing the process and starting it again.

This makes sense conceptually, but at the same time I could see this being problematic, especially because the cache won't be leveraged in the second run.

For the record, this is the same behavior you get if you use `hardhat_reset` with an URL but without a block number.

Also for the record: I tried to implement the alternative behavior (resetting the network to whatever block number was initially used) but it wasn't an easy thing to do.