### PR TITLE
Propagate HttpProviderError exception message

### DIFF
--- a/.changeset/twenty-toys-wave.md
+++ b/.changeset/twenty-toys-wave.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Propagate HttpProviderError exception messages.

--- a/packages/hardhat-core/src/internal/core/providers/http.ts
+++ b/packages/hardhat-core/src/internal/core/providers/http.ts
@@ -80,7 +80,7 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
   public async request(args: RequestArguments): Promise<unknown> {
     // We create the error here to capture the stack traces at this point,
     // the async call that follows would probably loose of the stack trace
-    const error = new ProviderError("HttpProviderError", -1);
+    const stackSavingError = new ProviderError("HttpProviderError", -1);
 
     const jsonRpcRequest = this._getJsonRpcRequest(
       args.method,
@@ -89,8 +89,11 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
     const jsonRpcResponse = await this._fetchJsonRpcResponse(jsonRpcRequest);
 
     if (isErrorResponse(jsonRpcResponse)) {
-      error.message = jsonRpcResponse.error.message;
-      error.code = jsonRpcResponse.error.code;
+      const error = new ProviderError(
+        jsonRpcResponse.error.message,
+        jsonRpcResponse.error.code,
+        stackSavingError
+      );
       error.data = jsonRpcResponse.error.data;
       // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
       throw error;
@@ -114,7 +117,7 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
   ): Promise<any[]> {
     // We create the errors here to capture the stack traces at this point,
     // the async call that follows would probably loose of the stack trace
-    const error = new ProviderError("HttpProviderError", -1);
+    const stackSavingError = new ProviderError("HttpProviderError", -1);
 
     // we need this to sort the responses
     const idToIndexMap: Record<string, number> = {};
@@ -129,8 +132,11 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
 
     for (const response of jsonRpcResponses) {
       if (isErrorResponse(response)) {
-        error.message = response.error.message;
-        error.code = response.error.code;
+      const error = new ProviderError(
+        jsonRpcResponse.error.message,
+        jsonRpcResponse.error.code,
+        stackSavingError
+      );
         error.data = response.error.data;
         // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
         throw error;

--- a/packages/hardhat-core/src/internal/core/providers/http.ts
+++ b/packages/hardhat-core/src/internal/core/providers/http.ts
@@ -135,7 +135,7 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
         const error = new ProviderError(
           response.error.message,
           response.error.code,
-          stackSavingError,
+          stackSavingError
         );
         error.data = response.error.data;
         // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error

--- a/packages/hardhat-core/src/internal/core/providers/http.ts
+++ b/packages/hardhat-core/src/internal/core/providers/http.ts
@@ -78,10 +78,6 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
   }
 
   public async request(args: RequestArguments): Promise<unknown> {
-    // We create the error here to capture the stack traces at this point,
-    // the async call that follows would probably loose of the stack trace
-    const stackSavingError = new ProviderError("HttpProviderError", -1);
-
     const jsonRpcRequest = this._getJsonRpcRequest(
       args.method,
       args.params as any[]
@@ -91,8 +87,7 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
     if (isErrorResponse(jsonRpcResponse)) {
       const error = new ProviderError(
         jsonRpcResponse.error.message,
-        jsonRpcResponse.error.code,
-        stackSavingError
+        jsonRpcResponse.error.code
       );
       error.data = jsonRpcResponse.error.data;
       // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error

--- a/packages/hardhat-core/src/internal/core/providers/http.ts
+++ b/packages/hardhat-core/src/internal/core/providers/http.ts
@@ -132,11 +132,11 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
 
     for (const response of jsonRpcResponses) {
       if (isErrorResponse(response)) {
-      const error = new ProviderError(
-        response.error.message,
-        response.error.code,
-        stackSavingError
-      );
+        const error = new ProviderError(
+          response.error.message,
+          response.error.code,
+          stackSavingError,
+        );
         error.data = response.error.data;
         // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
         throw error;

--- a/packages/hardhat-core/src/internal/core/providers/http.ts
+++ b/packages/hardhat-core/src/internal/core/providers/http.ts
@@ -133,8 +133,8 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
     for (const response of jsonRpcResponses) {
       if (isErrorResponse(response)) {
       const error = new ProviderError(
-        jsonRpcResponse.error.message,
-        jsonRpcResponse.error.code,
+        response.error.message,
+        response.error.code,
         stackSavingError
       );
         error.data = response.error.data;


### PR DESCRIPTION
Prior to this change, the error message is not visible when the exception is thrown.

Before:
```
npx hardhat run --network goerli scripts/deploy_big_contract.js
ProviderError: HttpProviderError
    at HttpProvider.request (/Users/user/research/tmp/hh-test1/node_modules/hardhat/src/internal/core/providers/http.ts:78:19)
    at LocalAccountsProvider.request (/Users/user/research/tmp/hh-test1/node_modules/hardhat/src/internal/core/providers/accounts.ts:187:34)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at EthersProviderWrapper.send (/Users/user/research/tmp/hh-test1/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
```

After:
```
npx hardhat run --network goerli scripts/deploy_big_contract.js
ProviderError: max code size exceeded
    at HttpProvider.request (/Users/user/research/tmp/hh-test1/node_modules/hardhat/src/internal/core/providers/http.ts:87:20)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at EthersProviderWrapper.send (/Users/user/research/tmp/hh-test1/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)

    Caused by: Error:
        at HttpProvider.request (/Users/user/research/tmp/hh-test1/node_modules/hardhat/src/internal/core/providers/http.ts:78:23)
        at LocalAccountsProvider.request (/Users/user/research/tmp/hh-test1/node_modules/hardhat/src/internal/core/providers/accounts.ts:187:34)
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
        at EthersProviderWrapper.send (/Users/user/research/tmp/hh-test1/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
```

Alternatively, if we remove the `stackSavingError` completely, the result is:
```
npx hardhat run --network goerli scripts/deploy_big_contract.js
ProviderError: max code size exceeded
    at HttpProvider.request (/Users/user/research/tmp/hh-test1/node_modules/hardhat/src/internal/core/providers/http.ts:84:11)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at EthersProviderWrapper.send (/Users/user/research/tmp/hh-test1/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
```

This is caused because for some reason, JS keeps using the error message used in the constructor, even after the `.message` property is altered:
<img width="482" alt="image" src="https://user-images.githubusercontent.com/168856/219390603-d8a32b97-3e5d-440a-8a11-a2e6b38c5c6b.png">
<img width="256" alt="image" src="https://user-images.githubusercontent.com/168856/219390911-8bca8a15-8902-4f99-9b7a-24a75997c701.png">
