### PR TITLE
Update testing-contracts.md

### DIFF
--- a/docs/src/content/tutorial/testing-contracts.md
+++ b/docs/src/content/tutorial/testing-contracts.md
@@ -245,14 +245,14 @@ describe("Token contract", function () {
         deployTokenFixture
       );
       // Transfer 50 tokens from owner to addr1
-      await expect(
-        hardhatToken.transfer(addr1.address, 50)
+      expect(
+        await hardhatToken.transfer(addr1.address, 50)
       ).to.changeTokenBalances(hardhatToken, [owner, addr1], [-50, 50]);
 
       // Transfer 50 tokens from addr1 to addr2
       // We use .connect(signer) to send a transaction from another account
-      await expect(
-        hardhatToken.connect(addr1).transfer(addr2.address, 50)
+      expect(
+        await hardhatToken.connect(addr1).transfer(addr2.address, 50)
       ).to.changeTokenBalances(hardhatToken, [addr1, addr2], [-50, 50]);
     });
 
@@ -262,13 +262,13 @@ describe("Token contract", function () {
       );
 
       // Transfer 50 tokens from owner to addr1
-      await expect(hardhatToken.transfer(addr1.address, 50))
+      expect(await hardhatToken.transfer(addr1.address, 50))
         .to.emit(hardhatToken, "Transfer")
         .withArgs(owner.address, addr1.address, 50);
 
       // Transfer 50 tokens from addr1 to addr2
       // We use .connect(signer) to send a transaction from another account
-      await expect(hardhatToken.connect(addr1).transfer(addr2.address, 50))
+      expect(await hardhatToken.connect(addr1).transfer(addr2.address, 50))
         .to.emit(hardhatToken, "Transfer")
         .withArgs(addr1.address, addr2.address, 50);
     });
@@ -281,8 +281,8 @@ describe("Token contract", function () {
 
       // Try to send 1 token from addr1 (0 tokens) to owner.
       // `require` will evaluate false and revert the transaction.
-      await expect(
-        hardhatToken.connect(addr1).transfer(owner.address, 1)
+      expect(
+        await hardhatToken.connect(addr1).transfer(owner.address, 1)
       ).to.be.revertedWith("Not enough tokens");
 
       // Owner balance shouldn't have changed.


### PR DESCRIPTION
In tutorial of test codes, the location of keyword 'await' would be proper being inside of `expect` ..

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
