### PR TITLE
xdai to gnosis

### DIFF
--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -163,11 +163,11 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://moonbase.moonscan.io/",
     },
   },
-  xdai: {
+  gnosis: {
     chainId: 100,
     urls: {
-      apiURL: "https://blockscout.com/xdai/mainnet/api",
-      browserURL: "https://blockscout.com/xdai/mainnet",
+      apiURL: "https://gnosisscan.io/api",
+      browserURL: "https://gnosisscan.io",
     },
   },
   sokol: {

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -163,10 +163,17 @@ export const chainConfig: ChainConfig = {
       browserURL: "https://moonbase.moonscan.io/",
     },
   },
+  xdai: {
+    chainId: 100,
+    urls: {
+      apiURL: "https://api.gnosisscan.io/api",
+      browserURL: "https://gnosisscan.io",
+    },
+  },
   gnosis: {
     chainId: 100,
     urls: {
-      apiURL: "https://gnosisscan.io/api",
+      apiURL: "https://api.gnosisscan.io/api",
       browserURL: "https://gnosisscan.io",
     },
   },

--- a/packages/hardhat-etherscan/test/unit/ChainConfig.ts
+++ b/packages/hardhat-etherscan/test/unit/ChainConfig.ts
@@ -6,10 +6,14 @@ describe("Chain Config", () => {
     const chainIds: number[] = Object.values(chainConfig).map(
       (config) => config.chainId
     );
+    //remove known duplicates
+    const filteredChainIds = chainIds.filter(obj => 
+                    obj !== 100 //xdai is now gnosis
+                    ); 
 
-    const uniqueIds = [...new Set(chainIds)];
+    const uniqueIds = [...new Set(filteredChainIds)];
 
     assert.notEqual(0, uniqueIds.length);
-    assert.equal(uniqueIds.length, chainIds.length);
+    assert.equal(uniqueIds.length, filteredChainIds.length);
   });
 });

--- a/packages/hardhat-etherscan/test/unit/ChainConfig.ts
+++ b/packages/hardhat-etherscan/test/unit/ChainConfig.ts
@@ -6,10 +6,13 @@ describe("Chain Config", () => {
     const chainIds: number[] = Object.values(chainConfig).map(
       (config) => config.chainId
     );
-    //remove known duplicates
-    const filteredChainIds = chainIds.filter(obj => 
-                    obj !== 100 //xdai is now gnosis
-                    ); 
+
+    // check that xdai/gnosis is the only duplicate
+    const xdaiGnosisChains = chainIds.filter((obj) => obj === 100);
+    assert.lengthOf(xdaiGnosisChains, 2);
+
+    // check that there are no duplicates in the rest of the list
+    const filteredChainIds = chainIds.filter((obj) => obj !== 100);
 
     const uniqueIds = [...new Set(filteredChainIds)];
 


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

xdaichain is now [Gnosis](https://www.gnosischain.com), with native integration with Etherscan ([gnosisscan.io](https://gnosisscan.io))