### PR TITLE
bad source mappings example

### DIFF
--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_8/console-logs/error/assert/test.json
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/0_8/console-logs/error/assert/test.json
@@ -1,5 +1,6 @@
 {
   "description": "Should output right parameters into console",
+  "only": true,
   "transactions": [
     {
       "file": "c.sol",


### PR DESCRIPTION
This draft is only created to show that there exist some internal dependencies between the tests which allow the `console-logs::error::assert` test to pass in main branch.

The test fails if run in isolation though.