### PR TITLE
Issue #2170: New check for getContractAt()

### DIFF
--- a/.changeset/slimy-weeks-jump.md
+++ b/.changeset/slimy-weeks-jump.md
@@ -2,4 +2,4 @@
 "@nomiclabs/hardhat-ethers": patch
 ---
 
-getContractAt() now throws an error if the address is not a contract.
+getContractAt() now throws an error if the address is not of a contract.

--- a/.changeset/slimy-weeks-jump.md
+++ b/.changeset/slimy-weeks-jump.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-ethers": patch
+---
+
+getContractAt() now throws an error if the address is not a contract.

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -79,6 +79,8 @@ The [`Contract`s](https://docs.ethers.io/v5/single-page/#/v5/api/contract/contra
 
 If there is no signer available, `getContractAt` returns [read-only](https://docs.ethers.io/v5/single-page/#/v5/api/contract/contract/-%23-Contract--readonly) contracts.
 
+If a non-contract address is provided to `getContractAt`, an error will be thrown.
+
 ## Usage
 
 There are no additional steps you need to take for this plugin to work.

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -79,7 +79,7 @@ The [`Contract`s](https://docs.ethers.io/v5/single-page/#/v5/api/contract/contra
 
 If there is no signer available, `getContractAt` returns [read-only](https://docs.ethers.io/v5/single-page/#/v5/api/contract/contract/-%23-Contract--readonly) contracts.
 
-If a non-contract address is provided to `getContractAt`, an error will be thrown.
+If the address provided to `getContractAt` is not the address of a contract account, an error will be thrown.
 
 ## Usage
 

--- a/packages/hardhat-ethers/src/internal/helpers.ts
+++ b/packages/hardhat-ethers/src/internal/helpers.ts
@@ -303,6 +303,13 @@ export async function getContractAt(
   address: string,
   signer?: ethers.Signer
 ) {
+  if (await hre.ethers.provider.getCode(address) === "0x") {
+    throw new NomicLabsHardhatPluginError(
+      pluginName,
+      `${address} is a non-contract address.`
+    );
+  }
+
   if (typeof nameOrAbi === "string") {
     const artifact = await hre.artifacts.readArtifact(nameOrAbi);
 

--- a/packages/hardhat-ethers/src/internal/helpers.ts
+++ b/packages/hardhat-ethers/src/internal/helpers.ts
@@ -303,7 +303,7 @@ export async function getContractAt(
   address: string,
   signer?: ethers.Signer
 ) {
-  if (await hre.ethers.provider.getCode(address) === "0x") {
+  if ((await hre.ethers.provider.getCode(address)) === "0x") {
     throw new NomicLabsHardhatPluginError(
       pluginName,
       `${address} is a non-contract address.`

--- a/packages/hardhat-ethers/src/internal/helpers.ts
+++ b/packages/hardhat-ethers/src/internal/helpers.ts
@@ -306,7 +306,7 @@ export async function getContractAt(
   if ((await hre.ethers.provider.getCode(address)) === "0x") {
     throw new NomicLabsHardhatPluginError(
       pluginName,
-      `${address} is a non-contract address.`
+      `${address} is not a contract account.`
     );
   }
 

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -714,7 +714,7 @@ describe("Ethers plugin", function () {
             const address = await signers[0].getAddress();
             return assert.isRejected(
               this.env.ethers.getContractAt("Greeter", address),
-              `${address} is a non-contract address.`
+              `${address} is not a contract account.`
             );
           });
 

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -710,7 +710,7 @@ describe("Ethers plugin", function () {
         });
 
         describe("by name and address", function () {
-          it("Should throw if address is not a contract", async function () {
+          it("Should throw if address does not belong to a contract", async function () {
             const address = await signers[0].getAddress();
             return assert.isRejected(this.env.ethers.getContractAt(
               "Greeter",

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -712,10 +712,10 @@ describe("Ethers plugin", function () {
         describe("by name and address", function () {
           it("Should throw if address does not belong to a contract", async function () {
             const address = await signers[0].getAddress();
-            return assert.isRejected(this.env.ethers.getContractAt(
-              "Greeter",
-              address
-            ), `${address} is a non-contract address.`);
+            return assert.isRejected(
+              this.env.ethers.getContractAt("Greeter", address),
+              `${address} is a non-contract address.`
+            );
           });
 
           it("Should return an instance of a contract", async function () {

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -710,6 +710,14 @@ describe("Ethers plugin", function () {
         });
 
         describe("by name and address", function () {
+          it("Should throw if address is not a contract", async function () {
+            const address = await signers[0].getAddress();
+            return assert.isRejected(this.env.ethers.getContractAt(
+              "Greeter",
+              address
+            ), `${address} is a non-contract address.`);
+          });
+
           it("Should return an instance of a contract", async function () {
             const contract = await this.env.ethers.getContractAt(
               "Greeter",


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.

---

New feature. Was previously discussed in [Issue #2170](https://github.com/NomicFoundation/hardhat/issues/2170).
Adds a check for input address to `getContractAt()` — now it MUST have code (be a contract), otherwise function throws.

What was done:

- [x] Changes to the module itself
- [x] Test update
- [x] README update 

All tests run fine:

![image](https://user-images.githubusercontent.com/38407640/178115745-d8d8fc71-2484-4a43-8ba8-0e1c3a306597.png)

**Let me know if anything else is needed for submission :)**