### PR TITLE
Make flatten task smarter: improve warning messages and add check for null metadata

### DIFF
--- a/.changeset/chilly-llamas-sniff.md
+++ b/.changeset/chilly-llamas-sniff.md
@@ -1,5 +1,0 @@
----
-"hardhat": patch
----
-
-Improved the formatting for warning messages and added a check to avoid errors when the flattened file metadata are null.

--- a/.changeset/chilly-llamas-sniff.md
+++ b/.changeset/chilly-llamas-sniff.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Improved the formatting for warning messages and added a check to avoid errors when the flattened file metadata are null.

--- a/packages/hardhat-core/src/builtin-tasks/flatten.ts
+++ b/packages/hardhat-core/src/builtin-tasks/flatten.ts
@@ -304,17 +304,17 @@ task(
     types.inputFile
   )
   .setAction(async ({ files }: { files: string[] | undefined }, { run }) => {
-    const [flattenedFile, metadata]: [string, FlattenMetadata] = await run(
-      TASK_FLATTEN_GET_FLATTENED_SOURCE_AND_METADATA,
-      { files }
-    );
+    const [flattenedFile, metadata]: [string, FlattenMetadata | null] =
+      await run(TASK_FLATTEN_GET_FLATTENED_SOURCE_AND_METADATA, { files });
 
     console.log(flattenedFile);
+
+    if (metadata === null) return;
 
     if (metadata.filesWithoutLicenses.length > 0) {
       console.warn(
         chalk.yellow(
-          `The following file(s) do NOT specify SPDX licenses: ${metadata.filesWithoutLicenses.join(
+          `\nThe following file(s) do NOT specify SPDX licenses: ${metadata.filesWithoutLicenses.join(
             ", "
           )}`
         )
@@ -327,7 +327,7 @@ task(
     ) {
       console.warn(
         chalk.yellow(
-          `Pragma abicoder directives are defined in some files, but they are not defined in the following ones: ${metadata.filesWithoutPragmaDirectives.join(
+          `\nPragma abicoder directives are defined in some files, but they are not defined in the following ones: ${metadata.filesWithoutPragmaDirectives.join(
             ", "
           )}`
         )
@@ -337,7 +337,7 @@ task(
     if (metadata.filesWithDifferentPragmaDirectives.length > 0) {
       console.warn(
         chalk.yellow(
-          `The flattened file is using the pragma abicoder directive '${
+          `\nThe flattened file is using the pragma abicoder directive '${
             metadata.pragmaDirective
           }' but these files have a different pragma abicoder directive: ${metadata.filesWithDifferentPragmaDirectives.join(
             ", "

--- a/packages/hardhat-core/test/builtin-tasks/flatten.ts
+++ b/packages/hardhat-core/test/builtin-tasks/flatten.ts
@@ -382,7 +382,7 @@ describe("Flatten task", () => {
       assert(
         spyFunctionConsoleWarn.calledWith(
           chalk.yellow(
-            `The following file(s) do NOT specify SPDX licenses: contracts/A.sol, contracts/B.sol, contracts/C.sol`
+            `\nThe following file(s) do NOT specify SPDX licenses: contracts/A.sol, contracts/B.sol, contracts/C.sol`
           )
         )
       );
@@ -390,7 +390,7 @@ describe("Flatten task", () => {
       assert(
         spyFunctionConsoleWarn.calledWith(
           chalk.yellow(
-            `Pragma abicoder directives are defined in some files, but they are not defined in the following ones: contracts/A.sol, contracts/B.sol`
+            `\nPragma abicoder directives are defined in some files, but they are not defined in the following ones: contracts/A.sol, contracts/B.sol`
           )
         )
       );
@@ -398,7 +398,7 @@ describe("Flatten task", () => {
       assert(
         spyFunctionConsoleWarn.calledWith(
           chalk.yellow(
-            `The flattened file is using the pragma abicoder directive 'pragma abicoder v2' but these files have a different pragma abicoder directive: contracts/C.sol`
+            `\nThe flattened file is using the pragma abicoder directive 'pragma abicoder v2' but these files have a different pragma abicoder directive: contracts/C.sol`
           )
         )
       );
@@ -410,6 +410,14 @@ describe("Flatten task", () => {
       });
 
       assert(!spyFunctionConsoleWarn.called);
+    });
+
+    describe("No contracts to flatten", () => {
+      useFixtureProject("flatten-task/no-contracts");
+
+      it("should not throw an error when metadata is null", async function () {
+        await this.env.run(TASK_FLATTEN);
+      });
     });
   });
 });

--- a/packages/hardhat-core/test/fixture-projects/flatten-task/no-contracts/hardhat.config.js
+++ b/packages/hardhat-core/test/fixture-projects/flatten-task/no-contracts/hardhat.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  solidity: "0.5.15",
+};


### PR DESCRIPTION
[Link to main issue](https://github.com/NomicFoundation/hardhat/issues/1499).

- Improve the formatting for warning messages
- Add a check to avoid errors when the flattened file metadata are null