### PR TITLE
Don't run changesets check in changesets PR

### DIFF
--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -19,7 +19,7 @@ jobs:
     name: Check that PR has a changeset
     runs-on: ubuntu-latest
     # don't run this check in the changesets PR
-    if:  github.head_ref != 'changeset-release/main'
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -18,6 +18,8 @@ jobs:
   check-if-changeset:
     name: Check that PR has a changeset
     runs-on: ubuntu-latest
+    # don't run this check in the changesets PR
+    if:  github.head_ref != 'changeset-release/main'
     steps:
       - uses: actions/github-script@v6
         with:


### PR DESCRIPTION
This will prevent the changesets check to run in PRs like [this one](https://github.com/NomicFoundation/hardhat/pull/3857).