### PR TITLE
Updated Sepolia testnet given Goerli congestion

### DIFF
--- a/docs/src/content/tutorial/deploying-to-a-live-network.md
+++ b/docs/src/content/tutorial/deploying-to-a-live-network.md
@@ -2,7 +2,7 @@
 
 Once you're ready to share your dApp with other people, you may want to deploy it to a live network. This way others can access an instance that's not running locally on your system.
 
-The "mainnet" Ethereum network deals with real money, but there are separate "testnet" networks that do not. These testnets provide shared staging environments that do a good job of mimicking the real world scenario without putting real money at stake, and [Ethereum has several](https://ethereum.org/en/developers/docs/networks/#ethereum-testnets), like _Goerli_ and _Sepolia_. We recommend you deploy your contracts to the _Goerli_ testnet.
+The "mainnet" Ethereum network deals with real money, but there are separate "testnet" networks that do not. These testnets provide shared staging environments that do a good job of mimicking the real world scenario without putting real money at stake, and [Ethereum has several](https://ethereum.org/en/developers/docs/networks/#ethereum-testnets), like _Goerli_ and _Sepolia_. Usually, we recommend you deploy your contracts to the _Goerli_ testnet. However,_Sepolia_may be a good option as the _Goerli_testnet has been getting more congested and costly. For more details on which testnet to use, read [here](https://www.alchemy.com/overviews/goerli-vs-sepolia).
 
 At the software level, deploying to a testnet is the same as deploying to mainnet. The only difference is which network you connect to. Let's look into what the code to deploy your contracts using ethers.js would look like.
 
@@ -49,7 +49,7 @@ Token address: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 
 ## Deploying to remote networks
 
-To deploy to a remote network such as mainnet or any testnet, you need to add a `network` entry to your `hardhat.config.js` file. We’ll use Goerli for this example, but you can add any network similarly:
+To deploy to a remote network such as mainnet or any testnet, you need to add a `network` entry to your `hardhat.config.js` file. We’ll use Goerli for this example, but you can add _Sepolia_ or any network similarly:
 
 ```js{5,11,15-20}
 require("@nomicfoundation/hardhat-toolbox");
@@ -75,13 +75,19 @@ module.exports = {
 };
 ```
 
-We're using [Alchemy](https://www.alchemyapi.io), but pointing `url` to any Ethereum node or gateway, like [Infura](https://www.infura.io/), would work. Go grab your `ALCHEMY_API_KEY` and come back.
+We're using [Alchemy](https://www.alchemy.com), but pointing `url` to any Ethereum node or gateway, like [Infura](https://www.infura.io/), would work. Go grab your `ALCHEMY_API_KEY` and come back.
 
-To deploy on Goerli you need to send some Goerli ether to the address that's going to be making the deployment. You can get testnet ether from a faucet, a service that distributes testing-ETH for free. Here is one for Goerli:
+To deploy on Goerli you need to send some Goerli ether to the address that's going to be making the deployment. You can get testnet ether from a faucet, a service that distributes testing-ETH for free. 
+
+Here is one for _Goerli_ ETH:
 
 - [Alchemy Goerli Faucet](https://goerlifaucet.com/)
 
 You'll have to change Metamask's network to Goerli before transacting.
+
+If you're deploying to the _Sepolia_ testnet, here is the faucet for _Sepolia_ ETH:
+
+- [Alchemy Sepolia Faucet](https://sepoliafaucet.com)
 
 :::tip
 


### PR DESCRIPTION
Added a few changes that I think will help developers given the recent congestion and cost of Goerli. Shelley from Alchemy here.

(1) Mentioned that Sepolia might be a good alternative to Goerli. Linked an article to help developers figure out what differences between the two and what elements should go into this decision (e.g., RPC / API support and smart contract dependencies)

(2) Added Sepolia is relevant sections to make it clear to developers on how to substitute it 1:1 for Goerli in terms of deployment

(3) Added Sepolia faucet given the stack.exchange / reddit / Tweets asking about non spammy, free Sepolia ETH. Want to make sure developers can use HardHat to deploy with everything they need from this one tutorial. For newer developers who aren't as familiar, I added language to explain how faucets provide test ETH that is then used to cover the cost of deployment to a testnet

(4) Formatted the article - spaces, commas, line breaks to make it even easier for a developer to read

Pls lmk of any questions, appreciate the work you guys do

@0xolishell

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
