### PR TITLE
Use pull_request_target as the workflow trigger

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -3,7 +3,7 @@ name: Add issue to project
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
Use the `pull_request_target` event instead of `pull_request`. `pull_request_target` runs in the target repository of the PR (which almost always means the `main` branch) and has write permissions and access to secrets. The "Add to project" workflow needs access to secrets, because it needs a token with org-level project permissions, and these are not available in the `GITHUB_TOKEN` secret.

Using `pull_request_target` is dangerous [in some scenarios](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), but I believe it's safe in this case: we are only running a single job with a single step that uses an official action.