### PR TITLE
Website fixes

### DIFF
--- a/docs/redirects.config.js
+++ b/docs/redirects.config.js
@@ -33,12 +33,12 @@ const customRedirects = [
   { source: "/links/stack-traces", destination: "/", permanent: false },
   {
     source: "/reportbug",
-    destination: "https://github.com/nomiclabs/hardhat/issues/new",
+    destination: "https://github.com/NomicFoundation/hardhat/issues/new",
     permanent: false
   },
   {
     source: "/report-bug",
-    destination: "https://github.com/nomiclabs/hardhat/issues/new",
+    destination: "https://github.com/NomicFoundation/hardhat/issues/new",
     permanent: false
   },
   {

--- a/docs/src/config.ts
+++ b/docs/src/config.ts
@@ -44,7 +44,7 @@ export const PLUGINS_PATH = path.join(
 );
 export const TEMP_PATH = path.join(process.cwd(), "temp/");
 export const REPO_URL =
-  "https://github.com/NomicFoundation/hardhat/edit/master/docs/src/content/";
+  "https://github.com/NomicFoundation/hardhat/edit/main/docs/src/content/";
 
 // Regular expression to find tool in query string.
 export const toolRegExp = /tool=[A-Z_]+/;

--- a/docs/src/content/hardhat-network/docs/reference/index.md
+++ b/docs/src/content/hardhat-network/docs/reference/index.md
@@ -387,7 +387,7 @@ await hre.network.provider.request({
 });
 ```
 
-If you are using [`hardhat-ethers`](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-ethers), call `getSigner` after impersonating the account:
+If you are using [`hardhat-ethers`](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-ethers), call `getSigner` after impersonating the account:
 
 ```
 const signer = await ethers.getSigner("0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6")

--- a/docs/src/content/hardhat-network/docs/reference/index.md
+++ b/docs/src/content/hardhat-network/docs/reference/index.md
@@ -387,7 +387,7 @@ await hre.network.provider.request({
 });
 ```
 
-If you are using [`hardhat-ethers`](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-ethers), call `getSigner` after impersonating the account:
+If you are using [`hardhat-ethers`](https://github.com/NomicFoundation/hardhat/tree/main/packages/hardhat-ethers), call `getSigner` after impersonating the account:
 
 ```
 const signer = await ethers.getSigner("0x364d6D0333432C3Ac016Ca832fb8594A8cE43Ca6")

--- a/docs/src/content/hardhat-runner/docs/advanced/building-plugins.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/building-plugins.md
@@ -107,4 +107,4 @@ Examples of suggested overrides are:
 - Linter integrations should override the `check` task.
 - Plugins generating intermediate files should override the `clean` task.
 
-For a list of all the built-in tasks and subtasks please take a look at [`task-names.ts`](https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/src/builtin-tasks/task-names.ts)
+For a list of all the built-in tasks and subtasks please take a look at [`task-names.ts`](https://github.com/nomiclabs/hardhat/blob/main/packages/hardhat-core/src/builtin-tasks/task-names.ts)

--- a/docs/src/content/hardhat-runner/docs/advanced/building-plugins.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/building-plugins.md
@@ -49,13 +49,13 @@ This is literally all it takes to put together a plugin for Hardhat. Now `hi` is
 
 ## Using the Hardhat TypeScript plugin boilerplate
 
-For a complete example of a plugin you can take a look at the [Hardhat TypeScript plugin boilerplate project](https://github.com/nomiclabs/hardhat-ts-plugin-boilerplate/).
+For a complete example of a plugin you can take a look at the [Hardhat TypeScript plugin boilerplate project](https://github.com/NomicFoundation/hardhat-ts-plugin-boilerplate/).
 
 Plugins don't need to be written in TypeScript, but we recommend doing it, as many of our users use it. Creating a plugin in JavaScript can lead to a subpar experience for them.
 
 ### Extending the HRE
 
-To learn how to successfully extend the [HRE](./hardhat-runtime-environment.md) in TypeScript, and to give your users type information about your extension, take a look at [`src/index.ts`](https://github.com/nomiclabs/hardhat-ts-plugin-boilerplate/blob/master/src/index.ts) in the boilerplate repo and read the [Extending the HRE](./hardhat-runtime-environment.md#extending-the-hre) documentation.
+To learn how to successfully extend the [HRE](./hardhat-runtime-environment.md) in TypeScript, and to give your users type information about your extension, take a look at [`src/index.ts`](https://github.com/NomicFoundation/hardhat-ts-plugin-boilerplate/blob/master/src/index.ts) in the boilerplate repo and read the [Extending the HRE](./hardhat-runtime-environment.md#extending-the-hre) documentation.
 
 Make sure to keep the type extension in your main file, as that convention is used across different plugins.
 
@@ -65,7 +65,7 @@ The boilerplate project also has an example on how to extend the Hardhat config.
 
 We strongly recommend doing this in TypeScript and properly extending the config types.
 
-An example on how to add fields to the Hardhat config can be found in [`src/index.ts`](https://github.com/nomiclabs/hardhat-ts-plugin-boilerplate/blob/master/src/index.ts).
+An example on how to add fields to the Hardhat config can be found in [`src/index.ts`](https://github.com/NomicFoundation/hardhat-ts-plugin-boilerplate/blob/master/src/index.ts).
 
 ## Plugin development best practices
 
@@ -81,7 +81,7 @@ Keeping startup time short is vital to give a good user experience.
 
 To do so, Hardhat and its plugins delay any slow import or initialization until the very last moment. To do so, you can use `lazyObject`, and `lazyFunction` from `hardhat/plugins`.
 
-An example on how to use them is present in [`src/index.ts`](https://github.com/nomiclabs/hardhat-ts-plugin-boilerplate/blob/master/src/index.ts).
+An example on how to use them is present in [`src/index.ts`](https://github.com/NomicFoundation/hardhat-ts-plugin-boilerplate/blob/master/src/index.ts).
 
 ## Notes on dependencies
 
@@ -107,4 +107,4 @@ Examples of suggested overrides are:
 - Linter integrations should override the `check` task.
 - Plugins generating intermediate files should override the `clean` task.
 
-For a list of all the built-in tasks and subtasks please take a look at [`task-names.ts`](https://github.com/nomiclabs/hardhat/blob/main/packages/hardhat-core/src/builtin-tasks/task-names.ts)
+For a list of all the built-in tasks and subtasks please take a look at [`task-names.ts`](https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-core/src/builtin-tasks/task-names.ts)

--- a/docs/src/content/hardhat-runner/docs/advanced/create-task.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/create-task.md
@@ -146,7 +146,7 @@ balance: Prints an account's balance
 For global options help run: hardhat help
 ```
 
-Let’s now get the account’s balance. The [Hardhat Runtime Environment](../advanced/hardhat-runtime-environment.md) will be available in the global scope. By using Hardhat’s [ether.js plugin](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-ethers), which is included in the Hardhat Toolbox, we get access to an ethers.js instance:
+Let’s now get the account’s balance. The [Hardhat Runtime Environment](../advanced/hardhat-runtime-environment.md) will be available in the global scope. By using Hardhat’s [ether.js plugin](https://github.com/NomicFoundation/hardhat/tree/main/packages/hardhat-ethers), which is included in the Hardhat Toolbox, we get access to an ethers.js instance:
 
 ```js
 task("balance", "Prints an account's balance")
@@ -288,7 +288,7 @@ Task overriding works very similarly to overriding methods when extending a clas
 
 Task override order is important since actions can only call the immediately overridden definition, using the `runSuper` function.
 
-Overriding built-in tasks is a great way to customize and extend Hardhat. To know which tasks to override, take a look at [src/builtin-tasks](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-core/src/builtin-tasks).
+Overriding built-in tasks is a great way to customize and extend Hardhat. To know which tasks to override, take a look at [src/builtin-tasks](https://github.com/NomicFoundation/hardhat/tree/main/packages/hardhat-core/src/builtin-tasks).
 
 #### The `runSuper` function
 

--- a/docs/src/content/hardhat-runner/docs/advanced/create-task.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/create-task.md
@@ -146,7 +146,7 @@ balance: Prints an account's balance
 For global options help run: hardhat help
 ```
 
-Let’s now get the account’s balance. The [Hardhat Runtime Environment](../advanced/hardhat-runtime-environment.md) will be available in the global scope. By using Hardhat’s [ether.js plugin](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-ethers), which is included in the Hardhat Toolbox, we get access to an ethers.js instance:
+Let’s now get the account’s balance. The [Hardhat Runtime Environment](../advanced/hardhat-runtime-environment.md) will be available in the global scope. By using Hardhat’s [ether.js plugin](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-ethers), which is included in the Hardhat Toolbox, we get access to an ethers.js instance:
 
 ```js
 task("balance", "Prints an account's balance")
@@ -288,7 +288,7 @@ Task overriding works very similarly to overriding methods when extending a clas
 
 Task override order is important since actions can only call the immediately overridden definition, using the `runSuper` function.
 
-Overriding built-in tasks is a great way to customize and extend Hardhat. To know which tasks to override, take a look at [src/builtin-tasks](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-core/src/builtin-tasks).
+Overriding built-in tasks is a great way to customize and extend Hardhat. To know which tasks to override, take a look at [src/builtin-tasks](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-core/src/builtin-tasks).
 
 #### The `runSuper` function
 

--- a/docs/src/content/hardhat-runner/docs/advanced/hardhat-runtime-environment.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/hardhat-runtime-environment.md
@@ -14,7 +14,7 @@ The HRE has a role of centralizing coordination across all Hardhat components. T
 
 By default, the HRE gives you programmatic access to the task runner and the config system, and exports an [EIP1193-compatible](https://eips.ethereum.org/EIPS/eip-1193) Ethereum provider.
 
-Plugins can extend the HRE. For example, [hardhat-ethers](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-ethers) adds a Ethers.js instance to it, making it available to tasks, tests and scripts.
+Plugins can extend the HRE. For example, [hardhat-ethers](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-ethers) adds a Ethers.js instance to it, making it available to tasks, tests and scripts.
 
 ### As global variables
 

--- a/docs/src/content/hardhat-runner/docs/advanced/hardhat-runtime-environment.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/hardhat-runtime-environment.md
@@ -14,7 +14,7 @@ The HRE has a role of centralizing coordination across all Hardhat components. T
 
 By default, the HRE gives you programmatic access to the task runner and the config system, and exports an [EIP1193-compatible](https://eips.ethereum.org/EIPS/eip-1193) Ethereum provider.
 
-Plugins can extend the HRE. For example, [hardhat-ethers](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-ethers) adds a Ethers.js instance to it, making it available to tasks, tests and scripts.
+Plugins can extend the HRE. For example, [hardhat-ethers](https://github.com/NomicFoundation/hardhat/tree/main/packages/hardhat-ethers) adds a Ethers.js instance to it, making it available to tasks, tests and scripts.
 
 ### As global variables
 

--- a/docs/src/content/hardhat-runner/docs/guides/getting-help.md
+++ b/docs/src/content/hardhat-runner/docs/guides/getting-help.md
@@ -2,7 +2,7 @@
 
 Hardhat has a strong community of users willing to help you in times of trouble. Please read this entire guide to learn where and how to ask for help more effectively.
 
-The first place to look for answers is the [GitHub Discussions section in the Hardhat repository.](https://github.com/nomiclabs/hardhat) We recommend you search there first, as the answer may already exist.
+The first place to look for answers is the [GitHub Discussions section in the Hardhat repository.](https://github.com/NomicFoundation/hardhat) We recommend you search there first, as the answer may already exist.
 
 If you can't find what you are looking for on GitHub Discussions, you can [create a new Discussion](https://github.com/NomicFoundation/hardhat/discussions/new).
 

--- a/docs/src/content/hardhat-runner/docs/other-guides/truffle-testing.md
+++ b/docs/src/content/hardhat-runner/docs/other-guides/truffle-testing.md
@@ -174,6 +174,6 @@ describe("Greeter contract", function() {
 });
 ```
 
-Checkout the plugin's [README file](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-truffle5) for more information about it.
+Checkout the plugin's [README file](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-truffle5) for more information about it.
 
 [hardhat runtime environment]: /documentation/#hardhat-runtime-environment-hre

--- a/docs/src/content/hardhat-runner/docs/other-guides/truffle-testing.md
+++ b/docs/src/content/hardhat-runner/docs/other-guides/truffle-testing.md
@@ -174,6 +174,6 @@ describe("Greeter contract", function() {
 });
 ```
 
-Checkout the plugin's [README file](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-truffle5) for more information about it.
+Checkout the plugin's [README file](https://github.com/NomicFoundation/hardhat/tree/main/packages/hardhat-truffle5) for more information about it.
 
 [hardhat runtime environment]: /documentation/#hardhat-runtime-environment-hre

--- a/docs/src/content/hardhat-runner/plugins/index.md
+++ b/docs/src/content/hardhat-runner/plugins/index.md
@@ -1,3 +1,3 @@
-Plugins are the backbone of Hardhat, and they're built using the same config API that you use in your Hardhat configuration. Read the [Building plugins](/advanced/building-plugins) guide to learn how to create your own, and [send a pull request](https://github.com/NomicFoundation/hardhat/blob/master/docs/src/content/hardhat-runner/plugins/plugins.ts#L9) to get it listed here.
+Plugins are the backbone of Hardhat, and they're built using the same config API that you use in your Hardhat configuration. Read the [Building plugins](/advanced/building-plugins) guide to learn how to create your own, and [send a pull request](https://github.com/NomicFoundation/hardhat/blob/main/docs/src/content/hardhat-runner/plugins/plugins.ts#L9) to get it listed here.
 
 Extend Hardhat's functionality with the plugins below.

--- a/docs/src/content/tutorial/testing-contracts.md
+++ b/docs/src/content/tutorial/testing-contracts.md
@@ -203,7 +203,7 @@ describe("Token contract", function () {
     const [owner, addr1, addr2] = await ethers.getSigners();
 
     // To deploy our contract, we just have to call Token.deploy() and await
-    // its deployed() method, which happens onces its transaction has been
+    // its deployed() method, which happens once its transaction has been
     // mined.
     const hardhatToken = await Token.deploy();
 
@@ -279,7 +279,7 @@ describe("Token contract", function () {
       );
       const initialOwnerBalance = await hardhatToken.balanceOf(owner.address);
 
-      // Try to send 1 token from addr1 (0 tokens) to owner (1000 tokens).
+      // Try to send 1 token from addr1 (0 tokens) to owner.
       // `require` will evaluate false and revert the transaction.
       await expect(
         hardhatToken.connect(addr1).transfer(owner.address, 1)

--- a/docs/src/model/markdown.tsx
+++ b/docs/src/model/markdown.tsx
@@ -325,6 +325,6 @@ export const getCommitDate = (fileName: string): string => {
 };
 
 export const getEditLink = (fileName: string): string => {
-  // https://github.com/NomicFoundation/hardhat/edit/master/docs/hardhat-network/guides/forking-other-networks.md
+  // https://github.com/NomicFoundation/hardhat/edit/main/docs/hardhat-network/guides/forking-other-networks.md
   return fileName.replace(DOCS_PATH, REPO_URL);
 };


### PR DESCRIPTION
Closes #3244.

The most important thing here is that the "Help us improve this page" link at the end of the docs pages is not working because of the `master -> main` change.

The rest are typos, more renaming of `master` to `main`, and changing `nomiclabs` to `NomicFoundation`.