### PR TITLE
fix: cache block numbers for block time duration

### DIFF
--- a/crates/rethnet_defaults/src/lib.rs
+++ b/crates/rethnet_defaults/src/lib.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 /// The default private keys from which the local accounts will be derived.
 pub const PRIVATE_KEYS: [&str; 20] = [
     // these were taken from the standard output of a run of `hardhat node`
@@ -32,3 +34,6 @@ pub const MAX_CONCURRENT_REQUESTS: usize = 5;
 
 /// The default depth of blocks to consider safe from a reorg and thus cacheable.
 pub const DEFAULT_SAFE_BLOCK_DEPTH: u64 = 128;
+
+/// The default delay between blocks. Should be the lowest possible to stay on the safe side.
+pub const DEFAULT_SAFE_BLOCK_TIME: Duration = Duration::from_secs(1);

--- a/crates/rethnet_eth/src/block.rs
+++ b/crates/rethnet_eth/src/block.rs
@@ -30,7 +30,7 @@ pub use self::{
     detailed::DetailedBlock,
     options::BlockOptions,
     reorg::{
-        is_safe_block_number, largest_possible_reorg, largest_safe_block_number,
+        block_time, is_safe_block_number, largest_possible_reorg, largest_safe_block_number,
         IsSafeBlockNumberArgs, LargestSafeBlockNumberArgs,
     },
 };

--- a/crates/rethnet_eth/src/block/reorg.rs
+++ b/crates/rethnet_eth/src/block/reorg.rs
@@ -1,4 +1,5 @@
 use crate::U256;
+use std::time::Duration;
 
 /// Test whether a block number is safe from a reorg for a specific chain based on the latest block
 /// number.
@@ -57,7 +58,7 @@ pub fn largest_possible_reorg(chain_id: &U256) -> U256 {
         1 | 4 | 5 | 42 => 32,
         // Ropsten
         3 => 100,
-        // xDai
+        // Gnosis/xDai
         100 => 38,
         _ => {
             log::warn!(
@@ -68,4 +69,24 @@ pub fn largest_possible_reorg(chain_id: &U256) -> U256 {
         }
     };
     U256::from(threshold)
+}
+
+/// The interval between blocks for a specific chain.
+pub fn block_time(chain_id: &U256) -> Duration {
+    let chain_id: u64 = chain_id.try_into().expect("invalid chain id");
+    match chain_id {
+        // Ethereum mainnet, Ropsten, Rinkeby, Goerli and Kovan testnets
+        // 32 blocks is one epoch on Ethereum mainnet
+        1 | 3 | 4 | 5 | 42 => Duration::from_secs(12),
+        // Gnosis/xDai
+        // https://gnosisscan.io/chart/blocktime
+        100 => Duration::from_secs(5),
+        _ => {
+            log::warn!(
+                "Unknown chain id {chain_id}, using default block time of {} seconds",
+                rethnet_defaults::DEFAULT_SAFE_BLOCK_TIME.as_secs(),
+            );
+            rethnet_defaults::DEFAULT_SAFE_BLOCK_TIME
+        }
+    }
 }

--- a/crates/rethnet_eth/src/remote/client.rs
+++ b/crates/rethnet_eth/src/remote/client.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{
     io,
     sync::atomic::{AtomicU64, Ordering},
@@ -21,7 +21,7 @@ use sha3::digest::FixedOutput;
 use sha3::{Digest, Sha3_256};
 use tokio::sync::{OnceCell, RwLock};
 
-use crate::block::{is_safe_block_number, IsSafeBlockNumberArgs};
+use crate::block::{block_time, is_safe_block_number, IsSafeBlockNumberArgs};
 use crate::remote::cacheable_method_invocation::{
     try_read_cache_key, try_write_cache_key, CacheKeyForSymbolicBlockTag,
     CacheKeyForUncheckedBlockNumber, ReadCacheKey, ResolvedSymbolicTag, WriteCacheKey,
@@ -143,7 +143,7 @@ pub struct Request<MethodInvocation> {
 pub struct RpcClient {
     url: String,
     chain_id: OnceCell<U256>,
-    largest_known_block_number: RwLock<Option<U256>>,
+    cached_block_number: RwLock<Option<CachedBlockNumber>>,
     client: ClientWithMiddleware,
     next_id: AtomicU64,
     rpc_cache_dir: PathBuf,
@@ -270,30 +270,27 @@ impl RpcClient {
         }
     }
 
+    /// Caches a block number for the duration of the block time of the chain.
+    async fn cached_block_number(&self) -> Result<U256, RpcClientError> {
+        let cached_block_number = { self.cached_block_number.read().await.clone() };
+
+        if let Some(cached_block_number) = cached_block_number {
+            let delta = block_time(&self.chain_id().await?);
+            if cached_block_number.timestamp.elapsed() < delta {
+                return Ok(cached_block_number.block_number);
+            }
+        }
+
+        // Caches the block number as side effect.
+        self.block_number().await
+    }
+
     async fn validate_block_number(
         &self,
         safety_checker: CacheKeyForUncheckedBlockNumber<'_>,
     ) -> Result<Option<String>, RpcClientError> {
         let chain_id = self.chain_id().await?;
-
-        // Use the largest known block number for validation if the given block number is safe
-        // relative to it.
-        let largest_known_block_number = { *self.largest_known_block_number.read().await };
-        if let Some(largest_known_block_number) = largest_known_block_number {
-            let args = IsSafeBlockNumberArgs {
-                chain_id: &chain_id,
-                latest_block_number: &largest_known_block_number,
-                block_number: safety_checker.block_number,
-            };
-            if is_safe_block_number(args) {
-                return Ok(
-                    safety_checker.validate_block_number(&chain_id, &largest_known_block_number)
-                );
-            }
-        };
-
-        // Otherwise fetch the latest block number and use that for validation.
-        let latest_block_number = self.block_number().await?;
+        let latest_block_number = self.cached_block_number().await?;
         Ok(safety_checker.validate_block_number(&chain_id, &latest_block_number))
     }
 
@@ -571,7 +568,7 @@ impl RpcClient {
         RpcClient {
             url: url.to_string(),
             chain_id: OnceCell::new(),
-            largest_known_block_number: RwLock::new(None),
+            cached_block_number: RwLock::new(None),
             client,
             next_id: AtomicU64::new(0),
             rpc_cache_dir: cache_dir.join(RPC_CACHE_DIR),
@@ -580,12 +577,13 @@ impl RpcClient {
 
     /// Calls `eth_blockNumber` and returns the block number.
     pub async fn block_number(&self) -> Result<U256, RpcClientError> {
+        println!("block number {:?}", Instant::now());
         let block_number: U256 = self
             .call_without_cache(MethodInvocation::BlockNumber())
             .await?;
         {
-            let mut write_guard = self.largest_known_block_number.write().await;
-            *write_guard = Some(block_number);
+            let mut write_guard = self.cached_block_number.write().await;
+            *write_guard = Some(CachedBlockNumber::new(block_number));
         }
         Ok(block_number)
     }
@@ -596,24 +594,8 @@ impl RpcClient {
         block_number: &U256,
     ) -> Result<bool, RpcClientError> {
         let chain_id = self.chain_id().await?;
+        let latest_block_number = self.cached_block_number().await?;
 
-        // See if the block number is safe to cache based on the largest known block number to
-        // avoid having to fetch the latest block number if it is.
-        let largest_known_block_number = { *self.largest_known_block_number.read().await };
-        if let Some(largest_known_block_number) = largest_known_block_number {
-            let is_safe = is_safe_block_number(IsSafeBlockNumberArgs {
-                chain_id: &chain_id,
-                latest_block_number: &largest_known_block_number,
-                block_number,
-            });
-            if is_safe {
-                return Ok(true);
-            }
-        }
-
-        // If it's not safe to cache based on the largest known block number, fetch the latest and
-        // check again.
-        let latest_block_number = self.block_number().await?;
         Ok(is_safe_block_number(IsSafeBlockNumberArgs {
             chain_id: &chain_id,
             latest_block_number: &latest_block_number,
@@ -785,6 +767,21 @@ impl RpcClient {
     /// Calls `net_version`.
     pub async fn network_id(&self) -> Result<U256, RpcClientError> {
         self.call(MethodInvocation::NetVersion()).await
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedBlockNumber {
+    block_number: U256,
+    timestamp: Instant,
+}
+
+impl CachedBlockNumber {
+    fn new(block_number: U256) -> Self {
+        Self {
+            block_number,
+            timestamp: Instant::now(),
+        }
     }
 }
 
@@ -1067,6 +1064,10 @@ mod tests {
             let client = TestRpcClient::new(&get_alchemy_url());
 
             let latest_block_number = client.block_number().await.unwrap();
+
+            {
+                assert!(client.cached_block_number.read().await.is_some());
+            }
 
             // Latest block number is never cacheable
             assert!(!client
@@ -1354,7 +1355,7 @@ mod tests {
 
             // Check that the block number call caches the largest known block number
             {
-                assert!(client.largest_known_block_number.read().await.is_some());
+                assert!(client.cached_block_number.read().await.is_some());
             }
 
             assert_eq!(client.files_in_cache().len(), 0);

--- a/crates/rethnet_eth/src/remote/client.rs
+++ b/crates/rethnet_eth/src/remote/client.rs
@@ -577,7 +577,6 @@ impl RpcClient {
 
     /// Calls `eth_blockNumber` and returns the block number.
     pub async fn block_number(&self) -> Result<U256, RpcClientError> {
-        println!("block number {:?}", Instant::now());
         let block_number: U256 = self
             .call_without_cache(MethodInvocation::BlockNumber())
             .await?;

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -41,7 +41,7 @@ import { useEnvironment } from "../../../../helpers/environment";
 describe("Hardhat module", function () {
   PROVIDERS.forEach(({ name, useProvider, isFork }) => {
     if (isFork) {
-      this.timeout(50000);
+      this.timeout(80000);
     }
 
     workaroundWindowsCiFailures.call(this, { isFork });


### PR DESCRIPTION
Fixes failure 2 in https://github.com/NomicFoundation/rethnet/issues/175 by caching block numbers for validation purposes for the block time interval.

This change brings down the running time of the tests from ~2 minutes to ~75 seconds (before the CI broke, these tests took around ~45 seconds). This is still over the initial 50 second timeout. If I disable the block number checks for in memory caches, the running time goes back to the initial ~45 seconds. Some slow down is to be expected here since the previous version of the code cached all block numbers, so I increased the timeout to 80 seconds. As an alternative we could pin the tests to a safe block number.

Do note however that these [tests run in <5 seconds](https://github.com/NomicFoundation/hardhat/actions/runs/6013413577/job/16310837774#step:6:2880) in the main branch, so more work remains here.

