### PR TITLE
♻️ Remove Deprecated Test Networks from `hardhat-verify`

### DIFF
--- a/.changeset/grumpy-pigs-complain.md
+++ b/.changeset/grumpy-pigs-complain.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Removed the `rinkeby`, `ropsten` and `kovan` deprecated test networks (thanks @pcaversaccio!)

--- a/packages/hardhat-verify/src/chain-config.ts
+++ b/packages/hardhat-verify/src/chain-config.ts
@@ -38,22 +38,6 @@ export const builtinChains: ChainConfig[] = [
     },
   },
   {
-    network: "ropsten",
-    chainId: 3,
-    urls: {
-      apiURL: "https://api-ropsten.etherscan.io/api",
-      browserURL: "https://ropsten.etherscan.io",
-    },
-  },
-  {
-    network: "rinkeby",
-    chainId: 4,
-    urls: {
-      apiURL: "https://api-rinkeby.etherscan.io/api",
-      browserURL: "https://rinkeby.etherscan.io",
-    },
-  },
-  {
     network: "goerli",
     chainId: 5,
     urls: {
@@ -67,14 +51,6 @@ export const builtinChains: ChainConfig[] = [
     urls: {
       apiURL: "https://api-optimistic.etherscan.io/api",
       browserURL: "https://optimistic.etherscan.io/",
-    },
-  },
-  {
-    network: "kovan",
-    chainId: 42,
-    urls: {
-      apiURL: "https://api-kovan.etherscan.io/api",
-      browserURL: "https://kovan.etherscan.io",
     },
   },
   {

--- a/packages/hardhat-verify/test/unit/config.ts
+++ b/packages/hardhat-verify/test/unit/config.ts
@@ -64,16 +64,16 @@ describe("Chain Config", () => {
     const userConfig: HardhatUserConfig = {
       etherscan: {
         apiKey: {
-          ropsten: "<ropsten-api-key>",
+          mainnet: "<mainnet-api-key>",
           sepolia: "<sepolia-api-key>",
         },
         customChains: [
           {
-            network: "ropsten",
-            chainId: 3,
+            network: "mainnet",
+            chainId: 1,
             urls: {
-              apiURL: "https://api-ropsten.etherscan.io/api",
-              browserURL: "https://ropsten.etherscan.io",
+              apiURL: "https://api.etherscan.io/api",
+              browserURL: "https://etherscan.io",
             },
           },
           {
@@ -89,16 +89,16 @@ describe("Chain Config", () => {
     };
     const expected: EtherscanConfig = {
       apiKey: {
-        ropsten: "<ropsten-api-key>",
+        mainnet: "<mainnet-api-key>",
         sepolia: "<sepolia-api-key>",
       },
       customChains: [
         {
-          network: "ropsten",
-          chainId: 3,
+          network: "mainnet",
+          chainId: 1,
           urls: {
-            apiURL: "https://api-ropsten.etherscan.io/api",
-            browserURL: "https://ropsten.etherscan.io",
+            apiURL: "https://api.etherscan.io/api",
+            browserURL: "https://etherscan.io",
           },
         },
         {


### PR DESCRIPTION
This PR removes the networks `rinkeby`, `ropsten`, and `kovan` from `hardhat-verify` since those are deprecated in the meantime.