### PR TITLE
Set "resolveJsonModule": true in sample tsconfig

### DIFF
--- a/.changeset/dull-files-dream.md
+++ b/.changeset/dull-files-dream.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Set "resolveJsonModule": true in sample tsconfig
+The `resolveJsonModule` compiler option is now enabled by default in the sample tsconfig (thanks @mlshv!)

--- a/.changeset/dull-files-dream.md
+++ b/.changeset/dull-files-dream.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Set "resolveJsonModule": true in sample tsconfig

--- a/packages/hardhat-core/sample-projects/typescript/tsconfig.json
+++ b/packages/hardhat-core/sample-projects/typescript/tsconfig.json
@@ -5,6 +5,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

<!-- Add a description of your PR here -->

I think `"resolveJsonModule": true` should be added to sample project tsconfig because it's a pretty common case to import ABI from JSON files in tests. By far, i've been adding this setting manually to all the projects bootstrapped with hardhat. I believe that it would be better include it by default.