### PR TITLE
test: Add Rethnet provider as JSON-RPC provider in Hardhat tests

### DIFF
--- a/crates/rethnet/tests/cli.rs
+++ b/crates/rethnet/tests/cli.rs
@@ -117,7 +117,8 @@ async fn node() -> Result<(), Box<dyn std::error::Error>> {
         Assert::new(output.clone())
             .stdout(contains(format!("Private Key: 0x{}", default_private_key)))
             .stdout(contains(format!(
-                "Account #{i}: {:?}",
+                "Account #{}: {:?}",
+                i + 1,
                 private_key_to_address(&context, default_private_key).unwrap()
             )));
     }

--- a/crates/rethnet_eth/src/remote.rs
+++ b/crates/rethnet_eth/src/remote.rs
@@ -62,6 +62,12 @@ pub enum Eip1898BlockSpec {
     },
 }
 
+impl Display for Eip1898BlockSpec {
+    fn fmt(&self, formatter: &mut Formatter) -> Result<(), fmt::Error> {
+        formatter.write_str(&serde_json::to_string(self).map_err(|_| fmt::Error)?)
+    }
+}
+
 /// possible block tags as defined by the Ethereum JSON-RPC specification
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub enum BlockTag {
@@ -121,12 +127,11 @@ impl BlockSpec {
 
 impl Display for BlockSpec {
     fn fmt(&self, formatter: &mut Formatter) -> Result<(), fmt::Error> {
-        let s = match self {
-            BlockSpec::Number(n) => n.to_string(),
-            BlockSpec::Tag(t) => t.to_string(),
-            BlockSpec::Eip1898(e) => serde_json::to_string(e).map_err(|_| fmt::Error)?,
-        };
-        formatter.write_str(&s)
+        match self {
+            BlockSpec::Number(n) => n.fmt(formatter),
+            BlockSpec::Tag(t) => t.fmt(formatter),
+            BlockSpec::Eip1898(e) => e.fmt(formatter),
+        }
     }
 }
 

--- a/crates/rethnet_eth/src/remote.rs
+++ b/crates/rethnet_eth/src/remote.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::fmt::{Display, Formatter};
+
 /// an Ethereum JSON-RPC client
 pub mod client;
 
@@ -79,6 +82,18 @@ pub enum BlockTag {
     Finalized,
 }
 
+impl Display for BlockTag {
+    fn fmt(&self, formatter: &mut Formatter) -> Result<(), fmt::Error> {
+        formatter.write_str(match self {
+            BlockTag::Earliest => "earliest",
+            BlockTag::Latest => "latest",
+            BlockTag::Pending => "pending",
+            BlockTag::Safe => "safe",
+            BlockTag::Finalized => "finalized",
+        })
+    }
+}
+
 /// For specifying a block
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(untagged)]
@@ -101,6 +116,17 @@ impl BlockSpec {
     /// Constructs a `BlockSpec` for the pending transactions.
     pub fn pending() -> Self {
         Self::Tag(BlockTag::Pending)
+    }
+}
+
+impl Display for BlockSpec {
+    fn fmt(&self, formatter: &mut Formatter) -> Result<(), fmt::Error> {
+        let s = match self {
+            BlockSpec::Number(n) => n.to_string(),
+            BlockSpec::Tag(t) => t.to_string(),
+            BlockSpec::Eip1898(e) => serde_json::to_string(e).map_err(|_| fmt::Error)?,
+        };
+        formatter.write_str(&s)
     }
 }
 

--- a/crates/rethnet_eth/src/remote.rs
+++ b/crates/rethnet_eth/src/remote.rs
@@ -189,7 +189,14 @@ impl serde::Serialize for ZeroXPrefixedBytes {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&format!("0x{}", hex::encode(&self.inner)))
+        let encoded = hex::encode(&self.inner);
+        serializer.serialize_str(&format!(
+            "0x{}",
+            match encoded.as_str() {
+                "00" => "",
+                other => other,
+            }
+        ))
     }
 }
 

