### PR TITLE
Use more future-proof type imports from ethers

### DIFF
--- a/packages/hardhat-ethers/src/internal/ethers-utils.ts
+++ b/packages/hardhat-ethers/src/internal/ethers-utils.ts
@@ -8,7 +8,7 @@ import type {
   TransactionReceiptParams,
   LogParams,
   JsonRpcTransactionRequest,
-} from "ethers/types/providers";
+} from "ethers";
 
 import {
   accessListify,

--- a/packages/hardhat-ethers/src/internal/hardhat-ethers-provider.ts
+++ b/packages/hardhat-ethers/src/internal/hardhat-ethers-provider.ts
@@ -1,9 +1,10 @@
-import type { AddressLike } from "ethers/types/address";
 import type {
+  AddressLike,
   BlockTag,
   TransactionRequest,
   Filter,
   FilterByBlockHash,
+  Listener,
   ProviderEvent,
   PerformActionTransaction,
   TransactionResponseParams,
@@ -11,8 +12,7 @@ import type {
   TransactionReceiptParams,
   LogParams,
   PerformActionFilter,
-} from "ethers/types/providers";
-import type { Listener } from "ethers/types/utils";
+} from "ethers";
 
 import {
   Block,

--- a/packages/hardhat-ethers/src/signers.ts
+++ b/packages/hardhat-ethers/src/signers.ts
@@ -1,4 +1,4 @@
-import type { BlockTag, TransactionRequest } from "ethers/types/providers";
+import type { BlockTag, TransactionRequest } from "ethers";
 import {
   assertArgument,
   ethers,


### PR DESCRIPTION
This fixes our latest-dependencies CI workflow.