### PR TITLE
fix: use the same fork block number between the blockchain and VM

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -174,6 +174,8 @@ export class HardhatNode extends EventEmitter {
         forkNetworkId
       );
 
+      config.forkConfig.blockNumber = Number(forkBlockNumber);
+
       blockchain = new ForkBlockchain(forkClient, forkBlockNumber, common);
 
       initialBlockTimeOffset = BigInt(


### PR DESCRIPTION
This resolves a bug where the Hardhat fork state could be created with a block number that forked 1 block later than the Hardhat blockchain. Since we were reading the fork block number from the state in EDR, this was creating a discrepancy.