### PR TITLE
removed abort-controller dependency from core

### DIFF
--- a/.changeset/chilly-meals-enjoy.md
+++ b/.changeset/chilly-meals-enjoy.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Removed the `abort-controller` dependency as it's not longer needed.

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -114,7 +114,6 @@
     "@sentry/node": "^5.18.1",
     "@types/bn.js": "^5.1.0",
     "@types/lru-cache": "^5.1.0",
-    "abort-controller": "^3.0.0",
     "adm-zip": "^0.4.16",
     "aggregate-error": "^3.0.0",
     "ansi-escapes": "^4.3.0",

--- a/packages/hardhat-core/src/internal/cli/analytics.ts
+++ b/packages/hardhat-core/src/internal/cli/analytics.ts
@@ -1,4 +1,3 @@
-import type AbortControllerT from "abort-controller";
 import type { request as RequestT } from "undici";
 
 import debug from "debug";
@@ -128,8 +127,6 @@ export class Analytics {
 
   private _sendHit(payload: AnalyticsPayload): [AbortAnalytics, Promise<void>] {
     const { request } = require("undici") as { request: typeof RequestT };
-    const AbortController =
-      require("abort-controller") as typeof AbortControllerT;
 
     const eventName = payload.events[0].name;
     log(`Sending hit for ${eventName}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,13 +2112,6 @@ abbrev@1.0.x:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
   integrity sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==
 
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
-
 abortcontroller-polyfill@^1.7.3:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz#6738495f4e901fbb57b6c0611d0c75f76c485bed"
@@ -4501,11 +4494,6 @@ ethjs-util@0.1.6, ethjs-util@^0.1.6:
   dependencies:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@4.0.4:
   version "4.0.4"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
The solution to https://github.com/NomicFoundation/hardhat/issues/4110. Removed abort-controller dependency that was recommended by docs of the package node-fetch, which is no longer being used. Now core will use the native AbortController API included in node versions 15+, which is a direct replacement. No additional changes are needed (see https://developer.mozilla.org/en-US/docs/Web/API/AbortController).