### PR TITLE
Misc optimizations

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -138,7 +138,6 @@
     "solc": "0.7.3",
     "source-map-support": "^0.5.13",
     "stacktrace-parser": "^0.1.10",
-    "true-case-path": "^2.2.1",
     "tsort": "0.0.1",
     "undici": "^5.4.0",
     "uuid": "^8.3.2",

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -134,7 +134,6 @@
     "raw-body": "^2.4.1",
     "resolve": "1.17.0",
     "semver": "^6.3.0",
-    "slash": "^3.0.0",
     "solc": "0.7.3",
     "source-map-support": "^0.5.13",
     "stacktrace-parser": "^0.1.10",

--- a/packages/hardhat-core/sample-projects/javascript/contracts/Lock.sol
+++ b/packages/hardhat-core/sample-projects/javascript/contracts/Lock.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.9;
 
 // Import this file to use console.log
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 contract Lock {
     uint public unlockTime;
@@ -21,7 +21,7 @@ contract Lock {
     }
 
     function withdraw() public {
-        // Uncomment this line to print a log in your terminal
+        // Uncomment this line and the import to "hardhat/console.sol" to print a log in your terminal
         // console.log("Unlock time is %o and block timestamp is %o", unlockTime, block.timestamp);
 
         require(block.timestamp >= unlockTime, "You can't withdraw yet");

--- a/packages/hardhat-core/sample-projects/javascript/contracts/Lock.sol
+++ b/packages/hardhat-core/sample-projects/javascript/contracts/Lock.sol
@@ -21,7 +21,7 @@ contract Lock {
     }
 
     function withdraw() public {
-        // Uncomment this line and the import to "hardhat/console.sol" to print a log in your terminal
+        // Uncomment this line, and the import of "hardhat/console.sol", to print a log in your terminal
         // console.log("Unlock time is %o and block timestamp is %o", unlockTime, block.timestamp);
 
         require(block.timestamp >= unlockTime, "You can't withdraw yet");

--- a/packages/hardhat-core/sample-projects/javascript/contracts/Lock.sol
+++ b/packages/hardhat-core/sample-projects/javascript/contracts/Lock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.9;
 
-// Import this file to use console.log
+// Uncomment this line to use console.log
 // import "hardhat/console.sol";
 
 contract Lock {

--- a/packages/hardhat-core/sample-projects/typescript/contracts/Lock.sol
+++ b/packages/hardhat-core/sample-projects/typescript/contracts/Lock.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.9;
 
 // Import this file to use console.log
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 contract Lock {
     uint public unlockTime;
@@ -21,7 +21,7 @@ contract Lock {
     }
 
     function withdraw() public {
-        // Uncomment this line to print a log in your terminal
+        // Uncomment this line and the import to "hardhat/console.sol" to print a log in your terminal
         // console.log("Unlock time is %o and block timestamp is %o", unlockTime, block.timestamp);
 
         require(block.timestamp >= unlockTime, "You can't withdraw yet");

--- a/packages/hardhat-core/sample-projects/typescript/contracts/Lock.sol
+++ b/packages/hardhat-core/sample-projects/typescript/contracts/Lock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.9;
 
-// Import this file to use console.log
+// Uncomment this line to use console.log
 // import "hardhat/console.sol";
 
 contract Lock {
@@ -21,7 +21,7 @@ contract Lock {
     }
 
     function withdraw() public {
-        // Uncomment this line and the import to "hardhat/console.sol" to print a log in your terminal
+        // Uncomment this line, and the import of "hardhat/console.sol", to print a log in your terminal
         // console.log("Unlock time is %o and block timestamp is %o", unlockTime, block.timestamp);
 
         require(block.timestamp >= unlockTime, "You can't withdraw yet");

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -2,7 +2,6 @@ import os from "os";
 import chalk from "chalk";
 import debug from "debug";
 import fsExtra from "fs-extra";
-import path from "path";
 import semver from "semver";
 import AggregateError from "aggregate-error";
 
@@ -27,7 +26,6 @@ import {
 import { DependencyGraph } from "../internal/solidity/dependencyGraph";
 import { Parser } from "../internal/solidity/parse";
 import { ResolvedFile, Resolver } from "../internal/solidity/resolver";
-import { glob } from "../internal/util/glob";
 import { getCompilersDir } from "../internal/util/global-dir";
 import { pluralize } from "../internal/util/strings";
 import { Artifacts, CompilerInput, CompilerOutput, SolcBuild } from "../types";
@@ -41,6 +39,7 @@ import {
 import { getFullyQualifiedName } from "../utils/contract-names";
 import { localPathToSourceName } from "../utils/source-names";
 
+import { getAllFilesMatching } from "../internal/util/fs-utils";
 import {
   TASK_COMPILE,
   TASK_COMPILE_GET_COMPILATION_TASKS,
@@ -116,7 +115,9 @@ const DEFAULT_CONCURRENCY_LEVEL = Math.max(os.cpus().length - 1, 1);
 subtask(
   TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS,
   async (_, { config }): Promise<string[]> => {
-    const paths = await glob(path.join(config.paths.sources, "**/*.sol"));
+    const paths = await getAllFilesMatching(config.paths.sources, (f) =>
+      f.endsWith(".sol")
+    );
 
     return paths;
   }

--- a/packages/hardhat-core/src/builtin-tasks/flatten.ts
+++ b/packages/hardhat-core/src/builtin-tasks/flatten.ts
@@ -1,5 +1,3 @@
-import * as fs from "fs";
-
 import { subtask, task, types } from "../internal/core/config/config-env";
 import { HardhatError } from "../internal/core/errors";
 import { ERRORS } from "../internal/core/errors-list";
@@ -7,6 +5,7 @@ import { DependencyGraph } from "../internal/solidity/dependencyGraph";
 import { ResolvedFile, ResolvedFilesMap } from "../internal/solidity/resolver";
 import { getPackageJson } from "../internal/util/packageInfo";
 
+import { getRealPathSync } from "../internal/util/fs-utils";
 import {
   TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
   TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES,
@@ -97,7 +96,7 @@ subtask(TASK_FLATTEN_GET_DEPENDENCY_GRAPH)
     const sourcePaths: string[] =
       files === undefined
         ? await run(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS)
-        : files.map((f) => fs.realpathSync(f));
+        : files.map((f) => getRealPathSync(f));
 
     const sourceNames: string[] = await run(
       TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES,

--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -8,8 +8,8 @@ import { subtask, task } from "../internal/core/config/config-env";
 import { isRunningWithTypescript } from "../internal/core/typescript-support";
 import { getForkCacheDirPath } from "../internal/hardhat-network/provider/utils/disk-cache";
 import { showForkRecommendationsBannerIfNecessary } from "../internal/hardhat-network/provider/utils/fork-recomendations-banner";
-import { glob } from "../internal/util/glob";
 import { pluralize } from "../internal/util/strings";
+import { getAllFilesMatching } from "../internal/util/fs-utils";
 
 import {
   TASK_COMPILE,
@@ -35,13 +35,17 @@ subtask(TASK_TEST_GET_TEST_FILES)
       return testFilesAbsolutePaths;
     }
 
-    const jsFiles = await glob(path.join(config.paths.tests, "**/*.js"));
+    const jsFiles = await getAllFilesMatching(config.paths.tests, (f) =>
+      f.endsWith("**/*.js")
+    );
 
     if (!isRunningWithTypescript(config)) {
       return jsFiles;
     }
 
-    const tsFiles = await glob(path.join(config.paths.tests, "**/*.ts"));
+    const tsFiles = await getAllFilesMatching(config.paths.tests, (f) =>
+      f.endsWith("**/*.ts")
+    );
 
     return [...jsFiles, ...tsFiles];
   });

--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -36,7 +36,7 @@ subtask(TASK_TEST_GET_TEST_FILES)
     }
 
     const jsFiles = await getAllFilesMatching(config.paths.tests, (f) =>
-      f.endsWith("**/*.js")
+      f.endsWith(".js")
     );
 
     if (!isRunningWithTypescript(config)) {
@@ -44,7 +44,7 @@ subtask(TASK_TEST_GET_TEST_FILES)
     }
 
     const tsFiles = await getAllFilesMatching(config.paths.tests, (f) =>
-      f.endsWith("**/*.ts")
+      f.endsWith(".ts")
     );
 
     return [...jsFiles, ...tsFiles];

--- a/packages/hardhat-core/src/builtin-tasks/utils/solidity-files-cache.ts
+++ b/packages/hardhat-core/src/builtin-tasks/utils/solidity-files-cache.ts
@@ -116,7 +116,7 @@ export class SolidityFilesCache {
     contentHash: string,
     solcConfig?: SolcConfig
   ): boolean {
-    const { isEqual }: LoDashStatic = require("lodash");
+    const isEqual = require("lodash/isEqual") as LoDashStatic["isEqual"];
 
     const cacheEntry = this.getEntry(absolutePath);
 

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -64,12 +64,8 @@ export class Artifacts implements IArtifacts {
   }
 
   public async artifactExists(name: string): Promise<boolean> {
-    try {
-      await this.readArtifact(name);
-      return true;
-    } catch {
-      return false;
-    }
+    const artifactPath = await this._getArtifactPath(name);
+    return fsExtra.pathExists(artifactPath);
   }
 
   public async getAllFullyQualifiedNames(): Promise<string[]> {

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -472,8 +472,6 @@ export class Artifacts implements IArtifacts {
         )
       );
 
-      console.log({ trueCasePath, artifactPath });
-
       if (artifactPath !== trueCasePath) {
         throw new HardhatError(ERRORS.ARTIFACTS.WRONG_CASING, {
           correct: this._getFullyQualifiedNameFromPath(trueCasePath),

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -34,8 +34,8 @@ import {
   FileNotFoundError,
   getAllFilesMatching,
   getAllFilesMatchingSync,
-  getRealCase,
-  getRealCaseSync,
+  getFileTrueCase,
+  getFileTrueCaseSync,
 } from "./util/fs-utils";
 
 const log = debug("hardhat:core:artifacts");
@@ -464,16 +464,24 @@ export class Artifacts implements IArtifacts {
       this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
 
     try {
-      const realCasePath = await getRealCase(artifactPath);
+      const trueCasePath = path.join(
+        this._artifactsPath,
+        await getFileTrueCase(
+          this._artifactsPath,
+          path.relative(this._artifactsPath, artifactPath)
+        )
+      );
 
-      if (artifactPath !== realCasePath) {
+      console.log({ trueCasePath, artifactPath });
+
+      if (artifactPath !== trueCasePath) {
         throw new HardhatError(ERRORS.ARTIFACTS.WRONG_CASING, {
-          correct: realCasePath,
-          incorrect: artifactPath,
+          correct: this._getFullyQualifiedNameFromPath(trueCasePath),
+          incorrect: fullyQualifiedName,
         });
       }
 
-      return artifactPath;
+      return trueCasePath;
     } catch (e) {
       if (e instanceof FileNotFoundError) {
         return this._handleWrongArtifactForFullyQualifiedName(
@@ -629,16 +637,22 @@ Please replace "${contractName}" for the correct contract name wherever you are 
       this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
 
     try {
-      const realCasePath = getRealCaseSync(artifactPath);
+      const trueCasePath = path.join(
+        this._artifactsPath,
+        getFileTrueCaseSync(
+          this._artifactsPath,
+          path.relative(this._artifactsPath, artifactPath)
+        )
+      );
 
-      if (artifactPath !== realCasePath) {
+      if (artifactPath !== trueCasePath) {
         throw new HardhatError(ERRORS.ARTIFACTS.WRONG_CASING, {
-          correct: realCasePath,
-          incorrect: artifactPath,
+          correct: this._getFullyQualifiedNameFromPath(trueCasePath),
+          incorrect: fullyQualifiedName,
         });
       }
 
-      return artifactPath;
+      return trueCasePath;
     } catch (e) {
       if (e instanceof FileNotFoundError) {
         return this._handleWrongArtifactForFullyQualifiedName(

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -105,7 +105,8 @@ export class Artifacts implements IArtifacts {
 
   public async getBuildInfoPaths(): Promise<string[]> {
     const paths = await getAllFilesMatching(
-      path.join(this._artifactsPath, BUILD_INFO_DIR_NAME)
+      path.join(this._artifactsPath, BUILD_INFO_DIR_NAME),
+      (f) => f.endsWith(".json")
     );
 
     return paths.sort();

--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -12,12 +12,12 @@ import {
   HardhatUserConfig,
 } from "../../../types";
 import { HardhatContext } from "../../context";
-import { SUPPORTED_SOLIDITY_VERSION_RANGE } from "../../hardhat-network/stack-traces/solidityTracer";
 import { findClosestPackageJson } from "../../util/packageInfo";
 import { HardhatError } from "../errors";
 import { ERRORS } from "../errors-list";
 import { getUserConfigPath } from "../project-structure";
 
+import { SUPPORTED_SOLIDITY_VERSION_RANGE } from "../../hardhat-network/stack-traces/constants";
 import { resolveConfig } from "./config-resolution";
 import { validateConfig } from "./config-validation";
 import { DEFAULT_SOLC_VERSION } from "./default-config";

--- a/packages/hardhat-core/src/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-resolution.ts
@@ -1,5 +1,4 @@
 import { BN } from "ethereumjs-util";
-import * as fs from "fs";
 import cloneDeep from "lodash/cloneDeep";
 import path from "path";
 
@@ -37,6 +36,7 @@ import { HardforkName } from "../../util/hardforks";
 import { fromEntries } from "../../util/lang";
 import { assertHardhatInvariant } from "../errors";
 
+import { getRealPathSync } from "../../util/fs-utils";
 import {
   DEFAULT_SOLC_VERSION,
   defaultDefaultNetwork,
@@ -432,7 +432,7 @@ export function resolveProjectPaths(
   userConfigPath: string,
   userPaths: ProjectPathsUserConfig = {}
 ): ProjectPathsConfig {
-  const configFile = fs.realpathSync(userConfigPath);
+  const configFile = getRealPathSync(userConfigPath);
   const configDir = path.dirname(configFile);
 
   const root = resolvePathFrom(configDir, "", userPaths.root);

--- a/packages/hardhat-core/src/internal/core/errors.ts
+++ b/packages/hardhat-core/src/internal/core/errors.ts
@@ -26,7 +26,7 @@ export class CustomError extends Error {
     this._stack = this.stack ?? "";
 
     Object.defineProperty(this, "stack", {
-      get: () => this[inspect].call(this),
+      get: () => this[inspect](),
     });
   }
 

--- a/packages/hardhat-core/src/internal/core/errors.ts
+++ b/packages/hardhat-core/src/internal/core/errors.ts
@@ -6,6 +6,8 @@ import { ErrorDescriptor, ERRORS, getErrorCode } from "./errors-list";
 const inspect = Symbol.for("nodejs.util.inspect.custom");
 
 export class CustomError extends Error {
+  private _stack: string;
+
   constructor(message: string, public readonly parent?: Error) {
     // WARNING: Using super when extending a builtin class doesn't work well
     // with TS if you are compiling to a version of JavaScript that doesn't have
@@ -20,16 +22,22 @@ export class CustomError extends Error {
     if ((Error as any).captureStackTrace !== undefined) {
       (Error as any).captureStackTrace(this, this.constructor);
     }
+
+    this._stack = this.stack ?? "";
+
+    Object.defineProperty(this, "stack", {
+      get: () => this[inspect].call(this),
+    });
   }
 
-  public [inspect]() {
-    let str = this.stack;
+  public [inspect](): string {
+    let str = this._stack;
     if (this.parent !== undefined) {
       const parentAsAny = this.parent as any;
       const causeString =
         parentAsAny[inspect]?.() ??
         parentAsAny.inspect?.() ??
-        parentAsAny.stack ??
+        parentAsAny._stack ??
         parentAsAny.toString();
       const nestedCauseStr = causeString
         .split("\n")

--- a/packages/hardhat-core/src/internal/core/errors.ts
+++ b/packages/hardhat-core/src/internal/core/errors.ts
@@ -37,7 +37,7 @@ export class CustomError extends Error {
       const causeString =
         parentAsAny[inspect]?.() ??
         parentAsAny.inspect?.() ??
-        parentAsAny._stack ??
+        parentAsAny.stack ??
         parentAsAny.toString();
       const nestedCauseStr = causeString
         .split("\n")

--- a/packages/hardhat-core/src/internal/core/execution-mode.ts
+++ b/packages/hardhat-core/src/internal/core/execution-mode.ts
@@ -1,6 +1,5 @@
-import * as fs from "fs";
-
 import { getPackageJsonPath } from "../util/packageInfo";
+import { getRealPathSync } from "../util/fs-utils";
 
 /**
  * Returns true if Hardhat is installed locally or linked from its repository,
@@ -20,7 +19,7 @@ export function isHardhatInstalledLocallyOrLinked(configPath?: string) {
     // We need to get the realpaths here, as hardhat may be linked and
     // running with `node --preserve-symlinks`
     return (
-      fs.realpathSync(resolvedPackageJson) === fs.realpathSync(thisPackageJson)
+      getRealPathSync(resolvedPackageJson) === getRealPathSync(thisPackageJson)
     );
   } catch {
     return false;

--- a/packages/hardhat-core/src/internal/core/providers/construction.ts
+++ b/packages/hardhat-core/src/internal/core/providers/construction.ts
@@ -12,13 +12,13 @@ import type {
   ProjectPathsConfig,
 } from "../../../types";
 
-import { HARDHAT_NETWORK_NAME } from "../../constants";
-import { ModulesLogger } from "../../hardhat-network/provider/modules/logger";
-import {
+import type {
   ForkConfig,
   MempoolOrder,
 } from "../../hardhat-network/provider/node-types";
-import { getForkCacheDirPath } from "../../hardhat-network/provider/utils/disk-cache";
+import type * as ModulesLoggerT from "../../hardhat-network/provider/modules/logger";
+import type * as DiskCacheT from "../../hardhat-network/provider/utils/disk-cache";
+import { HARDHAT_NETWORK_NAME } from "../../constants";
 import { parseDateString } from "../../util/date";
 
 import { normalizeHardhatNetworkAccountsConfig } from "./util";
@@ -80,6 +80,11 @@ export function createProvider(
     const accounts = normalizeHardhatNetworkAccountsConfig(
       hardhatNetConfig.accounts
     );
+
+    const { ModulesLogger } =
+      require("../../hardhat-network/provider/modules/logger") as typeof ModulesLoggerT;
+    const { getForkCacheDirPath } =
+      require("../../hardhat-network/provider/utils/disk-cache") as typeof DiskCacheT;
 
     eip1193Provider = new HardhatNetworkProvider(
       hardhatNetConfig.hardfork,

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -25,9 +25,9 @@ import {
   MethodNotSupportedError,
   ProviderError,
 } from "../../core/providers/errors";
-import { FIRST_SOLC_VERSION_SUPPORTED } from "../stack-traces/solidityTracer";
 import { Mutex } from "../../vendor/await-semaphore";
 
+import { FIRST_SOLC_VERSION_SUPPORTED } from "../stack-traces/constants";
 import { MiningTimer } from "./MiningTimer";
 import { DebugModule } from "./modules/debug";
 import { EthModule } from "./modules/eth";

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/constants.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/constants.ts
@@ -1,0 +1,2 @@
+export const SUPPORTED_SOLIDITY_VERSION_RANGE = "<=0.8.16";
+export const FIRST_SOLC_VERSION_SUPPORTED = "0.5.1";

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidityTracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidityTracer.ts
@@ -32,9 +32,6 @@ import {
   StackTraceEntryType,
 } from "./solidity-stack-trace";
 
-export const SUPPORTED_SOLIDITY_VERSION_RANGE = "<=0.8.16";
-export const FIRST_SOLC_VERSION_SUPPORTED = "0.5.1";
-
 export class SolidityTracer {
   private _errorInferrer = new ErrorInferrer();
 

--- a/packages/hardhat-core/src/internal/solidity/compilation-job.ts
+++ b/packages/hardhat-core/src/internal/solidity/compilation-job.ts
@@ -55,7 +55,8 @@ export class CompilationJob implements taskTypes.CompilationJob {
   }
 
   public merge(job: taskTypes.CompilationJob): CompilationJob {
-    const { isEqual }: LoDashStatic = require("lodash");
+    const isEqual = require("lodash/isEqual") as LoDashStatic["isEqual"];
+
     assertHardhatInvariant(
       isEqual(this.solidityConfig, job.getSolcConfig()),
       "Merging jobs with different solidity configurations"
@@ -103,8 +104,6 @@ function mergeCompilationJobs(
   jobs: taskTypes.CompilationJob[],
   isMergeable: (job: taskTypes.CompilationJob) => boolean
 ): taskTypes.CompilationJob[] {
-  const { flatten }: LoDashStatic = require("lodash");
-
   const jobsMap: Map<SolcConfig, taskTypes.CompilationJob[]> = new Map();
 
   for (const job of jobs) {
@@ -130,7 +129,8 @@ function mergeCompilationJobs(
     }
   }
 
-  return flatten([...jobsMap.values()]);
+  // Array#flat This method defaults to depth limit 1
+  return [...jobsMap.values()].flat(1_000_000);
 }
 
 /**
@@ -234,15 +234,15 @@ function getCompilerConfigForFile(
   transitiveDependencies: taskTypes.TransitiveDependency[],
   solidityConfig: SolidityConfig
 ): SolcConfig | CompilationJobCreationError {
-  const { uniq }: LoDashStatic = require("lodash");
-
   const transitiveDependenciesVersionPragmas = transitiveDependencies.map(
     ({ dependency }) => dependency.content.versionPragmas
   );
-  const versionRange = uniq([
-    ...file.content.versionPragmas,
-    ...transitiveDependenciesVersionPragmas,
-  ]).join(" ");
+  const versionRange = Array.from(
+    new Set([
+      ...file.content.versionPragmas,
+      ...transitiveDependenciesVersionPragmas,
+    ])
+  ).join(" ");
 
   const overrides = solidityConfig.overrides ?? {};
 

--- a/packages/hardhat-core/src/internal/solidity/compiler/index.ts
+++ b/packages/hardhat-core/src/internal/solidity/compiler/index.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import * as fs from "fs";
 import { CompilerInput, CompilerOutput } from "../../../types";
 
@@ -62,8 +62,9 @@ export class NativeCompiler implements ICompiler {
 
   public async compile(input: CompilerInput) {
     const output: string = await new Promise((resolve, reject) => {
-      const process = exec(
-        `${this._pathToSolc} --standard-json`,
+      const process = execFile(
+        this._pathToSolc,
+        [`--standard-json`],
         {
           maxBuffer: 1024 * 1024 * 500,
         },

--- a/packages/hardhat-core/src/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/src/internal/solidity/resolver.ts
@@ -132,10 +132,10 @@ export class Resolver {
 
       const isRelativeImport = this._isRelativeImport(imported);
 
-      if (!isRelativeImport) {
-        sourceName = normalizeSourceName(imported);
-      } else {
+      if (isRelativeImport) {
         sourceName = await this._relativeImportToSourceName(from, imported);
+      } else {
+        sourceName = normalizeSourceName(imported);
       }
 
       const cached = this._cache.get(sourceName);

--- a/packages/hardhat-core/src/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/src/internal/solidity/resolver.ts
@@ -19,6 +19,7 @@ import { assertHardhatInvariant, HardhatError } from "../core/errors";
 import { ERRORS } from "../core/errors-list";
 import { createNonCryptographicHashBasedIdentifier } from "../util/hash";
 
+import { getRealPath } from "../util/fs-utils";
 import { Parser } from "./parse";
 
 export interface ResolvedFilesMap {
@@ -279,7 +280,7 @@ export class Resolver {
     return this._resolveFile(
       sourceName,
       // We resolve to the real path here, as we may be resolving a linked library
-      await fsExtra.realpath(path.join(nodeModulesPath, sourceName)),
+      await getRealPath(path.join(nodeModulesPath, sourceName)),
       libraryName,
       libraryVersion
     );

--- a/packages/hardhat-core/src/internal/util/fs-utils.ts
+++ b/packages/hardhat-core/src/internal/util/fs-utils.ts
@@ -72,7 +72,7 @@ export async function fileExistsWithExactCasing(
 /**
  * Returns an array of files (not dirs) that match a condition.
  *
- * @param absolutePathToDir An existing directory.
+ * @param absolutePathToDir A directory. If it doesn't exist `[]` is returned.
  * @param matches
  */
 export async function getAllFilesMatching(
@@ -84,8 +84,7 @@ export async function getAllFilesMatching(
     dir = await fsPromises.readdir(absolutePathToDir);
   } catch (e: any) {
     if (e.code === "ENOENT") {
-      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
-      throw new FileNotFoundError(`File ${absolutePathToDir} not found`, e);
+      return [];
     }
 
     if (e.code === "ENOTDIR") {
@@ -128,8 +127,7 @@ export function getAllFilesMatchingSync(
     dir = fs.readdirSync(absolutePathToDir);
   } catch (e: any) {
     if (e.code === "ENOENT") {
-      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
-      throw new FileNotFoundError(`File ${absolutePathToDir} not found`, e);
+      return [];
     }
 
     if (e.code === "ENOTDIR") {

--- a/packages/hardhat-core/src/internal/util/fs-utils.ts
+++ b/packages/hardhat-core/src/internal/util/fs-utils.ts
@@ -1,0 +1,166 @@
+import fsPromises from "fs/promises";
+import fs from "fs";
+import path from "path";
+import { CustomError } from "../core/errors";
+
+// We use this error to encapsulate any other error possibly thrown by node's
+// fs apis, as sometimes their errors don't have stack traces.
+export class FileSystemAccessError extends CustomError {}
+
+export class FileNotFoundError extends CustomError {}
+export class InvalidDirectoryError extends CustomError {}
+
+/**
+ * Returns the real-case version of an absolute path.
+ *
+ * @throws FileNotFoundError if absolutePath doesn't exist.
+ */
+export async function getRealCase(absolutePath: string): Promise<string> {
+  try {
+    return await fsPromises.realpath(absolutePath);
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+      throw new FileNotFoundError(`File ${absolutePath} not found`, e);
+    }
+
+    // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+    throw new FileSystemAccessError(e.message, e);
+  }
+}
+
+/**
+ * Sync version of getRealCase
+ *
+ * @see getRealCase
+ */
+export function getRealCaseSync(absolutePath: string): string {
+  try {
+    return fs.realpathSync.native(absolutePath);
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+      throw new FileNotFoundError(`File ${absolutePath} not found`, e);
+    }
+
+    // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+    throw new FileSystemAccessError(e.message, e);
+  }
+}
+
+/**
+ * Returns true if absolutePath exists and it has the same casing in the FS.
+ */
+export async function fileExistsWithExactCasing(
+  absolutePath: string
+): Promise<boolean> {
+  try {
+    const realpath = await getRealCase(absolutePath);
+    return realpath === absolutePath;
+  } catch (e: any) {
+    if (e instanceof FileNotFoundError) {
+      return false;
+    }
+
+    // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+    throw new FileSystemAccessError(e.message, e);
+  }
+
+  return true;
+}
+
+/**
+ * Returns an array of files (not dirs) that match a condition.
+ *
+ * @param absolutePathToDir An existing directory.
+ * @param matches
+ */
+export async function getAllFilesMatching(
+  absolutePathToDir: string,
+  matches?: (absolutePathToFile: string) => boolean
+): Promise<string[]> {
+  let dir;
+  try {
+    dir = await fsPromises.readdir(absolutePathToDir);
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+      throw new FileNotFoundError(`File ${absolutePathToDir} not found`, e);
+    }
+
+    if (e.code === "ENOTDIR") {
+      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+      throw new InvalidDirectoryError(
+        `Expected ${absolutePathToDir} to be a directory but it isn't`
+      );
+    }
+
+    // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+    throw new FileSystemAccessError(e.message, e);
+  }
+
+  const results = await Promise.all(
+    dir.map(async (file) => {
+      const absolutePathToFile = path.join(absolutePathToDir, file);
+      const stats = await fsPromises.stat(absolutePathToFile);
+      if (stats.isDirectory()) {
+        return getAllFilesMatching(absolutePathToFile, matches);
+      } else {
+        if (matches === undefined || matches(absolutePathToFile)) {
+          return absolutePathToFile;
+        }
+      }
+    })
+  );
+
+  const filteredResults: Array<string | string[]> =
+    results.filter(isNotundefined);
+
+  return filteredResults.flat(1_000_000);
+}
+
+export function getAllFilesMatchingSync(
+  absolutePathToDir: string,
+  matches?: (absolutePathToFile: string) => boolean
+): string[] {
+  let dir: string[];
+  try {
+    dir = fs.readdirSync(absolutePathToDir);
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+      throw new FileNotFoundError(`File ${absolutePathToDir} not found`, e);
+    }
+
+    if (e.code === "ENOTDIR") {
+      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+      throw new InvalidDirectoryError(
+        `Expected ${absolutePathToDir} to be a directory but it isn't`
+      );
+    }
+
+    // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+    throw new FileSystemAccessError(e.message, e);
+  }
+
+  const results = dir.map((file) => {
+    const absolutePathToFile = path.join(absolutePathToDir, file);
+    const stats = fs.statSync(absolutePathToFile);
+    if (stats.isDirectory()) {
+      return getAllFilesMatchingSync(absolutePathToFile, matches);
+    } else {
+      if (matches === undefined || matches(absolutePathToFile)) {
+        return absolutePathToFile;
+      }
+    }
+  });
+
+  const filteredResults: Array<string | string[]> =
+    results.filter(isNotundefined);
+
+  return filteredResults.flat(1_000_000);
+}
+
+function isNotundefined<T>(t: T | undefined): t is T {
+  return t !== undefined;
+}

--- a/packages/hardhat-core/src/internal/util/fs-utils.ts
+++ b/packages/hardhat-core/src/internal/util/fs-utils.ts
@@ -69,8 +69,6 @@ export async function fileExistsWithExactCasing(
     // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
     throw new FileSystemAccessError(e.message, e);
   }
-
-  return true;
 }
 
 /**

--- a/packages/hardhat-core/src/internal/util/fs-utils.ts
+++ b/packages/hardhat-core/src/internal/util/fs-utils.ts
@@ -107,19 +107,17 @@ export async function getAllFilesMatching(
       const absolutePathToFile = path.join(absolutePathToDir, file);
       const stats = await fsPromises.stat(absolutePathToFile);
       if (stats.isDirectory()) {
-        return getAllFilesMatching(absolutePathToFile, matches);
+        const files = await getAllFilesMatching(absolutePathToFile, matches);
+        return files.flat();
+      } else if (matches === undefined || matches(absolutePathToFile)) {
+        return absolutePathToFile;
       } else {
-        if (matches === undefined || matches(absolutePathToFile)) {
-          return absolutePathToFile;
-        }
+        return [];
       }
     })
   );
 
-  const filteredResults: Array<string | string[]> =
-    results.filter(isNotundefined);
-
-  return filteredResults.flat(1_000_000);
+  return results.flat();
 }
 
 export function getAllFilesMatchingSync(
@@ -149,20 +147,13 @@ export function getAllFilesMatchingSync(
     const absolutePathToFile = path.join(absolutePathToDir, file);
     const stats = fs.statSync(absolutePathToFile);
     if (stats.isDirectory()) {
-      return getAllFilesMatchingSync(absolutePathToFile, matches);
+      return getAllFilesMatchingSync(absolutePathToFile, matches).flat();
+    } else if (matches === undefined || matches(absolutePathToFile)) {
+      return absolutePathToFile;
     } else {
-      if (matches === undefined || matches(absolutePathToFile)) {
-        return absolutePathToFile;
-      }
+      return [];
     }
   });
 
-  const filteredResults: Array<string | string[]> =
-    results.filter(isNotundefined);
-
-  return filteredResults.flat(1_000_000);
-}
-
-function isNotundefined<T>(t: T | undefined): t is T {
-  return t !== undefined;
+  return results.flat();
 }

--- a/packages/hardhat-core/src/internal/util/fs-utils.ts
+++ b/packages/hardhat-core/src/internal/util/fs-utils.ts
@@ -17,6 +17,8 @@ export class InvalidDirectoryError extends CustomError {}
  */
 export async function getRealCase(absolutePath: string): Promise<string> {
   try {
+    // This method returns the actual casing.
+    // Please read Node.js' docs to learn more.
     return await fsPromises.realpath(absolutePath);
   } catch (e: any) {
     if (e.code === "ENOENT") {
@@ -36,6 +38,8 @@ export async function getRealCase(absolutePath: string): Promise<string> {
  */
 export function getRealCaseSync(absolutePath: string): string {
   try {
+    // This method returns the actual casing.
+    // Please read Node.js' docs to learn more.
     return fs.realpathSync.native(absolutePath);
   } catch (e: any) {
     if (e.code === "ENOENT") {

--- a/packages/hardhat-core/src/internal/util/fs-utils.ts
+++ b/packages/hardhat-core/src/internal/util/fs-utils.ts
@@ -75,7 +75,7 @@ export async function fileExistsWithExactCasing(
  * Returns an array of files (not dirs) that match a condition.
  *
  * @param absolutePathToDir A directory. If it doesn't exist `[]` is returned.
- * @param matches
+ * @param matches A function to filter files (not directories)
  */
 export async function getAllFilesMatching(
   absolutePathToDir: string,
@@ -118,6 +118,11 @@ export async function getAllFilesMatching(
   return results.flat();
 }
 
+/**
+ * Sync version of getAllFilesMatching
+ *
+ * @see getAllFilesMatching
+ */
 export function getAllFilesMatchingSync(
   absolutePathToDir: string,
   matches?: (absolutePathToFile: string) => boolean

--- a/packages/hardhat-core/src/internal/util/fs-utils.ts
+++ b/packages/hardhat-core/src/internal/util/fs-utils.ts
@@ -7,23 +7,31 @@ import { CustomError } from "../core/errors";
 // fs apis, as sometimes their errors don't have stack traces.
 export class FileSystemAccessError extends CustomError {}
 
-export class FileNotFoundError extends CustomError {}
-export class InvalidDirectoryError extends CustomError {}
+export class FileNotFoundError extends CustomError {
+  constructor(filePath: string, parent?: Error) {
+    super(`File ${filePath} not found`, parent);
+  }
+}
+export class InvalidDirectoryError extends CustomError {
+  constructor(filePath: string, parent: Error) {
+    super(`Invalid directory ${filePath}`, parent);
+  }
+}
 
 /**
- * Returns the real-case version of an absolute path.
+ * Returns the real path of absolutePath, resolving symlinks.
  *
  * @throws FileNotFoundError if absolutePath doesn't exist.
  */
-export async function getRealCase(absolutePath: string): Promise<string> {
+export async function getRealPath(absolutePath: string): Promise<string> {
   try {
     // This method returns the actual casing.
     // Please read Node.js' docs to learn more.
-    return await fsPromises.realpath(absolutePath);
+    return await fsPromises.realpath(path.normalize(absolutePath));
   } catch (e: any) {
     if (e.code === "ENOENT") {
       // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
-      throw new FileNotFoundError(`File ${absolutePath} not found`, e);
+      throw new FileNotFoundError(absolutePath, e);
     }
 
     // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
@@ -32,38 +40,19 @@ export async function getRealCase(absolutePath: string): Promise<string> {
 }
 
 /**
- * Sync version of getRealCase
+ * Sync version of getRealPath
  *
  * @see getRealCase
  */
-export function getRealCaseSync(absolutePath: string): string {
+export function getRealPathSync(absolutePath: string): string {
   try {
     // This method returns the actual casing.
     // Please read Node.js' docs to learn more.
-    return fs.realpathSync.native(absolutePath);
+    return fs.realpathSync.native(path.normalize(absolutePath));
   } catch (e: any) {
     if (e.code === "ENOENT") {
       // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
-      throw new FileNotFoundError(`File ${absolutePath} not found`, e);
-    }
-
-    // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
-    throw new FileSystemAccessError(e.message, e);
-  }
-}
-
-/**
- * Returns true if absolutePath exists and it has the same casing in the FS.
- */
-export async function fileExistsWithExactCasing(
-  absolutePath: string
-): Promise<boolean> {
-  try {
-    const realpath = await getRealCase(absolutePath);
-    return realpath === absolutePath;
-  } catch (e: any) {
-    if (e instanceof FileNotFoundError) {
-      return false;
+      throw new FileNotFoundError(absolutePath, e);
     }
 
     // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
@@ -76,29 +65,15 @@ export async function fileExistsWithExactCasing(
  *
  * @param absolutePathToDir A directory. If it doesn't exist `[]` is returned.
  * @param matches A function to filter files (not directories)
+ * @returns An An array of absolute paths. Each file has its true case, except
+ *  for the initial absolutePathToDir part, which preserves the given casing.
+ *  No order is guaranteed.
  */
 export async function getAllFilesMatching(
   absolutePathToDir: string,
   matches?: (absolutePathToFile: string) => boolean
 ): Promise<string[]> {
-  let dir;
-  try {
-    dir = await fsPromises.readdir(absolutePathToDir);
-  } catch (e: any) {
-    if (e.code === "ENOENT") {
-      return [];
-    }
-
-    if (e.code === "ENOTDIR") {
-      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
-      throw new InvalidDirectoryError(
-        `Expected ${absolutePathToDir} to be a directory but it isn't`
-      );
-    }
-
-    // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
-    throw new FileSystemAccessError(e.message, e);
-  }
+  const dir = await readdir(absolutePathToDir);
 
   const results = await Promise.all(
     dir.map(async (file) => {
@@ -127,24 +102,7 @@ export function getAllFilesMatchingSync(
   absolutePathToDir: string,
   matches?: (absolutePathToFile: string) => boolean
 ): string[] {
-  let dir: string[];
-  try {
-    dir = fs.readdirSync(absolutePathToDir);
-  } catch (e: any) {
-    if (e.code === "ENOENT") {
-      return [];
-    }
-
-    if (e.code === "ENOTDIR") {
-      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
-      throw new InvalidDirectoryError(
-        `Expected ${absolutePathToDir} to be a directory but it isn't`
-      );
-    }
-
-    // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
-    throw new FileSystemAccessError(e.message, e);
-  }
+  const dir = readdirSync(absolutePathToDir);
 
   const results = dir.map((file) => {
     const absolutePathToFile = path.join(absolutePathToDir, file);
@@ -159,4 +117,107 @@ export function getAllFilesMatchingSync(
   });
 
   return results.flat();
+}
+
+/**
+ * Returns the true case relative path of `relativePath` from `from`, without
+ * resolving symlinks.
+ */
+export async function getFileTrueCase(
+  from: string,
+  relativePath: string
+): Promise<string> {
+  const dirEntries = await readdir(from);
+
+  const parts = relativePath.split(path.sep);
+  const nextDirLowerCase = parts[0].toLowerCase();
+
+  for (const dirEntry of dirEntries) {
+    if (dirEntry.toLowerCase() === nextDirLowerCase) {
+      if (parts.length === 1) {
+        return dirEntry;
+      }
+
+      return path.join(
+        dirEntry,
+        await getFileTrueCase(
+          path.join(from, dirEntry),
+          path.relative(parts[0], relativePath)
+        )
+      );
+    }
+  }
+
+  // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+  throw new FileNotFoundError(path.join(from, relativePath));
+}
+
+/**
+ * Sync version of getFileTrueCase
+ *
+ * @see getFileTrueCase
+ */
+export function getFileTrueCaseSync(
+  from: string,
+  relativePath: string
+): string {
+  const dirEntries = readdirSync(from);
+
+  const parts = relativePath.split(path.sep);
+  const nextDirLowerCase = parts[0].toLowerCase();
+
+  for (const dirEntry of dirEntries) {
+    if (dirEntry.toLowerCase() === nextDirLowerCase) {
+      if (parts.length === 1) {
+        return dirEntry;
+      }
+
+      return path.join(
+        dirEntry,
+        getFileTrueCaseSync(
+          path.join(from, dirEntry),
+          path.relative(parts[0], relativePath)
+        )
+      );
+    }
+  }
+
+  // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+  throw new FileNotFoundError(path.join(from, relativePath));
+}
+
+async function readdir(absolutePathToDir: string) {
+  try {
+    return await fsPromises.readdir(absolutePathToDir);
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+      return [];
+    }
+
+    if (e.code === "ENOTDIR") {
+      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+      throw new InvalidDirectoryError(absolutePathToDir, e);
+    }
+
+    // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+    throw new FileSystemAccessError(e.message, e);
+  }
+}
+
+function readdirSync(absolutePathToDir: string) {
+  try {
+    return fs.readdirSync(absolutePathToDir);
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+      return [];
+    }
+
+    if (e.code === "ENOTDIR") {
+      // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+      throw new InvalidDirectoryError(absolutePathToDir, e);
+    }
+
+    // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
+    throw new FileSystemAccessError(e.message, e);
+  }
 }

--- a/packages/hardhat-core/src/internal/util/glob.ts
+++ b/packages/hardhat-core/src/internal/util/glob.ts
@@ -3,6 +3,9 @@ import type { IOptions as GlobOptions } from "glob";
 import * as path from "path";
 import util from "util";
 
+/**
+ * @deprecated
+ */
 export async function glob(
   pattern: string,
   options: GlobOptions = {}
@@ -12,6 +15,9 @@ export async function glob(
   return files.map(path.normalize);
 }
 
+/**
+ * deprecated
+ */
 export function globSync(pattern: string, options: GlobOptions = {}): string[] {
   const files = require("glob").sync(pattern, options);
   return files.map(path.normalize);

--- a/packages/hardhat-core/src/internal/util/glob.ts
+++ b/packages/hardhat-core/src/internal/util/glob.ts
@@ -4,6 +4,12 @@ import * as path from "path";
 import util from "util";
 
 /**
+ * DO NOT USE THIS FUNCTION. It's SLOW and its semantics are optimized for
+ * user-facing CLI globs, not traversing the FS.
+ *
+ * It's not removed because unfortunately some plugins used it, like the truffle
+ * ones.
+ *
  * @deprecated
  */
 export async function glob(
@@ -16,7 +22,8 @@ export async function glob(
 }
 
 /**
- * deprecated
+ * @deprecated
+ * @see glob
  */
 export function globSync(pattern: string, options: GlobOptions = {}): string[] {
   const files = require("glob").sync(pattern, options);

--- a/packages/hardhat-core/src/types/config.ts
+++ b/packages/hardhat-core/src/types/config.ts
@@ -144,6 +144,7 @@ export interface HardhatNetworkConfig {
   mining: HardhatNetworkMiningConfig;
   accounts: HardhatNetworkAccountsConfig;
   blockGasLimit: number;
+  // TODO: This shouldn't be a BN, as it forces use to load ethereumjs-util
   minGasPrice: BN;
   throwOnTransactionFailures: boolean;
   throwOnCallFailures: boolean;

--- a/packages/hardhat-core/src/utils/source-names.ts
+++ b/packages/hardhat-core/src/utils/source-names.ts
@@ -188,8 +188,8 @@ export function replaceBackslashes(str: string): string {
 async function getPathTrueCase(fromDir: string, p: string): Promise<string> {
   try {
     const absolute = path.join(fromDir, p);
-    const tcp = await getRealCase(absolute);
-    return normalizeSourceName(path.relative(fromDir, tcp));
+    const realCase = await getRealCase(absolute);
+    return normalizeSourceName(path.relative(fromDir, realCase));
   } catch (error) {
     if (error instanceof FileNotFoundError) {
       throw new HardhatError(

--- a/packages/hardhat-core/src/utils/source-names.ts
+++ b/packages/hardhat-core/src/utils/source-names.ts
@@ -177,8 +177,23 @@ function isExplicitRelativePath(sourceName: string): boolean {
  * Note that a source name must not contain backslashes.
  */
 export function replaceBackslashes(str: string): string {
-  const slash = require("slash");
-  return slash(str);
+  // Based in the npm module slash
+  const isExtendedLengthPath = /^\\\\\?\\/.test(str);
+  const hasNonAscii = /[^\u0000-\u0080]+/.test(str);
+
+  if (isExtendedLengthPath || hasNonAscii) {
+    return str;
+  }
+
+  return str.replace(/\\/g, "/");
+}
+
+function slashesToPathSeparator(str: string): string {
+  if (path.sep === "/") {
+    return str;
+  }
+
+  return str.replace(/\//g, path.sep);
 }
 
 /**

--- a/packages/hardhat-core/test/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/test/builtin-tasks/compile.ts
@@ -5,13 +5,13 @@ import * as path from "path";
 import { TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS_FAILURE_REASONS } from "../../src/builtin-tasks/task-names";
 import { SOLIDITY_FILES_CACHE_FILENAME } from "../../src/internal/constants";
 import { ERRORS } from "../../src/internal/core/errors-list";
-import { globSync } from "../../src/internal/util/glob";
 import { CompilationJobCreationErrorReason } from "../../src/types/builtin-tasks";
 import { useEnvironment } from "../helpers/environment";
 import { expectHardhatErrorAsync } from "../helpers/errors";
 import { useFixtureProject } from "../helpers/project";
 import { assertValidJson } from "../utils/json";
 import { mockFile } from "../utils/mock-file";
+import { getAllFilesMatchingSync } from "../../src/internal/util/fs-utils";
 
 function assertFileExists(pathToFile: string) {
   assert.isTrue(
@@ -32,6 +32,13 @@ describe("compile task", function () {
     fsExtra.removeSync(path.join("cache", SOLIDITY_FILES_CACHE_FILENAME));
   });
 
+  function getBuildInfos() {
+    return getAllFilesMatchingSync(
+      fsExtra.realpathSync("artifacts/build-info"),
+      (f) => f.endsWith(".json")
+    );
+  }
+
   describe("project with single file", function () {
     useFixtureProject("compilation-single-file");
     useEnvironment();
@@ -43,7 +50,8 @@ describe("compile task", function () {
       assertBuildInfoExists(
         path.join("artifacts", "contracts", "A.sol", "A.dbg.json")
       );
-      const buildInfos = globSync("artifacts/build-info/*.json");
+
+      const buildInfos = getBuildInfos();
       assert.lengthOf(buildInfos, 1);
 
       assertValidJson(buildInfos[0]);
@@ -61,7 +69,7 @@ describe("compile task", function () {
       const artifactsDirectory = fsExtra.readdirSync("artifacts");
       assert.lengthOf(artifactsDirectory, 1);
 
-      const buildInfos = globSync("artifacts/build-info/*.json");
+      const buildInfos = getBuildInfos();
       assert.lengthOf(buildInfos, 0);
     });
   });
@@ -79,7 +87,7 @@ describe("compile task", function () {
       // 100 contracts, 2 files per contract
       assert.lengthOf(artifactsDirectory, 200);
 
-      const buildInfos = globSync("artifacts/build-info/*.json");
+      const buildInfos = getBuildInfos();
       assert.lengthOf(buildInfos, 1);
 
       assertValidJson(buildInfos[0]);
@@ -96,7 +104,7 @@ describe("compile task", function () {
       const contractsDirectory = fsExtra.readdirSync("artifacts/contracts");
       assert.lengthOf(contractsDirectory, 100);
 
-      const buildInfos = globSync("artifacts/build-info/*.json");
+      const buildInfos = getBuildInfos();
       assert.lengthOf(buildInfos, 1);
 
       assertValidJson(buildInfos[0]);
@@ -119,7 +127,7 @@ describe("compile task", function () {
         path.join("artifacts", "contracts", "B.sol", "B.dbg.json")
       );
 
-      const buildInfos = globSync("artifacts/build-info/*.json");
+      const buildInfos = getBuildInfos();
       assert.lengthOf(buildInfos, 2);
       assertValidJson(buildInfos[0]);
       assertValidJson(buildInfos[1]);

--- a/packages/hardhat-core/test/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/test/builtin-tasks/compile.ts
@@ -11,7 +11,10 @@ import { expectHardhatErrorAsync } from "../helpers/errors";
 import { useFixtureProject } from "../helpers/project";
 import { assertValidJson } from "../utils/json";
 import { mockFile } from "../utils/mock-file";
-import { getAllFilesMatchingSync } from "../../src/internal/util/fs-utils";
+import {
+  getAllFilesMatchingSync,
+  getRealPathSync,
+} from "../../src/internal/util/fs-utils";
 
 function assertFileExists(pathToFile: string) {
   assert.isTrue(
@@ -34,7 +37,7 @@ describe("compile task", function () {
 
   function getBuildInfos() {
     return getAllFilesMatchingSync(
-      fsExtra.realpathSync("artifacts/build-info"),
+      getRealPathSync("artifacts/build-info"),
       (f) => f.endsWith(".json")
     );
   }

--- a/packages/hardhat-core/test/helpers/fs.ts
+++ b/packages/hardhat-core/test/helpers/fs.ts
@@ -1,6 +1,7 @@
 import fsExtra from "fs-extra";
 import * as os from "os";
 import path from "path";
+import { getRealPath } from "../../src/internal/util/fs-utils";
 
 declare module "mocha" {
   interface Context {
@@ -9,7 +10,8 @@ declare module "mocha" {
 }
 
 async function getEmptyTmpDir(nameHint: string) {
-  const tmpDirContainer = os.tmpdir();
+  const tmpDirContainer = await getRealPath(os.tmpdir());
+
   const tmpDir = path.join(tmpDirContainer, `hardhat-tests-${nameHint}`);
   await fsExtra.ensureDir(tmpDir);
   await fsExtra.emptyDir(tmpDir);

--- a/packages/hardhat-core/test/helpers/project.ts
+++ b/packages/hardhat-core/test/helpers/project.ts
@@ -1,5 +1,6 @@
 import * as fsExtra from "fs-extra";
 import path from "path";
+import { getRealPath } from "../../src/internal/util/fs-utils";
 
 /**
  * This helper adds mocha hooks to run the tests inside one of the projects
@@ -38,5 +39,5 @@ export async function getFixtureProjectPath(
     throw new Error(`Fixture project ${projectName} doesn't exist`);
   }
 
-  return fsExtra.realpath(projectPath);
+  return getRealPath(projectPath);
 }

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -391,7 +391,7 @@ describe("Artifacts class", function () {
       const artifact = getArtifactFromContractOutput(sourceName, name, output);
 
       const artifacts = new Artifacts(this.tmpDir);
-      await artifacts.saveArtifactAndDebugFile(artifact, "");
+      await artifacts.saveArtifactAndDebugFile(artifact);
 
       const storedArtifact = await artifacts.readArtifact("MyLib.sol:Lib");
 

--- a/packages/hardhat-core/test/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-loading.ts
@@ -343,8 +343,8 @@ Hardhat plugin instead.`
         const files = ctx.getFilesLoadedDuringConfig();
 
         for (const file of builtinTasksFiles) {
-          // The task names may have been loaded before, so we ignore it.
-          if (file.endsWith("task-names.ts")) {
+          // The task names and the utils may have been loaded before, so we ignore them.
+          if (file.endsWith("task-names.ts") || file.includes("/utils/")) {
             continue;
           }
 

--- a/packages/hardhat-core/test/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-loading.ts
@@ -9,7 +9,6 @@ import { loadConfigAndTasks } from "../../../../src/internal/core/config/config-
 import { DEFAULT_SOLC_VERSION } from "../../../../src/internal/core/config/default-config";
 import { ERRORS } from "../../../../src/internal/core/errors-list";
 import { resetHardhatContext } from "../../../../src/internal/reset";
-import { glob } from "../../../../src/internal/util/glob";
 import { useEnvironment } from "../../../helpers/environment";
 import {
   expectHardhatError,
@@ -19,6 +18,7 @@ import {
   getFixtureProjectPath,
   useFixtureProject,
 } from "../../../helpers/project";
+import { getAllFilesMatching } from "../../../../src/internal/util/fs-utils";
 
 describe("config loading", function () {
   describe("default config path", function () {
@@ -320,8 +320,9 @@ Hardhat plugin instead.`
     });
 
     it("Should keep track of all the files imported when loading the config", async function () {
-      const builtinTasksFiles = await glob(
-        "../../../../src/builtin-tasks/*.ts"
+      const builtinTasksFiles = await getAllFilesMatching(
+        fsExtra.realpathSync("../../../../src/builtin-tasks/"),
+        (f) => f.endsWith(".ts")
       );
 
       const projectPath = await fsExtra.realpath(".");

--- a/packages/hardhat-core/test/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-loading.ts
@@ -327,7 +327,7 @@ Hardhat plugin instead.`
         // We use realpathSync and not getRealPathSync as that's what node uses
         // internally.
         fs.realpathSync(
-          path.normalize(`${__dirname}/../../../../src/builtin-tasks/`)
+          path.join(__dirname, "..", "..", "..", "..", "src", "builtin-tasks")
         ),
         (f) => f.endsWith(".ts")
       );
@@ -342,13 +342,19 @@ Hardhat plugin instead.`
 
         const files = ctx.getFilesLoadedDuringConfig();
 
+        const filesJson = JSON.stringify(files, undefined, 2);
+
         for (const file of builtinTasksFiles) {
           // The task names and the utils may have been loaded before, so we ignore them.
-          if (file.endsWith("task-names.ts") || file.includes("/utils/")) {
+          if (file.endsWith("task-names.ts") || file.includes("utils")) {
             continue;
           }
 
-          assert.include(files, file);
+          assert.include(
+            files,
+            file,
+            `${file} should be included in ${filesJson}`
+          );
         }
 
         // Must include the config file and the files directly and

--- a/packages/hardhat-core/test/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-loading.ts
@@ -346,7 +346,7 @@ Hardhat plugin instead.`
 
         for (const file of builtinTasksFiles) {
           // The task names and the utils may have been loaded before, so we ignore them.
-          if (file.endsWith("task-names.ts") || file.includes("utils")) {
+          if (file.endsWith("task-names.ts") || file.includes(path.join(path.sep, "utils", path.sep))) {
             continue;
           }
 

--- a/packages/hardhat-core/test/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-loading.ts
@@ -346,7 +346,10 @@ Hardhat plugin instead.`
 
         for (const file of builtinTasksFiles) {
           // The task names and the utils may have been loaded before, so we ignore them.
-          if (file.endsWith("task-names.ts") || file.includes(path.join(path.sep, "utils", path.sep))) {
+          if (
+            file.endsWith("task-names.ts") ||
+            file.includes(path.join(path.sep, "utils", path.sep))
+          ) {
             continue;
           }
 

--- a/packages/hardhat-core/test/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-loading.ts
@@ -1,8 +1,8 @@
 import { assert } from "chai";
-import fsExtra from "fs-extra";
 import path from "path";
 import sinon from "sinon";
 
+import fs from "fs";
 import { TASK_CLEAN } from "../../../../src/builtin-tasks/task-names";
 import { HardhatContext } from "../../../../src/internal/context";
 import { loadConfigAndTasks } from "../../../../src/internal/core/config/config-loading";
@@ -18,7 +18,10 @@ import {
   getFixtureProjectPath,
   useFixtureProject,
 } from "../../../helpers/project";
-import { getAllFilesMatching } from "../../../../src/internal/util/fs-utils";
+import {
+  getAllFilesMatching,
+  getRealPathSync,
+} from "../../../../src/internal/util/fs-utils";
 
 describe("config loading", function () {
   describe("default config path", function () {
@@ -321,11 +324,15 @@ Hardhat plugin instead.`
 
     it("Should keep track of all the files imported when loading the config", async function () {
       const builtinTasksFiles = await getAllFilesMatching(
-        fsExtra.realpathSync("../../../../src/builtin-tasks/"),
+        // We use realpathSync and not getRealPathSync as that's what node uses
+        // internally.
+        fs.realpathSync(
+          path.normalize(`${__dirname}/../../../../src/builtin-tasks/`)
+        ),
         (f) => f.endsWith(".ts")
       );
 
-      const projectPath = await fsExtra.realpath(".");
+      const projectPath = getRealPathSync(".");
 
       // We run this twice to make sure that the cache is cleaned properly
       for (let i = 0; i < 2; i++) {

--- a/packages/hardhat-core/test/internal/core/params/argumentTypes.ts
+++ b/packages/hardhat-core/test/internal/core/params/argumentTypes.ts
@@ -7,6 +7,7 @@ import { ERRORS } from "../../../../src/internal/core/errors-list";
 import * as types from "../../../../src/internal/core/params/argumentTypes";
 import { ArgumentType } from "../../../../src/types";
 import { expectHardhatError } from "../../../helpers/errors";
+import { getRealPath } from "../../../../src/internal/util/fs-utils";
 
 describe("argumentTypes", () => {
   it("should set the right name to all the argument types", () => {
@@ -221,7 +222,7 @@ describe("argumentTypes", () => {
     });
 
     it("Should work with an absolute path", async () => {
-      const absolute = await fsExtra.realpath(__filename);
+      const absolute = await getRealPath(__filename);
       const output = types.inputFile.parse("A file", absolute);
       assert.equal(output, absolute);
     });

--- a/packages/hardhat-core/test/internal/core/project-structure.ts
+++ b/packages/hardhat-core/test/internal/core/project-structure.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../src/internal/core/project-structure";
 import { expectHardhatError } from "../../helpers/errors";
 import { useFixtureProject } from "../../helpers/project";
+import { getRealPath } from "../../../src/internal/util/fs-utils";
 
 describe("project structure", () => {
   describe("isCwdInsideProject", () => {
@@ -45,7 +46,7 @@ describe("project structure", () => {
 
       before("get root path", async () => {
         // TODO: This is no longer needed once PR #71 gets merged
-        const pathToFixtureRoot = await fsExtra.realpath(
+        const pathToFixtureRoot = await getRealPath(
           path.join(
             __dirname,
             "..",
@@ -55,7 +56,7 @@ describe("project structure", () => {
           )
         );
 
-        configPath = await fsExtra.realpath(
+        configPath = await getRealPath(
           path.join(pathToFixtureRoot, "hardhat.config.js")
         );
       });

--- a/packages/hardhat-core/test/internal/core/typescript-support.ts
+++ b/packages/hardhat-core/test/internal/core/typescript-support.ts
@@ -1,5 +1,4 @@
 import { assert } from "chai";
-import fsExtra from "fs-extra";
 
 import { TASK_TEST_GET_TEST_FILES } from "../../../src/builtin-tasks/task-names";
 import { resetHardhatContext } from "../../../src/internal/reset";
@@ -7,6 +6,7 @@ import { useEnvironment } from "../../helpers/environment";
 import { useFixtureProject } from "../../helpers/project";
 import { expectHardhatError } from "../../helpers/errors";
 import { ERRORS } from "../../../src/internal/core/errors-list";
+import { getRealPath } from "../../../src/internal/util/fs-utils";
 
 describe("Typescript support", function () {
   describe("strict typescript config", function () {
@@ -54,8 +54,8 @@ describe("Typescript support", function () {
       });
 
       assert.deepEqual(tests.sort(), [
-        await fsExtra.realpath("test/js-test.js"),
-        await fsExtra.realpath("test/ts-test.ts"),
+        await getRealPath("test/js-test.js"),
+        await getRealPath("test/ts-test.ts"),
       ]);
     });
   });

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -26,10 +26,7 @@ import {
   SolidityStackTraceEntry,
   StackTraceEntryType,
 } from "../../../../src/internal/hardhat-network/stack-traces/solidity-stack-trace";
-import {
-  SolidityTracer,
-  SUPPORTED_SOLIDITY_VERSION_RANGE,
-} from "../../../../src/internal/hardhat-network/stack-traces/solidityTracer";
+import { SolidityTracer } from "../../../../src/internal/hardhat-network/stack-traces/solidityTracer";
 import { VmTraceDecoder } from "../../../../src/internal/hardhat-network/stack-traces/vm-trace-decoder";
 import {
   CompilerInput,
@@ -38,6 +35,7 @@ import {
 } from "../../../../src/types";
 import { setCWD } from "../helpers/cwd";
 
+import { SUPPORTED_SOLIDITY_VERSION_RANGE } from "../../../../src/internal/hardhat-network/stack-traces/constants";
 import {
   compileFiles,
   COMPILER_DOWNLOAD_TIMEOUT,

--- a/packages/hardhat-core/test/internal/solidity/dependencyGraph.ts
+++ b/packages/hardhat-core/test/internal/solidity/dependencyGraph.ts
@@ -1,5 +1,4 @@
 import { assert } from "chai";
-import * as fs from "fs";
 import fsExtra from "fs-extra";
 import path from "path";
 
@@ -15,6 +14,7 @@ import {
   useFixtureProject,
 } from "../../helpers/project";
 
+import { getRealPathSync } from "../../../src/internal/util/fs-utils";
 import { createMockData, MockFile } from "./helpers";
 
 function assertDeps(
@@ -56,7 +56,7 @@ describe("Dependency Graph", function () {
     let loop2: ResolvedFile;
 
     before("Mock some resolved files", function () {
-      projectRoot = fs.realpathSync(".");
+      projectRoot = getRealPathSync(".");
 
       fileWithoutDependencies = new ResolvedFile(
         "contracts/WD.sol",

--- a/packages/hardhat-core/test/internal/solidity/helpers.ts
+++ b/packages/hardhat-core/test/internal/solidity/helpers.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs";
 import fsExtra from "fs-extra";
 import path from "path";
 
@@ -9,8 +8,9 @@ import {
   Resolver,
 } from "../../../src/internal/solidity/resolver";
 import * as taskTypes from "../../../src/types/builtin-tasks";
+import { getRealPathSync } from "../../../src/internal/util/fs-utils";
 
-const projectRoot = fs.realpathSync(".");
+const projectRoot = getRealPathSync(".");
 
 export class MockFile {
   public readonly sourceName: string;

--- a/packages/hardhat-core/test/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/test/internal/solidity/resolver.ts
@@ -1,7 +1,6 @@
 import { assert } from "chai";
 import * as fsExtra from "fs-extra";
 import path from "path";
-import slash from "slash";
 
 import { TASK_COMPILE } from "../../../src/builtin-tasks/task-names";
 import { ERRORS } from "../../../src/internal/core/errors-list";
@@ -145,7 +144,7 @@ describe("Resolver", function () {
       );
 
       await expectHardhatErrorAsync(
-        () => resolver.resolveSourceName(slash(__dirname)),
+        () => resolver.resolveSourceName(replaceBackslashes(__dirname)),
         ERRORS.SOURCE_NAMES.INVALID_SOURCE_NAME_ABSOLUTE_PATH
       );
     });

--- a/packages/hardhat-core/test/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/test/internal/solidity/resolver.ts
@@ -17,6 +17,8 @@ import {
   getFixtureProjectPath,
   useFixtureProject,
 } from "../../helpers/project";
+import { replaceBackslashes } from "../../../src/utils/source-names";
+import { getRealPath } from "../../../src/internal/util/fs-utils";
 
 function assertResolvedFilePartiallyEquals(
   actual: ResolvedFile,
@@ -109,7 +111,7 @@ async function assertResolvedFileFromPath(
   libraryInfo?: LibraryInfo
 ) {
   const resolved = await resolverPromise;
-  const absolutePath = await fsExtra.realpath(filePath);
+  const absolutePath = await getRealPath(filePath);
 
   assert.equal(resolved.sourceName, expectedSourceName);
   assert.equal(resolved.absolutePath, absolutePath);

--- a/packages/hardhat-core/test/internal/util/fs-utils.ts
+++ b/packages/hardhat-core/test/internal/util/fs-utils.ts
@@ -44,7 +44,7 @@ describe("fs-utils", function () {
       await fsPromises.writeFile(actualPath, "");
 
       await assertWithBoth(
-        `${this.tmpDir}/a/../././///mixedCasingFile`,
+        path.join(this.tmpDir, "a", "..", ".", ".", "", "", "mixedCasingFile"),
         actualPath
       );
     });
@@ -172,17 +172,17 @@ describe("fs-utils", function () {
       // We test mixedCaseFilePath2 form tmpdir
       await assertWithBoth(
         this.tmpDir,
-        "mixedCaseDir/mixedCaseFile2",
+        path.join("mixedCaseDir", "mixedCaseFile2"),
         path.relative(this.tmpDir, mixedCaseFile2Path)
       );
       await assertWithBoth(
         this.tmpDir,
-        "mixedcasedir/MIXEDCASEFILE2",
+        path.join("mixedcasedir", "MIXEDCASEFILE2"),
         path.relative(this.tmpDir, mixedCaseFile2Path)
       );
       await assertWithBoth(
         this.tmpDir,
-        "MIXEDCASEDIR/mixedcasefile2",
+        path.join("MIXEDCASEDIR", "mixedcasefile2"),
         path.relative(this.tmpDir, mixedCaseFile2Path)
       );
 
@@ -228,7 +228,7 @@ describe("fs-utils", function () {
       await fsPromises.mkdir(path.join(this.tmpDir, "dir-with-extension.txt"));
       await fsPromises.mkdir(path.join(this.tmpDir, "dir-WithCasing"));
       await fsPromises.mkdir(
-        path.join(this.tmpDir, "dir-with-files/dir-within-dir")
+        path.join(this.tmpDir, "dir-with-files", "dir-within-dir")
       );
 
       await fsPromises.writeFile(path.join(this.tmpDir, "file-1.txt"), "");
@@ -236,31 +236,31 @@ describe("fs-utils", function () {
       await fsPromises.writeFile(path.join(this.tmpDir, "file-3.json"), "");
 
       await fsPromises.writeFile(
-        path.join(this.tmpDir, "dir-with-files/inner-file-1.json"),
+        path.join(this.tmpDir, "dir-with-files", "inner-file-1.json"),
         ""
       );
       await fsPromises.writeFile(
-        path.join(this.tmpDir, "dir-with-files/inner-file-2.txt"),
+        path.join(this.tmpDir, "dir-with-files", "inner-file-2.txt"),
         ""
       );
 
       // This dir has .txt extension and has a .txt and .json file
       await fsPromises.writeFile(
-        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-3.txt"),
+        path.join(this.tmpDir, "dir-with-extension.txt", "inner-file-3.txt"),
         ""
       );
       await fsPromises.writeFile(
-        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-4.json"),
-        ""
-      );
-
-      await fsPromises.writeFile(
-        path.join(this.tmpDir, "dir-WithCasing/file-WithCASING"),
+        path.join(this.tmpDir, "dir-with-extension.txt", "inner-file-4.json"),
         ""
       );
 
       await fsPromises.writeFile(
-        path.join(this.tmpDir, "dir-with-files/dir-within-dir/file-deep"),
+        path.join(this.tmpDir, "dir-WithCasing", "file-WithCASING"),
+        ""
+      );
+
+      await fsPromises.writeFile(
+        path.join(this.tmpDir, "dir-with-files", "dir-within-dir", "file-deep"),
         ""
       );
     });
@@ -294,16 +294,16 @@ describe("fs-utils", function () {
         path.join(this.tmpDir, "file-1.txt"),
         path.join(this.tmpDir, "file-2.txt"),
         path.join(this.tmpDir, "file-3.json"),
-        path.join(this.tmpDir, "dir-with-files/inner-file-1.json"),
-        path.join(this.tmpDir, "dir-with-files/inner-file-2.txt"),
-        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-3.txt"),
-        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-4.json"),
-        path.join(this.tmpDir, "dir-WithCasing/file-WithCASING"),
-        path.join(this.tmpDir, "dir-with-files/dir-within-dir/file-deep"),
+        path.join(this.tmpDir, "dir-with-files", "inner-file-1.json"),
+        path.join(this.tmpDir, "dir-with-files", "inner-file-2.txt"),
+        path.join(this.tmpDir, "dir-with-extension.txt", "inner-file-3.txt"),
+        path.join(this.tmpDir, "dir-with-extension.txt", "inner-file-4.json"),
+        path.join(this.tmpDir, "dir-WithCasing", "file-WithCASING"),
+        path.join(this.tmpDir, "dir-with-files", "dir-within-dir", "file-deep"),
       ]);
 
       await assertBoth(path.join(this.tmpDir, "dir-WithCasing"), undefined, [
-        path.join(this.tmpDir, "dir-WithCasing/file-WithCASING"),
+        path.join(this.tmpDir, "dir-WithCasing", "file-WithCASING"),
       ]);
     });
 
@@ -311,16 +311,16 @@ describe("fs-utils", function () {
       await assertBoth(this.tmpDir, (f) => f.endsWith(".txt"), [
         path.join(this.tmpDir, "file-1.txt"),
         path.join(this.tmpDir, "file-2.txt"),
-        path.join(this.tmpDir, "dir-with-files/inner-file-2.txt"),
-        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-3.txt"),
+        path.join(this.tmpDir, "dir-with-files", "inner-file-2.txt"),
+        path.join(this.tmpDir, "dir-with-extension.txt", "inner-file-3.txt"),
       ]);
 
       await assertBoth(this.tmpDir, (f) => !f.endsWith(".txt"), [
         path.join(this.tmpDir, "file-3.json"),
-        path.join(this.tmpDir, "dir-with-files/inner-file-1.json"),
-        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-4.json"),
-        path.join(this.tmpDir, "dir-WithCasing/file-WithCASING"),
-        path.join(this.tmpDir, "dir-with-files/dir-within-dir/file-deep"),
+        path.join(this.tmpDir, "dir-with-files", "inner-file-1.json"),
+        path.join(this.tmpDir, "dir-with-extension.txt", "inner-file-4.json"),
+        path.join(this.tmpDir, "dir-WithCasing", "file-WithCASING"),
+        path.join(this.tmpDir, "dir-with-files", "dir-within-dir", "file-deep"),
       ]);
     });
 
@@ -329,7 +329,7 @@ describe("fs-utils", function () {
         await assertBoth(
           this.tmpDir,
           (f) => f.toLowerCase().endsWith("withcasing"),
-          [path.join(this.tmpDir, "dir-WithCasing/file-WithCASING")]
+          [path.join(this.tmpDir, "dir-WithCasing", "file-WithCASING")]
         );
       });
     });

--- a/packages/hardhat-core/test/internal/util/fs-utils.ts
+++ b/packages/hardhat-core/test/internal/util/fs-utils.ts
@@ -1,0 +1,337 @@
+import fsPromises from "fs/promises";
+import path from "path";
+import { assert } from "chai";
+import { useTmpDir } from "../../helpers/fs";
+import {
+  FileNotFoundError,
+  FileSystemAccessError,
+  getAllFilesMatching,
+  getAllFilesMatchingSync,
+  getFileTrueCase,
+  getFileTrueCaseSync,
+  getRealPath,
+  getRealPathSync,
+} from "../../../src/internal/util/fs-utils";
+
+const IS_WINDOWS = process.platform === "win32";
+
+describe("fs-utils", function () {
+  describe("getRealPath and getRealPathSync", function () {
+    useTmpDir("ts-utils");
+
+    async function assertWithBoth(input: string, expected: string) {
+      assert.equal(await getRealPath(input), expected);
+      assert.equal(getRealPathSync(input), expected);
+    }
+
+    it("should resolve symlinks", async function () {
+      if (IS_WINDOWS) {
+        this.skip();
+      }
+
+      const actualPath = path.join(this.tmpDir, "mixedCasingFile");
+      const linkPath = path.join(this.tmpDir, "link");
+      await fsPromises.writeFile(actualPath, "");
+
+      await fsPromises.symlink(actualPath, linkPath);
+
+      await assertWithBoth(linkPath, actualPath);
+    });
+
+    it("should normalize the path", async function () {
+      const actualPath = path.join(this.tmpDir, "mixedCasingFile");
+
+      await fsPromises.writeFile(actualPath, "");
+
+      await assertWithBoth(
+        `${this.tmpDir}/a/../././///mixedCasingFile`,
+        actualPath
+      );
+    });
+
+    it("should throw FileNotFoundError if not found", async function () {
+      try {
+        await getRealPath(path.join(this.tmpDir, "not-exists"));
+        assert.fail("Should have thrown");
+      } catch (e) {
+        if (!(e instanceof FileNotFoundError)) {
+          throw e;
+        }
+      }
+
+      try {
+        getRealPathSync(path.join(this.tmpDir, "not-exists"));
+        assert.fail("Should have thrown");
+      } catch (e) {
+        if (!(e instanceof FileNotFoundError)) {
+          throw e;
+        }
+      }
+    });
+
+    it("should throw FileSystemAccessError if a different error is thrown", async function () {
+      const linkPath = path.join(this.tmpDir, "link");
+
+      await fsPromises.symlink(linkPath, linkPath);
+
+      try {
+        await getRealPath(linkPath);
+        assert.fail("Should have thrown");
+      } catch (e) {
+        if (!(e instanceof FileSystemAccessError)) {
+          throw e;
+        }
+      }
+
+      try {
+        getRealPathSync(linkPath);
+        assert.fail("Should have thrown");
+      } catch (e) {
+        if (!(e instanceof FileSystemAccessError)) {
+          throw e;
+        }
+      }
+    });
+  });
+
+  describe("getFileTrueCase and getFileTrueCaseSync", function () {
+    useTmpDir("getFileTrueCase");
+
+    async function assertWithBoth(
+      from: string,
+      relativePath: string,
+      expected: string
+    ) {
+      assert.equal(await getFileTrueCase(from, relativePath), expected);
+      assert.equal(getFileTrueCaseSync(from, relativePath), expected);
+    }
+
+    it("Should throw FileNotFoundError if not found", async function () {
+      try {
+        await getFileTrueCase(__dirname, "asd");
+        assert.fail("should have thrown");
+      } catch (e) {
+        if (!(e instanceof FileNotFoundError)) {
+          throw e;
+        }
+      }
+
+      try {
+        getFileTrueCaseSync(__dirname, "asd");
+        assert.fail("should have thrown");
+      } catch (e) {
+        if (!(e instanceof FileNotFoundError)) {
+          throw e;
+        }
+      }
+    });
+
+    it("Should return the true case of files and dirs", async function () {
+      const mixedCaseFilePath = path.join(this.tmpDir, "mixedCaseFile");
+      const mixedCaseDirPath = path.join(this.tmpDir, "mixedCaseDir");
+      const mixedCaseFile2Path = path.join(mixedCaseDirPath, "mixedCaseFile2");
+
+      await fsPromises.writeFile(mixedCaseFilePath, "");
+      await fsPromises.mkdir(mixedCaseDirPath);
+      await fsPromises.writeFile(mixedCaseFile2Path, "");
+
+      // We test mixedCaseFilePath form tmpdir
+      await assertWithBoth(
+        this.tmpDir,
+        "mixedCaseFile",
+        path.relative(this.tmpDir, mixedCaseFilePath)
+      );
+      await assertWithBoth(
+        this.tmpDir,
+        "mixedcasefile",
+        path.relative(this.tmpDir, mixedCaseFilePath)
+      );
+      await assertWithBoth(
+        this.tmpDir,
+        "MIXEDCASEFILE",
+        path.relative(this.tmpDir, mixedCaseFilePath)
+      );
+
+      // We test mixedCaseDirPath form tmpdir
+      await assertWithBoth(
+        this.tmpDir,
+        "mixedCaseDir",
+        path.relative(this.tmpDir, mixedCaseDirPath)
+      );
+      await assertWithBoth(
+        this.tmpDir,
+        "mixedcasedir",
+        path.relative(this.tmpDir, mixedCaseDirPath)
+      );
+      await assertWithBoth(
+        this.tmpDir,
+        "MIXEDCASEDIR",
+        path.relative(this.tmpDir, mixedCaseDirPath)
+      );
+
+      // We test mixedCaseFilePath2 form tmpdir
+      await assertWithBoth(
+        this.tmpDir,
+        "mixedCaseDir/mixedCaseFile2",
+        path.relative(this.tmpDir, mixedCaseFile2Path)
+      );
+      await assertWithBoth(
+        this.tmpDir,
+        "mixedcasedir/MIXEDCASEFILE2",
+        path.relative(this.tmpDir, mixedCaseFile2Path)
+      );
+      await assertWithBoth(
+        this.tmpDir,
+        "MIXEDCASEDIR/mixedcasefile2",
+        path.relative(this.tmpDir, mixedCaseFile2Path)
+      );
+
+      // We test mixedCaseFilePath2 form mixedCaseDir
+      await assertWithBoth(
+        mixedCaseDirPath,
+        "mixedCaseFile2",
+        path.relative(mixedCaseDirPath, mixedCaseFile2Path)
+      );
+      await assertWithBoth(
+        mixedCaseDirPath,
+        "MIXEDCASEFILE2",
+        path.relative(mixedCaseDirPath, mixedCaseFile2Path)
+      );
+      await assertWithBoth(
+        mixedCaseDirPath,
+        "mixedcasefile2",
+        path.relative(mixedCaseDirPath, mixedCaseFile2Path)
+      );
+    });
+
+    it("Should NOT resolve symlinks", async function () {
+      if (IS_WINDOWS) {
+        this.skip();
+      }
+
+      const actualPath = path.join(this.tmpDir, "mixedCasingFile");
+      const linkPath = path.join(this.tmpDir, "lInK");
+      await fsPromises.writeFile(actualPath, "");
+
+      await fsPromises.symlink(actualPath, linkPath);
+
+      await assertWithBoth(this.tmpDir, "link", "lInK");
+    });
+  });
+
+  describe("getAllFilesMatching and getAllFilesMatchingSync", function () {
+    useTmpDir("getAllFilesMatching");
+
+    beforeEach(async function () {
+      await fsPromises.mkdir(path.join(this.tmpDir, "dir-empty"));
+      await fsPromises.mkdir(path.join(this.tmpDir, "dir-with-files"));
+      await fsPromises.mkdir(path.join(this.tmpDir, "dir-with-extension.txt"));
+      await fsPromises.mkdir(path.join(this.tmpDir, "dir-WithCasing"));
+      await fsPromises.mkdir(
+        path.join(this.tmpDir, "dir-with-files/dir-within-dir")
+      );
+
+      await fsPromises.writeFile(path.join(this.tmpDir, "file-1.txt"), "");
+      await fsPromises.writeFile(path.join(this.tmpDir, "file-2.txt"), "");
+      await fsPromises.writeFile(path.join(this.tmpDir, "file-3.json"), "");
+
+      await fsPromises.writeFile(
+        path.join(this.tmpDir, "dir-with-files/inner-file-1.json"),
+        ""
+      );
+      await fsPromises.writeFile(
+        path.join(this.tmpDir, "dir-with-files/inner-file-2.txt"),
+        ""
+      );
+
+      // This dir has .txt extension and has a .txt and .json file
+      await fsPromises.writeFile(
+        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-3.txt"),
+        ""
+      );
+      await fsPromises.writeFile(
+        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-4.json"),
+        ""
+      );
+
+      await fsPromises.writeFile(
+        path.join(this.tmpDir, "dir-WithCasing/file-WithCASING"),
+        ""
+      );
+
+      await fsPromises.writeFile(
+        path.join(this.tmpDir, "dir-with-files/dir-within-dir/file-deep"),
+        ""
+      );
+    });
+
+    async function assertBoth(
+      dir: string,
+      matches: ((f: string) => boolean) | undefined,
+      expected: string[]
+    ) {
+      assert.deepEqual(
+        new Set(await getAllFilesMatching(dir, matches)),
+        new Set(expected)
+      );
+
+      assert.deepEqual(
+        new Set(getAllFilesMatchingSync(dir, matches)),
+        new Set(expected)
+      );
+    }
+
+    it("Should return an empty array if the dir doesn't exist", async function () {
+      await assertBoth(path.join(this.tmpDir, "not-in-fs"), undefined, []);
+    });
+
+    it("Should return an empty array if the dir is empty", async function () {
+      await assertBoth(path.join(this.tmpDir, "dir-empty"), undefined, []);
+    });
+
+    it("Should return every file by default, recursively", async function () {
+      await assertBoth(this.tmpDir, undefined, [
+        path.join(this.tmpDir, "file-1.txt"),
+        path.join(this.tmpDir, "file-2.txt"),
+        path.join(this.tmpDir, "file-3.json"),
+        path.join(this.tmpDir, "dir-with-files/inner-file-1.json"),
+        path.join(this.tmpDir, "dir-with-files/inner-file-2.txt"),
+        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-3.txt"),
+        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-4.json"),
+        path.join(this.tmpDir, "dir-WithCasing/file-WithCASING"),
+        path.join(this.tmpDir, "dir-with-files/dir-within-dir/file-deep"),
+      ]);
+
+      await assertBoth(path.join(this.tmpDir, "dir-WithCasing"), undefined, [
+        path.join(this.tmpDir, "dir-WithCasing/file-WithCASING"),
+      ]);
+    });
+
+    it("Should filter files and not dirs", async function () {
+      await assertBoth(this.tmpDir, (f) => f.endsWith(".txt"), [
+        path.join(this.tmpDir, "file-1.txt"),
+        path.join(this.tmpDir, "file-2.txt"),
+        path.join(this.tmpDir, "dir-with-files/inner-file-2.txt"),
+        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-3.txt"),
+      ]);
+
+      await assertBoth(this.tmpDir, (f) => !f.endsWith(".txt"), [
+        path.join(this.tmpDir, "file-3.json"),
+        path.join(this.tmpDir, "dir-with-files/inner-file-1.json"),
+        path.join(this.tmpDir, "dir-with-extension.txt/inner-file-4.json"),
+        path.join(this.tmpDir, "dir-WithCasing/file-WithCASING"),
+        path.join(this.tmpDir, "dir-with-files/dir-within-dir/file-deep"),
+      ]);
+    });
+
+    it("Should preserve the true casing of the files, except for the dir's path", async function () {
+      it("Should filter files and not dirs", async function () {
+        await assertBoth(
+          this.tmpDir,
+          (f) => f.toLowerCase().endsWith("withcasing"),
+          [path.join(this.tmpDir, "dir-WithCasing/file-WithCASING")]
+        );
+      });
+    });
+  });
+});

--- a/packages/hardhat-core/test/internal/util/packageInfo.ts
+++ b/packages/hardhat-core/test/internal/util/packageInfo.ts
@@ -1,11 +1,11 @@
 import { assert } from "chai";
-import fsExtra from "fs-extra";
 import path from "path";
 
 import {
   getPackageJson,
   getPackageRoot,
 } from "../../../src/internal/util/packageInfo";
+import { getRealPath } from "../../../src/internal/util/fs-utils";
 
 describe("packageInfo", () => {
   it("Should give the right package.json", async () => {
@@ -16,7 +16,7 @@ describe("packageInfo", () => {
   });
 
   it("should give the right package root", async () => {
-    const root = await fsExtra.realpath(path.join(__dirname, "..", "..", ".."));
+    const root = await getRealPath(path.join(__dirname, "..", "..", ".."));
     assert.equal(getPackageRoot(), root);
   });
 });

--- a/packages/hardhat-truffle5/src/index.ts
+++ b/packages/hardhat-truffle5/src/index.ts
@@ -5,7 +5,7 @@ import {
 } from "hardhat/builtin-tasks/task-names";
 import { extendEnvironment, subtask } from "hardhat/config";
 import { normalizeHardhatNetworkAccountsConfig } from "hardhat/internal/core/providers/util";
-import { glob } from "hardhat/internal/util/glob";
+import { getAllFilesMatching } from "hardhat/internal/util/fs-utils";
 import {
   HARDHAT_NETWORK_NAME,
   lazyFunction,
@@ -179,7 +179,11 @@ subtask(
   TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS,
   async (_, { config }, runSuper) => {
     const sources = await runSuper();
-    const testSources = await glob(join(config.paths.tests, "**", "*.sol"));
+
+    const testSources = await getAllFilesMatching(config.paths.tests, (f) =>
+      f.endsWith(".sol")
+    );
+
     return [...sources, ...testSources];
   }
 );

--- a/packages/hardhat-truffle5/src/index.ts
+++ b/packages/hardhat-truffle5/src/index.ts
@@ -5,7 +5,7 @@ import {
 } from "hardhat/builtin-tasks/task-names";
 import { extendEnvironment, subtask } from "hardhat/config";
 import { normalizeHardhatNetworkAccountsConfig } from "hardhat/internal/core/providers/util";
-import { getAllFilesMatching } from "hardhat/internal/util/fs-utils";
+import { glob } from "hardhat/internal/util/glob";
 import {
   HARDHAT_NETWORK_NAME,
   lazyFunction,
@@ -179,10 +179,7 @@ subtask(
   TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS,
   async (_, { config }, runSuper) => {
     const sources = await runSuper();
-
-    const testSources = await getAllFilesMatching(config.paths.tests, (f) =>
-      f.endsWith(".sol")
-    );
+    const testSources = await glob(join(config.paths.tests, "**", "*.sol"));
 
     return [...sources, ...testSources];
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10920,11 +10920,6 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==
 
-"true-case-path@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-2.2.1.tgz#c5bf04a5bbec3fd118be4084461b3a27c4d796bf"
-  integrity sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
-
 truffle-blockchain-utils@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz#a4e5c064dadd69f782a137f3d276d21095da7a47"


### PR DESCRIPTION
Sixth PR of the compilation times optimization effort.

This PR introduces multiple smaller optimizations:

* I created an fs-util module to replace slower dependencies with it (e.g. `glob`)
* Stopped using `loadash` whenever possible, and only load its necessary modules when we still use it.
* Use `execFile` instead of `exec` to run the compiler, as `exec` spawns a new shell (!!!!!!)
* Don't import `hardhat/console.sol` in the sample project as it's slow to compile.
* Some hardhat load time optimizations — Mostly requiring things when needed instead of at the top of the file
* Cache the solidity files resolution results — We were reading each file multiple times (!)
* We were reading some files just to check for their existence (!)

WIP: Parts of this require tests.

Depends on https://github.com/NomicFoundation/hardhat/pull/3052