### PR TITLE
Cache artifact paths

### DIFF
--- a/packages/hardhat-core/src/builtin-tasks/clean.ts
+++ b/packages/hardhat-core/src/builtin-tasks/clean.ts
@@ -12,10 +12,13 @@ subtask(TASK_CLEAN_GLOBAL, async () => {
 
 task(TASK_CLEAN, "Clears the cache and deletes all artifacts")
   .addFlag("global", "Clear the global cache")
-  .setAction(async ({ global }: { global: boolean }, { config, run }) => {
-    if (global) {
-      return run(TASK_CLEAN_GLOBAL);
+  .setAction(
+    async ({ global }: { global: boolean }, { config, run, artifacts }) => {
+      if (global) {
+        return run(TASK_CLEAN_GLOBAL);
+      }
+      await fsExtra.emptyDir(config.paths.cache);
+      await fsExtra.remove(config.paths.artifacts);
+      artifacts.clearCache?.();
     }
-    await fsExtra.emptyDir(config.paths.cache);
-    await fsExtra.remove(config.paths.artifacts);
-  });
+  );

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -1448,6 +1448,8 @@ async function invalidateCacheMissingArtifacts(
     }
   }
 
+  artifacts.clearCache?.();
+
   return solidityFilesCache;
 }
 

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -51,6 +51,7 @@ interface Cache {
 export class Artifacts implements IArtifacts {
   private _validArtifacts: Array<{ sourceName: string; artifacts: string[] }>;
 
+  // Undefined means that the cache is disabled.
   private _cache?: Cache = {
     artifactNameToArtifactPathCache: new Map(),
     artifactFQNToBuildInfoPathCache: new Map(),

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -405,7 +405,7 @@ export class Artifacts implements IArtifacts {
     };
   }
 
-  public disableCaching() {
+  public disableCache() {
     this._cache = undefined;
   }
 

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -181,37 +181,42 @@ export class Artifacts implements IArtifacts {
     artifact: Artifact,
     pathToBuildInfo?: string
   ) {
-    // artifact
-    const fullyQualifiedName = getFullyQualifiedName(
-      artifact.sourceName,
-      artifact.contractName
-    );
+    try {
+      // artifact
+      const fullyQualifiedName = getFullyQualifiedName(
+        artifact.sourceName,
+        artifact.contractName
+      );
 
-    const artifactPath =
-      this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
+      const artifactPath =
+        this.formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
 
-    await fsExtra.ensureDir(path.dirname(artifactPath));
+      await fsExtra.ensureDir(path.dirname(artifactPath));
 
-    await Promise.all([
-      fsExtra.writeJSON(artifactPath, artifact, {
-        spaces: 2,
-      }),
-      (async () => {
-        if (pathToBuildInfo === undefined) {
-          return;
-        }
-
-        // save debug file
-        const debugFilePath = this._getDebugFilePath(artifactPath);
-        const debugFile = this._createDebugFile(artifactPath, pathToBuildInfo);
-
-        await fsExtra.writeJSON(debugFilePath, debugFile, {
+      await Promise.all([
+        fsExtra.writeJSON(artifactPath, artifact, {
           spaces: 2,
-        });
-      })(),
-    ]);
+        }),
+        (async () => {
+          if (pathToBuildInfo === undefined) {
+            return;
+          }
 
-    this.clearCache();
+          // save debug file
+          const debugFilePath = this._getDebugFilePath(artifactPath);
+          const debugFile = this._createDebugFile(
+            artifactPath,
+            pathToBuildInfo
+          );
+
+          await fsExtra.writeJSON(debugFilePath, debugFile, {
+            spaces: 2,
+          });
+        })(),
+      ]);
+    } finally {
+      this.clearCache();
+    }
   }
 
   public async saveBuildInfo(
@@ -220,112 +225,114 @@ export class Artifacts implements IArtifacts {
     input: CompilerInput,
     output: CompilerOutput
   ): Promise<string> {
-    const buildInfoDir = path.join(this._artifactsPath, BUILD_INFO_DIR_NAME);
-    await fsExtra.ensureDir(buildInfoDir);
-
-    const buildInfoName = this._getBuildInfoName(
-      solcVersion,
-      solcLongVersion,
-      input
-    );
-
-    const buildInfo = this._createBuildInfo(
-      buildInfoName,
-      solcVersion,
-      solcLongVersion,
-      input,
-      output
-    );
-
-    const buildInfoPath = path.join(buildInfoDir, `${buildInfoName}.json`);
-
-    // JSON.stringify of the entire build info can be really slow
-    // in larger projects, so we stringify per part and incrementally create
-    // the JSON in the file.
-    //
-    // We split this code into different curly-brace-enclosed scopes so that
-    // partial JSON strings get out of scope sooner and hence can be reclaimed
-    // by the GC if needed.
-    const file = await fsPromises.open(buildInfoPath, "w");
     try {
-      {
-        const withoutOutput = JSON.stringify({
-          ...buildInfo,
-          output: undefined,
-        });
+      const buildInfoDir = path.join(this._artifactsPath, BUILD_INFO_DIR_NAME);
+      await fsExtra.ensureDir(buildInfoDir);
 
-        // We write the JSON (without output) except the last }
-        await file.write(withoutOutput.slice(0, -1));
-      }
+      const buildInfoName = this._getBuildInfoName(
+        solcVersion,
+        solcLongVersion,
+        input
+      );
 
-      {
-        const outputWithoutSourcesAndContracts = JSON.stringify({
-          ...buildInfo.output,
-          sources: undefined,
-          contracts: undefined,
-        });
+      const buildInfo = this._createBuildInfo(
+        buildInfoName,
+        solcVersion,
+        solcLongVersion,
+        input,
+        output
+      );
 
-        // We start writing the output
-        await file.write(',"output":');
+      const buildInfoPath = path.join(buildInfoDir, `${buildInfoName}.json`);
 
-        // Write the output object except for the last }
-        await file.write(outputWithoutSourcesAndContracts.slice(0, -1));
+      // JSON.stringify of the entire build info can be really slow
+      // in larger projects, so we stringify per part and incrementally create
+      // the JSON in the file.
+      //
+      // We split this code into different curly-brace-enclosed scopes so that
+      // partial JSON strings get out of scope sooner and hence can be reclaimed
+      // by the GC if needed.
+      const file = await fsPromises.open(buildInfoPath, "w");
+      try {
+        {
+          const withoutOutput = JSON.stringify({
+            ...buildInfo,
+            output: undefined,
+          });
 
-        // If there were other field apart from sources and contracts we need
-        // a comma
-        if (outputWithoutSourcesAndContracts.length > 2) {
-          await file.write(",");
-        }
-      }
-
-      // Writing the sources
-      await file.write('"sources":{');
-
-      let isFirst = true;
-      for (const [name, value] of Object.entries(
-        buildInfo.output.sources ?? {}
-      )) {
-        if (isFirst) {
-          isFirst = false;
-        } else {
-          await file.write(",");
+          // We write the JSON (without output) except the last }
+          await file.write(withoutOutput.slice(0, -1));
         }
 
-        await file.write(`${JSON.stringify(name)}:${JSON.stringify(value)}`);
-      }
+        {
+          const outputWithoutSourcesAndContracts = JSON.stringify({
+            ...buildInfo.output,
+            sources: undefined,
+            contracts: undefined,
+          });
 
-      // Close sources object
-      await file.write("}");
+          // We start writing the output
+          await file.write(',"output":');
 
-      // Writing the contracts
-      await file.write(',"contracts":{');
+          // Write the output object except for the last }
+          await file.write(outputWithoutSourcesAndContracts.slice(0, -1));
 
-      isFirst = true;
-      for (const [name, value] of Object.entries(
-        buildInfo.output.contracts ?? {}
-      )) {
-        if (isFirst) {
-          isFirst = false;
-        } else {
-          await file.write(",");
+          // If there were other field apart from sources and contracts we need
+          // a comma
+          if (outputWithoutSourcesAndContracts.length > 2) {
+            await file.write(",");
+          }
         }
 
-        await file.write(`${JSON.stringify(name)}:${JSON.stringify(value)}`);
+        // Writing the sources
+        await file.write('"sources":{');
+
+        let isFirst = true;
+        for (const [name, value] of Object.entries(
+          buildInfo.output.sources ?? {}
+        )) {
+          if (isFirst) {
+            isFirst = false;
+          } else {
+            await file.write(",");
+          }
+
+          await file.write(`${JSON.stringify(name)}:${JSON.stringify(value)}`);
+        }
+
+        // Close sources object
+        await file.write("}");
+
+        // Writing the contracts
+        await file.write(',"contracts":{');
+
+        isFirst = true;
+        for (const [name, value] of Object.entries(
+          buildInfo.output.contracts ?? {}
+        )) {
+          if (isFirst) {
+            isFirst = false;
+          } else {
+            await file.write(",");
+          }
+
+          await file.write(`${JSON.stringify(name)}:${JSON.stringify(value)}`);
+        }
+
+        // close contracts object
+        await file.write("}");
+        // close output object
+        await file.write("}");
+        // close build info object
+        await file.write("}");
+      } finally {
+        await file.close();
       }
 
-      // close contracts object
-      await file.write("}");
-      // close output object
-      await file.write("}");
-      // close build info object
-      await file.write("}");
+      return buildInfoPath;
     } finally {
-      await file.close();
+      this.clearCache();
     }
-
-    this.clearCache();
-
-    return buildInfoPath;
   }
 
   /**

--- a/packages/hardhat-core/src/types/artifacts.ts
+++ b/packages/hardhat-core/src/types/artifacts.ts
@@ -109,7 +109,7 @@ export interface Artifacts {
   clearCache?: () => void;
 
   /**
-   * This method, if present, disables the artifacts caching.
+   * This method, if present, disables the artifact paths cache.
    *
    * We recommend NOT using this method. The only reason it exists is for
    * backwards compatibility. If your app was assuming no cache, you can use it
@@ -117,7 +117,7 @@ export interface Artifacts {
    *
    * @see clearCache
    */
-  disableCaching?: () => void;
+  disableCache?: () => void;
 }
 
 /**

--- a/packages/hardhat-core/src/types/artifacts.ts
+++ b/packages/hardhat-core/src/types/artifacts.ts
@@ -97,6 +97,27 @@ export interface Artifacts {
    * @param fullyQualifiedName The FQN of the artifact.
    */
   formArtifactPathFromFullyQualifiedName(fullyQualifiedName: string): string;
+
+  /**
+   * Starting with Hardhat 2.11.0, the artifacts object caches the information
+   * about paths that it fetches from the filesystem (e.g. the list of
+   * artifacts, the path that an artifact name resolves to, etc.). The artifacts
+   * and buildInfos themselves are not cached, only their paths.
+   *
+   * This method, if present, clears that cache.
+   */
+  clearCache?: () => void;
+
+  /**
+   * This method, if present, disables the artifacts caching.
+   *
+   * We recommend NOT using this method. The only reason it exists is for
+   * backwards compatibility. If your app was assuming no cache, you can use it
+   * (e.g. from an HRE extender).
+   *
+   * @see clearCache
+   */
+  disableCaching?: () => void;
 }
 
 /**

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -3,7 +3,6 @@ import fsExtra from "fs-extra";
 import * as os from "os";
 import * as path from "path";
 
-import { beforeEach } from "mocha";
 import {
   Artifacts,
   getArtifactFromContractOutput,

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -1076,7 +1076,7 @@ describe("Artifacts class", function () {
         assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
         assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
 
-        // we create some other files, which should be returned after clearin
+        // we create some other files, which should be returned after clearing
         //  the cache
 
         await fsExtra.writeJSON(path.join(this.tmpDir, "c.sol", "B.json"), {});

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -3,6 +3,7 @@ import fsExtra from "fs-extra";
 import * as os from "os";
 import * as path from "path";
 
+import { beforeEach } from "mocha";
 import {
   Artifacts,
   getArtifactFromContractOutput,
@@ -1000,6 +1001,213 @@ describe("Artifacts class", function () {
             F: contract,
           },
         },
+      });
+    });
+  });
+
+  // TODO: How do we test that getting a path for an artifact and build
+  //   info gets cached?
+  describe("Caching", function () {
+    useTmpDir("artifacts");
+
+    const SOLC_INPUT: CompilerInput = {
+      sources: {},
+      settings: { optimizer: {}, outputSelection: {} },
+      language: "",
+    };
+
+    const SOLC_OUPUT: CompilerOutput = {
+      sources: {},
+      contracts: {},
+    };
+
+    let artifacts: Artifacts;
+    let buildInfoPath: string;
+    beforeEach(async function () {
+      artifacts = new Artifacts(this.tmpDir);
+      buildInfoPath = await artifacts.saveBuildInfo(
+        "0.4.12",
+        "0.4.12+123",
+        SOLC_INPUT,
+        SOLC_OUPUT
+      );
+
+      await artifacts.saveArtifactAndDebugFile(
+        {
+          _format: "",
+          abi: [],
+          contractName: "C",
+          sourceName: "c.sol",
+          bytecode: "",
+          deployedBytecode: "",
+          linkReferences: {},
+          deployedLinkReferences: {},
+        },
+        buildInfoPath
+      );
+    });
+
+    describe("Successful caching", function () {
+      it("Should cache the path to each artifact and build info, and the lists of paths", async function () {
+        assert.lengthOf(await artifacts.getArtifactPaths(), 1);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
+
+        // we create some other files, which shouldn't be returned
+
+        await fsExtra.writeJSON(path.join(this.tmpDir, "c.sol", "B.json"), {});
+        await fsExtra.writeJSON(
+          path.join(this.tmpDir, "c.sol", "B.dbg.json"),
+          {}
+        );
+        await fsExtra.writeJSON(
+          path.join(this.tmpDir, "build-info", "something.json"),
+          {}
+        );
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 1);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
+      });
+    });
+
+    describe("Clear cache", function () {
+      it("Should clear all the caches", async function () {
+        assert.lengthOf(await artifacts.getArtifactPaths(), 1);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
+
+        // we create some other files, which should be returned after clearin
+        //  the cache
+
+        await fsExtra.writeJSON(path.join(this.tmpDir, "c.sol", "B.json"), {});
+        await fsExtra.writeJSON(
+          path.join(this.tmpDir, "c.sol", "B.dbg.json"),
+          {}
+        );
+        await fsExtra.writeJSON(
+          path.join(this.tmpDir, "build-info", "something.json"),
+          {}
+        );
+
+        artifacts.clearCache();
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 2);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 2);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 2);
+      });
+
+      it("Shouldn't re-enable the cache", async function () {
+        artifacts.disableCaching();
+        artifacts.clearCache();
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 1);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
+
+        // we create some other files, which shouldn't be returned
+
+        await fsExtra.writeJSON(path.join(this.tmpDir, "c.sol", "B.json"), {});
+        await fsExtra.writeJSON(
+          path.join(this.tmpDir, "c.sol", "B.dbg.json"),
+          {}
+        );
+        await fsExtra.writeJSON(
+          path.join(this.tmpDir, "build-info", "something.json"),
+          {}
+        );
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 2);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 2);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 2);
+      });
+    });
+
+    describe("Automatic cache clearing", function () {
+      it("Should clear all the caches", async function () {
+        assert.lengthOf(await artifacts.getArtifactPaths(), 1);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
+
+        // create new artifacts clears the cache
+
+        buildInfoPath = await artifacts.saveBuildInfo(
+          "0.4.13",
+          "0.4.13+123",
+          SOLC_INPUT,
+          SOLC_OUPUT
+        );
+
+        await artifacts.saveArtifactAndDebugFile(
+          {
+            _format: "",
+            abi: [],
+            contractName: "C",
+            sourceName: "e.sol",
+            bytecode: "",
+            deployedBytecode: "",
+            linkReferences: {},
+            deployedLinkReferences: {},
+          },
+          buildInfoPath
+        );
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 2);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 2);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 2);
+      });
+
+      it("Shouldn't re-enable the cache", async function () {
+        artifacts.disableCaching();
+        artifacts.clearCache();
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 1);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
+
+        // create new artifacts clears the cache
+
+        buildInfoPath = await artifacts.saveBuildInfo(
+          "0.4.13",
+          "0.4.13+123",
+          SOLC_INPUT,
+          SOLC_OUPUT
+        );
+
+        await artifacts.saveArtifactAndDebugFile(
+          {
+            _format: "",
+            abi: [],
+            contractName: "C",
+            sourceName: "e.sol",
+            bytecode: "",
+            deployedBytecode: "",
+            linkReferences: {},
+            deployedLinkReferences: {},
+          },
+          buildInfoPath
+        );
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 2);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 2);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 2);
+
+        // we create some other files, which should be returned, as the cache
+        //  is disabled
+
+        await fsExtra.writeJSON(path.join(this.tmpDir, "c.sol", "B.json"), {});
+        await fsExtra.writeJSON(
+          path.join(this.tmpDir, "c.sol", "B.dbg.json"),
+          {}
+        );
+        await fsExtra.writeJSON(
+          path.join(this.tmpDir, "build-info", "something.json"),
+          {}
+        );
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 3);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 3);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 3);
       });
     });
   });

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -1098,13 +1098,21 @@ describe("Artifacts class", function () {
 
       it("Shouldn't re-enable the cache", async function () {
         artifacts.disableCaching();
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 1);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
+
+        // We clear the cache here and call the getters again, this shouldn't
+        // cache the results
         artifacts.clearCache();
 
         assert.lengthOf(await artifacts.getArtifactPaths(), 1);
         assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
         assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
 
-        // we create some other files, which shouldn't be returned
+        // we create some other files, which should be returned, as there's
+        // no cache
 
         await fsExtra.writeJSON(path.join(this.tmpDir, "c.sol", "B.json"), {});
         await fsExtra.writeJSON(

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -1217,6 +1217,38 @@ describe("Artifacts class", function () {
         assert.lengthOf(await artifacts.getBuildInfoPaths(), 3);
       });
     });
+
+    describe("Disabling cache", function () {
+      it("Should clear the cache", async function () {
+        assert.lengthOf(await artifacts.getArtifactPaths(), 1);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
+
+        // we create some other files, which shouldn't be returned
+
+        await fsExtra.writeJSON(path.join(this.tmpDir, "c.sol", "B.json"), {});
+        await fsExtra.writeJSON(
+          path.join(this.tmpDir, "c.sol", "B.dbg.json"),
+          {}
+        );
+        await fsExtra.writeJSON(
+          path.join(this.tmpDir, "build-info", "something.json"),
+          {}
+        );
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 1);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
+
+        artifacts.disableCaching();
+
+        // we disabled the cache, so now they should be returned
+
+        assert.lengthOf(await artifacts.getArtifactPaths(), 2);
+        assert.lengthOf(await artifacts.getDebugFilePaths(), 2);
+        assert.lengthOf(await artifacts.getBuildInfoPaths(), 2);
+      });
+    });
   });
 });
 

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -1097,7 +1097,7 @@ describe("Artifacts class", function () {
       });
 
       it("Shouldn't re-enable the cache", async function () {
-        artifacts.disableCaching();
+        artifacts.disableCache();
 
         assert.lengthOf(await artifacts.getArtifactPaths(), 1);
         assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
@@ -1165,7 +1165,7 @@ describe("Artifacts class", function () {
       });
 
       it("Shouldn't re-enable the cache", async function () {
-        artifacts.disableCaching();
+        artifacts.disableCache();
         artifacts.clearCache();
 
         assert.lengthOf(await artifacts.getArtifactPaths(), 1);
@@ -1240,7 +1240,7 @@ describe("Artifacts class", function () {
         assert.lengthOf(await artifacts.getDebugFilePaths(), 1);
         assert.lengthOf(await artifacts.getBuildInfoPaths(), 1);
 
-        artifacts.disableCaching();
+        artifacts.disableCache();
 
         // we disabled the cache, so now they should be returned
 


### PR DESCRIPTION
Seventh PR optimizing the compilation and test loop.

This PR modifies `hre.artifacts` so that it caches the paths to the different files.

Depends on #3053