### PR TITLE
Ensure concurrency safety across when downloading compilers for multiple hardhat projects

### DIFF
--- a/.changeset/nasty-moose-watch.md
+++ b/.changeset/nasty-moose-watch.md
@@ -1,0 +1,9 @@
+---
+"hardhat": patch
+---
+
+Ensure concurrency safety across when downloading compilers for multiple hardhat projects
+
+This fixes a concurrency issue that arises from the separation of the `isCompilerDownloaded` and `downloadCompiler` calls, where the previous call to `downloadCompiler` was safe, but `isCompilerDownloaded` was not.
+
+This also has the nice side effect of downloading the same compiler once and only once. 


### PR DESCRIPTION
Introduces a new wrapper around the compiler downloader that ensures multiple downloader calls within a transaction are guaranteed to execute sequentially.

This fixes a concurrency issue that arises from the separation of the `isCompilerDownloaded` and `downloadCompiler` calls, where the previous call to `downloadCompiler` was safe, but `isCompilerDownloaded` was not.

By allowing the composition of calls via `transaction`, and _only_ exposing the underlying downloader via the `transaction` method, we can expose a much safer API surface for managing the downloads of multiple compilers.

This also has the nice side effect of downloading the same compiler once and only once. Before this bug fix, we'd be seeing multiple re-downloads of the same compiler within our project, https://github.com/smartcontractkit/chainlink

I ended up creating a wrapper class rather than adding this functionality to the existing compiler class to preserve the current interface that it adheres to, so we can keep using the same interfaces for future compiler implementations without having to think about concurrency handling at the same time.


<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

