### PR TITLE
updated peer dependencies for typescript sample project creation

### DIFF
--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -43,24 +43,24 @@ const PEER_DEPENDENCIES: Dependencies = {
   hardhat: "^2.9.9",
   "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
   "@nomicfoundation/hardhat-chai-matchers": "^1.0.0",
-  "@nomiclabs/hardhat-ethers": "^2.0.0",
-  "@nomiclabs/hardhat-etherscan": "^3.0.0",
-  chai: "^4.2.0",
-  ethers: "^5.4.7",
+  "@nomiclabs/hardhat-ethers": "^2.1.0",
+  "@nomiclabs/hardhat-etherscan": "^3.1.0",
+  chai: "^4.3.6",
+  ethers: "^5.6.9",
   "hardhat-gas-reporter": "^1.0.8",
   "solidity-coverage": "^0.7.21",
   "@typechain/hardhat": "^6.1.2",
   typechain: "^8.1.0",
   "@typechain/ethers-v5": "^10.1.0",
-  "@ethersproject/abi": "^5.4.7",
-  "@ethersproject/providers": "^5.4.7",
+  "@ethersproject/abi": "^5.6.4",
+  "@ethersproject/providers": "^5.6.8",
 };
 
 const TYPESCRIPT_DEPENDENCIES: Dependencies = {};
 
 const TYPESCRIPT_PEER_DEPENDENCIES: Dependencies = {
-  "@types/chai": "^4.2.0",
-  "@types/mocha": "^9.1.0",
+  "@types/chai": "^4.3.1",
+  "@types/mocha": "^9.1.1",
   "@types/node": ">=12.0.0",
   "ts-node": ">=8.0.0",
   typescript: ">=4.5.0",


### PR DESCRIPTION
I followed the steps exactly for a TypeScript project with hardhat here: https://hardhat.org/hardhat-runner/docs/getting-started. 

I copy and pasted the packages listed by the cli tool after running `npx hardhat`. Two of them don't exist according to npm, `@ethersproject/abi@^5.4.7" "@ethersproject/providers@^5.4.7`. I tried lowering the packages to 5.4.5, the latest 5.4, but received the following error:

```
test/Lock.ts:78:35 - error TS2345: Argument of type 'SignerWithAddress' is not assignable to parameter of type 'string | Signer | Provider'.
  Type 'SignerWithAddress' is not assignable to type 'Signer'.
    Types of property 'provider' are incompatible.
      Type 'import("C:/Users/bogan/Desktop/codingStuff/devmint/hardhatTest/node_modules/ethers/node_modules/@ethersproject/abstract-provider/lib/index").Provider | undefined' is not assignable to type 'import("C:/Users/bogan/Desktop        Type 'import("C:/Users/bogan/Desktop/codingStuff/devmint/hardhatTest/node_modules/ethers/node_modules/@ethersproject/abstract-provider/lib/index").Provider' is not assignable to type 'import("C:/Users/bogan/Desktop/codingStuff/devmint/hardhatTest/node_modules/@ethersproject/abstract-provider/lib/index").Provider'.
          The types returned by 'getBlock(...)' are incompatible between these types.
            Type 'Promise<import("C:/Users/bogan/Desktop/codingStuff/devmint/hardhatTest/node_modules/ethers/node_modules/@ethersproject/abstract-provider/lib/index").Block>' is not assignable to type 'Promise<import("C:/Users/bogan/Desktop/codingStuff/devmint/hardhatTest/node_modules/@ethersproject/abstract-provider/lib/index").Block>'.
              Property '_difficulty' is missing in type 'import("C:/Users/bogan/Desktop/codingStuff/devmint/hardhatTest/node_modules/ethers/node_modules/@ethersproject/abstract-provider/lib/index").Block' but required in type 'import("C:/Users/bogan/Desktop/codingStuff/devmint/hardhatTest/node_modules/@ethersproject/abstract-provider/lib/index").Block'.

78         await expect(lock.connect(otherAccount).withdraw()).to.be.revertedWith(
```

The tests did not pass until I ran `npm update`.  This pr updates the dependencies to the working versions.


<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
