### PR TITLE
Ethereum Studio is no longer available

### DIFF
--- a/docs/src/content/hardhat-network/docs/overview/index.md
+++ b/docs/src/content/hardhat-network/docs/overview/index.md
@@ -15,7 +15,7 @@ It runs as either an in-process or stand-alone daemon, servicing JSON-RPC and We
 
 By default, it mines a block with each transaction that it receives, in order and with no delay.
 
-It's backed by the `@ethereumjs/vm` EVM implementation, the same one used by ganache, Remix and Ethereum Studio.
+It's backed by the `@ethereumjs/vm` EVM implementation, the same one used by ganache and Remix.
 
 ## How can I use it?
 


### PR DESCRIPTION
[See issue here](https://github.com/NomicFoundation/hardhat/issues/4390)

Remove `Ethereum Studio` from docs.