### PR TITLE
Network helpers: fix set storage at multi leading zeros slot

### DIFF
--- a/.changeset/famous-points-count.md
+++ b/.changeset/famous-points-count.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Fix `setStorageAt` so it can accept multiple leading zeros in the slot

--- a/packages/hardhat-network-helpers/src/utils.ts
+++ b/packages/hardhat-network-helpers/src/utils.ts
@@ -69,7 +69,7 @@ export function toRpcQuantity(x: NumberLike): string {
 
   if (hex === "0x0") return hex;
 
-  return hex.startsWith("0x") ? hex.replace("0x0", "0x") : `0x${hex}`;
+  return hex.startsWith("0x") ? hex.replace(/0x0+/, "0x") : `0x${hex}`;
 }
 
 export function assertValidAddress(address: string): void {

--- a/packages/hardhat-network-helpers/test/helpers/setStorageAt.ts
+++ b/packages/hardhat-network-helpers/test/helpers/setStorageAt.ts
@@ -40,6 +40,7 @@ describe("setStorageAt", function () {
       ["bigint", BigInt(1), 1],
       ["hex encoded", "0x1", 1],
       ["hex encoded with leading zeros", "0x01", 1],
+      ["hex encoded with several leading zeros", "0x001", 1],
       ["ethers's bignumber instances", ethers.BigNumber.from(1), 1],
       ["bn.js instances", new BN(1), 1],
     ];


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.
---

Fix #3122