### PR TITLE
docs: fix typos

### DIFF
--- a/.github/workflows/hardhat-network-tracing-all-solc-versions.yml
+++ b/.github/workflows/hardhat-network-tracing-all-solc-versions.yml
@@ -1,4 +1,4 @@
-name: Hardhat Network Tracing Capabilities, scheduled runs for all solc verisons
+name: Hardhat Network Tracing Capabilities, scheduled runs for all solc versions
 
 on:
   schedule:

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -17,7 +17,7 @@ const linariaConfig = withLinaria({
          * e.g. https://hardhat.org/hardhat-network/explanation/mining-modes.html becomes
          * https://hardhat.org/hardhat-network/explanation/mining-modes
          *
-         * We need this to keep the links of the pervious version workable.
+         * We need this to keep the links of the previous version workable.
          * 
          * The only exception is the privacy-policy.html file, which we host in
          * public/

--- a/docs/src/content/hardhat-vscode/docs/overview.md
+++ b/docs/src/content/hardhat-vscode/docs/overview.md
@@ -65,7 +65,7 @@ Rename the identifier under the cursor and all of its references:
 
 Apply solidity formatting to the current document.
 
-The formatting configuration can be overriden through a `.prettierrc` file, see [Formatting Configuration](./formatting.md#formatting-configuration).
+The formatting configuration can be overridden through a `.prettierrc` file, see [Formatting Configuration](./formatting.md#formatting-configuration).
 
 ![Reformat](/hardhat-vscode-images/format.gif "Reformat")
 

--- a/docs/src/content/tutorial/creating-a-new-hardhat-project.md
+++ b/docs/src/content/tutorial/creating-a-new-hardhat-project.md
@@ -123,7 +123,7 @@ You can create your own tasks. Check out the [Creating a task](/guides/create-ta
 
 ### Plugins
 
-Hardhat is unopinionated in terms of what tools you end up using, but it does come with some built-in defaults. All of which can be overriden. Most of the time the way to use a given tool is by consuming a plugin that integrates it into Hardhat.
+Hardhat is unopinionated in terms of what tools you end up using, but it does come with some built-in defaults. All of which can be overridden. Most of the time the way to use a given tool is by consuming a plugin that integrates it into Hardhat.
 
 In this tutorial we are going to use our recommended plugin, [`@nomicfoundation/hardhat-toolbox`](../hardhat-runner/plugins/nomicfoundation-hardhat-toolbox), which has everything you need for developing smart contracts.
 


### PR DESCRIPTION
Hey,

This tiny PR will fix : 

- 1 typo in `.github/workflows/hardhat-network-tracing-all-solc-versions.yml`
- 1 typo in `docs/next.config.js`
- 1 typo in `docs/src/content/hardhat-vscode/docs/overview.md`
- 1 typo in `docs/src/content/tutorial/creating-a-new-hardhat-project.md`



Cheers! :robot: