### PR TITLE
Don't check that address is a contract in getContractAt

### DIFF
--- a/.changeset/twelve-camels-peel.md
+++ b/.changeset/twelve-camels-peel.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-ethers": patch
+---
+
+`getContractAt` doesn't throw anymore if the given address is not a contract.

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -81,8 +81,6 @@ The [`Contract`s](https://docs.ethers.io/v5/single-page/#/v5/api/contract/contra
 
 If there is no signer available, `getContractAt` returns [read-only](https://docs.ethers.io/v5/single-page/#/v5/api/contract/contract/-%23-Contract--readonly) contracts.
 
-If the address provided to `getContractAt` is not the address of a contract account, an error will be thrown.
-
 ## Usage
 
 There are no additional steps you need to take for this plugin to work.

--- a/packages/hardhat-ethers/src/internal/helpers.ts
+++ b/packages/hardhat-ethers/src/internal/helpers.ts
@@ -303,13 +303,6 @@ export async function getContractAt(
   address: string,
   signer?: ethers.Signer
 ) {
-  if ((await hre.ethers.provider.getCode(address)) === "0x") {
-    throw new NomicLabsHardhatPluginError(
-      pluginName,
-      `${address} is not a contract account.`
-    );
-  }
-
   if (typeof nameOrAbi === "string") {
     const artifact = await hre.artifacts.readArtifact(nameOrAbi);
 

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -710,12 +710,10 @@ describe("Ethers plugin", function () {
         });
 
         describe("by name and address", function () {
-          it("Should throw if address does not belong to a contract", async function () {
+          it("Should not throw if address does not belong to a contract", async function () {
             const address = await signers[0].getAddress();
-            return assert.isRejected(
-              this.env.ethers.getContractAt("Greeter", address),
-              `${address} is not a contract account.`
-            );
+            // shouldn't throw
+            await this.env.ethers.getContractAt("Greeter", address);
           });
 
           it("Should return an instance of a contract", async function () {


### PR DESCRIPTION
This PR undoes the changes introduced in #2916. This broke smock and there surely are other scenarios where this is not a good idea.