### PR TITLE
Throw a clear error when native solc fails to run

### DIFF
--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -850,6 +850,21 @@ If this error persists, run \`npx hardhat clean --global\`.`,
 Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
       shouldBeReported: true,
     },
+    CANT_RUN_NATIVE_COMPILER: {
+      number: 505,
+      message: `A native version of solc failed to run.
+
+If you are running MacOS, try installing Apple Rosetta.
+
+If this error persists, run "npx hardhat clean --global".`,
+      title: "Failed to run native solc",
+      description: `Hardhat successfully downloaded a native version of solc but it doesn't run.
+
+If you are running MacOS, try installing Apple Rosetta.
+
+If this error persists, run "npx hardhat clean --global".`,
+      shouldBeReported: false,
+    },
   },
   BUILTIN_TASKS: {
     COMPILE_FAILURE: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,15 +2052,10 @@ ansi-styles@~1.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
   integrity sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA==
 
-antlr4@4.7.1:
+antlr4@4.7.1, antlr4@~4.8.0:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.7.1.tgz#69984014f096e9e775f53dd9744bf994d8959773"
   integrity sha512-haHyTW7Y9joE5MVs37P2lNYfU2RWBLfcRDD8OWldcdZm5TiCE91B5Xl1oWSwiDUSd4rlExpt2pu1fksYQjRBYQ==
-
-antlr4@~4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.8.0.tgz#f938ec171be7fc2855cd3a533e87647185b32b6a"
-  integrity sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg==
 
 antlr4ts@^0.5.0-alpha.4:
   version "0.5.0-alpha.4"


### PR DESCRIPTION
As part of the performance optimizations we started checking if the downloaded versions of solc work just once, right after downloading them.

This means that if you already had a non-runnable solc version in your fs, we'd try to use it and it will fail.

This PR makes that error more clear, and adds a hint to the user to clear their global cache, which would fix it.

Fixes #3126