### PR TITLE
Fix highlighted lines in console.log code example

### DIFF
--- a/docs/src/content/tutorial/debugging-with-hardhat-network.md
+++ b/docs/src/content/tutorial/debugging-with-hardhat-network.md
@@ -20,7 +20,7 @@ contract Token {
 
 Then you can just add some `console.log` calls to the `transfer()` function as if you were using it in JavaScript:
 
-```solidity{2,3}
+```solidity{4,9}
 function transfer(address to, uint256 amount) external {
     require(balances[msg.sender] >= amount, "Not enough tokens");
 


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Currently, the lines that are highlighted are not the lines that are referred-to in the text. This change highlights the pertinent code in the example code block.

![Screen Shot 2022-10-04 at 8 48 52 PM](https://user-images.githubusercontent.com/30811264/193970866-d49038bb-0509-4d12-a363-3bbb64fbc02e.png)

