### PR TITLE
chore(hooks): simplify pre-commit hooks

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -15,9 +15,8 @@ fi
 # Set -x  here to avoid printing secrets
 set -xe
 
-cargo check --workspace --all-targets --no-default-features --profile bench
 cargo check --workspace --all-targets --profile bench ${ALL_FEATURES}
-cargo test --workspace --all-targets ${ALL_FEATURES}
-cargo test --doc --workspace ${ALL_FEATURES}
 cargo clippy --all --all-targets ${ALL_FEATURES} -- -D warnings
 cargo fmt --all -- --check
+cargo test --doc --workspace ${ALL_FEATURES}
+cargo test --workspace --all-targets ${ALL_FEATURES}


### PR DESCRIPTION
This removes the run of `--no-default-features` from the commit hooks and changes the order to run lightweight commands first