### PR TITLE
Add Toolbox migration guide

### DIFF
--- a/packages/hardhat-toolbox/README.md
+++ b/packages/hardhat-toolbox/README.md
@@ -38,7 +38,7 @@ yarn add --dev @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-network
 
 Migrating an existing project to the Toolbox is easy:
 
-1. First, if you are using `hardhat-waffle`, we recommend you migrate to our [Hardhat Chai Matchers](https://next.hardhat.org/hardhat-chai-matchers). They are a drop-in replacement, so this should only take a few minutes. Learn how to do that [here](https://hardhat.org/hardhat-chai-matchers/docs/migrate-from-waffle).
+1. First, if you are using `hardhat-waffle`, we recommend you migrate to our [Hardhat Chai Matchers](https://hardhat.org/hardhat-chai-matchers). They are a drop-in replacement, so this should only take a few minutes. Learn how to do that [here](https://hardhat.org/hardhat-chai-matchers/docs/migrate-from-waffle).
 2. Install the toolbox and its dependencies. If you are using npm 7 or later, you just need to do `npm install --save-dev @nomicfoundation/hardhat-toolbox`. If not, check the [Installation section](#installation) above.
 3. Uninstall `@nomiclabs/hardhat-waffle` and `ethereum-waffle`, and remove the `@nomiclabs/hardhat-waffle` import from your Hardhat config.
 4. Import the Toolbox in your Hardhat config. This will make many other imports redundant, so you can remove any of these if you want:

--- a/packages/hardhat-toolbox/README.md
+++ b/packages/hardhat-toolbox/README.md
@@ -33,3 +33,18 @@ That's also the case if you are using yarn:
 ```
 yarn add --dev @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-network-helpers @nomicfoundation/hardhat-chai-matchers @nomiclabs/hardhat-ethers @nomiclabs/hardhat-etherscan chai ethers hardhat-gas-reporter solidity-coverage @typechain/hardhat typechain @typechain/ethers-v5 @ethersproject/abi @ethersproject/providers
 ```
+
+### Migrating to Hardhat Toolbox
+
+Migrating an existing project to the Toolbox is easy:
+
+1. First, if you are using `hardhat-waffle`, we recommend you migrate to our [Hardhat Chai Matchers](https://next.hardhat.org/hardhat-chai-matchers). They are a drop-in replacement, so this should only take a few minutes. Learn how to do that [here](https://hardhat.org/hardhat-chai-matchers/docs/migrate-from-waffle).
+2. Install the toolbox and its dependencies. If you are using npm 7 or later, you just need to do `npm install --save-dev @nomicfoundation/hardhat-toolbox`. If not, check the [Installation section](#installation) above.
+3. Uninstall `@nomiclabs/hardhat-waffle` and `ethereum-waffle`, and remove the `@nomiclabs/hardhat-waffle` import from your Hardhat config.
+4. Import the Toolbox in your Hardhat config. This will make many other imports redundant, so you can remove any of these if you want:
+
+   - `@nomiclabs/hardhat-ethers`
+   - `@nomiclabs/hardhat-etherscan`
+   - `hardhat-gas-reporter`
+   - `solidity-coverage`
+   - `@typechain/hardhat`

--- a/packages/hardhat-toolbox/src/index.ts
+++ b/packages/hardhat-toolbox/src/index.ts
@@ -1,5 +1,4 @@
 import "@nomicfoundation/hardhat-chai-matchers";
-import "@nomicfoundation/hardhat-network-helpers";
 import "@nomiclabs/hardhat-ethers";
 import "@nomiclabs/hardhat-etherscan";
 import "@typechain/hardhat";


### PR DESCRIPTION
I also noticed that we were importing the network helpers in the index of the plugin. I'm pretty sure that this is not necessary, so I removed it.