### PR TITLE
ci: add test provider with EDR RPC cache job

### DIFF
--- a/.github/workflows/hardhat-core-ci.yml
+++ b/.github/workflows/hardhat-core-ci.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Install package
         run: yarn --frozen-lockfile
 
-      - name: Cache stack trace artifacts
+      - name: Cache EDR RPC cache
         uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/hardhat-core-ci.yml
+++ b/.github/workflows/hardhat-core-ci.yml
@@ -119,7 +119,7 @@ jobs:
         run: yarn test:except-provider
 
   test-provider:
-    name: Test provider (${{ matrix.os }}, Node ${{ matrix.node }}, ${{ matrix.vm }})
+    name: Test provider (${{ matrix.os }}, Node ${{ matrix.node }}, ${{ matrix.vm }}, Retain RPC cache ${{ matrix.retain-rpc-cache }})
     runs-on: ${{ matrix.os }}
     needs: check-rethnet
     strategy:
@@ -129,6 +129,7 @@ jobs:
         # disable until actions/virtual-environments#4896 is fixed
         # os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         os: ["ubuntu-latest", "windows-latest"]
+        retain-rpc-cache: [true, false]
         vm: ["dual", "rethnet"]
     steps:
       - uses: actions/checkout@v3
@@ -157,52 +158,9 @@ jobs:
             packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/artifacts
           key: hardhat-network-stack-traces-tests-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/*.sol') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/test-files/**/test.json') }}-${{ hashFiles('packages/hardhat-core/test/internal/hardhat-network/stack-traces/**/*.ts') }}
 
-      - name: Build
-        run: yarn build
-
-      - name: Run tests
-        env:
-          INFURA_URL: ${{ secrets.INFURA_URL }}
-          ALCHEMY_URL: ${{ secrets.ALCHEMY_URL }}
-          HARDHAT_EXPERIMENTAL_VM_MODE: ${{ matrix.vm }}
-          DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true
-          FORCE_COLOR: 3
-        run: yarn test:provider
-
-  test-provider-with-edr-rpc-cache:
-    name: Test provider with EDR RPC cache (${{ matrix.os }}, Node ${{ matrix.node }}, ${{ matrix.vm }})
-    runs-on: ${{ matrix.os }}
-    needs: check-rethnet
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [18.15]
-        # disable until actions/virtual-environments#4896 is fixed
-        # os: ["macos-latest", "ubuntu-latest", "windows-latest"]
-        os: ["ubuntu-latest", "windows-latest"]
-        vm: ["rethnet"]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node }}
-          cache: yarn
-
-      - name: Install Rust (stable)
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install package
-        run: yarn --frozen-lockfile
-
       - name: Cache EDR RPC cache
         uses: actions/cache@v2
+        if: matrix.retain-rpc-cache == true
         with:
           path: |
             packages/hardhat-core/test/internal/hardhat-network/edr-cache

--- a/.github/workflows/hardhat-core-ci.yml
+++ b/.github/workflows/hardhat-core-ci.yml
@@ -169,6 +169,57 @@ jobs:
           FORCE_COLOR: 3
         run: yarn test:provider
 
+  test-provider-with-edr-rpc-cache:
+    name: Test provider with EDR RPC cache (${{ matrix.os }}, Node ${{ matrix.node }}, ${{ matrix.vm }})
+    runs-on: ${{ matrix.os }}
+    needs: check-rethnet
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [18.15]
+        # disable until actions/virtual-environments#4896 is fixed
+        # os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest"]
+        vm: ["rethnet"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: yarn
+
+      - name: Install Rust (stable)
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install package
+        run: yarn --frozen-lockfile
+
+      - name: Cache stack trace artifacts
+        uses: actions/cache@v2
+        with:
+          path: |
+            packages/hardhat-core/test/internal/hardhat-network/edr-cache
+          key: hardhat-network-edr-cache
+
+      - name: Build
+        run: yarn build
+
+      - name: Run tests
+        env:
+          INFURA_URL: ${{ secrets.INFURA_URL }}
+          ALCHEMY_URL: ${{ secrets.ALCHEMY_URL }}
+          HARDHAT_EXPERIMENTAL_VM_MODE: ${{ matrix.vm }}
+          DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true
+          FORCE_COLOR: 3
+        run: yarn test:provider
+
   test-rethnet-js:
     name: Test Rethnet bindings (${{ matrix.os }}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/reorgs-protection.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/reorgs-protection.ts
@@ -8,22 +8,22 @@
 export function getLargestPossibleReorg(networkId: number): bigint | undefined {
   // mainnet
   if (networkId === 1) {
-    return 5n;
+    return 32n;
   }
 
   // Kovan
   if (networkId === 42) {
-    return 5n;
+    return 32n;
   }
 
   // Goerli
   if (networkId === 5) {
-    return 5n;
+    return 32n;
   }
 
   // Rinkeby
   if (networkId === 4) {
-    return 5n;
+    return 32n;
   }
 
   // Ropsten
@@ -37,4 +37,4 @@ export function getLargestPossibleReorg(networkId: number): bigint | undefined {
   }
 }
 
-export const FALLBACK_MAX_REORG = 30n;
+export const FALLBACK_MAX_REORG = 128n;


### PR DESCRIPTION
Add a CI job for running `hardhat-core` tests in `rethnet` mode that retains the Rethnet RPC cache.

Resolves https://github.com/NomicFoundation/rethnet/issues/87

https://github.com/NomicFoundation/hardhat/pull/4375 should be merged first.