### PR TITLE
Add `--file` option in `compile` to compile specific script

### DIFF
--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -1322,7 +1322,7 @@ subtask(TASK_COMPILE_SOLIDITY)
           sourceNames = [file];
         } else {
           throw new HardhatError(ERRORS.RESOLVER.FILE_NOT_FOUND, {
-            file: file,
+            file,
           });
         }
       }


### PR DESCRIPTION
### Motivation
- When executing `hardhat compile`, a dependency graph is created based on the import of all solidity files in hardhat-core and compiled through solc.
- However, if there are a lot of solidity files like [contract-wizard](https://github.com/OpenZeppelin/contracts-wizard), even if only one file is modified, all files are compiled, so it takes a very long time to compile.
- In the current PR, an option called `--file` is added to the compile option and only specific files can be compiled through hardhat:
   ```shell
      npx hardhat compile --file contracts/path/path2/test.sol
   ```
- This is a huge speedup if you have a lot of contract files. For my code, I reduced the compile time by about 30x.

### Features
- [X] Add `--file` option in `compile` to compile specific script

