### PR TITLE
add regular expressions in revertedWith

### DIFF
--- a/.changeset/nine-starfishes-grab.md
+++ b/.changeset/nine-starfishes-grab.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-chai-matchers": patch
+---
+
+The `revertedWith` matcher now supports regular expressions (thanks @Dkdaniz!)

--- a/docs/src/content/hardhat-chai-matchers/docs/reference.md
+++ b/docs/src/content/hardhat-chai-matchers/docs/reference.md
@@ -48,7 +48,7 @@ await expect(token.transfer(address, 0)).to.be.revertedWith(
 );
 ```
 
-Assert that a transaction reverted with a specific regular expression reason:
+You can also use regular expressions:
 
 ```ts
 await expect(token.transfer(address, 0)).to.be.revertedWith(

--- a/docs/src/content/hardhat-chai-matchers/docs/reference.md
+++ b/docs/src/content/hardhat-chai-matchers/docs/reference.md
@@ -48,6 +48,14 @@ await expect(token.transfer(address, 0)).to.be.revertedWith(
 );
 ```
 
+Assert that a transaction reverted with a specific regular expression reason:
+
+```ts
+await expect(token.transfer(address, 0)).to.be.revertedWith(
+  /AccessControl: account .* is missing role .*/
+);
+```
+
 ### `.revertedWithCustomError`
 
 Assert that a transaction reverted with a specific [custom error](https://docs.soliditylang.org/en/v0.8.14/contracts.html#errors-and-the-revert-statement):

--- a/packages/hardhat-chai-matchers/src/internal/reverted/revertedWith.ts
+++ b/packages/hardhat-chai-matchers/src/internal/reverted/revertedWith.ts
@@ -4,21 +4,31 @@ import { decodeReturnData, getReturnDataFromError } from "./utils";
 export function supportRevertedWith(Assertion: Chai.AssertionStatic) {
   Assertion.addMethod(
     "revertedWith",
-    function (this: any, expectedReason: unknown) {
+    function (this: any, expectedReason: string | RegExp) {
       // capture negated flag before async code executes; see buildAssert's jsdoc
       const negated = this.__flags.negate;
 
       // validate expected reason
-      if (typeof expectedReason !== "string") {
-        throw new TypeError("Expected the revert reason to be a string");
+      if (
+        !(expectedReason instanceof RegExp) &&
+        typeof expectedReason !== "string"
+      ) {
+        throw new TypeError(
+          "Expected the revert reason to be a string or a regular expression"
+        );
       }
+
+      const expectedReasonString =
+        expectedReason instanceof RegExp
+          ? expectedReason.source
+          : expectedReason;
 
       const onSuccess = () => {
         const assert = buildAssert(negated, onSuccess);
 
         assert(
           false,
-          `Expected transaction to be reverted with reason '${expectedReason}', but it didn't revert`
+          `Expected transaction to be reverted with reason '${expectedReasonString}', but it didn't revert`
         );
       };
 
