### PR TITLE
hardhat-verify: fix list supported networks issue

### DIFF
--- a/.changeset/silver-meals-tan.m
+++ b/.changeset/silver-meals-tan.m
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-verify": patch
 ---
 
-Fixed a problem where the `--list-networks` flag wasn't working without passing an address
+Fixed a problem where the `--list-networks` flag wasn't working without passing an address (thanks @clauBv23!)

--- a/.changeset/silver-meals-tan.m
+++ b/.changeset/silver-meals-tan.m
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Fixed a problem where the `--list-networks` flag wasn't working without passing an address

--- a/.changeset/silver-meals-tan.md
+++ b/.changeset/silver-meals-tan.md
@@ -1,5 +1,5 @@
 ---
-"@nomicfoundation/hardhat-verify": minor
+"@nomicfoundation/hardhat-verify": patch
 ---
 
 Allow to list the supported networks list without providing the address as a parameter.

--- a/.changeset/silver-meals-tan.md
+++ b/.changeset/silver-meals-tan.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/hardhat-verify": patch
----
-
-Allow to list the supported networks list without providing the address as a parameter.

--- a/.changeset/silver-meals-tan.md
+++ b/.changeset/silver-meals-tan.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": minor
+---
+
+Allow to list the supported networks list without providing the address as a parameter.

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -21,7 +21,7 @@ import {
   TASK_VERIFY_RESOLVE_ARGUMENTS,
   TASK_VERIFY_VERIFY,
   TASK_VERIFY_ETHERSCAN,
-  TASK_VERIFY_GET_SUPPORTED_NETWORKS_LIST,
+  TASK_VERIFY_PRINT_SUPPORTED_NETWORKS,
 } from "./task-names";
 import { getCurrentChainConfig } from "./chain-config";
 import { etherscanConfigExtender } from "./config";
