### PR TITLE
Add no-compile flag to etherscan verify task

### DIFF
--- a/.changeset/sour-onions-knock.md
+++ b/.changeset/sour-onions-knock.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-etherscan": patch
+---
+
+Add `--no-compile` flag to the `verify` task


### PR DESCRIPTION
Adds an optional --no-compile flag to the verify task, which does what you'd expect it to do.