### PR TITLE
Elongated memory data for debug_traceTransaction

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-debug-tracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-debug-tracer.ts
@@ -319,11 +319,13 @@ export class VMDebugTracer {
   }
 
   private _getMemory(step: InterpreterStep): string[] {
-    const memory = Buffer.from(step.memory)
-      .toString("hex")
-      .match(/.{1,64}/g);
+    const rawMemory =
+      Buffer.from(step.memory)
+        .toString("hex")
+        .match(/.{1,64}/g) ?? [];
 
-    return memory === null ? [] : memory.slice(0, Number(step.memoryWordCount)); // Remove the additional non allocated memory
+    // Remove the additional non allocated memory
+    return rawMemory.slice(0, Number(step.memoryWordCount));
   }
 
   private _getStack(step: InterpreterStep): string[] {

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-debug-tracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-debug-tracer.ts
@@ -323,9 +323,7 @@ export class VMDebugTracer {
       .toString("hex")
       .match(/.{1,64}/g);
 
-    return memory === null
-      ? []
-      : memory?.slice(0, Number(step.memoryWordCount)); // Remove the additional non allocated memory
+    return memory === null ? [] : memory.slice(0, Number(step.memoryWordCount)); // Remove the additional non allocated memory
   }
 
   private _getStack(step: InterpreterStep): string[] {

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-debug-tracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-debug-tracer.ts
@@ -283,7 +283,11 @@ export class VMDebugTracer {
         // the increase in memory size of a revert is immediately
         // reflected, so we don't treat it as a memory expansion
         // of the previous step
-        if (structLog.op !== "REVERT") {
+        if (
+          structLog.op !== "REVERT" &&
+          (previousStructLog.op === "MSTORE" ||
+            previousStructLog.op === "MLOAD")
+        ) {
           const memoryLengthDifference =
             structLog.memory.length - previousStructLog.memory.length;
           for (let k = 0; k < memoryLengthDifference; k++) {
@@ -319,9 +323,9 @@ export class VMDebugTracer {
       .toString("hex")
       .match(/.{1,64}/g);
 
-    const result = memory === null ? [] : [...memory];
-
-    return result;
+    return memory === null
+      ? []
+      : memory?.slice(0, Number(step.memoryWordCount)); // Remove the additional non allocated memory
   }
 
   private _getStack(step: InterpreterStep): string[] {

--- a/packages/hardhat-core/test/fixture-debug-traces/elongatedMemoryRegressionTestTrace.ts
+++ b/packages/hardhat-core/test/fixture-debug-traces/elongatedMemoryRegressionTestTrace.ts
@@ -1,0 +1,58 @@
+import { RpcDebugTraceOutput } from "../../src/internal/hardhat-network/provider/output";
+
+export const trace: RpcDebugTraceOutput = {
+  gas: 21012,
+  failed: false,
+  returnValue: "",
+  structLogs: [
+    {
+      pc: 0,
+      op: "PUSH0",
+      gas: 5979000,
+      gasCost: 2,
+      depth: 1,
+      stack: [],
+      memory: [],
+      storage: {},
+    },
+    {
+      pc: 1,
+      op: "PUSH0",
+      gas: 5978998,
+      gasCost: 2,
+      depth: 1,
+      stack: [
+        "0000000000000000000000000000000000000000000000000000000000000000",
+      ],
+      memory: [],
+      storage: {},
+    },
+    {
+      pc: 2,
+      op: "MSTORE",
+      gas: 5978996,
+      gasCost: 6,
+      depth: 1,
+      stack: [
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+      ],
+      memory: [
+        "0000000000000000000000000000000000000000000000000000000000000000",
+      ],
+      storage: {},
+    },
+    {
+      pc: 3,
+      op: "PUSH0",
+      gas: 5978990,
+      gasCost: 2,
+      depth: 1,
+      stack: [],
+      memory: [
+        "0000000000000000000000000000000000000000000000000000000000000000",
+      ],
+      storage: {},
+    },
+  ],
+};

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -172,7 +172,7 @@ describe("Debug module", function () {
         });
 
         // Regression test, see issue: https://github.com/NomicFoundation/hardhat/issues/3858
-        it("The memory property should not have additional zeros", async function () {
+        it("The memory property should not have additional superfluous zeros", async function () {
           // push0 push0 mstore push0
           const bytecode = "0x5F5F525F";
           const address = "0x1234567890123456789012345678901234567890";

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -123,7 +123,7 @@ describe("Debug module", function () {
           });
         });
 
-        it.skip("Should return the right values for successful contract tx", async function () {
+        it("Should return the right values for successful contract tx", async function () {
           const contractAddress = await deployContract(
             this.provider,
             `0x${EXAMPLE_CONTRACT.bytecode.object}`,
@@ -245,7 +245,7 @@ describe("Debug module", function () {
       );
     });
 
-    it.skip("Should return the right values for a successful tx", async function () {
+    it("Should return the right values for a successful tx", async function () {
       const trace: RpcDebugTraceOutput = await provider.send(
         "debug_traceTransaction",
         ["0x89ebeb319fcd7bda9c7f8c1b78a7571842a705425b175f24f34fe8e6c60580d4"]
@@ -255,7 +255,7 @@ describe("Debug module", function () {
       assertEqualTraces(trace, mainnetReturnsDataTraceGeth);
     });
 
-    it.skip("Should return the right values for a reverted tx", async function () {
+    it("Should return the right values for a reverted tx", async function () {
       const trace: RpcDebugTraceOutput = await provider.send(
         "debug_traceTransaction",
         ["0x6214b912cc9916d8b7bf5f4ff876e259f5f3754ddebb6df8c8e897cad31ae148"]
@@ -285,7 +285,7 @@ describe("Debug module", function () {
       });
     });
 
-    it.skip("Should respect the disableStack option", async function () {
+    it("Should respect the disableStack option", async function () {
       const trace: RpcDebugTraceOutput = await provider.send(
         "debug_traceTransaction",
         [
@@ -306,7 +306,7 @@ describe("Debug module", function () {
       });
     });
 
-    it.skip("Should respect the disableStorage option", async function () {
+    it("Should respect the disableStorage option", async function () {
       const trace: RpcDebugTraceOutput = await provider.send(
         "debug_traceTransaction",
         [
@@ -370,7 +370,7 @@ describe("Debug module", function () {
     });
 
     // see https://github.com/NomicFoundation/hardhat/issues/3519
-    it.skip("Should return the right values for a successful tx", async function () {
+    it("Should return the right values for a successful tx", async function () {
       const trace: RpcDebugTraceOutput = await provider.send(
         "debug_traceTransaction",
         ["0xe0b1f8e11eb822107ddc35ce2d944147cc043acf680c39332ee95dd6508d107e"]

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/debug.ts
@@ -370,7 +370,7 @@ describe("Debug module", function () {
     });
 
     // see https://github.com/NomicFoundation/hardhat/issues/3519
-    it("Should return the right values for a successful tx", async function () {
+    it.skip("Should return the right values for a successful tx", async function () {
       const trace: RpcDebugTraceOutput = await provider.send(
         "debug_traceTransaction",
         ["0xe0b1f8e11eb822107ddc35ce2d944147cc043acf680c39332ee95dd6508d107e"]


### PR DESCRIPTION
[Link to issue](https://github.com/NomicFoundation/hardhat/issues/3858)

When calling the method debug_traceTransaction a large amount of 0s is retuned inside the memory property. This is wrong.

E.g.: 
The memory should stop after the 5th line, the one that starts with "0x82b429...."

<img width="299" alt="image" src="https://github.com/NomicFoundation/hardhat/assets/18092467/bc2454ff-51a1-447e-89b9-87a982720953">
