### PR TITLE
fix: hardhat-foundry plugin user-configured sources path not match pa…

### DIFF
--- a/.changeset/sharp-experts-play.md
+++ b/.changeset/sharp-experts-play.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-foundry": patch
+---
+
+Fixed a bug in how the configured sources paths are compared (thanks @bingryan!)

--- a/packages/hardhat-foundry/src/index.ts
+++ b/packages/hardhat-foundry/src/index.ts
@@ -56,7 +56,10 @@ extendConfig((config, userConfig) => {
   const userSourcesPath = userConfig.paths?.sources;
   const foundrySourcesPath = foundryConfig.src;
 
-  if (userSourcesPath !== undefined && userSourcesPath !== foundrySourcesPath) {
+  if (
+    userSourcesPath !== undefined &&
+    path.resolve(userSourcesPath) !== path.resolve(foundrySourcesPath)
+  ) {
     throw new HardhatFoundryError(
       `User-configured sources path (${userSourcesPath}) doesn't match path configured in foundry (${foundrySourcesPath})`
     );


### PR DESCRIPTION

- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

<!-- Add a description of your PR here -->

Fixes #3734.

this bug is in the conditional logic (the condition should be two paths, not two strings)