### PR TITLE
Negative block number queried when forked network block number is near zero

### DIFF
--- a/.changeset/healthy-poems-talk.md
+++ b/.changeset/healthy-poems-talk.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+Added logic to use the latest block as the forking block if the difference between the latest block and the max reorganization block is negative.
+This decision is based on the assumption that if the max reorganization block is greater than the latest block then there is a high probability that the fork is occurring on a devnet.

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/makeForkClient.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/makeForkClient.ts
@@ -44,7 +44,7 @@ export async function makeForkClient(
   const maxReorg = actualMaxReorg ?? FALLBACK_MAX_REORG;
 
   const latestBlock = await getLatestBlockNumber(provider);
-  const lastSafeBlock = latestBlock - maxReorg;
+  const lastSafeBlock = getLastSafeBlock(latestBlock, maxReorg);
 
   let forkBlockNumber;
   if (forkConfig.blockNumber !== undefined) {
@@ -126,4 +126,12 @@ async function getLatestBlockNumber(provider: HttpProvider) {
 
   const latestBlock = BigInt(latestBlockString);
   return latestBlock;
+}
+
+export function getLastSafeBlock(
+  latestBlock: bigint,
+  maxReorg: bigint
+): bigint {
+  // Design choice: if latestBlock - maxReorg gives a negative number than the newest block will be used
+  return latestBlock - maxReorg >= 0 ? latestBlock - maxReorg : latestBlock;
 }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/makeForkClient.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/makeForkClient.ts
@@ -132,6 +132,7 @@ export function getLastSafeBlock(
   latestBlock: bigint,
   maxReorg: bigint
 ): bigint {
-  // Design choice: if latestBlock - maxReorg gives a negative number than the newest block will be used
+  // Design choice: if latestBlock - maxReorg results in a negative number then the latestBlock block will be used.
+  // This decision is based on the assumption that if maxReorg > latestBlock then there is a high probability that the fork is occurring on a devnet.
   return latestBlock - maxReorg >= 0 ? latestBlock - maxReorg : latestBlock;
 }

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkBlockchain.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkBlockchain.ts
@@ -10,7 +10,10 @@ import { assert } from "chai";
 import { JsonRpcClient } from "../../../../../src/internal/hardhat-network/jsonrpc/client";
 import { ForkBlockchain } from "../../../../../src/internal/hardhat-network/provider/fork/ForkBlockchain";
 import { randomHashBuffer } from "../../../../../src/internal/hardhat-network/provider/utils/random";
-import { makeForkClient } from "../../../../../src/internal/hardhat-network/provider/utils/makeForkClient";
+import {
+  makeForkClient,
+  getLastSafeBlock,
+} from "../../../../../src/internal/hardhat-network/provider/utils/makeForkClient";
 import { ALCHEMY_URL } from "../../../../setup";
 import {
   createTestLog,
@@ -64,6 +67,18 @@ describe("ForkBlockchain", () => {
 
   it("can be constructed", () => {
     assert.instanceOf(fb, ForkBlockchain);
+  });
+
+  // TODO: remove regex code
+  describe("getLastSafeBlock", () => {
+    it("should return a safe block that is the difference between the latestBlock and maxReorg", () => {
+      assert.strictEqual(getLastSafeBlock(100n, 50n), 50n);
+      assert.strictEqual(getLastSafeBlock(100n, 100n), 0n); // 0 is a valid fork block number
+    });
+
+    it("should return latestBlock as fork block because the difference between the latestBlock and maxReorg is < 0", () => {
+      assert.strictEqual(getLastSafeBlock(100n, 50n), 50n);
+    });
   });
 
   describe("getBlock", () => {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkBlockchain.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkBlockchain.ts
@@ -77,7 +77,7 @@ describe("ForkBlockchain", () => {
     });
 
     it("should return latestBlock as fork block because the difference between the latestBlock and maxReorg is < 0", () => {
-      assert.strictEqual(getLastSafeBlock(100n, 50n), 50n);
+      assert.strictEqual(getLastSafeBlock(20n, 200n), 20n);
     });
   });
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkBlockchain.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/fork/ForkBlockchain.ts
@@ -69,7 +69,6 @@ describe("ForkBlockchain", () => {
     assert.instanceOf(fb, ForkBlockchain);
   });
 
-  // TODO: remove regex code
   describe("getLastSafeBlock", () => {
     it("should return a safe block that is the difference between the latestBlock and maxReorg", () => {
       assert.strictEqual(getLastSafeBlock(100n, 50n), 50n);


### PR DESCRIPTION
The code line: `const lastSafeBlock = latestBlock - maxReorg;` could result in a negative value when maxReorg > latestBlock.
Fix: add check, when the difference is a negative number then use latestBlock.