### PR TITLE
Support importing contracts through the current workspace name

### DIFF
--- a/packages/hardhat-core/.changeset/kind-shoes-drum.md
+++ b/packages/hardhat-core/.changeset/kind-shoes-drum.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Support importing contracts through the current workspace name

--- a/packages/hardhat-core/src/internal/core/errors-list.ts
+++ b/packages/hardhat-core/src/internal/core/errors-list.ts
@@ -826,18 +826,8 @@ Hardhat's compiler is case sensitive to ensure projects are portable across diff
 Try installing the library using npm.`,
       shouldBeReported: false,
     },
-    INCLUDES_OWN_PACKAGE_NAME: {
-      number: 412,
-      message:
-        "Invalid import %imported% from %from%. Trying to import file using the own package's name.",
-      title: "Invalid import: includes own package's name",
-      description: `A Solidity file is trying to import another using its own package name. This is most likely caused by an existing symlink for the package in your node_modules.
-
-Use a relative import instead of referencing the package's name.`,
-      shouldBeReported: false,
-    },
     IMPORTED_MAPPED_FILE_NOT_FOUND: {
-      number: 413,
+      number: 412,
       message:
         "File %importName% => %imported%, imported from %from%, not found.",
       title: "Imported mapped file not found",

--- a/packages/hardhat-core/src/internal/solidity/dependencyGraph.ts
+++ b/packages/hardhat-core/src/internal/solidity/dependencyGraph.ts
@@ -160,11 +160,11 @@ export class DependencyGraph implements taskTypes.DependencyGraph {
     resolver: Resolver,
     file: ResolvedFile
   ): Promise<void> {
-    if (this._visitedFiles.has(file.absolutePath)) {
+    if (this._visitedFiles.has(file.sourceName)) {
       return;
     }
 
-    this._visitedFiles.add(file.absolutePath);
+    this._visitedFiles.add(file.sourceName);
 
     const dependencies = new Set<ResolvedFile>();
     this._resolvedFiles.set(file.sourceName, file);

--- a/packages/hardhat-core/src/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/src/internal/solidity/resolver.ts
@@ -8,7 +8,6 @@ import {
   ResolvedFile as IResolvedFile,
 } from "../../types/builtin-tasks";
 import {
-  includesOwnPackageName,
   isAbsolutePathSourceName,
   isLocalSourceName,
   normalizeSourceName,
@@ -129,15 +128,6 @@ export class Resolver {
 
     if (isAbsolutePathSourceName(imported)) {
       throw new HardhatError(ERRORS.RESOLVER.INVALID_IMPORT_ABSOLUTE_PATH, {
-        from: from.sourceName,
-        imported,
-      });
-    }
-
-    // Edge-case where an import can contain the current package's name in monorepos.
-    // The path can be resolved because there's a symlink in the node modules.
-    if (await includesOwnPackageName(imported)) {
-      throw new HardhatError(ERRORS.RESOLVER.INCLUDES_OWN_PACKAGE_NAME, {
         from: from.sourceName,
         imported,
       });

--- a/packages/hardhat-core/src/internal/util/packageInfo.ts
+++ b/packages/hardhat-core/src/internal/util/packageInfo.ts
@@ -27,15 +27,6 @@ export function findClosestPackageJson(file: string): string | null {
   return findup.sync("package.json", { cwd: path.dirname(file) });
 }
 
-export async function getPackageName(file: string): Promise<string> {
-  const packageJsonPath = findClosestPackageJson(file);
-  if (packageJsonPath !== null && packageJsonPath !== "") {
-    const packageJson: PackageJson = await fsExtra.readJSON(packageJsonPath);
-    return packageJson.name;
-  }
-  return "";
-}
-
 export async function getPackageJson(): Promise<PackageJson> {
   const root = getPackageRoot();
   return fsExtra.readJSON(path.join(root, "package.json"));

--- a/packages/hardhat-core/src/utils/source-names.ts
+++ b/packages/hardhat-core/src/utils/source-names.ts
@@ -3,7 +3,6 @@ import path from "path";
 import { HardhatError } from "../internal/core/errors";
 import { ERRORS } from "../internal/core/errors-list";
 import { FileNotFoundError, getFileTrueCase } from "../internal/util/fs-utils";
-import { getPackageName } from "../internal/util/packageInfo";
 
 const NODE_MODULES = "node_modules";
 
@@ -228,18 +227,4 @@ async function getSourceNameTrueCase(
     // eslint-disable-next-line @nomiclabs/hardhat-internal-rules/only-hardhat-error
     throw error;
   }
-}
-
-/**
- * This function returns true if the sourceName contains the current package's name
- * as a substring
- */
-export async function includesOwnPackageName(
-  sourceName: string
-): Promise<boolean> {
-  const packageName = await getPackageName(sourceName);
-  if (packageName !== "") {
-    return sourceName.startsWith(`${packageName}/`);
-  }
-  return false;
 }

--- a/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/package.json
+++ b/packages/hardhat-core/test/fixture-projects/project-with-hardhat-directory/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "project-with-hardhat-directory",
-  "version": "1.0.0"
-}

--- a/packages/hardhat-core/test/internal/solidity/resolver.ts
+++ b/packages/hardhat-core/test/internal/solidity/resolver.ts
@@ -1,7 +1,6 @@
 import { assert } from "chai";
 import * as fsExtra from "fs-extra";
 import path from "path";
-import sinon from "sinon";
 
 import { TASK_COMPILE } from "../../../src/builtin-tasks/task-names";
 import { ERRORS } from "../../../src/internal/core/errors-list";
@@ -10,7 +9,6 @@ import {
   ResolvedFile,
   Resolver,
 } from "../../../src/internal/solidity/resolver";
-import * as packageInfo from "../../../src/internal/util/packageInfo";
 import { LibraryInfo } from "../../../src/types/builtin-tasks";
 import { useEnvironment } from "../../helpers/environment";
 import { expectHardhatErrorAsync } from "../../helpers/errors";
@@ -369,15 +367,6 @@ describe("Resolver", function () {
           () => resolver.resolveImport(localFrom, "/asd"),
           ERRORS.RESOLVER.INVALID_IMPORT_ABSOLUTE_PATH
         );
-      });
-
-      it("shouldn't let you import something that starts with the own package name", async function () {
-        sinon.stub(packageInfo, "getPackageName").resolves("myPackageName");
-        await expectHardhatErrorAsync(
-          () => resolver.resolveImport(localFrom, "myPackageName/src/file"),
-          ERRORS.RESOLVER.INCLUDES_OWN_PACKAGE_NAME
-        );
-        sinon.restore();
       });
     });
 

--- a/packages/hardhat-core/test/utils/source-names.ts
+++ b/packages/hardhat-core/test/utils/source-names.ts
@@ -1,11 +1,8 @@
 import { assert } from "chai";
 import path from "path";
-import sinon from "sinon";
 
 import { ERRORS } from "../../src/internal/core/errors-list";
-import * as packageInfo from "../../src/internal/util/packageInfo";
 import {
-  includesOwnPackageName,
   isAbsolutePathSourceName,
   isLocalSourceName,
   localPathToSourceName,
@@ -216,26 +213,6 @@ describe("Source names utilities", function () {
       assert.equal(replaceBackslashes("\\a"), "/a");
       assert.equal(replaceBackslashes("\\\\a"), "//a");
       assert.equal(replaceBackslashes("/\\\\a"), "///a");
-    });
-  });
-
-  describe("includesOwnPackageName", function () {
-    before(() => {
-      sinon.stub(packageInfo, "getPackageName").resolves("myPackageName");
-    });
-
-    after(() => {
-      sinon.restore();
-    });
-
-    it("Should return true if parsed string starts with the package name", async function () {
-      assert.isTrue(await includesOwnPackageName("myPackageName/src/file"));
-    });
-
-    it("Should return false if the parsed string doesn't start with the package name", async function () {
-      assert.isFalse(
-        await includesOwnPackageName("differentPackageName/src/file")
-      );
     });
   });
 });


### PR DESCRIPTION
- Reverted changes in https://github.com/NomicFoundation/hardhat/pull/1509/files

- file.absolutePath was changed to file.sourceName in `dependencyGraph.ts` as multiple sourceNames can be resolved to the same absolutePath (this fixes the original error at https://github.com/NomicFoundation/hardhat/issues/1500)
```
--- a/packages/hardhat-core/src/internal/solidity/dependencyGraph.ts
+++ b/packages/hardhat-core/src/internal/solidity/dependencyGraph.ts
@@ -160,11 +160,11 @@ export class DependencyGraph implements taskTypes.DependencyGraph {
     resolver: Resolver,
     file: ResolvedFile
   ): Promise<void> {
-    if (this._visitedFiles.has(file.absolutePath)) {
+    if (this._visitedFiles.has(file.sourceName)) {
       return;
     }

-    this._visitedFiles.add(file.absolutePath);
+    this._visitedFiles.add(file.sourceName);
```

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
