### PR TITLE
Optimized build info generation

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -22,7 +22,7 @@
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@types/shelljs": "^0.8.6",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-chai-matchers/package.json
+++ b/packages/hardhat-chai-matchers/package.json
@@ -41,7 +41,7 @@
     "@types/bn.js": "^5.1.0",
     "@types/chai": "^4.2.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "bignumber.js": "^9.0.2",

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -67,7 +67,7 @@
     "@types/glob": "^7.1.1",
     "@types/lodash": "^4.14.123",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@types/qs": "^6.5.3",
     "@types/resolve": "^1.17.1",
     "@types/semver": "^6.0.2",

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -185,7 +185,7 @@ export class Artifacts implements IArtifacts {
           ...buildInfo,
           output: undefined,
         });
-        await file.write(withoutOutput.substring(0, withoutOutput.length - 1));
+        await file.write(withoutOutput.slice(0, -1));
       }
 
       {

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -241,9 +241,11 @@ export class Artifacts implements IArtifacts {
         await file.write(`${JSON.stringify(name)}:${JSON.stringify(value)}`);
       }
 
+      // close contracts object
       await file.write("}");
-
+      // close output object
       await file.write("}");
+      // close build info object
       await file.write("}");
     } finally {
       await file.close();

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -189,6 +189,8 @@ export class Artifacts implements IArtifacts {
           ...buildInfo,
           output: undefined,
         });
+
+        // We write the JSON (without output) except the last }
         await file.write(withoutOutput.slice(0, -1));
       }
 
@@ -199,15 +201,20 @@ export class Artifacts implements IArtifacts {
           contracts: undefined,
         });
 
+        // We start writing the output
         await file.write(',"output":');
 
+        // Write the output object except for the last }
         await file.write(outputWithoutSourcesAndContracts.slice(0, 1));
 
+        // If there were other field apart from sources and contracts we need
+        // a comma
         if (outputWithoutSourcesAndContracts.length > 2) {
           await file.write(",");
         }
       }
 
+      // Writing the sources
       await file.write('"sources":{');
 
       let isFirst = true;
@@ -223,8 +230,10 @@ export class Artifacts implements IArtifacts {
         await file.write(`${JSON.stringify(name)}:${JSON.stringify(value)}`);
       }
 
+      // Close sources object
       await file.write("}");
 
