### PR TITLE
fixed name of plugin so the link works

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -656,7 +656,7 @@ const communityPlugins: IPlugin[] = [
     tags: ["Deployment", "Verification", "Migration"],
   },
   {
-    name: "hardhat notifier",
+    name: "hardhat-notifier",
     author: "Mister Singh",
     authorUrl: "https://www.npmjs.com/package/hardhat-notifier",
     description:


### PR DESCRIPTION
- [x] I didn't do anything of this.

---

fixed the name of hardhat-notifier plugin. it had a space in it, instead of a dash which broke the link
