### PR TITLE
Fix gas-provider error caused by empty blocks

### DIFF
--- a/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
+++ b/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
@@ -4,6 +4,7 @@ import {
   rpcQuantityToNumber,
   rpcQuantityToBigInt,
 } from "../jsonrpc/types/base-types";
+import * as BigIntUtils from "../../util/bigint";
 
 import { ProviderWrapper } from "./wrapper";
 
@@ -268,7 +269,10 @@ export class AutomaticGasPriceProvider extends ProviderWrapper {
             (AutomaticGasPriceProvider.EIP1559_BASE_FEE_MAX_FULL_BLOCKS_PREFERENCE -
               1n),
 
-        maxPriorityFeePerGas: rpcQuantityToBigInt(response.reward[0][0]),
+        maxPriorityFeePerGas: BigIntUtils.max(
+          rpcQuantityToBigInt(response.reward[0][0]),
+          1n
+        ),
       };
     } catch {
       this._nodeHasFeeHistory = false;


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

On a chain that supports EIP-1559, when there's an empty block, the reward returned from `eth_feeHistory` will be 0. However, `AutomaticGasPriceProvider` should set `maxPriorityFeePerGas` to be at least 1 to avoid `ProviderError: FeeTooLow, EffectivePriorityFeePerGas too low 0 < 1`.

This bug is found on [Chiado](https://docs.gnosischain.com/about/networks/chiado/), a minimal reproducible example and detailed analysis can be found [here](https://github.com/LEAFERx/chiado-ethers-mre).
