### PR TITLE
Remove yarn.lock in pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: |
             packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/artifacts
-          key: hardhat-network-stack-traces-tests-${{ hashFiles('yarn.lock') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/*.sol') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/test.json') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/**/*.ts') }}
+          key: hardhat-network-stack-traces-tests-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/*.sol') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/test.json') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/**/*.ts') }}
       - name: test
         env:
           DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true


### PR DESCRIPTION
This is the same change as in #3032, but for the pre-release workflow.