### PR TITLE
Fix compiler downloader

### DIFF
--- a/.changeset/hot-pans-doubt.md
+++ b/.changeset/hot-pans-doubt.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix compiler downloader

--- a/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
@@ -82,6 +82,12 @@ export interface ICompilerDownloader {
  */
 export class CompilerDownloader implements ICompilerDownloader {
   public static getCompilerPlatform(): CompilerPlatform {
+    // TODO: This check is seriously wrong. It doesn't take into account
+    //  the architecture nor the toolchain. This should check the triplet of
+    //  system instead (see: https://wiki.osdev.org/Target_Triplet).
+    //
+    //  The only reason this downloader works is that it validates if the
+    //  binaries actually run.
     switch (os.platform()) {
       case "win32":
         return CompilerPlatform.WINDOWS;

--- a/packages/hardhat-core/src/internal/util/global-dir.ts
+++ b/packages/hardhat-core/src/internal/util/global-dir.ts
@@ -90,7 +90,8 @@ export async function writeAnalyticsId(clientId: string) {
 
 export async function getCompilersDir() {
   const cache = await getCacheDir();
-  const compilersCache = path.join(cache, "compilers");
+  // Note: we introduce `-v2` to invalidate all the previous compilers at once
+  const compilersCache = path.join(cache, "compilers-v2");
   await fs.ensureDir(compilersCache);
   return compilersCache;
 }


### PR DESCRIPTION
When I changed the compiler downloader I tried to reuse previously downloaded compilers. This was a mistake, as the validation of those is now skipped. This lead to a situation where some users couldn't compile without cleaning the global cache.

On top of that, I realized that the criteria we use to pick the version of solc that we download is seriously wrong, and I added a TODO explaining that.