### PR TITLE
add `hardhat-txn-dot-xyz` and `hardhat-bytecode-exporter` and `hardhat-accounts` to plugin list

### DIFF
--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -246,6 +246,14 @@ const plugins = [
     tags: ["Bytecode", "Compiling"],
   },
   {
+    name: "@solidstate/hardhat-accounts",
+    author: "Nick Barry",
+    authorUrl: "https://github.com/ItsNickBarry",
+    url: "https://github.com/solidstate-network/hardhat-accounts/tree/master",
+    description: "Output list of available accounts and their balances",
+    tags: ["Accounts", "Balances"],
+  },
+  {
     name: "hardhat-watcher",
     author: "Xander Deseyn",
     authorUrl: "https://github.com/N1ghtly",

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -228,6 +228,15 @@ const plugins = [
     tags: ["Testing", "Mocha"],
   },
   {
+    name: "@solidstate/hardhat-txn-dot-xyz",
+    author: "Nick Barry",
+    authorUrl: "https://github.com/ItsNickBarry",
+    url:
+      "https://github.com/solidstate-network/hardhat-txn-dot-xyz/tree/master",
+    description: "Generate and execute on-chain transactions via txn.xyz",
+    tags: ["Signing", "Scripts"],
+  },
+  {
     name: "hardhat-watcher",
     author: "Xander Deseyn",
     authorUrl: "https://github.com/N1ghtly",

--- a/docs/.vuepress/plugins.js
+++ b/docs/.vuepress/plugins.js
@@ -237,6 +237,15 @@ const plugins = [
     tags: ["Signing", "Scripts"],
   },
   {
+    name: "@solidstate/hardhat-bytecode-exporter",
+    author: "Nick Barry",
+    authorUrl: "https://github.com/ItsNickBarry",
+    url:
+      "https://github.com/solidstate-network/hardhat-bytecode-exporter/tree/master",
+    description: "Automatically export contract bytecode on compilation",
+    tags: ["Bytecode", "Compiling"],
+  },
+  {
     name: "hardhat-watcher",
     author: "Xander Deseyn",
     authorUrl: "https://github.com/N1ghtly",


### PR DESCRIPTION
New plugin to integrate with ETHBogotá project [txn.xyz](https://www.txn.xyz/).

Also added bytecode exporter and account information output.