### PR TITLE
Show warning when etherscan config is within networks

### DIFF
--- a/.changeset/big-meals-mate.md
+++ b/.changeset/big-meals-mate.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-etherscan": patch
+---
+
+A warning is now shown when there is an etherscan entry in the networks object.

--- a/packages/hardhat-etherscan/src/config.ts
+++ b/packages/hardhat-etherscan/src/config.ts
@@ -58,7 +58,7 @@ export const etherscanConfigExtender: ConfigExtender = (
 
     // check that there is no etherscan entry in the networks object, since
     // this is a common mistake done by users
-    if (resolvedConfig.networks.etherscan !== undefined) {
+    if (resolvedConfig.networks?.etherscan !== undefined) {
       console.warn(
         chalk.yellow(
           `WARNING: you have an 'etherscan' entry in your networks configuration. This is likely a mistake. The etherscan configuration should be at the root of the configuration, not within the networks object.`

--- a/packages/hardhat-etherscan/src/config.ts
+++ b/packages/hardhat-etherscan/src/config.ts
@@ -1,5 +1,6 @@
 import type LodashT from "lodash";
 
+import chalk from "chalk";
 import { NomicLabsHardhatPluginError } from "hardhat/plugins";
 import { ConfigExtender } from "hardhat/types";
 import { chainConfig } from "./ChainConfig";
@@ -54,5 +55,15 @@ export const etherscanConfigExtender: ConfigExtender = (
     resolvedConfig.etherscan = { ...defaultConfig, ...customConfig };
   } else {
     resolvedConfig.etherscan = defaultConfig;
+
+    // check that there is no etherscan entry in the networks object, since
+    // this is a common mistake done by users
+    if (resolvedConfig.networks.etherscan !== undefined) {
+      console.warn(
+        chalk.yellow(
+          `WARNING: you have an 'etherscan' entry in your networks configuration. This is likely a mistake. The etherscan configuration should be at the root of the configuration, not within the networks object.`
+        )
+      );
+    }
   }
 };


### PR DESCRIPTION
Putting the etherscan config within `networks` instead of doing it at the root of the config seems to be a common mistake (see comments in [this issue](https://github.com/NomicFoundation/hardhat/issues/2351)).

This PR adds a warning when there's no top-level etherscan configuration but there is a `networks.etherscan` object.

In theory, this could be annoying to someone that has a valid `etherscan` network (for some reason?). In that case, the workaround would simply be to add `etherscan: {}` to the config.