### PR TITLE
Use solc 0.8.19 in docs and sample projects

### DIFF
--- a/docs/src/content/hardhat-runner/docs/advanced/create-task.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/create-task.md
@@ -93,7 +93,7 @@ task("balance", "Prints an account's balance").setAction(async () => {});
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: "{LATEST_SOLC_VERSION}",
+  solidity: "{RECOMMENDED_SOLC_VERSION}",
 };
 ```
 

--- a/docs/src/content/hardhat-runner/docs/config/index.md
+++ b/docs/src/content/hardhat-runner/docs/config/index.md
@@ -26,7 +26,7 @@ module.exports = {
     }
   },
   solidity: {
-    version: "{LATEST_SOLC_VERSION}",
+    version: "{RECOMMENDED_SOLC_VERSION}",
     settings: {
       optimizer: {
         enabled: true,
@@ -62,7 +62,7 @@ module.exports = {
     }
   },
   solidity: {
-    version: "{LATEST_SOLC_VERSION}",
+    version: "{RECOMMENDED_SOLC_VERSION}",
     settings: {
       optimizer: {
         enabled: true,
@@ -176,7 +176,7 @@ module.exports = {
 
 The `solidity` config is an optional field that can be one of the following:
 
-- A solc version to use, e.g. `"{LATEST_SOLC_VERSION}"`.
+- A solc version to use, e.g. `"{RECOMMENDED_SOLC_VERSION}"`.
 
 - An object which describes the configuration for a single compiler. It contains the following keys:
 

--- a/docs/src/content/hardhat-runner/docs/guides/compile-contracts.md
+++ b/docs/src/content/hardhat-runner/docs/guides/compile-contracts.md
@@ -27,7 +27,7 @@ If you need to customize the Solidity compiler options, then you can do so throu
 
 ```js
 module.exports = {
-  solidity: "{LATEST_SOLC_VERSION}",
+  solidity: "{RECOMMENDED_SOLC_VERSION}",
 };
 ```
 
@@ -44,7 +44,7 @@ The expanded usage allows for more control of the compiler:
 ```js
 module.exports = {
   solidity: {
-    version: "{LATEST_SOLC_VERSION}",
+    version: "{RECOMMENDED_SOLC_VERSION}",
     settings: {
       optimizer: {
         enabled: true,

--- a/docs/src/content/hardhat-runner/docs/guides/project-setup.md
+++ b/docs/src/content/hardhat-runner/docs/guides/project-setup.md
@@ -95,7 +95,7 @@ If you select _Create an empty hardhat.config.js_, Hardhat will create a `hardha
 ```js
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: "{LATEST_SOLC_VERSION}",
+  solidity: "{RECOMMENDED_SOLC_VERSION}",
 };
 ```
 
@@ -154,7 +154,7 @@ To use a plugin, the first step is always to install it using npm or yarn, follo
 import "@nomicfoundation/hardhat-toolbox";
 
 export default {
-  solidity: "{LATEST_SOLC_VERSION}",
+  solidity: "{RECOMMENDED_SOLC_VERSION}",
 };
 ```
 
@@ -166,7 +166,7 @@ export default {
 require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
-  solidity: "{LATEST_SOLC_VERSION}",
+  solidity: "{RECOMMENDED_SOLC_VERSION}",
 };
 ```
 

--- a/docs/src/content/hardhat-runner/docs/reference/solidity-support.md
+++ b/docs/src/content/hardhat-runner/docs/reference/solidity-support.md
@@ -35,7 +35,7 @@ If you use the `viaIR` option, we recommend you set the [optimization step seque
 
 ```
 solidity: {
-  version: "{LATEST_SOLC_VERSION}", // any version you want
+  version: "{RECOMMENDED_SOLC_VERSION}", // any version you want
   settings: {
     viaIR: true,
     optimizer: {

--- a/docs/src/content/tutorial/creating-a-new-hardhat-project.md
+++ b/docs/src/content/tutorial/creating-a-new-hardhat-project.md
@@ -164,6 +164,6 @@ require("@nomicfoundation/hardhat-toolbox");
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: "{LATEST_SOLC_VERSION}",
+  solidity: "{RECOMMENDED_SOLC_VERSION}",
 };
 ```

--- a/docs/src/content/tutorial/deploying-to-a-live-network.md
+++ b/docs/src/content/tutorial/deploying-to-a-live-network.md
@@ -67,7 +67,7 @@ const INFURA_API_KEY = "KEY";
 const SEPOLIA_PRIVATE_KEY = "YOUR SEPOLIA PRIVATE KEY";
 
 module.exports = {
-  solidity: "{LATEST_SOLC_VERSION}",
+  solidity: "{RECOMMENDED_SOLC_VERSION}",
   networks: {
     sepolia: {
       url: `https://sepolia.infura.io/v3/${INFURA_API_KEY}`,
@@ -97,7 +97,7 @@ const ALCHEMY_API_KEY = "KEY";
 const SEPOLIA_PRIVATE_KEY = "YOUR SEPOLIA PRIVATE KEY";
 
 module.exports = {
-  solidity: "{LATEST_SOLC_VERSION}",
+  solidity: "{RECOMMENDED_SOLC_VERSION}",
   networks: {
     sepolia: {
       url: `https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,

--- a/docs/src/content/tutorial/writing-and-compiling-contracts.md
+++ b/docs/src/content/tutorial/writing-and-compiling-contracts.md
@@ -107,7 +107,7 @@ To compile the contract run `npx hardhat compile` in your terminal. The `compile
 
 ```
 $ npx hardhat compile
-Compiling 1 file with {LATEST_SOLC_VERSION}
+Compiling 1 file with {RECOMMENDED_SOLC_VERSION}
 Compilation finished successfully
 ```
 

--- a/docs/src/model/markdown.tsx
+++ b/docs/src/model/markdown.tsx
@@ -104,7 +104,7 @@ export const withoutComments = (content: string) => {
 };
 
 export const replacePlaceholders = (content: string) => {
-  const latestSolcVersion = "0.8.20";
+  const recommendedSolcVersion = "0.8.19";
   const latestPragma = "^0.8.0";
   const hardhatPackageJson = fs
     .readFileSync(
@@ -123,7 +123,7 @@ export const replacePlaceholders = (content: string) => {
   const hardhatVersion = JSON.parse(hardhatPackageJson).version;
 
   return content
-    .replaceAll("{LATEST_SOLC_VERSION}", latestSolcVersion)
+    .replaceAll("{RECOMMENDED_SOLC_VERSION}", recommendedSolcVersion)
     .replaceAll("{LATEST_PRAGMA}", latestPragma)
     .replaceAll("{HARDHAT_VERSION}", hardhatVersion);
 };

--- a/packages/hardhat-core/sample-projects/javascript-esm/hardhat.config.cjs
+++ b/packages/hardhat-core/sample-projects/javascript-esm/hardhat.config.cjs
@@ -2,5 +2,5 @@ require("@nomicfoundation/hardhat-toolbox");
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: "0.8.20",
+  solidity: "0.8.19",
 };

--- a/packages/hardhat-core/sample-projects/javascript/hardhat.config.js
+++ b/packages/hardhat-core/sample-projects/javascript/hardhat.config.js
@@ -2,5 +2,5 @@ require("@nomicfoundation/hardhat-toolbox");
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: "0.8.20",
+  solidity: "0.8.19",
 };

--- a/packages/hardhat-core/sample-projects/typescript/hardhat.config.ts
+++ b/packages/hardhat-core/sample-projects/typescript/hardhat.config.ts
@@ -2,7 +2,7 @@ import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.20",
+  solidity: "0.8.19",
 };
 
 export default config;

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -227,7 +227,7 @@ async function printRecommendedDepsInstallationInstructions(
 // exported so we can test that it uses the latest supported version of solidity
 export const EMPTY_HARDHAT_CONFIG = `/** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: "0.8.20",
+  solidity: "0.8.19",
 };
 `;
 


### PR DESCRIPTION
Solc 0.8.20 by default generates bytecode with [`PUSH0` instructions](https://eips.ethereum.org/EIPS/eip-3855) which are not available in all chains. To make things safer for less experienced users, we are going to recommend 0.8.19 by default.