### PR TITLE
Fix escaped double quote in vyper docs

### DIFF
--- a/.changeset/little-pianos-suffer.md
+++ b/.changeset/little-pianos-suffer.md
@@ -1,5 +1,0 @@
----
-"@nomiclabs/hardhat-vyper": patch
----
-
-Fixed escaped double quote in vyper docs.

--- a/.changeset/little-pianos-suffer.md
+++ b/.changeset/little-pianos-suffer.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-vyper": patch
+---
+
+Fixed escaped double quote in vyper docs.

--- a/packages/hardhat-vyper/README.md
+++ b/packages/hardhat-vyper/README.md
@@ -78,7 +78,7 @@ Brownie allows you to use the test directive `#@ if mode == "test":` to specify 
 
 Example:
 
-```vy
+```py
 #@ if mode == "test":
 @external
 def _mint_for_testing(_to: address, _token_id: uint256):


### PR DESCRIPTION
Change the ```vy into ```py in the vyper docs.
With ```vy the " character is escaped into &quot;

Error:
<img width="240" alt="image" src="https://github.com/NomicFoundation/hardhat/assets/18092467/70a86194-3331-40f7-a859-1b9cd6f13313">

Expected:
<img width="239" alt="image" src="https://github.com/NomicFoundation/hardhat/assets/18092467/86772c40-23e3-42fe-9a86-f364e8e19701">

