### PR TITLE
chore: replace master with main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,19 +48,19 @@ The linter is always run in the CI, so make sure it passes before pushing code. 
 
 ## Branching
 
-We work on two branches, [`master`](https://github.com/nomiclabs/hardhat/tree/master) and [`development`](https://github.com/nomiclabs/hardhat/tree/development).
+We work on two branches, [`main`](https://github.com/nomiclabs/hardhat/tree/main) and [`development`](https://github.com/nomiclabs/hardhat/tree/development).
 
-The `master` branch is meant to be kept in sync with the latest released version of each package. Most pull requests are based on `master`, so when in doubt use this branch.
+The `main` branch is meant to be kept in sync with the latest released version of each package. Most pull requests are based on `main`, so when in doubt use this branch.
 
-The development branch is meant to be used for major, risky changes that are ready, but we can't or don't want to release yet. We never release new versions from development. When we want to release the changes from development, we go through a stricter QA process, merge those changes into master, and release from master. Examples of things that should be based on development are features that require significant changes to the codebase, or bug fixes that involve a major refactor.
+The development branch is meant to be used for major, risky changes that are ready, but we can't or don't want to release yet. We never release new versions from development. When we want to release the changes from development, we go through a stricter QA process, merge those changes into main, and release from main. Examples of things that should be based on development are features that require significant changes to the codebase, or bug fixes that involve a major refactor.
 
 ### Website and documentation branching
 
 If you are modifying the default config, adding a feature, or doing any kind of technical work that should be reflected in the documentation, the documentation change should be contained in the same branch and PR as the change.
 
-If you are working purely on the website or documentation, not as a result of a technical change, you should branch from [`master`](https://github.com/nomiclabs/hardhat/tree/master) and use it as the base branch in your pull request.
+If you are working purely on the website or documentation, not as a result of a technical change, you should branch from [`main`](https://github.com/nomiclabs/hardhat/tree/main) and use it as the base branch in your pull request.
 
-Note that the `master` branch is automatically deployed, so take care when merging into it.
+Note that the `main` branch is automatically deployed, so take care when merging into it.
 
 ## Dependencies
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,7 +2,7 @@
   "name": "@nomiclabs/common",
   "version": "0.0.1",
   "description": "Common logic and utilities to use throughout the project",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-truffle4",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-truffle4",
   "repository": "github:nomiclabs/hardhat",
   "author": "Nomic Labs LLC",
   "license": "MIT",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.1",
   "description": "e2e tests for Hardhat",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/e2e",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/e2e",
   "repository": "github:nomiclabs/hardhat",
   "author": "Nomic Labs LLC",
   "license": "MIT",

--- a/packages/hardhat-chai-matchers/package.json
+++ b/packages/hardhat-chai-matchers/package.json
@@ -2,7 +2,7 @@
   "name": "@nomicfoundation/hardhat-chai-matchers",
   "version": "1.0.4",
   "description": "Hardhat utils for testing",
-  "homepage": "https://github.com/nomicfoundation/hardhat/tree/master/packages/hardhat-chai-matchers",
+  "homepage": "https://github.com/nomicfoundation/hardhat/tree/main/packages/hardhat-chai-matchers",
   "repository": "github:nomicfoundation/hardhat",
   "author": "Nomic Foundation",
   "license": "MIT",

--- a/packages/hardhat-docker/README.md
+++ b/packages/hardhat-docker/README.md
@@ -6,7 +6,7 @@
 
 This package was originally created as a way to support Vyper compilation as there were no official Vyper binaries available at the time. However, that is no longer the case, and, as such, this package will not be supported moving forward.
 
-While this package will remain available on NPM for the time being, we highly recommend updating to the newest version of [`hardhat-vyper`](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-vyper) as it is more stable and utilizes native Vyper binaries for compilation.
+While this package will remain available on NPM for the time being, we highly recommend updating to the newest version of [`hardhat-vyper`](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-vyper) as it is more stable and utilizes native Vyper binaries for compilation.
 
 ## What
 

--- a/packages/hardhat-docker/package.json
+++ b/packages/hardhat-docker/package.json
@@ -2,7 +2,7 @@
   "name": "@nomiclabs/hardhat-docker",
   "version": "2.0.2",
   "description": "A library to manage Docker from Hardhat plugins",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-docker",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-docker",
   "repository": "github:nomiclabs/hardhat",
   "author": "Nomic Labs LLC",
   "license": "MIT",

--- a/packages/hardhat-ethers/package.json
+++ b/packages/hardhat-ethers/package.json
@@ -2,7 +2,7 @@
   "name": "@nomiclabs/hardhat-ethers",
   "version": "2.2.1",
   "description": "Hardhat plugin for ethers",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-ethers",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-ethers",
   "repository": "github:nomiclabs/hardhat",
   "author": "Nomic Labs LLC",
   "license": "MIT",

--- a/packages/hardhat-etherscan/package.json
+++ b/packages/hardhat-etherscan/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.2",
   "description": "Hardhat plugin for verifying contracts on etherscan",
   "repository": "github:nomiclabs/hardhat",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-etherscan",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-etherscan",
   "author": "Nomic Labs LLC",
   "contributors": [
     "Nomic Labs LLC",

--- a/packages/hardhat-etherscan/src/ChainConfig.ts
+++ b/packages/hardhat-etherscan/src/ChainConfig.ts
@@ -221,5 +221,5 @@ export const chainConfig: ChainConfig = {
   },
   // We are not adding new networks to the core of hardhat-etherscan anymore.
   // Please read this to learn how to manually add support for custom networks:
-  // https://github.com/NomicFoundation/hardhat/tree/master/packages/hardhat-etherscan#adding-support-for-other-networks
+  // https://github.com/NomicFoundation/hardhat/tree/main/packages/hardhat-etherscan#adding-support-for-other-networks
 };

--- a/packages/hardhat-ganache/package.json
+++ b/packages/hardhat-ganache/package.json
@@ -2,7 +2,7 @@
   "name": "@nomiclabs/hardhat-ganache",
   "version": "2.0.1",
   "description": "Hardhat plugin for managing Ganache",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-ganache",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-ganache",
   "repository": "github:nomiclabs/hardhat",
   "author": "Nomic Labs LLC",
   "license": "MIT",

--- a/packages/hardhat-network-helpers/package.json
+++ b/packages/hardhat-network-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@nomicfoundation/hardhat-network-helpers",
   "version": "1.0.6",
   "description": "Hardhat utils for testing",
-  "homepage": "https://github.com/nomicfoundation/hardhat/tree/master/packages/hardhat-network-helpers",
+  "homepage": "https://github.com/nomicfoundation/hardhat/tree/main/packages/hardhat-network-helpers",
   "repository": "github:nomicfoundation/hardhat",
   "author": "Nomic Foundation",
   "license": "MIT",

--- a/packages/hardhat-shorthand/package.json
+++ b/packages/hardhat-shorthand/package.json
@@ -2,7 +2,7 @@
   "name": "hardhat-shorthand",
   "version": "1.0.0",
   "description": "Launcher binary for Hardhat",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-shorthand",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-shorthand",
   "repository": "github:nomiclabs/hardhat",
   "author": "Nomic Labs LLC",
   "license": "MIT",

--- a/packages/hardhat-solhint/package.json
+++ b/packages/hardhat-solhint/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "Hardhat plugin for solhint",
   "repository": "github:nomiclabs/hardhat",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-solhint",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-solhint",
   "author": "Nomic Labs LLC",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/packages/hardhat-solpp/package.json
+++ b/packages/hardhat-solpp/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "Hardhat plugin for solpp",
   "repository": "github:nomiclabs/hardhat",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-solpp",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-solpp",
   "author": "Nomic Labs LLC",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/packages/hardhat-toolbox/package.json
+++ b/packages/hardhat-toolbox/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Nomic Foundation's recommended bundle of Hardhat plugins",
   "repository": "github:nomicfoundation/hardhat",
-  "homepage": "https://github.com/nomicfoundation/hardhat/tree/master/packages/hardhat-toolbox",
+  "homepage": "https://github.com/nomicfoundation/hardhat/tree/main/packages/hardhat-toolbox",
   "author": "Nomic Foundation",
   "contributors": [
     "Nomic Foundation"

--- a/packages/hardhat-truffle4/README.md
+++ b/packages/hardhat-truffle4/README.md
@@ -12,7 +12,7 @@ Additionally, you can **migrate your contracts to Solidity 5 without needing to 
 
 ## Required plugins
 
-This plugin requires [hardhat-web3-legacy](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-web3-legacy) as a prerequisite.
+This plugin requires [hardhat-web3-legacy](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-web3-legacy) as a prerequisite.
 
 ## Installation
 
@@ -38,7 +38,7 @@ This plugin creates no additional tasks.
 
 ## Environment extensions
 
-An instance of [`TruffleEnvironmentArtifacts`](https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-truffle4/src/artifacts.ts) is injected into `env.artifacts` and the method `contract()` is injected into the global scope for using in tests.
+An instance of [`TruffleEnvironmentArtifacts`](https://github.com/nomiclabs/hardhat/blob/main/packages/hardhat-truffle4/src/artifacts.ts) is injected into `env.artifacts` and the method `contract()` is injected into the global scope for using in tests.
 
 ## Usage
 

--- a/packages/hardhat-truffle4/package.json
+++ b/packages/hardhat-truffle4/package.json
@@ -2,7 +2,7 @@
   "name": "@nomiclabs/hardhat-truffle4",
   "version": "2.0.6",
   "description": "Truffle 4 Hardhat compatibility plugin",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-truffle4",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-truffle4",
   "repository": "github:nomiclabs/hardhat",
   "author": "Nomic Labs LLC",
   "license": "MIT",

--- a/packages/hardhat-truffle5/README.md
+++ b/packages/hardhat-truffle5/README.md
@@ -10,7 +10,7 @@ This plugin brings to Hardhat TruffleContracts from Truffle 5. With it you can c
 
 ## Required plugins
 
-This plugin requires [hardhat-web3](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-web3) as a prerequisite.
+This plugin requires [hardhat-web3](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-web3) as a prerequisite.
 
 ## Installation
 
@@ -36,7 +36,7 @@ This plugin creates no additional tasks.
 
 ## Environment extensions
 
-An instance of [`TruffleEnvironmentArtifacts`](https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-truffle5/src/artifacts.ts) is injected into `env.artifacts` and the method `contract()` is injected into the global scope for using in tests.
+An instance of [`TruffleEnvironmentArtifacts`](https://github.com/nomiclabs/hardhat/blob/main/packages/hardhat-truffle5/src/artifacts.ts) is injected into `env.artifacts` and the method `contract()` is injected into the global scope for using in tests.
 
 ## Usage
 

--- a/packages/hardhat-truffle5/package.json
+++ b/packages/hardhat-truffle5/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.7",
   "description": "Truffle 5 Hardhat compatibility plugin",
   "repository": "github:nomiclabs/hardhat",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-truffle5",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-truffle5",
   "author": "Nomic Labs LLC",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/packages/hardhat-vyper/package.json
+++ b/packages/hardhat-vyper/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.1",
   "description": "Hardhat plugin to develop smart contracts in Vyper",
   "repository": "github:nomiclabs/hardhat",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-vyper",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-vyper",
   "author": "Nomic Labs LLC",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/packages/hardhat-waffle/README.md
+++ b/packages/hardhat-waffle/README.md
@@ -46,7 +46,7 @@ The `waffle` object has these properties:
 - `createFixtureLoader`
 - `loadFixture`
 
-This plugin depends on [`@nomiclabs/hardhat-ethers`](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-ethers), so it also injects an `ethers` object into the HRE, which is documented [here](https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-ethers#environment-extensions).
+This plugin depends on [`@nomiclabs/hardhat-ethers`](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-ethers), so it also injects an `ethers` object into the HRE, which is documented [here](https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-ethers#environment-extensions).
 
 ## Usage
 

--- a/packages/hardhat-waffle/package.json
+++ b/packages/hardhat-waffle/package.json
@@ -2,7 +2,7 @@
   "name": "@nomiclabs/hardhat-waffle",
   "version": "2.0.3",
   "description": "Hardhat plugin to test smart contracts with Waffle",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-waffle",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-waffle",
   "repository": "github:nomiclabs/hardhat",
   "author": "Nomic Labs LLC",
   "license": "MIT",

--- a/packages/hardhat-web3-legacy/package.json
+++ b/packages/hardhat-web3-legacy/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "author": "Nomic Labs LLC",
   "license": "MIT",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-web3-legacy",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-web3-legacy",
   "repository": "github:nomiclabs/hardhat",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/hardhat-web3/package.json
+++ b/packages/hardhat-web3/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "author": "Nomic Labs LLC",
   "license": "MIT",
-  "homepage": "https://github.com/nomiclabs/hardhat/tree/master/packages/hardhat-web3",
+  "homepage": "https://github.com/nomiclabs/hardhat/tree/main/packages/hardhat-web3",
   "repository": "github:nomiclabs/hardhat",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

### Summary

I was reading the [Getting Started doc](https://hardhat.org/hardhat-runner/docs/getting-started#overview) and noticed that the **Help Us Improve this Page** link returned 404. I cloned the repo and did a find and replace for 'master' with 'main' and went through each link 1-by-1 to ensure the replacement was correct. I also noticed that nomiclabs repos have seemingly been transfered to NomicFoundation, but that update seemed a bit larger effort than I was willing to take on at the moment.

### Changes

- Fix 404s in docs.
- Fix links to GitHub showing "Branch master was renamed to main."
