### PR TITLE
Added hardhat-uniswap-v2-deploy-plugin

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -726,10 +726,11 @@ const communityPlugins: IPlugin[] = [
   },
   {
     name: "hardhat-uniswap-v2-deploy-plugin",
-    author; "Cyrille Derché",
+    author: "Cyrille Derché",
     authorUrl: "https://github.com/onmychain/hardhat-uniswap-v2-deploy-plugin",
-    description: "Hardhat plugin for Uniswap V2 (pancakeswap protocol) testing and deployment. You can use it to test features such as pair creation, liquidity provisioning, and swaps.",
-    tags: ["uniswap", "pancakeswap", "testing", "deployment", "automated"]
+    description:
+      "Hardhat plugin for Uniswap V2 (pancakeswap protocol) testing and deployment. You can use it to test features such as pair creation, liquidity provisioning, and swaps.",
+    tags: ["uniswap", "pancakeswap", "testing", "deployment", "automated"],
   },
 ];
 

--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -724,6 +724,13 @@ const communityPlugins: IPlugin[] = [
     description: "Hardhat plugin for integrating with Fireblocks",
     tags: ["Deployment", "Security"],
   },
+  {
+    name: "hardhat-uniswap-v2-deploy-plugin",
+    author; "Cyrille Derché",
+    authorUrl: "https://github.com/onmychain/hardhat-uniswap-v2-deploy-plugin",
+    description: "Hardhat plugin for Uniswap V2 (pancakeswap protocol) testing and deployment. You can use it to test features such as pair creation, liquidity provisioning, and swaps.",
+    tags: ["uniswap", "pancakeswap", "testing", "deployment", "automated"]
+  },
 ];
 
 const officialPlugins: IPlugin[] = [


### PR DESCRIPTION
Hardhat plugin for Uniswap V2 (pancakeswap protocol) testing and deployment. You can use it to test features such as pair creation, liquidity provisioning, and swaps.

https://github.com/onmychain/hardhat-uniswap-v2-deploy-plugin