### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/content/tutorial/testing-contracts.md
+++ b/docs/src/content/tutorial/testing-contracts.md
@@ -196,7 +196,7 @@ const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
 describe("Token contract", function () {
   // We define a fixture to reuse the same setup in every test. We use
   // loadFixture to run this setup once, snapshot that state, and reset Hardhat
-  // Network to that snapshopt in every test.
+  // Network to that snapshot in every test.
   async function deployTokenFixture() {
     // Get the ContractFactory and Signers here.
     const Token = await ethers.getContractFactory("Token");


### PR DESCRIPTION
Just fixed a typo in the documentation for the testing-contracts that will eventually be used to generate the Lock.ts test.
