### PR TITLE
add solidstate plugins to list

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -121,6 +121,44 @@ const communityPlugins: IPlugin[] = [
     tags: ["Documentation", "NatSpec"],
   },
   {
+    name: "@solidstate/hardhat-4byte-uploader",
+    author: "Nick Barry",
+    authorUrl: "https://github.com/ItsNickBarry",
+    description:
+      "Upload local function selectors to the Ethereum Selector Database",
+    tags: ["Bytecode", "ABI"],
+  },
+  {
+    name: "@solidstate/hardhat-test-short-circuit",
+    author: "Nick Barry",
+    authorUrl: "https://github.com/ItsNickBarry",
+    description:
+      "Stop Hardhat test execution on demand and print output from completed tests",
+    tags: ["Testing", "Mocha"],
+  },
+  {
+    name: "@solidstate/hardhat-txn-dot-xyz",
+    author: "Nick Barry",
+    authorUrl: "https://github.com/ItsNickBarry",
+    description: "Generate and execute on-chain transactions via txn.xyz",
+    tags: ["Signing", "Scripts"],
+  },
+  {
+    name: "@solidstate/hardhat-bytecode-exporter",
+    author: "Nick Barry",
+    authorUrl: "https://github.com/ItsNickBarry",
+    description: "Automatically export contract bytecode on compilation",
+    tags: ["Bytecode", "Compiling"],
+  },
+  {
+    name: "@solidstate/hardhat-accounts",
+    author: "Nick Barry",
+    authorUrl: "https://github.com/ItsNickBarry",
+    url: "https://github.com/solidstate-network/hardhat-accounts/tree/master",
+    description: "Output list of available accounts and their balances",
+    tags: ["Accounts", "Balances"],
+  },
+  {
     name: "hardhat-watcher",
     author: "Xander Deseyn",
     authorUrl: "https://github.com/N1ghtly",

--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -593,6 +593,14 @@ const communityPlugins: IPlugin[] = [
     tags: ["Tooling", "Deployment", "Testing"],
   },
   {
+    name: "hardhat-etherscan-contract-cloner",
+    author: "Tuckson",
+    authorUrl: "https://github.com/TucksonDev",
+    description:
+      "Hardhat plugin for cloning verified contracts from any supported network using Etherscan's API.",
+    tags: ["Etherscan", "Clone", "Smart contract"],
+  },
+  {
     name: "hardhat-interact",
     author: "Synthetix Core Contributors",
     authorUrl: "https://github.com/dbeal-eth",

--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -154,7 +154,6 @@ const communityPlugins: IPlugin[] = [
     name: "@solidstate/hardhat-accounts",
     author: "Nick Barry",
     authorUrl: "https://github.com/ItsNickBarry",
-    url: "https://github.com/solidstate-network/hardhat-accounts/tree/master",
     description: "Output list of available accounts and their balances",
     tags: ["Accounts", "Balances"],
   },


### PR DESCRIPTION
Replaces #3262.

Adds two missing plugins, and three new plugins, from the `@solidstate` namespace.