### PR TITLE
chore(internal): add ts-check to default config

### DIFF
--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -225,7 +225,8 @@ async function printRecommendedDepsInstallationInstructions(
 }
 
 // exported so we can test that it uses the latest supported version of solidity
-export const EMPTY_HARDHAT_CONFIG = `/** @type import('hardhat/config').HardhatUserConfig */
+export const EMPTY_HARDHAT_CONFIG = `// @ts-check
+/** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
   solidity: "0.8.19",
 };
@@ -315,7 +316,7 @@ async function createPackageJson() {
 function showStarOnGitHubMessage() {
   console.log(
     chalk.cyan("Give Hardhat a star on Github if you're enjoying it!") +
-      emoji(" 💞✨")
+      emoji(" ⭐️✨")
   );
   console.log();
   console.log(chalk.cyan("     https://github.com/NomicFoundation/hardhat"));


### PR DESCRIPTION
## Improve IDE type checking

```js
// @ts-check
``` 

This is required to get type checking when loading types as a JSDoc directive.

## Spurious emoji usage and console printing hyperlink format

Additionally, the comment "Give us a star on GitHub" has a heart, not a star. 
Adjusted Emoji accordingly.

You may consider an alternative to the current implementation such that:

```console
printf '\e]8;;https://github.com/nomicfoundation/hardhat\e\\ Give us a Star on GitHub\e]8;;\e\\\n'
````

returns simply:

<ins> Give us a Star on GitHub </ins>

>**Note**
> For more information on providing hyperlinks in shell environments you can refer to [this helpful gist](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) and [track OSC8 Adoption here](https://github.com/Alhadis/OSC8-Adoption)


gm