### PR TITLE
possible to derive private key from mnemonic included space character

### DIFF
--- a/.changeset/large-ties-smash.md
+++ b/.changeset/large-ties-smash.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Trim leading and trailing spaces in mnemonics.

--- a/packages/hardhat-core/src/internal/core/providers/accounts.ts
+++ b/packages/hardhat-core/src/internal/core/providers/accounts.ts
@@ -1,6 +1,6 @@
 import * as t from "io-ts";
 
-import { SignTypedDataVersion, signTypedData } from "@metamask/eth-sig-util";
+import { signTypedData, SignTypedDataVersion } from "@metamask/eth-sig-util";
 import { FeeMarketEIP1559Transaction } from "@nomicfoundation/ethereumjs-tx";
 import { EIP1193Provider, RequestArguments } from "../../../types";
 import { HardhatError } from "../errors";

--- a/packages/hardhat-core/src/internal/core/providers/accounts.ts
+++ b/packages/hardhat-core/src/internal/core/providers/accounts.ts
@@ -300,8 +300,11 @@ export class HDWalletProvider extends LocalAccountsProvider {
     count: number = 10,
     passphrase: string = ""
   ) {
+    // NOTE: If mnemonic has space or newline at the beginning or end, it will be trimmed.
+    // This is because mnemonic containing them may generate different private keys.
+    const trimmedMnemonic = mnemonic.trim();
     const privateKeys = derivePrivateKeys(
-      mnemonic,
+      trimmedMnemonic,
       hdpath,
       initialIndex,
       count,

--- a/packages/hardhat-core/src/internal/util/keys-derivation.ts
+++ b/packages/hardhat-core/src/internal/util/keys-derivation.ts
@@ -11,7 +11,10 @@ export function deriveKeyFromMnemonicAndPath(
   }: {
     mnemonicToSeedSync: typeof mnemonicToSeedSyncT;
   } = require("ethereum-cryptography/bip39");
-  const seed = mnemonicToSeedSync(mnemonic, passphrase);
+  // NOTE: If mnemonic has space or newline at the beginning or end, it will be trimmed.
+  // This is because mnemonic containing them may generate different private keys.
+  const trimmedMnemonic = mnemonic.trim();
+  const seed = mnemonicToSeedSync(trimmedMnemonic, passphrase);
 
   const {
     HDKey,

--- a/packages/hardhat-core/test/internal/util/keys-derivation.ts
+++ b/packages/hardhat-core/test/internal/util/keys-derivation.ts
@@ -1,14 +1,17 @@
-import { assert } from "chai";
 import {
   bufferToHex,
   privateToAddress,
-  toChecksumAddress,
+  toChecksumAddress
 } from "@nomicfoundation/ethereumjs-util";
+import { assert } from "chai";
 
 import { deriveKeyFromMnemonicAndPath } from "../../../src/internal/util/keys-derivation";
 
 const MNEMONIC =
   "atom exist unusual amazing find assault penalty wall curve lunar promote cattle";
+const ADDRESS = "0x9CFE3206BD8beDC01c1f04E644eCd3e96a16F095";
+const PASSPHRASE = "it is a secret";
+const ADDRESS_WITH_PASS = "0xCD0062c186566742271bD083e5E92402391C03B2";
 
 describe("Keys derivation", function () {
   describe("deriveKeyFromMnemonicAndPath", function () {
@@ -18,32 +21,89 @@ describe("Keys derivation", function () {
       const derivedPk = deriveKeyFromMnemonicAndPath(MNEMONIC, path, "");
       const address = bufferToHex(privateToAddress(derivedPk!));
 
-      assert.equal(
-        toChecksumAddress(address),
-        "0x9CFE3206BD8beDC01c1f04E644eCd3e96a16F095"
-      );
+      assert.equal(toChecksumAddress(address), ADDRESS);
 
-      const passphrase = "it is a secret";
       const derivedPkWithPass = deriveKeyFromMnemonicAndPath(
         MNEMONIC,
         path,
-        passphrase
+        PASSPHRASE
       );
       const addressWithPass = bufferToHex(privateToAddress(derivedPkWithPass!));
 
-      assert.equal(
-        toChecksumAddress(addressWithPass),
-        "0xCD0062c186566742271bD083e5E92402391C03B2"
-      );
+      assert.equal(toChecksumAddress(addressWithPass), ADDRESS_WITH_PASS);
     });
 
-    it("Should not derive the wrong keys that is added '\\n'", function () {
-      const mnemonic = `${MNEMONIC}\n`;
+    it("Should derive the right keys from '\\n{mnemonic}'", function () {
+      const mnemonic = `\n${MNEMONIC}`;
       const path = "m/123/123'";
 
-      assert.throws(() => {
-        deriveKeyFromMnemonicAndPath(mnemonic, path, "");
-      }, Error);
+      const derivedPk = deriveKeyFromMnemonicAndPath(mnemonic, path, "");
+      const address = bufferToHex(privateToAddress(derivedPk!));
+
+      assert.equal(toChecksumAddress(address), ADDRESS);
+
+      const derivedPkWithPass = deriveKeyFromMnemonicAndPath(
+        mnemonic,
+        path,
+        PASSPHRASE
+      );
+      const addressWithPass = bufferToHex(privateToAddress(derivedPkWithPass!));
+
+      assert.equal(toChecksumAddress(addressWithPass), ADDRESS_WITH_PASS);
     });
+  });
+  it("Should derive the right keys from '{mnemonic}\n'", function () {
+    const mnemonic = `${MNEMONIC}\n`;
+    const path = "m/123/123'";
+
+    const derivedPk = deriveKeyFromMnemonicAndPath(mnemonic, path, "");
+    const address = bufferToHex(privateToAddress(derivedPk!));
+
+    assert.equal(toChecksumAddress(address), ADDRESS);
+
+    const derivedPkWithPass = deriveKeyFromMnemonicAndPath(
+      mnemonic,
+      path,
+      PASSPHRASE
+    );
+    const addressWithPass = bufferToHex(privateToAddress(derivedPkWithPass!));
+
+    assert.equal(toChecksumAddress(addressWithPass), ADDRESS_WITH_PASS);
+  });
+  it("Should derive the right keys from ' {mnemonic}'", function () {
+    const mnemonic = ` ${MNEMONIC}`;
+    const path = "m/123/123'";
+
+    const derivedPk = deriveKeyFromMnemonicAndPath(mnemonic, path, "");
+    const address = bufferToHex(privateToAddress(derivedPk!));
+
+    assert.equal(toChecksumAddress(address), ADDRESS);
+
+    const derivedPkWithPass = deriveKeyFromMnemonicAndPath(
+      mnemonic,
+      path,
+      PASSPHRASE
+    );
+    const addressWithPass = bufferToHex(privateToAddress(derivedPkWithPass!));
+
+    assert.equal(toChecksumAddress(addressWithPass), ADDRESS_WITH_PASS);
+  });
+  it("Should derive the right keys from '{mnemonic} '", function () {
+    const mnemonic = `${MNEMONIC} `;
+    const path = "m/123/123'";
+
+    const derivedPk = deriveKeyFromMnemonicAndPath(mnemonic, path, "");
+    const address = bufferToHex(privateToAddress(derivedPk!));
+
+    assert.equal(toChecksumAddress(address), ADDRESS);
+
+    const derivedPkWithPass = deriveKeyFromMnemonicAndPath(
+      mnemonic,
+      path,
+      PASSPHRASE
+    );
+    const addressWithPass = bufferToHex(privateToAddress(derivedPkWithPass!));
+
+    assert.equal(toChecksumAddress(addressWithPass), ADDRESS_WITH_PASS);
   });
 });

--- a/packages/hardhat-core/test/internal/util/keys-derivation.ts
+++ b/packages/hardhat-core/test/internal/util/keys-derivation.ts
@@ -33,7 +33,7 @@ describe("Keys derivation", function () {
       assert.equal(toChecksumAddress(addressWithPass), ADDRESS_WITH_PASS);
     });
 
-    it("Should derive the right keys from '\\n{mnemonic}'", function () {
+    it("Should derive the right keys from '\n{mnemonic}'", function () {
       const mnemonic = `\n${MNEMONIC}`;
       const path = "m/123/123'";
 

--- a/packages/hardhat-core/test/internal/util/keys-derivation.ts
+++ b/packages/hardhat-core/test/internal/util/keys-derivation.ts
@@ -1,7 +1,7 @@
 import {
   bufferToHex,
   privateToAddress,
-  toChecksumAddress
+  toChecksumAddress,
 } from "@nomicfoundation/ethereumjs-util";
 import { assert } from "chai";
 

--- a/packages/hardhat-core/test/internal/util/keys-derivation.ts
+++ b/packages/hardhat-core/test/internal/util/keys-derivation.ts
@@ -7,14 +7,15 @@ import {
 
 import { deriveKeyFromMnemonicAndPath } from "../../../src/internal/util/keys-derivation";
 
+const MNEMONIC =
+  "atom exist unusual amazing find assault penalty wall curve lunar promote cattle";
+
 describe("Keys derivation", function () {
   describe("deriveKeyFromMnemonicAndPath", function () {
     it("Should derive the right keys", function () {
-      const mnemonic =
-        "atom exist unusual amazing find assault penalty wall curve lunar promote cattle";
       const path = "m/123/123'";
 
-      const derivedPk = deriveKeyFromMnemonicAndPath(mnemonic, path, "");
+      const derivedPk = deriveKeyFromMnemonicAndPath(MNEMONIC, path, "");
       const address = bufferToHex(privateToAddress(derivedPk!));
 
       assert.equal(
@@ -24,7 +25,7 @@ describe("Keys derivation", function () {
 
       const passphrase = "it is a secret";
       const derivedPkWithPass = deriveKeyFromMnemonicAndPath(
-        mnemonic,
+        MNEMONIC,
         path,
         passphrase
       );
@@ -34,6 +35,15 @@ describe("Keys derivation", function () {
         toChecksumAddress(addressWithPass),
         "0xCD0062c186566742271bD083e5E92402391C03B2"
       );
+    });
+
+    it("Should not derive the wrong keys that is added '\\n'", function () {
+      const mnemonic = `${MNEMONIC}\n`;
+      const path = "m/123/123'";
+
+      assert.throws(() => {
+        deriveKeyFromMnemonicAndPath(mnemonic, path, "");
+      }, Error);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [X] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.

---

Fixes https://github.com/NomicFoundation/hardhat/issues/3223

I fixed the logic to derive a private key from the mnemonic that included newline character or space character.
If a newline or space character is included, it is trimmed.