+      // Writing the contracts
       await file.write(',"contracts":{');
 
       isFirst = true;

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -178,6 +178,10 @@ export class Artifacts implements IArtifacts {
     // JSON.stringify of the entire build info can be really slow
     // in larger projects, so we stringify per part and incrementally create
     // the JSON in the file.
+    //
+    // We split this code into different curly-brace-enclosed scopes so that
+    // partial JSON strings get out of scope sooner and hence can be reclaimed
+    // by the GC if needed.
     const file = await fsPromises.open(buildInfoPath, "w");
     try {
       {

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -205,7 +205,7 @@ export class Artifacts implements IArtifacts {
         await file.write(',"output":');
 
         // Write the output object except for the last }
-        await file.write(outputWithoutSourcesAndContracts.slice(0, 1));
+        await file.write(outputWithoutSourcesAndContracts.slice(0, -1));
 
         // If there were other field apart from sources and contracts we need
         // a comma

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -197,12 +197,7 @@ export class Artifacts implements IArtifacts {
 
         await file.write(',"output":');
 
-        await file.write(
-          outputWithoutSourcesAndContracts.substring(
-            0,
-            outputWithoutSourcesAndContracts.length - 1
-          )
-        );
+        await file.write(outputWithoutSourcesAndContracts.slice(0, 1));
 
         if (outputWithoutSourcesAndContracts.length > 2) {
           await file.write(",");

--- a/packages/hardhat-core/src/internal/util/scripts-runner.ts
+++ b/packages/hardhat-core/src/internal/util/scripts-runner.ts
@@ -33,7 +33,7 @@ export async function runScript(
     });
 
     childProcess.once("close", (status) => {
-      log(`Script ${scriptPath} exited with status code ${status}`);
+      log(`Script ${scriptPath} exited with status code ${status ?? "null"}`);
 
       resolve(status as number);
     });

--- a/packages/hardhat-core/test/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/test/builtin-tasks/compile.ts
@@ -54,7 +54,7 @@ describe("compile task", function () {
     useFixtureProject("compilation-empty-file");
     useEnvironment();
 
-    it("should compile and emit build info file but no artifacts", async function () {
+    it("should compile and emit no artifact", async function () {
       await this.env.run("compile");
 
       // the artifacts directory only has the build-info directory
@@ -62,9 +62,7 @@ describe("compile task", function () {
       assert.lengthOf(artifactsDirectory, 1);
 
       const buildInfos = globSync("artifacts/build-info/*.json");
-      assert.lengthOf(buildInfos, 1);
-
-      assertValidJson(buildInfos[0]);
+      assert.lengthOf(buildInfos, 0);
     });
   });
 

--- a/packages/hardhat-core/test/fixture-projects/compilation-empty-file/.gitignore
+++ b/packages/hardhat-core/test/fixture-projects/compilation-empty-file/.gitignore
@@ -1,0 +1,2 @@
+artifacts/
+cache/

--- a/packages/hardhat-core/test/fixture-projects/compilation-empty-file/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/compilation-empty-file/hardhat.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  solidity: "0.5.15",
+};

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/.gitignore
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/.gitignore
@@ -1,0 +1,2 @@
+artifacts/
+cache/

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A1.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A1.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A10.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A10.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A100.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A100.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A11.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A11.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A12.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A12.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A13.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A13.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A14.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A14.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A15.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A15.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A16.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A16.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A17.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A17.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A18.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A18.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A19.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A19.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A2.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A2.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A20.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A20.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A21.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A21.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A22.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A22.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A23.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A23.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A24.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A24.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A25.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A25.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A26.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A26.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A27.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A27.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A28.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A28.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A29.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A29.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A3.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A3.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A30.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A30.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A31.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A31.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A32.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A32.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A33.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A33.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A34.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A34.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A35.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A35.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A36.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A36.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A37.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A37.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A38.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A38.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A39.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A39.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A4.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A4.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A40.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A40.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A41.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A41.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A42.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A42.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A43.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A43.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A44.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A44.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A45.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A45.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A46.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A46.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A47.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A47.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A48.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A48.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A49.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A49.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A5.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A5.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A50.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A50.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A51.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A51.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A52.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A52.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A53.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A53.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A54.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A54.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A55.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A55.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A56.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A56.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A57.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A57.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A58.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A58.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A59.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A59.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A6.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A6.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A60.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A60.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A61.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A61.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A62.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A62.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A63.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A63.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A64.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A64.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A65.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A65.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A66.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A66.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A67.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A67.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A68.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A68.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A69.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A69.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A7.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A7.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A70.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A70.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A71.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A71.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A72.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A72.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A73.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A73.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A74.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A74.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A75.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A75.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A76.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A76.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A77.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A77.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A78.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A78.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A79.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A79.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A8.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A8.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A80.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A80.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A81.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A81.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A82.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A82.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A83.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A83.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A84.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A84.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A85.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A85.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A86.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A86.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A87.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A87.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A88.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A88.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A89.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A89.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A9.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A9.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A90.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A90.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A91.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A91.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A92.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A92.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A93.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A93.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A94.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A94.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A95.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A95.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A96.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A96.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A97.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A97.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A98.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A98.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A99.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/contracts/A99.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.5.1;
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-many-files/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/compilation-many-files/hardhat.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  solidity: "0.5.15",
+};

--- a/packages/hardhat-core/test/fixture-projects/compilation-single-file-many-contracts/.gitignore
+++ b/packages/hardhat-core/test/fixture-projects/compilation-single-file-many-contracts/.gitignore
@@ -1,0 +1,2 @@
+artifacts/
+cache/

--- a/packages/hardhat-core/test/fixture-projects/compilation-single-file-many-contracts/contracts/A.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-single-file-many-contracts/contracts/A.sol
@@ -1,0 +1,1301 @@
+pragma solidity ^0.5.1;
+
+contract A1 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A2 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A3 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A4 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A5 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A6 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A7 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A8 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A9 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A10 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A11 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A12 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A13 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A14 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A15 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A16 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A17 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A18 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A19 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A20 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A21 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A22 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A23 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A24 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A25 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A26 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A27 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A28 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A29 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A30 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A31 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A32 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A33 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A34 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A35 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A36 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A37 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A38 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A39 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A40 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A41 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A42 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A43 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A44 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A45 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A46 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A47 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A48 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A49 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A50 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A51 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A52 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A53 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A54 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A55 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A56 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A57 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A58 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A59 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A60 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A61 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A62 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A63 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A64 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A65 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A66 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A67 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A68 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A69 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A70 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A71 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A72 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A73 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A74 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A75 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A76 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A77 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A78 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A79 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A80 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A81 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A82 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A83 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A84 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A85 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A86 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A87 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A88 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A89 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A90 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A91 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A92 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A93 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A94 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A95 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A96 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A97 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A98 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A99 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}
+
+contract A100 {
+  uint public x1; uint public x2; uint public x3; uint public x4; uint public x5; uint public x6; uint public x7; uint public x8; uint public x9; uint public x10;
+  uint public x11; uint public x12; uint public x13; uint public x14; uint public x15; uint public x16; uint public x17; uint public x18; uint public x19; uint public x20;
+  uint public x21; uint public x22; uint public x23; uint public x24; uint public x25; uint public x26; uint public x27; uint public x28; uint public x29; uint public x30;
+  uint public x31; uint public x32; uint public x33; uint public x34; uint public x35; uint public x36; uint public x37; uint public x38; uint public x39; uint public x40;
+  uint public x41; uint public x42; uint public x43; uint public x44; uint public x45; uint public x46; uint public x47; uint public x48; uint public x49; uint public x50;
+  uint public x51; uint public x52; uint public x53; uint public x54; uint public x55; uint public x56; uint public x57; uint public x58; uint public x59; uint public x60;
+  uint public x61; uint public x62; uint public x63; uint public x64; uint public x65; uint public x66; uint public x67; uint public x68; uint public x69; uint public x70;
+  uint public x71; uint public x72; uint public x73; uint public x74; uint public x75; uint public x76; uint public x77; uint public x78; uint public x79; uint public x80;
+  uint public x81; uint public x82; uint public x83; uint public x84; uint public x85; uint public x86; uint public x87; uint public x88; uint public x89; uint public x90;
+  uint public x91; uint public x92; uint public x93; uint public x94; uint public x95; uint public x96; uint public x97; uint public x98; uint public x99; uint public x100;
+}

--- a/packages/hardhat-core/test/fixture-projects/compilation-single-file-many-contracts/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/compilation-single-file-many-contracts/hardhat.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  solidity: "0.5.15",
+};

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -8,7 +8,7 @@ import {
   getArtifactFromContractOutput,
 } from "../../src/internal/artifacts";
 import { ERRORS } from "../../src/internal/core/errors-list";
-import { Artifact } from "../../src/types";
+import { Artifact, CompilerInput, CompilerOutput } from "../../src/types";
 import { getFullyQualifiedName } from "../../src/utils/contract-names";
 import { expectHardhatError, expectHardhatErrorAsync } from "../helpers/errors";
 import { useTmpDir } from "../helpers/fs";
@@ -907,6 +907,100 @@ describe("Artifacts class", function () {
 
       // -2 because of the ones that we tested above that are equal
       assert.equal(new Set(allPaths).size, allPaths.length - 2);
+    });
+
+    it("Should be able to save build-infos with partial fields", async function () {
+      const artifacts = new Artifacts(this.tmpDir);
+
+      async function assertBuildInfoIsCorrectylSavedAndHasTheRightOutput<
+        OutputT extends CompilerOutput
+      >(solcOutput: OutputT) {
+        const solcInput: CompilerInput = {
+          language: "solidity",
+          sources: {},
+          settings: {
+            optimizer: {},
+            outputSelection: {},
+          },
+        };
+
+        const buildInfoPath = await artifacts.saveBuildInfo(
+          "0.4.12",
+          "0.4.12+asd",
+          solcInput,
+          solcOutput
+        );
+        const read = await fsExtra.readJSON(buildInfoPath);
+        assert.deepEqual(read.output, solcOutput);
+      }
+
+      // empty sources and contracts
+      await assertBuildInfoIsCorrectylSavedAndHasTheRightOutput({
+        sources: {},
+        contracts: {},
+      });
+
+      // with unrelated data
+      await assertBuildInfoIsCorrectylSavedAndHasTheRightOutput({
+        sources: {},
+        contracts: {},
+        otherStuff: { a: 1 },
+      });
+
+      // with a single source
+      await assertBuildInfoIsCorrectylSavedAndHasTheRightOutput({
+        sources: { a: { id: 123, ast: {} } },
+        contracts: {},
+      });
+
+      // with a multiple sources
+      await assertBuildInfoIsCorrectylSavedAndHasTheRightOutput({
+        sources: { a: { id: 123, ast: {} }, b: { id: 1, ast: { asdas: 123 } } },
+        contracts: {},
+      });
+
+      const contract = {
+        abi: [],
+        evm: {
+          bytecode: {
+            object: "123",
+            sourceMap: "asd",
+            opcodes: "123asd",
+            linkReferences: {},
+          },
+          deployedBytecode: {
+            object: "123",
+            sourceMap: "asd",
+            opcodes: "123asd",
+            linkReferences: {},
+          },
+          methodIdentifiers: {},
+        },
+      };
+
+      // with a single contract
+      await assertBuildInfoIsCorrectylSavedAndHasTheRightOutput({
+        sources: {},
+        contracts: {
+          asd: {
+            C: contract,
+          },
+        },
+      });
+
+      // with multiple contracts
+      await assertBuildInfoIsCorrectylSavedAndHasTheRightOutput({
+        sources: {},
+        contracts: {
+          asd: {
+            C: contract,
+            B: contract,
+          },
+          f: {
+            F: contract,
+          },
+        },
+      });
     });
   });
 });

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -766,8 +766,8 @@ describe("Artifacts class", function () {
 
       const solcVersion = "0.5.6";
       const solcLongVersion = "0.5.6+12321";
-      const solcInput = { input: true } as any;
-      const solcOutput = { output: true } as any;
+      const solcInput = { input: {} } as any;
+      const solcOutput = { sources: {}, contracts: {} } as any;
 
       const buildInfoPath = await artifacts.saveBuildInfo(
         solcVersion,

--- a/packages/hardhat-core/test/utils/json.ts
+++ b/packages/hardhat-core/test/utils/json.ts
@@ -1,0 +1,12 @@
+import { assert } from "chai";
+import fs from "fs";
+
+export function assertValidJson(pathToJson: string) {
+  const content = fs.readFileSync(pathToJson).toString();
+
+  try {
+    JSON.parse(content);
+  } catch (e) {
+    assert.fail(`Invalid json file: ${pathToJson}`);
+  }
+}

--- a/packages/hardhat-docker/package.json
+++ b/packages/hardhat-docker/package.json
@@ -33,7 +33,7 @@
     "@types/dockerode": "^2.5.19",
     "@types/fs-extra": "^5.1.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-ethers/package.json
+++ b/packages/hardhat-ethers/package.json
@@ -41,7 +41,7 @@
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^7.1.3",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-etherscan/package.json
+++ b/packages/hardhat-etherscan/package.json
@@ -53,7 +53,7 @@
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@types/semver": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",

--- a/packages/hardhat-ganache/package.json
+++ b/packages/hardhat-ganache/package.json
@@ -42,7 +42,7 @@
     "@types/debug": "^4.1.4",
     "@types/fs-extra": "^5.1.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-network-helpers/package.json
+++ b/packages/hardhat-network-helpers/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-shorthand/package.json
+++ b/packages/hardhat-shorthand/package.json
@@ -36,7 +36,7 @@
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-solhint/package.json
+++ b/packages/hardhat-solhint/package.json
@@ -40,7 +40,7 @@
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-solpp/package.json
+++ b/packages/hardhat-solpp/package.json
@@ -41,7 +41,7 @@
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-toolbox/package.json
+++ b/packages/hardhat-toolbox/package.json
@@ -45,7 +45,7 @@
     "@typechain/hardhat": "^6.1.2",
     "@types/chai": "^4.2.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-truffle4/package.json
+++ b/packages/hardhat-truffle4/package.json
@@ -44,7 +44,7 @@
     "@types/fs-extra": "^5.1.0",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-truffle5/package.json
+++ b/packages/hardhat-truffle5/package.json
@@ -44,7 +44,7 @@
     "@types/fs-extra": "^5.1.0",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-vyper/package.json
+++ b/packages/hardhat-vyper/package.json
@@ -43,7 +43,7 @@
     "@types/fs-extra": "^5.1.0",
     "@types/lodash": "^4.14.123",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-waffle/package.json
+++ b/packages/hardhat-waffle/package.json
@@ -36,7 +36,7 @@
     "@types/chai": "^4.2.0",
     "@types/fs-extra": "^5.1.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-web3-legacy/package.json
+++ b/packages/hardhat-web3-legacy/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/packages/hardhat-web3/package.json
+++ b/packages/hardhat-web3/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "4.29.2",
     "@typescript-eslint/parser": "4.29.2",
     "chai": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,10 +1397,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
-"@types/node@^12.0.0", "@types/node@^12.12.6", "@types/node@^12.7.1":
+"@types/node@^12.12.6", "@types/node@^12.7.1":
   version "12.20.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
+"@types/node@^14.0.0":
+  version "14.18.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.22.tgz#fd2a15dca290fc9ad565b672fde746191cd0c6e6"
+  integrity sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw==
 
 "@types/node@^8.0.0":
   version "8.10.66"


### PR DESCRIPTION
Fourth PR of the compilation times optimization effort.

This PR optimizes how build info files are stored. The way it works is by incrementally generating the JSON and saving it into the FS. The reason this is faster is that node.js is very slow with huge strings, and the build info can be >100mb.

This saved ~0.5s in Open Zeppelin Contracts.

WIP: This requires tests, as it's not a trivial operation. We should check that the JSON is correctly created, especially under edgecases (e.g. files without contracts).

Depends on https://github.com/NomicFoundation/hardhat/pull/3050