### PR TITLE
add 2 plugins (hardhat-contract-clarity and transaction-retry-tool)

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -709,6 +709,22 @@ const communityPlugins: IPlugin[] = [
       "Hardhat plugin to generate customizable smart contracts documentation",
     tags: ["Documentation", "NatSpec", "Markdown"],
   },
+  {
+    name: "hardhat-contract-clarity",
+    author: "Marc-Aurele Besner",
+    authorUrl: "https://github.com/marc-aurele-besner",
+    description:
+      "This Hardhat plugin add 3 tasks to Hardhat, to summarize a smart contract in human readable format using OpenAI GPT-3, to create a readme looking at your package.json and a task to ask question to chatGPT when running into errors.",
+    tags: ["chatGPT", "openai", "gpt3", "ai"],
+  },
+  {
+    name: "transaction-retry-tool",
+    author: "Marc-Aurele Besner",
+    authorUrl: "https://github.com/marc-aurele-besner",
+    description:
+      "This Hardhat plugin provides two tasks and two functions to help you manage and optimize your transactions on Ethereum compatible blockchain. The two tasks include the ability to retry a transaction and retrieve the current gas cost.",
+    tags: ["transaction", "gasPrice", "retry", "helper"],
+  },
 ];
 
 const officialPlugins: IPlugin[] = [


### PR DESCRIPTION
- [x] I didn't do anything of this.

---

## Adding 2 new plugins to the website

[hardhat-contract-clarity](https://www.npmjs.com/package/hardhat-contract-clarity) A plugin to use chatGPT3 API to summarize contract (in text description), create a readme and ask about an error msg the powerful OpenAI ChatGPT

[transaction-retry-tool](https://www.npmjs.com/package/transaction-retry-tool) A tool to retry a transaction hash with a higher gas price