### PR TITLE
Remove unnecesary blocking operations

### DIFF
--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -1444,7 +1444,7 @@ async function invalidateCacheMissingArtifacts(
         )
       );
 
-      const missing = artifactsExist.find(([_, exists]) => exists);
+      const missing = artifactsExist.find(([_, exists]) => !exists);
       if (missing !== undefined) {
         log(
           `Invalidate cache for '${file.absolutePath}' because artifact '${missing[0]}' doesn't exist`

--- a/packages/hardhat-core/src/builtin-tasks/utils/solidity-files-cache.ts
+++ b/packages/hardhat-core/src/builtin-tasks/utils/solidity-files-cache.ts
@@ -57,7 +57,7 @@ export class SolidityFilesCache {
       _format: FORMAT_VERSION,
       files: {},
     };
-    if (fsExtra.existsSync(solidityFilesCachePath)) {
+    if (await fsExtra.pathExists(solidityFilesCachePath)) {
       cacheRaw = await fsExtra.readJson(solidityFilesCachePath);
     }
 
@@ -80,12 +80,13 @@ export class SolidityFilesCache {
   constructor(private _cache: Cache) {}
 
   public async removeNonExistingFiles() {
-    for (const absolutePath of Object.keys(this._cache.files)) {
-      if (!fsExtra.existsSync(absolutePath)) {
-        this.removeEntry(absolutePath);
-        continue;
-      }
-    }
+    await Promise.all(
+      Object.keys(this._cache.files).map(async (absolutePath) => {
+        if (!(await fsExtra.pathExists(absolutePath))) {
+          this.removeEntry(absolutePath);
+        }
+      })
+    );
   }
 
   public async writeToFile(solidityFilesCachePath: string) {

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -129,22 +129,24 @@ export class Artifacts implements IArtifacts {
 
     await fsExtra.ensureDir(path.dirname(artifactPath));
 
-    // write artifact
-    await fsExtra.writeJSON(artifactPath, artifact, {
-      spaces: 2,
-    });
+    await Promise.all([
+      fsExtra.writeJSON(artifactPath, artifact, {
+        spaces: 2,
+      }),
+      async () => {
+        if (pathToBuildInfo === undefined) {
+          return;
+        }
 
-    if (pathToBuildInfo === undefined) {
-      return;
-    }
+        // save debug file
+        const debugFilePath = this._getDebugFilePath(artifactPath);
+        const debugFile = this._createDebugFile(artifactPath, pathToBuildInfo);
 
-    // save debug file
-    const debugFilePath = this._getDebugFilePath(artifactPath);
-    const debugFile = this._createDebugFile(artifactPath, pathToBuildInfo);
-
-    await fsExtra.writeJSON(debugFilePath, debugFile, {
-      spaces: 2,
-    });
+        await fsExtra.writeJSON(debugFilePath, debugFile, {
+          spaces: 2,
+        });
+      },
+    ]);
   }
 
   public async saveBuildInfo(

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -133,7 +133,7 @@ export class Artifacts implements IArtifacts {
       fsExtra.writeJSON(artifactPath, artifact, {
         spaces: 2,
       }),
-      async () => {
+      (async () => {
         if (pathToBuildInfo === undefined) {
           return;
         }
@@ -145,7 +145,7 @@ export class Artifacts implements IArtifacts {
         await fsExtra.writeJSON(debugFilePath, debugFile, {
           spaces: 2,
         });
-      },
+      })(),
     ]);
   }
 

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -183,18 +183,14 @@ export class Artifacts implements IArtifacts {
    */
   public async removeObsoleteArtifacts() {
     const validArtifactPaths = await Promise.all(
-      this._validArtifacts.map(({ sourceName, artifacts }) =>
-        Promise.all(
-          artifacts.map((artifactName) =>
-            this._getArtifactPath(
-              getFullyQualifiedName(sourceName, artifactName)
-            )
-          )
+      this._validArtifacts.flatMap(({ sourceName, artifacts }) =>
+        artifacts.map((artifactName) =>
+          this._getArtifactPath(getFullyQualifiedName(sourceName, artifactName))
         )
       )
     );
 
-    const validArtifactsPathsSet = new Set<string>(...validArtifactPaths);
+    const validArtifactsPathsSet = new Set<string>(validArtifactPaths);
 
     for (const { sourceName, artifacts } of this._validArtifacts) {
       for (const artifactName of artifacts) {

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -254,7 +254,7 @@ export class Artifacts implements IArtifacts {
 
     await Promise.all(
       buildInfoFiles
-        .filter((buildInfoFile) => validBuildInfos.has(buildInfoFile))
+        .filter((buildInfoFile) => !validBuildInfos.has(buildInfoFile))
         .map(async (buildInfoFile) => {
           log(`Removing buildInfo '${buildInfoFile}'`);
           await fsExtra.unlink(buildInfoFile);

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -246,9 +246,11 @@ export class Artifacts implements IArtifacts {
       })
     );
 
-    const validBuildInfos = new Set<string>(
-      ...buildInfos.filter((bf) => bf !== undefined)
+    const filteredBuildInfos: string[] = buildInfos.filter(
+      (bf): bf is string => typeof bf === "string"
     );
+
+    const validBuildInfos = new Set<string>(filteredBuildInfos);
 
     const buildInfoFiles = await this.getBuildInfoPaths();
 

--- a/packages/hardhat-core/src/internal/solidity/dependencyGraph.ts
+++ b/packages/hardhat-core/src/internal/solidity/dependencyGraph.ts
@@ -9,9 +9,11 @@ export class DependencyGraph implements taskTypes.DependencyGraph {
   ): Promise<DependencyGraph> {
     const graph = new DependencyGraph();
 
-    for (const resolvedFile of resolvedFiles) {
-      await graph._addDependenciesFrom(resolver, resolvedFile);
-    }
+    await Promise.all(
+      resolvedFiles.map((resolvedFile) =>
+        graph._addDependenciesFrom(resolver, resolvedFile)
+      )
+    );
 
     return graph;
   }
@@ -167,11 +169,13 @@ export class DependencyGraph implements taskTypes.DependencyGraph {
     this._resolvedFiles.set(file.sourceName, file);
     this._dependenciesPerFile.set(file.sourceName, dependencies);
 
-    for (const imp of file.content.imports) {
-      const dependency = await resolver.resolveImport(file, imp);
-      dependencies.add(dependency);
+    await Promise.all(
+      file.content.imports.map(async (imp) => {
+        const dependency = await resolver.resolveImport(file, imp);
+        dependencies.add(dependency);
 
-      await this._addDependenciesFrom(resolver, dependency);
-    }
+        await this._addDependenciesFrom(resolver, dependency);
+      })
+    );
   }
 }


### PR DESCRIPTION
Third PR of the compilation times optimization effort.

This PR removes many blocking operations in favor of async ones. A common pattern here is changing an iteration for a `await Promise.all(arr.map(...))`.

I believe this PR is ready to review, as these are internal changes that probably don't require new tests.

Depends on https://github.com/NomicFoundation/hardhat/pull/3049