### PR TITLE
Fix deletion of valid build-info file

### DIFF
--- a/.changeset/seven-shrimps-tell.md
+++ b/.changeset/seven-shrimps-tell.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed an issue in the compilation pipeline where a valid build-info file was mistakenly deleted

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -444,8 +444,6 @@ export class Artifacts implements IArtifacts {
         const buildInfoFile = await this._getBuildInfoFromDebugFile(debugFile);
         if (buildInfoFile !== undefined) {
           return path.resolve(path.dirname(debugFile), buildInfoFile);
-        } else {
-          return undefined;
         }
       })
     );
@@ -859,20 +857,14 @@ Please replace "${contractName}" for the correct contract name wherever you are 
   }
 
   /**
-   * Remove the artifact file, its debug file and, if it exists, its build
-   * info file.
+   * Remove the artifact file and its debug file.
    */
   private async _removeArtifactFiles(artifactPath: string) {
     await fsExtra.remove(artifactPath);
 
     const debugFilePath = this._getDebugFilePath(artifactPath);
-    const buildInfoPath = await this._getBuildInfoFromDebugFile(debugFilePath);
 
     await fsExtra.remove(debugFilePath);
-
-    if (buildInfoPath !== undefined) {
-      await fsExtra.remove(buildInfoPath);
-    }
   }
 
   /**

--- a/packages/hardhat-core/test/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/test/builtin-tasks/compile.ts
@@ -852,10 +852,10 @@ Read about compiler configuration at https://hardhat.org/config
     it("should not remove the build-info if it is still referenced by an external library", async function () {
       await this.env.run("compile");
 
-      const pathContractA = path.join("contracts", "A.sol");
-      let contractA = fsExtra.readFileSync(pathContractA, "utf-8");
+      const pathToContractA = path.join("contracts", "A.sol");
+      let contractA = fsExtra.readFileSync(pathToContractA, "utf-8");
       contractA = contractA.replace("contract A", "contract B");
-      fsExtra.writeFileSync(pathContractA, contractA, "utf-8");
+      fsExtra.writeFileSync(pathToContractA, contractA, "utf-8");
 
       /**
        * The _validArtifacts variable is not cleared when running the compile
@@ -870,30 +870,30 @@ Read about compiler configuration at https://hardhat.org/config
       await this.env.run("compile");
 
       // asserts
-      const buildInfoPathB = path.join(
+      const pathToBuildInfoB = path.join(
         "artifacts",
         "contracts",
         "A.sol",
         "B.dbg.json"
       );
-      assertBuildInfoExists(buildInfoPathB);
-      const buildInfoPathConsole = path.join(
+      assertBuildInfoExists(pathToBuildInfoB);
+      const pathToBuildInfoConsole = path.join(
         "artifacts",
         "dependency",
         "contracts",
         "console.sol",
         "console.dbg.json"
       );
-      assertBuildInfoExists(buildInfoPathConsole);
+      assertBuildInfoExists(pathToBuildInfoConsole);
     });
 
     it("should not remove the build-info if it is still referenced by another local contract", async function () {
       await this.env.run("compile");
 
-      const pathContractC = path.join("contracts", "C.sol");
-      let contractC = fsExtra.readFileSync(pathContractC, "utf-8");
+      const pathToContractC = path.join("contracts", "C.sol");
+      let contractC = fsExtra.readFileSync(pathToContractC, "utf-8");
       contractC = contractC.replace("contract C", "contract D");
-      fsExtra.writeFileSync(pathContractC, contractC, "utf-8");
+      fsExtra.writeFileSync(pathToContractC, contractC, "utf-8");
 
       /**
        * The _validArtifacts variable is not cleared when running the compile
@@ -908,32 +908,32 @@ Read about compiler configuration at https://hardhat.org/config
       await this.env.run("compile");
 
       // asserts
-      const buildInfoPathC = path.join(
+      const pathToBuildInfoC = path.join(
         "artifacts",
         "contracts",
         "C.sol",
         "D.dbg.json"
       );
-      assertBuildInfoExists(buildInfoPathC);
-      const buildInfoPathE = path.join(
+      assertBuildInfoExists(pathToBuildInfoC);
+      const pathToBuildInfoE = path.join(
         "artifacts",
         "contracts",
         "E.sol",
         "E.dbg.json"
       );
-      assertBuildInfoExists(buildInfoPathE);
+      assertBuildInfoExists(pathToBuildInfoE);
     });
 
     afterEach(() => {
-      const pathContractA = path.join("contracts", "A.sol");
-      let contractA = fsExtra.readFileSync(pathContractA, "utf-8");
+      const pathToContractA = path.join("contracts", "A.sol");
+      let contractA = fsExtra.readFileSync(pathToContractA, "utf-8");
       contractA = contractA.replace("contract B", "contract A");
-      fsExtra.writeFileSync(pathContractA, contractA, "utf-8");
+      fsExtra.writeFileSync(pathToContractA, contractA, "utf-8");
 
-      const pathContractC = path.join("contracts", "C.sol");
-      let contractC = fsExtra.readFileSync(pathContractC, "utf-8");
+      const pathToContractC = path.join("contracts", "C.sol");
+      let contractC = fsExtra.readFileSync(pathToContractC, "utf-8");
       contractC = contractC.replace("contract D", "contract C");
-      fsExtra.writeFileSync(pathContractC, contractC, "utf-8");
+      fsExtra.writeFileSync(pathToContractC, contractC, "utf-8");
     });
   });
 });

--- a/packages/hardhat-core/test/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/test/builtin-tasks/compile.ts
@@ -869,6 +869,9 @@ Read about compiler configuration at https://hardhat.org/config
 
       await this.env.run("compile");
 
+      contractA = contractA.replace("contract B", "contract A");
+      fsExtra.writeFileSync(pathToContractA, contractA, "utf-8");
+
       // asserts
       const pathToBuildInfoB = path.join(
         "artifacts",
@@ -907,6 +910,9 @@ Read about compiler configuration at https://hardhat.org/config
 
       await this.env.run("compile");
 
+      contractC = contractC.replace("contract D", "contract C");
+      fsExtra.writeFileSync(pathToContractC, contractC, "utf-8");
+
       // asserts
       const pathToBuildInfoC = path.join(
         "artifacts",
@@ -922,18 +928,6 @@ Read about compiler configuration at https://hardhat.org/config
         "E.dbg.json"
       );
       assertBuildInfoExists(pathToBuildInfoE);
-    });
-
-    afterEach(() => {
-      const pathToContractA = path.join("contracts", "A.sol");
-      let contractA = fsExtra.readFileSync(pathToContractA, "utf-8");
-      contractA = contractA.replace("contract B", "contract A");
-      fsExtra.writeFileSync(pathToContractA, contractA, "utf-8");
-
-      const pathToContractC = path.join("contracts", "C.sol");
-      let contractC = fsExtra.readFileSync(pathToContractC, "utf-8");
-      contractC = contractC.replace("contract D", "contract C");
-      fsExtra.writeFileSync(pathToContractC, contractC, "utf-8");
     });
   });
 });

--- a/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/.gitignore
+++ b/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/.gitignore
@@ -1,0 +1,2 @@
+artifacts/
+cache/

--- a/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/contracts/A.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/contracts/A.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import "dependency/contracts/console.sol";
+
+contract A {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/contracts/C.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/contracts/C.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import "./E.sol";
+
+contract C {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/contracts/E.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/contracts/E.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import "dependency/contracts/console.sol";
+
+contract E {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/contracts/E.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/contracts/E.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.19;
 
-import "dependency/contracts/console.sol";
-
 contract E {}

--- a/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/hardhat.config.js
@@ -1,0 +1,7 @@
+// This project is compiled from scratch multiple times in the same test, which
+// produces a lot of logs. We override this task to omit those logs.
+subtask("compile:solidity:log:compilation-result", () => {});
+
+module.exports = {
+  solidity: "0.8.19",
+};

--- a/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/node_modules/dependency/contracts/console.sol
+++ b/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/node_modules/dependency/contracts/console.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+contract console {
+  constructor() {}
+}

--- a/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/node_modules/dependency/package.json
+++ b/packages/hardhat-core/test/fixture-projects/compilation-contract-with-deps/node_modules/dependency/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "dependency",
+  "version": "1.2.3"
+}


### PR DESCRIPTION
Bug reproduction steps:

1. Create a contract that imports a dependency (can be local or external).
2. Compile the project.
3. Rename the contract, only changing the contract name (filename remains the same).
4. Compile again without using `--force` or `hh clean`.
5. Go to the artifacts folder. The debug file of the renamed contract will reference a valid build-info file. However, the imported dependency's debug file will point to a missing build-info file.

This issue occurs because the renamed contract is recompiled while the imported contract remains unchanged (which is correct). However, during the artifact cleanup, the original build-info file, which is still pointed by the imported contract, is mistakenly deleted. Two possible fixes are:

1. Ensure that every debug file points to the correct build-info file by adjusting the debug file pointers.
2. **Modify the cleanup process to delete build-info files only if they are not associated with any debug files. Although this fix was partially implemented, the build-info files were unintentionally deleted along with the invalid artifacts in `_removeArtifactFiles`.**

Closes #1117