### PR TITLE
Re-enable hardhat-ethers test

### DIFF
--- a/packages/hardhat-ethers/test/contracts.ts
+++ b/packages/hardhat-ethers/test/contracts.ts
@@ -113,8 +113,7 @@ describe("contracts", function () {
     await contract.off("Inc", listener);
   });
 
-  // temporarily skipped because contract.once doesn't call provider.off
-  it.skip("should wait for an event using .once", async function () {
+  it("should wait for an event using .once", async function () {
     const signer = await this.env.ethers.provider.getSigner(0);
 
     const factory = new this.env.ethers.ContractFactory<[], ExampleContract>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4413,6 +4413,7 @@ ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.1, ethereumjs-util@^7.1.2, ethereum
     rlp "^2.2.4"
 
 "ethers-v5@npm:ethers@5", ethers@^5.0.0, ethers@^5.0.13, ethers@^5.7.1:
+  name ethers-v5
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -4464,9 +4465,9 @@ ethers@^4.0.0-beta.1, ethers@^4.0.32, ethers@^4.0.40:
     xmlhttprequest "1.8.0"
 
 ethers@^6.1.0, ethers@^6.4.0:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.6.2.tgz#0b6131b5fa291fec69b7ae379cb6bb2405c505a7"
-  integrity sha512-vyWfVAj2g7xeZIivOqlbpt7PbS2MzvJkKgsncgn4A/1xZr8Q3BznBmEBRQyPXKCgHmX4PzRQLpnYG7jl/yutMg==
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.6.3.tgz#9bf11d1bd0f18c7c55087d1a52fdc8f3c33c8bab"
+  integrity sha512-g8wLXeRWSGDD0T+wsL3pvyc3aYnmxEEAwH8LSoDTDRhRsmJeNs9YMXlNU7ax2caO+zHkeI9MkHiz6rwxEjN4Mw==
   dependencies:
     "@adraffy/ens-normalize" "1.9.2"
     "@noble/hashes" "1.1.2"


### PR DESCRIPTION
[`ethers@6.6.3`](https://github.com/ethers-io/ethers.js/releases/tag/v6.6.3) fixed a problem that was causing Hardhat to hang when `contract.once` was used.

This PR re-enables a test that was skipped for some reason. I also updated the `yarn.lock` so that ethers v6.6.3 is used locally.