### PR TITLE
Proof of concept for proper traces in chai matchers

### DIFF
--- a/packages/hardhat-chai-matchers/.eslintrc.js
+++ b/packages/hardhat-chai-matchers/.eslintrc.js
@@ -4,4 +4,7 @@ module.exports = {
     project: `${__dirname}/src/tsconfig.json`,
     sourceType: "module",
   },
+  rules: {
+    "@typescript-eslint/ban-types": "off"
+  }
 };

--- a/packages/hardhat-chai-matchers/src/internal/reverted/revertedWith.ts
+++ b/packages/hardhat-chai-matchers/src/internal/reverted/revertedWith.ts
@@ -1,45 +1,64 @@
+import { AssertionError } from "chai";
 import { decodeReturnData, getReturnDataFromError } from "./utils";
+
+const buildAssert =
+  (negated: boolean, ssfi: Function) =>
+  (condition: boolean, messageFalse: string, messageTrue?: string) => {
+    if (!negated && !condition) {
+      throw new AssertionError(messageFalse, undefined, ssfi);
+    }
+
+    if (negated && condition && messageTrue !== undefined) {
+      throw new AssertionError(messageTrue, undefined, ssfi);
+    }
+  };
 
 export function supportRevertedWith(Assertion: Chai.AssertionStatic) {
   Assertion.addMethod(
     "revertedWith",
     function (this: any, expectedReason: unknown) {
+      const negated = this.__flags.negate;
+
       // validate expected reason
       if (typeof expectedReason !== "string") {
         throw new TypeError("Expected the revert reason to be a string");
       }
 
       const onSuccess = () => {
-        this.assert(
+        const assert = buildAssert(negated, onSuccess);
+
+        assert(
           false,
           `Expected transaction to be reverted with reason '${expectedReason}', but it didn't revert`
         );
       };
 
       const onError = (error: any) => {
+        const assert = buildAssert(negated, onError);
+
         const returnData = getReturnDataFromError(error);
         const decodedReturnData = decodeReturnData(returnData);
 
         if (decodedReturnData.kind === "Empty") {
-          this.assert(
+          assert(
             false,
             `Expected transaction to be reverted with reason '${expectedReason}', but it reverted without a reason`
           );
         } else if (decodedReturnData.kind === "Error") {
-          this.assert(
+          assert(
             decodedReturnData.reason === expectedReason,
             `Expected transaction to be reverted with reason '${expectedReason}', but it reverted with reason '${decodedReturnData.reason}'`,
             `Expected transaction NOT to be reverted with reason '${expectedReason}', but it was`
           );
         } else if (decodedReturnData.kind === "Panic") {
-          this.assert(
+          assert(
             false,
             `Expected transaction to be reverted with reason '${expectedReason}', but it reverted with panic code ${decodedReturnData.code.toHexString()} (${
               decodedReturnData.description
             })`
           );
         } else if (decodedReturnData.kind === "Custom") {
-          this.assert(
+          assert(
             false,
             `Expected transaction to be reverted with reason '${expectedReason}', but it reverted with a custom error`
           );

--- a/packages/hardhat-chai-matchers/src/internal/withArgs.ts
+++ b/packages/hardhat-chai-matchers/src/internal/withArgs.ts
@@ -72,9 +72,9 @@ export function supportWithArgs(
 
     const promise = this.then === undefined ? Promise.resolve() : this;
 
-    const derivedPromise = promise.then(() => {
+    const onSuccess = () => {
       if (emitCalled) {
-        return emitWithArgs(this, Assertion, utils, expectedArgs);
+        return emitWithArgs(this, Assertion, utils, expectedArgs, onSuccess);
       } else {
         return revertedWithCustomErrorWithArgs(
           this,
@@ -83,7 +83,9 @@ export function supportWithArgs(
           expectedArgs
         );
       }
-    });
+    };
+
+    const derivedPromise = promise.then(onSuccess);
 
     this.then = derivedPromise.then.bind(derivedPromise);
     this.catch = derivedPromise.catch.bind(derivedPromise);


### PR DESCRIPTION
The code is a bit awful but keep in mind that, if we decide on doing this, it won't be _much_ better.

Stack traces sometimes look like this, which is ideal:

![image](https://user-images.githubusercontent.com/417134/178476442-476a9269-f80d-4a45-8d03-6ba06a64500d.png)

But sometimes look like this, which I couldn't improve and I guess it's acceptable:

![image](https://user-images.githubusercontent.com/417134/178477656-b7f2d6d8-6cf4-4d99-9a0d-d19a52b6f52a.png)
