### PR TITLE
Remove compilation artifacts in the hardhat-core/clean script

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -36,7 +36,7 @@
     "test:forking": "mocha --recursive \"test/internal/hardhat-network/{helpers,jsonrpc,provider}/**/*.ts\"",
     "build": "tsc --build .",
     "prepublishOnly": "yarn build",
-    "clean": "rimraf builtin-tasks internal types utils *.d.ts *.map *.js build-test tsconfig.tsbuildinfo test/internal/hardhat-network/provider/.hardhat_node_test_cache **/compiler-input-solc-*.json **/compiler-output-solc-*.json"
+    "clean": "rimraf builtin-tasks internal types utils *.d.ts *.map *.js build-test tsconfig.tsbuildinfo test/internal/hardhat-network/provider/.hardhat_node_test_cache test/internal/hardhat-network/stack-traces/test-files/artifacts"
   },
   "files": [
     "builtin-tasks/",

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -36,7 +36,7 @@
     "test:forking": "mocha --recursive \"test/internal/hardhat-network/{helpers,jsonrpc,provider}/**/*.ts\"",
     "build": "tsc --build .",
     "prepublishOnly": "yarn build",
-    "clean": "rimraf builtin-tasks internal types utils *.d.ts *.map *.js build-test tsconfig.tsbuildinfo test/internal/hardhat-network/provider/.hardhat_node_test_cache"
+    "clean": "rimraf builtin-tasks internal types utils *.d.ts *.map *.js build-test tsconfig.tsbuildinfo test/internal/hardhat-network/provider/.hardhat_node_test_cache **/compiler-input-solc-*.json **/compiler-output-solc-*.json"
   },
   "files": [
     "builtin-tasks/",


### PR DESCRIPTION
This adds removal of compiler-input and compiler-output artifacts to the hardhat-core/clean script.