### PR TITLE
Make the flatten task deterministic

### DIFF
--- a/.changeset/rich-berries-confess.md
+++ b/.changeset/rich-berries-confess.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed a bug that was causing the flatten task to produce non-deterministic results

--- a/packages/hardhat-core/src/builtin-tasks/flatten.ts
+++ b/packages/hardhat-core/src/builtin-tasks/flatten.ts
@@ -19,12 +19,23 @@ function getSortedFiles(dependenciesGraph: DependencyGraph) {
   const tsort = require("tsort");
   const graph = tsort();
 
+  // sort the graph entries to make the results deterministic
+  const dependencies = dependenciesGraph
+    .entries()
+    .sort(([a], [b]) => a.sourceName.localeCompare(b.sourceName));
+
   const filesMap: ResolvedFilesMap = {};
-  const resolvedFiles = dependenciesGraph.getResolvedFiles();
+  const resolvedFiles = dependencies.map(([f]) => f);
+
   resolvedFiles.forEach((f) => (filesMap[f.sourceName] = f));
 
-  for (const [from, deps] of dependenciesGraph.entries()) {
-    for (const to of deps) {
+  for (const [from, deps] of dependencies) {
+    // sort the dependencies to make the results deterministic
+    const sortedDeps = [...deps].sort((a, b) =>
+      a.sourceName.localeCompare(b.sourceName)
+    );
+
+    for (const to of sortedDeps) {
       graph.add(to.sourceName, from.sourceName);
     }
   }

--- a/packages/hardhat-core/src/builtin-tasks/flatten.ts
+++ b/packages/hardhat-core/src/builtin-tasks/flatten.ts
@@ -25,7 +25,7 @@ function getSortedFiles(dependenciesGraph: DependencyGraph) {
     .sort(([a], [b]) => a.sourceName.localeCompare(b.sourceName));
 
   const filesMap: ResolvedFilesMap = {};
-  const resolvedFiles = dependencies.map(([f]) => f);
+  const resolvedFiles = dependencies.map(([file, _deps]) => file);
 
   resolvedFiles.forEach((f) => (filesMap[f.sourceName] = f));
 

--- a/packages/hardhat-core/src/internal/solidity/dependencyGraph.ts
+++ b/packages/hardhat-core/src/internal/solidity/dependencyGraph.ts
@@ -9,6 +9,7 @@ export class DependencyGraph implements taskTypes.DependencyGraph {
   ): Promise<DependencyGraph> {
     const graph = new DependencyGraph();
 
+    // TODO refactor this to make the results deterministic
     await Promise.all(
       resolvedFiles.map((resolvedFile) =>
         graph._addDependenciesFrom(resolver, resolvedFile)
@@ -169,6 +170,7 @@ export class DependencyGraph implements taskTypes.DependencyGraph {
     this._resolvedFiles.set(file.sourceName, file);
     this._dependenciesPerFile.set(file.sourceName, dependencies);
 
+    // TODO refactor this to make the results deterministic
     await Promise.all(
       file.content.imports.map(async (imp) => {
         const dependency = await resolver.resolveImport(file, imp);

--- a/packages/hardhat-core/test/builtin-tasks/flatten.ts
+++ b/packages/hardhat-core/test/builtin-tasks/flatten.ts
@@ -85,4 +85,24 @@ describe("Flatten task", () => {
       assert.isFalse(flattenedFiles.includes("} from"));
     });
   });
+
+  describe("project where two contracts import the same dependency", function () {
+    useFixtureProject("consistent-build-info-names");
+    useEnvironment();
+
+    it("should always produce the same flattened file", async function () {
+      const runs = 100;
+      const flattenedFiles: string[] = [];
+
+      for (let i = 0; i < runs; i++) {
+        const flattened = await this.env.run(TASK_FLATTEN_GET_FLATTENED_SOURCE);
+
+        flattenedFiles.push(flattened);
+      }
+
+      for (let i = 0; i + 1 < runs; i++) {
+        assert.equal(flattenedFiles[i], flattenedFiles[i + 1]);
+      }
+    });
+  });
 });


### PR DESCRIPTION
Fixes #3390.

Ideally this should be fixed in the `DependencyGraph` class itself, but the way the graph is built (side-effects based) makes it a bit hard. So I just fixed this in the flatten task itself.