### PR TITLE
fix: support for both input or data field in rpcCallRequest

### DIFF
--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/input/callRequest.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/input/callRequest.ts
@@ -19,7 +19,8 @@ export const rpcCallRequest = t.type(
     gas: optionalOrNullable(rpcQuantity),
     gasPrice: optionalOrNullable(rpcQuantity),
     value: optionalOrNullable(rpcQuantity),
-    data: optionalOrNullable(rpcData),
+    data: optionalOrNullable(rpcData), // deprecated, use input instead
+    input: optionalOrNullable(rpcData),
     accessList: optionalOrNullable(rpcAccessList),
     maxFeePerGas: optionalOrNullable(rpcQuantity),
     maxPriorityFeePerGas: optionalOrNullable(rpcQuantity),

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/base.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/base.ts
@@ -94,7 +94,7 @@ export class Base {
         rpcCall.from !== undefined
           ? rpcCall.from
           : await this._getDefaultCallFrom(),
-      data: rpcCall.data !== undefined ? rpcCall.data : toBuffer([]),
+      data: rpcCall.input !== undefined ? rpcCall.input : (rpcCall.data !== undefined ? rpcCall.data : toBuffer([])),
       gasLimit:
         rpcCall.gas !== undefined ? rpcCall.gas : this._node.getBlockGasLimit(),
       value: rpcCall.value !== undefined ? rpcCall.value : 0n,


### PR DESCRIPTION
Issue: 
go-ethereum from version 13.0 stopped working with local hardhat node. They did a change replacing `data` to `input` field in `eth_call` and other methods https://github.com/ethereum/go-ethereum/pull/28078 referencing [Ethereum specification](https://github.com/ethereum/execution-apis/blob/main/src/schemas/transaction.yaml#L52-L54)


Update:
replaces rpcCallRequest to use `input` field instead of `data`. Fallbacks to `data` if input not set for backward compatibility.

