### PR TITLE
fix: avoid caching of remote queries for block tags

### DIFF
--- a/crates/rethnet_eth/src/block.rs
+++ b/crates/rethnet_eth/src/block.rs
@@ -6,6 +6,7 @@
 mod detailed;
 mod difficulty;
 mod options;
+mod reorg;
 
 use revm_primitives::{
     keccak256,
@@ -25,7 +26,11 @@ use crate::{
 };
 
 use self::difficulty::calculate_ethash_canonical_difficulty;
-pub use self::{detailed::DetailedBlock, options::BlockOptions};
+pub use self::{
+    detailed::DetailedBlock,
+    options::BlockOptions,
+    reorg::{largest_possible_reorg, largest_safe_block_number},
+};
 
 /// Ethereum block
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/rethnet_eth/src/block/reorg.rs
+++ b/crates/rethnet_eth/src/block/reorg.rs
@@ -1,0 +1,33 @@
+use crate::U256;
+
+/// The largest block number that is safe from a reorg for a specific chain based on the latest
+/// block number.
+pub fn largest_safe_block_number(chain_id: &U256, latest_block_number: &U256) -> U256 {
+    latest_block_number.saturating_sub(largest_possible_reorg(chain_id))
+}
+
+/// Retrieves the largest possible size of a reorg, i.e. ensures a "safe" block.
+///
+/// # Source
+///
+/// These numbers were taken from:
+/// <https://github.com/NomicFoundation/hardhat/blob/caa504fe0e53c183578f42d66f4740b8ec147051/packages/hardhat-core/src/internal/hardhat-network/provider/utils/reorgs-protection.ts>
+pub fn largest_possible_reorg(chain_id: &U256) -> U256 {
+    let chain_id: u64 = chain_id.try_into().expect("invalid chain id");
+    let threshold: u64 = match chain_id {
+        // mainnet
+        1 => 5,
+        // Ropsten
+        3 => 100,
+        // Rinkeby
+        4 => 5,
+        // Goerli
+        5 => 5,
+        // Kovan
+        42 => 5,
+        // xDai
+        100 => 38,
+        _ => 30,
+    };
+    U256::from(threshold)
+}


### PR DESCRIPTION
Draft PR to avoid caching of remote queries for block tags by 

1. checking that cached requests with block number parameters are safe from reorgs 
2. and by resolving block numbers for requests with symbolic block spec (e.g. "safe") arguments when possible from the response.

TODOs left:

- Wanna sleep on it and see if the code structure makes sense tomorrow
- Add some tests
