### PR TITLE
Add a devcontainer setup for Hardhat and EDR

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "Hardhat + EDR",
+  "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "16" /* Keep in sync with the oldest version of Node.js that Hardhat supports */
+    },
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "1.70" /* Keep in sync with rust-toolchain */,
+      "profile": "default"
+    }
+  },
+  /* libudev-dev is required by hardhat-ledger. pkg-config is required by EDR to use OpenSSL */
+  "postCreateCommand": "sudo apt update && sudo apt install -y libudev-dev pkg-config"
+}


### PR DESCRIPTION
This PR adds a devcontainer that can be used to develop both Hardhat and EDR out of the box.

I used a base debian image and used [devcontainer features](https://github.com/devcontainers/features) to setup Node and Rust's development environments.

This devcontainer also installs a few native dependencies that are required to be able to build both projects.

As it's a single commit, it should be easy to cherry-pick these changes in `rethnet/main`, @Wodann.