### PR TITLE
Add HARDHAT_DISABLE_TELEMETRY_PROMPT envvar

### DIFF
--- a/.changeset/fluffy-papayas-reflect.md
+++ b/.changeset/fluffy-papayas-reflect.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added a HARDHAT_DISABLE_TELEMETRY_PROMPT environment variable that can be set to `true` to prevent Hardaht from showing the telemetry consent prompt.

--- a/.changeset/fluffy-papayas-reflect.md
+++ b/.changeset/fluffy-papayas-reflect.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Added a HARDHAT_DISABLE_TELEMETRY_PROMPT environment variable that can be set to `true` to prevent Hardaht from showing the telemetry consent prompt.
+Added a HARDHAT_DISABLE_TELEMETRY_PROMPT environment variable that can be set to `true` to prevent Hardhat from showing the telemetry consent prompt.

--- a/docs/src/content/hardhat-runner/docs/advanced/scripts.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/scripts.md
@@ -65,7 +65,7 @@ Lock with 1 ETH deployed to: 0x5FbDB2315678afecb367f032d93F642f64180aa3
 
 ### Hardhat arguments
 
-You can still pass arguments to Hardhat when running a standalone script. This is done by setting environment variables. These are:
+You can still pass arguments to Hardhat when running a standalone script. This is done by setting environment variables. Some of these are:
 
 - `HARDHAT_NETWORK`: Sets the network to connect to.
 
@@ -75,4 +75,4 @@ You can still pass arguments to Hardhat when running a standalone script. This i
 
 - `HARDHAT_MAX_MEMORY`: Sets the maximum amount of memory that Hardhat can use.
 
-For example, instead of doing `npx hardhat --network localhost run script.js`, you can do `HARDHAT_NETWORK=localhost node script.js`.
+For example, instead of doing `npx hardhat --network localhost run script.js`, you can do `HARDHAT_NETWORK=localhost node script.js`. Check our [Environment variables](/hardhat-runner/docs/reference/environment-variables) reference to learn more about this.

--- a/docs/src/content/hardhat-runner/docs/reference/_dirinfo.yaml
+++ b/docs/src/content/hardhat-runner/docs/reference/_dirinfo.yaml
@@ -3,3 +3,4 @@ section-title: Reference
 order:
   - /stability-guarantees
   - /solidity-support
+  - /environment-variables

--- a/docs/src/content/hardhat-runner/docs/reference/environment-variables.md
+++ b/docs/src/content/hardhat-runner/docs/reference/environment-variables.md
@@ -30,7 +30,6 @@ HARDHAT_NETWORK=mainnet npx hardhat run --network localhost scripts/deploy.js
 
 then the `localhost` network is going to be used.
 
-
 ## Other environment variables
 
 Besides the environment variables that correspond to global parameters, there are some special environment variables that affect how Hardhat works. Variables starting with `HARDHAT_EXPERIMENTAL_` are experimental and could be removed in future versions.

--- a/docs/src/content/hardhat-runner/docs/reference/environment-variables.md
+++ b/docs/src/content/hardhat-runner/docs/reference/environment-variables.md
@@ -1,0 +1,39 @@
+# Environment variables
+
+You can use certain environment variables to configure Hardhat's behavior.
+
+## Setting parameters with environment variables
+
+Every global flag or parameter accepted by Hardhat can also be specified using an environment variable. For example, to select the network you normally do:
+
+```bash
+npx hardhat --network localhost run scripts/deploy.js
+```
+
+But you can get the same behavior by setting the `HARDHAT_NETWORK` environment variable:
+
+```bash
+HARDHAT_NETWORK=localhost npx hardhat run scripts/deploy.js
+```
+
+In general, each flag or parameter of the form `--some-option` can be set using the `HARDHAT_SOME_OPTION` environment variable. For flags, which don't accept values, you can enable or disable them by setting them to `true` or `false`:
+
+```bash
+HARDHAT_VERBOSE=true npx hardhat run scripts/deploy.js
+```
+
+Options specified with the `--some-option` form have precedence over environment variables. That is, if you run:
+
+```bash
+HARDHAT_NETWORK=mainnet npx hardhat run --network localhost scripts/deploy.js
+```
+
+then the `localhost` network is going to be used.
+
+
+## Other environment variables
+
+Besides the environment variables that correspond to global parameters, there are some special environment variables that affect how Hardhat works. Variables starting with `HARDHAT_EXPERIMENTAL_` are experimental and could be removed in future versions.
+
+- `HARDHAT_DISABLE_TELEMETRY_PROMPT`: if set to `true`, Hardhat won't prompt the user asking for telemetry consent. This prompt is already not shown in CIs or when the output is not a TTY, but in some cases (like automated scripts that write to stdout) you might want to set this variable.
+- `HARDHAT_EXPERIMENTAL_ALLOW_NON_LOCAL_INSTALLATION`: if set to `true`, Hardhat won't check if the `hardhat` package is locally installed.

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -212,7 +212,8 @@ async function main() {
       telemetryConsent === undefined &&
       !isHelpCommand &&
       !isRunningOnCiServer() &&
-      process.stdout.isTTY === true
+      process.stdout.isTTY === true &&
+      process.env.HARDHAT_DISABLE_TELEMETRY_PROMPT !== "true"
     ) {
       telemetryConsent = await confirmTelemetryConsent();
 

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -403,7 +403,10 @@ export async function createProject() {
     await addGitIgnore(projectRoot);
   }
 
-  if (hasConsentedTelemetry() === undefined) {
+  if (
+    process.env.HARDHAT_DISABLE_TELEMETRY_PROMPT !== "true" &&
+    hasConsentedTelemetry() === undefined
+  ) {
     const telemetryConsent = await confirmTelemetryConsent();
 
     if (telemetryConsent !== undefined) {


### PR DESCRIPTION
Closes #4012.

Adds a new `HARDHAT_DISABLE_TELEMETRY_PROMPT` variable that, if set to true, will prevent Hardhat from showing the telemetry consent prompt the first time it's run, or during the project initialization.

I also wrote an "Environment variables" reference page, which was long overdue.