### PR TITLE
refactor: remove reorg constants from defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,7 +2577,6 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "rethnet_defaults",
  "rethnet_test_utils",
  "revm-primitives",
  "rlp",

--- a/crates/rethnet_defaults/src/lib.rs
+++ b/crates/rethnet_defaults/src/lib.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 /// The default private keys from which the local accounts will be derived.
 pub const PRIVATE_KEYS: [&str; 20] = [
     // these were taken from the standard output of a run of `hardhat node`
@@ -31,9 +29,3 @@ pub const CACHE_DIR: &str = "./edr-cache";
 
 /// Maximum concurrent requests to a remote blockchain node to avoid getting rate limited.
 pub const MAX_CONCURRENT_REQUESTS: usize = 5;
-
-/// The default depth of blocks to consider safe from a reorg and thus cacheable.
-pub const DEFAULT_SAFE_BLOCK_DEPTH: u64 = 128;
-
-/// The default delay between blocks. Should be the lowest possible to stay on the safe side.
-pub const DEFAULT_SAFE_BLOCK_TIME: Duration = Duration::from_secs(1);

--- a/crates/rethnet_eth/Cargo.toml
+++ b/crates/rethnet_eth/Cargo.toml
@@ -20,7 +20,6 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 # https://github.com/TrueLayer/reqwest-middleware/blob/main/reqwest-retry/CHANGELOG.md#unreleased
 reqwest-middleware = { git = "https://github.com/TrueLayer/reqwest-middleware", rev = "a54319a", default-features = false }
 reqwest-retry = { git = "https://github.com/TrueLayer/reqwest-middleware", rev = "a54319a", default-features = false }
-rethnet_defaults = { version = "0.1.0-dev", path = "../rethnet_defaults" }
 revm-primitives = { git = "https://github.com/Wodann/revm", rev = "19df2ba", version = "1.1", default-features = false }
 # revm-primitives = { path = "../../../revm/crates/primitives", version = "1.0", default-features = false }
 rlp = { version = "0.5.2", default-features = false, features = ["derive"] }

--- a/crates/rethnet_eth/src/block/reorg.rs
+++ b/crates/rethnet_eth/src/block/reorg.rs
@@ -1,6 +1,12 @@
 use crate::U256;
 use std::time::Duration;
 
+/// The default depth of blocks to consider safe from a reorg and thus cacheable.
+const DEFAULT_SAFE_BLOCK_DEPTH: u64 = 128;
+
+/// The default delay between blocks. Should be the lowest possible to stay on the safe side.
+const DEFAULT_SAFE_BLOCK_TIME: Duration = Duration::from_secs(1);
+
 /// Test whether a block number is safe from a reorg for a specific chain based on the latest block
 /// number.
 pub fn is_safe_block_number(args: IsSafeBlockNumberArgs<'_>) -> bool {
@@ -63,9 +69,9 @@ pub fn largest_possible_reorg(chain_id: &U256) -> U256 {
         _ => {
             log::warn!(
                 "Unknown chain id {chain_id}, using default safe block depth of {}",
-                rethnet_defaults::DEFAULT_SAFE_BLOCK_DEPTH,
+                DEFAULT_SAFE_BLOCK_DEPTH,
             );
-            rethnet_defaults::DEFAULT_SAFE_BLOCK_DEPTH
+            DEFAULT_SAFE_BLOCK_DEPTH
         }
     };
     U256::from(threshold)
@@ -84,9 +90,9 @@ pub fn block_time(chain_id: &U256) -> Duration {
         _ => {
             log::warn!(
                 "Unknown chain id {chain_id}, using default block time of {} seconds",
-                rethnet_defaults::DEFAULT_SAFE_BLOCK_TIME.as_secs(),
+                DEFAULT_SAFE_BLOCK_TIME.as_secs(),
             );
-            rethnet_defaults::DEFAULT_SAFE_BLOCK_TIME
+            DEFAULT_SAFE_BLOCK_TIME
         }
     }
 }


### PR DESCRIPTION
Remove reorg constants from `rethnet_defaults` to remove dependency of `rethnet_eth` on `rethnet_defaults`. 