### PR TITLE
Use our mirror to download the Vyper compilers

### DIFF
--- a/.changeset/healthy-cups-march.md
+++ b/.changeset/healthy-cups-march.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-vyper": patch
+---
+
+Use our mirror to download Vyper releases, which should be more stable

--- a/.changeset/quiet-queens-talk.md
+++ b/.changeset/quiet-queens-talk.md
@@ -1,5 +1,0 @@
----
-"@nomiclabs/hardhat-vyper": patch
----
-
-Document how to use the plugin in Github Actions

--- a/.github/workflows/LATEST_DEPENDENCY_VERSIONS.yml
+++ b/.github/workflows/LATEST_DEPENDENCY_VERSIONS.yml
@@ -25,7 +25,6 @@ jobs:
         run: yarn list
       - name: Run tests
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true
           FORCE_COLOR: 3
         run: yarn test || (echo "===== Retry =====" && yarn test)

--- a/.github/workflows/hardhat-vyper-ci.yml
+++ b/.github/workflows/hardhat-vyper-ci.yml
@@ -44,5 +44,3 @@ jobs:
         run: yarn build
       - name: Run tests
         run: yarn test
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -36,7 +36,6 @@ jobs:
           DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true
           FORCE_COLOR: 3
           NODE_OPTIONS: "--max-old-space-size=4096"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn test
       - name: Check dependency versions
         run: node scripts/check-dependencies.js

--- a/packages/hardhat-vyper/.mocharc.json
+++ b/packages/hardhat-vyper/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "require": "ts-node/register/files",
   "ignore": ["test/fixture-projects/**/*"],
-  "timeout": 10000
+  "timeout": 25000
 }

--- a/packages/hardhat-vyper/README.md
+++ b/packages/hardhat-vyper/README.md
@@ -75,9 +75,3 @@ There are no additional steps you need to take for this plugin to work.
 ### Additional notes
 
 The oldest vyper version supported by this plugin is 0.2.0. Versions older than this will not work and will throw an error.
-
-### Using this plugin in GitHub Actions
-
-This plugin downloads the Vyper compiler from GitHub. This can lead to your GitHub Actions being rate-limited by GitHub.
-
-To avoid this, you need to set up your [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authenticationg) as an [environment variable in the steps running Hardhat](https://docs.github.com/en/actions/learn-github-actions/variables).

--- a/packages/hardhat-vyper/src/constants.ts
+++ b/packages/hardhat-vyper/src/constants.ts
@@ -3,6 +3,3 @@ export const ARTIFACT_FORMAT_VERSION = "hh-vyper-artifact-1";
 export const DEBUG_NAMESPACE = "hardhat:plugin:vyper";
 export const CACHE_FORMAT_VERSION = "hh-vy-cache-1";
 export const VYPER_FILES_CACHE_FILENAME = "vyper-files-cache.json";
-
-export const GITHUB_RELEASES_URL =
-  "https://api.github.com/repos/vyperlang/vyper/releases?per_page=100";

--- a/packages/hardhat-vyper/src/downloader.ts
+++ b/packages/hardhat-vyper/src/downloader.ts
@@ -9,11 +9,11 @@ import {
   CompilerPlatform,
   CompilerRelease,
 } from "./types";
-import { GITHUB_RELEASES_URL } from "./constants";
 import { VyperPluginError, getLogger } from "./util";
 
 const log = getLogger("downloader");
 
+const VYPER_RELEASES_MIRROR_URL = "https://vyper-releases-mirror.hardhat.org";
 const DOWNLOAD_TIMEOUT_MS = 30_000;
 
 async function downloadFile(
@@ -22,19 +22,7 @@ async function downloadFile(
 ): Promise<void> {
   const { download } = await import("hardhat/internal/util/download");
   log(`Downloading from ${url} to ${destinationFile}`);
-
-  const headers: { [name: string]: string } = {};
-  // If we are running in GitHub Actions we use the GitHub token as auth to
-  // avoid hitting a rate limit.
-  // Inspired by https://github.com/vyperlang/vvm/blob/5c37a2f4bbebc8c5f7f1dbb8ff89a4df1070ec44/vvm/install.py#L139
-  if (process.env.GITHUB_TOKEN !== undefined) {
-    const base64 = Buffer.from(process.env.GITHUB_TOKEN, "ascii").toString(
-      "base64"
-    );
-    headers.Authorization = `Basic ${base64}`;
-  }
-
-  await download(url, destinationFile, DOWNLOAD_TIMEOUT_MS, headers);
+  await download(url, destinationFile, DOWNLOAD_TIMEOUT_MS);
 }
 
 type DownloadFunction = (url: string, destinationFile: string) => Promise<void>;
@@ -73,7 +61,7 @@ export class CompilerDownloader {
   }
 
   public async initCompilersList(
-    { forceDownload } = { forceDownload: true }
+    { forceDownload } = { forceDownload: false }
   ): Promise<void> {
     if (forceDownload || !this.compilersListExists) {
       await this._downloadCompilersList();
@@ -146,7 +134,10 @@ export class CompilerDownloader {
 
   private async _downloadCompilersList(): Promise<void> {
     try {
-      await this._download(GITHUB_RELEASES_URL, this.compilersListPath);
+      await this._download(
+        `${VYPER_RELEASES_MIRROR_URL}/list.json`,
+        this.compilersListPath
+      );
     } catch (e: unknown) {
       throw new VyperPluginError(
         "Failed to download compiler list",
@@ -174,11 +165,13 @@ export class CompilerDownloader {
     const version = compilerAsset.name.split("+")[0].replace("vyper.", "");
     log(`Downloading compiler version ${version} platform ${this._platform}`);
 
+    const urlParts = compilerAsset.browser_download_url.split("/");
+    const mirroredUrl = `${VYPER_RELEASES_MIRROR_URL}/${
+      urlParts[urlParts.length - 1]
+    }`;
+
     try {
-      await this._download(
-        compilerAsset.browser_download_url,
-        downloadedFilePath
-      );
+      await this._download(mirroredUrl, downloadedFilePath);
     } catch (e: unknown) {
       throw new VyperPluginError("Compiler download failed", e as Error);
     }


### PR DESCRIPTION
Previously we were downloading directly from Github, which is unstable and rate-limited. 

I created [a mirror of the releases page](https://github.com/NomicFoundation/vyper-releases-mirror) using github actions and vercel, and this PR uses it.