### PR TITLE
refactor: change allow dead code to underscore prefix for tempdir

### DIFF
--- a/crates/rethnet_eth/src/remote/client.rs
+++ b/crates/rethnet_eth/src/remote/client.rs
@@ -452,8 +452,7 @@ mod tests {
         client: RpcClient,
 
         // Need to keep the tempdir around to prevent it from being deleted
-        #[allow(dead_code)]
-        cache_dir: TempDir,
+        _cache_dir: TempDir,
     }
 
     impl TestRpcClient {
@@ -461,7 +460,7 @@ mod tests {
             let tempdir = TempDir::new().unwrap();
             Self {
                 client: RpcClient::new(url, tempdir.path().into()),
-                cache_dir: tempdir,
+                _cache_dir: tempdir,
             }
         }
     }

--- a/crates/rethnet_evm/benches/state/util.rs
+++ b/crates/rethnet_evm/benches/state/util.rs
@@ -37,8 +37,7 @@ pub struct RethnetStates {
     #[allow(dead_code)]
     fork_snapshots: Vec<B256>,
     // We have to keep the cache dir around to prevent it from being deleted
-    #[allow(dead_code)]
-    cache_dir: TempDir,
+    _cache_dir: TempDir,
 }
 
 impl RethnetStates {
@@ -71,7 +70,7 @@ impl RethnetStates {
             ),
             fork_checkpoints: Vec::default(),
             fork_snapshots: Vec::default(),
-            cache_dir,
+            _cache_dir: cache_dir,
         }
     }
 

--- a/crates/rethnet_evm/src/state/fork.rs
+++ b/crates/rethnet_evm/src/state/fork.rs
@@ -354,8 +354,7 @@ mod tests {
     struct TestForkState {
         fork_state: ForkState,
         // We need to keep it around as long as the fork state is alive
-        #[allow(dead_code)]
-        tempdir: tempfile::TempDir,
+        _tempdir: tempfile::TempDir,
     }
 
     impl TestForkState {
@@ -395,7 +394,7 @@ mod tests {
             );
             Self {
                 fork_state,
-                tempdir,
+                _tempdir: tempdir,
             }
         }
     }

--- a/crates/rethnet_rpc_server/tests/integration_tests.rs
+++ b/crates/rethnet_rpc_server/tests/integration_tests.rs
@@ -31,8 +31,7 @@ const PRIVATE_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784
 struct TestFixture {
     server_address: SocketAddr,
     // We need to keep the tempdir alive for the duration of the test
-    #[allow(dead_code)]
-    cache_dir: TempDir,
+    _cache_dir: TempDir,
 }
 
 async fn start_server() -> TestFixture {
@@ -76,7 +75,7 @@ async fn start_server() -> TestFixture {
 
     TestFixture {
         server_address: address,
-        cache_dir,
+        _cache_dir: cache_dir,
     }
 }
 


### PR DESCRIPTION
This is a follow up from https://github.com/NomicFoundation/hardhat/pull/4294 to change `#[allow(dead_code)]` annotations for the test temp dir to prefixed names.