### PR TITLE
Add deployContract to hardhat-ethers readme

### DIFF
--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -54,6 +54,8 @@ interface FactoryOptions {
   libraries?: Libraries;
 }
 
+function deployContract(name: string, constructorArgs?: any[], signer?: ethers.Signer): Promise<ethers.Contract>;
+
 function getContractFactory(name: string, signer?: ethers.Signer): Promise<ethers.ContractFactory>;
 
 function getContractFactory(name: string, factoryOptions: FactoryOptions): Promise<ethers.ContractFactory>;


### PR DESCRIPTION
Closes #3355. I didn't add the overloaded versions to keep it simple.