@@ -148,7 +148,7 @@ task(TASK_VERIFY, "Verifies a contract on Etherscan")
   .addFlag("listNetworks", "Print the list of supported networks")
   .setAction(async (taskArgs: VerifyTaskArgs, { run }) => {
     if (taskArgs.listNetworks) {
-      await run(TASK_VERIFY_GET_SUPPORTED_NETWORKS_LIST);
+      await run(TASK_VERIFY_PRINT_SUPPORTED_NETWORKS);
       return;
     }
     const verificationArgs: VerificationArgs = await run(
@@ -551,7 +551,7 @@ subtask(TASK_VERIFY_VERIFY)
   );
 
 subtask(
-  TASK_VERIFY_GET_SUPPORTED_NETWORKS_LIST,
+  TASK_VERIFY_PRINT_SUPPORTED_NETWORKS,
   "Prints the supported networks list"
 ).setAction(async ({}, { config }) => {
   await printSupportedNetworks(config.etherscan.customChains);

--- a/packages/hardhat-verify/src/task-names.ts
+++ b/packages/hardhat-verify/src/task-names.ts
@@ -10,5 +10,5 @@ export const TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT =
   "verify:etherscan-get-minimal-input";
 export const TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION =
   "verify:etherscan-attempt-verification";
-export const TASK_VERIFY_GET_SUPPORTED_NETWORKS_LIST =
-  "verify:get-supported-networks-list";
+export const TASK_VERIFY_PRINT_SUPPORTED_NETWORKS =
+  "verify:print-supported-networks";

--- a/packages/hardhat-verify/src/task-names.ts
+++ b/packages/hardhat-verify/src/task-names.ts
@@ -10,3 +10,5 @@ export const TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT =
   "verify:etherscan-get-minimal-input";
 export const TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION =
   "verify:etherscan-attempt-verification";
+export const TASK_VERIFY_GET_SUPPORTED_NETWORKS_LIST =
+  "verify:get-supported-networks-list";

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -22,8 +22,6 @@ describe("verify task integration tests", () => {
   it("should return after printing the supported networks", async function () {
     const logStub = sinon.stub(console, "log");
     const taskResponse = await this.hre.run(TASK_VERIFY, {
-      address: getRandomAddress(this.hre),
-      constructorArgsParams: [],
       listNetworks: true,
     });
 

--- a/packages/hardhat-verify/test/unit/index.ts
+++ b/packages/hardhat-verify/test/unit/index.ts
@@ -2,6 +2,7 @@ import { assert, expect } from "chai";
 import {
   TASK_VERIFY_RESOLVE_ARGUMENTS,
   TASK_VERIFY_VERIFY,
+  TASK_VERIFY_GET_SUPPORTED_NETWORKS_LIST,
 } from "../../src/task-names";
 import { getRandomAddress, useEnvironment } from "../helpers";
 
@@ -60,7 +61,7 @@ describe("verify task", () => {
           ConstructorLib: "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
         },
         contractFQN: "contracts/TestContract.sol:TestContract",
-        listNetworks: true,
+        // listNetworks: true,
       };
       const proccesedArgs = await this.hre.run(TASK_VERIFY_RESOLVE_ARGUMENTS, {
         address,
@@ -68,7 +69,7 @@ describe("verify task", () => {
         constructorArgs: "constructor-args.js",
         libraries: "libraries.js",
         contract: "contracts/TestContract.sol:TestContract",
-        listNetworks: true,
+        // listNetworks: true,
       });
 
       assert.deepEqual(proccesedArgs, expectedArgs);
@@ -126,6 +127,12 @@ describe("verify task", () => {
           libraries: ["0x...1", "0x...2", "0x...3"],
         })
       ).to.be.rejectedWith(/The libraries parameter should be a dictionary./);
+    });
+  });
+
+  describe("verify:get-supported-networks-list", () => {
+    it("should be able to run the networks list", async function () {
+      await this.hre.run(TASK_VERIFY_GET_SUPPORTED_NETWORKS_LIST);
     });
   });
 });

--- a/packages/hardhat-verify/test/unit/index.ts
+++ b/packages/hardhat-verify/test/unit/index.ts
@@ -2,7 +2,6 @@ import { assert, expect } from "chai";
 import {
   TASK_VERIFY_RESOLVE_ARGUMENTS,
   TASK_VERIFY_VERIFY,
-  TASK_VERIFY_GET_SUPPORTED_NETWORKS_LIST,
 } from "../../src/task-names";
 import { getRandomAddress, useEnvironment } from "../helpers";
 
@@ -61,7 +60,6 @@ describe("verify task", () => {
           ConstructorLib: "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
         },
         contractFQN: "contracts/TestContract.sol:TestContract",
-        // listNetworks: true,
       };
       const proccesedArgs = await this.hre.run(TASK_VERIFY_RESOLVE_ARGUMENTS, {
         address,
@@ -69,7 +67,6 @@ describe("verify task", () => {
         constructorArgs: "constructor-args.js",
         libraries: "libraries.js",
         contract: "contracts/TestContract.sol:TestContract",
-        // listNetworks: true,
       });
 
       assert.deepEqual(proccesedArgs, expectedArgs);
@@ -127,12 +124,6 @@ describe("verify task", () => {
           libraries: ["0x...1", "0x...2", "0x...3"],
         })
       ).to.be.rejectedWith(/The libraries parameter should be a dictionary./);
-    });
-  });
-
-  describe("verify:get-supported-networks-list", () => {
-    it("should be able to run the networks list", async function () {
-      await this.hre.run(TASK_VERIFY_GET_SUPPORTED_NETWORKS_LIST);
     });
   });
 });

--- a/packages/hardhat-verify/test/unit/index.ts
+++ b/packages/hardhat-verify/test/unit/index.ts
@@ -42,7 +42,7 @@ describe("verify task", () => {
       ).to.be.rejectedWith(/A valid fully qualified name was expected./);
     });
 
-    it("should return the proccesed arguments", async function () {
+    it("should return the processed arguments", async function () {
       const address = getRandomAddress(this.hre);
       const expectedArgs = {
         address,
@@ -61,7 +61,7 @@ describe("verify task", () => {
         },
         contractFQN: "contracts/TestContract.sol:TestContract",
       };
-      const proccesedArgs = await this.hre.run(TASK_VERIFY_RESOLVE_ARGUMENTS, {
+      const processedArgs = await this.hre.run(TASK_VERIFY_RESOLVE_ARGUMENTS, {
         address,
         constructorArgsParams: [],
         constructorArgs: "constructor-args.js",
@@ -69,7 +69,7 @@ describe("verify task", () => {
         contract: "contracts/TestContract.sol:TestContract",
       });
 
-      assert.deepEqual(proccesedArgs, expectedArgs);
+      assert.deepEqual(processedArgs, expectedArgs);
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
Fixes: #4023 

A new task was added for listing the supported networks and it was used to list them without having to pass an address as a parameter. 