### PR TITLE
Consume downloads instead of piping them

### DIFF
--- a/.changeset/tricky-parents-warn.md
+++ b/.changeset/tricky-parents-warn.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed an issue related to compiler downloads in node v18.16.x


### PR DESCRIPTION
This is a workaround for an issue related to node v18.16.0 (and v18.16.1), the stream module and undici. See https://github.com/nodejs/undici/issues/2173 for the details.

Fixes #3877.