### PR TITLE
Fix how native solc is checked after download

### DIFF
--- a/.changeset/tall-llamas-remember.md
+++ b/.changeset/tall-llamas-remember.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed a problem that was preventing Hardhat from being used in Alpine Linux.


### PR DESCRIPTION
Use `util.promisify` instead of implementing our own handling of the `execFile` result. This fixes #3195 because of some very fun reasons.

### tl;dr

The previous implementation wasn't handling the case were the `ChildProcess` instance emitted an `"error"` event. You would expect that this would hang the process forever, but you would be wrong (I know I was).

The reason it was erroring is that, in an alpine-based docker image, the solc binary couldn't even be executed. This caused an error instead of emitting an `"exit"` event with a non-zero code.

### Explanation

The problem here is a combination of two weird things I had no idea about.

First, when you download a solc native binary in an alpine-based docker container, the file cannot be executed. The fun part is that `execFile` errors with a `ENOENT` error, and running it in the shell fails with a "file not found" error. This was already misleading enough. [Here's](https://jvns.ca/blog/2021/11/17/debugging-a-weird--file-not-found--error/) a good explanation of why that happens.

Second, and most important: in that scenario the `ChildProcess` instance returned by `execFile` would emit an `error` event, and we weren't handling that. In my mental model of how node.js works, this should've caused the Hardhat process to hang forever, but my mental model was wrong. Unresolved promises don't prevent the node process from finishing if there's no pending IO or timeouts or whatever, as explained [here](https://github.com/nodejs/node/issues/25504).

In other words: `hh compile` was downloading a binary that didn't work and finishing with a successful exit code. After that, successive executions would try to use that compiler and fail.

The lesson I take from this is that we should be super careful when we convert something like an event emitter into a promise.