### PR TITLE
Allow skipping of local installation check

### DIFF
--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -171,7 +171,10 @@ async function main() {
       }
     }
 
-    if (!isHardhatInstalledLocallyOrLinked()) {
+    if (
+      process.env.__HARDHAT_ALLOW_NON_LOCAL_INSTALLATION !== "true" &&
+      !isHardhatInstalledLocallyOrLinked()
+    ) {
       throw new HardhatError(ERRORS.GENERAL.NON_LOCAL_INSTALLATION);
     }
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [] I didn't do anything of this.

---

Based on [this discussion ](https://github.com/NomicFoundation/hardhat/issues/3226), the check for local installation is not valid in all cases. In this PR I've simply added an env variable to skip this check. I would highly advise that the check is removed entirely as the current implementation is not correct. Having the hardhat package.json within the sub-directory of the cwd does not capture all cases of local installation. 

Additionally this is purely predicting that there'll be a future error and preventing cli from running. It might be best to allow the cli to run until an error case is hit
