### PR TITLE
Update Optimism testnet support from deprecated Kovan to Goerli

### DIFF
--- a/.changeset/pink-dodos-obey.md
+++ b/.changeset/pink-dodos-obey.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-etherscan": patch
+---
+
+Added Optimism Goerli and removed Optimism Kovan

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -100,6 +100,13 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://kovan-optimistic.etherscan.io/",
     },
   },
+  optimisticGoerli: {
+    chainId: 420,
+    urls: {
+      apiURL: "https://api-goerli-optimistic.etherscan.io/api",
+      browserURL: "https://goerli-optimistic.etherscan.io/",
+    },
+  },
   polygon: {
     chainId: 137,
     urls: {

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -93,13 +93,6 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://optimistic.etherscan.io/",
     },
   },
-  optimisticKovan: {
-    chainId: 69,
-    urls: {
-      apiURL: "https://api-kovan-optimistic.etherscan.io/api",
-      browserURL: "https://kovan-optimistic.etherscan.io/",
-    },
-  },
   optimisticGoerli: {
     chainId: 420,
     urls: {


### PR DESCRIPTION
This PR updates the Optimism Testnet endpoint from Kovan to Goerli.

Optimism's Kovan testnet has been [deprecated](https://community.optimism.io/docs/useful-tools/networks/#test-eth) and replaced with the [Goerli testnet](https://community.optimism.io/docs/useful-tools/networks/#optimism-goerli).

I am aware that hardhat team is not going to support any additional network but i think we need Optimism Goerli instead of Optimism Kovan. This PR addresses #3172 .