### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/content/hardhat-runner/docs/guides/project-setup.md
+++ b/docs/src/content/hardhat-runner/docs/guides/project-setup.md
@@ -103,7 +103,7 @@ And this is enough to run Hardhat using a default project structure.
 
 ### Sample Hardhat project
 
-If you select _Create a JavaScript project_, a simple project creation wizard will ask you some questions. After that, the wizard will create some directories and files and installthe necessary dependencies. The most important of these dependencies is the [Hardhat Toolbox](/hardhat-runner/plugins/nomicfoundation-hardhat-toolbox), a plugin that bundles all the things you need to start working with Hardhat.
+If you select _Create a JavaScript project_, a simple project creation wizard will ask you some questions. After that, the wizard will create some directories and files and install the necessary dependencies. The most important of these dependencies is the [Hardhat Toolbox](/hardhat-runner/plugins/nomicfoundation-hardhat-toolbox), a plugin that bundles all the things you need to start working with Hardhat.
 
 The initialized project has the following structure:
 


### PR DESCRIPTION
**What this PR fixes:**

It fixes a typo in the documentation.
It changes `installthe` to `install the`

The typo can be seen here in production: https://hardhat.org/hardhat-runner/docs/guides/project-setup#sample-hardhat-project



> 
> * [ ]  Because this PR includes a **bug fix**, relevant tests have been included.
> * [ ]  Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
> * [x]  I didn't do anything of this.