### PR TITLE
Update peer dependency to fix `hardhat/common` dep

### DIFF
--- a/.changeset/big-items-scream.md
+++ b/.changeset/big-items-scream.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Fix peer dependency on `hardhat` to pull in `hardhat/common`

--- a/packages/hardhat-network-helpers/package.json
+++ b/packages/hardhat-network-helpers/package.json
@@ -60,6 +60,6 @@
     "typescript": "~4.5.2"
   },
   "peerDependencies": {
-    "hardhat": "^2.0.0"
+    "hardhat": "^2.9.5"
   }
 }

--- a/packages/hardhat-network-helpers/package.json
+++ b/packages/hardhat-network-helpers/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-import": "2.24.1",
     "eslint-plugin-prettier": "3.4.0",
     "ethers": "^5.0.0",
-    "hardhat": "^2.0.0",
+    "hardhat": "^2.9.5",
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
The `@nomicfoundation/hardhat-network-helpers` module requires the
`hardhat/common` module at runtime. This was added to `hardhat` in
commit 6f5f2f8cd2bd ("Include common directory in the published files"),
which was first released in `hardhat@2.9.5`. The peer dependency should
reflect this so that adding `hardhat-network-helpers` to a project with
(say) `hardhat@2.9.3` doesn't silently produce a broken installation.

wchargin-branch: hardhat-common-peer-dep
