### PR TITLE
fix: fix RPC cache when tmp is on different filesystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "triehash",
+ "uuid",
  "walkdir",
 ]
 
@@ -3550,6 +3551,15 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/crates/rethnet_eth/Cargo.toml
+++ b/crates/rethnet_eth/Cargo.toml
@@ -27,10 +27,10 @@ secp256k1 = { version = "0.24.0", default-features = false, features = ["alloc",
 serde = { version = "1.0.147", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0.89", optional = true }
 sha3 = { version = "0.10.8", default-features = false }
-tempfile = { version = "3.7.1", default-features = false }
 thiserror = { version = "1.0.37", default-features = false }
 tokio = { version = "1.21.2", default-features = false, features = ["fs", "sync"] }
 triehash = { version = "0.8.4", default-features = false }
+uuid = { version = "1.4.1", default-features = false, features = ["v4"]}
 
 [dev-dependencies]
 lazy_static = "1.4.0"
@@ -38,6 +38,7 @@ mockito = { version = "1.0.2", default-features = false }
 paste = { version = "1.0.14", default-features = false }
 rethnet_test_utils = { version = "0.1.0-dev", path = "../rethnet_test_utils" }
 serial_test = "2.0.0"
+tempfile = { version = "3.7.1", default-features = false }
 tokio = { version = "1.23.0", features = ["macros"] }
 walkdir = { version = "2.3.3", default-features =  false }
 
@@ -45,5 +46,5 @@ walkdir = { version = "2.3.3", default-features =  false }
 default = ["std"]
 # fastrlp = ["dep:open-fastrlp", "ruint/fastrlp"] Broken due to lack of support for fastrlp in primitive-types
 serde = ["dep:serde", "bytes/serde", "ethbloom/serialize", "primitive-types/serde", "revm-primitives/serde", "serde_json"]
-std = ["bytes/std", "ethbloom/std", "futures/std", "hash256-std-hasher/std", "hash-db/std", "hex/std", "itertools/use_std", "open-fastrlp?/std", "primitive-types/std", "revm-primitives/std", "rlp/std", "secp256k1/std", "serde?/std", "sha3/std", "triehash/std"]
+std = ["bytes/std", "ethbloom/std", "futures/std", "hash256-std-hasher/std", "hash-db/std", "hex/std", "itertools/use_std", "open-fastrlp?/std", "primitive-types/std", "revm-primitives/std", "rlp/std", "secp256k1/std", "serde?/std", "sha3/std", "triehash/std", "uuid/std"]
 test-remote = ["serde"]


### PR DESCRIPTION
Fix RPC cache when `tmp` is on different filesystem by using a temporary directory under the RPC cache dir instead of the system default `tmp` directory. The downside of this approach is that left-over files won't be cleared up in case we crash between creating a temporary file and moving it into its place. This is an acceptable trade-off imo.

Closes https://github.com/NomicFoundation/edr/issues/196