### PR TITLE
Add support for Celoscan

### DIFF
--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -205,4 +205,18 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://explorer.pops.one",
     },
   },
+  alfajores: {
+    chainId: 44787,
+    urls: {
+      apiURL: "https://api-alfajores.celoscan.io/api",
+      browserURL: "https://alfajores.celoscan.io",
+    },
+  },
+  celo: {
+    chainId: 42220,
+    urls: {
+      apiURL: "https://api.celoscan.io/api",
+      browserURL: "https://celoscan.io/",
+    },
+  },
 };


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
--> #2932 
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
## What does this PR introduce?

Add support for Celo and Alfajores network, by adding the Celo and Alfajores chain specifications under`ChainConfig.ts`.

This is to enable to verify contracts deployed on Celo via the command:

`npx hardhat verify --network celo`