### PR TITLE
Fix bug in AutomaticGasPriceProvider

### DIFF
--- a/.changeset/sixty-zoos-explain.md
+++ b/.changeset/sixty-zoos-explain.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed a bug when `gasPrice` was set to `"auto"`, which is the default configuration when connecting to a JSON-RPC network. This bug was preventing the results from `eth_feeHistory` from being used when they should.

--- a/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
+++ b/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
@@ -143,7 +143,7 @@ export class AutomaticGasPriceProvider extends ProviderWrapper {
     3n;
 
   // See eth_feeHistory for an explanation of what this means
-  public static readonly EIP1559_REWARD_PERCENTILE: bigint = 50n;
+  public static readonly EIP1559_REWARD_PERCENTILE = 50;
 
   private _nodeHasFeeHistory?: boolean;
   private _nodeSupportsEIP1559?: boolean;

--- a/packages/hardhat-core/test/internal/core/providers/mocks.ts
+++ b/packages/hardhat-core/test/internal/core/providers/mocks.ts
@@ -32,6 +32,9 @@ export class MockedProvider extends EventEmitter implements EIP1193Provider {
     method,
     params = [],
   }: RequestArguments): Promise<any> {
+    // stringify the params to make sure they are serializable
+    JSON.stringify(params);
+
     this._latestParams[method] = params;
 
     if (this._numberOfCalls[method] === undefined) {


### PR DESCRIPTION
Closes #3395.

Bigints are not serializable, so the call to `eth_feeHistory` was always failing.

This is hard to test, so I just added a statement stringifying the params in the `MockProvider` used by the tests. This makes the request fail if the params are not serializable, which is a bit more realistic. The relevant tests failed with that change, and the fix made them pass again.