### PR TITLE
debug_traceTransaction ignores "tracer" param

### DIFF
--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/input/debugTraceTransaction.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/input/debugTraceTransaction.ts
@@ -5,6 +5,8 @@ import { optionalOrNullable } from "../../../../util/io-ts";
 export const rpcDebugTracingConfig = optionalOrNullable(
   t.type(
     {
+      tracer: optionalOrNullable(t.string),
+      callTracer: optionalOrNullable(t.boolean),
       disableStorage: optionalOrNullable(t.boolean),
       disableMemory: optionalOrNullable(t.boolean),
       disableStack: optionalOrNullable(t.boolean),

--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/input/debugTraceTransaction.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/input/debugTraceTransaction.ts
@@ -6,7 +6,6 @@ export const rpcDebugTracingConfig = optionalOrNullable(
   t.type(
     {
       tracer: optionalOrNullable(t.string),
-      callTracer: optionalOrNullable(t.boolean),
       disableStorage: optionalOrNullable(t.boolean),
       disableMemory: optionalOrNullable(t.boolean),
       disableStack: optionalOrNullable(t.boolean),

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/debug.ts
@@ -14,7 +14,7 @@ import { RpcDebugTraceOutput } from "../output";
 /* eslint-disable @nomicfoundation/hardhat-internal-rules/only-hardhat-error */
 
 export class DebugModule {
-  public static readonly supportedTracers = ["structLogs"];
+  public static readonly supportedTracers = ["callTracer"];
 
   constructor(private readonly _node: HardhatNode) {}
 
@@ -50,8 +50,7 @@ export class DebugModule {
 
   private _validateTracerParam(config: RpcDebugTracingConfig) {
     if (
-      config !== undefined &&
-      config.tracer !== undefined &&
+      config?.tracer !== undefined &&
       !DebugModule.supportedTracers.includes(config.tracer)
     ) {
       throw new InvalidArgumentsError(

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/debug.ts
@@ -43,12 +43,12 @@ export class DebugModule {
       rpcDebugTracingConfig
     );
 
-    this._throwErrIfTracerIsNotSupported(validatedParams[1]);
+    this._validateTracerParam(validatedParams[1]);
 
     return validatedParams;
   }
 
-  private _throwErrIfTracerIsNotSupported(config: RpcDebugTracingConfig) {
+  private _validateTracerParam(config: RpcDebugTracingConfig) {
     if (
       config !== undefined &&
       config.tracer !== undefined &&

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/debug.ts
@@ -14,7 +14,7 @@ import { RpcDebugTraceOutput } from "../output";
 /* eslint-disable @nomicfoundation/hardhat-internal-rules/only-hardhat-error */
 
 export class DebugModule {
-  static readonly supportedTracers = ["structLogs"];
+  public static readonly supportedTracers = ["structLogs"];
 
   constructor(private readonly _node: HardhatNode) {}
 
@@ -50,8 +50,8 @@ export class DebugModule {
 
   private _throwErrIfTracerIsNotSupported(config: RpcDebugTracingConfig) {
     if (
-      config &&
-      config.tracer &&
+      config !== undefined &&
+      config.tracer !== undefined &&
       !DebugModule.supportedTracers.includes(config.tracer)
     ) {
       throw new InvalidArgumentsError(

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/debug.ts
@@ -14,8 +14,6 @@ import { RpcDebugTraceOutput } from "../output";
 /* eslint-disable @nomicfoundation/hardhat-internal-rules/only-hardhat-error */
 
 export class DebugModule {
-  public static readonly supportedTracers = ["callTracer"];
-
   constructor(private readonly _node: HardhatNode) {}
 
   public async processRequest(
@@ -49,16 +47,9 @@ export class DebugModule {
   }
 
   private _validateTracerParam(config: RpcDebugTracingConfig) {
-    if (
-      config?.tracer !== undefined &&
-      !DebugModule.supportedTracers.includes(config.tracer)
-    ) {
+    if (config?.tracer !== undefined) {
       throw new InvalidArgumentsError(
-        `tracer '${
-          config.tracer
-        }' is not allowed. Available values are: ${DebugModule.supportedTracers.join(
-          ", "
-        )}`
+        "Hardhat currently only supports the default tracer, so no tracer parameter should be passed."
       );
     }
   }

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -81,7 +81,7 @@ describe("Debug module", function () {
                 tracer: "unsupportedTracer",
               },
             ],
-            "tracer 'unsupportedTracer' is not allowed. Available values are: callTracer"
+            "Hardhat currently only supports the default tracer, so no tracer parameter should be passed."
           );
         });
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -14,7 +14,10 @@ import { trace as mainnetReturnsDataTraceGeth } from "../../../../fixture-debug-
 import { trace as mainnetRevertTrace } from "../../../../fixture-debug-traces/mainnetRevertTrace";
 import { trace as modifiesStateTrace } from "../../../../fixture-debug-traces/modifiesStateTrace";
 import { ALCHEMY_URL } from "../../../../setup";
-import { assertInvalidInputError } from "../../helpers/assertions";
+import {
+  assertInvalidArgumentsError,
+  assertInvalidInputError,
+} from "../../helpers/assertions";
 import { FORK_TESTS_CACHE_PATH } from "../../helpers/constants";
 import { EXAMPLE_CONTRACT } from "../../helpers/contracts";
 import { setCWD } from "../../helpers/cwd";
@@ -31,9 +34,9 @@ import { sendDummyTransaction } from "../../helpers/sendDummyTransaction";
 import { deployContract } from "../../helpers/transactions";
 import { assertEqualTraces } from "../utils/assertEqualTraces";
 
-// temporarily skipped because the latest version of ethereumjs
+// TODO: temporarily skip some of the tests because the latest version of ethereumjs
 // sometimes wrongly adds dummy empty words in the memory field
-describe.skip("Debug module", function () {
+describe("Debug module", function () {
   PROVIDERS.forEach(({ name, useProvider }) => {
     describe(`${name} provider`, function () {
       setCWD();
@@ -68,7 +71,21 @@ describe.skip("Debug module", function () {
           });
         });
 
-        it("Should return the right values for fake sender txs", async function () {
+        it("Should throw an error when the value passed as tracer is not supported", async function () {
+          await assertInvalidArgumentsError(
+            this.provider,
+            "debug_traceTransaction",
+            [
+              "0x1234567876543234567876543456765434567aeaeaed67616732632762762373",
+              {
+                tracer: "wrongTracer",
+              },
+            ],
+            "tracer 'wrongTracer' is not allowed. Available values are: structLogs"
+          );
+        });
+
+        it.skip("Should return the right values for fake sender txs", async function () {
           const impersonatedAddress =
             "0xC014BA5EC014ba5ec014Ba5EC014ba5Ec014bA5E";
 
@@ -106,7 +123,7 @@ describe.skip("Debug module", function () {
           });
         });
 
-        it("Should return the right values for successful contract tx", async function () {
+        it.skip("Should return the right values for successful contract tx", async function () {
           const contractAddress = await deployContract(
             this.provider,
             `0x${EXAMPLE_CONTRACT.bytecode.object}`,
@@ -228,7 +245,7 @@ describe.skip("Debug module", function () {
       );
     });
 
-    it("Should return the right values for a successful tx", async function () {
+    it.skip("Should return the right values for a successful tx", async function () {
       const trace: RpcDebugTraceOutput = await provider.send(
         "debug_traceTransaction",
         ["0x89ebeb319fcd7bda9c7f8c1b78a7571842a705425b175f24f34fe8e6c60580d4"]
@@ -238,7 +255,7 @@ describe.skip("Debug module", function () {
       assertEqualTraces(trace, mainnetReturnsDataTraceGeth);
     });
 
-    it("Should return the right values for a reverted tx", async function () {
+    it.skip("Should return the right values for a reverted tx", async function () {
       const trace: RpcDebugTraceOutput = await provider.send(
         "debug_traceTransaction",
         ["0x6214b912cc9916d8b7bf5f4ff876e259f5f3754ddebb6df8c8e897cad31ae148"]
@@ -268,7 +285,7 @@ describe.skip("Debug module", function () {
       });
     });
 
-    it("Should respect the disableStack option", async function () {
+    it.skip("Should respect the disableStack option", async function () {
       const trace: RpcDebugTraceOutput = await provider.send(
         "debug_traceTransaction",
         [
@@ -289,7 +306,7 @@ describe.skip("Debug module", function () {
       });
     });
 
-    it("Should respect the disableStorage option", async function () {
+    it.skip("Should respect the disableStorage option", async function () {
       const trace: RpcDebugTraceOutput = await provider.send(
         "debug_traceTransaction",
         [

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -78,10 +78,10 @@ describe("Debug module", function () {
             [
               "0x1234567876543234567876543456765434567aeaeaed67616732632762762373",
               {
-                tracer: "wrongTracer",
+                tracer: "unsupportedTracer",
               },
             ],
-            "tracer 'wrongTracer' is not allowed. Available values are: structLogs"
+            "tracer 'unsupportedTracer' is not allowed. Available values are: callTracer"
           );
         });
 


### PR DESCRIPTION
When calling `debug_traceTransaction` passing a `tracer` parameter that is not supported an error should be thrown.  [See issue here](https://github.com/NomicFoundation/hardhat/issues/3973).