### PR TITLE
Add getBuildInfoSync

### DIFF
--- a/.changeset/stale-donkeys-punch.md
+++ b/.changeset/stale-donkeys-punch.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added a `getBuildInfoSync` function to the `hre.artifacts` object (thanks @emretepedev!)

--- a/packages/hardhat-core/src/types/artifacts.ts
+++ b/packages/hardhat-core/src/types/artifacts.ts
@@ -42,6 +42,11 @@ export interface Artifacts {
   getBuildInfo(fullyQualifiedName: string): Promise<BuildInfo | undefined>;
 
   /**
+   * Synchronous version of getBuildInfo.
+   */
+  getBuildInfoSync(fullyQualifiedName: string): BuildInfo | undefined;
+
+  /**
    * Returns an array with the absolute paths of all the existing artifacts.
    *
    * Note that there's an artifact per contract.

--- a/packages/hardhat-core/test/internal/artifacts.ts
+++ b/packages/hardhat-core/test/internal/artifacts.ts
@@ -757,7 +757,7 @@ describe("Artifacts class", function () {
       assert.isTrue(artifactPath.endsWith(".json"));
     });
 
-    it("Should be possible to get a build info from a fully qualified name", async function () {
+    it("Should be possible to get a build info from a fully qualified name (async)", async function () {
       const contractName = "Lib";
       const sourceName = "source.sol";
       const output = COMPILER_OUTPUTS.Lib;
@@ -794,7 +794,44 @@ describe("Artifacts class", function () {
       assert.deepEqual(storedBuildInfo?.output, solcOutput);
     });
 
-    it("Trying to get a build info of an artifact that doesn't have one should just return undefined", async function () {
+    it("Should be possible to get a build info from a fully qualified name (sync)", async function () {
+      const contractName = "Lib";
+      const sourceName = "source.sol";
+      const output = COMPILER_OUTPUTS.Lib;
+
+      const artifacts = new Artifacts(this.tmpDir);
+
+      const solcVersion = "0.5.6";
+      const solcLongVersion = "0.5.6+12321";
+      const solcInput = { input: {} } as any;
+      const solcOutput = { sources: {}, contracts: {} } as any;
+
+      const buildInfoPath = await artifacts.saveBuildInfo(
+        solcVersion,
+        solcLongVersion,
+        solcInput,
+        solcOutput
+      );
+
+      const artifact = getArtifactFromContractOutput(
+        sourceName,
+        contractName,
+        output
+      );
+
+      await artifacts.saveArtifactAndDebugFile(artifact, buildInfoPath);
+
+      const storedBuildInfo = artifacts.getBuildInfoSync(
+        getFullyQualifiedName(sourceName, contractName)
+      );
+
+      assert.equal(storedBuildInfo?.solcVersion, solcVersion);
+      assert.equal(storedBuildInfo?.solcLongVersion, solcLongVersion);
+      assert.deepEqual(storedBuildInfo?.input, solcInput);
+      assert.deepEqual(storedBuildInfo?.output, solcOutput);
+    });
+
+    it("Trying to get a build info of an artifact that doesn't have one should just return undefined (async)", async function () {
       const contractName = "Lib";
       const sourceName = "source.sol";
       const output = COMPILER_OUTPUTS.Lib;
@@ -810,6 +847,28 @@ describe("Artifacts class", function () {
       await artifacts.saveArtifactAndDebugFile(artifact);
 
       const storedBuildInfo = await artifacts.getBuildInfo(
+        getFullyQualifiedName(sourceName, contractName)
+      );
+
+      assert.isUndefined(storedBuildInfo);
+    });
+
+    it("Trying to get a build info of an artifact that doesn't have one should just return undefined (sync)", async function () {
+      const contractName = "Lib";
+      const sourceName = "source.sol";
+      const output = COMPILER_OUTPUTS.Lib;
+
+      const artifacts = new Artifacts(this.tmpDir);
+
+      const artifact = getArtifactFromContractOutput(
+        sourceName,
+        contractName,
+        output
+      );
+
+      await artifacts.saveArtifactAndDebugFile(artifact);
+
+      const storedBuildInfo = artifacts.getBuildInfoSync(
         getFullyQualifiedName(sourceName, contractName)
       );
 


### PR DESCRIPTION
I needed a synchronized version of **getBuildInfo** (like readArtifactSync) in a Hardhat plugin I am developing.

It would be nice to have a synchronized version to use in the constructor as well.