### PR TITLE
Add hardhat_metadata RPC method

### DIFF
--- a/.changeset/real-donuts-hope.md
+++ b/.changeset/real-donuts-hope.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added a new `hardhat_metadata` RPC method

--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/output/metadata.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/output/metadata.ts
@@ -6,9 +6,6 @@ export interface HardhatMetadata {
   // The chain's id. Used to sign transactions.
   chainId: number;
 
-  // The network's id. Normally matches the chainId. Should not be used to sign transactions.
-  networkId: number;
-
   // A 0x-prefixed hex-encoded 32 bytes id which uniquiely identifies an instance/run
   // of Hardhat Network. Running Hardhat Network more than once (even with the same version
   // and parameters) would always result in different `instanceId`s.

--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/output/metadata.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/output/metadata.ts
@@ -1,0 +1,35 @@
+export interface HardhatMetadata {
+  // A string identifying the version of Hardhat, for debugging purposes,
+  // not meant to be displayed to users.
+  clientVersion: string;
+
+  // The chain's id. Used to sign transactions.
+  chainId: number;
+
+  // The network's id. Normally matches the chainId. Should not be used to sign transactions.
+  networkId: number;
+
+  // A 0x-prefixed hex-encoded 32 bytes id which uniquiely identifies an instance/run
+  // of Hardhat Network. Running Hardhat Network more than once (even with the same version
+  // and parameters) would always result in different `instanceId`s.
+  // Running `hardhat_reset` would change the `instanceId` of an existing Hardhat Network.
+  instanceId: string;
+
+  // The latest block's number in Hardhat Network
+  latestBlockNumber: number;
+
+  // The latest block's hash in Hardhat Network
+  latestBlockHash: string;
+
+  // This field is only present when Hardhat Network is forking another chain.
+  forkedNetwork?: {
+    // The chainId of the network that is being forked
+    chainId: number;
+
+    // The number of the block that the network forked from.
+    forkBlockNumber: number;
+
+    // The hash of the block that the network forked from.
+    forkBlockHash: string;
+  };
+}

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/hardhat.ts
@@ -22,6 +22,7 @@ import {
   rpcCompilerOutput,
 } from "../../../core/jsonrpc/types/input/solc";
 import { validateParams } from "../../../core/jsonrpc/types/input/validation";
+import { HardhatMetadata } from "../../../core/jsonrpc/types/output/metadata";
 import {
   InvalidInputError,
   MethodNotFoundError,
@@ -92,6 +93,9 @@ export class HardhatModule {
         return this._dropTransactionAction(
           ...this._dropTransactionParams(params)
         );
+
+      case "hardhat_metadata":
+        return this._metadataAction(...this._metadataParams(params));
 
       case "hardhat_setBalance":
         return this._setBalanceAction(...this._setBalanceParams(params));
@@ -270,6 +274,16 @@ export class HardhatModule {
 
   private async _dropTransactionAction(hash: Buffer): Promise<boolean> {
     return this._node.dropTransaction(hash);
+  }
+
+  // hardhat_metadata
+
+  private _metadataParams(params: any[]): [] {
+    return validateParams(params);
+  }
+
+  private async _metadataAction(): Promise<HardhatMetadata> {
+    return this._node.getMetadata();
   }
 
   // hardhat_setBalance

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/web3.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/web3.ts
@@ -5,11 +5,13 @@ import {
 import { validateParams } from "../../../core/jsonrpc/types/input/validation";
 import { MethodNotFoundError } from "../../../core/providers/errors";
 import { keccak256 } from "../../../util/keccak";
-import { getPackageJson } from "../../../util/packageInfo";
+import { HardhatNode } from "../node";
 
 /* eslint-disable @nomiclabs/hardhat-internal-rules/only-hardhat-error */
 
 export class Web3Module {
+  constructor(private readonly _node: HardhatNode) {}
+
   public async processRequest(
     method: string,
     params: any[] = []
@@ -32,9 +34,7 @@ export class Web3Module {
   }
 
   private async _clientVersionAction(): Promise<string> {
-    const hardhatPackage = await getPackageJson();
-    const ethereumjsVMPackage = require("@nomicfoundation/ethereumjs-vm/package.json");
-    return `HardhatNetwork/${hardhatPackage.version}/@nomicfoundation/ethereumjs-vm/${ethereumjsVMPackage.version}`;
+    return this._node.getClientVersion();
   }
 
   // web3_sha3

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -2552,7 +2552,6 @@ Hardhat Network's forking functionality only works with blocks from at least spu
     const metadata: HardhatMetadata = {
       clientVersion,
       chainId: this._configChainId,
-      networkId: this._configNetworkId,
       instanceId,
       latestBlockNumber: Number(latestBlock.header.number),
       latestBlockHash,

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -16,6 +16,7 @@ import {
   privateToAddress,
   setLengthLeft,
   toBuffer,
+  bufferToBigInt,
 } from "@nomicfoundation/ethereumjs-util";
 import {
   Bloom,
@@ -32,6 +33,7 @@ import {
 } from "@nomicfoundation/ethereumjs-statemanager";
 import { SignTypedDataVersion, signTypedData } from "@metamask/eth-sig-util";
 import chalk from "chalk";
+import { randomBytes } from "crypto";
 import debug from "debug";
 import EventEmitter from "events";
 
@@ -51,6 +53,7 @@ import {
   InvalidInputError,
   TransactionExecutionError,
 } from "../../core/providers/errors";
+import { HardhatMetadata } from "../../core/jsonrpc/types/output/metadata";
 import { Reporter } from "../../sentry/reporter";
 import { getDifferenceInSeconds } from "../../util/date";
 import {
@@ -58,6 +61,7 @@ import {
   hardforkGte,
   HardforkName,
 } from "../../util/hardforks";
+import { getPackageJson } from "../../util/packageInfo";
 import { createModelsAndDecodeBytecodes } from "../stack-traces/compiler-to-model";
 import { ConsoleLogger } from "../stack-traces/consoleLogger";
 import { ContractsIdentifier } from "../stack-traces/contracts-identifier";
@@ -150,6 +154,7 @@ export class HardhatNode extends EventEmitter {
     let nextBlockBaseFeePerGas: bigint | undefined;
     let forkNetworkId: number | undefined;
     let forkBlockNum: bigint | undefined;
+    let forkBlockHash: string | undefined;
     let hardforkActivations: HardforkHistoryConfig = new Map();
 
     const initialBaseFeePerGasConfig =
@@ -168,11 +173,13 @@ export class HardhatNode extends EventEmitter {
         forkClient: _forkClient,
         forkBlockNumber,
         forkBlockTimestamp,
+        forkBlockHash: _forkBlockHash,
       } = await makeForkClient(config.forkConfig, config.forkCachePath);
       forkClient = _forkClient;
 
       forkNetworkId = forkClient.getNetworkId();
       forkBlockNum = forkBlockNumber;
+      forkBlockHash = _forkBlockHash;
 
       this._validateHardforks(
         config.forkConfig.blockNumber,
@@ -267,8 +274,11 @@ export class HardhatNode extends EventEmitter {
       blockchain,
     });
 
+    const instanceId = bufferToBigInt(randomBytes(32));
+
     const node = new HardhatNode(
       vm,
+      instanceId,
       stateManager,
       blockchain,
       txPool,
@@ -286,6 +296,7 @@ export class HardhatNode extends EventEmitter {
       tracingConfig,
       forkNetworkId,
       forkBlockNum,
+      forkBlockHash,
       nextBlockBaseFeePerGas,
       forkClient
     );
@@ -352,6 +363,7 @@ Hardhat Network's forking functionality only works with blocks from at least spu
 
   private constructor(
     private readonly _vm: VM,
+    private readonly _instanceId: bigint,
     private readonly _stateManager: StateManager,
     private readonly _blockchain: HardhatBlockchainInterface,
     private readonly _txPool: TxPool,
@@ -369,6 +381,7 @@ Hardhat Network's forking functionality only works with blocks from at least spu
     tracingConfig?: TracingConfig,
     private _forkNetworkId?: number,
     private _forkBlockNumber?: bigint,
+    private _forkBlockHash?: string,
     nextBlockBaseFee?: bigint,
     private _forkClient?: JsonRpcClient
   ) {
@@ -2517,6 +2530,52 @@ Hardhat Network's forking functionality only works with blocks from at least spu
 
   public setPrevRandao(prevRandao: Buffer): void {
     this._mixHashGenerator.setNext(prevRandao);
+  }
+
+  public async getClientVersion(): Promise<string> {
+    const hardhatPackage = await getPackageJson();
+    const ethereumjsVMPackage = require("@nomicfoundation/ethereumjs-vm/package.json");
+    return `HardhatNetwork/${hardhatPackage.version}/@nomicfoundation/ethereumjs-vm/${ethereumjsVMPackage.version}`;
+  }
+
+  public async getMetadata(): Promise<HardhatMetadata> {
+    const clientVersion = await this.getClientVersion();
+
+    const instanceIdHex = BigIntUtils.toEvmWord(this._instanceId);
+    const instanceId = `0x${instanceIdHex}`;
+
+    const latestBlock = await this.getLatestBlock();
+
+    const latestBlockHashHex = latestBlock.header.hash().toString("hex");
+    const latestBlockHash = `0x${latestBlockHashHex}`;
+
+    const metadata: HardhatMetadata = {
+      clientVersion,
+      chainId: this._configChainId,
+      networkId: this._configNetworkId,
+      instanceId,
+      latestBlockNumber: Number(latestBlock.header.number),
+      latestBlockHash,
+    };
+
+    if (this._forkBlockNumber !== undefined) {
+      assertHardhatInvariant(
+        this._forkNetworkId !== undefined,
+        "this._forkNetworkId should be defined if this._forkBlockNumber is defined"
+      );
+      assertHardhatInvariant(
+        this._forkBlockHash !== undefined,
+        "this._forkBlockhash should be defined if this._forkBlockNumber is defined"
+      );
+
+      metadata.forkedNetwork = {
+        chainId: this._forkNetworkId,
+        forkBlockNumber: Number(this._forkBlockNumber),
+        forkBlockHash: this._forkBlockHash,
+      };
+    }
+
+    return metadata;
   }
 
   private _getNextMixHash(): Buffer {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -265,7 +265,7 @@ export class HardhatNetworkProvider
     const miningTimer = this._makeMiningTimer();
 
     this._netModule = new NetModule(common);
-    this._web3Module = new Web3Module();
+    this._web3Module = new Web3Module(node);
     this._evmModule = new EvmModule(
       node,
       miningTimer,

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/makeForkClient.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/makeForkClient.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 
 import { HARDHAT_NETWORK_NAME } from "../../../constants";
+import { assertHardhatInvariant } from "../../../core/errors";
 import {
   numberToRpcQuantity,
   rpcQuantityToNumber,
@@ -29,6 +30,7 @@ export async function makeForkClient(
   forkClient: JsonRpcClient;
   forkBlockNumber: bigint;
   forkBlockTimestamp: number;
+  forkBlockHash: string;
 }> {
   const provider = new HttpProvider(
     forkConfig.jsonRpcUrl,
@@ -88,7 +90,14 @@ Please use block number ${lastSafeBlock} or wait for the block to get ${
     cacheToDiskEnabled ? forkCachePath : undefined
   );
 
-  return { forkClient, forkBlockNumber, forkBlockTimestamp };
+  const forkBlockHash = block.hash;
+
+  assertHardhatInvariant(
+    forkBlockHash !== null,
+    "Forked block should have a hash"
+  );
+
+  return { forkClient, forkBlockNumber, forkBlockTimestamp, forkBlockHash };
 }
 
 async function getBlockByNumber(

--- a/packages/hardhat-core/test/fixture-projects/non-default-chainid/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/non-default-chainid/hardhat.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  solidity: "0.5.15",
+  networks: {
+    hardhat: {
+      chainId: 1000,
+    },
+  },
+};

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -30,6 +30,9 @@ import { getPendingBaseFeePerGas } from "../../helpers/getPendingBaseFeePerGas";
 import { RpcBlockOutput } from "../../../../../src/internal/hardhat-network/provider/output";
 import * as BigIntUtils from "../../../../../src/internal/util/bigint";
 import { EXAMPLE_DIFFICULTY_CONTRACT } from "../../helpers/contracts";
+import { HardhatMetadata } from "../../../../../src/internal/core/jsonrpc/types/output/metadata";
+import { useFixtureProject } from "../../../../helpers/project";
+import { useEnvironment } from "../../../../helpers/environment";
 
 describe("Hardhat module", function () {
   PROVIDERS.forEach(({ name, useProvider, isFork }) => {
@@ -2763,6 +2766,160 @@ describe("Hardhat module", function () {
           });
         });
       });
+
+      describe("hardhat_metadata", function () {
+        it("has the right fields", async function () {
+          const metadata = await this.provider.send("hardhat_metadata");
+
+          assert.isString(metadata.clientVersion);
+          assert.isNumber(metadata.chainId);
+          assert.isNumber(metadata.networkId);
+          assert.isString(metadata.instanceId);
+          assert.isNumber(metadata.latestBlockNumber);
+          assert.isString(metadata.latestBlockHash);
+
+          // check that instance id is 32 bytes long
+          assert.lengthOf(metadata.instanceId, 66);
+
+          if (isFork) {
+            assert.isDefined(metadata.forkedNetwork);
+            assert.isNumber(metadata.forkedNetwork.chainId);
+            assert.isNumber(metadata.forkedNetwork.forkBlockNumber);
+            assert.isString(metadata.forkedNetwork.forkBlockHash);
+          } else {
+            assert.notProperty(metadata, "forkedNetwork");
+          }
+        });
+
+        it("shouldn't change the instance id when a block is mined", async function () {
+          const metadataBefore: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          // send a transaction to generate a new block
+          await sendTxToZeroAddress(this.provider);
+
+          const metadataAfter: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          assert.equal(metadataBefore.instanceId, metadataAfter.instanceId);
+        });
+
+        it("changes its instanceId when hardhat_reset is used", async function () {
+          const metadataBefore: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          await this.provider.send("hardhat_reset");
+
+          const metadataAfter: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          assert.notEqual(metadataBefore.instanceId, metadataAfter.instanceId);
+        });
+
+        it("doesn't change its instandeId when snapshots are used", async function () {
+          const snapshotId = await this.provider.send("evm_snapshot");
+
+          const metadataBefore: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          await sendTxToZeroAddress(this.provider);
+          await this.provider.send("evm_revert", [snapshotId]);
+
+          const metadataAfter: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          assert.equal(metadataBefore.instanceId, metadataAfter.instanceId);
+        });
+
+        it("updates the block number and block hash when a new block is mined (sending a tx)", async function () {
+          const metadataBefore: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          // send a transaction to generate a new block
+          await sendTxToZeroAddress(this.provider);
+
+          const metadataAfter: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          assert.equal(
+            metadataAfter.latestBlockNumber,
+            metadataBefore.latestBlockNumber + 1
+          );
+          assert.notEqual(
+            metadataBefore.latestBlockHash,
+            metadataAfter.latestBlockHash
+          );
+        });
+
+        it("updates the block number and block hash when a new block is mined (using hardhat_mine)", async function () {
+          const metadataBefore: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          await this.provider.send("hardhat_mine", ["0x100"]);
+
+          const metadataAfter: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          assert.equal(
+            metadataAfter.latestBlockNumber,
+            metadataBefore.latestBlockNumber + 0x100
+          );
+          assert.notEqual(
+            metadataBefore.latestBlockHash,
+            metadataAfter.latestBlockHash
+          );
+        });
+
+        it("forkBlockNumber and forkBlockHash don't change when a block is mined", async function () {
+          if (!isFork) {
+            return this.skip();
+          }
+
+          const metadataBefore: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          // send a transaction to generate a new block
+          await sendTxToZeroAddress(this.provider);
+
+          const metadataAfter: HardhatMetadata = await this.provider.send(
+            "hardhat_metadata"
+          );
+
+          assert.equal(
+            metadataBefore.forkedNetwork!.forkBlockNumber,
+            metadataAfter.forkedNetwork!.forkBlockNumber
+          );
+          assert.equal(
+            metadataBefore.forkedNetwork!.forkBlockHash,
+            metadataAfter.forkedNetwork!.forkBlockHash
+          );
+        });
+      });
+    });
+  });
+
+  describe("fixture project tests", function () {
+    useFixtureProject("non-default-chainid");
+    useEnvironment();
+
+    it("should return the chainId and networkId set in the config", async function () {
+      const metadata: HardhatMetadata = await this.env.network.provider.send(
+        "hardhat_metadata"
+      );
+
+      assert.equal(metadata.chainId, 1000);
+      assert.equal(metadata.networkId, 1000);
     });
   });
 });

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -2773,7 +2773,6 @@ describe("Hardhat module", function () {
 
           assert.isString(metadata.clientVersion);
           assert.isNumber(metadata.chainId);
-          assert.isNumber(metadata.networkId);
           assert.isString(metadata.instanceId);
           assert.isNumber(metadata.latestBlockNumber);
           assert.isString(metadata.latestBlockHash);
@@ -2913,13 +2912,12 @@ describe("Hardhat module", function () {
     useFixtureProject("non-default-chainid");
     useEnvironment();
 
-    it("should return the chainId and networkId set in the config", async function () {
+    it("should return the chainId set in the config", async function () {
       const metadata: HardhatMetadata = await this.env.network.provider.send(
         "hardhat_metadata"
       );
 
       assert.equal(metadata.chainId, 1000);
-      assert.equal(metadata.networkId, 1000);
     });
   });
 });


### PR DESCRIPTION
Adds a new `hardhat_metadata` RPC method. This method is meant to be used by other tools, like wallets or deployment systems, to get information about the instance of the network.