### PR TITLE
fix: ethers.Signer check in getContractFactory

### DIFF
--- a/.changeset/fix-getContractFactory-signer.md
+++ b/.changeset/fix-getContractFactory-signer.md
@@ -2,4 +2,4 @@
 "@nomiclabs/hardhat-ethers": patch
 ---
 
-fix: ethers.Signer check in getContractFactory
+Make getContractFactory's params validation more flexible.

--- a/.changeset/fix-getContractFactory-signer.md
+++ b/.changeset/fix-getContractFactory-signer.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-ethers": patch
+---
+
+fix: ethers.Signer check in getContractFactory

--- a/packages/hardhat-ethers/src/internal/helpers.ts
+++ b/packages/hardhat-ethers/src/internal/helpers.ts
@@ -116,8 +116,7 @@ export async function getContractFactory(
 function isFactoryOptions(
   signerOrOptions?: ethers.Signer | FactoryOptions
 ): signerOrOptions is FactoryOptions {
-  const { Signer } = require("ethers") as typeof ethers;
-  if (signerOrOptions === undefined || signerOrOptions instanceof Signer) {
+  if (signerOrOptions === undefined || ["Wallet", "SignerWithAddress", "Signer"].includes(signerOrOptions.constructor.name)) {
     return false;
   }
 

--- a/packages/hardhat-ethers/src/internal/helpers.ts
+++ b/packages/hardhat-ethers/src/internal/helpers.ts
@@ -117,7 +117,7 @@ function isFactoryOptions(
   signerOrOptions?: ethers.Signer | FactoryOptions
 ): signerOrOptions is FactoryOptions {
   const { Signer } = require("ethers") as typeof ethers;
-  return !Signer.isSigner(signerOrOptions);
+  return signerOrOptions !== undefined && !Signer.isSigner(signerOrOptions);
 }
 
 export async function getContractFactoryFromArtifact(

--- a/packages/hardhat-ethers/src/internal/helpers.ts
+++ b/packages/hardhat-ethers/src/internal/helpers.ts
@@ -116,16 +116,8 @@ export async function getContractFactory(
 function isFactoryOptions(
   signerOrOptions?: ethers.Signer | FactoryOptions
 ): signerOrOptions is FactoryOptions {
-  if (
-    signerOrOptions === undefined ||
-    ["Wallet", "SignerWithAddress", "Signer"].includes(
-      signerOrOptions.constructor.name
-    )
-  ) {
-    return false;
-  }
-
-  return true;
+  const { Signer } = require("ethers") as typeof ethers;
+  return !Signer.isSigner(signerOrOptions);
 }
 
 export async function getContractFactoryFromArtifact(

--- a/packages/hardhat-ethers/src/internal/helpers.ts
+++ b/packages/hardhat-ethers/src/internal/helpers.ts
@@ -116,7 +116,12 @@ export async function getContractFactory(
 function isFactoryOptions(
   signerOrOptions?: ethers.Signer | FactoryOptions
 ): signerOrOptions is FactoryOptions {
-  if (signerOrOptions === undefined || ["Wallet", "SignerWithAddress", "Signer"].includes(signerOrOptions.constructor.name)) {
+  if (
+    signerOrOptions === undefined ||
+    ["Wallet", "SignerWithAddress", "Signer"].includes(
+      signerOrOptions.constructor.name
+    )
+  ) {
     return false;
   }
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ X ] Because this PR includes a **bug fix**, relevant tests have been included.

---

The current instanceof check will fail for ethers.Wallets that are imported from another ethers outside hardhat.

Consider this code that deploys a test contract from a clean wallet (to achieve deterministic addresses):
```typescript
import { ethers } from "hardhat"
import { Wallet, utils } from "ethers"

async function deployMyContract(deployer: Wallet) {
    return (await ethers.getContractFactory("MyContract", deployer)).deploy()
}

async function deployContracts() {
    const [admin] = await ethers.getSigners() as unknown as Wallet[]
    const cleanWallet = new Wallet(utils.id("testing"), admin.provider)
    await (await admin.sendTransaction({ to: cleanWallet.address, value: parseEther("1") })).wait()
    await deployMyContract(cleanWallet)
}
```

The problem is, if deployer is created like this, then the currently modified check fails to recognize that deployer is in fact an ethers.Signer. This means that (very confusingly!) the deployer address will be something else (probably the first in the `getSigners()` array).