### PR TITLE
updates copyright year at the footer using Date module

### DIFF
--- a/docs/src/assets/trustedTeamsLogos/logos.ts
+++ b/docs/src/assets/trustedTeamsLogos/logos.ts
@@ -44,7 +44,7 @@ export const TrustedTeamsLogos = [
   },
   {
     img: require("./aragonOne.png"),
-    alt: "ARAGONE ONE company logo",
+    alt: "ARAGON ONE company logo",
   },
   {
     img: require("./kleros.png"),
@@ -215,7 +215,7 @@ export const TrustedTeamsLogosDark = [
   },
   {
     img: require("./dark/aragonOne-dark.png"),
-    alt: "ARAGONE ONE company logo",
+    alt: "ARAGON ONE company logo",
   },
   {
     img: require("./dark/kleros-dark.png"),

--- a/docs/src/components/LandingFooter.tsx
+++ b/docs/src/components/LandingFooter.tsx
@@ -141,7 +141,7 @@ const LandingFooter = () => {
         </span>
       </SupportedBy>
       <Legal>
-        Copyright 2022 Nomic Foundation |
+        Copyright {new Date().getFullYear()} Nomic Foundation |
         <Link href={PRIVACY_POLICY_PATH} passHref>
           <PrivacyPolicyLink>Privacy Policy</PrivacyPolicyLink>
         </Link>

--- a/docs/src/content/home.ts
+++ b/docs/src/content/home.ts
@@ -174,7 +174,7 @@ const reviewsBlockContent = [
     position: "CTO  at  Aragon One",
     personImage: reviewsBlock.brett,
     companyImage: "/images/reveiws-logo/aone.svg",
-    alt: "Aragone One logo",
+    alt: "Aragon One logo",
     comment:
       '"Our interest in Hardhat was driven by our own experience of building and maintaining developer tooling for the Aragon ecosystem. Not only were these efforts time consuming, difficult, and error-prone, we also found ourselves constantly re-inventing the wheel in areas we did not want to care about or force opinions on (e.g. Ganache connections, Truffle providers, test strategy). Hardhat, with its plugin ecosystem, has effectively eliminated many of these problems for us. We feel confident piggybacking on the best for the underlying layers so that we can focus our attention on exposing the power of the Aragon ecosystem to our community."',
   },


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
Solves issue #3697 

This PR merely changes the footer copyright year from _hard-coded_ 2022 to 2023 using `Date()` module. This will remove the need for yearly updates on the landing page.