### PR TITLE
WIP: Update hardhat-ganache to new ganache npm module

### DIFF
--- a/packages/hardhat-ganache/README.md
+++ b/packages/hardhat-ganache/README.md
@@ -28,7 +28,7 @@ import "@nomiclabs/hardhat-ganache";
 
 ## Tasks
 
-This plugin hooks into the `test` and `run` tasks to wrap them in the instantiation and termination of a `ganache-core` instance. This plugin creates no additional tasks.
+This plugin hooks into the `test` and `run` tasks to wrap them in the instantiation and termination of a `ganache` instance. This plugin creates no additional tasks.
 
 ## Environment extensions
 

--- a/packages/hardhat-ganache/package.json
+++ b/packages/hardhat-ganache/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "debug": "^4.1.1",
-    "ganache-core": "^2.7.0",
+    "ganache": "^7.7.3",
     "ts-interface-checker": "^0.1.9"
   },
   "devDependencies": {

--- a/packages/hardhat-ganache/src/ganache-service.ts
+++ b/packages/hardhat-ganache/src/ganache-service.ts
@@ -84,7 +84,9 @@ export class GanacheService {
     };
   }
 
-  public static async create(options: HardhatGanacheOptions): Promise<GanacheService> {
+  public static async create(
+    options: HardhatGanacheOptions
+  ): Promise<GanacheService> {
     // We use this weird way of importing this library here as a workaround
     // to this issue https://github.com/trufflesuite/ganache-core/issues/465
     // const Ganache = (() => require)()("ganache");
@@ -98,7 +100,7 @@ export class GanacheService {
     return new GanacheService(options);
   }
 
-  private readonly _server: Server<"ethereum">|undefined;
+  private readonly _server: Server<"ethereum"> | undefined;
   private readonly _ganacheOptions: ServerOptions<"ethereum">;
   private readonly _hardhatGanacheOptions: HardhatGanacheOptions;
 
@@ -106,12 +108,12 @@ export class GanacheService {
     log("Initializing server");
 
     // Validate and Transform received options before initialize server
-    this._hardhatGanacheOptions = options
+    this._hardhatGanacheOptions = options;
     this._ganacheOptions = this._validateAndTransformOptions(options);
 
     try {
       // Initialize server and provider with given options
-     // console.log("this._ganacheOptions",this._ganacheOptions)
+      // console.log("this._ganacheOptions",this._ganacheOptions)
       this._server = ganache.server(this._ganacheOptions) as Server<"ethereum">;
 
       // Note: this seems to be deprecated
@@ -150,16 +152,15 @@ export class GanacheService {
       log("Starting server");
 
       // Get port and hostname from validated options
-      const port = this._hardhatGanacheOptions.port||8545;
-      const hostname = this._hardhatGanacheOptions.hostname||"localhost";
+      const port = this._hardhatGanacheOptions.port || 8545;
+      const hostname = this._hardhatGanacheOptions.hostname || "localhost";
 
       // Start server with current configs (port and hostname)
       await new Promise<void>((resolve, reject) => {
-
         // Note: I can't figure out how to do this with new version of ganache
-        //Note: call back seems to be doing the job
+        // Note: call back seems to be doing the job
         // eslint-disable-next-line prefer-const
-        //let onError: (err: Error) => void;
+        // let onError: (err: Error) => void;
 
         // const onListening = () => {
         //   this._server?.removeListener("error", onError);
@@ -175,8 +176,8 @@ export class GanacheService {
         // this._server.once("error", onError);
 
         this._server?.listen(port, hostname, async (err) => {
-          if (err) reject(err);
-    
+          if (err != null) reject(err);
+
           console.log(`ganache listening on port ${port}...`);
           const provider = this._server?.provider;
           const accounts = await provider?.request({
@@ -212,17 +213,18 @@ export class GanacheService {
       log("Stopping server");
 
       // Stop server and Wait for it
-      await new Promise<void>(async(resolve, reject) => {
-        await this._server?.close(
-        //   (err: Error) => {
-        //   if (err !== undefined && err !== null) {
-        //     reject(err);
-        //   } else {
-        //     resolve();
-        //   }
-        // }
-        );
-        resolve()
+      await new Promise<void>(async (resolve, reject) => {
+        await this._server
+          ?.close
+          //   (err: Error) => {
+          //   if (err !== undefined && err !== null) {
+          //     reject(err);
+          //   } else {
+          //     resolve();
+          //   }
+          // }
+          ();
+        resolve();
       });
     } catch (e: any) {
       const error = new NomicLabsHardhatPluginError(
@@ -240,13 +242,15 @@ export class GanacheService {
     this._checkForServiceErrors();
   }
 
-  private _validateAndTransformOptions(options: HardhatGanacheOptions): ServerOptions<"ethereum"> {
-    let validatedOptions = options;
-   // console.log("_validateAndTransformOptions",options)
+  private _validateAndTransformOptions(
+    options: HardhatGanacheOptions
+  ): ServerOptions<"ethereum"> {
+    const validatedOptions = options;
+    // console.log("_validateAndTransformOptions",options)
 
     // Validate and parse hostname and port from URL (this validation is priority)
     const url = new URL(options.url);
-    console.log("url",url)
+    console.log("url", url);
     if (url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
       throw new NomicLabsHardhatPluginError(
         "@nomiclabs/hardhat-ganache",
@@ -281,7 +285,7 @@ export class GanacheService {
         ? parseInt(url.port, 10)
         : DEFAULT_PORT;
 
-        // This part was supposed to convert to snakecase which is not necessary anymore
+    // This part was supposed to convert to snakecase which is not necessary anymore
     // const optionsToInclude = [
     //   "accountsKeyPath",
     //   "dbPath",
@@ -298,48 +302,48 @@ export class GanacheService {
     //   }
     // }
 
-   let resp={
-    gasPrice: 20000000000,
-    gasLimit: 6721975,
-    wallet:{
-      totalAccounts:validatedOptions.totalAccounts,
-      defaultBalance:validatedOptions.defaultBalanceEther,
-      // hdPath:validatedOptions.hdPath,
-      // unlockedAccounts:validatedOptions.unlockedAccounts,
-     // accountKeysPath:validatedOptions.accountKeysPath,
-      mnemonic:validatedOptions.mnemonic
-    }
-  }
-  
-    return resp
-    
-    // TODO: make a function that correctly does this conversion:
-        return {
+    const resp = {
       gasPrice: 20000000000,
       gasLimit: 6721975,
-      //server:{rpcEndpoint:validatedOptions.url},
-      wallet:{
-        totalAccounts:validatedOptions.totalAccounts,
-        defaultBalance:validatedOptions.defaultBalanceEther,
-        hdPath:validatedOptions.hdPath,
-        unlockedAccounts:validatedOptions.unlockedAccounts,
-        accountKeysPath:validatedOptions.accountKeysPath,
-        mnemonic:validatedOptions.mnemonic
+      wallet: {
+        totalAccounts: validatedOptions.totalAccounts,
+        defaultBalance: validatedOptions.defaultBalanceEther,
+        // hdPath:validatedOptions.hdPath,
+        // unlockedAccounts:validatedOptions.unlockedAccounts,
+        // accountKeysPath:validatedOptions.accountKeysPath,
+        mnemonic: validatedOptions.mnemonic,
       },
-      hardfork:validatedOptions.hardfork,
+    };
+
+    return resp;
+
+    // TODO: make a function that correctly does this conversion:
+    return {
+      gasPrice: 20000000000,
+      gasLimit: 6721975,
+      // server:{rpcEndpoint:validatedOptions.url},
+      wallet: {
+        totalAccounts: validatedOptions.totalAccounts,
+        defaultBalance: validatedOptions.defaultBalanceEther,
+        hdPath: validatedOptions.hdPath,
+        unlockedAccounts: validatedOptions.unlockedAccounts,
+        accountKeysPath: validatedOptions.accountKeysPath,
+        mnemonic: validatedOptions.mnemonic,
+      },
+      hardfork: validatedOptions.hardfork,
       allowUnlimitedContractSize: validatedOptions.allowUnlimitedContractSize,
-      chain:{
-        allowUnlimitedContractSize:validatedOptions.allowUnlimitedContractSize,
-        hardfork:validatedOptions.hardfork
+      chain: {
+        allowUnlimitedContractSize: validatedOptions.allowUnlimitedContractSize,
+        hardfork: validatedOptions.hardfork,
       },
-      miner:{
-        blockTime:validatedOptions.blockTime
+      miner: {
+        blockTime: validatedOptions.blockTime,
       },
-      logging:{
-        debug:validatedOptions.debug
+      logging: {
+        debug: validatedOptions.debug,
       },
-      //@ts-ignore
-      fork:validatedOptions.fork
+      // @ts-ignore
+      fork: validatedOptions.fork,
     };
   }
   // Note: this doesnt seem to be supported anymore

--- a/packages/hardhat-ganache/src/ganache-service.ts
+++ b/packages/hardhat-ganache/src/ganache-service.ts
@@ -363,7 +363,7 @@ export class GanacheService {
   //   });
   // }
 
-   private async _checkForServiceErrors() {
+  private async _checkForServiceErrors() {
     // console.log("ho",GanacheService.error,this._server)
     if (GanacheService.error !== undefined) {
       if (this._server !== undefined) {

--- a/packages/hardhat-ganache/src/ganache-service.ts
+++ b/packages/hardhat-ganache/src/ganache-service.ts
@@ -146,7 +146,7 @@ export class GanacheService {
 
   public async startServer() {
     // Verify service state before start (TODO Maybe extract this to a decorator)
-    this._checkForServiceErrors();
+    await this._checkForServiceErrors();
 
     try {
       log("Starting server");
@@ -202,12 +202,12 @@ export class GanacheService {
     }
 
     // Verify service state after start (TODO Maybe extract this to a decorator)
-    this._checkForServiceErrors();
+    await this._checkForServiceErrors();
   }
 
   public async stopServer() {
     // Verify service state before continue (TODO Maybe extract this to a decorator)
-    this._checkForServiceErrors();
+    await this._checkForServiceErrors();
 
     try {
       log("Stopping server");
@@ -239,7 +239,7 @@ export class GanacheService {
       }
     }
 
-    this._checkForServiceErrors();
+    await this._checkForServiceErrors();
   }
 
   private _validateAndTransformOptions(
@@ -363,11 +363,11 @@ export class GanacheService {
   //   });
   // }
 
-  private _checkForServiceErrors() {
+   private async _checkForServiceErrors() {
     // console.log("ho",GanacheService.error,this._server)
     if (GanacheService.error !== undefined) {
       if (this._server !== undefined) {
-        this._server.close();
+        await this._server.close();
       }
 
       throw new NomicLabsHardhatPluginError(

--- a/packages/hardhat-ganache/src/index.ts
+++ b/packages/hardhat-ganache/src/index.ts
@@ -1,15 +1,15 @@
 import debug from "debug";
-import { TASK_RUN, TASK_TEST } from "hardhat/builtin-tasks/task-names";
-import { extendConfig, task } from "hardhat/config";
+import { TASK_RUN, TASK_TEST } from "hardhat/src/builtin-tasks/task-names";
+import { extendConfig, task } from "hardhat/src/config";
 import {
   HardhatRuntimeEnvironment,
   RunSuperFunction,
   TaskArguments,
-} from "hardhat/types";
+} from "hardhat/src/types";
 
 const log = debug("hardhat:plugin:ganache");
 
-import { GanacheService } from "./ganache-service";
+import { GanacheService, HardhatGanacheOptions } from "./ganache-service";
 
 task(TASK_TEST, async (_args, env, runSuper) => {
   return handlePluginTask(env, runSuper);
@@ -39,8 +39,8 @@ async function handlePluginTask(
   }
 
   log("Starting Ganache");
-
-  const options = env.network.config;
+  //console.log("env.network",env.network)
+  const options = env.network.config as unknown as HardhatGanacheOptions;
   const ganacheService = await GanacheService.create(options);
 
   await ganacheService.startServer();

--- a/packages/hardhat-ganache/src/index.ts
+++ b/packages/hardhat-ganache/src/index.ts
@@ -39,7 +39,7 @@ async function handlePluginTask(
   }
 
   log("Starting Ganache");
-  //console.log("env.network",env.network)
+  // console.log("env.network",env.network)
   const options = env.network.config as unknown as HardhatGanacheOptions;
   const ganacheService = await GanacheService.create(options);
 

--- a/packages/hardhat-ganache/test/fixture-projects/hardhat-project-with-configs/scripts/custom-accounts-sample.js
+++ b/packages/hardhat-ganache/test/fixture-projects/hardhat-project-with-configs/scripts/custom-accounts-sample.js
@@ -4,7 +4,7 @@ const env = require("hardhat");
 async function main() {
   const customConfigs = require("../hardhat.config.ts").default;
   const customOptions = customConfigs.networks.ganache;
-  console.log("customOptions",customOptions)
+  console.log("customOptions", customOptions);
 
   const accounts = await env.network.provider.send("eth_accounts");
 
@@ -14,7 +14,7 @@ async function main() {
   }
 
   // Test for validity of all data
-console.log("accounts.length",accounts.length)
+  console.log("accounts.length", accounts.length);
   // Test for: totalAccounts
   if (accounts.length !== customOptions.totalAccounts) {
     throw new Error("Invalid: total accounts");

--- a/packages/hardhat-ganache/test/fixture-projects/hardhat-project-with-configs/scripts/custom-accounts-sample.js
+++ b/packages/hardhat-ganache/test/fixture-projects/hardhat-project-with-configs/scripts/custom-accounts-sample.js
@@ -4,6 +4,7 @@ const env = require("hardhat");
 async function main() {
   const customConfigs = require("../hardhat.config.ts").default;
   const customOptions = customConfigs.networks.ganache;
+  console.log("customOptions",customOptions)
 
   const accounts = await env.network.provider.send("eth_accounts");
 
@@ -13,7 +14,7 @@ async function main() {
   }
 
   // Test for validity of all data
-
+console.log("accounts.length",accounts.length)
   // Test for: totalAccounts
   if (accounts.length !== customOptions.totalAccounts) {
     throw new Error("Invalid: total accounts");

--- a/packages/hardhat-ganache/test/helpers.ts
+++ b/packages/hardhat-ganache/test/helpers.ts
@@ -1,5 +1,5 @@
-import { resetHardhatContext } from "hardhat/plugins-testing";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { resetHardhatContext } from "hardhat/src/plugins-testing";
+import { HardhatRuntimeEnvironment } from "hardhat/src/types";
 import path from "path";
 
 declare module "mocha" {

--- a/packages/hardhat-ganache/test/index.ts
+++ b/packages/hardhat-ganache/test/index.ts
@@ -6,7 +6,7 @@ import { useEnvironment } from "./helpers";
 
 // Note: Skipping as this plugin hasn't been updated to the latest Ganache version,
 //   so it doesn't work well with Node 18
-describe.skip("Ganache plugin with empty configs", function () {
+describe("Ganache plugin with empty configs", function () {
   useEnvironment("hardhat-project", "ganache");
 
   it("Should add ganache network to the config", function () {
@@ -51,16 +51,15 @@ describe.skip("Ganache plugin with empty configs", function () {
   });
 });
 
-// Note: Skipping as this plugin hasn't been updated to the latest Ganache version,
-//   so it doesn't work well with Node 18
-describe.skip("Ganache plugin with custom configs", function () {
+// Note: Each of the skipped test is working when ran with .only
+describe("Ganache plugin with custom configs", function () {
   useEnvironment("hardhat-project-with-configs", "ganache");
 
   it("Should add ganache network to hardhat's config", function () {
     assert.isDefined(this.env.config.networks.ganache);
   });
 
-  it("Should load custom configs in hardhat's config'", function () {
+  it.skip("Should load custom configs in hardhat's config'", function () {
     assert.isDefined(this.env.config.networks.ganache);
     const customConfigs =
       require("./fixture-projects/hardhat-project-with-configs/hardhat.config.ts").default;
@@ -76,7 +75,7 @@ describe.skip("Ganache plugin with custom configs", function () {
     }
   });
 
-  it("Should expose merged (custom + defaults) configs in hardhat's config", function () {
+  it.skip("Should expose merged (custom + defaults) configs in hardhat's config", function () {
     assert.isDefined(this.env.config.networks.ganache);
     const customConfigs =
       require("./fixture-projects/hardhat-project-with-configs/hardhat.config.ts").default;
@@ -94,7 +93,7 @@ describe.skip("Ganache plugin with custom configs", function () {
     }
   });
 
-  it("Should run Hardhat RUN task using Ganache with custom configs", async function () {
+  it.skip("Should run Hardhat RUN task using Ganache with custom configs", async function () {
     await this.env.run("run", {
       noCompile: true,
       script: "scripts/custom-accounts-sample.js",

--- a/packages/hardhat-ganache/test/index.ts
+++ b/packages/hardhat-ganache/test/index.ts
@@ -59,7 +59,7 @@ describe("Ganache plugin with custom configs", function () {
     assert.isDefined(this.env.config.networks.ganache);
   });
 
-  it.skip("Should load custom configs in hardhat's config'", function () {
+  it("Should load custom configs in hardhat's config'", function () {
     assert.isDefined(this.env.config.networks.ganache);
     const customConfigs =
       require("./fixture-projects/hardhat-project-with-configs/hardhat.config.ts").default;
@@ -75,7 +75,7 @@ describe("Ganache plugin with custom configs", function () {
     }
   });
 
-  it.skip("Should expose merged (custom + defaults) configs in hardhat's config", function () {
+  it("Should expose merged (custom + defaults) configs in hardhat's config", function () {
     assert.isDefined(this.env.config.networks.ganache);
     const customConfigs =
       require("./fixture-projects/hardhat-project-with-configs/hardhat.config.ts").default;
@@ -93,7 +93,7 @@ describe("Ganache plugin with custom configs", function () {
     }
   });
 
-  it.skip("Should run Hardhat RUN task using Ganache with custom configs", async function () {
+  it("Should run Hardhat RUN task using Ganache with custom configs", async function () {
     await this.env.run("run", {
       noCompile: true,
       script: "scripts/custom-accounts-sample.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11400,10 +11400,10 @@ ts-interface-builder@^0.2.0:
     glob "^7.1.6"
     typescript "^3.0.0"
 
-ts-interface-checker@^0.1.9:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
-  integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+ts-interface-checker@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-1.0.2.tgz#63f73a098b0ed34b982df1f490c54890e8e5e0b3"
+  integrity sha512-4IKKvhZRXhvtYF/mtu+OCfBqJKV6LczUq4kQYcpT+iSB7++R9+giWnp2ecwWMIcnG16btVOkXFnoxLSYMN1Q1g==
 
 ts-node@^8.1.0:
   version "8.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,6 +1481,13 @@
     ethers "^4.0.32"
     web3 "1.5.3"
 
+"@trufflesuite/bigint-buffer@1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.10.tgz#a1d9ca22d3cad1a138b78baaf15543637a3e1692"
+  integrity sha512-pYIQC5EcMmID74t26GCC67946mgTJFiLXOT/BYozgrd4UEY2JHEGLhWi9cMiQCt5BSqFEvKkCHNnoj82SRjiEw==
+  dependencies:
+    node-gyp-build "4.4.0"
+
 "@trufflesuite/chromafi@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@trufflesuite/chromafi/-/chromafi-3.0.0.tgz#f6956408c1af6a38a6ed1657783ce59504a1eb8b"
@@ -1658,7 +1665,7 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
 
-"@types/lru-cache@^5.1.0":
+"@types/lru-cache@5.1.1", "@types/lru-cache@^5.1.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
   integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
@@ -1763,6 +1770,11 @@
   integrity sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==
   dependencies:
     "@types/node" "*"
+
+"@types/seedrandom@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-3.0.1.tgz#1254750a4fec4aff2ebec088ccd0bb02e91fedb4"
+  integrity sha512-giB9gzDeiCeloIXDgzFBCgjj1k4WxcDrZtGl6h1IqmUPlxF+Nx8Ve+96QCyDZ/HseB/uvDsKbpib9hU5cU53pw==
 
 "@types/semver@^6.0.0", "@types/semver@^6.0.2":
   version "6.2.3"
@@ -2015,7 +2027,7 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-abstract-level@^1.0.0, abstract-level@^1.0.2, abstract-level@^1.0.3:
+abstract-level@1.0.3, abstract-level@^1.0.0, abstract-level@^1.0.2, abstract-level@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abstract-level/-/abstract-level-1.0.3.tgz#78a67d3d84da55ee15201486ab44c09560070741"
   integrity sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==
@@ -2034,6 +2046,18 @@ abstract-leveldown@3.0.0:
   integrity sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==
   dependencies:
     xtend "~4.0.0"
+
+abstract-leveldown@7.2.0, abstract-leveldown@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz#08d19d4e26fb5be426f7a57004851b39e1795a2e"
+  integrity sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==
+  dependencies:
+    buffer "^6.0.3"
+    catering "^2.0.0"
+    is-buffer "^2.0.5"
+    level-concat-iterator "^3.0.0"
+    level-supports "^2.0.1"
+    queue-microtask "^1.2.3"
 
 abstract-leveldown@^2.4.1, abstract-leveldown@~2.7.1:
   version "2.7.2"
@@ -2418,7 +2442,7 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-async-eventemitter@^0.2.2, async-eventemitter@^0.2.4:
+async-eventemitter@0.2.4, async-eventemitter@^0.2.2, async-eventemitter@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/async-eventemitter/-/async-eventemitter-0.2.4.tgz#f5e7c8ca7d3e46aab9ec40a292baf686a0bafaca"
   integrity sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==
@@ -3381,6 +3405,13 @@ buffer@^5.0.5, buffer@^5.2.1, buffer@^5.5.0, buffer@^5.6.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+bufferutil@4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.5.tgz#da9ea8166911cc276bf677b8aed2d02d31f59028"
+  integrity sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 bufferutil@^4.0.1:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.6.tgz#ebd6c67c7922a0e902f053e5d8be5ec850e48433"
@@ -3535,7 +3566,7 @@ caseless@^0.12.0, caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
-catering@^2.1.0, catering@^2.1.1:
+catering@^2.0.0, catering@^2.1.0, catering@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/catering/-/catering-2.1.1.tgz#66acba06ed5ee28d5286133982a927de9a04b510"
   integrity sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==
@@ -4619,6 +4650,11 @@ elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5
     inherits "^2.0.4"
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
+
+emittery@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.10.0.tgz#bb373c660a9d421bb44706ec4967ed50c02a8026"
+  integrity sha512-AGvFfs+d0JKCJQ4o01ASQLGPmSCxgfU9RFXvzPvZdjKK8oscynksuJhWrSTSw7j7Ep/sZct5b5ZhYCi8S/t0HQ==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -6140,7 +6176,7 @@ ganache-cli@^6.12.2:
     source-map-support "0.5.12"
     yargs "13.2.4"
 
-ganache-core@^2.13.2, ganache-core@^2.7.0:
+ganache-core@^2.13.2:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.13.2.tgz#27e6fc5417c10e6e76e2e646671869d7665814a3"
   integrity sha512-tIF5cR+ANQz0+3pHWxHjIwHqFXcVo0Mb+kcsNhglNFALcYo49aQpnS9dqHartqPfMFjiHh/qFoD3mYK0d/qGgw==
@@ -6176,6 +6212,26 @@ ganache-core@^2.13.2, ganache-core@^2.7.0:
   optionalDependencies:
     ethereumjs-wallet "0.6.5"
     web3 "1.2.11"
+
+ganache@^7.7.3:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/ganache/-/ganache-7.7.3.tgz#c36f982166239a3cf8ae040942c08a4ba6e62dc3"
+  integrity sha512-dZTUHjzSuvDTMUpKaBTWJnpcWpsBUtqciA8ttdmC/r/XRXJhDa0EpypisYULhoV8tx76G08mOuM/B1vhPbh20A==
+  dependencies:
+    "@trufflesuite/bigint-buffer" "1.1.10"
+    "@types/bn.js" "^5.1.0"
+    "@types/lru-cache" "5.1.1"
+    "@types/seedrandom" "3.0.1"
+    abstract-level "1.0.3"
+    abstract-leveldown "7.2.0"
+    async-eventemitter "0.2.4"
+    emittery "0.10.0"
+    keccak "3.0.2"
+    leveldown "6.1.0"
+    secp256k1 "4.0.3"
+  optionalDependencies:
+    bufferutil "4.0.5"
+    utf-8-validate "5.0.7"
 
 get-caller-file@^1.0.1:
   version "1.0.3"
@@ -7509,7 +7565,7 @@ keccak@3.0.1:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 
-keccak@^3.0.0, keccak@^3.0.2:
+keccak@3.0.2, keccak@^3.0.0, keccak@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.2.tgz#4c2c6e8c54e04f2670ee49fa734eb9da152206e0"
   integrity sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==
@@ -7593,6 +7649,13 @@ level-codec@~7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-7.0.1.tgz#341f22f907ce0f16763f24bddd681e395a0fb8a7"
   integrity sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==
+
+level-concat-iterator@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz#5235b1f744bc34847ed65a50548aa88d22e881cf"
+  integrity sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==
+  dependencies:
+    catering "^2.1.0"
 
 level-errors@^1.0.3:
   version "1.1.2"
@@ -7682,6 +7745,11 @@ level-sublevel@6.6.4:
     typewiselite "~1.0.0"
     xtend "~4.0.0"
 
+level-supports@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-2.1.0.tgz#9af908d853597ecd592293b2fad124375be79c5f"
+  integrity sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==
+
 level-supports@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/level-supports/-/level-supports-4.0.1.tgz#431546f9d81f10ff0fea0e74533a0e875c08c66a"
@@ -7719,6 +7787,15 @@ level@^8.0.0:
   dependencies:
     browser-level "^1.0.1"
     classic-level "^1.2.0"
+
+leveldown@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/leveldown/-/leveldown-6.1.0.tgz#7ab1297706f70c657d1a72b31b40323aa612b9ee"
+  integrity sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==
+  dependencies:
+    abstract-leveldown "^7.2.0"
+    napi-macros "~2.0.0"
+    node-gyp-build "^4.3.0"
 
 levelup@3.1.1, levelup@^3.0.0:
   version "3.1.1"
@@ -8616,7 +8693,7 @@ node-fetch@~1.7.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
+node-gyp-build@4.4.0, node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.4.0.tgz#42e99687ce87ddeaf3a10b99dc06abc11021f3f4"
   integrity sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==
@@ -10129,7 +10206,7 @@ scryptsy@^1.2.1:
   dependencies:
     pbkdf2 "^3.0.3"
 
-secp256k1@^4.0.1:
+secp256k1@4.0.3, secp256k1@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.3.tgz#c4559ecd1b8d3c1827ed2d1b94190d69ce267303"
   integrity sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==
@@ -11323,10 +11400,10 @@ ts-interface-builder@^0.2.0:
     glob "^7.1.6"
     typescript "^3.0.0"
 
-ts-interface-checker@^0.1.9:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
-  integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+ts-interface-checker@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-1.0.2.tgz#63f73a098b0ed34b982df1f490c54890e8e5e0b3"
+  integrity sha512-4IKKvhZRXhvtYF/mtu+OCfBqJKV6LczUq4kQYcpT+iSB7++R9+giWnp2ecwWMIcnG16btVOkXFnoxLSYMN1Q1g==
 
 ts-node@^8.1.0:
   version "8.10.2"
@@ -11696,6 +11773,13 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf-8-validate@5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.7.tgz#c15a19a6af1f7ad9ec7ddc425747ca28c3644922"
+  integrity sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==
+  dependencies:
+    node-gyp-build "^4.3.0"
 
 utf-8-validate@^5.0.2:
   version "5.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11400,10 +11400,10 @@ ts-interface-builder@^0.2.0:
     glob "^7.1.6"
     typescript "^3.0.0"
 
-ts-interface-checker@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-1.0.2.tgz#63f73a098b0ed34b982df1f490c54890e8e5e0b3"
-  integrity sha512-4IKKvhZRXhvtYF/mtu+OCfBqJKV6LczUq4kQYcpT+iSB7++R9+giWnp2ecwWMIcnG16btVOkXFnoxLSYMN1Q1g==
+ts-interface-checker@^0.1.9:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
+  integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
 ts-node@^8.1.0:
   version "8.10.2"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Handles https://github.com/NomicFoundation/hardhat/issues/3556

- Replaces the old ganache-core module with ganache.
- Changes default PORT to 8545
- Create function input is typed HardhatGanacheOptions instead of GanacheOptions in order not to confuse with the require input for the ganache server (`ServerOptions<"ethereum">`)
- _validateAndTransformOptions takes HardhatGanacheOptions input, verifies them and return correct input for the new ganache server creation (`ServerOptions<"ethereum">`) (this is not complete because it lacks a few custom parameters that are hardcoded to default, but it should work with the tests). Also remove the snakecase part from this function because this is not necessary with the new module
- Remove _registerSystemErrorsHandlers because the new package doesn't seem to support it
- Uses a simplified getDefaultOptions because the ganache package already has many default options

Some tests aren't passing yet.
I also need to write the function that supports proper custom network option conversion.