### PR TITLE
Fix GH workflows filters

### DIFF
--- a/.github/workflows/comment-on-linter-error.yml
+++ b/.github/workflows/comment-on-linter-error.yml
@@ -5,7 +5,7 @@ on:
     types:
       - opened
     branches:
-      - master
+      - $default-branch
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -10,7 +10,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/e2e/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/hardhat-chai-matchers-ci.yml
+++ b/.github/workflows/hardhat-chai-matchers-ci.yml
@@ -9,7 +9,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-chai-matchers/**"
       - "packages/hardhat-common/**"

--- a/.github/workflows/hardhat-core-ci.yml
+++ b/.github/workflows/hardhat-core-ci.yml
@@ -9,7 +9,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-core/**"
       - "packages/hardhat-common/**"

--- a/.github/workflows/hardhat-ethers-ci.yml
+++ b/.github/workflows/hardhat-ethers-ci.yml
@@ -10,7 +10,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-ethers/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/hardhat-etherscan-ci.yml
+++ b/.github/workflows/hardhat-etherscan-ci.yml
@@ -10,7 +10,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-etherscan/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/hardhat-ganache-ci.yml
+++ b/.github/workflows/hardhat-ganache-ci.yml
@@ -10,7 +10,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-ganache/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/hardhat-network-forking-ci.yml
+++ b/.github/workflows/hardhat-network-forking-ci.yml
@@ -9,7 +9,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-core/**"
       - "packages/hardhat-common/**"

--- a/.github/workflows/hardhat-network-helpers-ci.yml
+++ b/.github/workflows/hardhat-network-helpers-ci.yml
@@ -9,7 +9,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-network-helpers/**"
       - "packages/hardhat-common/**"

--- a/.github/workflows/hardhat-network-tracing-ci.yml
+++ b/.github/workflows/hardhat-network-tracing-ci.yml
@@ -9,7 +9,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-core/**"
       - "packages/hardhat-common/**"

--- a/.github/workflows/hardhat-shorthand-ci.yml
+++ b/.github/workflows/hardhat-shorthand-ci.yml
@@ -10,7 +10,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-shorthand/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/hardhat-solhint-ci.yml
+++ b/.github/workflows/hardhat-solhint-ci.yml
@@ -10,7 +10,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-solhint/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/hardhat-solpp-ci.yml
+++ b/.github/workflows/hardhat-solpp-ci.yml
@@ -10,7 +10,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-solpp/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/hardhat-toolbox-ci.yml
+++ b/.github/workflows/hardhat-toolbox-ci.yml
@@ -14,7 +14,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-toolbox/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/hardhat-truffle4-ci.yml
+++ b/.github/workflows/hardhat-truffle4-ci.yml
@@ -11,7 +11,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-truffle4/**"
       - "packages/hardhat-web3-legacy/**"

--- a/.github/workflows/hardhat-truffle5-ci.yml
+++ b/.github/workflows/hardhat-truffle5-ci.yml
@@ -11,7 +11,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-truffle5/**"
       - "packages/hardhat-web3/**"

--- a/.github/workflows/hardhat-vyper-ci.yml
+++ b/.github/workflows/hardhat-vyper-ci.yml
@@ -10,7 +10,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-vyper/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/hardhat-waffle-ci.yml
+++ b/.github/workflows/hardhat-waffle-ci.yml
@@ -11,7 +11,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-waffle/**"
       - "packages/hardhat-ethers/**"

--- a/.github/workflows/hardhat-web3-ci.yml
+++ b/.github/workflows/hardhat-web3-ci.yml
@@ -10,7 +10,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-web3/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/hardhat-web3-legacy-ci.yml
+++ b/.github/workflows/hardhat-web3-legacy-ci.yml
@@ -10,7 +10,7 @@ on:
       - "config/**"
   pull_request:
     branches:
-      - "*"
+      - "**"
     paths:
       - "packages/hardhat-web3-legacy/**"
       - "packages/hardhat-core/**"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     branches: [$default-branch]
   pull_request:
     branches:
-      - "*"
+      - "**"
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - $default-branch
 
 jobs:
   release:


### PR DESCRIPTION
Use `$default-branch` instead of master, and `**` instead of `*`. From [the docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet):

```
*: Matches zero or more characters, but does not match the / character. For example, Octo* matches Octocat.
**: Matches zero or more of any character.
```