### PR TITLE
Website UI improvements: hero x-index order and sidebar scrollbar

### DIFF
--- a/docs/src/components/DocumentationLayout.tsx
+++ b/docs/src/components/DocumentationLayout.tsx
@@ -92,7 +92,7 @@ export const SidebarContainer = styled.aside<{ isSidebarOpen: boolean }>`
   left: ${({ isSidebarOpen }) => (isSidebarOpen ? "0px" : "-120vw")};
   height: calc(100vh - 136px);
   display: flex;
-  overflow-y: scroll;
+  overflow-y: auto;
   transition: all ease-out 0.25s;
   z-index: 50;
   background-color: ${tm(({ colors }) => colors.neutral0)};

--- a/docs/src/components/landingBlocks/HeroBlock.tsx
+++ b/docs/src/components/landingBlocks/HeroBlock.tsx
@@ -45,7 +45,7 @@ const Block = styled.div`
   padding: 0 0 24px;
   min-height: 100px;
   &.content {
-    z-index: 1;
+    z-index: 2;
   }
   & svg {
     margin: 0 auto;


### PR DESCRIPTION

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

I changed the `z-index` of the hero element so this doesn't happen:

![ethereum logo over text](https://user-images.githubusercontent.com/17814535/213884383-8a8568d6-a3fa-4422-ac86-c4091cdfb689.png)

And configured the sidebar to not have a scrollbar when one isn't necessary, like so:

![unnecessary sidebar](https://user-images.githubusercontent.com/17814535/213884422-4e4c48bd-e2e5-4287-b308-eef91f2934c0.png)
