### PR TITLE
feat: cache batch requests per method call

### DIFF
--- a/crates/rethnet_eth/Cargo.toml
+++ b/crates/rethnet_eth/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 bytes = { version = "1.2.1", default-features = false }
 ethbloom = { version = "0.13.0", default-features = false, features = ["rlp"] }
-futures = { version = "0.3.28", features = ["alloc", "async-await", "executor"] }
+futures = {version = "0.3.28", default-features = false}
 hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 hashbrown = { version = "0.13", default-features = false, features = ["ahash"] }

--- a/crates/rethnet_eth/src/remote/client.rs
+++ b/crates/rethnet_eth/src/remote/client.rs
@@ -178,8 +178,8 @@ impl RpcClient {
     async fn make_cache_path(&self, cache_key: &CacheKey) -> Result<PathBuf, RpcClientError> {
         let chain_id = self.chain_id().await?;
 
-        // TODO We should use a human readable name for the chain id as directory name once
-        // available.
+        // TODO We should use a human readable name for the chain id
+        // Tracking issue: <https://github.com/NomicFoundation/rethnet/issues/172>
         let directory = self
             .rpc_cache_dir
             .join(Self::hash_bytes(chain_id.as_le_bytes().as_ref()));

--- a/crates/rethnet_eth/src/remote/client.rs
+++ b/crates/rethnet_eth/src/remote/client.rs
@@ -381,7 +381,7 @@ impl RpcClient {
             .collect::<Vec<_>>();
 
         let mut results: Vec<Option<serde_json::Value>> = stream::iter(&cache_keys)
-            .map(|cache_key| async { self.try_from_cache(cache_key.as_ref()).await })
+            .map(|cache_key| self.try_from_cache(cache_key.as_ref()))
             .buffered(PARALLEL_DISK_READS)
             .collect::<Vec<Result<_, RpcClientError>>>()
             .await

--- a/crates/rethnet_eth/src/remote/client.rs
+++ b/crates/rethnet_eth/src/remote/client.rs
@@ -26,9 +26,9 @@ use super::{
 };
 
 const RPC_CACHE_DIR: &str = "rpc_cache";
-// More than 16 parallel reads does not significantly improve performance on any disk/workload, but
+// More than 16 concurrent reads does not significantly improve performance on any disk/workload, but
 // it can cause slow downs based on this article <https://pkolaczk.github.io/disk-parallelism/>.
-const PARALLEL_DISK_READS: usize = 16;
+const CONCURRENT_DISK_READS: usize = 16;
 
 /// Specialized error types
 #[derive(Debug, thiserror::Error)]
@@ -382,7 +382,7 @@ impl RpcClient {
 
         let mut results: Vec<Option<serde_json::Value>> = stream::iter(&cache_keys)
             .map(|cache_key| self.try_from_cache(cache_key.as_ref()))
-            .buffered(PARALLEL_DISK_READS)
+            .buffered(CONCURRENT_DISK_READS)
             .collect::<Vec<Result<_, RpcClientError>>>()
             .await
             .into_iter()

--- a/crates/rethnet_eth/src/remote/client.rs
+++ b/crates/rethnet_eth/src/remote/client.rs
@@ -652,6 +652,21 @@ mod tests {
         }
     }
 
+    #[test]
+    fn get_ids_zero() {
+        let client = RpcClient::new("http://localhost:8545", PathBuf::new());
+        let ids = client.get_ids(0);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn get_ids_more() {
+        let client = RpcClient::new("http://localhost:8545", PathBuf::new());
+        let count = 11;
+        let ids = client.get_ids(count);
+        assert_eq!(ids.len(), 11);
+    }
+
     #[tokio::test]
     async fn send_request_body_500_status() {
         const STATUS_CODE: u16 = 500;


### PR DESCRIPTION
This PR contains changes that are a prerequisite for https://github.com/NomicFoundation/rethnet/issues/88:

- Per call cache resolution of batch requests
- Store only the call results instead of the JSON-RPC responses in the on-disk cache
- Some refactoring to simplify things
