### PR TITLE
Fix stack traces test that use custom solc

### DIFF
--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
@@ -1,6 +1,9 @@
 import fs from "fs";
 import path from "path";
-import { NativeCompiler } from "../../../../src/internal/solidity/compiler";
+import {
+  Compiler as SolcJsCompiler,
+  NativeCompiler,
+} from "../../../../src/internal/solidity/compiler";
 import {
   Compiler,
   CompilerDownloader,
@@ -76,12 +79,14 @@ async function compile(
   input: CompilerInput,
   compiler: Compiler
 ): Promise<[CompilerInput, CompilerOutput]> {
+  let runnableCompiler: any;
   if (compiler.isSolcJs) {
-    throw new Error("These tests expect to be able to run native solc");
+    runnableCompiler = new SolcJsCompiler(compiler.compilerPath);
+  } else {
+    runnableCompiler = new NativeCompiler(compiler.compilerPath);
   }
-  const nativeCompiler = new NativeCompiler(compiler.compilerPath);
 
-  const output = await nativeCompiler.compile(input);
+  const output = await runnableCompiler.compile(input);
 
   if (output.errors) {
     for (const error of output.errors) {
@@ -98,7 +103,19 @@ export async function compileFiles(
   sources: string[],
   compilerOptions: CompilerOptions
 ): Promise<[CompilerInput, CompilerOutput]> {
-  const compiler = await getCompilerForVersion(compilerOptions.solidityVersion);
+  let compiler: Compiler;
+  // special case for running tests with custom solc
+  if (path.isAbsolute(compilerOptions.compilerPath)) {
+    compiler = {
+      compilerPath: compilerOptions.compilerPath,
+      isSolcJs: true,
+      version: compilerOptions.solidityVersion,
+      longVersion: compilerOptions.solidityVersion,
+    };
+  } else {
+    compiler = await getCompilerForVersion(compilerOptions.solidityVersion);
+  }
+
   return compile(getSolcInputForFiles(sources, compilerOptions), compiler);
 }
 


### PR DESCRIPTION
This is kind of a hack, but it fixes #3295.

#3205 improves the code of the stack traces tests, and I will add a better fix for this there.

Also, @cameel, this only works with solcjs, but we now can also easily support using a custom native solc. Would that be useful for you?