### PR TITLE
Loosen HH Network's error propagation heuristic

### DIFF
--- a/.changeset/fifty-jeans-double.md
+++ b/.changeset/fifty-jeans-double.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Better Solidity errors propagation

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/error-inferrer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/error-inferrer.ts
@@ -1586,6 +1586,12 @@ export class ErrorInferrer {
       return true;
     }
 
+    // If the return data is not empty, and it's still the same, we assume it
+    // is being propagated
+    if (trace.returnData.length > 0) {
+      return true;
+    }
+
     return this._failsRightAfterCall(trace, callSubtraceStepIndex);
   }
 

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_8/call-message/external-calls/asm-reverts-propagation/c.sol
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_8/call-message/external-calls/asm-reverts-propagation/c.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.8.0;
+
+contract A {
+  uint counter;
+
+  function a() external {
+    counter++;
+    revert("a reason");
+  }
+}
+
+contract C {
+  A a = new A();
+
+  function test() external {
+    (bool ok, bytes memory data) = address(a).call(bytes(hex"0dbe671f"));
+    if (!ok) {
+      assembly {
+        revert(add(32, data), mload(data))
+      }
+    }
+  }
+}

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_8/call-message/external-calls/asm-reverts-propagation/test.json
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_8/call-message/external-calls/asm-reverts-propagation/test.json
@@ -1,0 +1,33 @@
+{
+  "transactions": [
+    {
+      "file": "c.sol",
+      "contract": "C"
+    },
+    {
+      "to": 0,
+      "function": "test",
+      "stackTrace": [
+        {
+          "type": "CALLSTACK_ENTRY",
+          "sourceReference": {
+            "contract": "C",
+            "file": "c.sol",
+            "function": "test",
+            "line": 16
+          }
+        },
+        {
+          "type": "REVERT_ERROR",
+          "message": "a reason",
+          "sourceReference": {
+            "contract": "A",
+            "file": "c.sol",
+            "function": "a",
+            "line": 8
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
As shown in #2546, Hardhat Network can be too restrictive when deciding if an error is being propagated or not. In particular, it never considers asm-based manual propagation as actual propagation.

This PR loosens our heuristic significantly. If the previous heuristic fails, but the error of the trace and subtrace are equal and not empty, we still consider it to propagate.

There's a minor chance of this resulting in false positives, but I think it's reasonably small.

Another alternative is checking if the `return` opcode is inside of an inline assembly block, but to do that in a performant way we'd need to make a larger change.