### PR TITLE
Fix vyper compiler download timeouts

### DIFF
--- a/.changeset/healthy-fishes-mix.md
+++ b/.changeset/healthy-fishes-mix.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-vyper": patch
+---
+
+Fix vyper compiler download timeouts

--- a/.changeset/wise-moose-know.md
+++ b/.changeset/wise-moose-know.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Accept extra headers in the internal download module

--- a/packages/hardhat-core/src/internal/util/download.ts
+++ b/packages/hardhat-core/src/internal/util/download.ts
@@ -20,7 +20,8 @@ function resolveTempFileName(filePath: string): string {
 export async function download(
   url: string,
   filePath: string,
-  timeoutMillis = 10000
+  timeoutMillis = 10000,
+  extraHeaders: { [name: string]: string } = {}
 ) {
   const { pipeline } = await import("stream");
   const { getGlobalDispatcher, ProxyAgent, request } = await import("undici");
@@ -47,6 +48,7 @@ export async function download(
     maxRedirections: 10,
     method: "GET",
     headers: {
+      ...extraHeaders,
       "User-Agent": `hardhat ${hardhatVersion ?? "(unknown version)"}`,
     },
   });

--- a/packages/hardhat-vyper/src/downloader.ts
+++ b/packages/hardhat-vyper/src/downloader.ts
@@ -14,13 +14,27 @@ import { VyperPluginError, getLogger } from "./util";
 
 const log = getLogger("downloader");
 
+const DOWNLOAD_TIMEOUT_MS = 30_000;
+
 async function downloadFile(
   url: string,
   destinationFile: string
 ): Promise<void> {
   const { download } = await import("hardhat/internal/util/download");
   log(`Downloading from ${url} to ${destinationFile}`);
-  await download(url, destinationFile);
+
+  const headers: { [name: string]: string } = {};
+  // If we are running in GitHub Actions we use the GitHub token as auth to
+  // avoid hitting a rate limit.
+  // Inspired by https://github.com/vyperlang/vvm/blob/5c37a2f4bbebc8c5f7f1dbb8ff89a4df1070ec44/vvm/install.py#L139
+  if (process.env.GITHUB_TOKEN !== undefined) {
+    const base64 = Buffer.from(process.env.GITHUB_TOKEN, "ascii").toString(
+      "base64"
+    );
+    headers.Authorization = `Basic ${base64}`;
+  }
+
+  await download(url, destinationFile, DOWNLOAD_TIMEOUT_MS, headers);
 }
 
 type DownloadFunction = (url: string, destinationFile: string) => Promise<void>;


### PR DESCRIPTION
This PR aims to fix the timeouts when downloading the vyper compiler, as reported by @nventuro

Apparently there are two sources of errors:

1) Plain timeouts when the download takes more than 10s (!)
2) A rate limit that github applies

This PR bumps the timeout, and copies a clever trick that `vvm` uses when running on github actions.