--- a/crates/rethnet_eth/src/remote/methods.rs
+++ b/crates/rethnet_eth/src/remote/methods.rs
@@ -279,6 +279,9 @@ pub enum MethodInvocation {
         deserialize_with = "sequence_to_single"
     )]
     Unsubscribe(Vec<ZeroXPrefixedBytes>),
+    /// evm_snapshot
+    #[serde(rename = "evm_snapshot")]
+    EvmSnapshot(),
 }
 
 /// subscription type to be used with eth_subscribe

--- a/crates/rethnet_eth/src/remote/methods.rs
+++ b/crates/rethnet_eth/src/remote/methods.rs
@@ -279,6 +279,13 @@ pub enum MethodInvocation {
         deserialize_with = "sequence_to_single"
     )]
     Unsubscribe(Vec<ZeroXPrefixedBytes>),
+    /// evm_setAutomine
+    #[serde(
+        rename = "evm_setAutomine",
+        serialize_with = "single_to_sequence",
+        deserialize_with = "sequence_to_single"
+    )]
+    EvmSetAutomine(bool),
     /// evm_snapshot
     #[serde(rename = "evm_snapshot")]
     EvmSnapshot(),

--- a/crates/rethnet_eth/tests/integration_tests.rs
+++ b/crates/rethnet_eth/tests/integration_tests.rs
@@ -366,6 +366,11 @@ fn test_serde_eth_unsubscribe() {
 }
 
 #[test]
+fn test_evm_set_automine() {
+    help_test_method_invocation_serde(MethodInvocation::EvmSetAutomine(false));
+}
+
+#[test]
 fn test_evm_snapshot() {
     help_test_method_invocation_serde(MethodInvocation::EvmSnapshot());
 }

--- a/crates/rethnet_eth/tests/integration_tests.rs
+++ b/crates/rethnet_eth/tests/integration_tests.rs
@@ -364,3 +364,8 @@ fn test_serde_eth_unsubscribe() {
     )
     .into()]));
 }
+
+#[test]
+fn test_evm_snapshot() {
+    help_test_method_invocation_serde(MethodInvocation::EvmSnapshot());
+}

--- a/crates/rethnet_evm/src/state/hybrid.rs
+++ b/crates/rethnet_evm/src/state/hybrid.rs
@@ -363,7 +363,7 @@ mod tests {
     use rethnet_eth::Bytes;
 
     #[test]
-    fn repro_provider_test_should_result_in_a_modified_balance() {
+    fn test_irregular_state_modification() {
         // this test reproduces the sequence of calls that are induced by (the current
         // implementation of rethnet_rpc_server) being used as a provider in the hardhat tests and
         // running the hardhat_setBalance test entitled "should result in a modified balance".

--- a/crates/rethnet_evm/src/state/hybrid.rs
+++ b/crates/rethnet_evm/src/state/hybrid.rs
@@ -414,6 +414,7 @@ mod tests {
                 },
             )
             .unwrap();
+        state.make_snapshot();
 
         /* [eth_getBalance]
          * state_root

--- a/crates/rethnet_evm/src/state/hybrid.rs
+++ b/crates/rethnet_evm/src/state/hybrid.rs
@@ -355,3 +355,74 @@ impl StateHistory for HybridState<RethnetLayer> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rethnet_eth::Bytes;
+
+    #[test]
+    fn repro_provider_test_should_result_in_a_modified_balance() {
+        // this test reproduces the sequence of calls that are induced by (the current
+        // implementation of rethnet_rpc_server) being used as a provider in the hardhat tests and
+        // running the hardhat_setBalance test entitled "should result in a modified balance".
+
+        let mut state: HybridState<RethnetLayer> = Default::default();
+
+        let seed = 1;
+        let address = Address::from_low_u64_ne(1);
+        state
+            .insert_account(
+                address,
+                AccountInfo::new(
+                    U256::from(seed),
+                    seed,
+                    Bytecode::new_raw(Bytes::copy_from_slice(address.as_bytes())),
+                ),
+            )
+            .unwrap();
+
+        /* [eth_getBalance]
+         * state_root
+         * basic
+         * set_block_context(that state root)
+         * state_root
+         */
+        let state_root = state.state_root().unwrap();
+        state.basic(address).unwrap();
+        state.set_block_context(&state_root, None).unwrap();
+        state.state_root().unwrap();
+
+        /* [hardhat_setBalance]
+         * modify_account
+         */
+        let balance = U256::from(1000);
+        state
+            .modify_account(
+                address,
+                AccountModifierFn::new(Box::new(move |account_balance, _, _| {
+                    *account_balance = balance
+                })),
+                &|| {
+                    Ok(AccountInfo {
+                        balance,
+                        nonce: 0,
+                        code: None,
+                        code_hash: KECCAK_EMPTY,
+                    })
+                },
+            )
+            .unwrap();
+
+        /* [eth_getBalance]
+         * state_root
+         * basic
+         * set_block_context(that last state root) -- FAILS
+         */
+        let state_root = state.state_root().unwrap();
+        state.basic(address).unwrap();
+        state.set_block_context(&state_root, None).unwrap();
+        state.state_root().unwrap();
+    }
+}

