### PR TITLE
allow linting classes that extend the HardhatPluginError class

### DIFF
--- a/.changeset/lazy-seas-exercise.md
+++ b/.changeset/lazy-seas-exercise.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/eslint-plugin-hardhat-internal-rules": patch
+---
+
+allow linting classes that extend the HardhatPluginError class

--- a/packages/eslint-plugin/onlyHardhatErrorRule.js
+++ b/packages/eslint-plugin/onlyHardhatErrorRule.js
@@ -1,12 +1,14 @@
 const { ESLintUtils } = require("@typescript-eslint/experimental-utils");
 
 function onlyHardhatErrorRule(context) {
-  const parserServices = ESLintUtils.getParserServices(context)
+  const parserServices = ESLintUtils.getParserServices(context);
   const checker = parserServices.program.getTypeChecker();
 
   return {
     ThrowStatement(node) {
-      const expression = parserServices.esTreeNodeToTSNodeMap.get(node.argument);
+      const expression = parserServices.esTreeNodeToTSNodeMap.get(
+        node.argument
+      );
 
       if (!isHardhatError(expression, checker)) {
         const exceptionName = getExpressionClassName(expression, checker);
@@ -21,12 +23,14 @@ function onlyHardhatErrorRule(context) {
 }
 
 function onlyHardhatPluginErrorRule(context) {
-  const parserServices = ESLintUtils.getParserServices(context)
+  const parserServices = ESLintUtils.getParserServices(context);
   const checker = parserServices.program.getTypeChecker();
 
   return {
     ThrowStatement(node) {
-      const expression = parserServices.esTreeNodeToTSNodeMap.get(node.argument);
+      const expression = parserServices.esTreeNodeToTSNodeMap.get(
+        node.argument
+      );
 
       if (!isHardhatPluginError(expression, checker)) {
         const exceptionName = getExpressionClassName(expression, checker);
@@ -50,12 +54,28 @@ function getExpressionClassName(expression, tc) {
   return exceptionType.symbol.getName();
 }
 
+function getExpressionClassNameAndBaseClass(expression, tc) {
+  const exceptionType = tc.getTypeAtLocation(expression);
+
+  if (exceptionType.symbol === undefined) {
+    return ["[UNKNOWN EXCEPTION TYPE]"];
+  }
+
+  const className = exceptionType.symbol.getName();
+  const baseClass =
+    exceptionType.resolvedBaseConstructorType?.symbol?.getName();
+
+  return [className, baseClass];
+}
+
 function isHardhatError(expression, tc) {
   return getExpressionClassName(expression, tc) === "HardhatError";
 }
 
 function isHardhatPluginError(expression, tc) {
-  return getExpressionClassName(expression, tc) === "HardhatPluginError";
+  return getExpressionClassNameAndBaseClass(expression, tc).includes(
+    "HardhatPluginError"
+  );
 }
 
-module.exports = { onlyHardhatErrorRule, onlyHardhatPluginErrorRule }
+module.exports = { onlyHardhatErrorRule, onlyHardhatPluginErrorRule };

--- a/packages/eslint-plugin/onlyHardhatErrorRule.js
+++ b/packages/eslint-plugin/onlyHardhatErrorRule.js
@@ -63,7 +63,8 @@ function getExpressionClassNameAndBaseClass(expression, tc) {
 
   const className = exceptionType.symbol.getName();
   const baseClass =
-    exceptionType.resolvedBaseConstructorType?.symbol?.getName();
+    exceptionType.resolvedBaseConstructorType?.symbol?.getName() ??
+    "[UNKNOWN BASE CLASS]";
 
   return [className, baseClass];
 }


### PR DESCRIPTION
Most of the PR changes are just things our own linting auto-fixed, but the main change is a small tweak to the logic for the hardhat plugin error linter to make it possible to use the lint rule for error classes that extend the `HardhatPluginError` class (i.e. `IgnitionError`)