### PR TITLE
Move `compile` task call from `verify:verify` subtask to `verify` task

### DIFF
--- a/packages/hardhat-etherscan/src/index.ts
+++ b/packages/hardhat-etherscan/src/index.ts
@@ -168,7 +168,7 @@ const verify: ActionType<VerificationArgs> = async (
   });
 
   if (!noCompile) {
-      // Make sure that contract artifacts are up-to-date.
+    // Make sure that contract artifacts are up-to-date.
     await run(TASK_COMPILE, { quiet: true });
   }
 


### PR DESCRIPTION
Currently when the `verify:verify` subtask is executed programmatically to verify contracts (e.g. in a deployment script) it runs the `compile` task as well. The compilation is rerun multiple times during the deployment process, which is not necessary as it's assumed the compilation was already called before running the deployment.

In the example below I want to deploy three contracts (with `hardhat-deploy` plugin) and then verify them. The contracts will be compiled before the deployment and then each `verify:verify` execution will compile them again.
```
const ContractA = await hre.deployments.deploy("ContractA")
const ContractB = await hre.deployments.deploy("ContractB")
const ContractC = await hre.deployments.deploy("ContractC")

await hre.run("verify:verify", { address: ContractA.address })
await hre.run("verify:verify", { address: ContractB.address })
await hre.run("verify:verify", { address: ContractC.address })
```

Here I propose that the `compile` task execution is moved to the main `verify` task with an optional flag `noCompile` to skip the compilation. This is inspired by the way the `test` task handles compilation: https://github.com/NomicFoundation/hardhat/blob/d377c39aee35234b370a90a1a4a1227717061719/packages/hardhat-core/src/builtin-tasks/test.ts#L153-L155

Closes: https://github.com/NomicFoundation/hardhat/issues/3173