### PR TITLE
chore: sync pre-commit hook to CI

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh -x
+#
+# Intended to be in sync with .github/workflows/hardhat-core-ci.yml's
+# test-rethnet-rs
+
+set -e
+
+cargo test --workspace --all-targets --features tracing,bench-once
+cargo test --doc --workspace --features tracing
+cargo clippy --all -- -D warnings
+cargo fmt --all -- --check

--- a/crates/rethnet/Cargo.toml
+++ b/crates/rethnet/Cargo.toml
@@ -11,4 +11,4 @@ pretty_env_logger = { version = "0.4.0", default-features = false }
 [dev-dependencies.cargo-husky]
 version = "1.5.0"
 default-features = false
-features = ["precommit-hook", "run-cargo-test", "run-cargo-fmt", "run-cargo-clippy", "run-for-all"]
+features = ["user-hooks"]


### PR DESCRIPTION
given that we've just made a bunch of changes to the CI test scripts, it was bothering me that the `pre-commit` git hook wasn't matching up with those recent changes.