### PR TITLE
Test slow-imports rule

### DIFF
--- a/.github/workflows/test-slow-imports-rule.yml
+++ b/.github/workflows/test-slow-imports-rule.yml
@@ -1,0 +1,39 @@
+# This workflow checks that our slow-imports rule works correctly.
+# This is done by intentionally breaking the rule, running the linter, and checking
+# that we got a non-zero exit code. It's not a completely fault-proof strategy,
+# but it's an useful smoke test.
+name: Slow imports rule check
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/test-slow-imports-rule.yml"
+
+defaults:
+  run:
+    working-directory: packages/hardhat-core
+
+jobs:
+  test-slow-imports-rule:
+    name: Check that the slow-imports rule works correctly
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: actions/checkout@v2
+      - name: Install
+        run: yarn
+      - name: Add slow import
+        run: echo 'import "lodash";' >> src/internal/constants.ts
+      - name: Build
+        run: yarn build
+      - name: Run eslint
+        id: run-linter
+        run: yarn eslint
+        continue-on-error: true
+      - name: Check linter status code
+        run: test ${{ steps.run-linter.outcome }} != success


### PR DESCRIPTION
Add a workflow that runs a simple smoke test to validate that our slow-imports eslint rule works as expected.

This will run once per day. The alternative was to try to figure out which file changes could break this (probably any change in the rules source and any change in `yarn.lock`), but I think once per day is simpler and good enough.