### PR TITLE
feat: retry for rpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +465,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,7 +509,7 @@ version = "4.0.0"
 source = "git+https://github.com/Wodann/cita-trie?rev=60efef5#60efef58be0b76c528b6d7fa45a8eccdfd8f615c"
 dependencies = [
  "hasher",
- "parking_lot",
+ "parking_lot 0.12.1",
  "rlp",
 ]
 
@@ -698,7 +725,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -1118,8 +1145,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1335,6 +1364,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1467,18 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1556,6 +1620,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1901,12 +1975,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1917,7 +2016,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
 ]
@@ -2200,6 +2299,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -2271,6 +2379,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -2286,6 +2395,42 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.2.3"
+source = "git+https://github.com/TrueLayer/reqwest-middleware?rev=a54319a#a54319a9d65926c899440e5970c04592f30ed048"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.2.2"
+source = "git+https://github.com/TrueLayer/reqwest-middleware?rev=a54319a#a54319a9d65926c899440e5970c04592f30ed048"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "getrandom",
+ "http",
+ "hyper",
+ "parking_lot 0.11.2",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "task-local-extensions",
+ "tokio",
+ "tracing",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -2332,6 +2477,7 @@ dependencies = [
  "hash256-std-hasher",
  "hashbrown 0.13.2",
  "hex",
+ "hyper",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -2340,6 +2486,8 @@ dependencies = [
  "paste",
  "primitive-types 0.11.1",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "rethnet_defaults",
  "rethnet_test_utils",
  "revm-primitives",
@@ -2370,7 +2518,7 @@ dependencies = [
  "lazy_static",
  "log",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "rethnet_defaults",
  "rethnet_eth",
  "rethnet_test_utils",
@@ -2393,7 +2541,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "parking_lot",
+ "parking_lot 0.12.1",
  "rethnet",
  "rethnet_defaults",
  "rethnet_eth",
@@ -2414,7 +2562,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "hex",
  "hyper",
- "parking_lot",
+ "parking_lot 0.12.1",
  "reqwest",
  "rethnet_eth",
  "rethnet_evm",
@@ -2437,6 +2585,17 @@ version = "0.1.0-dev"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e09bbcb5003282bcb688f0bae741b278e9c7e8f378f561522c9806c58e075d9b"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rand",
 ]
 
 [[package]]
@@ -2819,7 +2978,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "parking_lot",
+ "parking_lot 0.12.1",
  "serial_test_derive",
 ]
 
@@ -3011,6 +3170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "task-local-extensions"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
+dependencies = [
+ "pin-utils",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,7 +3186,7 @@ checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys",
 ]
@@ -3119,7 +3287,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.3",
@@ -3299,7 +3467,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -3353,6 +3521,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -3511,6 +3688,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,6 +3742,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/rethnet_eth/Cargo.toml
+++ b/crates/rethnet_eth/Cargo.toml
@@ -11,11 +11,16 @@ hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 hashbrown = { version = "0.13", default-features = false, features = ["ahash"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+hyper = {version = "0.14.27", default-features = false}
 itertools = { version = "0.10.5", default-features = false, features = ["use_alloc"] }
 log = { version = "0.4.17", default-features = false }
 open-fastrlp = { version = "0.1.2", default-features = false, features = ["derive"], optional = true }
 primitive-types = { version = "0.11.1", default-features = false, features = ["rlp"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
+# We need the git versions pending the release of `RetryableStrategy`
+# https://github.com/TrueLayer/reqwest-middleware/blob/main/reqwest-retry/CHANGELOG.md#unreleased
+reqwest-middleware = { git = "https://github.com/TrueLayer/reqwest-middleware", rev = "a54319a", default-features = false }
+reqwest-retry = { git = "https://github.com/TrueLayer/reqwest-middleware", rev = "a54319a", default-features = false }
 rethnet_defaults = { version = "0.1.0-dev", path = "../rethnet_defaults" }
 revm-primitives = { git = "https://github.com/Wodann/revm", rev = "9fdf446", version = "1.1", default-features = false }
 # revm-primitives = { path = "../../../revm/crates/primitives", version = "1.0", default-features = false }

--- a/crates/rethnet_eth/src/remote/client.rs
+++ b/crates/rethnet_eth/src/remote/client.rs
@@ -831,7 +831,7 @@ mod tests {
         let error = TestRpcClient::new(&server.url())
             .call::<Option<eth::Transaction>>(MethodInvocation::GetTransactionByHash(hash))
             .await
-            .expect_err("should have failed to interpret response as a Transaction");
+            .expect_err("should have failed to due to a HTTP status error");
 
         if let RpcClientError::HttpStatus(error) = error {
             assert_eq!(

--- a/crates/rethnet_eth/src/remote/client.rs
+++ b/crates/rethnet_eth/src/remote/client.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use std::{
     io,
     sync::atomic::{AtomicU64, Ordering},
@@ -8,7 +9,13 @@ use std::{
 use bytes::Bytes;
 use futures::{stream, StreamExt};
 use itertools::{izip, Itertools};
+use reqwest::Client as HttpClient;
+use reqwest_middleware::{ClientBuilder as HttpClientBuilder, ClientWithMiddleware};
+use reqwest_retry::{
+    policies::ExponentialBackoff, RetryTransientMiddleware, Retryable, RetryableStrategy,
+};
 use revm_primitives::{AccountInfo, Address, Bytecode, B256, KECCAK_EMPTY, U256};
+
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha3::digest::FixedOutput;
@@ -29,13 +36,18 @@ const RPC_CACHE_DIR: &str = "rpc_cache";
 // More than 16 concurrent reads does not significantly improve performance on any disk/workload, but
 // it can cause slow downs based on this article <https://pkolaczk.github.io/disk-parallelism/>.
 const CONCURRENT_DISK_READS: usize = 16;
+// Retry parameters for rate limited requests.
+const BACKOFF_EXPONENT: u32 = 2;
+const MIN_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+const MAX_RETRY_INTERVAL: Duration = Duration::from_secs(16);
+const TOTAL_RETRY_DURATION: Duration = Duration::from_secs(60);
 
 /// Specialized error types
 #[derive(Debug, thiserror::Error)]
 pub enum RpcClientError {
     /// The message could not be sent to the remote node
     #[error(transparent)]
-    FailedToSend(reqwest::Error),
+    FailedToSend(reqwest_middleware::Error),
 
     /// The remote node failed to reply with the body of the response
     #[error("The response text was corrupted: {0}.")]
@@ -131,7 +143,7 @@ pub struct Request<MethodInvocation> {
 pub struct RpcClient {
     url: String,
     chain_id: OnceCell<U256>,
-    client: reqwest::Client,
+    client: ClientWithMiddleware,
     next_id: AtomicU64,
     rpc_cache_dir: PathBuf,
 }
@@ -449,10 +461,21 @@ impl RpcClient {
     /// Create a new instance, given a remote node URL.
     /// The cache directory is the global EDR cache directory configured by the user.
     pub fn new(url: &str, cache_dir: PathBuf) -> Self {
+        let retry_policy = ExponentialBackoff::builder()
+            .retry_bounds(MIN_RETRY_INTERVAL, MAX_RETRY_INTERVAL)
+            .backoff_exponent(BACKOFF_EXPONENT)
+            .build_with_total_retry_duration(TOTAL_RETRY_DURATION);
+        let client = HttpClientBuilder::new(HttpClient::new())
+            .with(RetryTransientMiddleware::new_with_policy_and_strategy(
+                retry_policy,
+                RetryStrategy,
+            ))
+            .build();
+
         RpcClient {
             url: url.to_string(),
             chain_id: OnceCell::new(),
-            client: reqwest::Client::new(),
+            client,
             next_id: AtomicU64::new(0),
             rpc_cache_dir: cache_dir.join(RPC_CACHE_DIR),
         }
@@ -634,6 +657,97 @@ fn log_cache_error(cache_key: CacheKey, message: &'static str, error: impl Into<
     log::error!("{cache_error}");
 }
 
+struct RetryStrategy;
+
+impl RetryableStrategy for RetryStrategy {
+    fn handle(
+        &self,
+        res: &Result<reqwest::Response, reqwest_middleware::Error>,
+    ) -> Option<Retryable> {
+        match res {
+            Ok(success) => reqwest_retry::default_on_request_success(success),
+            Err(error) => on_request_failure(error),
+        }
+    }
+}
+
+// Adapted from <https://github.com/TrueLayer/reqwest-middleware/blob/a54319a9d65926c899440e5970c04592f30ed048/reqwest-retry/src/retryable_strategy.rs#L134>
+// under the MIT license.
+// With the difference that we don't retry on connection errors as it leads to retrying invalid domains.
+fn on_request_failure(error: &reqwest_middleware::Error) -> Option<Retryable> {
+    use reqwest_middleware::Error;
+
+    match error {
+        // If something fails in the middleware we're screwed.
+        Error::Middleware(_) => Some(Retryable::Fatal),
+        Error::Reqwest(error) => {
+            if error.is_timeout() {
+                Some(Retryable::Transient)
+            } else if error.is_body()
+                || error.is_decode()
+                || error.is_builder()
+                || error.is_redirect()
+            {
+                Some(Retryable::Fatal)
+            } else if error.is_request() {
+                // It seems that hyper::Error(IncompleteMessage) is not correctly handled by reqwest.
+                // Here we check if the Reqwest error was originated by hyper and map it consistently.
+                if let Some(hyper_error) = get_source_error_type::<hyper::Error>(&error) {
+                    // The hyper::Error(IncompleteMessage) is raised if the HTTP response is well formatted but does not contain all the bytes.
+                    // This can happen when the server has started sending back the response but the connection is cut halfway thorugh.
+                    // We can safely retry the call, hence marking this error as [`Retryable::Transient`].
+                    // Instead hyper::Error(Canceled) is raised when the connection is
+                    // gracefully closed on the server side.
+                    if hyper_error.is_incomplete_message() || hyper_error.is_canceled() {
+                        Some(Retryable::Transient)
+
+                        // Try and downcast the hyper error to io::Error if that is the
+                        // underlying error, and try and classify it.
+                    } else if let Some(io_error) = get_source_error_type::<io::Error>(hyper_error) {
+                        Some(classify_io_error(io_error))
+                    } else {
+                        Some(Retryable::Fatal)
+                    }
+                } else {
+                    Some(Retryable::Fatal)
+                }
+            } else {
+                // We omit checking if error.is_status() since we check that already.
+                // However, if Response::error_for_status is used the status will still
+                // remain in the response object.
+                None
+            }
+        }
+    }
+}
+
+// From <https://github.com/TrueLayer/reqwest-middleware/blob/a54319a9d65926c899440e5970c04592f30ed048/reqwest-retry/src/retryable_strategy.rs#L189>
+// under the MIT license.
+fn classify_io_error(error: &io::Error) -> Retryable {
+    match error.kind() {
+        io::ErrorKind::ConnectionReset | io::ErrorKind::ConnectionAborted => Retryable::Transient,
+        _ => Retryable::Fatal,
+    }
+}
+
+/// Downcasts the given err source into T.
+/// From <https://github.com/TrueLayer/reqwest-middleware/blob/a54319a9d65926c899440e5970c04592f30ed048/reqwest-retry/src/retryable_strategy.rs#L200>
+/// under the MIT license.
+fn get_source_error_type<T: std::error::Error + 'static>(
+    err: &dyn std::error::Error,
+) -> Option<&T> {
+    let mut source = err.source();
+
+    while let Some(err) = source {
+        if let Some(err) = err.downcast_ref::<T>() {
+            return Some(err);
+        }
+
+        source = err.source();
+    }
+    None
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[repr(transparent)]
 #[serde(transparent)]
@@ -698,8 +812,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_request_body_500_status() {
-        const STATUS_CODE: u16 = 500;
+    async fn send_request_body_400_status() {
+        const STATUS_CODE: u16 = 400;
 
         let mut server = mockito::Server::new_async().await;
 
@@ -1088,7 +1202,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn get_block_with_transaction_data() {
+        async fn get_block_with_transaction_data_cached() {
             let alchemy_url = get_alchemy_url();
             let client = TestRpcClient::new(&alchemy_url);
 


### PR DESCRIPTION
Add retry logic for the rpc client to help without rate limiting. 

In addition to 429 responses, it also handles 5xx responses and request timeouts.

Testing strategy: without this change the local test suite fails on my machine with rate limit errors, with this change, it succeeds.