### PR TITLE
Fix load fixture issue when reverting to future state

### DIFF
--- a/.changeset/warm-ghosts-rescue.md
+++ b/.changeset/warm-ghosts-rescue.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Fixed an error triggered by certain combinations of `loadFixture` calls (#3249, thanks @skosito!)  

--- a/packages/hardhat-network-helpers/src/helpers/takeSnapshot.ts
+++ b/packages/hardhat-network-helpers/src/helpers/takeSnapshot.ts
@@ -7,6 +7,7 @@ export interface SnapshotRestorer {
    * taken.
    */
   restore(): Promise<void>;
+  snapshotId: any;
 }
 
 /**
@@ -38,5 +39,6 @@ export async function takeSnapshot(): Promise<SnapshotRestorer> {
         method: "evm_snapshot",
       });
     },
+    snapshotId
   };
 }

--- a/packages/hardhat-network-helpers/src/helpers/takeSnapshot.ts
+++ b/packages/hardhat-network-helpers/src/helpers/takeSnapshot.ts
@@ -1,4 +1,4 @@
-import { InvalidSnapshotError } from "../errors";
+import { HardhatNetworkHelpersError, InvalidSnapshotError } from "../errors";
 import { getHardhatProvider } from "../utils";
 
 export interface SnapshotRestorer {
@@ -7,7 +7,7 @@ export interface SnapshotRestorer {
    * taken.
    */
   restore(): Promise<void>;
-  snapshotId: any;
+  snapshotId: string;
 }
 
 /**
@@ -22,6 +22,12 @@ export async function takeSnapshot(): Promise<SnapshotRestorer> {
   let snapshotId = await provider.request({
     method: "evm_snapshot",
   });
+
+  if (typeof snapshotId !== "string") {
+    throw new HardhatNetworkHelpersError(
+      "Assertion error: the value returned by evm_snapshot should be a string"
+    );
+  }
 
   return {
     restore: async () => {

--- a/packages/hardhat-network-helpers/src/helpers/takeSnapshot.ts
+++ b/packages/hardhat-network-helpers/src/helpers/takeSnapshot.ts
@@ -39,6 +39,6 @@ export async function takeSnapshot(): Promise<SnapshotRestorer> {
         method: "evm_snapshot",
       });
     },
-    snapshotId
+    snapshotId,
   };
 }

--- a/packages/hardhat-network-helpers/src/loadFixture.ts
+++ b/packages/hardhat-network-helpers/src/loadFixture.ts
@@ -14,7 +14,7 @@ interface Snapshot<T> {
   data: T;
 }
 
-const snapshots: Array<Snapshot<any>> = [];
+let snapshots: Array<Snapshot<any>> = [];
 
 /**
  * Useful in tests for setting up the desired state of the network.
@@ -42,6 +42,7 @@ export async function loadFixture<T>(fixture: Fixture<T>): Promise<T> {
   if (snapshot !== undefined) {
     try {
       await snapshot.restorer.restore();
+      snapshots = snapshots.filter(s => s.restorer.snapshotId <= snapshot.restorer.snapshotId);
     } catch (e) {
       if (e instanceof InvalidSnapshotError) {
         throw new FixtureSnapshotError(e);

--- a/packages/hardhat-network-helpers/src/loadFixture.ts
+++ b/packages/hardhat-network-helpers/src/loadFixture.ts
@@ -43,7 +43,8 @@ export async function loadFixture<T>(fixture: Fixture<T>): Promise<T> {
     try {
       await snapshot.restorer.restore();
       snapshots = snapshots.filter(
-        (s) => s.restorer.snapshotId <= snapshot.restorer.snapshotId
+        (s) =>
+          Number(s.restorer.snapshotId) <= Number(snapshot.restorer.snapshotId)
       );
     } catch (e) {
       if (e instanceof InvalidSnapshotError) {

--- a/packages/hardhat-network-helpers/src/loadFixture.ts
+++ b/packages/hardhat-network-helpers/src/loadFixture.ts
@@ -42,7 +42,9 @@ export async function loadFixture<T>(fixture: Fixture<T>): Promise<T> {
   if (snapshot !== undefined) {
     try {
       await snapshot.restorer.restore();
-      snapshots = snapshots.filter(s => s.restorer.snapshotId <= snapshot.restorer.snapshotId);
+      snapshots = snapshots.filter(
+        (s) => s.restorer.snapshotId <= snapshot.restorer.snapshotId
+      );
     } catch (e) {
       if (e instanceof InvalidSnapshotError) {
         throw new FixtureSnapshotError(e);

--- a/packages/hardhat-network-helpers/test/loadFixture.ts
+++ b/packages/hardhat-network-helpers/test/loadFixture.ts
@@ -76,11 +76,13 @@ describe("loadFixture", function () {
     assert.equal(await loadFixture(mineBlockFixture), 123);
   });
 
-  it("should throw the right error when an invalid snapshot is reverted", async function () {
+  it("should take snapshot again when trying to revert to future state", async function () {
+    let calledCount = 0;
     async function mineBlockFixture() {
       await mineBlock();
     }
     async function mineTwoBlocksFixture() {
+      calledCount++;
       await mineBlock();
       await mineBlock();
     }
@@ -88,10 +90,8 @@ describe("loadFixture", function () {
     await loadFixture(mineBlockFixture);
     await loadFixture(mineTwoBlocksFixture);
     await loadFixture(mineBlockFixture);
-    await assert.isRejected(
-      loadFixture(mineTwoBlocksFixture),
-      FixtureSnapshotError
-    );
+    await loadFixture(mineTwoBlocksFixture);
+    assert.equal(calledCount, 2);
   });
 
   it("should throw when an anonymous regular function is used", async function () {

--- a/packages/hardhat-network-helpers/test/loadFixture.ts
+++ b/packages/hardhat-network-helpers/test/loadFixture.ts
@@ -91,6 +91,45 @@ describe("loadFixture", function () {
     assert.equal(calledCount, 2);
   });
 
+  it("should take snapshot again when trying to revert to future state (edge case)", async function () {
+    // This tests is meant to check that snapshot ids are compared as numbers
+    // and not as strings.
+    // We run 16 fixtures, so that the last one has a snapshot id of 0x10, and
+    // then we run again the second one (with a snapshot id of 0x2). The last
+    // one should be removed because 0x2 <= 0x10, but this won't happen if they
+    // are compared as strings.
+
+    // keep track of how many times each fixture is called
+    const calledCount: Map<number, number> = new Map();
+    const fixturesFunctions = [...Array(16)].map((x, i) => {
+      calledCount.set(i, 0);
+      return async function mineBlockFixture() {
+        calledCount.set(i, calledCount.get(i)! + 1);
+      };
+    });
+
+    // run all fixtures and check they were called once
+    for (const fixtureFunction of fixturesFunctions) {
+      await loadFixture(fixtureFunction);
+    }
+    for (let i = 0; i < fixturesFunctions.length; i++) {
+      assert.equal(calledCount.get(i), 1);
+    }
+
+    // we run the second fixture again, this should remove all the ones that
+    // are afte rit
+    await loadFixture(fixturesFunctions[1]);
+    assert.equal(calledCount.get(1), 1);
+
+    // the last fixture should be run again
+    await loadFixture(fixturesFunctions[15]);
+    assert.equal(calledCount.get(15), 2);
+
+    // the first one shouldn't be removed
+    await loadFixture(fixturesFunctions[0]);
+    assert.equal(calledCount.get(0), 1);
+  });
+
   it("should throw when an anonymous regular function is used", async function () {
     await assert.isRejected(
       loadFixture(async function () {}),

--- a/packages/hardhat-network-helpers/test/loadFixture.ts
+++ b/packages/hardhat-network-helpers/test/loadFixture.ts
@@ -1,9 +1,6 @@
 import { assert } from "chai";
 
-import {
-  FixtureAnonymousFunctionError,
-  FixtureSnapshotError,
-} from "../src/errors";
+import { FixtureAnonymousFunctionError } from "../src/errors";
 import { loadFixture } from "../src/loadFixture";
 import { useEnvironment, rpcQuantityToNumber } from "./test-utils";
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
Please check this issue https://github.com/NomicFoundation/hardhat/issues/3249 for more details and discussion.

The way that loadFixture is working now is that allows situations like this:

```
Load fixture 1
...
Load fixture n - 1
Load fixture n
```

Up until this point every loadFixture takes a snapshot and store it in snapshots array. If loadFixture is called for any `n-i` it will work because it reverts the state to previous state. However, it also allows this, which fails because it tries to revert from previous to future state:

```
Load fixture 1
...
Load fixture n 
Load fixture n - i
Load fixture n -> fails with invalid snapshot error
```

My proposal is to remove all snapshots that have snapshot id bigger than snapshot being restored. This way it will ensure that every time loadFixture is called for future state snapshot is simple re-taken again.
Running tests in hardhat-network-helpers package failed only one test, describing exactly this issue, so i modified it.
I tested this a bit in project I am working on and it fixed the issue.
