### PR TITLE
Pin `web3` version in installation guides

### DIFF
--- a/docs/src/content/hardhat-runner/docs/other-guides/truffle-testing.md
+++ b/docs/src/content/hardhat-runner/docs/other-guides/truffle-testing.md
@@ -26,7 +26,7 @@ Now run `npx hardhat` inside your project folder and select `Create an empty har
 Let's now install the `Truffle` and `Web3.js` plugins, as well as `web3.js` itself.
 
 ```
-npm install --save-dev @nomiclabs/hardhat-truffle5 @nomiclabs/hardhat-web3 web3
+npm install --save-dev @nomiclabs/hardhat-truffle5 @nomiclabs/hardhat-web3 'web3@^1.0.0-beta.36'
 ```
 
 Enable the Truffle 5 plugin on your Hardhat config file by requiring it:

--- a/packages/hardhat-truffle5/README.md
+++ b/packages/hardhat-truffle5/README.md
@@ -15,7 +15,7 @@ This plugin requires [hardhat-web3](https://github.com/nomiclabs/hardhat/tree/ma
 ## Installation
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-truffle5 @nomiclabs/hardhat-web3 web3
+npm install --save-dev @nomiclabs/hardhat-truffle5 @nomiclabs/hardhat-web3 'web3@^1.0.0-beta.36'
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-web3/README.md
+++ b/packages/hardhat-web3/README.md
@@ -11,7 +11,7 @@ This plugin brings to Hardhat the Web3 module and an initialized instance of Web
 # Installation
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-web3 web3
+npm install --save-dev @nomiclabs/hardhat-web3 'web3@^1.0.0-beta.36'
 ```
 
 And add the following statement to your `hardhat.config.js`:


### PR DESCRIPTION
This PR pins the `web3` version in the installation guide of `hardhat-truffle5` and `hardhat-web3`. The reason is that `web3` version `4.0.1` just got released (https://github.com/web3/web3.js/releases/tag/v4.0.1) and `npm` targets this version now which I think is incompatible with the current `hardhat-truffle5` and `hardhat-web3` versions.

I don't think this PR deserves a changeset, but lmk if you want one.