### PR TITLE
Upgrade to typescript v5

### DIFF
--- a/.github/workflows/compile-with-typescript-v4.yml
+++ b/.github/workflows/compile-with-typescript-v4.yml
@@ -1,0 +1,22 @@
+name: Compile with typescript v4
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  compile_with_typescript_v4:
+    name: Compile with typescript v4
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Install typescript v4 in all packages
+        run: sed -i 's/"typescript": "~5.0.0"/"typescript": "^4.0.0"/' package.json packages/*/package.json && yarn
+      - name: Build
+        run: yarn build

--- a/.github/workflows/compile-with-typescript-v4.yml
+++ b/.github/workflows/compile-with-typescript-v4.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: 16
       - name: Install typescript v4 in all packages
-        run: sed -i 's/"typescript": "~5.0.0"/"typescript": "^4.0.0"/' package.json packages/*/package.json && yarn
+        run: |
+          sed -i 's/"typescript": "~5.0.0"/"typescript": "^4.0.0"/' package.json packages/*/package.json && yarn
       - name: Build
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@changesets/cli": "^2.16.0",
     "prettier": "2.4.1",
     "shelljs": "^0.8.5",
-    "typescript": "~4.7.4",
+    "typescript": "~5.0.0",
     "wsrun": "^5.2.2"
   },
   "scripts": {

--- a/packages/hardhat-chai-matchers/package.json
+++ b/packages/hardhat-chai-matchers/package.json
@@ -59,7 +59,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.0",

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -92,7 +92,7 @@
     "sinon": "^9.0.0",
     "time-require": "^0.1.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.1.2",

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/fork/rpcToTxData.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/fork/rpcToTxData.ts
@@ -1,10 +1,19 @@
+import type { BigIntLike } from "@nomicfoundation/ethereumjs-util";
+
 import {
   AccessListEIP2930TxData,
   TxData,
 } from "@nomicfoundation/ethereumjs-tx";
 
-import { FeeMarketEIP1559TxData } from "@nomicfoundation/ethereumjs-tx/dist/types";
 import { RpcTransaction } from "../../../core/jsonrpc/types/output/transaction";
+
+// the FeeMarketEIP1559TxData interface from ethereum js also has a
+// `gasPrice?: never | null` property, which causes a compilation
+// error in the latest version of typescript
+interface FeeMarketEIP1559TxData extends AccessListEIP2930TxData {
+  maxPriorityFeePerGas?: BigIntLike;
+  maxFeePerGas?: BigIntLike;
+}
 
 export function rpcToTxData(
   rpcTransaction: RpcTransaction

--- a/packages/hardhat-core/src/internal/util/unsafe.ts
+++ b/packages/hardhat-core/src/internal/util/unsafe.ts
@@ -10,6 +10,6 @@ export const unsafeObjectKeys = Object.keys as <T>(
  * This function is a typed version of `Object.entries`. Note that it's type
  * unsafe. You have to be sure that `o` has exactly the same keys as `T`.
  */
-export function unsafeObjectEntries<T>(o: T) {
+export function unsafeObjectEntries<T extends object>(o: T) {
   return Object.entries(o) as Array<[keyof T, T[keyof T]]>;
 }

--- a/packages/hardhat-ethers/package.json
+++ b/packages/hardhat-ethers/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.0",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "ethers": "^6.1.0",

--- a/packages/hardhat-foundry/package.json
+++ b/packages/hardhat-foundry/package.json
@@ -50,7 +50,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "hardhat": "^2.12.6"

--- a/packages/hardhat-ledger/package.json
+++ b/packages/hardhat-ledger/package.json
@@ -65,7 +65,7 @@
     "prettier": "2.4.1",
     "ts-node": "^10.8.0",
     "sinon": "^9.0.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "hardhat": "^2.16.0"

--- a/packages/hardhat-network-helpers/package.json
+++ b/packages/hardhat-network-helpers/package.json
@@ -58,7 +58,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "hardhat": "^2.9.5"

--- a/packages/hardhat-shorthand/package.json
+++ b/packages/hardhat-shorthand/package.json
@@ -50,7 +50,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "dependencies": {
     "@fvictorio/tabtab": "^0.0.3",

--- a/packages/hardhat-solhint/package.json
+++ b/packages/hardhat-solhint/package.json
@@ -56,7 +56,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^9.0.0",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "hardhat": "^2.0.0"

--- a/packages/hardhat-solpp/package.json
+++ b/packages/hardhat-solpp/package.json
@@ -55,7 +55,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "hardhat": "^2.0.0"

--- a/packages/hardhat-toolbox/package.json
+++ b/packages/hardhat-toolbox/package.json
@@ -64,7 +64,7 @@
     "solidity-coverage": "^0.8.1",
     "ts-node": "^10.8.0",
     "typechain": "^8.2.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",

--- a/packages/hardhat-truffle4/package.json
+++ b/packages/hardhat-truffle4/package.json
@@ -58,7 +58,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4",
+    "typescript": "~5.0.0",
     "web3": "^0.20.0"
   },
   "peerDependencies": {

--- a/packages/hardhat-truffle5/package.json
+++ b/packages/hardhat-truffle5/package.json
@@ -58,7 +58,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4",
+    "typescript": "~5.0.0",
     "web3": "^1.0.0-beta.36"
   },
   "peerDependencies": {

--- a/packages/hardhat-verify/package.json
+++ b/packages/hardhat-verify/package.json
@@ -71,7 +71,7 @@
     "sinon": "^9.0.0",
     "sinon-chai": "^3.7.0",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "hardhat": "^2.0.4"

--- a/packages/hardhat-vyper/package.json
+++ b/packages/hardhat-vyper/package.json
@@ -58,7 +58,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4"
+    "typescript": "~5.0.0"
   },
   "peerDependencies": {
     "hardhat": "^2.8.3"

--- a/packages/hardhat-web3-legacy/package.json
+++ b/packages/hardhat-web3-legacy/package.json
@@ -49,7 +49,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4",
+    "typescript": "~5.0.0",
     "web3": "^0.20.0"
   },
   "peerDependencies": {

--- a/packages/hardhat-web3/package.json
+++ b/packages/hardhat-web3/package.json
@@ -49,7 +49,7 @@
     "prettier": "2.4.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.0",
-    "typescript": "~4.7.4",
+    "typescript": "~5.0.0",
     "web3": "^1.0.0-beta.36"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9529,10 +9529,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@~4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@~5.0.0:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
We'll need this to be able to use viem.

@alcuadrado important things here:
- I'm using `~5.0.0` as the version range in all packages (even the toolbox).
- [This commit](https://github.com/NomicFoundation/hardhat/pull/4184/commits/999c5ea64f15b2873650676c8279e2807721c037) is the one that fixes the two compilation errors that showed up after upgrading.
- I added a workflow to compile the whole repository with typescript v4. I also pushed a temporary commit to double-check that the workflow fails as expected (see [here](https://github.com/NomicFoundation/hardhat/actions/runs/5620956258/job/15230842149)).