### PR TITLE
Add Fig as an autocomplete tip

### DIFF
--- a/docs/src/content/hardhat-runner/docs/getting-started/index.md
+++ b/docs/src/content/hardhat-runner/docs/getting-started/index.md
@@ -57,6 +57,16 @@ yarn add --dev hardhat
 
 To use your local installation of Hardhat, you need to use `npx` to run it (i.e. `npx hardhat`).
 
+:::tip
+
+You can get IDE-style autocompletions for hardhat with <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a> [Fig](https://fig.io/). It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
 ## Quick Start
 
 :::tip


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including hardhat. It looks like this:

<img width="405" alt="image" src="https://user-images.githubusercontent.com/4949076/181606530-1d3d7e38-74db-4b0e-ab3c-0c7fa2b7faf5.png">

We think this will help users become more efficient with hardhat CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!
