### PR TITLE
[hardhat-vyper] Warn when test mode directive is present in contract sources

### DIFF
--- a/.changeset/five-colts-remain.md
+++ b/.changeset/five-colts-remain.md
@@ -2,4 +2,4 @@
 "@nomiclabs/hardhat-vyper": patch
 ---
 
-Added a check to validate that the Brownie code does not contain the directive `#@ if mode == "test":` because we currently do not support this feature.
+Added a check to validate that the Brownie code does not contain the directive `#@ if mode == "test":` because we do not support this feature.

--- a/.changeset/five-colts-remain.md
+++ b/.changeset/five-colts-remain.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-vyper": patch
+---
+
+Added a check to validate that the Brownie code does not contain the directive `#@ if mode == "test":` because we currently do not support this feature.

--- a/packages/hardhat-vyper/README.md
+++ b/packages/hardhat-vyper/README.md
@@ -74,7 +74,7 @@ There are no additional steps you need to take for this plugin to work.
 
 ## Test directives
 
-Brownie allows you to use the test directive `#@ if mode == "test":` to specify when a portion of code should be compiled only for testing purposes.
+Brownie allows you to use the test directive `#@ if mode == "test":` to specify when a portion of code should be included only for testing purposes.
 
 Example:
 

--- a/packages/hardhat-vyper/README.md
+++ b/packages/hardhat-vyper/README.md
@@ -86,7 +86,7 @@ def _mint_for_testing(_to: address, _token_id: uint256):
 #@ endif
 ```
 
-We currently do NOT support this feature. An error will be thrown every time that, when compiling a contract, the directive `#@ if mode == "test":` is found.
+We do NOT support this feature. An error will be thrown every time that, when compiling a contract, the directive `#@ if mode == "test":` is found.
 
 ### Additional notes
 

