### PR TITLE
test: re-enable tests related to max initcode size

### DIFF
--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/hardforks.ts
@@ -1701,11 +1701,6 @@ describe("Eth module - hardfork dependant tests", function () {
           });
 
           it("should allow initcodes larger than the EIP-3860 limit", async function () {
-            if (process.env.HARDHAT_EXPERIMENTAL_VM_MODE !== "ethereumjs") {
-              // disabled until we can disable the initcode check in revm
-              this.skip();
-            }
-
             const code = "ff".repeat(maxInitcodeSize + 100);
 
             const tx = getTxToDeployBytecode(code, maxCodeSize);
@@ -1726,11 +1721,6 @@ describe("Eth module - hardfork dependant tests", function () {
           });
 
           it("should allow initcodes larger than the EIP-3860 limit from impersonated accounts", async function () {
-            if (process.env.HARDHAT_EXPERIMENTAL_VM_MODE !== "ethereumjs") {
-              // disabled until we can disable the initcode check in revm
-              this.skip();
-            }
-
             const code = "ff".repeat(maxInitcodeSize + 100);
 
             const impersonatedAddress =
@@ -1770,11 +1760,6 @@ describe("Eth module - hardfork dependant tests", function () {
           });
 
           it("should allow initcodes larger than the EIP-3860 limit in raw transactions", async function () {
-            if (process.env.HARDHAT_EXPERIMENTAL_VM_MODE !== "ethereumjs") {
-              // disabled until we can disable the initcode check in revm
-              this.skip();
-            }
-
             const code = "ff".repeat(maxInitcodeSize + 100);
 
             const txData = getTxToDeployBytecode(code, maxCodeSize);


### PR DESCRIPTION
Re-enable tests related to max initcode size. Fixes https://github.com/NomicFoundation/edr/issues/103

As it turns out, the tests are passing without making a change to REVM, since REVM derives max initcode size from the contract code size and we're setting the contract code size to the maximum when `allowUnlimitedContractSize` is set to true in the EDR.