### PR TITLE
Update @ethersproject dependency versions

### DIFF
--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -52,8 +52,8 @@ const PEER_DEPENDENCIES: Dependencies = {
   "@typechain/hardhat": "^6.1.2",
   typechain: "^8.1.0",
   "@typechain/ethers-v5": "^10.1.0",
-  "@ethersproject/abi": "^5.4.7",
-  "@ethersproject/providers": "^5.4.7",
+  "@ethersproject/abi": "^5.6.4",
+  "@ethersproject/providers": "^5.6.8",
 };
 
 const TYPESCRIPT_DEPENDENCIES: Dependencies = {};


### PR DESCRIPTION
Was getting an error when running the command from:

You need to install these dependencies to run the sample project:
npm install --save-dev "hardhat@^2.9.9" "@nomicfoundation/hardhat-toolbox@^1.0.1" "@nomicfoundation/hardhat-network-helpers@^1.0.0" "@nomicfoundation/hardhat-chai-matchers@^1.0.0" "@nomiclabs/hardhat-ethers@^2.0.0" "@nomiclabs/hardhat-etherscan@^3.0.0" "chai@^4.2.0" "ethers@^5.4.7" "hardhat-gas-reporter@^1.0.8" "solidity-coverage@^0.7.21" "@typechain/hardhat@^6.1.2" "typechain@^8.1.0" "@typechain/ethers-v5@^10.1.0" "@ethersproject/abi@^5.4.7" "@ethersproject/providers@^5.4.7"

npm ERR! code ETARGET
npm ERR! notarget No matching version found for @ethersproject/abi@5.4.7.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

![Screenshot 2022-08-14 100441](https://user-images.githubusercontent.com/20736739/184528087-2389cc0d-d9ba-4ce4-adc4-2e397879530c.jpg)

--------------

Have updated @ethersproject/abi and @ethersproject/providers to the latest versions.