### PR TITLE
Stack traces tests improvements

### DIFF
--- a/.github/workflows/hardhat-network-tracing-all-solc-versions.yml
+++ b/.github/workflows/hardhat-network-tracing-all-solc-versions.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/artifacts
+            packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/artifacts
           key: hardhat-network-stack-traces-tests-${{ hashFiles('yarn.lock') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/*.sol') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/test.json') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/**/*.ts') }}
       - name: Run tests
         env:

--- a/.github/workflows/hardhat-network-tracing-all-solc-versions.yml
+++ b/.github/workflows/hardhat-network-tracing-all-solc-versions.yml
@@ -41,4 +41,5 @@ jobs:
           DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true
           FORCE_COLOR: 3
           NODE_OPTIONS: "--max-old-space-size=4096"
+          HARDHAT_TESTS_ALL_SOLC_VERSIONS: true
         run: yarn test:tracing

--- a/.github/workflows/hardhat-network-tracing-ci.yml
+++ b/.github/workflows/hardhat-network-tracing-ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/artifacts
+            packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/artifacts
           key: hardhat-network-stack-traces-tests-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/*.sol') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/test.json') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/**/*.ts') }}
       - name: Run tests
         env:

--- a/.github/workflows/hardhat-network-tracing-ci.yml
+++ b/.github/workflows/hardhat-network-tracing-ci.yml
@@ -52,5 +52,4 @@ jobs:
           DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true
           FORCE_COLOR: 3
           NODE_OPTIONS: "--max-old-space-size=4096"
-          HARDHAT_TESTS_ONLY_LATEST_SOLC_VERSIONS: true
         run: yarn test:tracing

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/artifacts
+            packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/artifacts
           key: hardhat-network-stack-traces-tests-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/*.sol') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/test.json') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/**/*.ts') }}
       - name: test
         env:

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
@@ -1,8 +1,12 @@
 import fs from "fs";
 import path from "path";
-import solcWrapper from "solc/wrapper";
+import { NativeCompiler } from "../../../../src/internal/solidity/compiler";
+import {
+  Compiler,
+  CompilerDownloader,
+} from "../../../../src/internal/solidity/compiler/downloader";
+import { getCompilersDir } from "../../../../src/internal/util/global-dir";
 
-import { download } from "../../../../src/internal/util/download";
 import { CompilerInput, CompilerOutput } from "../../../../src/types";
 
 export interface CompilerOptions {
@@ -66,71 +70,18 @@ function getSolcInputForLiteral(
   return getSolcInput({ [filename]: { content: source } }, compilerOptions);
 }
 
-/**
- * Copied from `solidity/compiler/index.ts`.
- */
-function loadCompilerSources(compilerPath: string) {
-  const Module = module.constructor as any;
-  const previousHook = Module._extensions[".js"];
-
-  Module._extensions[".js"] = function (
-    module: NodeJS.Module,
-    filename: string
-  ) {
-    const content = fs.readFileSync(filename, "utf8");
-    Object.getPrototypeOf(module)._compile.call(module, content, filename);
-  };
-
-  const loadedSolc = require(compilerPath);
-
-  Module._extensions[".js"] = previousHook;
-
-  return loadedSolc;
-}
-
 export const COMPILER_DOWNLOAD_TIMEOUT = 10000;
-
-function getCompilersDownloadDir() {
-  return path.join(__dirname, "compilers");
-}
-
-function getCompilerDownloadPath(compilerPath: string) {
-  const compilersDir = getCompilersDownloadDir();
-  return path.resolve(compilersDir, compilerPath);
-}
-
-export async function downloadSolc(compilerPath: string): Promise<void> {
-  const absoluteCompilerPath = getCompilerDownloadPath(compilerPath);
-  const compilerUrl = `https://solc-bin.ethereum.org/bin/${compilerPath}`;
-
-  if (fs.existsSync(absoluteCompilerPath)) {
-    return;
-  }
-
-  await download(compilerUrl, absoluteCompilerPath, COMPILER_DOWNLOAD_TIMEOUT);
-}
-
-async function getSolc(compilerPath: string): Promise<any> {
-  const isAbsolutePath = path.isAbsolute(compilerPath);
-
-  if (!isAbsolutePath) {
-    await downloadSolc(compilerPath);
-  }
-
-  const absoluteCompilerPath = isAbsolutePath
-    ? compilerPath
-    : getCompilerDownloadPath(compilerPath);
-
-  return solcWrapper(loadCompilerSources(absoluteCompilerPath));
-}
 
 async function compile(
   input: CompilerInput,
-  compilerOptions: CompilerOptions
+  compiler: Compiler
 ): Promise<[CompilerInput, CompilerOutput]> {
-  const solc = await getSolc(compilerOptions.compilerPath);
+  if (compiler.isSolcJs) {
+    throw new Error("These tests expect to be able to run native solc");
+  }
+  const nativeCompiler = new NativeCompiler(compiler.compilerPath);
 
-  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const output = await nativeCompiler.compile(input);
 
   if (output.errors) {
     for (const error of output.errors) {
@@ -147,10 +98,8 @@ export async function compileFiles(
   sources: string[],
   compilerOptions: CompilerOptions
 ): Promise<[CompilerInput, CompilerOutput]> {
-  return compile(
-    getSolcInputForFiles(sources, compilerOptions),
-    compilerOptions
-  );
+  const compiler = await getCompilerForVersion(compilerOptions.solidityVersion);
+  return compile(getSolcInputForFiles(sources, compilerOptions), compiler);
 }
 
 export async function compileLiteral(
@@ -162,8 +111,45 @@ export async function compileLiteral(
   },
   filename: string = "literal.sol"
 ): Promise<[CompilerInput, CompilerOutput]> {
+  await downloadCompiler(compilerOptions.solidityVersion);
+  const compiler = await getCompilerForVersion(compilerOptions.solidityVersion);
+
   return compile(
     getSolcInputForLiteral(source, compilerOptions, filename),
-    compilerOptions
+    compiler
   );
+}
+
+async function getCompilerForVersion(
+  solidityVersion: string
+): Promise<Compiler> {
+  const compilersCache = await getCompilersDir();
+  const compilerPlatform = CompilerDownloader.getCompilerPlatform();
+  const downloader = CompilerDownloader.getConcurrencySafeDownloader(
+    compilerPlatform,
+    compilersCache
+  );
+  const compiler = await downloader.getCompiler(solidityVersion);
+  if (compiler === undefined) {
+    throw new Error("Expected compiler to be downloaded");
+  }
+
+  return compiler;
+}
+
+export async function downloadCompiler(solidityVersion: string) {
+  const compilersCache = await getCompilersDir();
+  const compilerPlatform = CompilerDownloader.getCompilerPlatform();
+  const downloader = CompilerDownloader.getConcurrencySafeDownloader(
+    compilerPlatform,
+    compilersCache
+  );
+
+  const isCompilerDownloaded = await downloader.isCompilerDownloaded(
+    solidityVersion
+  );
+
+  if (!isCompilerDownloaded) {
+    await downloader.downloadCompiler(solidityVersion);
+  }
 }

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -887,7 +887,15 @@ describe("Stack traces", function () {
   }
 
   before("Download solcjs binaries", async function () {
-    const paths = new Set(solidityCompilers.map((c) => c.compilerPath));
+    const solidityCompilersToDownload = [
+      ...solidity05Compilers,
+      ...solidity06Compilers,
+      ...solidity07Compilers,
+      ...solidity08Compilers,
+    ];
+    const paths = new Set(
+      solidityCompilersToDownload.map((c) => c.compilerPath)
+    );
 
     this.timeout(paths.size * COMPILER_DOWNLOAD_TIMEOUT);
 

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -888,7 +888,7 @@ describe("Stack traces", function () {
     return;
   }
 
-  before("Download solcjs binaries", async function () {
+  before("Download solc binaries", async function () {
     const solidityCompilersToDownload = [
       ...solidity05Compilers,
       ...solidity06Compilers,

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -41,7 +41,7 @@ import {
   compileFiles,
   COMPILER_DOWNLOAD_TIMEOUT,
   CompilerOptions,
-  downloadSolc,
+  downloadCompiler,
 } from "./compilation";
 import {
   encodeCall,
@@ -895,14 +895,14 @@ describe("Stack traces", function () {
       ...solidity07Compilers,
       ...solidity08Compilers,
     ];
-    const paths = new Set(
-      solidityCompilersToDownload.map((c) => c.compilerPath)
+
+    this.timeout(
+      solidityCompilersToDownload.length * COMPILER_DOWNLOAD_TIMEOUT
     );
 
-    this.timeout(paths.size * COMPILER_DOWNLOAD_TIMEOUT);
-
-    for (const p of paths) {
-      await downloadSolc(p);
+    for (const { solidityVersion } of solidityCompilersToDownload) {
+      console.log("Downloading solc", solidityVersion);
+      await downloadCompiler(solidityVersion);
     }
   });
 

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -805,7 +805,7 @@ const solidityCompilers: SolidityCompiler[] = [
 ];
 
 const onlyLatestSolcVersions =
-  process.env.HARDHAT_TESTS_ONLY_LATEST_SOLC_VERSIONS !== undefined;
+  process.env.HARDHAT_TESTS_ALL_SOLC_VERSIONS === undefined;
 
 const filterSolcVersionBy =
   (versionRange: string) =>

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -2,6 +2,7 @@ import { toBuffer } from "@nomicfoundation/ethereumjs-util";
 import { VM } from "@nomicfoundation/ethereumjs-vm";
 import { assert } from "chai";
 import fs from "fs";
+import fsExtra from "fs-extra";
 import path from "path";
 import semver from "semver";
 
@@ -200,11 +201,12 @@ async function compileIfNecessary(
     .map((s) => fs.statSync(s).ctimeMs)
     .reduce((t1, t2) => Math.max(t1, t2), 0);
 
-  const artifacts = path.join(testDir, "artifacts");
+  // save the artifacts in test-files/artifacts/<path-to-test-dir>
+  const testFilesDir = path.join(__dirname, "test-files");
+  const relativeTestDir = path.relative(testFilesDir, testDir);
+  const artifacts = path.join(testFilesDir, "artifacts", relativeTestDir);
 
-  if (!fs.existsSync(artifacts)) {
-    fs.mkdirSync(artifacts);
-  }
+  fsExtra.ensureDirSync(artifacts);
 
   const optimizerModifier =
     runs !== undefined ? `optimized-with-runs-${runs}` : "unoptimized";


### PR DESCRIPTION
Some improvements for the stack traces tests:

- Make testing all solc versions opt-in instead of opt-out. This makes tests take less time locally and in ome workflows (like the pre-release one) that don't need to test all versions.
- Use native solc instead of solcjs
- Put all the artifacts in a common directory instead of having a different one for each test.