### PR TITLE
fix: align Hardhat Network safe reorg depth with Rethnet

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/reorgs-protection.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/reorgs-protection.ts
@@ -8,22 +8,22 @@
 export function getLargestPossibleReorg(networkId: number): bigint | undefined {
   // mainnet
   if (networkId === 1) {
-    return 5n;
+    return 32n;
   }
 
   // Kovan
   if (networkId === 42) {
-    return 5n;
+    return 32n;
   }
 
   // Goerli
   if (networkId === 5) {
-    return 5n;
+    return 32n;
   }
 
   // Rinkeby
   if (networkId === 4) {
-    return 5n;
+    return 32n;
   }
 
   // Ropsten
@@ -37,4 +37,4 @@ export function getLargestPossibleReorg(networkId: number): bigint | undefined {
   }
 }
 
-export const FALLBACK_MAX_REORG = 30n;
+export const FALLBACK_MAX_REORG = 128n;


### PR DESCRIPTION
When implementing the Rethnet RPC cache we [decided](https://github.com/NomicFoundation/rethnet/issues/88#issuecomment-1690506457) to use a more conservative safe reorg depth than Hardhat Network. This PR changes the Hardhat Network reorg depth numbers to match the ones in [Rethnet.](https://github.com/NomicFoundation/hardhat/blob/db287b4463e4b3cedade1f315edc0903ddbe2645/crates/rethnet_eth/src/block/reorg.rs#L57)

The motivation for this PR is that if no fork block number is provided in the `hardhat-core` tests, they’ll use a fallback fork block number [calculated](https://github.com/NomicFoundation/hardhat/blob/db287b4463e4b3cedade1f315edc0903ddbe2645/packages/hardhat-core/src/internal/hardhat-network/provider/RethnetState.ts#L42) with the Hardhat Network logic and [pass it](https://github.com/NomicFoundation/hardhat/blob/db287b4463e4b3cedade1f315edc0903ddbe2645/packages/hardhat-core/src/internal/hardhat-network/provider/RethnetState.ts#L50) to Rethnet's `ForkState`. Since Rethnet doesn't consider this block number cacheable currently, the tests will run much slower due to cache misses.