### PR TITLE
Re-enable test skipped because of Alchemy bug

### DIFF
--- a/packages/hardhat-core/test/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/jsonrpc/client.ts
@@ -346,10 +346,6 @@ describe("JsonRpcClient", () => {
           });
 
           it("returns null for non-existent block", async function () {
-            if (rpcProvider === "Alchemy") {
-              // skipped because of https://github.com/NomicFoundation/hardhat/issues/3712
-              this.skip();
-            }
             const block = await client.getBlockByNumber(
               forkNumber + 1000n,
               true


### PR DESCRIPTION
Re-enable test that was skipped because of a bug in Alchemy, [see bug here](https://github.com/NomicFoundation/hardhat/issues/3712).
