### PR TITLE
feat: solidity coverage support in EDR mode

### DIFF
--- a/crates/rethnet_evm_napi/index.d.ts
+++ b/crates/rethnet_evm_napi/index.d.ts
@@ -227,6 +227,10 @@ export interface TracingStep {
   readonly depth: number
   /** The program counter */
   readonly pc: bigint
+  /** The executed op code */
+  readonly opcode: string
+  /** The top entry on the stack. None if the stack is empty. */
+  readonly stackTop?: bigint
 }
 export interface TracingMessageResult {
   /** Execution result */

--- a/crates/rethnet_evm_napi/src/trace.rs
+++ b/crates/rethnet_evm_napi/src/trace.rs
@@ -6,6 +6,7 @@ use napi::{
 };
 use napi_derive::napi;
 use rethnet_evm::trace::BeforeMessage;
+use rethnet_evm::OPCODE_JUMPMAP;
 
 use crate::transaction::result::ExecutionResult;
 
@@ -93,9 +94,12 @@ pub struct TracingStep {
     /// The program counter
     #[napi(readonly)]
     pub pc: BigInt,
-    // /// The executed op code
-    // #[napi(readonly)]
-    // pub opcode: String,
+    /// The executed op code
+    #[napi(readonly)]
+    pub opcode: String,
+    /// The top entry on the stack. None if the stack is empty.
+    #[napi(readonly)]
+    pub stack_top: Option<BigInt>,
     // /// The return value of the step
     // #[napi(readonly)]
     // pub return_value: u8,
@@ -130,9 +134,13 @@ impl TracingStep {
         Self {
             depth: step.depth as u8,
             pc: BigInt::from(step.pc),
-            // opcode: OPCODE_JUMPMAP[usize::from(step.opcode)]
-            //     .unwrap_or("")
-            //     .to_string(),
+            opcode: OPCODE_JUMPMAP[usize::from(step.opcode)]
+                .unwrap_or("")
+                .to_string(),
+            stack_top: step.stack_top.map(|v| BigInt {
+                sign_bit: false,
+                words: v.into_limbs().to_vec(),
+            }),
             // gas_cost: BigInt::from(0u64),
             // gas_refunded: BigInt::from(0u64),
             // gas_left: BigInt::from(0u64),

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/context/rethnet.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/context/rethnet.ts
@@ -1,6 +1,5 @@
 import { Blockchain, RethnetContext, SpecId } from "@ignored/edr";
 import { AsyncEventEmitter } from "@nomicfoundation/ethereumjs-util";
-import { EVMEvents } from "@nomicfoundation/ethereumjs-evm/src/types";
 
 import { BlockchainAdapter } from "../blockchain";
 import { RethnetBlockchain } from "../blockchain/rethnet";
@@ -9,7 +8,7 @@ import { MemPoolAdapter } from "../mem-pool";
 import { BlockMinerAdapter } from "../miner";
 import { VMAdapter } from "../vm/vm-adapter";
 import { RethnetMiner } from "../miner/rethnet";
-import { RethnetAdapter } from "../vm/rethnet";
+import { RethnetAdapter, VMStub } from "../vm/rethnet";
 import { NodeConfig, isForkedNodeConfig } from "../node-types";
 import {
   ethereumjsHeaderDataToRethnetBlockOptions,
@@ -136,9 +135,9 @@ export class RethnetEthContext implements EthContextAdapter {
     const limitContractCodeSize =
       config.allowUnlimitedContractSize === true ? 2n ** 64n - 1n : undefined;
 
-    const vmStub = {
+    const vmStub: VMStub = {
       evm: {
-        events: new AsyncEventEmitter<EVMEvents>(),
+        events: new AsyncEventEmitter(),
       },
     };
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/miner/rethnet.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/miner/rethnet.ts
@@ -80,8 +80,6 @@ export class RethnetMiner implements BlockMinerAdapter {
           this._vmStub.evm.events.emit("step", {
             pc: Number(traceItem.pc),
             depth: traceItem.depth,
-            // Ignored because we don't provide all the fields for opcode just what solidity-coverage expects.
-            // @ts-ignore
             opcode: { name: traceItem.opcode },
             stackTop: traceItem.stackTop,
           });

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/miner/rethnet.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/miner/rethnet.ts
@@ -14,6 +14,7 @@ import { RethnetBlockchain } from "../blockchain/rethnet";
 import { RethnetStateManager } from "../RethnetState";
 import { RethnetMemPool } from "../mem-pool/rethnet";
 import { RandomBufferGenerator } from "../utils/random";
+import { VMStub } from "../vm/rethnet";
 
 export class RethnetMiner implements BlockMinerAdapter {
   constructor(
@@ -23,7 +24,8 @@ export class RethnetMiner implements BlockMinerAdapter {
     private readonly _common: Common,
     private readonly _limitContractCodeSize: bigint | undefined,
     private _mineOrdering: MineOrdering,
-    private _prevRandaoGenerator: RandomBufferGenerator
+    private _prevRandaoGenerator: RandomBufferGenerator,
+    private _vmStub: VMStub
   ) {}
 
   public async mineBlock(
@@ -73,6 +75,16 @@ export class RethnetMiner implements BlockMinerAdapter {
       for (const traceItem of mineTrace) {
         if ("pc" in traceItem) {
           await vmTracer.addStep(traceItem);
+
+          // For solidity-coverage compatibility
+          this._vmStub.evm.events.emit("step", {
+            pc: Number(traceItem.pc),
+            depth: traceItem.depth,
+            // Ignored because we don't provide all the fields for opcode just what solidity-coverage expects.
+            // @ts-ignore
+            opcode: { name: traceItem.opcode },
+            stackTop: traceItem.stackTop,
+          });
         } else if ("executionResult" in traceItem) {
           await vmTracer.addAfterMessage(traceItem);
         } else {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/ethereumjs.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/ethereumjs.ts
@@ -690,7 +690,7 @@ export class EthereumJSAdapter implements VMAdapter {
       await this._vmTracer.addStep({
         depth: step.depth,
         pc: BigInt(step.pc),
-        // opcode: step.opcode.name,
+        opcode: step.opcode.name,
         // returnValue: 0, // Do we have error values in ethereumjs?
         // gasCost: BigInt(step.opcode.fee) + (step.opcode.dynamicFee ?? 0n),
         // gasRefunded: step.gasRefund,

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/rethnet.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/rethnet.ts
@@ -157,7 +157,6 @@ export class RethnetAdapter implements VMAdapter {
 
     // For solidity-coverage compatibility
     for (const step of this._vmTracer.tracingSteps) {
-      console.log("emitting", step);
       this._vm.evm.events.emit("step", {
         pc: Number(step.pc),
         depth: step.depth,


### PR DESCRIPTION
Add [`solidity-coverage`](https://github.com/sc-forks/solidity-coverage/tree/master) support for Hardhat network in EDR mode. Resolves https://github.com/NomicFoundation/edr/issues/44

I had to make [changes](https://github.com/sc-forks/solidity-coverage/pull/817) in `solidity-coverage` as the property layout of the EthereumJS VM changed after the dual mode changes from

```
node._vm.evm.events
```

to 

```
node._context._vm._vm.evm.events
```

I tested the changes in this PR by running the `solidity-coverage` test suite in [my fork](https://github.com/agostbiro/solidity-coverage/tree/agostbiro/hardhat-dual-vm-mode-compat) against a local version of `hardhat` with `HARDHAT_EXPERIMENTAL_VM_MODE=rethnet` and `HARDHAT_EXPERIMENTAL_VM_MODE=ethereumjs`.