--- a/crates/rethnet_rpc_server/src/lib.rs
+++ b/crates/rethnet_rpc_server/src/lib.rs
@@ -177,7 +177,9 @@ async fn restore_block_context<T>(
         .write()
         .await
         .set_block_context(&state_root, None)
-        .map_err(|_| error_response_data(0, "Failed to restore previous block context"))
+        .map_err(|e| {
+            error_response_data(0, &format!("Failed to restore previous block context: {e}"))
+        })
 }
 
 async fn get_account_info<T>(

--- a/crates/rethnet_rpc_server/src/lib.rs
+++ b/crates/rethnet_rpc_server/src/lib.rs
@@ -606,7 +606,7 @@ impl Server {
                         },
                     )| {
                         let address = public_key_to_address(private_key.public_key(&secp256k1));
-                        event!(Level::INFO, "Account #{i}: {address:?}");
+                        event!(Level::INFO, "Account #{}: {address:?}", i + 1);
                         event!(
                             Level::INFO,
                             "Private Key: 0x{}",

--- a/crates/rethnet_rpc_server/src/lib.rs
+++ b/crates/rethnet_rpc_server/src/lib.rs
@@ -266,7 +266,7 @@ async fn handle_get_storage_at(
     address: Address,
     position: U256,
     block: Option<BlockSpec>,
-) -> ResponseData<U256WithoutLeadingZeroes> {
+) -> ResponseData<U256> {
     event!(
         Level::INFO,
         "eth_getStorageAt({address:?}, {position:?}, {block:?})"
@@ -276,9 +276,7 @@ async fn handle_get_storage_at(
             let value = state.rethnet_state.read().await.storage(address, position);
             match restore_block_context(&state, previous_state_root).await {
                 Ok(()) => match value {
-                    Ok(value) => ResponseData::Success {
-                        result: U256WithoutLeadingZeroes(value),
-                    },
+                    Ok(value) => ResponseData::Success { result: value },
                     Err(e) => {
                         error_response_data(0, &format!("failed to retrieve storage value: {}", e))
                     }

--- a/crates/rethnet_rpc_server/src/lib.rs
+++ b/crates/rethnet_rpc_server/src/lib.rs
@@ -211,7 +211,7 @@ async fn handle_get_balance(
     block: Option<BlockSpec>,
 ) -> ResponseData<U256WithoutLeadingZeroes> {
     event!(Level::INFO, "eth_getBalance({address:?}, {block:?})");
-    match set_block_context(&state, block.clone()).await {
+    match set_block_context(&state, block).await {
         Ok(previous_state_root) => {
             let account_info = get_account_info(&state, address).await;
             match restore_block_context(&state, previous_state_root).await {

--- a/crates/rethnet_rpc_server/src/lib.rs
+++ b/crates/rethnet_rpc_server/src/lib.rs
@@ -316,7 +316,11 @@ async fn handle_get_transaction_count(
     }
 }
 
-async fn handle_set_balance(state: StateType, address: Address, balance: U256) -> ResponseData<()> {
+async fn handle_set_balance(
+    state: StateType,
+    address: Address,
+    balance: U256,
+) -> ResponseData<bool> {
     event!(Level::INFO, "hardhat_setBalance({address:?}, {balance:?})");
     match state.rethnet_state.write().await.modify_account(
         address,
@@ -332,7 +336,7 @@ async fn handle_set_balance(state: StateType, address: Address, balance: U256) -
             })
         },
     ) {
-        Ok(()) => ResponseData::Success { result: () },
+        Ok(()) => ResponseData::Success { result: true },
         Err(e) => ResponseData::new_error(0, &e.to_string(), None),
     }
 }
@@ -341,7 +345,7 @@ async fn handle_set_code(
     state: StateType,
     address: Address,
     code: ZeroXPrefixedBytes,
-) -> ResponseData<()> {
+) -> ResponseData<bool> {
     event!(Level::INFO, "hardhat_setCode({address:?}, {code:?})");
     let code_1 = code.clone();
     let code_2 = code.clone();
@@ -359,12 +363,12 @@ async fn handle_set_code(
             })
         },
     ) {
-        Ok(()) => ResponseData::Success { result: () },
+        Ok(()) => ResponseData::Success { result: true },
         Err(e) => ResponseData::new_error(0, &e.to_string(), None),
     }
 }
 
-async fn handle_set_nonce(state: StateType, address: Address, nonce: U256) -> ResponseData<()> {
+async fn handle_set_nonce(state: StateType, address: Address, nonce: U256) -> ResponseData<bool> {
     event!(Level::INFO, "hardhat_setNonce({address:?}, {nonce:?})");
     match TryInto::<u64>::try_into(nonce) {
         Ok(nonce) => {
@@ -380,7 +384,7 @@ async fn handle_set_nonce(state: StateType, address: Address, nonce: U256) -> Re
                     })
                 },
             ) {
-                Ok(()) => ResponseData::Success { result: () },
+                Ok(()) => ResponseData::Success { result: true },
                 Err(error) => ResponseData::new_error(0, &error.to_string(), None),
             }
         }
@@ -393,7 +397,7 @@ async fn handle_set_storage_at(
     address: Address,
     position: U256,
     value: U256,
-) -> ResponseData<()> {
+) -> ResponseData<bool> {
     event!(
         Level::INFO,
         "hardhat_setStorageAt({address:?}, {position:?}, {value:?})"
@@ -404,7 +408,7 @@ async fn handle_set_storage_at(
         .await
         .set_account_storage_slot(address, position, value)
     {
-        Ok(()) => ResponseData::Success { result: () },
+        Ok(()) => ResponseData::Success { result: true },
         Err(e) => ResponseData::new_error(0, &e.to_string(), None),
     }
 }

--- a/crates/rethnet_rpc_server/tests/integration_tests.rs
+++ b/crates/rethnet_rpc_server/tests/integration_tests.rs
@@ -142,7 +142,7 @@ async fn test_get_code_success() {
             Address::from_low_u64_ne(1),
             Some(BlockSpec::latest()),
         )),
-        ZeroXPrefixedBytes::from(Bytes::from_static(b"\0")),
+        ZeroXPrefixedBytes::from(Bytes::from_static(b"")),
     )
     .await;
 }

--- a/crates/rethnet_rpc_server/tests/integration_tests.rs
+++ b/crates/rethnet_rpc_server/tests/integration_tests.rs
@@ -197,7 +197,7 @@ async fn test_set_balance_success() {
     verify_response(
         &server_address,
         MethodInvocation::Hardhat(HardhatMethodInvocation::SetBalance(address, new_balance)),
-        (),
+        true,
     )
     .await;
 
@@ -222,7 +222,7 @@ async fn test_set_nonce_success() {
     verify_response(
         &server_address,
         MethodInvocation::Hardhat(HardhatMethodInvocation::SetNonce(address, new_nonce)),
-        (),
+        true,
     )
     .await;
 
@@ -247,7 +247,7 @@ async fn test_set_code_success() {
     verify_response(
         &server_address,
         MethodInvocation::Hardhat(HardhatMethodInvocation::SetCode(address, new_code.clone())),
-        (),
+        true,
     )
     .await;
 
@@ -276,7 +276,7 @@ async fn test_set_storage_at_success() {
             U256::ZERO,
             new_storage_value,
         )),
-        (),
+        true,
     )
     .await;
 

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
@@ -199,7 +199,7 @@ if (RETHNET_BINARY !== undefined) {
   PROVIDERS.push({
     name: "Rethnet",
     isFork: false,
-    isJsonRpc: false,
+    isJsonRpc: true,
     networkId: DEFAULT_NETWORK_ID,
     chainId: DEFAULT_CHAIN_ID,
     useProvider: (options: UseProviderOptions = {}) => {

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
@@ -67,7 +67,6 @@ export const PROVIDERS = [
     isJsonRpc: false,
     networkId: DEFAULT_NETWORK_ID,
     chainId: DEFAULT_CHAIN_ID,
-    rethnetBinary: undefined as string | undefined,
     useProvider: (options: UseProviderOptions = {}) => {
       useProvider({ useJsonRpc: false, loggerEnabled: true, ...options });
     },
@@ -78,7 +77,6 @@ export const PROVIDERS = [
     isJsonRpc: true,
     networkId: DEFAULT_NETWORK_ID,
     chainId: DEFAULT_CHAIN_ID,
-    rethnetBinary: undefined as string | undefined,
     useProvider: (options: UseProviderOptions = {}) => {
       useProvider({ useJsonRpc: true, loggerEnabled: true, ...options });
     },
@@ -137,7 +135,6 @@ if (ALCHEMY_URL !== undefined) {
     isJsonRpc: false,
     networkId: DEFAULT_NETWORK_ID,
     chainId: DEFAULT_CHAIN_ID,
-    rethnetBinary: undefined,
     useProvider: (options: UseProviderOptions = {}) => {
       useProvider({
         useJsonRpc: false,
@@ -203,7 +200,6 @@ if (RETHNET_BINARY !== undefined) {
     name: "Rethnet",
     isFork: false,
     isJsonRpc: false,
-    rethnetBinary: RETHNET_BINARY,
     networkId: DEFAULT_NETWORK_ID,
     chainId: DEFAULT_CHAIN_ID,
     useProvider: (options: UseProviderOptions = {}) => {

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/providers.ts
@@ -8,7 +8,7 @@ import {
   HardhatNetworkMempoolConfig,
   HardhatNetworkMiningConfig,
 } from "../../../../src/types";
-import { ALCHEMY_URL, INFURA_URL } from "../../../setup";
+import { ALCHEMY_URL, INFURA_URL, RETHNET_BINARY } from "../../../setup";
 
 import { useProvider, UseProviderOptions } from "./useProvider";
 
@@ -67,6 +67,7 @@ export const PROVIDERS = [
     isJsonRpc: false,
     networkId: DEFAULT_NETWORK_ID,
     chainId: DEFAULT_CHAIN_ID,
+    rethnetBinary: undefined as string | undefined,
     useProvider: (options: UseProviderOptions = {}) => {
       useProvider({ useJsonRpc: false, loggerEnabled: true, ...options });
     },
@@ -77,6 +78,7 @@ export const PROVIDERS = [
     isJsonRpc: true,
     networkId: DEFAULT_NETWORK_ID,
     chainId: DEFAULT_CHAIN_ID,
+    rethnetBinary: undefined as string | undefined,
     useProvider: (options: UseProviderOptions = {}) => {
       useProvider({ useJsonRpc: true, loggerEnabled: true, ...options });
     },
@@ -135,6 +137,7 @@ if (ALCHEMY_URL !== undefined) {
     isJsonRpc: false,
     networkId: DEFAULT_NETWORK_ID,
     chainId: DEFAULT_CHAIN_ID,
+    rethnetBinary: undefined,
     useProvider: (options: UseProviderOptions = {}) => {
       useProvider({
         useJsonRpc: false,
@@ -189,6 +192,25 @@ if (INFURA_URL !== undefined) {
         useJsonRpc: false,
         loggerEnabled: true,
         forkConfig: { jsonRpcUrl: url, blockNumber: options.forkBlockNumber },
+        ...options,
+      });
+    },
+  });
+}
+
+if (RETHNET_BINARY !== undefined) {
+  PROVIDERS.push({
+    name: "Rethnet",
+    isFork: false,
+    isJsonRpc: false,
+    rethnetBinary: RETHNET_BINARY,
+    networkId: DEFAULT_NETWORK_ID,
+    chainId: DEFAULT_CHAIN_ID,
+    useProvider: (options: UseProviderOptions = {}) => {
+      useProvider({
+        useJsonRpc: true,
+        rethnetBinary: RETHNET_BINARY,
+        loggerEnabled: true,
         ...options,
       });
     },

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/spawnRethnetProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/spawnRethnetProvider.ts
@@ -8,7 +8,7 @@ import { sleep } from "./sleep";
 
 export function spawnRethnetProvider(pathToBinary: string): {
   childProcess: ChildProcess;
-  processExit: Promise<unknown>;
+  isReady: Promise<unknown>; // resolves in 2 seconds, or sooner if process fails or exits
   httpProvider: HttpProvider;
 } {
   const childProcess = spawn(normalize(pathToBinary), ["node", "-vv"]);
@@ -74,7 +74,7 @@ export function spawnRethnetProvider(pathToBinary: string): {
   );
   return {
     childProcess,
-    processExit: Promise.race([sleep(2000), exit, error]),
+    isReady: Promise.race([sleep(2000), exit, error]),
     httpProvider,
   };
 }

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/spawnRethnetProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/spawnRethnetProvider.ts
@@ -8,7 +8,7 @@ import { sleep } from "./sleep";
 
 export function spawnRethnetProvider(pathToBinary: string): {
   childProcess: ChildProcess;
-  isReady: Promise<unknown>; // resolves in 2 seconds, or sooner if process fails or exits
+  isReady: Promise<unknown>; // resolves in 2 seconds, or rejects if process fails or exits before that
   httpProvider: HttpProvider;
 } {
   const childProcess = spawn(normalize(pathToBinary), ["node", "-vv"]);

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -1,5 +1,5 @@
 import type { Client as ClientT } from "undici";
-import { normalize } from "node:path";
+import { normalize, resolve as resolvePath } from "node:path";
 import { spawn } from "node:child_process";
 
 import { HardhatNetworkChainsConfig } from "../../../../src/types/config";
@@ -162,7 +162,7 @@ export function useProvider({
       const error = new Promise((_resolve, reject) => {
         this.rethnetProcess.on("error", (err: Error) => {
           if (err.message.includes("ENOENT")) {
-            reject(new Error("Rethnet executable not found"));
+            reject(new Error(`Rethnet executable not found at ${resolvePath(rethnetBinary)}`));
           } else {
             reject(
               new Error(`Rethnet subprocess error: ${err}. ${outputForError()}`)

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -121,7 +121,7 @@ export function useProvider({
     }
 
     if (rethnetBinary !== undefined) {
-      const { childProcess, processExit, httpProvider } =
+      const { childProcess, isReady, httpProvider } =
         spawnRethnetProvider(rethnetBinary);
 
       this.rethnetProcess = childProcess;
@@ -131,7 +131,7 @@ export function useProvider({
 
       this.provider = new BackwardsCompatibilityProviderAdapter(httpProvider);
 
-      await processExit;
+      await isReady;
     }
   });
 

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_MEMPOOL_CONFIG,
   DEFAULT_USE_JSON_RPC,
 } from "./providers";
+import { sleep } from "./sleep";
 
 declare module "mocha" {
   interface Context {
@@ -142,8 +143,6 @@ export function useProvider({
         return `stdout:\n${stdout}\nstderr:\n${stderr}`;
       }
 
-      const wait = new Promise((resolve) => setTimeout(resolve, 2000));
-
       const exit = new Promise<void>((resolve, reject) => {
         this.rethnetProcess.on("exit", (code: number, signal: string) => {
           if (signal === "SIGKILL") {
@@ -175,8 +174,8 @@ export function useProvider({
         });
       });
 
-      // sleep a moment to let the server initialize
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      // wait for the server to initialize:
+      await sleep(250);
 
       const { Client } = require("undici") as { Client: typeof ClientT };
       const url = "http://127.0.0.1:8545";
@@ -193,7 +192,7 @@ export function useProvider({
         )
       );
 
-      await Promise.race([wait, exit, error]);
+      await Promise.race([sleep(2000), exit, error]);
     }
   });
 

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -162,7 +162,11 @@ export function useProvider({
       const error = new Promise((_resolve, reject) => {
         this.rethnetProcess.on("error", (err: Error) => {
           if (err.message.includes("ENOENT")) {
-            reject(new Error(`Rethnet executable not found at ${resolvePath(rethnetBinary)}`));
+            reject(
+              new Error(
+                `Rethnet executable not found at ${resolvePath(rethnetBinary)}`
+              )
+            );
           } else {
             reject(
               new Error(`Rethnet subprocess error: ${err}. ${outputForError()}`)

--- a/packages/hardhat-core/test/setup.ts
+++ b/packages/hardhat-core/test/setup.ts
@@ -17,6 +17,7 @@ function getEnv(key: string): string | undefined {
 
 export const INFURA_URL = getEnv("INFURA_URL");
 export const ALCHEMY_URL = getEnv("ALCHEMY_URL");
+export const RETHNET_BINARY = getEnv("RETHNET_BINARY");
 
 function printForkingLogicNotBeingTestedWarning(varName: string) {
   console.warn(
@@ -32,4 +33,12 @@ if (INFURA_URL === undefined) {
 
 if (ALCHEMY_URL === undefined) {
   printForkingLogicNotBeingTestedWarning("ALCHEMY_URL");
+}
+
+if (RETHNET_BINARY === undefined) {
+  console.warn(
+    chalk.yellow(
+      `TEST RUN INCOMPLETE: You need to define the env variable RETHNET_BINARY`
+    )
+  );
 }


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/rethnet/issues/94

- [x] figure out why the `eth_getBalance` test `should result in a modified balance` is failing with `Failed to restore previous block context`
- [x] figure out why `hardhat_setStorageAt` is responding with `null` in some cases:
  - [x] sending `0xff` for the storage value is expected to yield error `[-32000] Storage value must be exactly 32 bytes long. Received 0xff, which is 1 bytes long`, but we’re responding with just `null`
  - [x] sending `0xffff` for the storage value is expected to yield error `[-32000] Storage value must be exactly 32 bytes long. Received 0xffff, which is 2 bytes long.`, but we’re responding with just `null`
  - [x] sending `0x` followed by 31 `f`s as the storage value is expected to yield error `[-32000] Storage value must be exactly 32 bytes long. Received 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, which is 31 bytes long.` but we’re responding with just `null`