### PR TITLE
feat: make EDR remote node cache directory configurable

### DIFF
--- a/crates/rethnet/src/config.rs
+++ b/crates/rethnet/src/config.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::{str::FromStr, time::SystemTime};
 
 use anyhow::anyhow;
@@ -41,6 +42,8 @@ pub const DEFAULT_PRIVATE_KEYS: [&str; 20] = [
     "df57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e",
 ];
 
+pub const DEFAULT_CACHE_DIR: &str = "./edr-cache";
+
 /// struct representing the deserialized conifguration file, eg hardhat.config.json
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
@@ -61,6 +64,7 @@ pub struct ConfigFile {
     pub initial_date: Option<SystemTime>,
     #[serde(deserialize_with = "u64_number")]
     pub network_id: Number,
+    pub cache_dir: PathBuf,
 }
 
 impl ConfigFile {
@@ -97,6 +101,7 @@ impl ConfigFile {
             initial_base_fee_per_gas: Some(self.initial_base_fee_per_gas.into()),
             initial_date: self.initial_date,
             network_id: cli_args.network_id.unwrap_or(self.network_id.try_into()?),
+            cache_dir: cli_args.cache_dir.unwrap_or(self.cache_dir),
         })
     }
 }
@@ -128,6 +133,7 @@ impl Default for ConfigFile {
             initial_base_fee_per_gas: Number::U256(U256::from(1000000000)),
             initial_date: None,
             network_id: chain_id,
+            cache_dir: DEFAULT_CACHE_DIR.into(),
         }
     }
 }

--- a/crates/rethnet/src/lib.rs
+++ b/crates/rethnet/src/lib.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
 use clap::{Args, Parser, Subcommand};
@@ -51,6 +51,8 @@ pub struct NodeArgs {
     coinbase: Option<Address>,
     #[clap(long)]
     network_id: Option<u64>,
+    #[clap(long)]
+    cache_dir: Option<PathBuf>,
     #[clap(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
 }

--- a/crates/rethnet_eth/Cargo.toml
+++ b/crates/rethnet_eth/Cargo.toml
@@ -26,6 +26,7 @@ triehash = { version = "0.8.4", default-features = false }
 
 [dev-dependencies]
 mockito = { version = "1.0.2", default-features = false }
+tempfile = { version = "3.7.1" }
 tokio = { version = "1.23.0", features = ["macros"] }
 rethnet_test_utils = { version = "0.1.0-dev", path = "../rethnet_test_utils" }
 

