### PR TITLE
fix: WETH contract test

### DIFF
--- a/crates/rethnet_evm/benches/state/state_debug.rs
+++ b/crates/rethnet_evm/benches/state/state_debug.rs
@@ -24,7 +24,6 @@ fn bench_account_storage_root_account_doesnt_exist(c: &mut Criterion) {
             debug_assert!(state.basic(address).unwrap().is_none());
             let result = state.account_storage_root(&address);
             debug_assert!(result.is_ok());
-            debug_assert!(result.unwrap().is_none());
         },
         &Permutations::storage_scales(),
         &[1],

--- a/crates/rethnet_evm/src/state/fork.rs
+++ b/crates/rethnet_evm/src/state/fork.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use rethnet_eth::{
     remote::{BlockSpec, RpcClient},
+    trie::KECCAK_NULL_RLP,
     Address, B256, U256,
 };
 use revm::{
@@ -171,8 +172,9 @@ impl DatabaseCommit for ForkState {
 impl StateDebug for ForkState {
     type Error = StateError;
 
-    fn account_storage_root(&self, address: &Address) -> Result<Option<B256>, Self::Error> {
-        self.local_state.account_storage_root(address)
+    fn account_storage_root(&self, _address: &Address) -> Result<Option<B256>, Self::Error> {
+        // HACK: Hardhat ignores the storage root, so we set it to the default value
+        Ok(Some(KECCAK_NULL_RLP))
     }
 
     fn insert_account(

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/dual.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/dual.ts
@@ -600,7 +600,14 @@ function assertEqualAccounts(
         "hex"
       )} !== ${rethnetAccount.storageRoot.toString("hex")}`
     );
-    throw new Error("Different storageRoot");
+    differences.push("storageRoot");
+  }
+
+  if (differences.length !== 0) {
+    console.trace(`Different accounts (${address.toString()}): ${differences}`);
+    throw new Error(
+      `Different accounts (${address.toString()}): ${differences}`
+    );
   }
 }
 


### PR DESCRIPTION
`ForkState` does not currently calculate an accurate account storage root as we have no easy way of combining historic account storage with the local one.

As this is line with Hardhat, we'll for now opt to just return a KECCAK hash of the null RLP-encoding.

If people request the feature for Hardhat (or EDR), we might add proper support in the future.