### PR TITLE
Add test for memory-safe console.sol

### DIFF
--- a/packages/hardhat-core/test/console/console.ts
+++ b/packages/hardhat-core/test/console/console.ts
@@ -6,7 +6,7 @@ describe("console.sol", function () {
   useEnvironment();
 
   it("should be memory safe", async function () {
-    // the memory-safe-consoel fixture project won't compile
+    // the memory-safe-console fixture project won't compile
     // if console.sol is not memory-safe
     await this.env.run("compile");
   });

--- a/packages/hardhat-core/test/console/console.ts
+++ b/packages/hardhat-core/test/console/console.ts
@@ -1,0 +1,13 @@
+import { useEnvironment } from "../helpers/environment";
+import { useFixtureProject } from "../helpers/project";
+
+describe("console.sol", function () {
+  useFixtureProject("memory-safe-console");
+  useEnvironment();
+
+  it("should be memory safe", async function () {
+    // the memory-safe-consoel fixture project won't compile
+    // if console.sol is not memory-safe
+    await this.env.run("compile");
+  });
+});

--- a/packages/hardhat-core/test/fixture-projects/memory-safe-console/.gitignore
+++ b/packages/hardhat-core/test/fixture-projects/memory-safe-console/.gitignore
@@ -1,0 +1,2 @@
+artifacts/
+cache/

--- a/packages/hardhat-core/test/fixture-projects/memory-safe-console/contracts/Test.sol
+++ b/packages/hardhat-core/test/fixture-projects/memory-safe-console/contracts/Test.sol
@@ -1,0 +1,11 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.18;
+
+import "hardhat/console.sol";
+
+// this file won't compile if viaIR is enabled and `console.sol` is not memory-safe
+contract Test {
+    function logSum(uint256 arg0, uint256 arg1, uint256 arg2, uint256 arg3, uint256 arg4, uint256 arg5, uint256 arg6, uint256 arg7, uint256 arg8, uint256 arg9, uint256 arg10, uint256 arg11, uint256 arg12, uint256 arg13, uint256 arg14, uint256 arg15, uint256 arg16) public view {
+        console.log(arg0 + arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + arg14 + arg15 + arg16);
+    }
+}

--- a/packages/hardhat-core/test/fixture-projects/memory-safe-console/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/memory-safe-console/hardhat.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  solidity: {
+    version: "0.8.18",
+    settings: {
+      optimizer: {
+        enabled: true,
+      },
+      viaIR: true,
+    },
+  },
+};

--- a/packages/hardhat-core/test/fixture-projects/memory-safe-console/package.json
+++ b/packages/hardhat-core/test/fixture-projects/memory-safe-console/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "memory-safe-console"
+}


### PR DESCRIPTION
Add a fixture project that doesn't compile if `console.sol` is not memory safe, and a test that just compiles that project.