### PR TITLE
fix aurora browser urls

### DIFF
--- a/.changeset/polite-mugs-cry.m
+++ b/.changeset/polite-mugs-cry.m
@@ -1,5 +1,5 @@
 ---
-"@nomiclabs/hardhat-etherscan": patch
+"@nomiclabs/hardhat-verify": patch
 ---
 
-Fix URLs for the Aurora networks (thanks @zZoMROT!)
+Fix URLs for the Aurora networks (thanks @zZoMROT and @ZumZoom!)

--- a/packages/hardhat-verify/src/chain-config.ts
+++ b/packages/hardhat-verify/src/chain-config.ts
@@ -258,7 +258,7 @@ export const builtinChains: ChainConfig[] = [
     chainId: 1313161554,
     urls: {
       apiURL: "https://explorer.mainnet.aurora.dev/api",
-      browserURL: "https://aurorascan.dev/",
+      browserURL: "https://explorer.mainnet.aurora.dev",
     },
   },
   {
@@ -266,7 +266,7 @@ export const builtinChains: ChainConfig[] = [
     chainId: 1313161555,
     urls: {
       apiURL: "https://explorer.testnet.aurora.dev/api",
-      browserURL: "https://testnet.aurorascan.dev",
+      browserURL: "https://explorer.testnet.aurora.dev",
     },
   },
   {


### PR DESCRIPTION
Aurora team dropped support of the previous domain names. This change is needed to fix verification on Aurora.