### PR TITLE
Add option to allow mining blocks with the same timestamp

### DIFF
--- a/.changeset/early-parrots-attend.md
+++ b/.changeset/early-parrots-attend.md
@@ -1,0 +1,6 @@
+---
+"hardhat": patch
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Added an option in Hardhat Network to allow mining blocks with the same timestamp

--- a/docs/src/content/hardhat-network/docs/reference/index.md
+++ b/docs/src/content/hardhat-network/docs/reference/index.md
@@ -84,6 +84,10 @@ An optional string setting the date of the blockchain. Valid values are [Javascr
 
 An optional boolean that disables the contract size limit imposed by the [EIP 170](https://eips.ethereum.org/EIPS/eip-170). Default value: `false`
 
+#### `allowBlocksWithSameTimestamp`
+
+A boolean to allow mining blocks that have the same timestamp. This is not allowed by default because Ethereum's consensus rules specify that each block should have a different timestamp. Default value: `false`
+
 #### `forking`
 
 An object that describes the [forking](./guides/forking-other-networks.md) configuration that can have the following fields:

--- a/packages/hardhat-core/scripts/test-debug-trace-transaction.ts
+++ b/packages/hardhat-core/scripts/test-debug-trace-transaction.ts
@@ -29,22 +29,23 @@ async function main(
   const txHashBuffer = Buffer.from(strip0x(txHash), "hex");
 
   const hardhatNetworkProvider = new HardhatNetworkProvider(
-    DEFAULT_HARDFORK,
-    DEFAULT_CHAIN_ID,
-    DEFAULT_NETWORK_ID,
-    100000000,
-    true,
-    true,
-    false, // mining.auto
-    0, // mining.interval
-    new ModulesLogger(true),
-    DEFAULT_ACCOUNTS,
-    undefined,
-    DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
-    undefined,
-    undefined,
-    forkConfig,
-    FORK_TESTS_CACHE_PATH
+    {
+      hardfork: DEFAULT_HARDFORK,
+      chainId: DEFAULT_CHAIN_ID,
+      networkId: DEFAULT_NETWORK_ID,
+      blockGasLimit: 100000000,
+      minGasPrice: 0n,
+      throwOnTransactionFailures: true,
+      throwOnCallFailures: true,
+      automine: false,
+      intervalMining: 0,
+      genesisAccounts: DEFAULT_ACCOUNTS,
+      allowUnlimitedContractSize: DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
+      forkConfig,
+      forkCachePath: FORK_TESTS_CACHE_PATH,
+      allowBlocksWithSameTimestamp: false,
+    },
+    new ModulesLogger(true)
   );
 
   const provider = new BackwardsCompatibilityProviderAdapter(

--- a/packages/hardhat-core/scripts/test-debug-trace-transaction.ts
+++ b/packages/hardhat-core/scripts/test-debug-trace-transaction.ts
@@ -11,7 +11,6 @@ import {
   DEFAULT_CHAIN_ID,
   DEFAULT_HARDFORK,
   DEFAULT_NETWORK_ID,
-  DEFAULT_NETWORK_NAME,
 } from "../test/internal/hardhat-network/helpers/providers";
 import { assertEqualTraces } from "../test/internal/hardhat-network/provider/utils/assertEqualTraces";
 
@@ -31,7 +30,6 @@ async function main(
 
   const hardhatNetworkProvider = new HardhatNetworkProvider(
     DEFAULT_HARDFORK,
-    DEFAULT_NETWORK_NAME,
     DEFAULT_CHAIN_ID,
     DEFAULT_NETWORK_ID,
     100000000,

--- a/packages/hardhat-core/src/internal/core/providers/construction.ts
+++ b/packages/hardhat-core/src/internal/core/providers/construction.ts
@@ -86,31 +86,34 @@ export function createProvider(
       require("../../hardhat-network/provider/utils/disk-cache") as typeof DiskCacheT;
 
     eip1193Provider = new HardhatNetworkProvider(
-      hardhatNetConfig.hardfork,
-      HARDHAT_NETWORK_NAME,
-      hardhatNetConfig.chainId,
-      hardhatNetConfig.chainId,
-      hardhatNetConfig.blockGasLimit,
-      hardhatNetConfig.initialBaseFeePerGas,
-      hardhatNetConfig.minGasPrice,
-      hardhatNetConfig.throwOnTransactionFailures,
-      hardhatNetConfig.throwOnCallFailures,
-      hardhatNetConfig.mining.auto,
-      hardhatNetConfig.mining.interval,
-      // This cast is valid because of the config validation and resolution
-      hardhatNetConfig.mining.mempool.order as MempoolOrder,
-      hardhatNetConfig.chains,
+      {
+        chainId: hardhatNetConfig.chainId,
+        networkId: hardhatNetConfig.chainId,
+        hardfork: hardhatNetConfig.hardfork,
+        blockGasLimit: hardhatNetConfig.blockGasLimit,
+        initialBaseFeePerGas: hardhatNetConfig.initialBaseFeePerGas,
+        minGasPrice: hardhatNetConfig.minGasPrice,
+        throwOnTransactionFailures: hardhatNetConfig.throwOnTransactionFailures,
+        throwOnCallFailures: hardhatNetConfig.throwOnCallFailures,
+        automine: hardhatNetConfig.mining.auto,
+        intervalMining: hardhatNetConfig.mining.interval,
+        // This cast is valid because of the config validation and resolution
+        mempoolOrder: hardhatNetConfig.mining.mempool.order as MempoolOrder,
+        chains: hardhatNetConfig.chains,
+        coinbase: hardhatNetConfig.coinbase,
+        genesisAccounts: accounts,
+        allowUnlimitedContractSize: hardhatNetConfig.allowUnlimitedContractSize,
+        initialDate:
+          hardhatNetConfig.initialDate !== undefined
+            ? parseDateString(hardhatNetConfig.initialDate)
+            : undefined,
+        experimentalHardhatNetworkMessageTraceHooks,
+        forkConfig,
+        forkCachePath:
+          paths !== undefined ? getForkCacheDirPath(paths) : undefined,
+      },
       new ModulesLogger(hardhatNetConfig.loggingEnabled),
-      accounts,
-      artifacts,
-      hardhatNetConfig.allowUnlimitedContractSize,
-      hardhatNetConfig.initialDate !== undefined
-        ? parseDateString(hardhatNetConfig.initialDate)
-        : undefined,
-      experimentalHardhatNetworkMessageTraceHooks,
-      forkConfig,
-      paths !== undefined ? getForkCacheDirPath(paths) : undefined,
-      hardhatNetConfig.coinbase
+      artifacts
     );
   } else {
     const HttpProvider = importProvider<

--- a/packages/hardhat-core/src/internal/core/providers/construction.ts
+++ b/packages/hardhat-core/src/internal/core/providers/construction.ts
@@ -103,6 +103,8 @@ export function createProvider(
         coinbase: hardhatNetConfig.coinbase,
         genesisAccounts: accounts,
         allowUnlimitedContractSize: hardhatNetConfig.allowUnlimitedContractSize,
+        allowBlocksWithSameTimestamp:
+          hardhatNetConfig.allowBlocksWithSameTimestamp ?? false,
         initialDate:
           hardhatNetConfig.initialDate !== undefined
             ? parseDateString(hardhatNetConfig.initialDate)

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
@@ -31,6 +31,7 @@ interface CommonConfig {
   mempoolOrder: MempoolOrder;
   coinbase: string;
   chains: HardhatNetworkChainsConfig;
+  allowBlocksWithSameTimestamp: boolean;
 }
 
 export type LocalNodeConfig = CommonConfig;

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
@@ -24,7 +24,6 @@ interface CommonConfig {
   hardfork: string;
   minGasPrice: bigint;
   networkId: number;
-  networkName: string;
   allowUnlimitedContractSize?: boolean;
   initialDate?: Date;
   tracingConfig?: TracingConfig;

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -142,6 +142,7 @@ export class HardhatNode extends EventEmitter {
       mempoolOrder,
       networkId,
       chainId,
+      allowBlocksWithSameTimestamp,
     } = config;
 
     let stateManager: StateManager;
@@ -283,6 +284,7 @@ export class HardhatNode extends EventEmitter {
       hardfork,
       hardforkActivations,
       mixHashGenerator,
+      allowBlocksWithSameTimestamp,
       tracingConfig,
       forkNetworkId,
       forkBlockNum,
@@ -366,6 +368,7 @@ Hardhat Network's forking functionality only works with blocks from at least spu
     public readonly hardfork: HardforkName,
     private readonly _hardforkActivations: HardforkHistoryConfig,
     private _mixHashGenerator: RandomBufferGenerator,
+    private _allowBlocksWithSameTimestamp: boolean,
     tracingConfig?: TracingConfig,
     private _forkNetworkId?: number,
     private _forkBlockNumber?: bigint,
@@ -481,7 +484,8 @@ Hardhat Network's forking functionality only works with blocks from at least spu
     const [, offsetShouldChange, newOffset] = timestampAndOffset;
 
     const needsTimestampIncrease =
-      await this._timestampClashesWithPreviousBlockOne(blockTimestamp);
+      !this._allowBlocksWithSameTimestamp &&
+      (await this._timestampClashesWithPreviousBlockOne(blockTimestamp));
     if (needsTimestampIncrease) {
       blockTimestamp += 1n;
     }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -58,6 +58,29 @@ const PRIVATE_RPC_METHODS = new Set([
 
 export const DEFAULT_COINBASE = "0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e";
 
+interface HardhatNetworkProviderConfig {
+  hardfork: string;
+  chainId: number;
+  networkId: number;
+  blockGasLimit: number;
+  minGasPrice: bigint;
+  automine: boolean;
+  intervalMining: IntervalMiningConfig;
+  mempoolOrder: MempoolOrder;
+  chains: HardhatNetworkChainsConfig;
+  genesisAccounts: GenesisAccount[];
+  allowUnlimitedContractSize: boolean;
+  throwOnTransactionFailures: boolean;
+  throwOnCallFailures: boolean;
+
+  initialBaseFeePerGas?: number;
+  initialDate?: Date;
+  coinbase?: string;
+  experimentalHardhatNetworkMessageTraceHooks?: BoundExperimentalHardhatNetworkMessageTraceHook[];
+  forkConfig?: ForkConfig;
+  forkCachePath?: string;
+}
+
 export class HardhatNetworkProvider
   extends EventEmitter
   implements EIP1193Provider
@@ -75,28 +98,9 @@ export class HardhatNetworkProvider
   private _common?: Common;
 
   constructor(
-    private readonly _hardfork: string,
-    private readonly _networkName: string,
-    private readonly _chainId: number,
-    private readonly _networkId: number,
-    private readonly _blockGasLimit: number,
-    private readonly _initialBaseFeePerGas: number | undefined,
-    private readonly _minGasPrice: bigint,
-    private readonly _throwOnTransactionFailures: boolean,
-    private readonly _throwOnCallFailures: boolean,
-    private readonly _automine: boolean,
-    private readonly _intervalMining: IntervalMiningConfig,
-    private readonly _mempoolOrder: MempoolOrder,
-    private readonly _chains: HardhatNetworkChainsConfig,
+    private readonly _config: HardhatNetworkProviderConfig,
     private readonly _logger: ModulesLogger,
-    private readonly _genesisAccounts: GenesisAccount[] = [],
-    private readonly _artifacts?: Artifacts,
-    private readonly _allowUnlimitedContractSize = false,
-    private readonly _initialDate?: Date,
-    private readonly _experimentalHardhatNetworkMessageTraceHooks: BoundExperimentalHardhatNetworkMessageTraceHook[] = [],
-    private _forkConfig?: ForkConfig,
-    private readonly _forkCachePath?: string,
-    private readonly _coinbase = DEFAULT_COINBASE
+    private readonly _artifacts?: Artifacts
   ) {
     super();
   }
@@ -228,24 +232,25 @@ export class HardhatNetworkProvider
     }
 
     const config: NodeConfig = {
-      automine: this._automine,
-      blockGasLimit: this._blockGasLimit,
-      minGasPrice: this._minGasPrice,
-      genesisAccounts: this._genesisAccounts,
-      allowUnlimitedContractSize: this._allowUnlimitedContractSize,
+      automine: this._config.automine,
+      blockGasLimit: this._config.blockGasLimit,
+      minGasPrice: this._config.minGasPrice,
+      genesisAccounts: this._config.genesisAccounts,
+      allowUnlimitedContractSize: this._config.allowUnlimitedContractSize,
       tracingConfig: await this._makeTracingConfig(),
-      initialBaseFeePerGas: this._initialBaseFeePerGas,
-      mempoolOrder: this._mempoolOrder,
-      hardfork: this._hardfork,
-      networkName: this._networkName,
-      chainId: this._chainId,
-      networkId: this._networkId,
-      initialDate: this._initialDate,
-      forkConfig: this._forkConfig,
+      initialBaseFeePerGas: this._config.initialBaseFeePerGas,
+      mempoolOrder: this._config.mempoolOrder,
+      hardfork: this._config.hardfork,
+      chainId: this._config.chainId,
+      networkId: this._config.networkId,
+      initialDate: this._config.initialDate,
+      forkConfig: this._config.forkConfig,
       forkCachePath:
-        this._forkConfig !== undefined ? this._forkCachePath : undefined,
-      coinbase: this._coinbase,
-      chains: this._chains,
+        this._config.forkConfig !== undefined
+          ? this._config.forkCachePath
+          : undefined,
+      coinbase: this._config.coinbase ?? DEFAULT_COINBASE,
+      chains: this._config.chains,
     };
 
     const [common, node] = await HardhatNode.create(config);
@@ -256,10 +261,10 @@ export class HardhatNetworkProvider
     this._ethModule = new EthModule(
       common,
       node,
-      this._throwOnTransactionFailures,
-      this._throwOnCallFailures,
+      this._config.throwOnTransactionFailures,
+      this._config.throwOnCallFailures,
       this._logger,
-      this._experimentalHardhatNetworkMessageTraceHooks
+      this._config.experimentalHardhatNetworkMessageTraceHooks
     );
 
     const miningTimer = this._makeMiningTimer();
@@ -270,7 +275,7 @@ export class HardhatNetworkProvider
       node,
       miningTimer,
       this._logger,
-      this._experimentalHardhatNetworkMessageTraceHooks
+      this._config.experimentalHardhatNetworkMessageTraceHooks
     );
     this._hardhatModule = new HardhatModule(
       node,
@@ -279,7 +284,7 @@ export class HardhatNetworkProvider
         this._logger.setEnabled(loggingEnabled);
       },
       this._logger,
-      this._experimentalHardhatNetworkMessageTraceHooks
+      this._config.experimentalHardhatNetworkMessageTraceHooks
     );
     this._debugModule = new DebugModule(node);
     this._personalModule = new PersonalModule(node);
@@ -320,13 +325,16 @@ export class HardhatNetworkProvider
   }
 
   private _makeMiningTimer(): MiningTimer {
-    const miningTimer = new MiningTimer(this._intervalMining, async () => {
-      try {
-        await this.request({ method: "hardhat_intervalMine" });
-      } catch (e) {
-        console.error("Unexpected error calling hardhat_intervalMine:", e);
+    const miningTimer = new MiningTimer(
+      this._config.intervalMining,
+      async () => {
+        try {
+          await this.request({ method: "hardhat_intervalMine" });
+        } catch (e) {
+          console.error("Unexpected error calling hardhat_intervalMine:", e);
+        }
       }
-    });
+    );
 
     miningTimer.start();
 
@@ -334,7 +342,7 @@ export class HardhatNetworkProvider
   }
 
   private async _reset(miningTimer: MiningTimer, forkConfig?: ForkConfig) {
-    this._forkConfig = forkConfig;
+    this._config.forkConfig = forkConfig;
     if (this._node !== undefined) {
       this._stopForwardingNodeEvents(this._node);
     }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -72,6 +72,7 @@ interface HardhatNetworkProviderConfig {
   allowUnlimitedContractSize: boolean;
   throwOnTransactionFailures: boolean;
   throwOnCallFailures: boolean;
+  allowBlocksWithSameTimestamp: boolean;
 
   initialBaseFeePerGas?: number;
   initialDate?: Date;
@@ -251,6 +252,7 @@ export class HardhatNetworkProvider
           : undefined,
       coinbase: this._config.coinbase ?? DEFAULT_COINBASE,
       chains: this._config.chains,
+      allowBlocksWithSameTimestamp: this._config.allowBlocksWithSameTimestamp,
     };
 
     const [common, node] = await HardhatNode.create(config);
@@ -275,6 +277,7 @@ export class HardhatNetworkProvider
       node,
       miningTimer,
       this._logger,
+      this._config.allowBlocksWithSameTimestamp,
       this._config.experimentalHardhatNetworkMessageTraceHooks
     );
     this._hardhatModule = new HardhatModule(

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/putGenesisBlock.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/putGenesisBlock.ts
@@ -12,7 +12,7 @@ import { getCurrentTimestamp } from "./getCurrentTimestamp";
 export async function putGenesisBlock(
   blockchain: HardhatBlockchain,
   common: Common,
-  { initialDate, blockGasLimit }: LocalNodeConfig,
+  { initialDate, blockGasLimit: initialBlockGasLimit }: LocalNodeConfig,
   stateTrie: Trie,
   hardfork: HardforkName,
   initialMixHash: Buffer,
@@ -27,7 +27,7 @@ export async function putGenesisBlock(
 
   const header: HeaderData = {
     timestamp: `0x${initialBlockTimestamp.toString(16)}`,
-    gasLimit: blockGasLimit,
+    gasLimit: initialBlockGasLimit,
     difficulty: isPostMerge ? 0 : 1,
     nonce: isPostMerge ? "0x0000000000000000" : "0x0000000000000042",
     extraData: "0x1234",

--- a/packages/hardhat-core/src/types/config.ts
+++ b/packages/hardhat-core/src/types/config.ts
@@ -51,6 +51,7 @@ export interface HardhatNetworkUserConfig {
   throwOnTransactionFailures?: boolean;
   throwOnCallFailures?: boolean;
   allowUnlimitedContractSize?: boolean;
+  allowBlocksWithSameTimestamp?: boolean;
   initialDate?: string;
   loggingEnabled?: boolean;
   forking?: HardhatNetworkForkingUserConfig;
@@ -151,6 +152,7 @@ export interface HardhatNetworkConfig {
   forking?: HardhatNetworkForkingConfig;
   coinbase?: string;
   chains: HardhatNetworkChainsConfig;
+  allowBlocksWithSameTimestamp?: boolean;
 }
 
 export type HardhatNetworkAccountsConfig =

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
@@ -13,7 +13,6 @@ import { ALCHEMY_URL, INFURA_URL } from "../../../setup";
 import { useProvider, UseProviderOptions } from "./useProvider";
 
 export const DEFAULT_HARDFORK = "london";
-export const DEFAULT_NETWORK_NAME = "TestNet";
 export const DEFAULT_CHAIN_ID = 123;
 export const DEFAULT_NETWORK_ID = 234;
 export const DEFAULT_BLOCK_GAS_LIMIT = 6000000n;

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -22,7 +22,6 @@ import {
   DEFAULT_HARDFORK,
   DEFAULT_MINING_CONFIG,
   DEFAULT_NETWORK_ID,
-  DEFAULT_NETWORK_NAME,
   DEFAULT_MEMPOOL_CONFIG,
   DEFAULT_USE_JSON_RPC,
 } from "./providers";
@@ -43,7 +42,6 @@ export interface UseProviderOptions {
   forkConfig?: ForkConfig;
   mining?: HardhatNetworkMiningConfig;
   hardfork?: string;
-  networkName?: string;
   chainId?: number;
   networkId?: number;
   blockGasLimit?: bigint;
@@ -61,7 +59,6 @@ export function useProvider({
   forkConfig,
   mining = DEFAULT_MINING_CONFIG,
   hardfork = DEFAULT_HARDFORK,
-  networkName = DEFAULT_NETWORK_NAME,
   chainId = DEFAULT_CHAIN_ID,
   networkId = DEFAULT_NETWORK_ID,
   blockGasLimit = DEFAULT_BLOCK_GAS_LIMIT,
@@ -75,29 +72,28 @@ export function useProvider({
   beforeEach("Initialize provider", async function () {
     this.logger = new FakeModulesLogger(loggerEnabled);
     this.hardhatNetworkProvider = new HardhatNetworkProvider(
-      hardfork,
-      networkName,
-      chainId,
-      networkId,
-      Number(blockGasLimit),
-      initialBaseFeePerGas === undefined
-        ? undefined
-        : Number(initialBaseFeePerGas),
-      0n, // minGasPrice
-      true,
-      true,
-      mining.auto,
-      mining.interval,
-      mempool.order as MempoolOrder,
-      chains,
-      this.logger,
-      accounts,
-      undefined,
-      allowUnlimitedContractSize,
-      undefined,
-      undefined,
-      forkConfig,
-      coinbase
+      {
+        hardfork,
+        chainId,
+        networkId,
+        blockGasLimit: Number(blockGasLimit),
+        initialBaseFeePerGas:
+          initialBaseFeePerGas === undefined
+            ? undefined
+            : Number(initialBaseFeePerGas),
+        minGasPrice: 0n,
+        throwOnTransactionFailures: true,
+        throwOnCallFailures: true,
+        automine: mining.auto,
+        intervalMining: mining.interval,
+        mempoolOrder: mempool.order as MempoolOrder,
+        chains,
+        genesisAccounts: accounts,
+        allowUnlimitedContractSize,
+        forkConfig,
+        coinbase,
+      },
+      this.logger
     );
     this.provider = new BackwardsCompatibilityProviderAdapter(
       this.hardhatNetworkProvider

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -92,6 +92,7 @@ export function useProvider({
         allowUnlimitedContractSize,
         forkConfig,
         coinbase,
+        allowBlocksWithSameTimestamp: false,
       },
       this.logger
     );

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -47,6 +47,7 @@ export interface UseProviderOptions {
   blockGasLimit?: bigint;
   accounts?: Array<{ privateKey: string; balance: bigint }>;
   allowUnlimitedContractSize?: boolean;
+  allowBlocksWithSameTimestamp?: boolean;
   initialBaseFeePerGas?: bigint;
   mempool?: HardhatNetworkMempoolConfig;
   coinbase?: string;
@@ -64,6 +65,7 @@ export function useProvider({
   blockGasLimit = DEFAULT_BLOCK_GAS_LIMIT,
   accounts = DEFAULT_ACCOUNTS,
   allowUnlimitedContractSize = DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
+  allowBlocksWithSameTimestamp = false,
   initialBaseFeePerGas,
   mempool = DEFAULT_MEMPOOL_CONFIG,
   coinbase,
@@ -92,7 +94,7 @@ export function useProvider({
         allowUnlimitedContractSize,
         forkConfig,
         coinbase,
-        allowBlocksWithSameTimestamp: false,
+        allowBlocksWithSameTimestamp,
       },
       this.logger
     );

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -25,7 +25,6 @@ import {
   DEFAULT_CHAIN_ID,
   DEFAULT_HARDFORK,
   DEFAULT_NETWORK_ID,
-  DEFAULT_NETWORK_NAME,
   PROVIDERS,
 } from "../../helpers/providers";
 import { sendDummyTransaction } from "../../helpers/sendDummyTransaction";
@@ -176,27 +175,24 @@ describe("Debug module", function () {
       const logger = new ModulesLogger(false);
 
       const hardhatNetworkProvider = new HardhatNetworkProvider(
-        DEFAULT_HARDFORK,
-        DEFAULT_NETWORK_NAME,
-        DEFAULT_CHAIN_ID,
-        DEFAULT_NETWORK_ID,
-        13000000,
-        undefined,
-        0n,
-        true,
-        true,
-        false, // mining.auto
-        0, // mining.interval
-        "priority", // mining.mempool.order
-        defaultHardhatNetworkParams.chains,
-        logger,
-        DEFAULT_ACCOUNTS,
-        undefined,
-        DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
-        undefined,
-        undefined,
-        forkConfig,
-        FORK_TESTS_CACHE_PATH
+        {
+          hardfork: DEFAULT_HARDFORK,
+          chainId: DEFAULT_CHAIN_ID,
+          networkId: DEFAULT_NETWORK_ID,
+          blockGasLimit: 13000000,
+          minGasPrice: 0n,
+          throwOnTransactionFailures: true,
+          throwOnCallFailures: true,
+          automine: false,
+          intervalMining: 0,
+          mempoolOrder: "priority",
+          chains: defaultHardhatNetworkParams.chains,
+          genesisAccounts: DEFAULT_ACCOUNTS,
+          allowUnlimitedContractSize: DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
+          forkConfig,
+          forkCachePath: FORK_TESTS_CACHE_PATH,
+        },
+        logger
       );
 
       provider = new BackwardsCompatibilityProviderAdapter(
@@ -302,27 +298,24 @@ describe("Debug module", function () {
       const logger = new ModulesLogger(false);
 
       const hardhatNetworkProvider = new HardhatNetworkProvider(
-        DEFAULT_HARDFORK,
-        DEFAULT_NETWORK_NAME,
-        DEFAULT_CHAIN_ID,
-        DEFAULT_NETWORK_ID,
-        13000000,
-        undefined,
-        0n,
-        true,
-        true,
-        false, // mining.auto
-        0, // mining.interval
-        "priority", // mining.mempool.order
-        defaultHardhatNetworkParams.chains,
-        logger,
-        DEFAULT_ACCOUNTS,
-        undefined,
-        DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
-        undefined,
-        undefined,
-        forkConfig,
-        FORK_TESTS_CACHE_PATH
+        {
+          hardfork: DEFAULT_HARDFORK,
+          chainId: DEFAULT_CHAIN_ID,
+          networkId: DEFAULT_NETWORK_ID,
+          blockGasLimit: 13000000,
+          minGasPrice: 0n,
+          throwOnTransactionFailures: true,
+          throwOnCallFailures: true,
+          automine: false,
+          intervalMining: 0,
+          mempoolOrder: "priority",
+          chains: defaultHardhatNetworkParams.chains,
+          genesisAccounts: DEFAULT_ACCOUNTS,
+          allowUnlimitedContractSize: DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
+          forkConfig,
+          forkCachePath: FORK_TESTS_CACHE_PATH,
+        },
+        logger
       );
 
       provider = new BackwardsCompatibilityProviderAdapter(

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -191,6 +191,7 @@ describe("Debug module", function () {
           allowUnlimitedContractSize: DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
           forkConfig,
           forkCachePath: FORK_TESTS_CACHE_PATH,
+          allowBlocksWithSameTimestamp: false,
         },
         logger
       );
@@ -314,6 +315,7 @@ describe("Debug module", function () {
           allowUnlimitedContractSize: DEFAULT_ALLOW_UNLIMITED_CONTRACT_SIZE,
           forkConfig,
           forkCachePath: FORK_TESTS_CACHE_PATH,
+          allowBlocksWithSameTimestamp: false,
         },
         logger
       );

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
@@ -38,8 +38,8 @@ import {
   DEFAULT_HARDFORK,
   DEFAULT_NETWORK_ID,
 } from "../helpers/providers";
-import { runFullBlock } from "./utils/runFullBlock";
 import { sleep } from "../helpers/sleep";
+import { runFullBlock } from "./utils/runFullBlock";
 
 interface ForkedBlock {
   networkName: string;

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
@@ -76,6 +76,7 @@ describe("HardhatNode", () => {
     mempoolOrder: "priority",
     coinbase: "0x0000000000000000000000000000000000000000",
     chains: defaultHardhatNetworkParams.chains,
+    allowBlocksWithSameTimestamp: false,
   };
   const gasPrice = 20;
   let node: HardhatNode;
@@ -854,6 +855,7 @@ describe("HardhatNode", () => {
       chains: defaultHardhatNetworkParams.chains,
       mempoolOrder: "priority",
       coinbase: "0x0000000000000000000000000000000000000000",
+      allowBlocksWithSameTimestamp: false,
     };
 
     describe("when forking with a default hardfork activation history", function () {
@@ -1019,6 +1021,7 @@ describe("HardhatNode", () => {
       chains: defaultHardhatNetworkParams.chains,
       mempoolOrder: "priority",
       coinbase: "0x0000000000000000000000000000000000000000",
+      allowBlocksWithSameTimestamp: false,
     };
     const [, hardhatNode] = await HardhatNode.create(nodeConfig);
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/node.ts
@@ -37,7 +37,6 @@ import {
   DEFAULT_CHAIN_ID,
   DEFAULT_HARDFORK,
   DEFAULT_NETWORK_ID,
-  DEFAULT_NETWORK_NAME,
 } from "../helpers/providers";
 import { runFullBlock } from "./utils/runFullBlock";
 
@@ -68,7 +67,6 @@ describe("HardhatNode", () => {
   const config: NodeConfig = {
     automine: false,
     hardfork: DEFAULT_HARDFORK,
-    networkName: DEFAULT_NETWORK_NAME,
     chainId: DEFAULT_CHAIN_ID,
     networkId: DEFAULT_NETWORK_ID,
     blockGasLimit: Number(DEFAULT_BLOCK_GAS_LIMIT),
@@ -842,7 +840,6 @@ describe("HardhatNode", () => {
 
     const baseNodeConfig: ForkedNodeConfig = {
       automine: true,
-      networkName: "mainnet",
       chainId: 1,
       networkId: 1,
       hardfork: "london",
@@ -1008,7 +1005,6 @@ describe("HardhatNode", () => {
     }
     const nodeConfig: ForkedNodeConfig = {
       automine: true,
-      networkName: "mainnet",
       chainId: 1,
       networkId: 1,
       hardfork: "london",

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/utils/runFullBlock.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/utils/runFullBlock.ts
@@ -38,7 +38,6 @@ export async function runFullBlock(
 
   const forkedNodeConfig: ForkedNodeConfig = {
     automine: true,
-    networkName: "mainnet",
     chainId,
     networkId: 1,
     hardfork,

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/utils/runFullBlock.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/utils/runFullBlock.ts
@@ -49,6 +49,7 @@ export async function runFullBlock(
     mempoolOrder: "priority",
     coinbase: "0x0000000000000000000000000000000000000000",
     chains: defaultHardhatNetworkParams.chains,
+    allowBlocksWithSameTimestamp: false,
   };
 
   const [common, forkedNode] = await HardhatNode.create(forkedNodeConfig);

--- a/packages/hardhat-network-helpers/src/helpers/time/increase.ts
+++ b/packages/hardhat-network-helpers/src/helpers/time/increase.ts
@@ -3,7 +3,7 @@ import type { NumberLike } from "../../types";
 import {
   getHardhatProvider,
   toRpcQuantity,
-  assertPositiveNumber,
+  assertNonNegativeNumber,
   toBigInt,
 } from "../../utils";
 import { mine } from "../mine";
@@ -20,7 +20,7 @@ export async function increase(amountInSeconds: NumberLike): Promise<number> {
   const provider = await getHardhatProvider();
 
   const normalizedAmount = toBigInt(amountInSeconds);
-  assertPositiveNumber(normalizedAmount);
+  assertNonNegativeNumber(normalizedAmount);
 
   const latestTimestamp = BigInt(await latest());
 

--- a/packages/hardhat-network-helpers/src/helpers/time/increaseTo.ts
+++ b/packages/hardhat-network-helpers/src/helpers/time/increaseTo.ts
@@ -1,14 +1,7 @@
 import type { NumberLike } from "../../types";
 
-import {
-  getHardhatProvider,
-  toRpcQuantity,
-  assertLargerThan,
-  toBigInt,
-} from "../../utils";
+import { getHardhatProvider, toRpcQuantity, toBigInt } from "../../utils";
 import { mine } from "../mine";
-
-import { latest } from "./latest";
 
 /**
  * Mines a new block whose timestamp is `timestamp`
@@ -19,10 +12,6 @@ export async function increaseTo(timestamp: NumberLike): Promise<void> {
   const provider = await getHardhatProvider();
 
   const normalizedTimestamp = toBigInt(timestamp);
-
-  const latestTimestamp = BigInt(await latest());
-
-  assertLargerThan(normalizedTimestamp, latestTimestamp, "timestamp");
 
   await provider.request({
     method: "evm_setNextBlockTimestamp",

--- a/packages/hardhat-network-helpers/src/helpers/time/setNextBlockTimestamp.ts
+++ b/packages/hardhat-network-helpers/src/helpers/time/setNextBlockTimestamp.ts
@@ -1,12 +1,7 @@
 import type { NumberLike } from "../../types";
 
-import {
-  getHardhatProvider,
-  toRpcQuantity,
-  assertLargerThan,
-} from "../../utils";
+import { getHardhatProvider, toRpcQuantity } from "../../utils";
 
-import { latest } from "./latest";
 import { millis } from "./duration";
 
 /**
@@ -21,14 +16,6 @@ export async function setNextBlockTimestamp(
 
   const timestampRpc = toRpcQuantity(
     timestamp instanceof Date ? millis(timestamp.valueOf()) : timestamp
-  );
-
-  const latestTimestampRpc = toRpcQuantity(await latest());
-
-  assertLargerThan(
-    BigInt(timestampRpc),
-    BigInt(latestTimestampRpc),
-    "timestamp"
   );
 
   await provider.request({

--- a/packages/hardhat-network-helpers/src/utils.ts
+++ b/packages/hardhat-network-helpers/src/utils.ts
@@ -104,10 +104,10 @@ export function assertTxHash(hexString: string): void {
   }
 }
 
-export function assertPositiveNumber(n: bigint): void {
-  if (n <= BigInt(0)) {
+export function assertNonNegativeNumber(n: bigint): void {
+  if (n < BigInt(0)) {
     throw new HardhatNetworkHelpersError(
-      `Invalid input: expected a positive number but ${n} was given.`
+      `Invalid input: expected a non-negative number but ${n} was given.`
     );
   }
 }

--- a/packages/hardhat-network-helpers/test/fixture-projects/allow-blocks-same-timestamp/hardhat.config.js
+++ b/packages/hardhat-network-helpers/test/fixture-projects/allow-blocks-same-timestamp/hardhat.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  solidity: "0.8.3",
+  networks: {
+    hardhat: {
+      allowBlocksWithSameTimestamp: true,
+    },
+  },
+};

--- a/packages/hardhat-network-helpers/test/helpers/time/increaseTo.ts
+++ b/packages/hardhat-network-helpers/test/helpers/time/increaseTo.ts
@@ -6,89 +6,114 @@ import * as hh from "../../../src";
 import { useEnvironment } from "../../test-utils";
 
 describe("time#increaseTo", function () {
-  useEnvironment("simple");
+  describe("simple project", function () {
+    useEnvironment("simple");
 
-  it("should mine a new block with the given timestamp", async function () {
-    const initialBlockNumber = await hh.time.latestBlock();
-    const initialTimestamp = await hh.time.latest();
-
-    const newTimestamp = initialTimestamp + 10000;
-
-    await hh.time.increaseTo(newTimestamp);
-
-    const endBlockNumber = await hh.time.latestBlock();
-    const endTimestamp = await hh.time.latest();
-
-    assert.equal(endBlockNumber, initialBlockNumber + 1);
-    assert.equal(newTimestamp, endTimestamp);
-    assert(endTimestamp - initialTimestamp === 10000);
-  });
-
-  it("should throw if given a timestamp that is equal to the current block timestamp", async function () {
-    const initialTimestamp = await hh.time.latest();
-
-    await assert.isRejected(hh.time.increaseTo(initialTimestamp));
-  });
-
-  it("should throw if given a timestamp that is less than the current block timestamp", async function () {
-    const initialTimestamp = await hh.time.latest();
-
-    await assert.isRejected(hh.time.increaseTo(initialTimestamp - 1));
-  });
-
-  describe("accepted parameter types for timestamp", function () {
-    it(`should accept an argument of type bigint`, async function () {
+    it("should mine a new block with the given timestamp", async function () {
+      const initialBlockNumber = await hh.time.latestBlock();
       const initialTimestamp = await hh.time.latest();
 
-      const newTimestamp = initialTimestamp + 3600;
+      const newTimestamp = initialTimestamp + 10000;
 
-      await hh.time.increaseTo(BigInt(newTimestamp));
+      await hh.time.increaseTo(newTimestamp);
 
+      const endBlockNumber = await hh.time.latestBlock();
       const endTimestamp = await hh.time.latest();
 
+      assert.equal(endBlockNumber, initialBlockNumber + 1);
       assert.equal(newTimestamp, endTimestamp);
-      assert(endTimestamp - initialTimestamp === 3600);
+      assert(endTimestamp - initialTimestamp === 10000);
     });
 
-    it(`should accept an argument of type ethers's bignumber`, async function () {
+    it("should throw if given a timestamp that is equal to the current block timestamp", async function () {
       const initialTimestamp = await hh.time.latest();
 
-      const newTimestamp = initialTimestamp + 3600;
-
-      await hh.time.increaseTo(ethers.BigNumber.from(newTimestamp));
-
-      const endTimestamp = await hh.time.latest();
-
-      assert.equal(newTimestamp, endTimestamp);
-      assert(endTimestamp - initialTimestamp === 3600);
+      await assert.isRejected(hh.time.increaseTo(initialTimestamp));
     });
 
-    it(`should accept an argument of type hex string`, async function () {
+    it("should throw if given a timestamp that is less than the current block timestamp", async function () {
       const initialTimestamp = await hh.time.latest();
 
-      const newTimestamp = initialTimestamp + 3600;
-
-      await hh.time.increaseTo(
-        ethers.BigNumber.from(newTimestamp).toHexString()
-      );
-
-      const endTimestamp = await hh.time.latest();
-
-      assert.equal(newTimestamp, endTimestamp);
-      assert(endTimestamp - initialTimestamp === 3600);
+      await assert.isRejected(hh.time.increaseTo(initialTimestamp - 1));
     });
 
-    it(`should accept an argument of type bn.js`, async function () {
+    describe("accepted parameter types for timestamp", function () {
+      it(`should accept an argument of type bigint`, async function () {
+        const initialTimestamp = await hh.time.latest();
+
+        const newTimestamp = initialTimestamp + 3600;
+
+        await hh.time.increaseTo(BigInt(newTimestamp));
+
+        const endTimestamp = await hh.time.latest();
+
+        assert.equal(newTimestamp, endTimestamp);
+        assert(endTimestamp - initialTimestamp === 3600);
+      });
+
+      it(`should accept an argument of type ethers's bignumber`, async function () {
+        const initialTimestamp = await hh.time.latest();
+
+        const newTimestamp = initialTimestamp + 3600;
+
+        await hh.time.increaseTo(ethers.BigNumber.from(newTimestamp));
+
+        const endTimestamp = await hh.time.latest();
+
+        assert.equal(newTimestamp, endTimestamp);
+        assert(endTimestamp - initialTimestamp === 3600);
+      });
+
+      it(`should accept an argument of type hex string`, async function () {
+        const initialTimestamp = await hh.time.latest();
+
+        const newTimestamp = initialTimestamp + 3600;
+
+        await hh.time.increaseTo(
+          ethers.BigNumber.from(newTimestamp).toHexString()
+        );
+
+        const endTimestamp = await hh.time.latest();
+
+        assert.equal(newTimestamp, endTimestamp);
+        assert(endTimestamp - initialTimestamp === 3600);
+      });
+
+      it(`should accept an argument of type bn.js`, async function () {
+        const initialTimestamp = await hh.time.latest();
+
+        const newTimestamp = initialTimestamp + 3600;
+
+        await hh.time.increaseTo(new BN(newTimestamp));
+
+        const endTimestamp = await hh.time.latest();
+
+        assert.equal(newTimestamp, endTimestamp);
+        assert(endTimestamp - initialTimestamp === 3600);
+      });
+    });
+  });
+
+  describe("blocks with same timestamp", function () {
+    useEnvironment("allow-blocks-same-timestamp");
+
+    it("should not throw if given a timestamp that is equal to the current block timestamp", async function () {
+      const initialBlockNumber = await hh.time.latestBlock();
       const initialTimestamp = await hh.time.latest();
 
-      const newTimestamp = initialTimestamp + 3600;
+      await hh.time.increaseTo(initialTimestamp);
 
-      await hh.time.increaseTo(new BN(newTimestamp));
-
+      const endBlockNumber = await hh.time.latestBlock();
       const endTimestamp = await hh.time.latest();
 
-      assert.equal(newTimestamp, endTimestamp);
-      assert(endTimestamp - initialTimestamp === 3600);
+      assert.equal(endBlockNumber, initialBlockNumber + 1);
+      assert.equal(endTimestamp, initialTimestamp);
+    });
+
+    it("should throw if given a timestamp that is less than the current block timestamp", async function () {
+      const initialTimestamp = await hh.time.latest();
+
+      await assert.isRejected(hh.time.increaseTo(initialTimestamp - 1));
     });
   });
 });

--- a/packages/hardhat-network-helpers/test/helpers/time/setNextBlockTimestamp.ts
+++ b/packages/hardhat-network-helpers/test/helpers/time/setNextBlockTimestamp.ts
@@ -4,58 +4,86 @@ import * as hh from "../../../src";
 import { useEnvironment } from "../../test-utils";
 
 describe("time#setNextBlockTimestamp", function () {
-  useEnvironment("simple");
+  describe("simple project", function () {
+    useEnvironment("simple");
 
-  it("should not mine a new block", async function () {
-    const initialHeight = await hh.time.latestBlock();
+    it("should not mine a new block", async function () {
+      const initialHeight = await hh.time.latestBlock();
 
-    await hh.time.setNextBlockTimestamp((await hh.time.latest()) + 1);
+      await hh.time.setNextBlockTimestamp((await hh.time.latest()) + 1);
 
-    const endHeight = await hh.time.latestBlock();
+      const endHeight = await hh.time.latestBlock();
 
-    assert.equal(initialHeight, endHeight);
+      assert.equal(initialHeight, endHeight);
+    });
+
+    it("should set the next block to the given timestamp [epoch seconds]", async function () {
+      const initialHeight = await hh.time.latestBlock();
+      const newTimestamp = (await hh.time.latest()) + 10_000;
+
+      await hh.time.setNextBlockTimestamp(newTimestamp);
+      await hh.mine();
+
+      const endHeight = await hh.time.latestBlock();
+      const endTimestamp = await hh.time.latest();
+
+      assert.equal(initialHeight + 1, endHeight);
+      assert.equal(newTimestamp, endTimestamp);
+    });
+
+    it("should set the next block to the given timestamp [Date]", async function () {
+      const initialHeight = await hh.time.latestBlock();
+      const newTimestamp = (await hh.time.latest()) + 10_000;
+
+      // multiply by 1000 because Date accepts Epoch millis
+      await hh.time.setNextBlockTimestamp(new Date(newTimestamp * 1000));
+      await hh.mine();
+
+      const endHeight = await hh.time.latestBlock();
+      const endTimestamp = await hh.time.latest();
+
+      assert.equal(initialHeight + 1, endHeight);
+      assert.equal(newTimestamp, endTimestamp);
+    });
+
+    it("should throw if given a timestamp that is equal to the current block timestamp", async function () {
+      const initialTimestamp = await hh.time.latest();
+
+      await assert.isRejected(hh.time.setNextBlockTimestamp(initialTimestamp));
+    });
+
+    it("should throw if given a timestamp that is less than the current block timestamp", async function () {
+      const initialTimestamp = await hh.time.latest();
+
+      await assert.isRejected(
+        hh.time.setNextBlockTimestamp(initialTimestamp - 1)
+      );
+    });
   });
 
-  it("should set the next block to the given timestamp [epoch seconds]", async function () {
-    const initialHeight = await hh.time.latestBlock();
-    const newTimestamp = (await hh.time.latest()) + 10_000;
+  describe("blocks with same timestamp", function () {
+    useEnvironment("allow-blocks-same-timestamp");
 
-    await hh.time.setNextBlockTimestamp(newTimestamp);
-    await hh.mine();
+    it("should not throw if given a timestamp that is equal to the current block timestamp", async function () {
+      const initialTimestamp = await hh.time.latest();
 
-    const endHeight = await hh.time.latestBlock();
-    const endTimestamp = await hh.time.latest();
+      await hh.time.setNextBlockTimestamp(initialTimestamp);
+    });
 
-    assert.equal(initialHeight + 1, endHeight);
-    assert.equal(newTimestamp, endTimestamp);
-  });
+    it("should throw if given a timestamp that is less than the current block timestamp", async function () {
+      const initialBlockNumber = await hh.time.latestBlock();
+      const initialTimestamp = await hh.time.latest();
 
-  it("should set the next block to the given timestamp [Date]", async function () {
-    const initialHeight = await hh.time.latestBlock();
-    const newTimestamp = (await hh.time.latest()) + 10_000;
+      await assert.isRejected(
+        hh.time.setNextBlockTimestamp(initialTimestamp - 1)
+      );
+      await hh.mine();
 
-    // multiply by 1000 because Date accepts Epoch millis
-    await hh.time.setNextBlockTimestamp(new Date(newTimestamp * 1000));
-    await hh.mine();
+      const endBlockNumber = await hh.time.latestBlock();
+      const endTimestamp = await hh.time.latest();
 
-    const endHeight = await hh.time.latestBlock();
-    const endTimestamp = await hh.time.latest();
-
-    assert.equal(initialHeight + 1, endHeight);
-    assert.equal(newTimestamp, endTimestamp);
-  });
-
-  it("should throw if given a timestamp that is equal to the current block timestamp", async function () {
-    const initialTimestamp = await hh.time.latest();
-
-    await assert.isRejected(hh.time.setNextBlockTimestamp(initialTimestamp));
-  });
-
-  it("should throw if given a timestamp that is less than the current block timestamp", async function () {
-    const initialTimestamp = await hh.time.latest();
-
-    await assert.isRejected(
-      hh.time.setNextBlockTimestamp(initialTimestamp - 1)
-    );
+      assert.equal(endBlockNumber, initialBlockNumber + 1);
+      assert.equal(endTimestamp, initialTimestamp);
+    });
   });
 });


### PR DESCRIPTION
This PR adds a new `allowBlocksWithSameTimestamp` option to Hardhat Network that doesn't force the timestamp of new blocks to be different than the last one.

The first commit in this PR should be reviewed on its own to make things simpler. It's a refactor that I think it was long due: it changes the constructor of `HardhatNetworkProvider` so that it receives most of its parameters in an object. This makes the code easier to read and change in several places. I also removed the "network name" parameter, since it wasn't used anywhere.

The rest of the changes adds the new option, modifies the network helpers to not check the timestamp (instead letting Hardhat itself throw an error if there's a wrong argument), update the docs and add tests.

Closes #2560.
Closes #3045.