### PR TITLE
misc: cleanup ethereumjs-specific code

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -103,7 +103,6 @@ import { Bloom } from "./utils/bloom";
 import { getCurrentTimestamp } from "./utils/getCurrentTimestamp";
 import { makeCommon } from "./utils/makeCommon";
 import { makeForkClient } from "./utils/makeForkClient";
-import { makeStateTrie } from "./utils/makeStateTrie";
 import { putGenesisBlock } from "./utils/putGenesisBlock";
 import { txMapToArray } from "./utils/txMapToArray";
 import { RandomBufferGenerator } from "./utils/random";

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/putGenesisBlock.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/putGenesisBlock.ts
@@ -1,6 +1,5 @@
 import { Block, HeaderData } from "@nomicfoundation/ethereumjs-block";
 import { Common } from "@nomicfoundation/ethereumjs-common";
-import { Trie } from "@nomicfoundation/ethereumjs-trie";
 import { bufferToHex } from "@nomicfoundation/ethereumjs-util";
 
 import { dateToTimestampSeconds } from "../../../util/date";
@@ -13,7 +12,7 @@ export async function putGenesisBlock(
   blockchain: HardhatBlockchain,
   common: Common,
   { initialDate, blockGasLimit }: LocalNodeConfig,
-  stateTrie: Trie,
+  stateRoot: Buffer,
   hardfork: HardforkName,
   initialMixHash: Buffer,
   initialBaseFee?: bigint
@@ -31,7 +30,7 @@ export async function putGenesisBlock(
     difficulty: isPostMerge ? 0 : 1,
     nonce: isPostMerge ? "0x0000000000000000" : "0x0000000000000042",
     extraData: "0x1234",
-    stateRoot: bufferToHex(stateTrie.root()),
+    stateRoot: bufferToHex(stateRoot),
   };
 
   if (isPostMerge) {


### PR DESCRIPTION
Avoids usage of an ethereumjs-specific state trie and instead uses the `VMAdapter` interface.