### PR TITLE
chore: fix edr package version in hardhat-core

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -142,7 +142,7 @@
     "p-map": "^4.0.0",
     "raw-body": "^2.4.1",
     "resolve": "1.17.0",
-    "@ignored/edr": "0.1.0-alpha.0",
+    "@ignored/edr": "^0.1.0-alpha",
     "semver": "^6.3.0",
     "solc": "0.7.3",
     "source-map-support": "^0.5.13",


### PR DESCRIPTION
The `edr` package version got pinned by accident in https://github.com/NomicFoundation/hardhat/pull/4415, this PR fixes that.