### PR TITLE
Better error message when URL is an empty string #2730

### DIFF
--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -437,6 +437,13 @@ Please double check your transactions' parameters.`,
 Please check that you are sending an \`address\` parameter.`,
       shouldBeReported: false,
     },
+    EMPTY_URL:{
+      number:117,
+      message:"Only Absolute URLs are supported",
+      title:"Empty URL",
+      description:" An empty url is passed for the selected network in deploy.js file",
+      shouldBeReported:true
+    }
   },
   TASK_DEFINITIONS: {
     PARAM_AFTER_VARIADIC: {

--- a/packages/hardhat-core/src/internal/core/providers/http.ts
+++ b/packages/hardhat-core/src/internal/core/providers/http.ts
@@ -49,6 +49,8 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
 
     const { Pool, ProxyAgent } = require("undici") as typeof Undici;
 
+    if(this.url.trim().length==0) throw new HardhatError(ERRORS.NETWORK.EMPTY_URL);
+
     const url = new URL(this._url);
     this._path = url.pathname;
     this._authHeader =

--- a/packages/hardhat-core/test/internal/core/providers/http.ts
+++ b/packages/hardhat-core/test/internal/core/providers/http.ts
@@ -69,5 +69,13 @@ describe("HttpProvider", function () {
       assert.equal(result, successResponse.result);
       assert(tooManyRequestsReturned);
     });
+    it("should throw error if the url is empty",async function(){
+
+      const provider = new HttpProvider("", networkName, {}, 20000);
+      await expectErrorAsync(async () => {
+        await provider.request({ method: "net_version" });
+      }, "Only absolute urls are supported");
+
+    })
   });
 });


### PR DESCRIPTION
**bug fix**
1- This PR deals with the error if an empty url is passed in config.js.
2- The test is also written for this bug fix.