### PR TITLE
feat: Support .cts extension with ts-node 10+

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@changesets/cli": "^2.16.0",
     "prettier": "2.4.1",
     "shelljs": "^0.8.5",
-    "typescript": "~4.5.2",
+    "typescript": "~4.7.4",
     "wsrun": "^5.2.2"
   },
   "scripts": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -36,7 +36,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.5",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   }
 }

--- a/packages/hardhat-chai-matchers/package.json
+++ b/packages/hardhat-chai-matchers/package.json
@@ -57,8 +57,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",

--- a/packages/hardhat-core/.mocharc.json
+++ b/packages/hardhat-core/.mocharc.json
@@ -3,6 +3,7 @@
   "file": "./test/setup.ts",
   "exclude": [
     "test/fixture-projects/**/*.ts",
+    "test/fixture-projects/**/*.cts",
     "test/fixture-projects/**/*.js",
     "test/helpers/**/*.ts"
   ],

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -93,8 +93,8 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.0",
     "time-require": "^0.1.2",
-    "ts-node": "^10.9.1",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.1.2",

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -93,7 +93,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.0",
     "time-require": "^0.1.2",
-    "ts-node": "^8.1.0",
+    "ts-node": "^10.9.1",
     "typescript": "~4.5.2"
   },
   "dependencies": {

--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -165,6 +165,8 @@ export function analyzeModuleNotFoundError(error: any, configPath: string) {
   const throwingFile = stackTrace
     .filter((x) => x.file !== null)
     .map((x) => x.file!)
+    // ignore frames related to source map support
+    .filter((x) => !x.includes("@cspotcode/source-map-support"))
     .find((x) => path.isAbsolute(x));
 
   if (throwingFile === null || throwingFile === undefined) {

--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -166,7 +166,7 @@ export function analyzeModuleNotFoundError(error: any, configPath: string) {
     .filter((x) => x.file !== null)
     .map((x) => x.file!)
     // ignore frames related to source map support
-    .filter((x) => !x.includes("@cspotcode/source-map-support"))
+    .filter((x) => !x.includes(path.join("@cspotcode", "source-map-support")))
     .find((x) => path.isAbsolute(x));
 
   if (throwingFile === null || throwingFile === undefined) {

--- a/packages/hardhat-core/src/internal/core/project-structure.ts
+++ b/packages/hardhat-core/src/internal/core/project-structure.ts
@@ -18,14 +18,14 @@ export function isCwdInsideProject() {
 }
 
 export function getUserConfigPath() {
-  const tsConfigPath = findUp.sync(TS_CONFIG_FILENAME);
-  if (tsConfigPath !== null) {
-    return tsConfigPath;
-  }
-
   const ctsConfigPath = findUp.sync(CTS_CONFIG_FILENAME);
   if (ctsConfigPath !== null) {
     return ctsConfigPath;
+  }
+
+  const tsConfigPath = findUp.sync(TS_CONFIG_FILENAME);
+  if (tsConfigPath !== null) {
+    return tsConfigPath;
   }
 
   const pathToConfigFile = findUp.sync(JS_CONFIG_FILENAME);

--- a/packages/hardhat-core/src/internal/core/project-structure.ts
+++ b/packages/hardhat-core/src/internal/core/project-structure.ts
@@ -8,6 +8,7 @@ import { HardhatError } from "./errors";
 import { ERRORS } from "./errors-list";
 const JS_CONFIG_FILENAME = "hardhat.config.js";
 const TS_CONFIG_FILENAME = "hardhat.config.ts";
+const CTS_CONFIG_FILENAME = "hardhat.config.cts";
 
 export function isCwdInsideProject() {
   return (
@@ -20,6 +21,11 @@ export function getUserConfigPath() {
   const tsConfigPath = findUp.sync(TS_CONFIG_FILENAME);
   if (tsConfigPath !== null) {
     return tsConfigPath;
+  }
+
+  const ctsConfigPath = findUp.sync(CTS_CONFIG_FILENAME);
+  if (ctsConfigPath !== null) {
+    return ctsConfigPath;
   }
 
   const pathToConfigFile = findUp.sync(JS_CONFIG_FILENAME);

--- a/packages/hardhat-core/src/internal/core/typescript-support.ts
+++ b/packages/hardhat-core/src/internal/core/typescript-support.ts
@@ -81,5 +81,5 @@ export function loadTsNode(
 }
 
 function isTypescriptFile(path: string): boolean {
-  return path.endsWith(".ts");
+  return path.endsWith(".ts") || path.endsWith(".cts");
 }

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/consoleLogger.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/consoleLogger.ts
@@ -139,7 +139,7 @@ export class ConsoleLogger {
 
   private _decode(data: Buffer, types: string[]): ConsoleLogs {
     return types.map((type, i) => {
-      const position = i * 32;
+      const position: number = i * 32;
       switch (types[i]) {
         case Uint256Ty:
           return bufferToBigInt(

--- a/packages/hardhat-core/test/fixture-projects/typescript-esm-project/hardhat.config.cts
+++ b/packages/hardhat-core/test/fixture-projects/typescript-esm-project/hardhat.config.cts
@@ -1,0 +1,8 @@
+export default {
+  networks: {
+    network: {
+      url: "",
+    },
+  },
+  solidity: "0.5.15",
+};

--- a/packages/hardhat-core/test/fixture-projects/typescript-esm-project/package.json
+++ b/packages/hardhat-core/test/fixture-projects/typescript-esm-project/package.json
@@ -1,3 +1,3 @@
 {
-    "type": "module"
+  "type": "module"
 }

--- a/packages/hardhat-core/test/fixture-projects/typescript-esm-project/package.json
+++ b/packages/hardhat-core/test/fixture-projects/typescript-esm-project/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/packages/hardhat-core/test/fixture-projects/typescript-esm-project/tsconfig.json
+++ b/packages/hardhat-core/test/fixture-projects/typescript-esm-project/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "ESNext"
+    }
+}

--- a/packages/hardhat-core/test/fixture-projects/typescript-esm-project/tsconfig.json
+++ b/packages/hardhat-core/test/fixture-projects/typescript-esm-project/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "compilerOptions": {
-        "module": "ESNext"
-    }
+  "compilerOptions": {
+    "module": "ESNext"
+  }
 }

--- a/packages/hardhat-core/test/internal/core/typescript-support.ts
+++ b/packages/hardhat-core/test/internal/core/typescript-support.ts
@@ -33,6 +33,15 @@ describe("Typescript support", function () {
     });
   });
 
+  describe("hardhat.config.cts", function () {
+    useFixtureProject("typescript-esm-project");
+    useEnvironment();
+
+    it("Should load the config", function () {
+      assert.isDefined(this.env.config.networks.network);
+    });
+  });
+
   describe("Typescript scripts", function () {
     useFixtureProject("typescript-project");
     useEnvironment();

--- a/packages/hardhat-docker/package.json
+++ b/packages/hardhat-docker/package.json
@@ -44,8 +44,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {},
   "dependencies": {

--- a/packages/hardhat-ethers/package.json
+++ b/packages/hardhat-ethers/package.json
@@ -55,8 +55,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "ethers": "^5.0.0",

--- a/packages/hardhat-etherscan/package.json
+++ b/packages/hardhat-etherscan/package.json
@@ -67,8 +67,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "hardhat": "^2.0.4"

--- a/packages/hardhat-ganache/package.json
+++ b/packages/hardhat-ganache/package.json
@@ -55,8 +55,8 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-interface-builder": "^0.2.0",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "hardhat": "^2.0.0"

--- a/packages/hardhat-network-helpers/package.json
+++ b/packages/hardhat-network-helpers/package.json
@@ -56,8 +56,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "hardhat": "^2.9.5"

--- a/packages/hardhat-shorthand/package.json
+++ b/packages/hardhat-shorthand/package.json
@@ -48,8 +48,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "dependencies": {
     "@fvictorio/tabtab": "^0.0.3",

--- a/packages/hardhat-solhint/package.json
+++ b/packages/hardhat-solhint/package.json
@@ -53,8 +53,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "hardhat": "^2.0.0"

--- a/packages/hardhat-solpp/package.json
+++ b/packages/hardhat-solpp/package.json
@@ -53,8 +53,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "hardhat": "^2.0.0"

--- a/packages/hardhat-toolbox/package.json
+++ b/packages/hardhat-toolbox/package.json
@@ -60,9 +60,9 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "solidity-coverage": "^0.7.21",
-    "ts-node": "^8.1.0",
+    "ts-node": "^10.8.0",
     "typechain": "^8.1.0",
-    "typescript": "~4.5.2"
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "@ethersproject/abi": "^5.4.7",

--- a/packages/hardhat-truffle4/package.json
+++ b/packages/hardhat-truffle4/package.json
@@ -56,8 +56,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2",
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4",
     "web3": "^0.20.0"
   },
   "peerDependencies": {

--- a/packages/hardhat-truffle5/package.json
+++ b/packages/hardhat-truffle5/package.json
@@ -56,8 +56,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2",
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4",
     "web3": "^1.0.0-beta.36"
   },
   "peerDependencies": {

--- a/packages/hardhat-vyper/package.json
+++ b/packages/hardhat-vyper/package.json
@@ -55,8 +55,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "hardhat": "^2.8.3"

--- a/packages/hardhat-waffle/package.json
+++ b/packages/hardhat-waffle/package.json
@@ -50,8 +50,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2"
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4"
   },
   "peerDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",

--- a/packages/hardhat-web3-legacy/package.json
+++ b/packages/hardhat-web3-legacy/package.json
@@ -47,8 +47,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2",
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4",
     "web3": "^0.20.0"
   },
   "peerDependencies": {

--- a/packages/hardhat-web3/package.json
+++ b/packages/hardhat-web3/package.json
@@ -47,8 +47,8 @@
     "mocha": "^10.0.0",
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.5.2",
+    "ts-node": "^10.8.0",
+    "typescript": "~4.7.4",
     "web3": "^1.0.0-beta.36"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,6 +236,13 @@
     human-id "^1.0.2"
     prettier "^1.19.1"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@ensdomains/address-encoder@^0.1.7":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@ensdomains/address-encoder/-/address-encoder-0.1.9.tgz#f948c485443d9ef7ed2c0c4790e931c33334d02d"
@@ -767,6 +774,24 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
@@ -1319,6 +1344,26 @@
     lodash.merge "^4.6.2"
     strip-ansi "^4.0.0"
     strip-indent "^2.0.0"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
 "@typechain/ethers-v5@^10.1.0":
   version "10.1.0"
@@ -1901,6 +1946,11 @@ acorn-jsx@^5.0.0, acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^6.0.7:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
@@ -1910,6 +1960,11 @@ acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.4.1:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 address@^1.0.1:
   version "1.2.0"
@@ -3924,6 +3979,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@^2.1.0, cross-fetch@^2.1.1:
   version "2.2.6"
@@ -11129,6 +11189,25 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 ts-node@^8.1.0:
   version "8.10.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
@@ -11565,6 +11644,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10433,7 +10433,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.13, source-map-support@^0.5.17, source-map-support@^0.5.19:
+source-map-support@^0.5.13, source-map-support@^0.5.19:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -11189,7 +11189,7 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-ts-node@^10.9.1:
+ts-node@^10.8.0:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -11206,17 +11206,6 @@ ts-node@^10.9.1:
     diff "^4.0.1"
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
-    yn "3.1.1"
-
-ts-node@^8.1.0:
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
-  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
-  dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.17"
     yn "3.1.1"
 
 tsconfig-paths@^3.10.1:
@@ -11399,10 +11388,10 @@ typescript@^3.0.0:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@~4.5.2:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@~4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] I talked about the limitations in the ESM PR and suggestion in the ts-node transpile PR

---

<!-- Add a description of your PR here -->
Due to the way hardhat registers tasks, v3 can't support ESM (as I outlined at https://github.com/NomicFoundation/hardhat/pull/1994#issuecomment-972459102); however, TypeScript added ESM support and many projects are converting to ESM-only. The ts-node team added support for the `.cts` extension in https://github.com/TypeStrong/ts-node/pull/1694, which allows individual files to be resolved as commonjs (see https://github.com/TypeStrong/ts-node#module-type-overrides).

This change should allow a monorepo to become `"type": "module"` and still use hardhat in commonjs mode. 🎉 
