### PR TITLE
fix: rpc result serde and avoid rate limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,18 +2333,21 @@ dependencies = [
  "hashbrown 0.13.2",
  "hex",
  "itertools 0.10.5",
+ "lazy_static",
  "log",
  "mockito",
  "open-fastrlp",
  "paste",
  "primitive-types 0.11.1",
  "reqwest",
+ "rethnet_defaults",
  "rethnet_test_utils",
  "revm-primitives",
  "rlp",
  "secp256k1 0.24.3",
  "serde",
  "serde_json",
+ "serial_test",
  "sha3",
  "tempfile",
  "thiserror",
@@ -2351,15 +2367,18 @@ dependencies = [
  "hashbrown 0.13.2",
  "hasher",
  "itertools 0.11.0",
+ "lazy_static",
  "log",
  "once_cell",
  "parking_lot",
+ "rethnet_defaults",
  "rethnet_eth",
  "rethnet_test_utils",
  "revm",
  "rlp",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2788,6 +2807,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/crates/rethnet_defaults/src/lib.rs
+++ b/crates/rethnet_defaults/src/lib.rs
@@ -26,3 +26,6 @@ pub const PRIVATE_KEYS: [&str; 20] = [
 /// The default cache directory. Cache dirs for specific subsystems such as the RPC Client are
 /// subdirectories of this directory.
 pub const CACHE_DIR: &str = "./edr-cache";
+
+/// Maximum concurrent requests to a remote blockchain node to avoid getting rate limited.
+pub const MAX_CONCURRENT_REQUESTS: usize = 5;

--- a/crates/rethnet_eth/Cargo.toml
+++ b/crates/rethnet_eth/Cargo.toml
@@ -16,6 +16,7 @@ log = { version = "0.4.17", default-features = false }
 open-fastrlp = { version = "0.1.2", default-features = false, features = ["derive"], optional = true }
 primitive-types = { version = "0.11.1", default-features = false, features = ["rlp"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
+rethnet_defaults = { version = "0.1.0-dev", path = "../rethnet_defaults" }
 revm-primitives = { git = "https://github.com/Wodann/revm", rev = "9fdf446", version = "1.1", default-features = false }
 # revm-primitives = { path = "../../../revm/crates/primitives", version = "1.0", default-features = false }
 rlp = { version = "0.5.2", default-features = false, features = ["derive"] }
@@ -28,9 +29,11 @@ tokio = { version = "1.21.2", default-features = false, features = ["fs", "sync"
 triehash = { version = "0.8.4", default-features = false }
 
 [dev-dependencies]
+lazy_static = "1.4.0"
 mockito = { version = "1.0.2", default-features = false }
 paste = { version = "1.0.14", default-features = false }
 rethnet_test_utils = { version = "0.1.0-dev", path = "../rethnet_test_utils" }
+serial_test = "2.0.0"
 tempfile = { version = "3.7.1", default-features =  false }
 tokio = { version = "1.23.0", features = ["macros"] }
 walkdir = { version = "2.3.3", default-features =  false }

--- a/crates/rethnet_eth/src/remote/client.rs
+++ b/crates/rethnet_eth/src/remote/client.rs
@@ -589,6 +589,24 @@ impl RpcClient {
             .await
     }
 
+    /// Methods for retrieving multiple transaction receipts in one batch
+    pub async fn get_transaction_receipts(
+        &self,
+        hashes: impl IntoIterator<Item = &B256>,
+    ) -> Result<Option<Vec<BlockReceipt>>, RpcClientError> {
+        let requests: Vec<MethodInvocation> = hashes
+            .into_iter()
+            .map(|transaction_hash| MethodInvocation::GetTransactionReceipt(*transaction_hash))
+            .collect();
+
+        let responses = self.batch_call(&requests).await?;
+
+        responses
+            .into_iter()
+            .map(Self::parse_response_value::<Option<BlockReceipt>>)
+            .collect::<Result<Option<Vec<BlockReceipt>>, _>>()
+    }
+
     /// Calls `eth_getStorageAt`.
     pub async fn get_storage_at(
         &self,

--- a/crates/rethnet_eth/src/remote/eth.rs
+++ b/crates/rethnet_eth/src/remote/eth.rs
@@ -36,7 +36,7 @@ pub struct Transaction {
     /// block number where this transaction was in
     pub block_number: Option<U256>,
     /// integer of the transactions index position in the block. null when its pending
-    #[serde(deserialize_with = "crate::serde::optional_u64_from_hex")]
+    #[serde(with = "crate::serde::optional_u64")]
     pub transaction_index: Option<u64>,
     /// address of the sender
     pub from: Address,
@@ -52,14 +52,23 @@ pub struct Transaction {
     #[serde(with = "crate::serde::bytes")]
     pub input: Bytes,
     /// ECDSA recovery id
-    #[serde(alias = "yParity", with = "crate::serde::u64")]
+    #[serde(with = "crate::serde::u64")]
     pub v: u64,
+    /// Y-parity for EIP-2930 and EIP-1559 transactions. In theory these transactions types
+    /// shouldn't have a `v` field, but in practice they are returned by nodes.
+    #[serde(
+        default,
+        rename = "yParity",
+        skip_serializing_if = "Option::is_none",
+        with = "crate::serde::optional_u64"
+    )]
+    pub y_parity: Option<u64>,
     /// ECDSA signature r
     pub r: U256,
     /// ECDSA signature s
     pub s: U256,
     /// chain ID
-    #[serde(default, deserialize_with = "crate::serde::optional_u64_from_hex")]
+    #[serde(default, with = "crate::serde::optional_u64")]
     pub chain_id: Option<u64>,
     /// integer of the transaction type, 0x0 for legacy transactions, 0x1 for access list types, 0x2 for dynamic fees
     #[serde(rename = "type", default, with = "crate::serde::u64")]
@@ -139,7 +148,7 @@ pub struct Block<TX> {
     /// mix hash
     pub mix_hash: B256,
     /// hash of the generated proof-of-work. null when its pending block.
-    #[serde(deserialize_with = "crate::serde::optional_u64_from_hex")]
+    #[serde(with = "crate::serde::optional_u64")]
     pub nonce: Option<u64>,
     /// base fee per gas
     pub base_fee_per_gas: Option<U256>,

--- a/crates/rethnet_eth/src/serde.rs
+++ b/crates/rethnet_eth/src/serde.rs
@@ -253,6 +253,13 @@ pub mod u256 {
     }
 }
 
+fn u64_from_0x_hex_str<'de, D>(s: &str) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    u64::from_str_radix(&s[2..], 16).map_err(serde::de::Error::custom)
+}
+
 /// Helper module for (de)serializing [`std::primitive::u64`]s from and into `0x`-prefixed hexadecimal strings.
 pub mod u64 {
     /// Helper function for deserializing a [`std::primitive::u64`] from a `0x`-prefixed hexadecimal string.
@@ -260,8 +267,8 @@ pub mod u64 {
     where
         D: serde::Deserializer<'de>,
     {
-        let s: &str = serde::Deserialize::deserialize(deserializer)?;
-        Ok(u64::from_str_radix(&s[2..], 16).expect("failed to parse u64"))
+        let s: String = serde::Deserialize::deserialize(deserializer)?;
+        super::u64_from_0x_hex_str::<D>(&s)
     }
 
     /// Helper function for serializing a [`std::primitive::u64`] into a 0x-prefixed hexadecimal string.
@@ -277,6 +284,34 @@ pub mod u64 {
     }
 }
 
+/// Helper module for (de)serializing an [`Option<std::primitive::u64>`] from a `0x`-prefixed hexadecimal string.
+pub mod optional_u64 {
+    /// Helper function for deserializing an [`Option<std::primitive::u64>`] from a `0x`-prefixed hexadecimal string.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: Option<String> = serde::Deserialize::deserialize(deserializer)?;
+        if let Some(s) = s {
+            Ok(Some(super::u64_from_0x_hex_str::<D>(&s)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Helper function for serializing a [`Option<std::primitive::u64>`] into a `0x`-prefixed hexadecimal string.
+    pub fn serialize<S>(value: &Option<u64>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if let Some(value) = value {
+            super::u64::serialize(value, s)
+        } else {
+            s.serialize_none()
+        }
+    }
+}
+
 /// Helper module for (de)serializing [`std::primitive::u8`]s from and into `0x`-prefixed hexadecimal strings.
 pub mod u8 {
     /// Helper function for deserializing a [`std::primitive::u8`] from a `0x`-prefixed hexadecimal string.
@@ -284,7 +319,7 @@ pub mod u8 {
     where
         D: serde::Deserializer<'de>,
     {
-        let s: &str = serde::Deserialize::deserialize(deserializer)?;
+        let s: String = serde::Deserialize::deserialize(deserializer)?;
         Ok(u8::from_str_radix(&s[2..], 16).expect("failed to parse u8"))
     }
 
@@ -301,53 +336,49 @@ pub mod u8 {
     }
 }
 
-/// Helper function for deserializing an [`Option<std::primitive::u64>`] from an optional `0x`-prefixed hexadecimal string.
-pub fn optional_u64_from_hex<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let s: Option<&str> = serde::Deserialize::deserialize(deserializer)?;
-    Ok(s.map(|s| u64::from_str_radix(&s[2..], 16).expect("failed to parse u64")))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
-    #[test]
-    fn test_bytes_serde() {
-        const BYTES: &[u8] = &[0x01, 0x02, 0x03];
-        let expected = Bytes::from_static(BYTES);
-
-        let serialized = serde_json::to_string(&expected).unwrap();
-        let deserialized: Bytes = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, expected);
+    #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    struct TestStructSerde {
+        #[serde(with = "u8")]
+        u8: u8,
+        #[serde(with = "u64")]
+        u64: u64,
+        #[serde(with = "optional_u64")]
+        optional_u64: Option<u64>,
+        #[serde(serialize_with = "u256::serialize")]
+        u256: U256,
+        #[serde(with = "bytes")]
+        bytes: Bytes,
     }
 
-    #[test]
-    fn test_u8_serde() {
-        let expected = 0x01;
-
-        let serialized = serde_json::to_string(&expected).unwrap();
-        let deserialized: u8 = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, expected);
+    impl TestStructSerde {
+        fn json() -> serde_json::Value {
+            json!({
+                "u8": "0x01",
+                // 2 bytes (too large for u8)
+                "u64": "0x1234",
+                "optional_u64": "0x1234",
+                // 9 bytes ff (more than u64 fits) and 2 leading zeroes
+                "u256": "0x00ffffffffffffffffff",
+                // 33 bytes (too large for u256)
+                "bytes": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+            })
+        }
     }
-
     #[test]
-    fn test_u64_serde() {
-        let expected = 0x01;
+    fn test_serde() {
+        let json = TestStructSerde::json();
 
-        let serialized = serde_json::to_string(&expected).unwrap();
-        let deserialized: u64 = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, expected);
-    }
+        let test_struct: TestStructSerde = serde_json::from_value(json).unwrap();
 
-    #[test]
-    fn test_u256_serde() {
-        let expected = U256::from(0x01);
+        let serialized = serde_json::to_string(&test_struct).unwrap();
 
-        let serialized = serde_json::to_string(&expected).unwrap();
-        let deserialized: U256 = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, expected);
+        let deserialized = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(test_struct, deserialized);
     }
 }

--- a/crates/rethnet_eth/tests/receipt.rs
+++ b/crates/rethnet_eth/tests/receipt.rs
@@ -1,5 +1,14 @@
 #[cfg(feature = "test-remote")]
-mod alchemy {
+mod remote {
+    use lazy_static::lazy_static;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    lazy_static! {
+        // Use same cache dir for all tests
+        static ref CACHE_DIR: TempDir = TempDir::new().unwrap();
+    }
+
     macro_rules! impl_test_remote_block_receipt_root {
         ($(
             $name:ident => $block_number:literal,
@@ -7,15 +16,14 @@ mod alchemy {
             $(
                 paste::item! {
                     #[tokio::test]
+                    #[serial]
                     async fn [<test_remote_block_receipt_root_ $name>]() {
-                        use futures::future::{self, FutureExt};
+                        use futures::{stream, StreamExt};
                         use rethnet_eth::{block::BlockAndCallers, remote::{RpcClient, BlockSpec}, trie::ordered_trie_root};
                         use rethnet_test_utils::env::get_alchemy_url;
                         use revm_primitives::U256;
-                        use tempfile::TempDir;
 
-                        let tempdir = TempDir::new().unwrap();
-                        let client = RpcClient::new(&get_alchemy_url(), tempdir.path().into());
+                        let client = RpcClient::new(&get_alchemy_url(), CACHE_DIR.path().into());
 
                         let block_number = U256::from($block_number);
 
@@ -24,16 +32,21 @@ mod alchemy {
                             .await
                             .expect("Should succeed");
 
-                        let receipts = future::try_join_all(block.transactions.iter().map(|transaction| {
-                            client
-                                .get_transaction_receipt(&transaction.hash)
-                                .map(|result| result.map(|result| result.unwrap()))
-                        })).await.expect("Should succeed");
+                        let receipts = stream::iter(block.transactions.iter())
+                            .map(|transaction|
+                                client
+                                    .get_transaction_receipt(&transaction.hash)
+                            )
+                            // Limit concurrent requests to avoid getting rate limited.
+                            .buffered(rethnet_defaults::MAX_CONCURRENT_REQUESTS)
+                            .collect::<Vec<_>>()
+                            .await.into_iter().collect::<Result<Vec<_>, _>>()
+                            .expect("Should succeed");
 
                         let receipts_root = ordered_trie_root(
                             receipts
                                 .into_iter()
-                                .map(|receipt| rlp::encode(&**receipt).freeze()),
+                                .map(|receipt| rlp::encode(&**receipt.unwrap()).freeze()),
                         );
 
                         let BlockAndCallers { block, .. } = block

--- a/crates/rethnet_evm/Cargo.toml
+++ b/crates/rethnet_evm/Cargo.toml
@@ -16,6 +16,7 @@ itertools = { version = "0.11.0", default-features = false, features = ["use_all
 log = { version = "0.4.17", default-features = false }
 once_cell = { version = "1.18.0", default-features = false, features = ["alloc", "race", "std"] }
 parking_lot = { version = "0.12.1", default-features = false }
+rethnet_defaults = { version = "0.1.0-dev", path = "../rethnet_defaults" }
 rethnet_eth = { version = "0.1.0-dev", path = "../rethnet_eth", features = ["serde"] }
 revm = { git = "https://github.com/Wodann/revm", rev = "9fdf446", version = "3.3", default-features = false, features = ["dev", "secp256k1", "serde", "std"] }
 # revm = { path = "../../../revm/crates/revm", version = "3.0", default-features = false, features = ["dev", "serde", "std"] }
@@ -28,7 +29,9 @@ tracing = { version = "0.1.37", features = ["attributes", "std"], optional = tru
 
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false, features = ["cargo_bench_support", "html_reports", "plotters"] }
+lazy_static = "1.4.0"
 rethnet_test_utils = { version = "0.1.0-dev", path = "../rethnet_test_utils" }
+serial_test = "2.0.0"
 tempfile = "3.7.1"
 
 [features]

--- a/crates/rethnet_evm/benches/state/database_commit.rs
+++ b/crates/rethnet_evm/benches/state/database_commit.rs
@@ -11,13 +11,12 @@ fn bench_database_commit(c: &mut Criterion) {
     use hashbrown::HashMap;
     use revm::primitives::KECCAK_EMPTY;
 
-    use rethnet_eth::serde::optional_u64_from_hex;
     use rethnet_evm::{Account, AccountInfo, StorageSlot};
 
     #[derive(Debug, serde::Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct AccountState {
-        #[serde(deserialize_with = "optional_u64_from_hex")]
+        #[serde(deserialize_with = "rethnet_eth::serde::optional_u64::deserialize")]
         nonce: Option<u64>,
         balance: Option<U256>,
         storage: HashMap<U256, Option<U256>>,

--- a/crates/rethnet_evm/src/blockchain/remote.rs
+++ b/crates/rethnet_evm/src/blockchain/remote.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use futures::future::{self, FutureExt};
+use futures::future::FutureExt;
+use futures::{stream, StreamExt};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use rethnet_eth::{
     block::{BlockAndCallers, DetailedBlock},
@@ -158,12 +159,19 @@ impl RemoteBlockchain {
             .collect();
 
         let receipts = tokio::task::block_in_place(move || {
-            self.runtime.block_on({
-                future::try_join_all(transaction_hashes.iter().map(|hash| {
-                    self.client
-                        .get_transaction_receipt(hash)
-                        .map(|result| result.map(|receipt| Arc::new(receipt.unwrap())))
-                }))
+            self.runtime.block_on(async {
+                stream::iter(transaction_hashes.iter())
+                    .map(|hash| {
+                        self.client
+                            .get_transaction_receipt(hash)
+                            .map(|result| result.map(|receipt| Arc::new(receipt.unwrap())))
+                    })
+                    // Limit concurrent requests to avoid getting rate limited.
+                    .buffered(rethnet_defaults::MAX_CONCURRENT_REQUESTS)
+                    .collect::<Vec<_>>()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()
             })
         })?;
 


### PR DESCRIPTION
This PR started out as a quickfix for `Block<Transaction>` deserialization that was blocking @Wodann , but then some new issues popped up for which I also included fixes. Specifically, this PR contains:

- Make it possible for `Block<Transaction>` to be deserialized from `serde_json::Value`
- Make it possible for `TypedReceipt<Log>` to be deserialized from `serde_json::Value`
- Fix deserialization for `yParity` in `Block`. Geth recently [started to return](https://github.com/ethereum/go-ethereum/pull/27744) `yParity` alongside the `v` parameter for EIP-2930 and EIP-1559 transactions even though these should only contain the `yParity` parameter in theory. I discovered this when fetching blocks from Infura.
- Join some remote tests in the rpc client to reduce requests to avoid getting rated limited
- Limit concurrent requests for transaction receipts to avoid getting rate limited
- Use shared cache for integration tests and make them sequential to avoid getting rate limited
