### PR TITLE
Improve colors when printing compiler errors

### DIFF
--- a/.changeset/few-sheep-drive.md
+++ b/.changeset/few-sheep-drive.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Stop colorizing the entire message when an error is printed

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -753,13 +753,13 @@ subtask(TASK_COMPILE_SOLIDITY_LOG_COMPILATION_ERRORS)
 
     for (const error of output.errors) {
       if (error.severity === "error") {
-        const errorMessage =
+        const errorMessage: string =
           getFormattedInternalCompilerErrorMessage(error) ??
           error.formattedMessage;
 
-        console.error(chalk.red(errorMessage));
+        console.error(errorMessage.replace(/^\w+:/, t => chalk.red.bold(t)));
       } else {
-        console.warn(chalk.yellow(error.formattedMessage));
+        console.warn((error.formattedMessage as string).replace(/^\w+/, t => chalk.yellow.bold(t)));
       }
     }
 

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -757,9 +757,13 @@ subtask(TASK_COMPILE_SOLIDITY_LOG_COMPILATION_ERRORS)
           getFormattedInternalCompilerErrorMessage(error) ??
           error.formattedMessage;
 
-        console.error(errorMessage.replace(/^\w+:/, t => chalk.red.bold(t)));
+        console.error(errorMessage.replace(/^\w+:/, (t) => chalk.red.bold(t)));
       } else {
-        console.warn((error.formattedMessage as string).replace(/^\w+/, t => chalk.yellow.bold(t)));
+        console.warn(
+          (error.formattedMessage as string).replace(/^\w+/, (t) =>
+            chalk.yellow.bold(t)
+          )
+        );
       }
     }
 

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -313,11 +313,12 @@ async function main() {
 
     if (HardhatError.isHardhatError(error)) {
       isHardhatError = true;
-      console.error(chalk.red(`Error ${error.message}`));
+      console.error(error.message.replace(/^\w+:/, (t) => chalk.red.bold(t)));
     } else if (HardhatPluginError.isHardhatPluginError(error)) {
       isHardhatError = true;
       console.error(
-        chalk.red(`Error in plugin ${error.pluginName}: ${error.message}`)
+        chalk.red.bold(`Error in plugin ${error.pluginName}:`),
+        error.message
       );
     } else if (error instanceof Error) {
       console.error(chalk.red("An unexpected error occurred:"));

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -313,7 +313,10 @@ async function main() {
 
     if (HardhatError.isHardhatError(error)) {
       isHardhatError = true;
-      console.error(error.message.replace(/^\w+:/, (t) => chalk.red.bold(t)));
+      console.error(
+        chalk.red.bold("Error"),
+        error.message.replace(/^\w+:/, (t) => chalk.red.bold(t))
+      );
     } else if (HardhatPluginError.isHardhatPluginError(error)) {
       isHardhatError = true;
       console.error(


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/hardhat/issues/680

---

<!-- Add a description of your PR here -->

Before:

![image](https://user-images.githubusercontent.com/481465/188987251-ffd60222-341b-4084-9f4a-d30f4ee7fe65.png)

After:

![image](https://user-images.githubusercontent.com/481465/188987053-6fd25a7d-51fb-476b-80a8-1261d8e5340a.png)


Opening as a Draft because as you can see there are other errors which are still printed entirely colored. Changing that would be more effort but it would look more consistent. Let me know your thoughts.

Note this may conflict with a potential future Solidity feature: https://github.com/ethereum/solidity/issues/11507

To-do:
- [ ] Check if we can handle https://github.com/NomicFoundation/hardhat/issues/1846 here