### PR TITLE
docs(rethnet): clarify that modify_account operates on empty accounts

### DIFF
--- a/crates/rethnet_evm/src/state/debug.rs
+++ b/crates/rethnet_evm/src/state/debug.rs
@@ -21,7 +21,8 @@ pub trait StateDebug {
         account_info: AccountInfo,
     ) -> Result<(), Self::Error>;
 
-    /// Modifies the account at the specified address using the provided function.
+    /// Modifies the account at the specified address using the provided function. If the address
+    /// points to an empty account, that will be modified instead.
     fn modify_account(
         &mut self,
         address: Address,

--- a/crates/rethnet_evm/src/state/layered_state.rs
+++ b/crates/rethnet_evm/src/state/layered_state.rs
@@ -372,7 +372,6 @@ impl StateDebug for LayeredState<RethnetLayer> {
         address: Address,
         modifier: Box<dyn Fn(&mut U256, &mut u64, &mut Option<Bytecode>) + Send>,
     ) -> Result<(), Self::Error> {
-        // TODO: Move account insertion out of LayeredState when forking
         let account_info = self.account_or_insert_mut(&address);
         let old_code_hash = account_info.code_hash;
 


### PR DESCRIPTION
Depends on:
- [x] #3593
- [x] #3683 
- [x] #3684 
- [x] #3688