### PR TITLE
Hardhat-verify: more generic success message

### DIFF
--- a/.changeset/tidy-points-arrive.md
+++ b/.changeset/tidy-points-arrive.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-verify": patch
 ---
 
-Modify success message for a more generic one.
+Success messages are now more generic (thanks @clauBv23!).

--- a/.changeset/tidy-points-arrive.md
+++ b/.changeset/tidy-points-arrive.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Modify success message for a more generic one.

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -493,7 +493,7 @@ for verification on the block explorer. Waiting for verification result...
 
       if (verificationStatus.isSuccess()) {
         const contractURL = verificationInterface.getContractUrl(address);
-        console.log(`Successfully verified contract ${contractInformation.contractName} on Etherscan.
+        console.log(`Successfully verified contract ${contractInformation.contractName} on the block explorer.
 ${contractURL}`);
       }
 

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -462,7 +462,7 @@ contracts/SimpleContract.sol:SimpleContract at ${simpleContractAddress}
 for verification on the block explorer. Waiting for verification result...
 `);
       expect(logStub.getCall(1)).to.be
-        .calledWith(`Successfully verified contract SimpleContract on Etherscan.
+        .calledWith(`Successfully verified contract SimpleContract on the block explorer.
 https://hardhat.etherscan.io/address/${simpleContractAddress}#code`);
       logStub.restore();
       assert.isUndefined(taskResponse);
@@ -512,7 +512,7 @@ contracts/SimpleContract.sol:SimpleContract at ${simpleContractAddress}
 for verification on the block explorer. Waiting for verification result...
 `);
       expect(logStub.getCall(3)).to.be
-        .calledWith(`Successfully verified contract SimpleContract on Etherscan.
+        .calledWith(`Successfully verified contract SimpleContract on the block explorer.
 https://hardhat.etherscan.io/address/${simpleContractAddress}#code`);
       logStub.restore();
       assert.equal(verifyCallCount, 2);
@@ -595,7 +595,7 @@ contracts/WithLibs.sol:BothLibs at ${bothLibsContractAddress}
 for verification on the block explorer. Waiting for verification result...
 `);
       expect(logStub.getCall(1)).to.be
-        .calledWith(`Successfully verified contract BothLibs on Etherscan.
+        .calledWith(`Successfully verified contract BothLibs on the block explorer.
 https://hardhat.etherscan.io/address/${bothLibsContractAddress}#code`);
       logStub.restore();
       assert.isUndefined(taskResponse);


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
Modify the success message for a more generic one. 
The `on Etherscan` statement was changed by `the block explorer` being consistent with similar message on https://github.com/NomicFoundation/hardhat/blob/c21648d99ce333718dbedb7703f933d63236a23e/packages/hardhat-verify/src/index.ts#L477-L480

Fixes #3960