### PR TITLE
Hardhat verify add sourcify boilerplate

### DIFF
--- a/.changeset/tough-gorillas-matter.md
+++ b/.changeset/tough-gorillas-matter.md
@@ -1,0 +1,8 @@
+---
+"@nomicfoundation/hardhat-verify": major
+---
+
+- Added the option to deactivate verification providers by using the 'enabled' field in the plugin's configuration.
+- Improved error handling: Errors are now displayed at the end of the verification process, providing better visibility.
+- Introduced a warning when the Sourcify configuration is missing, helping users avoid potential issues.
+- Implemented enhancements to allow multiple verification providers to run simultaneously, preventing any blocking.

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -119,7 +119,7 @@ subtask(
 
 subtask(
   TASK_VERIFY_GET_VERIFICATION_SUBTASKS,
-  async (_, { config }): Promise<string[]> => {
+  async (_, { config, userConfig }): Promise<string[]> => {
     const verificationSubtasks = [];
 
     if (config.etherscan.enabled) {
@@ -128,7 +128,7 @@ subtask(
 
     if (config.sourcify.enabled) {
       verificationSubtasks.push(TASK_VERIFY_SOURCIFY);
-    } else {
+    } else if (userConfig.sourcify?.enabled === undefined) {
       verificationSubtasks.push(TASK_VERIFY_SOURCIFY_DISABLED_WARNING);
     }
 

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -1,25 +1,10 @@
-import type LodashCloneDeepT from "lodash.clonedeep";
-import type {
-  CompilationJob,
-  CompilerInput,
-  DependencyGraph,
-} from "hardhat/types";
+import type { LibraryToAddress } from "./internal/solc/artifacts";
 
 import chalk from "chalk";
 import { extendConfig, subtask, task, types } from "hardhat/config";
-import { isFullyQualifiedName } from "hardhat/utils/contract-names";
-import {
-  TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE,
-  TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT,
-  TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
-} from "hardhat/builtin-tasks/task-names";
 import {
   TASK_VERIFY,
-  TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION,
-  TASK_VERIFY_ETHERSCAN_GET_CONTRACT_INFORMATION,
-  TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT,
   TASK_VERIFY_GET_VERIFICATION_SUBTASKS,
-  TASK_VERIFY_RESOLVE_ARGUMENTS,
   TASK_VERIFY_VERIFY,
   TASK_VERIFY_ETHERSCAN,
   TASK_VERIFY_PRINT_SUPPORTED_NETWORKS,
@@ -31,45 +16,21 @@ import {
   sourcifyConfigExtender,
 } from "./internal/config";
 import {
-  MissingAddressError,
-  InvalidAddressError,
-  InvalidContractNameError,
   InvalidConstructorArgumentsError,
   InvalidLibrariesError,
-  CompilerVersionsMismatchError,
-  ContractNotFoundError,
-  BuildInfoNotFoundError,
-  BuildInfoCompilerVersionMismatchError,
-  DeployedBytecodeMismatchError,
-  UnexpectedNumberOfFilesError,
-  VerificationAPIUnexpectedMessageError,
-  ContractVerificationFailedError,
   HardhatVerifyError,
 } from "./internal/errors";
 import {
-  sleep,
-  encodeArguments,
-  getCompilerVersions,
   printSupportedNetworks,
-  resolveConstructorArguments,
-  resolveLibraries,
   printVerificationErrors,
 } from "./internal/utilities";
-import { Etherscan } from "./internal/etherscan";
-import { Bytecode } from "./internal/solc/bytecode";
-import {
-  ContractInformation,
-  ExtendedContractInformation,
-  extractInferredContractInformation,
-  extractMatchingContractInformation,
-  getLibraryInformation,
-  LibraryToAddress,
-} from "./internal/solc/artifacts";
 
 import "./internal/type-extensions";
+import "./internal/tasks/etherscan";
+import "./internal/tasks/sourcify";
 
 // Main task args
-interface VerifyTaskArgs {
+export interface VerifyTaskArgs {
   address?: string;
   constructorArgsParams: string[];
   constructorArgs?: string;
@@ -84,38 +45,6 @@ interface VerifySubtaskArgs {
   constructorArguments: string[];
   libraries: LibraryToAddress;
   contract?: string;
-}
-
-// parsed verification args
-interface VerificationArgs {
-  address: string;
-  constructorArgs: string[];
-  libraries: LibraryToAddress;
-  contractFQN?: string;
-}
-
-interface GetContractInformationArgs {
-  contractFQN?: string;
-  deployedBytecode: Bytecode;
-  matchingCompilerVersions: string[];
-  libraries: LibraryToAddress;
-}
-
-interface GetMinimalInputArgs {
-  sourceName: string;
-}
-
-interface AttemptVerificationArgs {
-  address: string;
-  compilerInput: CompilerInput;
-  contractInformation: ExtendedContractInformation;
-  verificationInterface: Etherscan;
-  encodedConstructorArguments: string;
-}
-
-interface VerificationResponse {
-  success: boolean;
-  message: string;
 }
 
 extendConfig(etherscanConfigExtender);
@@ -182,6 +111,13 @@ task(TASK_VERIFY, "Verifies a contract on Etherscan")
   });
 
 subtask(
+  TASK_VERIFY_PRINT_SUPPORTED_NETWORKS,
+  "Prints the supported networks list"
+).setAction(async ({}, { config }) => {
+  await printSupportedNetworks(config.etherscan.customChains);
+});
+
+subtask(
   TASK_VERIFY_GET_VERIFICATION_SUBTASKS,
   async (_, { config }): Promise<string[]> => {
     const verificationSubtasks = [];
@@ -207,367 +143,6 @@ subtask(
     return verificationSubtasks;
   }
 );
-
-subtask(TASK_VERIFY_SOURCIFY_DISABLED_WARNING, async (): Promise<void> => {
-  console.warn(
-    chalk.yellow(
-      `WARNING: Skipping Sourcify verification: Sourcify is disabled. To enable it, add this entry to your config:
-
-sourcify: {
-enabled: true
-}
-
-Learn more at https://...`
-    )
-  );
-});
-
-/**
- * Main Etherscan verification subtask.
- *
- * Verifies a contract in Etherscan by coordinating various subtasks related
- * to contract verification.
- */
-subtask(TASK_VERIFY_ETHERSCAN)
-  .addParam("address")
-  .addOptionalParam("constructorArgsParams", undefined, undefined, types.any)
-  .addOptionalParam("constructorArgs")
-  // TODO: [remove-verify-subtask] change to types.inputFile
-  .addOptionalParam("libraries", undefined, undefined, types.any)
-  .addOptionalParam("contract")
-  .addFlag("listNetworks")
-  .setAction(async (taskArgs: VerifyTaskArgs, { config, network, run }) => {
-    const {
-      address,
-      constructorArgs,
-      libraries,
-      contractFQN,
-    }: VerificationArgs = await run(TASK_VERIFY_RESOLVE_ARGUMENTS, taskArgs);
-
-    const chainConfig = await Etherscan.getCurrentChainConfig(
-      network.name,
-      network.provider,
-      config.etherscan.customChains
-    );
-
-    const etherscan = Etherscan.fromChainConfig(
-      config.etherscan.apiKey,
-      chainConfig
-    );
-
-    const isVerified = await etherscan.isVerified(address);
-    if (isVerified) {
-      const contractURL = etherscan.getContractUrl(address);
-      console.log(`The contract ${address} has already been verified.
-${contractURL}`);
-      return;
-    }
-
-    const configCompilerVersions = await getCompilerVersions(config.solidity);
-
-    const deployedBytecode = await Bytecode.getDeployedContractBytecode(
-      address,
-      network.provider,
-      network.name
-    );
-
-    const matchingCompilerVersions = await deployedBytecode.getMatchingVersions(
-      configCompilerVersions
-    );
-    // don't error if the bytecode appears to be OVM bytecode, because we can't infer a specific OVM solc version from the bytecode
-    if (matchingCompilerVersions.length === 0 && !deployedBytecode.isOvm()) {
-      throw new CompilerVersionsMismatchError(
-        configCompilerVersions,
-        deployedBytecode.getVersion(),
-        network.name
-      );
-    }
-
-    const contractInformation: ExtendedContractInformation = await run(
-      TASK_VERIFY_ETHERSCAN_GET_CONTRACT_INFORMATION,
-      {
-        contractFQN,
-        deployedBytecode,
-        matchingCompilerVersions,
-        libraries,
-      }
-    );
-
-    const minimalInput: CompilerInput = await run(
-      TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT,
-      {
-        sourceName: contractInformation.sourceName,
-      }
-    );
-
-    const encodedConstructorArguments = await encodeArguments(
-      contractInformation.contractOutput.abi,
-      contractInformation.sourceName,
-      contractInformation.contractName,
-      constructorArgs
-    );
-
-    // First, try to verify the contract using the minimal input
-    const { success: minimalInputVerificationSuccess }: VerificationResponse =
-      await run(TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION, {
-        address,
-        compilerInput: minimalInput,
-        contractInformation,
-        verificationInterface: etherscan,
-        encodedConstructorArguments,
-      });
-
-    if (minimalInputVerificationSuccess) {
-      return;
-    }
-
-    console.log(`We tried verifying your contract ${contractInformation.contractName} without including any unrelated one, but it failed.
-Trying again with the full solc input used to compile and deploy it.
-This means that unrelated contracts may be displayed on Etherscan...
-`);
-
-    // If verifying with the minimal input failed, try again with the full compiler input
-    const {
-      success: fullCompilerInputVerificationSuccess,
-      message: verificationMessage,
-    }: VerificationResponse = await run(
-      TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION,
-      {
-        address,
-        compilerInput: contractInformation.compilerInput,
-        contractInformation,
-        verificationInterface: etherscan,
-        encodedConstructorArguments,
-      }
-    );
-
-    if (fullCompilerInputVerificationSuccess) {
-      return;
-    }
-
-    throw new ContractVerificationFailedError(
-      verificationMessage,
-      contractInformation.undetectableLibraries
-    );
-  });
-
-subtask(TASK_VERIFY_RESOLVE_ARGUMENTS)
-  .addOptionalParam("address")
-  .addOptionalParam("constructorArgsParams", undefined, [], types.any)
-  .addOptionalParam("constructorArgs", undefined, undefined, types.inputFile)
-  // TODO: [remove-verify-subtask] change to types.inputFile
-  .addOptionalParam("libraries", undefined, undefined, types.any)
-  .addOptionalParam("contract")
-  .setAction(
-    async ({
-      address,
-      constructorArgsParams,
-      constructorArgs: constructorArgsModule,
-      contract,
-      libraries: librariesModule,
-    }: VerifyTaskArgs): Promise<VerificationArgs> => {
-      if (address === undefined) {
-        throw new MissingAddressError();
-      }
-
-      const { isAddress } = await import("@ethersproject/address");
-      if (!isAddress(address)) {
-        throw new InvalidAddressError(address);
-      }
-
-      if (contract !== undefined && !isFullyQualifiedName(contract)) {
-        throw new InvalidContractNameError(contract);
-      }
-
-      const constructorArgs = await resolveConstructorArguments(
-        constructorArgsParams,
-        constructorArgsModule
-      );
-
-      // TODO: [remove-verify-subtask] librariesModule should always be string
-      let libraries;
-      if (typeof librariesModule === "object") {
-        libraries = librariesModule;
-      } else {
-        libraries = await resolveLibraries(librariesModule);
-      }
-
-      return {
-        address,
-        constructorArgs,
-        libraries,
-        contractFQN: contract,
-      };
-    }
-  );
-
-subtask(TASK_VERIFY_ETHERSCAN_GET_CONTRACT_INFORMATION)
-  .addParam("deployedBytecode", undefined, undefined, types.any)
-  .addParam("matchingCompilerVersions", undefined, undefined, types.any)
-  .addParam("libraries", undefined, undefined, types.any)
-  .addOptionalParam("contractFQN")
-  .setAction(
-    async (
-      {
-        contractFQN,
-        deployedBytecode,
-        matchingCompilerVersions,
-        libraries,
-      }: GetContractInformationArgs,
-      { network, artifacts }
-    ): Promise<ExtendedContractInformation> => {
-      let contractInformation: ContractInformation | null;
-
-      if (contractFQN !== undefined) {
-        let artifactExists;
-        try {
-          artifactExists = await artifacts.artifactExists(contractFQN);
-        } catch (error) {
-          artifactExists = false;
-        }
-
-        if (!artifactExists) {
-          throw new ContractNotFoundError(contractFQN);
-        }
-
-        const buildInfo = await artifacts.getBuildInfo(contractFQN);
-        if (buildInfo === undefined) {
-          throw new BuildInfoNotFoundError(contractFQN);
-        }
-
-        if (
-          !matchingCompilerVersions.includes(buildInfo.solcVersion) &&
-          !deployedBytecode.isOvm()
-        ) {
-          throw new BuildInfoCompilerVersionMismatchError(
-            contractFQN,
-            deployedBytecode.getVersion(),
-            deployedBytecode.hasVersionRange(),
-            buildInfo.solcVersion,
-            network.name
-          );
-        }
-
-        contractInformation = extractMatchingContractInformation(
-          contractFQN,
-          buildInfo,
-          deployedBytecode
-        );
-
-        if (contractInformation === null) {
-          throw new DeployedBytecodeMismatchError(network.name, contractFQN);
-        }
-      } else {
-        contractInformation = await extractInferredContractInformation(
-          artifacts,
-          network,
-          matchingCompilerVersions,
-          deployedBytecode
-        );
-      }
-
-      // map contractInformation libraries
-      const libraryInformation = await getLibraryInformation(
-        contractInformation,
-        libraries
-      );
-
-      return {
-        ...contractInformation,
-        ...libraryInformation,
-      };
-    }
-  );
-
-subtask(TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT)
-  .addParam("sourceName")
-  .setAction(async ({ sourceName }: GetMinimalInputArgs, { run }) => {
-    const cloneDeep = require("lodash.clonedeep") as typeof LodashCloneDeepT;
-    const dependencyGraph: DependencyGraph = await run(
-      TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
-      { sourceNames: [sourceName] }
-    );
-
-    const resolvedFiles = dependencyGraph
-      .getResolvedFiles()
-      .filter((resolvedFile) => resolvedFile.sourceName === sourceName);
-
-    if (resolvedFiles.length !== 1) {
-      throw new UnexpectedNumberOfFilesError();
-    }
-
-    const compilationJob: CompilationJob = await run(
-      TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE,
-      {
-        dependencyGraph,
-        file: resolvedFiles[0],
-      }
-    );
-
-    const minimalInput: CompilerInput = await run(
-      TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT,
-      {
-        compilationJob,
-      }
-    );
-
-    return cloneDeep(minimalInput);
-  });
-
-subtask(TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION)
-  .addParam("address")
-  .addParam("compilerInput", undefined, undefined, types.any)
-  .addParam("contractInformation", undefined, undefined, types.any)
-  .addParam("verificationInterface", undefined, undefined, types.any)
-  .addParam("encodedConstructorArguments")
-  .setAction(
-    async ({
-      address,
-      compilerInput,
-      contractInformation,
-      verificationInterface,
-      encodedConstructorArguments,
-    }: AttemptVerificationArgs): Promise<VerificationResponse> => {
-      // Ensure the linking information is present in the compiler input;
-      compilerInput.settings.libraries = contractInformation.libraries;
-
-      const { message: guid } = await verificationInterface.verify(
-        address,
-        JSON.stringify(compilerInput),
-        `${contractInformation.sourceName}:${contractInformation.contractName}`,
-        `v${contractInformation.solcLongVersion}`,
-        encodedConstructorArguments
-      );
-
-      console.log(`Successfully submitted source code for contract
-${contractInformation.sourceName}:${contractInformation.contractName} at ${address}
-for verification on the block explorer. Waiting for verification result...
-`);
-
-      // Compilation is bound to take some time so there's no sense in requesting status immediately.
-      await sleep(700);
-      const verificationStatus =
-        await verificationInterface.getVerificationStatus(guid);
-
-      if (!(verificationStatus.isFailure() || verificationStatus.isSuccess())) {
-        // Reaching this point shouldn't be possible unless the API is behaving in a new way.
-        throw new VerificationAPIUnexpectedMessageError(
-          verificationStatus.message
-        );
-      }
-
-      if (verificationStatus.isSuccess()) {
-        const contractURL = verificationInterface.getContractUrl(address);
-        console.log(`Successfully verified contract ${contractInformation.contractName} on the block explorer.
-${contractURL}`);
-      }
-
-      return {
-        success: verificationStatus.isSuccess(),
-        message: verificationStatus.message,
-      };
-    }
-  );
 
 /**
  * This subtask is used for backwards compatibility.
@@ -601,10 +176,3 @@ subtask(TASK_VERIFY_VERIFY)
       });
     }
   );
-
-subtask(
-  TASK_VERIFY_PRINT_SUPPORTED_NETWORKS,
-  "Prints the supported networks list"
-).setAction(async ({}, { config }) => {
-  await printSupportedNetworks(config.etherscan.customChains);
-});

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -147,7 +147,7 @@ subtask(
 /**
  * This subtask is used for backwards compatibility.
  * TODO [remove-verify-subtask]: if you're going to remove this subtask,
- * update TASK_VERIFY_ETHERSCAN and TASK_VERIFY_RESOLVE_ARGUMENTS accordingly
+ * update TASK_VERIFY_ETHERSCAN and TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS accordingly
  */
 subtask(TASK_VERIFY_VERIFY)
   .addOptionalParam("address")

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -24,6 +24,7 @@ import {
   TASK_VERIFY_ETHERSCAN,
   TASK_VERIFY_PRINT_SUPPORTED_NETWORKS,
   TASK_VERIFY_SOURCIFY,
+  TASK_VERIFY_SOURCIFY_DISABLED_WARNING,
 } from "./internal/task-names";
 import {
   etherscanConfigExtender,
@@ -180,9 +181,6 @@ task(TASK_VERIFY, "Verifies a contract on Etherscan")
     }
   });
 
-/**
- * Returns a list of verification subtasks.
- */
 subtask(
   TASK_VERIFY_GET_VERIFICATION_SUBTASKS,
   async (_, { config }): Promise<string[]> => {
@@ -195,20 +193,10 @@ subtask(
     if (config.sourcify.enabled) {
       verificationSubtasks.push(TASK_VERIFY_SOURCIFY);
     } else {
-      console.warn(
-        chalk.yellow(
-          `WARNING: Skipping Sourcify verification: Sourcify is disabled. To enable it, add this entry to your config:
-
-sourcify: {
-  enabled: true
-}
-
-Learn more at https://...`
-        )
-      );
+      verificationSubtasks.push(TASK_VERIFY_SOURCIFY_DISABLED_WARNING);
     }
 
-    if (verificationSubtasks.length === 0) {
+    if (!config.etherscan.enabled && !config.sourcify.enabled) {
       console.warn(
         chalk.yellow(
           `WARNING: No verification services are enabled. Please enable at least one verification service in your configuration.`
@@ -219,6 +207,20 @@ Learn more at https://...`
     return verificationSubtasks;
   }
 );
+
+subtask(TASK_VERIFY_SOURCIFY_DISABLED_WARNING, async (): Promise<void> => {
+  console.warn(
+    chalk.yellow(
+      `WARNING: Skipping Sourcify verification: Sourcify is disabled. To enable it, add this entry to your config:
+
+sourcify: {
+enabled: true
+}
+
+Learn more at https://...`
+    )
+  );
+});
 
 /**
  * Main Etherscan verification subtask.

--- a/packages/hardhat-verify/src/internal/config.ts
+++ b/packages/hardhat-verify/src/internal/config.ts
@@ -1,6 +1,6 @@
 import type LodashCloneDeepT from "lodash.clonedeep";
 import type { HardhatConfig, HardhatUserConfig } from "hardhat/types";
-import type { EtherscanConfig } from "../types";
+import type { EtherscanConfig, SourcifyConfig } from "../types";
 
 import chalk from "chalk";
 
@@ -8,27 +8,37 @@ export function etherscanConfigExtender(
   config: HardhatConfig,
   userConfig: Readonly<HardhatUserConfig>
 ): void {
-  const defaultConfig: EtherscanConfig = {
+  const defaultEtherscanConfig: EtherscanConfig = {
     apiKey: "",
     customChains: [],
+    enabled: true,
   };
+  const cloneDeep = require("lodash.clonedeep") as typeof LodashCloneDeepT;
+  const userEtherscanConfig = cloneDeep(userConfig.etherscan);
+  config.etherscan = { ...defaultEtherscanConfig, ...userEtherscanConfig };
 
-  if (userConfig.etherscan !== undefined) {
-    const cloneDeep = require("lodash.clonedeep") as typeof LodashCloneDeepT;
-    const customConfig = cloneDeep(userConfig.etherscan);
-
-    config.etherscan = { ...defaultConfig, ...customConfig };
-  } else {
-    config.etherscan = defaultConfig;
-
-    // check that there is no etherscan entry in the networks object, since
-    // this is a common mistake made by users
-    if (config.networks?.etherscan !== undefined) {
-      console.warn(
-        chalk.yellow(
-          "WARNING: you have an 'etherscan' entry in your networks configuration. This is likely a mistake. The etherscan configuration should be at the root of the configuration, not within the networks object."
-        )
-      );
-    }
+  // check that there is no etherscan entry in the networks object, since
+  // this is a common mistake made by users
+  if (
+    userConfig.etherscan === undefined &&
+    config.networks?.etherscan !== undefined
+  ) {
+    console.warn(
+      chalk.yellow(
+        "WARNING: you have an 'etherscan' entry in your networks configuration. This is likely a mistake. The etherscan configuration should be at the root of the configuration, not within the networks object."
+      )
+    );
   }
+}
+
+export function sourcifyConfigExtender(
+  config: HardhatConfig,
+  userConfig: Readonly<HardhatUserConfig>
+): void {
+  const defaultSourcifyConfig: SourcifyConfig = {
+    enabled: false,
+  };
+  const cloneDeep = require("lodash.clonedeep") as typeof LodashCloneDeepT;
+  const userSourcifyConfig = cloneDeep(userConfig.sourcify);
+  config.sourcify = { ...defaultSourcifyConfig, ...userSourcifyConfig };
 }

--- a/packages/hardhat-verify/src/internal/task-names.ts
+++ b/packages/hardhat-verify/src/internal/task-names.ts
@@ -1,13 +1,14 @@
 export const TASK_VERIFY = "verify";
 export const TASK_VERIFY_GET_VERIFICATION_SUBTASKS =
   "verify:get-verification-subtasks";
-export const TASK_VERIFY_RESOLVE_ARGUMENTS = "verify:resolve-arguments";
 export const TASK_VERIFY_VERIFY = "verify:verify";
 export const TASK_VERIFY_PRINT_SUPPORTED_NETWORKS =
   "verify:print-supported-networks";
 
 // Etherscan
 export const TASK_VERIFY_ETHERSCAN = "verify:etherscan";
+export const TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS =
+  "verify:etherscan-resolve-arguments";
 export const TASK_VERIFY_ETHERSCAN_GET_CONTRACT_INFORMATION =
   "verify:etherscan-get-contract-information";
 export const TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT =

--- a/packages/hardhat-verify/src/internal/task-names.ts
+++ b/packages/hardhat-verify/src/internal/task-names.ts
@@ -17,3 +17,5 @@ export const TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION =
 
 // Sourcify
 export const TASK_VERIFY_SOURCIFY = "verify:sourcify";
+export const TASK_VERIFY_SOURCIFY_DISABLED_WARNING =
+  "verify:sourcify-disabled-warning";

--- a/packages/hardhat-verify/src/internal/task-names.ts
+++ b/packages/hardhat-verify/src/internal/task-names.ts
@@ -3,6 +3,10 @@ export const TASK_VERIFY_GET_VERIFICATION_SUBTASKS =
   "verify:get-verification-subtasks";
 export const TASK_VERIFY_RESOLVE_ARGUMENTS = "verify:resolve-arguments";
 export const TASK_VERIFY_VERIFY = "verify:verify";
+export const TASK_VERIFY_PRINT_SUPPORTED_NETWORKS =
+  "verify:print-supported-networks";
+
+// Etherscan
 export const TASK_VERIFY_ETHERSCAN = "verify:etherscan";
 export const TASK_VERIFY_ETHERSCAN_GET_CONTRACT_INFORMATION =
   "verify:etherscan-get-contract-information";
@@ -10,5 +14,6 @@ export const TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT =
   "verify:etherscan-get-minimal-input";
 export const TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION =
   "verify:etherscan-attempt-verification";
-export const TASK_VERIFY_PRINT_SUPPORTED_NETWORKS =
-  "verify:print-supported-networks";
+
+// Sourcify
+export const TASK_VERIFY_SOURCIFY = "verify:sourcify";

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -41,7 +41,7 @@ import {
 import { Bytecode } from "../solc/bytecode";
 import {
   TASK_VERIFY_ETHERSCAN,
-  TASK_VERIFY_RESOLVE_ARGUMENTS,
+  TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS,
   TASK_VERIFY_ETHERSCAN_GET_CONTRACT_INFORMATION,
   TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT,
   TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION,
@@ -106,7 +106,10 @@ subtask(TASK_VERIFY_ETHERSCAN)
       constructorArgs,
       libraries,
       contractFQN,
-    }: VerificationArgs = await run(TASK_VERIFY_RESOLVE_ARGUMENTS, taskArgs);
+    }: VerificationArgs = await run(
+      TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS,
+      taskArgs
+    );
 
     const chainConfig = await Etherscan.getCurrentChainConfig(
       network.name,
@@ -215,7 +218,7 @@ This means that unrelated contracts may be displayed on Etherscan...
     );
   });
 
-subtask(TASK_VERIFY_RESOLVE_ARGUMENTS)
+subtask(TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS)
   .addOptionalParam("address")
   .addOptionalParam("constructorArgsParams", undefined, [], types.any)
   .addOptionalParam("constructorArgs", undefined, undefined, types.inputFile)

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -426,7 +426,7 @@ for verification on the block explorer. Waiting for verification result...
       if (verificationStatus.isSuccess()) {
         const contractURL = verificationInterface.getContractUrl(address);
         console.log(`Successfully verified contract ${contractInformation.contractName} on the block explorer.
-${contractURL}`);
+${contractURL}\n`);
       }
 
       return {

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -1,0 +1,434 @@
+import type LodashCloneDeepT from "lodash.clonedeep";
+import type {
+  CompilerInput,
+  DependencyGraph,
+  CompilationJob,
+} from "hardhat/types";
+import type { VerifyTaskArgs } from "../..";
+import type {
+  LibraryToAddress,
+  ExtendedContractInformation,
+  ContractInformation,
+} from "../solc/artifacts";
+
+import { subtask, types } from "hardhat/config";
+import {
+  TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
+  TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE,
+  TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT,
+} from "hardhat/builtin-tasks/task-names";
+import { isFullyQualifiedName } from "hardhat/utils/contract-names";
+
+import {
+  CompilerVersionsMismatchError,
+  ContractVerificationFailedError,
+  MissingAddressError,
+  InvalidAddressError,
+  InvalidContractNameError,
+  ContractNotFoundError,
+  BuildInfoNotFoundError,
+  BuildInfoCompilerVersionMismatchError,
+  DeployedBytecodeMismatchError,
+  UnexpectedNumberOfFilesError,
+  VerificationAPIUnexpectedMessageError,
+} from "../errors";
+import { Etherscan } from "../etherscan";
+import {
+  extractMatchingContractInformation,
+  extractInferredContractInformation,
+  getLibraryInformation,
+} from "../solc/artifacts";
+import { Bytecode } from "../solc/bytecode";
+import {
+  TASK_VERIFY_ETHERSCAN,
+  TASK_VERIFY_RESOLVE_ARGUMENTS,
+  TASK_VERIFY_ETHERSCAN_GET_CONTRACT_INFORMATION,
+  TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT,
+  TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION,
+} from "../task-names";
+import {
+  getCompilerVersions,
+  encodeArguments,
+  resolveConstructorArguments,
+  resolveLibraries,
+  sleep,
+} from "../utilities";
+
+// parsed verification args
+interface VerificationArgs {
+  address: string;
+  constructorArgs: string[];
+  libraries: LibraryToAddress;
+  contractFQN?: string;
+}
+
+interface GetContractInformationArgs {
+  contractFQN?: string;
+  deployedBytecode: Bytecode;
+  matchingCompilerVersions: string[];
+  libraries: LibraryToAddress;
+}
+
+interface GetMinimalInputArgs {
+  sourceName: string;
+}
+
+interface AttemptVerificationArgs {
+  address: string;
+  compilerInput: CompilerInput;
+  contractInformation: ExtendedContractInformation;
+  verificationInterface: Etherscan;
+  encodedConstructorArguments: string;
+}
+
+interface VerificationResponse {
+  success: boolean;
+  message: string;
+}
+
+/**
+ * Main Etherscan verification subtask.
+ *
+ * Verifies a contract in Etherscan by coordinating various subtasks related
+ * to contract verification.
+ */
+subtask(TASK_VERIFY_ETHERSCAN)
+  .addParam("address")
+  .addOptionalParam("constructorArgsParams", undefined, undefined, types.any)
+  .addOptionalParam("constructorArgs")
+  // TODO: [remove-verify-subtask] change to types.inputFile
+  .addOptionalParam("libraries", undefined, undefined, types.any)
+  .addOptionalParam("contract")
+  .addFlag("listNetworks")
+  .setAction(async (taskArgs: VerifyTaskArgs, { config, network, run }) => {
+    const {
+      address,
+      constructorArgs,
+      libraries,
+      contractFQN,
+    }: VerificationArgs = await run(TASK_VERIFY_RESOLVE_ARGUMENTS, taskArgs);
+
+    const chainConfig = await Etherscan.getCurrentChainConfig(
+      network.name,
+      network.provider,
+      config.etherscan.customChains
+    );
+
+    const etherscan = Etherscan.fromChainConfig(
+      config.etherscan.apiKey,
+      chainConfig
+    );
+
+    const isVerified = await etherscan.isVerified(address);
+    if (isVerified) {
+      const contractURL = etherscan.getContractUrl(address);
+      console.log(`The contract ${address} has already been verified.
+${contractURL}`);
+      return;
+    }
+
+    const configCompilerVersions = await getCompilerVersions(config.solidity);
+
+    const deployedBytecode = await Bytecode.getDeployedContractBytecode(
+      address,
+      network.provider,
+      network.name
+    );
+
+    const matchingCompilerVersions = await deployedBytecode.getMatchingVersions(
+      configCompilerVersions
+    );
+    // don't error if the bytecode appears to be OVM bytecode, because we can't infer a specific OVM solc version from the bytecode
+    if (matchingCompilerVersions.length === 0 && !deployedBytecode.isOvm()) {
+      throw new CompilerVersionsMismatchError(
+        configCompilerVersions,
+        deployedBytecode.getVersion(),
+        network.name
+      );
+    }
+
+    const contractInformation: ExtendedContractInformation = await run(
+      TASK_VERIFY_ETHERSCAN_GET_CONTRACT_INFORMATION,
+      {
+        contractFQN,
+        deployedBytecode,
+        matchingCompilerVersions,
+        libraries,
+      }
+    );
+
+    const minimalInput: CompilerInput = await run(
+      TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT,
+      {
+        sourceName: contractInformation.sourceName,
+      }
+    );
+
+    const encodedConstructorArguments = await encodeArguments(
+      contractInformation.contractOutput.abi,
+      contractInformation.sourceName,
+      contractInformation.contractName,
+      constructorArgs
+    );
+
+    // First, try to verify the contract using the minimal input
+    const { success: minimalInputVerificationSuccess }: VerificationResponse =
+      await run(TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION, {
+        address,
+        compilerInput: minimalInput,
+        contractInformation,
+        verificationInterface: etherscan,
+        encodedConstructorArguments,
+      });
+
+    if (minimalInputVerificationSuccess) {
+      return;
+    }
+
+    console.log(`We tried verifying your contract ${contractInformation.contractName} without including any unrelated one, but it failed.
+Trying again with the full solc input used to compile and deploy it.
+This means that unrelated contracts may be displayed on Etherscan...
+`);
+
+    // If verifying with the minimal input failed, try again with the full compiler input
+    const {
+      success: fullCompilerInputVerificationSuccess,
+      message: verificationMessage,
+    }: VerificationResponse = await run(
+      TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION,
+      {
+        address,
+        compilerInput: contractInformation.compilerInput,
+        contractInformation,
+        verificationInterface: etherscan,
+        encodedConstructorArguments,
+      }
+    );
+
+    if (fullCompilerInputVerificationSuccess) {
+      return;
+    }
+
+    throw new ContractVerificationFailedError(
+      verificationMessage,
+      contractInformation.undetectableLibraries
+    );
+  });
+
+subtask(TASK_VERIFY_RESOLVE_ARGUMENTS)
+  .addOptionalParam("address")
+  .addOptionalParam("constructorArgsParams", undefined, [], types.any)
+  .addOptionalParam("constructorArgs", undefined, undefined, types.inputFile)
+  // TODO: [remove-verify-subtask] change to types.inputFile
+  .addOptionalParam("libraries", undefined, undefined, types.any)
+  .addOptionalParam("contract")
+  .setAction(
+    async ({
+      address,
+      constructorArgsParams,
+      constructorArgs: constructorArgsModule,
+      contract,
+      libraries: librariesModule,
+    }: VerifyTaskArgs): Promise<VerificationArgs> => {
+      if (address === undefined) {
+        throw new MissingAddressError();
+      }
+
+      const { isAddress } = await import("@ethersproject/address");
+      if (!isAddress(address)) {
+        throw new InvalidAddressError(address);
+      }
+
+      if (contract !== undefined && !isFullyQualifiedName(contract)) {
+        throw new InvalidContractNameError(contract);
+      }
+
+      const constructorArgs = await resolveConstructorArguments(
+        constructorArgsParams,
+        constructorArgsModule
+      );
+
+      // TODO: [remove-verify-subtask] librariesModule should always be string
+      let libraries;
+      if (typeof librariesModule === "object") {
+        libraries = librariesModule;
+      } else {
+        libraries = await resolveLibraries(librariesModule);
+      }
+
+      return {
+        address,
+        constructorArgs,
+        libraries,
+        contractFQN: contract,
+      };
+    }
+  );
+
+subtask(TASK_VERIFY_ETHERSCAN_GET_CONTRACT_INFORMATION)
+  .addParam("deployedBytecode", undefined, undefined, types.any)
+  .addParam("matchingCompilerVersions", undefined, undefined, types.any)
+  .addParam("libraries", undefined, undefined, types.any)
+  .addOptionalParam("contractFQN")
+  .setAction(
+    async (
+      {
+        contractFQN,
+        deployedBytecode,
+        matchingCompilerVersions,
+        libraries,
+      }: GetContractInformationArgs,
+      { network, artifacts }
+    ): Promise<ExtendedContractInformation> => {
+      let contractInformation: ContractInformation | null;
+
+      if (contractFQN !== undefined) {
+        let artifactExists;
+        try {
+          artifactExists = await artifacts.artifactExists(contractFQN);
+        } catch (error) {
+          artifactExists = false;
+        }
+
+        if (!artifactExists) {
+          throw new ContractNotFoundError(contractFQN);
+        }
+
+        const buildInfo = await artifacts.getBuildInfo(contractFQN);
+        if (buildInfo === undefined) {
+          throw new BuildInfoNotFoundError(contractFQN);
+        }
+
+        if (
+          !matchingCompilerVersions.includes(buildInfo.solcVersion) &&
+          !deployedBytecode.isOvm()
+        ) {
+          throw new BuildInfoCompilerVersionMismatchError(
+            contractFQN,
+            deployedBytecode.getVersion(),
+            deployedBytecode.hasVersionRange(),
+            buildInfo.solcVersion,
+            network.name
+          );
+        }
+
+        contractInformation = extractMatchingContractInformation(
+          contractFQN,
+          buildInfo,
+          deployedBytecode
+        );
+
+        if (contractInformation === null) {
+          throw new DeployedBytecodeMismatchError(network.name, contractFQN);
+        }
+      } else {
+        contractInformation = await extractInferredContractInformation(
+          artifacts,
+          network,
+          matchingCompilerVersions,
+          deployedBytecode
+        );
+      }
+
+      // map contractInformation libraries
+      const libraryInformation = await getLibraryInformation(
+        contractInformation,
+        libraries
+      );
+
+      return {
+        ...contractInformation,
+        ...libraryInformation,
+      };
+    }
+  );
+
+subtask(TASK_VERIFY_ETHERSCAN_GET_MINIMAL_INPUT)
+  .addParam("sourceName")
+  .setAction(async ({ sourceName }: GetMinimalInputArgs, { run }) => {
+    const cloneDeep = require("lodash.clonedeep") as typeof LodashCloneDeepT;
+    const dependencyGraph: DependencyGraph = await run(
+      TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
+      { sourceNames: [sourceName] }
+    );
+
+    const resolvedFiles = dependencyGraph
+      .getResolvedFiles()
+      .filter((resolvedFile) => resolvedFile.sourceName === sourceName);
+
+    if (resolvedFiles.length !== 1) {
+      throw new UnexpectedNumberOfFilesError();
+    }
+
+    const compilationJob: CompilationJob = await run(
+      TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOB_FOR_FILE,
+      {
+        dependencyGraph,
+        file: resolvedFiles[0],
+      }
+    );
+
+    const minimalInput: CompilerInput = await run(
+      TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT,
+      {
+        compilationJob,
+      }
+    );
+
+    return cloneDeep(minimalInput);
+  });
+
+subtask(TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION)
+  .addParam("address")
+  .addParam("compilerInput", undefined, undefined, types.any)
+  .addParam("contractInformation", undefined, undefined, types.any)
+  .addParam("verificationInterface", undefined, undefined, types.any)
+  .addParam("encodedConstructorArguments")
+  .setAction(
+    async ({
+      address,
+      compilerInput,
+      contractInformation,
+      verificationInterface,
+      encodedConstructorArguments,
+    }: AttemptVerificationArgs): Promise<VerificationResponse> => {
+      // Ensure the linking information is present in the compiler input;
+      compilerInput.settings.libraries = contractInformation.libraries;
+
+      const { message: guid } = await verificationInterface.verify(
+        address,
+        JSON.stringify(compilerInput),
+        `${contractInformation.sourceName}:${contractInformation.contractName}`,
+        `v${contractInformation.solcLongVersion}`,
+        encodedConstructorArguments
+      );
+
+      console.log(`Successfully submitted source code for contract
+${contractInformation.sourceName}:${contractInformation.contractName} at ${address}
+for verification on the block explorer. Waiting for verification result...
+`);
+
+      // Compilation is bound to take some time so there's no sense in requesting status immediately.
+      await sleep(700);
+      const verificationStatus =
+        await verificationInterface.getVerificationStatus(guid);
+
+      if (!(verificationStatus.isFailure() || verificationStatus.isSuccess())) {
+        // Reaching this point shouldn't be possible unless the API is behaving in a new way.
+        throw new VerificationAPIUnexpectedMessageError(
+          verificationStatus.message
+        );
+      }
+
+      if (verificationStatus.isSuccess()) {
+        const contractURL = verificationInterface.getContractUrl(address);
+        console.log(`Successfully verified contract ${contractInformation.contractName} on the block explorer.
+${contractURL}`);
+      }
+
+      return {
+        success: verificationStatus.isSuccess(),
+        message: verificationStatus.message,
+      };
+    }
+  );

--- a/packages/hardhat-verify/src/internal/tasks/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/tasks/sourcify.ts
@@ -1,7 +1,20 @@
 import chalk from "chalk";
 import { subtask } from "hardhat/config";
 
-import { TASK_VERIFY_SOURCIFY_DISABLED_WARNING } from "../task-names";
+import {
+  TASK_VERIFY_SOURCIFY,
+  TASK_VERIFY_SOURCIFY_DISABLED_WARNING,
+} from "../task-names";
+
+/**
+ * Main Sourcify verification subtask.
+ *
+ * Verifies a contract in Sourcify by coordinating various subtasks related
+ * to contract verification.
+ */
+subtask(TASK_VERIFY_SOURCIFY, async () => {
+  // code here
+});
 
 subtask(TASK_VERIFY_SOURCIFY_DISABLED_WARNING, async () => {
   console.warn(

--- a/packages/hardhat-verify/src/internal/tasks/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/tasks/sourcify.ts
@@ -1,0 +1,18 @@
+import chalk from "chalk";
+import { subtask } from "hardhat/config";
+
+import { TASK_VERIFY_SOURCIFY_DISABLED_WARNING } from "../task-names";
+
+subtask(TASK_VERIFY_SOURCIFY_DISABLED_WARNING, async () => {
+  console.warn(
+    chalk.yellow(
+      `WARNING: Skipping Sourcify verification: Sourcify is disabled. To enable it, add this entry to your config:
+
+sourcify: {
+enabled: true
+}
+
+Learn more at https://...`
+    )
+  );
+});

--- a/packages/hardhat-verify/src/internal/type-extensions.ts
+++ b/packages/hardhat-verify/src/internal/type-extensions.ts
@@ -1,13 +1,15 @@
-import type { EtherscanConfig } from "../types";
+import type { EtherscanConfig, SourcifyConfig } from "../types";
 
 import "hardhat/types/config";
 
 declare module "hardhat/types/config" {
   interface HardhatUserConfig {
     etherscan?: Partial<EtherscanConfig>;
+    sourcify?: Partial<SourcifyConfig>;
   }
 
   interface HardhatConfig {
     etherscan: EtherscanConfig;
+    sourcify: SourcifyConfig;
   }
 }

--- a/packages/hardhat-verify/src/internal/utilities.ts
+++ b/packages/hardhat-verify/src/internal/utilities.ts
@@ -11,6 +11,7 @@ import {
   ABIArgumentTypeError,
   EtherscanVersionNotSupportedError,
   ExclusiveConstructorArgumentsError,
+  HardhatVerifyError,
   ImportingModuleError,
   InvalidConstructorArgumentsModuleError,
   InvalidLibrariesModuleError,
@@ -75,6 +76,49 @@ ${customNetworksTable}
 To learn how to add custom networks, follow these instructions: https://hardhat.org/verify-custom-networks
 `.trimStart()
   );
+}
+
+/**
+ * Prints verification errors to the console.
+ * @param errors - An object containing verification errors, where the keys
+ * are the names of verification subtasks and the values are HardhatVerifyError
+ * objects describing the specific errors.
+ * @remarks This function formats and logs the verification errors to the
+ * console with a red color using chalk. Each error is displayed along with the
+ * name of the verification provider it belongs to.
+ * @example
+ * const errors: Record<string, HardhatVerifyError> = {
+ *   verify:etherscan: { message: 'Error message for Etherscan' },
+ *   verify:sourcify: { message: 'Error message for Sourcify' },
+ *   // Add more errors here...
+ * };
+ * printVerificationErrors(errors);
+ * // Output:
+ * // hardhat-verify found one or more errors during the verification process:
+ * //
+ * // Etherscan:
+ * // Error message for Etherscan
+ * //
+ * // Sourcify:
+ * // Error message for Sourcify
+ * //
+ * // ... (more errors if present)
+ */
+export function printVerificationErrors(
+  errors: Record<string, HardhatVerifyError>
+) {
+  let errorMessage =
+    "hardhat-verify found one or more errors during the verification process:\n\n";
+
+  for (const verificationSubtask of Object.keys(errors)) {
+    const error = errors[verificationSubtask];
+    const verificationProvider = verificationSubtask
+      .split(":")[1]
+      .replace(/^\w/, (c) => c.toUpperCase());
+    errorMessage += `${verificationProvider}:\n${error.message}\n\n`;
+  }
+
+  console.error(chalk.red(errorMessage));
 }
 
 /**

--- a/packages/hardhat-verify/src/types.ts
+++ b/packages/hardhat-verify/src/types.ts
@@ -10,6 +10,11 @@ export interface ChainConfig {
 export interface EtherscanConfig {
   apiKey: ApiKey;
   customChains: ChainConfig[];
+  enabled: boolean;
+}
+
+export interface SourcifyConfig {
+  enabled: boolean;
 }
 
 export type ApiKey = string | Record<string, string>;

--- a/packages/hardhat-verify/test/helpers.ts
+++ b/packages/hardhat-verify/test/helpers.ts
@@ -2,6 +2,7 @@ import type {} from "@nomicfoundation/hardhat-ethers";
 import type { FactoryOptions, HardhatRuntimeEnvironment } from "hardhat/types";
 
 import path from "path";
+import debug from "debug";
 import { resetHardhatContext } from "hardhat/plugins-testing";
 
 declare module "mocha" {
@@ -9,6 +10,8 @@ declare module "mocha" {
     hre: HardhatRuntimeEnvironment;
   }
 }
+
+const log = debug("hardhat:hardhat-verify:tests");
 
 export const useEnvironment = (fixtureProjectName: string): void => {
   before("Loading hardhat environment", function () {
@@ -36,7 +39,7 @@ export const deployContract = async (
   const contract = await factory.deploy(...constructorArguments);
   await contract.deploymentTransaction()?.wait(confirmations);
   const contractAddress = await contract.getAddress();
-  console.log(`Deployed ${contractName} at ${contractAddress}`);
+  log(`Deployed ${contractName} at ${contractAddress}`);
   return contractAddress;
 };
 

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import sinon from "sinon";
+import sinon, { SinonStub } from "sinon";
 import { assert, expect } from "chai";
 import { TASK_CLEAN, TASK_COMPILE } from "hardhat/builtin-tasks/task-names";
 import { SolcConfig } from "hardhat/types/config";
@@ -18,6 +18,17 @@ import "../../src/internal/type-extensions";
 describe("verify task integration tests", () => {
   useEnvironment("hardhat-project");
   mockEnvironment();
+
+  // suppress warnings
+  let warnStub: SinonStub;
+  before(() => {
+    warnStub = sinon.stub(console, "warn");
+  });
+
+  // suppress warnings
+  after(() => {
+    warnStub.restore();
+  });
 
   it("should return after printing the supported networks", async function () {
     const logStub = sinon.stub(console, "log");
@@ -38,6 +49,7 @@ describe("verify task integration tests", () => {
     // cleanup the etherscan config since we have hardhat defined as custom chain
     const originalConfig = this.hre.config.etherscan;
     this.hre.config.etherscan = {
+      enabled: true,
       apiKey: "",
       customChains: [],
     };

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -4,7 +4,11 @@ import sinon, { SinonStub } from "sinon";
 import { assert, expect } from "chai";
 import { TASK_CLEAN, TASK_COMPILE } from "hardhat/builtin-tasks/task-names";
 import { SolcConfig } from "hardhat/types/config";
-import { TASK_VERIFY, TASK_VERIFY_VERIFY } from "../../src/internal/task-names";
+import {
+  TASK_VERIFY,
+  TASK_VERIFY_ETHERSCAN,
+  TASK_VERIFY_VERIFY,
+} from "../../src/internal/task-names";
 import { deployContract, getRandomAddress, useEnvironment } from "../helpers";
 import {
   interceptGetStatus,
@@ -55,7 +59,7 @@ describe("verify task integration tests", () => {
     };
 
     await expect(
-      this.hre.run(TASK_VERIFY, {
+      this.hre.run(TASK_VERIFY_ETHERSCAN, {
         address,
         constructorArgsParams: [],
       })
@@ -75,7 +79,7 @@ describe("verify task integration tests", () => {
       const logStub = sinon.stub(console, "log");
       const address = getRandomAddress(this.hre);
 
-      const taskResponse = await this.hre.run(TASK_VERIFY, {
+      const taskResponse = await this.hre.run(TASK_VERIFY_ETHERSCAN, {
         address,
         constructorArgsParams: [],
       });
@@ -144,7 +148,7 @@ https://hardhat.etherscan.io/address/${address}#code`
       const address = getRandomAddress(this.hre);
 
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address,
           constructorArgsParams: [],
         })
@@ -163,7 +167,7 @@ https://hardhat.etherscan.io/address/${address}#code`
         ];
 
         await expect(
-          this.hre.run(TASK_VERIFY, {
+          this.hre.run(TASK_VERIFY_ETHERSCAN, {
             address: simpleContractAddress,
             constructorArgsParams: [],
           })
@@ -183,7 +187,7 @@ https://hardhat.etherscan.io/address/${address}#code`
 
         // task will fail since we deleted all the artifacts
         await expect(
-          this.hre.run(TASK_VERIFY, {
+          this.hre.run(TASK_VERIFY_ETHERSCAN, {
             address: simpleContractAddress,
             constructorArgsParams: [],
           })
@@ -201,7 +205,7 @@ https://hardhat.etherscan.io/address/${address}#code`
 
     it("should throw if the deployed bytecode matches more than one contract", async function () {
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: duplicatedContractAddress,
           constructorArgsParams: [],
         })
@@ -214,7 +218,7 @@ https://hardhat.etherscan.io/address/${address}#code`
       const contractFQN = "contracts/SimpleContract.sol:NotFound";
 
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
           contract: contractFQN,
@@ -228,7 +232,7 @@ https://hardhat.etherscan.io/address/${address}#code`
 
     it("should throw if there is an invalid address in the libraries parameter", async function () {
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
           libraries: "invalid-libraries.js",
@@ -240,7 +244,7 @@ https://hardhat.etherscan.io/address/${address}#code`
 
     it("should throw if the specified library is not used by the contract", async function () {
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: bothLibsContractAddress,
           constructorArgsParams: [],
           libraries: "not-used-libraries.js",
@@ -252,7 +256,7 @@ https://hardhat.etherscan.io/address/${address}#code`
 
     it("should throw if the specified library is listed more than once in the libraries parameter", async function () {
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: onlyNormalLibContractAddress,
           constructorArgsParams: [],
           libraries: "duplicated-libraries.js",
@@ -264,7 +268,7 @@ https://hardhat.etherscan.io/address/${address}#code`
 
     it("should throw if deployed library address does not match the address defined in the libraries parameter", async function () {
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: onlyNormalLibContractAddress,
           constructorArgsParams: [],
           libraries: "mismatched-address-libraries.js",
@@ -278,7 +282,7 @@ https://hardhat.etherscan.io/address/${address}#code`
 
     it("should throw if there are undetectable libraries not specified by the libraries parameter", async function () {
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: bothLibsContractAddress,
           constructorArgsParams: [],
           libraries: "missing-undetectable-libraries.js",
@@ -293,7 +297,7 @@ This can occur if the library is only called in the contract constructor. The mi
     it("should throw if the verification request fails", async function () {
       // do not intercept the verifysourcecode request so it throws an error
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
         })
@@ -306,7 +310,7 @@ This can occur if the library is only called in the contract constructor. The mi
       interceptVerify({ error: "error verifying contract" }, 500);
 
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
         })
@@ -322,7 +326,7 @@ The HTTP server response is not ok. Status code: 500 Response text: {"error":"er
       });
 
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
         })
@@ -340,7 +344,7 @@ The HTTP server response is not ok. Status code: 500 Response text: {"error":"er
       });
 
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
         })
@@ -356,7 +360,7 @@ The HTTP server response is not ok. Status code: 500 Response text: {"error":"er
       const logStub = sinon.stub(console, "log");
 
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
         })
@@ -379,7 +383,7 @@ for verification on the block explorer. Waiting for verification result...
       const logStub = sinon.stub(console, "log");
 
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
         })
@@ -407,7 +411,7 @@ for verification on the block explorer. Waiting for verification result...
       const logStub = sinon.stub(console, "log");
 
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
         })
@@ -435,7 +439,7 @@ for verification on the block explorer. Waiting for verification result...
       const logStub = sinon.stub(console, "log");
 
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
         })
@@ -552,7 +556,7 @@ https://hardhat.etherscan.io/address/${simpleContractAddress}#code`);
       const logStub = sinon.stub(console, "log");
 
       await expect(
-        this.hre.run(TASK_VERIFY, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: bothLibsContractAddress,
           constructorArgsParams: ["50"],
           libraries: "libraries.js",

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -479,7 +479,7 @@ for verification on the block explorer. Waiting for verification result...
 `);
       expect(logStub.getCall(1)).to.be
         .calledWith(`Successfully verified contract SimpleContract on the block explorer.
-https://hardhat.etherscan.io/address/${simpleContractAddress}#code`);
+https://hardhat.etherscan.io/address/${simpleContractAddress}#code\n`);
       logStub.restore();
       assert.isUndefined(taskResponse);
     });
@@ -529,7 +529,7 @@ for verification on the block explorer. Waiting for verification result...
 `);
       expect(logStub.getCall(3)).to.be
         .calledWith(`Successfully verified contract SimpleContract on the block explorer.
-https://hardhat.etherscan.io/address/${simpleContractAddress}#code`);
+https://hardhat.etherscan.io/address/${simpleContractAddress}#code\n`);
       logStub.restore();
       assert.equal(verifyCallCount, 2);
       assert.equal(getStatusCallCount, 2);
@@ -612,7 +612,7 @@ for verification on the block explorer. Waiting for verification result...
 `);
       expect(logStub.getCall(1)).to.be
         .calledWith(`Successfully verified contract BothLibs on the block explorer.
-https://hardhat.etherscan.io/address/${bothLibsContractAddress}#code`);
+https://hardhat.etherscan.io/address/${bothLibsContractAddress}#code\n`);
       logStub.restore();
       assert.isUndefined(taskResponse);
     });

--- a/packages/hardhat-verify/test/unit/config.ts
+++ b/packages/hardhat-verify/test/unit/config.ts
@@ -1,16 +1,37 @@
 import type { HardhatConfig, HardhatUserConfig } from "hardhat/types";
-import type { EtherscanConfig } from "../../src/types";
+import type { EtherscanConfig, SourcifyConfig } from "../../src/types";
 
 import sinon from "sinon";
 import { assert, expect } from "chai";
 
-import { etherscanConfigExtender } from "../../src/internal/config";
+import {
+  etherscanConfigExtender,
+  sourcifyConfigExtender,
+} from "../../src/internal/config";
 
-describe("Chain Config", () => {
-  it("should extend the hardhat config with the user config", async () => {
-    const hardhatConfig = {} as HardhatConfig;
-    const userConfig: HardhatUserConfig = {
-      etherscan: {
+describe("Extend config", () => {
+  describe("Etherscan config extender", () => {
+    it("should extend the hardhat config with the user config", async () => {
+      const hardhatConfig = {} as HardhatConfig;
+      const userConfig: HardhatUserConfig = {
+        etherscan: {
+          apiKey: {
+            goerli: "<goerli-api-key>",
+          },
+          customChains: [
+            {
+              network: "goerli",
+              chainId: 5,
+              urls: {
+                apiURL: "https://api-goerli.etherscan.io/api",
+                browserURL: "https://goerli.etherscan.io",
+              },
+            },
+          ],
+        },
+      };
+      const expected: EtherscanConfig = {
+        enabled: true,
         apiKey: {
           goerli: "<goerli-api-key>",
         },
@@ -24,49 +45,58 @@ describe("Chain Config", () => {
             },
           },
         ],
-      },
-    };
-    const expected: EtherscanConfig = {
-      enabled: true,
-      apiKey: {
-        goerli: "<goerli-api-key>",
-      },
-      customChains: [
-        {
-          network: "goerli",
-          chainId: 5,
-          urls: {
-            apiURL: "https://api-goerli.etherscan.io/api",
-            browserURL: "https://goerli.etherscan.io",
-          },
-        },
-      ],
-    };
-    etherscanConfigExtender(hardhatConfig, userConfig);
+      };
+      etherscanConfigExtender(hardhatConfig, userConfig);
 
-    assert.deepEqual(hardhatConfig.etherscan, expected);
-  });
+      assert.deepEqual(hardhatConfig.etherscan, expected);
+    });
 
-  it("should override the hardhat config with the user config", async () => {
-    const hardhatConfig = {} as HardhatConfig;
-    hardhatConfig.etherscan = {
-      enabled: true,
-      apiKey: {
-        goerli: "<goerli-api-key>",
-      },
-      customChains: [
-        {
-          network: "goerli",
-          chainId: 5,
-          urls: {
-            apiURL: "https://api-goerli.etherscan.io/api",
-            browserURL: "https://goerli.etherscan.io",
-          },
+    it("should override the hardhat config with the user config", async () => {
+      const hardhatConfig = {} as HardhatConfig;
+      hardhatConfig.etherscan = {
+        enabled: true,
+        apiKey: {
+          goerli: "<goerli-api-key>",
         },
-      ],
-    };
-    const userConfig: HardhatUserConfig = {
-      etherscan: {
+        customChains: [
+          {
+            network: "goerli",
+            chainId: 5,
+            urls: {
+              apiURL: "https://api-goerli.etherscan.io/api",
+              browserURL: "https://goerli.etherscan.io",
+            },
+          },
+        ],
+      };
+      const userConfig: HardhatUserConfig = {
+        etherscan: {
+          apiKey: {
+            mainnet: "<mainnet-api-key>",
+            sepolia: "<sepolia-api-key>",
+          },
+          customChains: [
+            {
+              network: "mainnet",
+              chainId: 1,
+              urls: {
+                apiURL: "https://api.etherscan.io/api",
+                browserURL: "https://etherscan.io",
+              },
+            },
+            {
+              network: "sepolia",
+              chainId: 11155111,
+              urls: {
+                apiURL: "https://api-sepolia.etherscan.io/api",
+                browserURL: "https://sepolia.etherscan.io",
+              },
+            },
+          ],
+        },
+      };
+      const expected: EtherscanConfig = {
+        enabled: true,
         apiKey: {
           mainnet: "<mainnet-api-key>",
           sepolia: "<sepolia-api-key>",
@@ -89,71 +119,59 @@ describe("Chain Config", () => {
             },
           },
         ],
-      },
-    };
-    const expected: EtherscanConfig = {
-      enabled: true,
-      apiKey: {
-        mainnet: "<mainnet-api-key>",
-        sepolia: "<sepolia-api-key>",
-      },
-      customChains: [
-        {
-          network: "mainnet",
-          chainId: 1,
-          urls: {
-            apiURL: "https://api.etherscan.io/api",
-            browserURL: "https://etherscan.io",
-          },
-        },
-        {
-          network: "sepolia",
-          chainId: 11155111,
-          urls: {
-            apiURL: "https://api-sepolia.etherscan.io/api",
-            browserURL: "https://sepolia.etherscan.io",
-          },
-        },
-      ],
-    };
-    etherscanConfigExtender(hardhatConfig, userConfig);
+      };
+      etherscanConfigExtender(hardhatConfig, userConfig);
 
-    assert.deepEqual(hardhatConfig.etherscan, expected);
+      assert.deepEqual(hardhatConfig.etherscan, expected);
+    });
+
+    it("should set default values when user config is not provided", async () => {
+      const hardhatConfig = {} as HardhatConfig;
+      const userConfig: HardhatUserConfig = {};
+      const expected: EtherscanConfig = {
+        enabled: true,
+        apiKey: "",
+        customChains: [],
+      };
+      etherscanConfigExtender(hardhatConfig, userConfig);
+
+      assert.deepEqual(hardhatConfig.etherscan, expected);
+    });
+
+    it("should display a warning message if there is an etherscan entry in the networks object", async () => {
+      const warnStub = sinon.stub(console, "warn");
+      const hardhatConfig = {
+        networks: {
+          etherscan: {
+            apiKey: {
+              goerli: "<goerli-api-key>",
+            },
+          },
+        },
+      };
+      const userConfig: HardhatUserConfig = {};
+
+      // @ts-expect-error
+      etherscanConfigExtender(hardhatConfig, userConfig);
+      expect(warnStub).to.be.calledOnceWith(
+        sinon.match(
+          /WARNING: you have an 'etherscan' entry in your networks configuration./
+        )
+      );
+      warnStub.restore();
+    });
   });
 
-  it("should set default values when user config is not provided", async () => {
-    const hardhatConfig = {} as HardhatConfig;
-    const userConfig: HardhatUserConfig = {};
-    const expected: EtherscanConfig = {
-      enabled: true,
-      apiKey: "",
-      customChains: [],
-    };
-    etherscanConfigExtender(hardhatConfig, userConfig);
+  describe("Sourcify config extender", () => {
+    it("should set default values when user config is not provided", async () => {
+      const hardhatConfig = {} as HardhatConfig;
+      const userConfig: HardhatUserConfig = {};
+      const expected: SourcifyConfig = {
+        enabled: false,
+      };
+      sourcifyConfigExtender(hardhatConfig, userConfig);
 
-    assert.deepEqual(hardhatConfig.etherscan, expected);
-  });
-
-  it("should display a warning message if there is an etherscan entry in the networks object", async () => {
-    const warnStub = sinon.stub(console, "warn");
-    const hardhatConfig = {
-      networks: {
-        etherscan: {
-          apiKey: {
-            goerli: "<goerli-api-key>",
-          },
-        },
-      },
-    };
-    const userConfig: HardhatUserConfig = {};
-
-    // @ts-expect-error
-    etherscanConfigExtender(hardhatConfig, userConfig);
-    expect(warnStub).to.be.calledOnceWith(
-      sinon.match(
-        /WARNING: you have an 'etherscan' entry in your networks configuration./
-      )
-    );
-    warnStub.restore();
+      assert.deepEqual(hardhatConfig.sourcify, expected);
+    });
   });
 });

--- a/packages/hardhat-verify/test/unit/config.ts
+++ b/packages/hardhat-verify/test/unit/config.ts
@@ -27,6 +27,7 @@ describe("Chain Config", () => {
       },
     };
     const expected: EtherscanConfig = {
+      enabled: true,
       apiKey: {
         goerli: "<goerli-api-key>",
       },
@@ -49,6 +50,7 @@ describe("Chain Config", () => {
   it("should override the hardhat config with the user config", async () => {
     const hardhatConfig = {} as HardhatConfig;
     hardhatConfig.etherscan = {
+      enabled: true,
       apiKey: {
         goerli: "<goerli-api-key>",
       },
@@ -90,6 +92,7 @@ describe("Chain Config", () => {
       },
     };
     const expected: EtherscanConfig = {
+      enabled: true,
       apiKey: {
         mainnet: "<mainnet-api-key>",
         sepolia: "<sepolia-api-key>",
@@ -122,6 +125,7 @@ describe("Chain Config", () => {
     const hardhatConfig = {} as HardhatConfig;
     const userConfig: HardhatUserConfig = {};
     const expected: EtherscanConfig = {
+      enabled: true,
       apiKey: "",
       customChains: [],
     };

--- a/packages/hardhat-verify/test/unit/index.ts
+++ b/packages/hardhat-verify/test/unit/index.ts
@@ -187,24 +187,6 @@ describe("verify task", () => {
       );
     });
 
-    it("should ignore the sourcify subtask if it is disabled", async function () {
-      const originalConfig = this.hre.config.sourcify;
-      this.hre.config.sourcify = {
-        enabled: false,
-      };
-
-      const verificationSubtasks: string[] = await this.hre.run(
-        TASK_VERIFY_GET_VERIFICATION_SUBTASKS
-      );
-
-      this.hre.config.sourcify = originalConfig;
-
-      assert.isFalse(verificationSubtasks.includes(TASK_VERIFY_SOURCIFY));
-      assert.isTrue(
-        verificationSubtasks.includes(TASK_VERIFY_SOURCIFY_DISABLED_WARNING)
-      );
-    });
-
     it("should provide a warning message if both etherscan and sourcify are disabled", async function () {
       const originalEtherscanConfig = this.hre.config.etherscan;
       this.hre.config.etherscan = {

--- a/packages/hardhat-verify/test/unit/index.ts
+++ b/packages/hardhat-verify/test/unit/index.ts
@@ -6,6 +6,7 @@ import {
   TASK_VERIFY_GET_VERIFICATION_SUBTASKS,
   TASK_VERIFY_RESOLVE_ARGUMENTS,
   TASK_VERIFY_SOURCIFY,
+  TASK_VERIFY_SOURCIFY_DISABLED_WARNING,
   TASK_VERIFY_VERIFY,
 } from "../../src/internal/task-names";
 import { getRandomAddress, useEnvironment } from "../helpers";
@@ -160,10 +161,8 @@ describe("verify task", () => {
       );
 
       assert.isFalse(verificationSubtasks.includes(TASK_VERIFY_SOURCIFY));
-      expect(warnStub).to.be.calledOnceWith(
-        sinon.match(
-          /WARNING: Skipping Sourcify verification: Sourcify is disabled./
-        )
+      assert.isTrue(
+        verificationSubtasks.includes(TASK_VERIFY_SOURCIFY_DISABLED_WARNING)
       );
     });
 
@@ -180,6 +179,9 @@ describe("verify task", () => {
       this.hre.config.sourcify = originalConfig;
 
       assert.isTrue(verificationSubtasks.includes(TASK_VERIFY_SOURCIFY));
+      assert.isFalse(
+        verificationSubtasks.includes(TASK_VERIFY_SOURCIFY_DISABLED_WARNING)
+      );
     });
 
     it("should ignore the sourcify subtask if it is disabled", async function () {
@@ -195,10 +197,8 @@ describe("verify task", () => {
       this.hre.config.sourcify = originalConfig;
 
       assert.isFalse(verificationSubtasks.includes(TASK_VERIFY_SOURCIFY));
-      expect(warnStub).to.be.calledOnceWith(
-        sinon.match(
-          /WARNING: Skipping Sourcify verification: Sourcify is disabled./
-        )
+      assert.isTrue(
+        verificationSubtasks.includes(TASK_VERIFY_SOURCIFY_DISABLED_WARNING)
       );
     });
 
@@ -214,19 +214,14 @@ describe("verify task", () => {
         enabled: false,
       };
 
-      const verificationSubtasks: string[] = await this.hre.run(
-        TASK_VERIFY_GET_VERIFICATION_SUBTASKS
-      );
+      await this.hre.run(TASK_VERIFY_GET_VERIFICATION_SUBTASKS);
 
       this.hre.config.etherscan = originalEtherscanConfig;
       this.hre.config.sourcify = originalSourcifyConfig;
 
-      assert.equal(verificationSubtasks.length, 0);
-      assert.isTrue(warnStub.calledTwice);
+      assert.isTrue(warnStub.calledOnce);
       expect(warnStub).to.be.calledWith(
-        sinon.match(
-          /WARNING: Skipping Sourcify verification: Sourcify is disabled./
-        )
+        sinon.match(/WARNING: No verification services are enabled./)
       );
     });
   });

--- a/packages/hardhat-verify/test/unit/index.ts
+++ b/packages/hardhat-verify/test/unit/index.ts
@@ -4,7 +4,7 @@ import sinon, { SinonStub } from "sinon";
 import {
   TASK_VERIFY_ETHERSCAN,
   TASK_VERIFY_GET_VERIFICATION_SUBTASKS,
-  TASK_VERIFY_RESOLVE_ARGUMENTS,
+  TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS,
   TASK_VERIFY_SOURCIFY,
   TASK_VERIFY_SOURCIFY_DISABLED_WARNING,
   TASK_VERIFY_VERIFY,
@@ -14,10 +14,10 @@ import { getRandomAddress, useEnvironment } from "../helpers";
 describe("verify task", () => {
   useEnvironment("hardhat-project");
 
-  describe(TASK_VERIFY_RESOLVE_ARGUMENTS, () => {
+  describe(TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS, () => {
     it("should throw if address is not provided", async function () {
       await expect(
-        this.hre.run(TASK_VERIFY_RESOLVE_ARGUMENTS, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS, {
           constructorArgsParams: [],
           constructorArgs: "constructor-args.js",
           libraries: "libraries.js",
@@ -27,7 +27,7 @@ describe("verify task", () => {
 
     it("should throw if address is invalid", async function () {
       await expect(
-        this.hre.run(TASK_VERIFY_RESOLVE_ARGUMENTS, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS, {
           address: "invalidAddress",
           constructorArgsParams: [],
           constructorArgs: "constructor-args.js",
@@ -38,7 +38,7 @@ describe("verify task", () => {
 
     it("should throw if contract is not a fully qualified name", async function () {
       await expect(
-        this.hre.run(TASK_VERIFY_RESOLVE_ARGUMENTS, {
+        this.hre.run(TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS, {
           address: getRandomAddress(this.hre),
           constructorArgsParams: [],
           constructorArgs: "constructor-args.js",
@@ -67,13 +67,16 @@ describe("verify task", () => {
         },
         contractFQN: "contracts/TestContract.sol:TestContract",
       };
-      const processedArgs = await this.hre.run(TASK_VERIFY_RESOLVE_ARGUMENTS, {
-        address,
-        constructorArgsParams: [],
-        constructorArgs: "constructor-args.js",
-        libraries: "libraries.js",
-        contract: "contracts/TestContract.sol:TestContract",
-      });
+      const processedArgs = await this.hre.run(
+        TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS,
+        {
+          address,
+          constructorArgsParams: [],
+          constructorArgs: "constructor-args.js",
+          libraries: "libraries.js",
+          contract: "contracts/TestContract.sol:TestContract",
+        }
+      );
 
       assert.deepEqual(processedArgs, expectedArgs);
     });

--- a/packages/hardhat-verify/test/unit/index.ts
+++ b/packages/hardhat-verify/test/unit/index.ts
@@ -79,36 +79,6 @@ describe("verify task", () => {
   });
 
   describe(TASK_VERIFY_VERIFY, () => {
-    it("should throw if address is not provided", async function () {
-      await expect(
-        this.hre.run(TASK_VERIFY_VERIFY, {
-          constructorArguments: [],
-          libraries: {},
-        })
-      ).to.be.rejectedWith(/You didn’t provide any address./);
-    });
-
-    it("should throw if address is invalid", async function () {
-      await expect(
-        this.hre.run(TASK_VERIFY_VERIFY, {
-          address: "invalidAddress",
-          constructorArguments: [],
-          libraries: {},
-        })
-      ).to.be.rejectedWith(/invalidAddress is an invalid address./);
-    });
-
-    it("should throw if contract is not a fully qualified name", async function () {
-      await expect(
-        this.hre.run(TASK_VERIFY_VERIFY, {
-          address: getRandomAddress(this.hre),
-          constructorArguments: [],
-          libraries: {},
-          contract: "not-a-fully-qualified-name",
-        })
-      ).to.be.rejectedWith(/A valid fully qualified name was expected./);
-    });
-
     it("should throw if constructorArguments is not an array", async function () {
       await expect(
         this.hre.run(TASK_VERIFY_VERIFY, {
@@ -138,8 +108,6 @@ describe("verify task", () => {
     beforeEach(() => {
       warnStub = sinon.stub(console, "warn");
     });
-
-    // suppress warnings
     afterEach(() => {
       warnStub.restore();
     });

--- a/packages/hardhat-verify/test/unit/utilities.ts
+++ b/packages/hardhat-verify/test/unit/utilities.ts
@@ -1,17 +1,85 @@
 import type { JsonFragment } from "@ethersproject/abi";
 import type { SolidityConfig } from "hardhat/types";
+import type { ChainConfig } from "../../src/types";
 
 import path from "path";
 import { assert, expect } from "chai";
+import sinon from "sinon";
+import chalk from "chalk";
 
 import {
   encodeArguments,
   getCompilerVersions,
+  printSupportedNetworks,
+  printVerificationErrors,
   resolveConstructorArguments,
   resolveLibraries,
 } from "../../src/internal/utilities";
+import { HardhatVerifyError } from "../../src/internal/errors";
+import { builtinChains } from "../../src/internal/chain-config";
 
 describe("Utilities", () => {
+  describe("printSupportedNetworks", () => {
+    it("should print supported and custom networks", async () => {
+      const customChains: ChainConfig[] = [
+        {
+          network: "MyNetwork",
+          chainId: 1337,
+          urls: {
+            apiURL: "https://api.mynetwork.io/api",
+            browserURL: "https://mynetwork.io",
+          },
+        },
+      ];
+
+      const logStub = sinon.stub(console, "log");
+
+      await printSupportedNetworks(customChains);
+
+      sinon.restore();
+
+      assert.isTrue(logStub.calledOnce);
+      const actualTableOutput = logStub.getCall(0).args[0];
+      const allChains = [...builtinChains, ...customChains];
+      allChains.forEach(({ network, chainId }) => {
+        const regex = new RegExp(`║\\s*${network}\\s*│\\s*${chainId}\\s*║`);
+        assert.isTrue(regex.test(actualTableOutput));
+      });
+    });
+  });
+
+  describe("printVerificationErrors", () => {
+    it("should print verification errors", () => {
+      const errors: Record<string, HardhatVerifyError> = {
+        "verify:etherscan": new HardhatVerifyError("Etherscan error message"),
+        "verify:sourcify": new HardhatVerifyError("Sourcify error message"),
+      };
+
+      const errorStub = sinon.stub(console, "error");
+
+      printVerificationErrors(errors);
+
+      sinon.restore();
+
+      assert.isTrue(errorStub.calledOnce);
+      const errorMessage = errorStub.getCall(0).args[0];
+      assert.equal(
+        errorMessage,
+        chalk.red(
+          `hardhat-verify found one or more errors during the verification process:
+
+Etherscan:
+Etherscan error message
+
+Sourcify:
+Sourcify error message
+
+`
+        )
+      );
+    });
+  });
+
   describe("resolveConstructorArguments", () => {
     it("should return the constructorArgsParams if constructorArgsModule is not defined", async () => {
       const constructorArgsParams = ["1", "arg2", "false"];


### PR DESCRIPTION
 - Added the ability to deactivate the verification providers through the `enabled` field in the plugin's configuration.
 - Display errors at the end of the verification process and return with a non-zero exit code, allowing multiple verification providers to be executed without blocking each other.
 - Display a warning when the Sourcify configuration is missing.