### PR TITLE
Wrapping user config in a Proxy breaks RegExps in config #2181

### DIFF
--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -142,10 +142,12 @@ function deepFreezeUserConfig(
 
   return new Proxy(config, {
     get(target: any, property: string | number | symbol, receiver: any): any {
-      return deepFreezeUserConfig(Reflect.get(target, property, receiver), [
-        ...propertyPath,
-        property,
-      ]);
+      let result = Reflect.get(target, property, receiver);
+      if (result instanceof Function) {
+        result = result.bind(target);
+      }
+
+      return deepFreezeUserConfig(result, [...propertyPath, property]);
     },
 
     set(

--- a/packages/hardhat-core/test/fixture-projects/regexp-field-in-config/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/regexp-field-in-config/hardhat.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  regExpField: new RegExp("ab+c", "i"),
+};

--- a/packages/hardhat-core/test/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-loading.ts
@@ -22,6 +22,7 @@ import {
   getAllFilesMatching,
   getRealPathSync,
 } from "../../../../src/internal/util/fs-utils";
+import { HardhatConfig } from "../../../../src/types/config";
 
 describe("config loading", function () {
   describe("default config path", function () {
@@ -555,6 +556,26 @@ Hardhat plugin instead.`
       it("Should not throw", function () {
         loadConfigAndTasks();
       });
+    });
+  });
+
+  describe("Config with regexp field", function () {
+    useFixtureProject("regexp-field-in-config");
+    useEnvironment();
+
+    interface HardhatConfigWRegexp extends HardhatConfig {
+      regExpField?: RegExp;
+    }
+
+    it("Regexp field test method should return expected results", function () {
+      const regExpField: RegExp = (this.env.config as HardhatConfigWRegexp)
+        .regExpField as RegExp;
+
+      assert.isDefined(regExpField);
+      assert.deepEqual(regExpField, new RegExp("ab+c", "i"));
+
+      assert.equal(regExpField.test("abc"), true);
+      assert.equal(regExpField.test("ac"), false);
     });
   });
 });


### PR DESCRIPTION
Added .bind when fields in user config is function.

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
User config is wrapped in Proxy and calling a function in `config.<regexp field>` breaks because it's not bounded with the correct `this` object. Using .bind method below fix this issue. 

```
let result = Reflect.get(target, property, receiver);
if (result instanceof Function) {
  result = result.bind(target);
}
```

