### PR TITLE
fix: disable in-memory cache for unsafe block number

### DIFF
--- a/crates/rethnet_eth/src/block.rs
+++ b/crates/rethnet_eth/src/block.rs
@@ -32,7 +32,10 @@ use self::difficulty::calculate_ethash_canonical_difficulty;
 pub use self::{
     detailed::DetailedBlock,
     options::BlockOptions,
-    reorg::{largest_possible_reorg, largest_safe_block_number},
+    reorg::{
+        is_safe_block_number, largest_possible_reorg, largest_safe_block_number,
+        IsSafeBlockNumberArgs, LargestSafeBlockNumberArgs,
+    },
 };
 
 /// Ethereum block

--- a/crates/rethnet_eth/src/block/reorg.rs
+++ b/crates/rethnet_eth/src/block/reorg.rs
@@ -1,9 +1,46 @@
 use crate::U256;
 
+/// Test whether a block number is safe from a reorg for a specific chain based on the latest block
+/// number.
+pub fn is_safe_block_number(args: IsSafeBlockNumberArgs<'_>) -> bool {
+    let safe_block_number = largest_safe_block_number((&args).into());
+    args.block_number <= &safe_block_number
+}
+
+/// Arguments for the `is_safe_block_number` function.
+/// The purpose of this struct is to prevent mixing up the U256 arguments.
+pub struct IsSafeBlockNumberArgs<'a> {
+    /// The chain id
+    pub chain_id: &'a U256,
+    /// The latest known block number
+    pub latest_block_number: &'a U256,
+    /// The block number to test
+    pub block_number: &'a U256,
+}
+
+impl<'a> From<&'a IsSafeBlockNumberArgs<'a>> for LargestSafeBlockNumberArgs<'a> {
+    fn from(value: &'a IsSafeBlockNumberArgs<'a>) -> LargestSafeBlockNumberArgs<'a> {
+        LargestSafeBlockNumberArgs {
+            chain_id: value.chain_id,
+            latest_block_number: value.latest_block_number,
+        }
+    }
+}
+
 /// The largest block number that is safe from a reorg for a specific chain based on the latest
 /// block number.
-pub fn largest_safe_block_number(chain_id: &U256, latest_block_number: &U256) -> U256 {
-    latest_block_number.saturating_sub(largest_possible_reorg(chain_id))
+pub fn largest_safe_block_number(args: LargestSafeBlockNumberArgs<'_>) -> U256 {
+    args.latest_block_number
+        .saturating_sub(largest_possible_reorg(args.chain_id))
+}
+
+/// Arguments for the `largest_safe_block_number` function.
+/// The purpose of this struct is to prevent mixing up the U256 arguments.
+pub struct LargestSafeBlockNumberArgs<'a> {
+    /// The chain id
+    pub chain_id: &'a U256,
+    /// The latest known block number
+    pub latest_block_number: &'a U256,
 }
 
 /// Retrieves the largest possible size of a reorg, i.e. ensures a "safe" block.

