### PR TITLE
Fix .withArgs when arrays have different length

### DIFF
--- a/.changeset/lazy-hornets-clap.md
+++ b/.changeset/lazy-hornets-clap.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-chai-matchers": patch
+---
+
+Fixed a problem when `.withArgs` was used with arrays with different length

--- a/packages/hardhat-chai-matchers/src/internal/emit.ts
+++ b/packages/hardhat-chai-matchers/src/internal/emit.ts
@@ -165,6 +165,17 @@ function assertArgsArraysEqual(
       expectedArgs[index]?.length !== undefined &&
       typeof expectedArgs[index] !== "string"
     ) {
+      const expectedLength = expectedArgs[index].length;
+      const actualLength = actualArgs[index].length;
+      assert(
+        expectedLength === actualLength,
+        `Expected the ${ordinal(
+          index + 1
+        )} argument of the "${eventName}" event to have ${expectedLength} ${
+          expectedLength === 1 ? "element" : "elements"
+        }, but it has ${actualLength}`
+      );
+
       for (let j = 0; j < expectedArgs[index].length; j++) {
         new Assertion(actualArgs[index][j], undefined, ssfi, true).equal(
           expectedArgs[index][j]

--- a/packages/hardhat-chai-matchers/src/internal/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/src/internal/reverted/revertedWithCustomError.ts
@@ -1,4 +1,5 @@
 import { AssertionError } from "chai";
+import ordinal from "ordinal";
 
 import { buildAssert, Ssfi } from "../../utils";
 import { decodeReturnData, getReturnDataFromError } from "./utils";
@@ -193,6 +194,16 @@ export async function revertedWithCustomErrorWithArgs(
         throw e;
       }
     } else if (Array.isArray(expectedArg)) {
+      const expectedLength = expectedArg.length;
+      const actualLength = actualArg.length;
+      assert(
+        expectedLength === actualLength,
+        `Expected the ${ordinal(i + 1)} argument of the "${
+          customError.name
+        }" custom error to have ${expectedLength} ${
+          expectedLength === 1 ? "element" : "elements"
+        }, but it has ${actualLength}`
+      );
       new Assertion(actualArg).to.deep.equal(expectedArg);
     } else {
       new Assertion(actualArg).to.equal(expectedArg);

--- a/packages/hardhat-chai-matchers/test/events.ts
+++ b/packages/hardhat-chai-matchers/test/events.ts
@@ -337,6 +337,26 @@ describe(".to.emit (contract events)", () => {
             "expected 1 to equal 3"
           );
         });
+
+        it("Should fail when the arrays don't have the same length", async function () {
+          await expect(
+            expect(contract.emitUintArray(1, 2))
+              .to.emit(contract, "WithUintArray")
+              .withArgs([1])
+          ).to.be.eventually.rejectedWith(
+            AssertionError,
+            'Expected the 1st argument of the "WithUintArray" event to have 1 element, but it has 2'
+          );
+
+          await expect(
+            expect(contract.emitUintArray(1, 2))
+              .to.emit(contract, "WithUintArray")
+              .withArgs([1, 2, 3])
+          ).to.be.eventually.rejectedWith(
+            AssertionError,
+            'Expected the 1st argument of the "WithUintArray" event to have 3 elements, but it has 2'
+          );
+        });
       });
 
       describe("with a bytes32 array argument", function () {

--- a/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
@@ -317,6 +317,26 @@ describe("INTEGRATION: Reverted with custom error", function () {
         );
       });
 
+      it("should fail when the arrays don't have the same length", async function () {
+        await expect(
+          expect(matchers.revertWithCustomErrorWithPair(1, 2))
+            .to.be.revertedWithCustomError(matchers, "CustomErrorWithPair")
+            .withArgs([1])
+        ).to.be.rejectedWith(
+          AssertionError,
+          'Expected the 1st argument of the "CustomErrorWithPair" custom error to have 1 element, but it has 2'
+        );
+
+        await expect(
+          expect(matchers.revertWithCustomErrorWithPair(1, 2))
+            .to.be.revertedWithCustomError(matchers, "CustomErrorWithPair")
+            .withArgs([1, 2, 3])
+        ).to.be.rejectedWith(
+          AssertionError,
+          'Expected the 1st argument of the "CustomErrorWithPair" custom error to have 3 elements, but it has 2'
+        );
+      });
+
       it("Should fail when used with .not.", async function () {
         expect(() =>
           expect(matchers.revertWithSomeCustomError())


### PR DESCRIPTION
Fixes #3080.