### PR TITLE
Allow setting chainId, `hardhat_reset`

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/hardhat.ts
@@ -38,7 +38,10 @@ import { ModulesLogger } from "./logger";
 export class HardhatModule {
   constructor(
     private readonly _node: HardhatNode,
-    private readonly _resetCallback: (forkConfig?: ForkConfig) => Promise<void>,
+    private readonly _resetCallback: (
+      forkConfig?: ForkConfig,
+      chainId?: number
+    ) => Promise<void>,
     private readonly _setLoggingEnabledCallback: (
       loggingEnabled: boolean
     ) => void,
@@ -212,14 +215,16 @@ export class HardhatModule {
 
   // hardhat_reset
 
-  private _resetParams(params: any[]): [RpcHardhatNetworkConfig | undefined] {
+  private _resetParams(
+    params: any[]
+  ): [(RpcHardhatNetworkConfig & { chainId?: number }) | undefined] {
     return validateParams(params, optionalRpcHardhatNetworkConfig);
   }
 
   private async _resetAction(
-    networkConfig?: RpcHardhatNetworkConfig
+    networkConfig?: RpcHardhatNetworkConfig & { chainId?: number }
   ): Promise<true> {
-    await this._resetCallback(networkConfig?.forking);
+    await this._resetCallback(networkConfig?.forking, networkConfig?.chainId);
     return true;
   }
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -274,7 +274,8 @@ export class HardhatNetworkProvider
     );
     this._hardhatModule = new HardhatModule(
       node,
-      (forkConfig?: ForkConfig, chainId?: number) => this._reset(miningTimer, forkConfig, chainId),
+      (forkConfig?: ForkConfig, chainId?: number) =>
+        this._reset(miningTimer, forkConfig, chainId),
       (loggingEnabled: boolean) => {
         this._logger.setEnabled(loggingEnabled);
       },
@@ -333,7 +334,11 @@ export class HardhatNetworkProvider
     return miningTimer;
   }
 
-  private async _reset(miningTimer: MiningTimer, forkConfig?: ForkConfig, chainId?: number) {
+  private async _reset(
+    miningTimer: MiningTimer,
+    forkConfig?: ForkConfig,
+    chainId?: number
+  ) {
     this._forkConfig = forkConfig;
     this._chainId = chainId ?? this._chainId;
     if (this._node !== undefined) {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -77,7 +77,7 @@ export class HardhatNetworkProvider
   constructor(
     private readonly _hardfork: string,
     private readonly _networkName: string,
-    private readonly _chainId: number,
+    private _chainId: number,
     private readonly _networkId: number,
     private readonly _blockGasLimit: number,
     private readonly _initialBaseFeePerGas: number | undefined,
@@ -274,7 +274,7 @@ export class HardhatNetworkProvider
     );
     this._hardhatModule = new HardhatModule(
       node,
-      (forkConfig?: ForkConfig) => this._reset(miningTimer, forkConfig),
+      (forkConfig?: ForkConfig, chainId?: number) => this._reset(miningTimer, forkConfig, chainId),
       (loggingEnabled: boolean) => {
         this._logger.setEnabled(loggingEnabled);
       },
@@ -333,8 +333,9 @@ export class HardhatNetworkProvider
     return miningTimer;
   }
 
-  private async _reset(miningTimer: MiningTimer, forkConfig?: ForkConfig) {
+  private async _reset(miningTimer: MiningTimer, forkConfig?: ForkConfig, chainId?: number) {
     this._forkConfig = forkConfig;
+    this._chainId = chainId ?? this._chainId;
     if (this._node !== undefined) {
       this._stopForwardingNodeEvents(this._node);
     }

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -1268,6 +1268,16 @@ describe("Hardhat module", function () {
               },
             },
           ]);
+
+          await assertInvalidArgumentsError(this.provider, "hardhat_reset", [
+            {
+              forking: {
+                jsonRpcUrl: ALCHEMY_URL,
+                blockNumber: safeBlockInThePast,
+              },
+              chainId: "not a number",
+            },
+          ]);
         });
 
         it("returns true", async function () {
@@ -1359,6 +1369,12 @@ describe("Hardhat module", function () {
           );
         };
 
+        const getCurrentChainId = async (): Promise<number> => {
+          return rpcQuantityToNumber(
+            await this.ctx.provider.send("eth_chainId")
+          );
+        };
+
         function testForkedProviderBehaviour() {
           it("can reset the forked provider to a given forkBlockNumber", async function () {
             await this.provider.send("hardhat_reset", [
@@ -1397,6 +1413,21 @@ describe("Hardhat module", function () {
 
             await this.provider.send("hardhat_reset", [{}]);
             assert.equal(await getLatestBlockNumber(), 0);
+          });
+
+          it("can reset the forked provider and set chainId", async function () {
+            await this.provider.send("hardhat_reset", [
+              {
+                forking: {
+                  ALCHEMY_URL,
+                  safeBlockInThePast,
+                },
+                chainId: 200,
+              },
+            ]);
+
+            assert.equal(await getLatestBlockNumber(), safeBlockInThePast);
+            assert.equal(await getCurrentChainId(), 200);
           });
         }
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team. 
#1697

---

<!-- Add a description of your PR here -->
This PR enables setting the `chainId` in `hardhat_reset` EVM calls. This is an incredibly useful feature as it allows for testing across multiple chains in a single test suite. Currently, it is impossible to change the chainId mid test run.