@@ -31,25 +41,30 @@ export function supportRevertedWith(Assertion: Chai.AssertionStatic) {
         if (decodedReturnData.kind === "Empty") {
           assert(
             false,
-            `Expected transaction to be reverted with reason '${expectedReason}', but it reverted without a reason`
+            `Expected transaction to be reverted with reason '${expectedReasonString}', but it reverted without a reason`
           );
         } else if (decodedReturnData.kind === "Error") {
+          const isReverted =
+            expectedReason instanceof RegExp
+              ? expectedReason.test(decodedReturnData.reason)
+              : decodedReturnData.reason === expectedReasonString;
+
           assert(
-            decodedReturnData.reason === expectedReason,
-            `Expected transaction to be reverted with reason '${expectedReason}', but it reverted with reason '${decodedReturnData.reason}'`,
-            `Expected transaction NOT to be reverted with reason '${expectedReason}', but it was`
+            isReverted,
+            `Expected transaction to be reverted with reason '${expectedReasonString}', but it reverted with reason '${decodedReturnData.reason}'`,
+            `Expected transaction NOT to be reverted with reason '${expectedReasonString}', but it was`
           );
         } else if (decodedReturnData.kind === "Panic") {
           assert(
             false,
-            `Expected transaction to be reverted with reason '${expectedReason}', but it reverted with panic code ${decodedReturnData.code.toHexString()} (${
+            `Expected transaction to be reverted with reason '${expectedReasonString}', but it reverted with panic code ${decodedReturnData.code.toHexString()} (${
               decodedReturnData.description
             })`
           );
         } else if (decodedReturnData.kind === "Custom") {
           assert(
             false,
-            `Expected transaction to be reverted with reason '${expectedReason}', but it reverted with a custom error`
+            `Expected transaction to be reverted with reason '${expectedReasonString}', but it reverted with a custom error`
           );
         } else {
           const _exhaustiveCheck: never = decodedReturnData;

--- a/packages/hardhat-chai-matchers/src/internal/reverted/revertedWith.ts
+++ b/packages/hardhat-chai-matchers/src/internal/reverted/revertedWith.ts
@@ -44,13 +44,13 @@ export function supportRevertedWith(Assertion: Chai.AssertionStatic) {
             `Expected transaction to be reverted with reason '${expectedReasonString}', but it reverted without a reason`
           );
         } else if (decodedReturnData.kind === "Error") {
-          const isReverted =
+          const matchesExpectedReason =
             expectedReason instanceof RegExp
               ? expectedReason.test(decodedReturnData.reason)
               : decodedReturnData.reason === expectedReasonString;
 
           assert(
-            isReverted,
+            matchesExpectedReason,
             `Expected transaction to be reverted with reason '${expectedReasonString}', but it reverted with reason '${decodedReturnData.reason}'`,
             `Expected transaction NOT to be reverted with reason '${expectedReasonString}', but it was`
           );

--- a/packages/hardhat-chai-matchers/src/types.ts
+++ b/packages/hardhat-chai-matchers/src/types.ts
@@ -6,7 +6,7 @@ declare namespace Chai {
       TypeComparison {
     emit(contract: any, eventName: string): EmitAssertion;
     reverted: AsyncAssertion;
-    revertedWith(reason: string): AsyncAssertion;
+    revertedWith(reason: string | RegExp): AsyncAssertion;
     revertedWithoutReason(): AsyncAssertion;
     revertedWithPanic(code?: any): AsyncAssertion;
     revertedWithCustomError(

--- a/packages/hardhat-chai-matchers/test/reverted/revertedWith.ts
+++ b/packages/hardhat-chai-matchers/test/reverted/revertedWith.ts
@@ -103,6 +103,14 @@ describe("INTEGRATION: Reverted with", function () {
         await runSuccessfulAsserts({
           matchers,
           method: "revertsWith",
+          args: ["regular expression reason"],
+          successfulAssert: (x) =>
+            expect(x).to.be.revertedWith(/regular .* reason/),
+        });
+
+        await runSuccessfulAsserts({
+          matchers,
+          method: "revertsWith",
           args: ["some reason"],
           successfulAssert: (x) =>
             expect(x).to.not.be.revertedWith("another reason"),
@@ -128,6 +136,18 @@ describe("INTEGRATION: Reverted with", function () {
           failedAssert: (x) => expect(x).to.be.revertedWith("some reason"),
           failedAssertReason:
             "Expected transaction to be reverted with reason 'some reason', but it reverted with reason 'another reason'",
+        });
+      });
+
+      it("failed asserts: expected a different regular expression reason ", async function () {
+        await runFailedAsserts({
+          matchers,
+          method: "revertsWith",
+          args: ["another regular expression reason"],
+          failedAssert: (x) =>
+            expect(x).to.be.revertedWith(/some regular .* reason/),
+          failedAssertReason:
+            "Expected transaction to be reverted with reason 'some regular .* reason', but it reverted with reason 'another regular expression reason'",
         });
       });
     });
@@ -187,7 +207,10 @@ describe("INTEGRATION: Reverted with", function () {
         expect(() =>
           // @ts-expect-error
           expect(hash).to.be.revertedWith(10)
-        ).to.throw(TypeError, "Expected the revert reason to be a string");
+        ).to.throw(
+          TypeError,
+          "Expected the revert reason to be a string or a regular expression"
+        );
       });
 
       it("errors that are not related to a reverted transaction", async function () {


### PR DESCRIPTION
# Description

This PR should provide the ability for the developer to use regular expressions in the revertedWith function within the hardhat-chai-matchers plugin.

Issue [Add support RegExp in the revertedWith function #3241](https://github.com/NomicFoundation/hardhat/issues/3241)

# How does this functionality work?

We enter a regular expression and the function revertedWith will perform the necessary tests based on the given expression as in the example below:

```js
   it("Should returns error role access",  async () => {
      const { stablecoin, addr1, } = await loadFixture(deployStablecoin);

      await expect(stablecoin.connect(addr1).pause()).to.be.revertedWith(/AccessControl: account .* is missing role .*/)
   });
```

# Checklist:

- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] Documentation has been changed
