### PR TITLE
Increase test timeout in hh-truffle4

### DIFF
--- a/packages/hardhat-truffle4/.mocharc.json
+++ b/packages/hardhat-truffle4/.mocharc.json
@@ -2,5 +2,5 @@
   "require": "ts-node/register/files",
   "file": "../common/run-with-ganache",
   "ignore": ["test/fixture-projects/**/*"],
-  "timeout": 10000
+  "timeout": 60000
 }


### PR DESCRIPTION
Doing this to see if it stops the CI false negatives for this package on windows.