--- a/packages/hardhat-vyper/README.md
+++ b/packages/hardhat-vyper/README.md
@@ -72,6 +72,22 @@ module.exports = {
 
 There are no additional steps you need to take for this plugin to work.
 
+## Test directives
+
+Brownie allows you to use the test directive `#@ if mode == "test":` to specify when a portion of code should be compiled only for testing purposes.
+
+Example:
+
+```vy
+#@ if mode == "test":
+@external
+def _mint_for_testing(_to: address, _token_id: uint256):
+    self._mint(_to, _token_id)
+#@ endif
+```
+
+We currently do NOT support this feature. An error will be thrown every time that, when compiling a contract, the directive `#@ if mode == "test":` is found.
+
 ### Additional notes
 
 The oldest vyper version supported by this plugin is 0.2.0. Versions older than this will not work and will throw an error.

--- a/packages/hardhat-vyper/package.json
+++ b/packages/hardhat-vyper/package.json
@@ -47,6 +47,7 @@
     "@typescript-eslint/eslint-plugin": "5.61.0",
     "@typescript-eslint/parser": "5.61.0",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",

--- a/packages/hardhat-vyper/src/parser.ts
+++ b/packages/hardhat-vyper/src/parser.ts
@@ -1,4 +1,5 @@
 import { VyperFilesCache } from "./cache";
+import { VyperPluginError } from "./util";
 
 interface ParsedData {
   versionPragma: string;
@@ -35,10 +36,10 @@ export class Parser {
 
   private _validateTestModeNotUsed(fileContent: string, absolutePath: string) {
     if (fileContent.includes('#@ if mode == "test":')) {
-      throw new Error(
+      throw new VyperPluginError(
         `We found a test directive in the file at path ${absolutePath}.` +
           ` Test directives are a Brownie feature not supported by Hardhat.` +
-          ` Learn more at https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-vyper#test-directives.`
+          ` Learn more at https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-vyper#test-directives`
       );
     }
   }

--- a/packages/hardhat-vyper/src/parser.ts
+++ b/packages/hardhat-vyper/src/parser.ts
@@ -16,6 +16,8 @@ export class Parser {
     absolutePath: string,
     contentHash: string
   ): ParsedData {
+    this._validateTestModeNotUsed(fileContent, absolutePath);
+
     const cacheResult = this._getFromCache(absolutePath, contentHash);
 
     if (cacheResult !== null) {
@@ -29,6 +31,16 @@ export class Parser {
     this._cache.set(contentHash, result);
 
     return result;
+  }
+
+  private _validateTestModeNotUsed(fileContent: string, absolutePath: string) {
+    if (fileContent.includes('#@ if mode == "test":')) {
+      throw new Error(
+        `We found a test directive in the file at path ${absolutePath}.` +
+          ` Test directives are a Brownie feature not supported by Hardhat.` +
+          ` Learn more at https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-vyper#test-directives.`
+      );
+    }
   }
 
   private _getFromCache(

--- a/packages/hardhat-vyper/test/fixture-projects/compilation-single-file-test-directive/contracts/A.vy
+++ b/packages/hardhat-vyper/test/fixture-projects/compilation-single-file-test-directive/contracts/A.vy
@@ -1,0 +1,7 @@
+# @version 0.3.0
+
+#@ if mode == "test":
+@external
+def test() -> int128:
+  return 42
+#@ endif

--- a/packages/hardhat-vyper/test/fixture-projects/compilation-single-file-test-directive/hardhat.config.js
+++ b/packages/hardhat-vyper/test/fixture-projects/compilation-single-file-test-directive/hardhat.config.js
@@ -1,0 +1,5 @@
+require("../../../src/index");
+
+module.exports = {
+  vyper: "0.3.0",
+};

--- a/packages/hardhat-vyper/test/tests.ts
+++ b/packages/hardhat-vyper/test/tests.ts
@@ -1,4 +1,5 @@
-import { assert } from "chai";
+import { assert, expect, use } from "chai";
+import chaiAsPromised from "chai-as-promised";
 import * as fsExtra from "fs-extra";
 import path from "path";
 
@@ -11,6 +12,8 @@ import {
   assertFileExists,
   expectVyperErrorAsync,
 } from "./helpers";
+
+use(chaiAsPromised);
 
 describe("Vyper plugin", function () {
   beforeEach(function () {
@@ -104,6 +107,27 @@ describe("Vyper plugin", function () {
       assert.isUndefined(
         JSON.parse(JSON.stringify(this.env.artifacts.readArtifactSync("A").abi))
           .gas
+      );
+    });
+  });
+
+  describe("project should not compile", function () {
+    useFixtureProject("compilation-single-file-test-directive");
+    useEnvironment();
+
+    it("should throw an error because a test directive is present in the source file", async function () {
+      const filePath = path.join(
+        __dirname,
+        "fixture-projects",
+        "compilation-single-file-test-directive",
+        "contracts",
+        "A.vy"
+      );
+
+      await expect(this.env.run(TASK_COMPILE)).to.be.rejectedWith(
+        `We found a test directive in the file at path ${filePath}.` +
+          ` Test directives are a Brownie feature not supported by Hardhat.` +
+          ` Learn more at https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-vyper#test-directives.`
       );
     });
   });

--- a/packages/hardhat-vyper/test/tests.ts
+++ b/packages/hardhat-vyper/test/tests.ts
@@ -127,7 +127,7 @@ describe("Vyper plugin", function () {
       await expect(this.env.run(TASK_COMPILE)).to.be.rejectedWith(
         `We found a test directive in the file at path ${filePath}.` +
           ` Test directives are a Brownie feature not supported by Hardhat.` +
-          ` Learn more at https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-vyper#test-directives.`
+          ` Learn more at https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-vyper#test-directives`
       );
     });
   });


### PR DESCRIPTION
Our vyper plugin only compiles things in test mode, which is dangerous, as it can leave things like this in production deployments.
[See issue here](https://github.com/NomicFoundation/hardhat/issues/2540).

Example:
```
#@ if mode == "test":
@external
def _mint_for_testing(_to: address, _token_id: uint256):
    self._mint(_to, _token_id)
#@ endif
```

Solution: 
throw an error explaining that we currently do not support this feature if a test directive is found in the code.