### PR TITLE
Reduce noise in test output

### DIFF
--- a/packages/hardhat-core/test/fixture-projects/consistent-build-info-names/contracts/A.sol
+++ b/packages/hardhat-core/test/fixture-projects/consistent-build-info-names/contracts/A.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;
 
 import "dependency/contracts/Dep1.sol";

--- a/packages/hardhat-core/test/fixture-projects/consistent-build-info-names/contracts/B.sol
+++ b/packages/hardhat-core/test/fixture-projects/consistent-build-info-names/contracts/B.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;
 
 import "dependency/contracts/Dep1.sol";

--- a/packages/hardhat-core/test/fixture-projects/consistent-build-info-names/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/consistent-build-info-names/hardhat.config.js
@@ -1,3 +1,7 @@
+// This project is compiled from scratch multiple times in the same test, which
+// produces a lot of logs. We override this task to omit those logs.
+subtask("compile:solidity:log:compilation-result", () => {});
+
 module.exports = {
   solidity: "0.7.3",
 };

--- a/packages/hardhat-core/test/fixture-projects/consistent-build-info-names/node_modules/dependency/contracts/Dep1.sol
+++ b/packages/hardhat-core/test/fixture-projects/consistent-build-info-names/node_modules/dependency/contracts/Dep1.sol
@@ -1,1 +1,2 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;

--- a/packages/hardhat-core/test/fixture-projects/consistent-build-info-names/node_modules/dependency/contracts/Dep2.sol
+++ b/packages/hardhat-core/test/fixture-projects/consistent-build-info-names/node_modules/dependency/contracts/Dep2.sol
@@ -1,1 +1,2 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.7.0;

--- a/packages/hardhat-core/test/fixture-projects/project-with-scripts/contracts/a.sol
+++ b/packages/hardhat-core/test/fixture-projects/project-with-scripts/contracts/a.sol
@@ -1,2 +1,3 @@
+pragma solidity ^0.5.0;
 contract A {}
 


### PR DESCRIPTION
This PR:

- Adds some licenses/pragmas to prevent some solc warnings in the test output
- Disables the compilation result log in a test that runs 100 compilations, by overriding a subtask in the fixture project. We can't just use `quiet: true` here because because the test is compiled fresh (after a `hh clean`).