--- a/crates/rethnet_evm/src/blockchain/forked.rs
+++ b/crates/rethnet_evm/src/blockchain/forked.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use hashbrown::HashMap;
@@ -58,11 +59,12 @@ impl ForkedBlockchain {
         runtime: Arc<Runtime>,
         spec_id: SpecId,
         remote_url: &str,
+        cache_dir: PathBuf,
         fork_block_number: Option<U256>,
     ) -> Result<Self, CreationError> {
         const FALLBACK_MAX_REORG: u64 = 30;
 
-        let rpc_client = RpcClient::new(remote_url);
+        let rpc_client = RpcClient::new(remote_url, cache_dir);
 
         let (chain_id, network_id, latest_block_number) = tokio::join!(
             rpc_client.chain_id(),

--- a/crates/rethnet_evm/src/state/fork.rs
+++ b/crates/rethnet_evm/src/state/fork.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use hashbrown::{HashMap, HashSet};
@@ -43,12 +44,13 @@ impl ForkState {
         runtime: Arc<Runtime>,
         hash_generator: Arc<Mutex<RandomHashGenerator>>,
         url: &str,
+        cache_dir: PathBuf,
         fork_block_number: U256,
         mut accounts: HashMap<Address, AccountInfo>,
     ) -> Self {
-        let rpc_client = RpcClient::new(url);
+        let rpc_client = RpcClient::new(url, cache_dir.clone());
 
-        let remote_state = RemoteState::new(runtime.clone(), url, fork_block_number);
+        let remote_state = RemoteState::new(runtime.clone(), url, cache_dir, fork_block_number);
 
         accounts.iter_mut().for_each(|(address, mut account_info)| {
             let nonce = runtime

--- a/crates/rethnet_evm/src/state/remote.rs
+++ b/crates/rethnet_evm/src/state/remote.rs
@@ -1,5 +1,6 @@
 mod cached;
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use revm::{
@@ -28,9 +29,9 @@ pub struct RemoteState {
 impl RemoteState {
     /// Construct a new instance using the URL of a remote Ethereum node and a
     /// block number from which data will be pulled.
-    pub fn new(runtime: Arc<Runtime>, url: &str, block_number: U256) -> Self {
+    pub fn new(runtime: Arc<Runtime>, url: &str, cache_dir: PathBuf, block_number: U256) -> Self {
         Self {
-            client: RpcClient::new(url),
+            client: RpcClient::new(url, cache_dir),
             runtime,
             block_number,
         }

--- a/crates/rethnet_evm_napi/Cargo.toml
+++ b/crates/rethnet_evm_napi/Cargo.toml
@@ -11,6 +11,7 @@ crossbeam-channel = { version = "0.5.6", default-features = false }
 # when napi is pinned, be sure to pin napi-derive to the same version
 napi = { version = "2.12.4", default-features = false, features = ["async", "error_anyhow", "napi8", "serde-json"] }
 napi-derive = "2.12.3"
+rethnet = { version = "0.1.0-dev", path = "../rethnet" }
 rethnet_evm = { version = "0.1.0-dev", path = "../rethnet_evm" }
 rethnet_eth = { version = "0.1.0-dev", path = "../rethnet_eth" }
 secp256k1 = { version = "0.24.0", default-features = false, features = ["alloc"] }

--- a/crates/rethnet_evm_napi/src/state.rs
+++ b/crates/rethnet_evm_napi/src/state.rs
@@ -1,6 +1,7 @@
 use std::{
     mem,
     ops::Deref,
+    path::PathBuf,
     sync::{
         mpsc::{channel, Sender},
         Arc,
@@ -13,6 +14,7 @@ use napi::{
     Env, JsFunction, JsObject, JsString, NapiRaw, Status,
 };
 use napi_derive::napi;
+use rethnet::config::DEFAULT_CACHE_DIR;
 use rethnet_eth::{signature::private_key_to_address, Address, Bytes, B256, U256};
 use rethnet_evm::{
     state::{AccountModifierFn, ForkState, HybridState, StateError, StateHistory, SyncState},
@@ -156,8 +158,10 @@ impl StateManager {
         remote_node_url: JsString,
         fork_block_number: BigInt,
         accounts: Vec<GenesisAccount>,
+        cache_dir: Option<String>,
     ) -> napi::Result<Self> {
         let fork_block_number: U256 = BigInt::try_cast(fork_block_number)?;
+        let cache_dir: PathBuf = cache_dir.unwrap_or_else(|| DEFAULT_CACHE_DIR.into()).into();
 
         let accounts = genesis_accounts(accounts)?;
         Self::with_state(
@@ -167,6 +171,7 @@ impl StateManager {
                 context.runtime().clone(),
                 context.state_root_generator.clone(),
                 remote_node_url.into_utf8()?.as_str()?,
+                cache_dir,
                 fork_block_number,
                 accounts,
             ),

--- a/crates/rethnet_rpc_server/Cargo.toml
+++ b/crates/rethnet_rpc_server/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { version = "0.1.37", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 rethnet_test_utils = { version = "0.1.0-dev", path = "../rethnet_test_utils" }
+tempfile = { version = "3.7.1" }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["fmt"] }
 
 [build-dependencies]

--- a/crates/rethnet_rpc_server/src/config.rs
+++ b/crates/rethnet_rpc_server/src/config.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::time::SystemTime;
 
 use secp256k1::SecretKey;
@@ -20,6 +21,7 @@ pub struct Config {
     pub initial_base_fee_per_gas: Option<U256>,
     pub initial_date: Option<SystemTime>,
     pub network_id: u64,
+    pub cache_dir: PathBuf,
 }
 
 /// configuration input for a single account

--- a/crates/rethnet_rpc_server/src/lib.rs
+++ b/crates/rethnet_rpc_server/src/lib.rs
@@ -982,6 +982,7 @@ impl Server {
         let chain_id = config.chain_id;
         let next_block_timestamp = RwLock::new(U256::ZERO);
         let spec_id = config.hardfork;
+        let cache_dir = config.cache_dir;
 
         let (rethnet_state, blockchain, fork_block_number): (
             RethnetStateType,
@@ -1002,6 +1003,7 @@ impl Server {
                 Arc::clone(&runtime),
                 spec_id,
                 &config.json_rpc_url,
+                cache_dir.clone(),
                 config.block_number.map(U256::from),
             )
             .await?;
@@ -1014,6 +1016,7 @@ impl Server {
                 Arc::clone(&runtime),
                 Arc::new(parking_lot::Mutex::new(hash_generator)),
                 &config.json_rpc_url,
+                cache_dir,
                 fork_block_number,
                 genesis_accounts,
             )));

--- a/crates/rethnet_rpc_server/tests/integration_tests.rs
+++ b/crates/rethnet_rpc_server/tests/integration_tests.rs
@@ -4,6 +4,7 @@ use std::time::SystemTime;
 
 use hashbrown::HashMap;
 use secp256k1::{Secp256k1, SecretKey};
+use tempfile::TempDir;
 use tracing::Level;
 
 use rethnet_eth::{
@@ -27,7 +28,14 @@ use rethnet_rpc_server::{
 
 const PRIVATE_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
-async fn start_server() -> SocketAddr {
+struct TestFixture {
+    server_address: SocketAddr,
+    // We need to keep the tempdir alive for the duration of the test
+    #[allow(dead_code)]
+    cache_dir: TempDir,
+}
+
+async fn start_server() -> TestFixture {
     let mut accounts: HashMap<Address, AccountInfo> = HashMap::default();
     accounts.insert(
         Address::from_low_u64_ne(1),
@@ -38,6 +46,8 @@ async fn start_server() -> SocketAddr {
             nonce: 0,
         },
     );
+
+    let cache_dir = TempDir::new().expect("should create temp dir");
 
     let server = Server::new(Config {
         address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
@@ -56,13 +66,18 @@ async fn start_server() -> SocketAddr {
         initial_base_fee_per_gas: Some(U256::from(1000000000)),
         initial_date: Some(SystemTime::now()),
         network_id: 123,
+        cache_dir: cache_dir.path().to_path_buf(),
     })
     .await
     .unwrap();
 
     let address = server.local_addr();
     tokio::spawn(async move { server.serve().await.unwrap() });
-    address
+
+    TestFixture {
+        server_address: address,
+        cache_dir,
+    }
 }
 
 async fn submit_request(address: &SocketAddr, request: &RpcRequest<MethodInvocation>) -> String {
@@ -86,7 +101,7 @@ async fn submit_request(address: &SocketAddr, request: &RpcRequest<MethodInvocat
 }
 
 async fn verify_response<ResponseT>(
-    server: &SocketAddr,
+    fixture: &TestFixture,
     method: MethodInvocation,
     response: ResponseT,
 ) where
@@ -104,7 +119,7 @@ async fn verify_response<ResponseT>(
         data: jsonrpc::ResponseData::Success { result: response },
     };
 
-    let unparsed_response = submit_request(server, &request).await;
+    let unparsed_response = submit_request(&fixture.server_address, &request).await;
 
     let actual_response: jsonrpc::Response<ResponseT> =
         serde_json::from_str(&unparsed_response).expect("should deserialize from JSON");


### PR DESCRIPTION
This PR makes the remote node cache directory configurable in EDR (resolves https://github.com/NomicFoundation/rethnet/issues/82). 

I'm not sure about the server configuration approach and how the configuration option is exposed to Node, but figured it's easier to discuss it in a PR, so here it is. Happy to readjust!