### PR TITLE
ci: add exit flag to prevent test hanging

### DIFF
--- a/packages/hardhat-ethers/package.json
+++ b/packages/hardhat-ethers/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "yarn prettier --write && yarn eslint --fix",
     "eslint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prettier": "prettier \"**/*.{js,md,json}\"",
-    "test": "mocha --recursive \"test/**/*.ts\"",
+    "test": "mocha --recursive \"test/**/*.ts\" --exit",
     "prebuild": "cd ../../crates/rethnet_evm_napi && yarn build",
     "build": "tsc --build .",
     "prepublishOnly": "yarn build",


### PR DESCRIPTION
Add `--exit` flag to `mocha` for `hardhat-ethers` prevent tests hanging.