### PR TITLE
Adding the ability to pass arguments to scripts called in RUN tasks.

### DIFF
--- a/packages/hardhat-core/src/builtin-tasks/run.ts
+++ b/packages/hardhat-core/src/builtin-tasks/run.ts
@@ -18,7 +18,7 @@ task(TASK_RUN, "Runs a user-defined script after compiling the project")
   .addFlag("noCompile", "Don't compile before running this task")
   .setAction(
     async (
-      { script, noCompile }: { script: string; noCompile: boolean },
+      { script, noCompile, scriptArgs }: { script: string; noCompile: boolean; scriptArgs: string[] },
       { run, hardhatArguments }
     ) => {
       if (!(await fsExtra.pathExists(script))) {
@@ -36,7 +36,7 @@ task(TASK_RUN, "Runs a user-defined script after compiling the project")
       );
 
       try {
-        process.exitCode = await runScriptWithHardhat(hardhatArguments, script);
+        process.exitCode = await runScriptWithHardhat(hardhatArguments, script, scriptArgs);
       } catch (error) {
         if (error instanceof Error) {
           throw new HardhatError(

--- a/packages/hardhat-core/src/internal/cli/ArgumentsParser.ts
+++ b/packages/hardhat-core/src/internal/cli/ArgumentsParser.ts
@@ -111,14 +111,14 @@ export class ArgumentsParser {
     taskDefinition: TaskDefinition,
     rawCLAs: string[]
   ): TaskArguments {
-    const { paramArguments, rawPositionalArguments, passthroughArguments } =
+    const { paramArguments, rawPositionalArguments } =
       this._parseTaskParamArguments(taskDefinition, rawCLAs);
 
     const positionalArguments = this._parsePositionalParamArgs(
       rawPositionalArguments,
       taskDefinition.positionalParamDefinitions
     );
-    return { taskArguments: { ...paramArguments, ...positionalArguments }, passthroughArguments: passthroughArguments };
+    return { ...paramArguments, ...positionalArguments };
   }
 
   private _parseTaskParamArguments(
@@ -127,7 +127,6 @@ export class ArgumentsParser {
   ) {
     const paramArguments: { scriptArgs?: string[] } = {}; // Allow for CLI arguments to be passed through to RUN task
     const rawPositionalArguments: string[] = [];
-    let passthroughArguments: string[] = [];
 
     for (let i = 0; i < rawCLAs.length; i++) {
       const arg = rawCLAs[i];
@@ -159,7 +158,7 @@ export class ArgumentsParser {
 
     this._addTaskDefaultArguments(taskDefinition, paramArguments);
 
-    return { paramArguments, rawPositionalArguments, passthroughArguments };
+    return { paramArguments, rawPositionalArguments };
   }
 
   private _addHardhatDefaultArguments(

--- a/packages/hardhat-core/src/internal/cli/cli.ts
+++ b/packages/hardhat-core/src/internal/cli/cli.ts
@@ -7,7 +7,7 @@ import {
   TASK_HELP,
   TASK_TEST,
 } from "../../builtin-tasks/task-names";
-import { HardhatConfig, TaskArguments } from "../../types";
+import { HardhatConfig, TaskArguments, ScriptArgs } from "../../types";
 import { HARDHAT_NAME } from "../constants";
 import { HardhatContext } from "../context";
 import {
@@ -236,6 +236,7 @@ async function main() {
     const [abortAnalytics, hitPromise] = await analytics.sendTaskHit();
 
     let taskArguments: TaskArguments;
+    let scriptArgs: ScriptArgs;
 
     // --help is a also special case
     if (hardhatArguments.help && taskName !== TASK_HELP) {
@@ -277,7 +278,7 @@ async function main() {
     try {
       const timestampBeforeRun = new Date().getTime();
 
-      await env.run(taskName, taskArguments);
+      await env.run(taskName, taskArguments, scriptArgs);
 
       const timestampAfterRun = new Date().getTime();
 

--- a/packages/hardhat-core/src/types/runtime.ts
+++ b/packages/hardhat-core/src/types/runtime.ts
@@ -145,6 +145,7 @@ export interface TaskDefinition extends ConfigurableTaskDefinition {
  * thus we have no other option than forcing it to be just 'any'.
  */
 export type TaskArguments = any;
+export type ScriptArgs = any;
 
 export interface SubtaskArguments {
   [subtaskName: string]: TaskArguments;


### PR DESCRIPTION
Uses standard end-of-options double-dash syntax:
`npx hardhat run myScript.js --network fork -- --myparam=NootNoot`

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this; My Discord question went unanswered. This PR is my attempt at discussing the issue with the HH team. I'm happy to discuss and make changes as needed.