--- a/crates/rethnet_evm/src/blockchain/forked.rs
+++ b/crates/rethnet_evm/src/blockchain/forked.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use rethnet_eth::block::LargestSafeBlockNumberArgs;
 use rethnet_eth::{
     block::{largest_possible_reorg, largest_safe_block_number, DetailedBlock},
     remote::{RpcClient, RpcClientError},
@@ -73,7 +74,10 @@ impl ForkedBlockchain {
         let network_id = network_id?;
         let latest_block_number = latest_block_number?;
 
-        let safe_block_number = largest_safe_block_number(&chain_id, &latest_block_number);
+        let safe_block_number = largest_safe_block_number(LargestSafeBlockNumberArgs {
+            chain_id: &chain_id,
+            latest_block_number: &latest_block_number,
+        });
 
         let fork_block_number = if let Some(fork_block_number) = fork_block_number {
             if fork_block_number > latest_block_number {

--- a/crates/rethnet_evm/src/state/remote.rs
+++ b/crates/rethnet_evm/src/state/remote.rs
@@ -41,6 +41,14 @@ impl RemoteState {
         &self.block_number
     }
 
+    /// Whether the current state is cacheable based on the block number.
+    pub fn is_cacheable(&self) -> Result<bool, StateError> {
+        Ok(tokio::task::block_in_place(move || {
+            self.runtime
+                .block_on(self.client.is_cacheable_block_number(&self.block_number))
+        })?)
+    }
+
     /// Sets the block number used for calls to the remote Ethereum node.
     pub fn set_block_number(&mut self, block_number: &U256) {
         self.block_number = *block_number;

--- a/crates/rethnet_evm/src/state/remote/cached.rs
+++ b/crates/rethnet_evm/src/state/remote/cached.rs
@@ -48,18 +48,19 @@ impl State for CachedRemoteState {
         }
 
         if let Some(mut account_info) = self.remote.basic(address)? {
-            // Split code and store separately
-            if let Some(code) = account_info.code.take() {
-                let block_code = self
-                    .code_cache
-                    .entry(*self.remote.block_number())
-                    .or_default();
+            if self.remote.is_cacheable()? {
+                // Split code and store separately
+                if let Some(code) = account_info.code.take() {
+                    let block_code = self
+                        .code_cache
+                        .entry(*self.remote.block_number())
+                        .or_default();
 
-                block_code.entry(account_info.code_hash).or_insert(code);
+                    block_code.entry(account_info.code_hash).or_insert(code);
+                }
+
+                block_accounts.insert(address, account_info.clone().into());
             }
-
-            block_accounts.insert(address, account_info.clone().into());
-
             return Ok(Some(account_info));
         }
 
@@ -88,7 +89,14 @@ impl State for CachedRemoteState {
             Entry::Occupied(mut account_entry) => {
                 match account_entry.get_mut().storage.entry(index) {
                     Entry::Occupied(entry) => *entry.get(),
-                    Entry::Vacant(entry) => *entry.insert(self.remote.storage(address, index)?),
+                    Entry::Vacant(entry) => {
+                        let value = self.remote.storage(address, index)?;
+                        if self.remote.is_cacheable()? {
+                            *entry.insert(value)
+                        } else {
+                            value
+                        }
+                    }
                 }
             }
             Entry::Vacant(account_entry) => {
@@ -99,11 +107,64 @@ impl State for CachedRemoteState {
                     .map_or_else(RethnetAccount::default, RethnetAccount::from);
 
                 let value = self.remote.storage(address, index)?;
-                account.storage.insert(index, value);
 
-                account_entry.insert(account);
+                if self.remote.is_cacheable()? {
+                    account.storage.insert(index, value);
+                    account_entry.insert(account);
+                }
+
                 value
             }
         })
+    }
+}
+
+#[cfg(all(test, feature = "test-remote"))]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    use rethnet_eth::remote::RpcClient;
+    use rethnet_test_utils::env::get_alchemy_url;
+    use tokio::runtime::Builder;
+
+    use super::*;
+
+    #[test]
+    fn no_cache_for_unsafe_block_number() {
+        let runtime = Arc::new(
+            Builder::new_multi_thread()
+                .enable_io()
+                .enable_time()
+                .build()
+                .expect("failed to construct async runtime"),
+        );
+
+        let tempdir = tempfile::tempdir().expect("can create tempdir");
+
+        let rpc_client = RpcClient::new(&get_alchemy_url(), tempdir.path().to_path_buf());
+
+        let dai_address = Address::from_str("0x6b175474e89094c44da98b954eedeac495271d0f")
+            .expect("failed to parse address");
+
+        // Latest block number is always unsafe
+        let block_number = runtime.block_on(rpc_client.block_number()).unwrap();
+
+        let remote = RemoteState::new(runtime, rpc_client, block_number);
+        let mut cached = CachedRemoteState::new(remote);
+
+        cached.basic(dai_address).expect("should succeed").unwrap();
+
+        cached
+            .storage(dai_address, U256::from(0))
+            .expect("should succeed");
+
+        for entry in cached.account_cache.values() {
+            assert!(entry.is_empty());
+        }
+
+        for entry in cached.code_cache.values() {
+            assert!(entry.is_empty());
+        }
     }
 }


### PR DESCRIPTION
This PR disables in-memory caching for unsafe block numbers. 

I'm not 100% sure if this is the right approach, but figured it's easiest to discuss in the context of a PR.