### PR TITLE
Fix #1978 - ability to deploy to networks behind a corporate proxies

### DIFF
--- a/docs/src/content/hardhat-runner/docs/guides/deploying.md
+++ b/docs/src/content/hardhat-runner/docs/guides/deploying.md
@@ -55,3 +55,5 @@ As general rule, you can target any network from your Hardhat config using:
 ```
 npx hardhat run --network <your-network> scripts/deploy.js
 ```
+
+If you are behind a corporate proxy, you may need to set the `HTTP_PROXY` or `HTTPS_PROXY` environment variable to the URL of your proxy.

--- a/packages/hardhat-core/src/internal/core/providers/http.ts
+++ b/packages/hardhat-core/src/internal/core/providers/http.ts
@@ -167,8 +167,9 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
     try {
       const response = await this._dispatcher.request({
           method: "POST",
-          origin: this._proxy ? this._url: '',
-          path: this._proxy ? '' : this._path,
+          //Assuming undici pool ignores origin anyway
+          origin: new URL(this._url).origin,
+          path: this._path,
           body: JSON.stringify(request),
           maxRedirections: 10,
           headersTimeout:

--- a/packages/hardhat-core/test/internal/core/providers/http-proxy.ts
+++ b/packages/hardhat-core/test/internal/core/providers/http-proxy.ts
@@ -1,0 +1,69 @@
+import { assert } from "chai";
+
+import { HttpProvider } from "../../../../src/internal/core/providers/http";
+import { INFURA_URL, PROXY_URL } from "../../../setup";
+
+describe("Request With Proxy", function () {
+    const rpcUrl = INFURA_URL;
+
+    let env: typeof process.env;
+    const simpleRequest = {
+      method: "eth_getTransactionCount",
+      params: ["0x0000000000000000000000000000000000000000", "latest"],
+    };
+
+    describe("Assuming No HTTPS_PROXY environment", function () {
+      it("Request is successful", async function () {
+        if (rpcUrl === undefined) {
+          this.skip();
+        }
+
+        const provider = new HttpProvider(rpcUrl, "Test");
+        assert.isOk(await provider.request(simpleRequest));
+      });
+    });
+
+    describe("Assuming HTTPS_PROXY environment", function () {
+      before(function () {
+        // Save the Environment Settings and Set
+        env = process.env;
+        process.env.HTTPS_PROXY = PROXY_URL;
+      });
+
+      it("Request is successful", async function () {
+        if (rpcUrl === undefined) {
+          this.skip();
+        }
+
+        const provider = new HttpProvider(rpcUrl, "Test");
+        assert.isOk(await provider.request(simpleRequest));
+      });
+
+      after(function () {
+        // restoring everything back to the environment
+        process.env = env;
+      });
+    });
+
+    describe("Request with HTTPS_PROXY environment", function () {
+      before(function () {
+        // Save the Environment Settings and Set
+        env = process.env;
+        process.env.HTTP_PROXY = PROXY_URL;
+      });
+
+      it("Request is successful", async function () {
+        if (rpcUrl === undefined) {
+          this.skip();
+        }
+
+        const provider = new HttpProvider(rpcUrl, "Test");
+        assert.isOk(await provider.request(simpleRequest));
+      });
+
+      after(function () {
+        // restoring everything back to the environment
+        process.env = env;
+      });
+    });
+  });

--- a/packages/hardhat-core/test/setup.ts
+++ b/packages/hardhat-core/test/setup.ts
@@ -17,6 +17,8 @@ function getEnv(key: string): string | undefined {
 
 export const INFURA_URL = getEnv("INFURA_URL");
 export const ALCHEMY_URL = getEnv("ALCHEMY_URL");
+export const PROXY_URL = getEnv("PROXY_URL");
+
 
 function printForkingLogicNotBeingTestedWarning(varName: string) {
   console.warn(
@@ -32,4 +34,8 @@ if (INFURA_URL === undefined) {
 
 if (ALCHEMY_URL === undefined) {
   printForkingLogicNotBeingTestedWarning("ALCHEMY_URL");
+}
+
+if (PROXY_URL === undefined) {
+  printForkingLogicNotBeingTestedWarning("PROXY_URL");
 }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [] I didn't do anything of this.

---
This PR addresses the issue with connecting to 3rd party networks behind corporate proxy. Currently undici Pool's does not support proxy. (https://github.com/nodejs/undici/issues/1270). 

We patched our local harhat to make it work. 

Relevant issues on hardhat issue tracker.

https://github.com/NomicFoundation/hardhat/issues/1978



