### PR TITLE
feat(core): return forkUrl in hardhat_metadata

### DIFF
--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/output/metadata.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/output/metadata.ts
@@ -28,5 +28,8 @@ export interface HardhatMetadata {
 
     // The hash of the block that the network forked from.
     forkBlockHash: string;
+
+    // The json rpc URL of the network that is being forked.
+    forkUrl: string;
   };
 }

--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/client.ts
@@ -38,6 +38,10 @@ export class JsonRpcClient {
     return this._networkId;
   }
 
+  public get httpProvider(): HttpProvider {
+    return this._httpProvider;
+  }
+
   public async getDebugTraceTransaction(transactionHash: Buffer): Promise<any> {
     return this._perform(
       "debug_traceTransaction",

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -2634,6 +2634,7 @@ Hardhat Network's forking functionality only works with blocks from at least spu
         chainId: this._forkNetworkId,
         forkBlockNumber: Number(this._forkBlockNumber),
         forkBlockHash: this._forkBlockHash,
+        forkUrl: this._forkClient!.httpProvider.url
       };
     }
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team. Created after opening the PR: https://github.com/NomicFoundation/edr/issues/442
- [ ] I didn't do anything of this.

---

Expose `forkUrl` so users are able to reset a forked state back to original fork block number with the same RPC queried from `hardhat_metadata`.