### PR TITLE
fix: EDR build on Windows ARM

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -333,16 +333,38 @@ jobs:
           run: |
             set -e
             yarn test
+  check_commit:
+    name: Check commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Check if commit message is a release commit
+        id: check_commit
+        # Must match commit check in publish step
+        run: |
+          if git log -1 --pretty=%B | grep "^edr-[0-9]\+\.[0-9]\+\.[0-9]\+";
+          then
+            echo "{match}={true}" >> "$GITHUB_OUTPUT"
+          else
+            echo "{match}={false}" >> "$GITHUB_OUTPUT"
+          fi
+    outputs:
+      match: ${{ steps.check_commit.outputs.match }}
   publish:
     name: Publish
     environment: edr-release
     runs-on: ubuntu-latest
     needs:
+      - check_commit
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding
       - test-linux-x64-musl-binding
       - test-linux-aarch64-gnu-binding
       - test-linux-aarch64-musl-binding
+    if: ${{ needs.check_commit.outputs.match == 'true' }}
     defaults:
       run:
         working-directory: ./crates/rethnet_evm_napi

--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -81,6 +81,9 @@ jobs:
               rustup target add aarch64-unknown-linux-musl &&
               yarn build --target aarch64-unknown-linux-musl &&
               /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node
+          - host: windows-latest
+            target: aarch64-pc-windows-msvc
+            build: yarn build --target aarch64-pc-windows-msvc
     name: stable - ${{ matrix.settings.target }} - node@18
     runs-on: ${{ matrix.settings.host }}
     defaults:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -66,15 +66,15 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anyhow"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6f84b74db2535ebae81eede2f39b947dcbf01d093ae5f791e5dd414a1bf289"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arrayvec"
@@ -134,7 +134,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -238,9 +238,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64ct"
@@ -267,7 +267,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.28",
+ "syn 2.0.38",
  "which",
 ]
 
@@ -322,20 +322,20 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
 dependencies = [
  "memchr",
- "regex-automata 0.3.6",
+ "regex-automata 0.4.1",
  "serde",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-slice-cast"
@@ -345,9 +345,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "c-kzg"
 version = "0.1.0"
-source = "git+https://github.com/ethereum/c-kzg-4844#fbef59a3f9e8fa998bdb5069d212daf83d586aa5"
+source = "git+https://github.com/ethereum/c-kzg-4844#f3fffecd1ce7e8b6620cd5bac50c660efc20e48c"
 dependencies = [
  "bindgen",
  "blst",
@@ -385,7 +385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "599aa35200ffff8f04c1925aa1acc92fa2e08874379ef42e210a80e527e60838"
 dependencies = [
  "serde",
- "toml 0.7.6",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -396,9 +396,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -420,14 +420,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -615,9 +615,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
+checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -637,12 +637,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f34ba9a9bcb8645379e9de8cb3ecfcf4d1c85ba66d90deb3259206fa5aa193b"
+checksum = "37e366bff8cd32dd8754b0991fb66b279dc48f598c3a18914852a6673deef583"
 dependencies = [
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -682,12 +682,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.1"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -779,9 +779,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "ecdsa"
@@ -805,9 +805,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -824,22 +824,22 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "enumn"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b893c4eb2dc092c811165f84dc7447fae16fb66521717968c34c509b39b1a5c5"
+checksum = "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -863,23 +863,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -912,9 +901,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ff"
@@ -1042,7 +1031,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1124,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
  "bytes",
  "fnv",
@@ -1170,9 +1159,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -1204,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -1419,12 +1408,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -1517,9 +1506,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -1533,15 +1522,15 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lock_api"
@@ -1570,15 +1559,15 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "mime"
@@ -1624,14 +1613,13 @@ dependencies = [
 
 [[package]]
 name = "mockito"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c762b6267c4593555bb38f1df19e9318985bc4de60b5e8462890856a9a5b4c"
+checksum = "f8d3038e23466858569c2d30a537f691fa0d53b51626630ae08262943e3bbb8b"
 dependencies = [
  "assert-json-diff",
  "futures",
  "hyper",
- "lazy_static",
  "log",
  "rand",
  "regex",
@@ -1756,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1809,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
@@ -1823,15 +1811,15 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -1874,11 +1862,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.56"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1895,7 +1883,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1940,9 +1928,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
+checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -1954,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a296c3079b5fefbc499e1de58dc26c09b1b9a5952d26694ee89f04a43ebbb3e"
+checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2047,14 +2035,14 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -2114,13 +2102,13 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "predicates-core",
 ]
 
@@ -2152,12 +2140,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2175,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash 0.8.0",
  "uint",
@@ -2219,21 +2207,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.4.0",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -2249,9 +2236,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -2321,14 +2308,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.6",
- "regex-syntax 0.7.4",
+ "regex-automata 0.4.1",
+ "regex-syntax 0.8.0",
 ]
 
 [[package]]
@@ -2342,13 +2329,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.8.0",
 ]
 
 [[package]]
@@ -2359,15 +2346,15 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64",
  "bytes",
@@ -2391,6 +2378,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -2447,6 +2435,7 @@ dependencies = [
  "cargo-husky",
  "clap",
  "hex",
+ "k256",
  "predicates",
  "pretty_env_logger",
  "reqwest",
@@ -2454,12 +2443,11 @@ dependencies = [
  "rethnet_eth",
  "rethnet_evm",
  "rethnet_rpc_server",
- "secp256k1 0.24.3",
  "serde",
  "serde_json",
  "signal-child",
  "tokio",
- "toml 0.7.6",
+ "toml 0.7.8",
  "tracing",
  "tracing-subscriber",
  "winsafe",
@@ -2481,6 +2469,7 @@ dependencies = [
  "hex",
  "hyper",
  "itertools 0.10.5",
+ "k256",
  "lazy_static",
  "log",
  "mockito",
@@ -2493,7 +2482,6 @@ dependencies = [
  "rethnet_test_utils",
  "revm-primitives",
  "rlp",
- "secp256k1 0.24.3",
  "serde",
  "serde_json",
  "serial_test",
@@ -2518,7 +2506,7 @@ dependencies = [
  "dyn-clone",
  "futures",
  "hasher",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "itertools 0.11.0",
  "lazy_static",
  "log",
@@ -2544,6 +2532,7 @@ version = "0.1.0-dev"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
+ "k256",
  "napi",
  "napi-build",
  "napi-derive",
@@ -2553,7 +2542,6 @@ dependencies = [
  "rethnet_defaults",
  "rethnet_eth",
  "rethnet_evm",
- "secp256k1 0.24.3",
  "serde_json",
  "tracing",
  "tracing-flame",
@@ -2570,12 +2558,12 @@ dependencies = [
  "cargo_toml",
  "hex",
  "hyper",
+ "k256",
  "parking_lot 0.12.1",
  "reqwest",
  "rethnet_eth",
  "rethnet_evm",
  "rethnet_test_utils",
- "secp256k1 0.24.3",
  "serde",
  "serde_json",
  "sha3",
@@ -2642,7 +2630,7 @@ dependencies = [
  "once_cell",
  "revm-primitives",
  "ripemd",
- "secp256k1 0.27.0",
+ "secp256k1",
  "sha2",
  "sha3",
  "substrate-bn",
@@ -2661,11 +2649,11 @@ dependencies = [
  "derive_more",
  "enumn",
  "fixed-hash 0.8.0",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "hex",
  "hex-literal",
  "once_cell",
- "primitive-types 0.12.1",
+ "primitive-types 0.12.2",
  "rlp",
  "ruint",
  "serde",
@@ -2719,7 +2707,7 @@ version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95294d6e3a6192f3aabf91c38f56505a625aa495533442744185a36d75a790c4"
 dependencies = [
- "primitive-types 0.12.1",
+ "primitive-types 0.12.2",
  "proptest",
  "rand",
  "rlp",
@@ -2764,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2827,29 +2815,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
-dependencies = [
- "secp256k1-sys 0.6.1",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "secp256k1-sys 0.8.1",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
-dependencies = [
- "cc",
+ "secp256k1-sys",
 ]
 
 [[package]]
@@ -2886,37 +2856,37 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "itoa",
  "ryu",
  "serde",
@@ -2975,14 +2945,14 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3001,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -3041,24 +3011,24 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
@@ -3072,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -3140,9 +3110,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3154,6 +3124,27 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "tap"
@@ -3172,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3185,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -3206,22 +3197,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.46"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9207952ae1a003f42d3d5e892dac3c6ba42aa6ac0c79a6a91a2b5cb4253e75c"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.46"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3279,9 +3270,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.31.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40de3a2ba249dcb097e01be5e67a5ff53cf250397715a071a81543e8a832a920"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3291,7 +3282,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys",
 ]
@@ -3304,7 +3295,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3319,9 +3310,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3342,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3363,11 +3354,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3436,7 +3427,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3495,9 +3486,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uint"
@@ -3534,9 +3525,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -3555,9 +3546,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3602,9 +3593,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -3646,7 +3637,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -3680,7 +3671,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3746,9 +3737,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -3779,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1eeca1c172a285ee6c2c84c341ccea837e7c01b12fbb2d0fe3c9e550ce49ec8"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -3794,62 +3785,63 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10d0c968ba7f6166195e13d593af609ec2e3d24f916f081690695cf5eaffb2f"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571d8d4e62f26d4932099a9efe89660e8bd5087775a2ab5cdd8b747b811f1058"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2229ad223e178db5fbbc8bd8d3835e51e566b8474bfca58d2e6150c48bb723cd"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600956e2d840c194eedfc5d18f8242bc2e17c7775b6684488af3a9fff6fe3287"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea99ff3f8b49fb7a8e0d305e5aec485bd068c2ba691b6e277d29eaeac945868a"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1a05a1ece9a7a0d5a7ccf30ba2c33e3a61a30e042ffd247567d1de1d94120d"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.12"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
+checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3884,5 +3876,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.38",
 ]

--- a/crates/rethnet/Cargo.toml
+++ b/crates/rethnet/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 anyhow = "1.0.65"
 clap = { version = "3.2.22", default-features = false, features = ["std", "derive"] }
 hex = { version = "0.4.3", default-features = false }
+k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "std"] }
 pretty_env_logger = { version = "0.4.0", default-features = false }
 rethnet_defaults = { version = "0.1.0-dev", path = "../rethnet_defaults" }
 rethnet_eth = { version = "0.1.0-dev", path = "../rethnet_eth" }
 rethnet_evm = { version = "0.1.0-dev", path = "../rethnet_evm" }
 rethnet_rpc_server = { version = "0.1.0-dev", path = "../rethnet_rpc_server" }
-secp256k1 = { version = "0.24.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.147", default-features = false, features = ["derive"] }
 tokio = { version = "1.23.0", features = ["macros", "signal"] }
 toml = "0.7.6"

--- a/crates/rethnet/src/config.rs
+++ b/crates/rethnet/src/config.rs
@@ -93,8 +93,7 @@ impl Default for ConfigFile {
                 .into_iter()
                 .map(|s| AccountConfig {
                     secret_key: Bytes::from_iter(
-                        hex::decode(s)
-                            .expect("should decode all default private keys from strings"),
+                        hex::decode(s).expect("should decode all default secret keys from strings"),
                     )
                     .into(),
                     balance: Number::U256(U256::from(10000)),

--- a/crates/rethnet/tests/cli.rs
+++ b/crates/rethnet/tests/cli.rs
@@ -149,13 +149,13 @@ async fn node() -> Result<(), Box<dyn std::error::Error>> {
 
     // assert that the standard output of the server process contains the expected log entries:
     Assert::new(output.clone()).stdout(contains("Listening on 127.0.0.1:8549"));
-    for (i, default_private_key) in rethnet_defaults::SECRET_KEYS.to_vec().iter().enumerate() {
+    for (i, default_secret_key) in rethnet_defaults::SECRET_KEYS.to_vec().iter().enumerate() {
         Assert::new(output.clone())
-            .stdout(contains(format!("Private Key: 0x{default_private_key}")))
+            .stdout(contains(format!("Secret Key: 0x{default_secret_key}")))
             .stdout(contains(format!(
                 "Account #{}: {:?}",
                 i + 1,
-                secret_key_to_address(default_private_key).unwrap()
+                secret_key_to_address(default_secret_key).unwrap()
             )));
     }
     for method_invocation in method_invocations {

--- a/crates/rethnet/tests/cli.rs
+++ b/crates/rethnet/tests/cli.rs
@@ -5,7 +5,6 @@ use assert_cmd::{
     cargo::CommandCargoExt, // for process::Command::cargo_bin
 };
 use predicates::str::contains;
-use secp256k1::Secp256k1;
 
 use rethnet_eth::{
     remote::{
@@ -14,18 +13,14 @@ use rethnet_eth::{
         methods::{MethodInvocation as EthMethodInvocation, U256OrUsize},
         BlockSpec,
     },
-    signature::private_key_to_address,
+    signature::secret_key_to_address,
     Bytes, U256,
 };
 use rethnet_rpc_server::{HardhatMethodInvocation, MethodInvocation};
 
 #[tokio::test]
 async fn node() -> Result<(), Box<dyn std::error::Error>> {
-    let address = private_key_to_address(
-        &Secp256k1::signing_only(),
-        rethnet_defaults::PRIVATE_KEYS[0],
-    )
-    .unwrap();
+    let address = secret_key_to_address(rethnet_defaults::SECRET_KEYS[0]).unwrap();
 
     // the order of operations is a little weird in this test, because we spawn a separate process
     // for the server, and we want to make sure that we end that process gracefully. more
@@ -154,14 +149,13 @@ async fn node() -> Result<(), Box<dyn std::error::Error>> {
 
     // assert that the standard output of the server process contains the expected log entries:
     Assert::new(output.clone()).stdout(contains("Listening on 127.0.0.1:8549"));
-    let context = Secp256k1::signing_only();
-    for (i, default_private_key) in rethnet_defaults::PRIVATE_KEYS.to_vec().iter().enumerate() {
+    for (i, default_private_key) in rethnet_defaults::SECRET_KEYS.to_vec().iter().enumerate() {
         Assert::new(output.clone())
             .stdout(contains(format!("Private Key: 0x{default_private_key}")))
             .stdout(contains(format!(
                 "Account #{}: {:?}",
                 i + 1,
-                private_key_to_address(&context, default_private_key).unwrap()
+                secret_key_to_address(default_private_key).unwrap()
             )));
     }
     for method_invocation in method_invocations {

--- a/crates/rethnet_defaults/src/lib.rs
+++ b/crates/rethnet_defaults/src/lib.rs
@@ -1,5 +1,5 @@
 /// The default private keys from which the local accounts will be derived.
-pub const PRIVATE_KEYS: [&str; 20] = [
+pub const SECRET_KEYS: [&str; 20] = [
     // these were taken from the standard output of a run of `hardhat node`
     "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
     "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",

--- a/crates/rethnet_defaults/src/lib.rs
+++ b/crates/rethnet_defaults/src/lib.rs
@@ -1,4 +1,4 @@
-/// The default private keys from which the local accounts will be derived.
+/// The default secret keys from which the local accounts will be derived.
 pub const SECRET_KEYS: [&str; 20] = [
     // these were taken from the standard output of a run of `hardhat node`
     "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",

--- a/crates/rethnet_eth/Cargo.toml
+++ b/crates/rethnet_eth/Cargo.toml
@@ -12,7 +12,7 @@ hash256-std-hasher = { version = "0.15.2", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hyper = {version = "0.14.27", default-features = false}
 itertools = { version = "0.10.5", default-features = false, features = ["use_alloc"] }
-k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables"] }
+k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8",] }
 log = { version = "0.4.17", default-features = false }
 open-fastrlp = { version = "0.1.2", default-features = false, features = ["derive"], optional = true }
 primitive-types = { version = "0.11.1", default-features = false, features = ["rlp"] }
@@ -46,5 +46,5 @@ walkdir = { version = "2.3.3", default-features =  false }
 default = ["std"]
 # fastrlp = ["dep:open-fastrlp", "ruint/fastrlp"] Broken due to lack of support for fastrlp in primitive-types
 serde = ["dep:serde", "bytes/serde", "ethbloom/serialize", "primitive-types/serde", "revm-primitives/serde", "serde_json"]
-std = ["bytes/std", "ethbloom/std", "futures/std", "hash256-std-hasher/std", "hash-db/std", "hex/std", "itertools/use_std", "k256/std", "open-fastrlp?/std", "primitive-types/std", "revm-primitives/std", "rlp/std", "serde?/std", "sha3/std", "triehash/std", "uuid/std"]
+std = ["bytes/std", "ethbloom/std", "futures/std", "hash256-std-hasher/std", "hash-db/std", "hex/std", "itertools/use_std", "k256/std", "k256/precomputed-tables", "open-fastrlp?/std", "primitive-types/std", "revm-primitives/std", "rlp/std", "serde?/std", "sha3/std", "triehash/std", "uuid/std"]
 test-remote = ["serde"]

--- a/crates/rethnet_eth/Cargo.toml
+++ b/crates/rethnet_eth/Cargo.toml
@@ -12,6 +12,7 @@ hash256-std-hasher = { version = "0.15.2", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hyper = {version = "0.14.27", default-features = false}
 itertools = { version = "0.10.5", default-features = false, features = ["use_alloc"] }
+k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables"] }
 log = { version = "0.4.17", default-features = false }
 open-fastrlp = { version = "0.1.2", default-features = false, features = ["derive"], optional = true }
 primitive-types = { version = "0.11.1", default-features = false, features = ["rlp"] }
@@ -23,7 +24,6 @@ reqwest-retry = { git = "https://github.com/TrueLayer/reqwest-middleware", rev =
 revm-primitives = { git = "https://github.com/Wodann/revm", rev = "20df365", version = "1.1", default-features = false }
 # revm-primitives = { path = "../../../revm/crates/primitives", version = "1.1", default-features = false }
 rlp = { version = "0.5.2", default-features = false, features = ["derive"] }
-secp256k1 = { version = "0.24.0", default-features = false, features = ["alloc", "recovery"] }
 serde = { version = "1.0.147", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1.0.89", optional = true }
 sha3 = { version = "0.10.8", default-features = false }
@@ -46,5 +46,5 @@ walkdir = { version = "2.3.3", default-features =  false }
 default = ["std"]
 # fastrlp = ["dep:open-fastrlp", "ruint/fastrlp"] Broken due to lack of support for fastrlp in primitive-types
 serde = ["dep:serde", "bytes/serde", "ethbloom/serialize", "primitive-types/serde", "revm-primitives/serde", "serde_json"]
-std = ["bytes/std", "ethbloom/std", "futures/std", "hash256-std-hasher/std", "hash-db/std", "hex/std", "itertools/use_std", "open-fastrlp?/std", "primitive-types/std", "revm-primitives/std", "rlp/std", "secp256k1/std", "serde?/std", "sha3/std", "triehash/std", "uuid/std"]
+std = ["bytes/std", "ethbloom/std", "futures/std", "hash256-std-hasher/std", "hash-db/std", "hex/std", "itertools/use_std", "k256/std", "open-fastrlp?/std", "primitive-types/std", "revm-primitives/std", "rlp/std", "serde?/std", "sha3/std", "triehash/std", "uuid/std"]
 test-remote = ["serde"]

--- a/crates/rethnet_eth/src/lib.rs
+++ b/crates/rethnet_eth/src/lib.rs
@@ -39,7 +39,6 @@ pub use revm_primitives::{
     ruint::aliases::{B512, B64, U64},
     Address, SpecId, B160, B256, U256,
 };
-pub use secp256k1;
 
 /// A secret key
 pub type Secret = B256;

--- a/crates/rethnet_eth/src/signature.rs
+++ b/crates/rethnet_eth/src/signature.rs
@@ -399,10 +399,10 @@ mod tests {
     }
 
     #[test]
-    fn test_private_key_to_address() {
+    fn test_secret_key_to_address() {
         // `hardhat node`s default addresses are shown on startup. this is the first one:
         //     Account #0: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 (10000 ETH)
-        //     Private Key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+        //     Secret Key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
         // we'll use these as fixtures.
 
         let expected_address = Address::from_str("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")

--- a/crates/rethnet_eth/src/signature.rs
+++ b/crates/rethnet_eth/src/signature.rs
@@ -21,8 +21,8 @@ use crate::{utils::hash_message, Address, B256, U256};
 
 /// Converts a [`PublicKey`] to an [`Address`].
 pub fn public_key_to_address(public_key: PublicKey) -> Address {
-    let pk = public_key.to_encoded_point(/* compress = */ false);
-    let hash = Keccak256::digest(&pk.as_bytes()[1..]);
+    let public_key = public_key.to_encoded_point(/* compress = */ false);
+    let hash = Keccak256::digest(&public_key.as_bytes()[1..]);
     // Only take the lower 160 bits of the hash
     Address::from_slice(&hash[12..])
 }
@@ -39,22 +39,22 @@ pub fn public_key_to_address(public_key: PublicKey) -> Address {
 /// let address = secret_key_to_address(secret_key).unwrap();
 /// ```
 pub fn secret_key_to_address(secret_key: &str) -> Result<Address, SignatureError> {
-    let sk = secret_key_from_str(secret_key)?;
-    Ok(public_key_to_address(sk.public_key()))
+    let secret_key = secret_key_from_str(secret_key)?;
+    Ok(public_key_to_address(secret_key.public_key()))
 }
 
 /// Converts a hex string to a secret key.
 pub fn secret_key_from_str(secret_key: &str) -> Result<SecretKey, SignatureError> {
-    let sk = if let Some(stripped) = secret_key.strip_prefix("0x") {
+    let secret_key = if let Some(stripped) = secret_key.strip_prefix("0x") {
         hex::decode(stripped)
     } else {
         hex::decode(secret_key)
     }
     .map_err(SignatureError::DecodingError)?;
-    let sk = FieldBytes::from_exact_iter(sk.into_iter()).ok_or_else(|| {
+    let secret_key = FieldBytes::from_exact_iter(secret_key.into_iter()).ok_or_else(|| {
         SignatureError::InvalidSecretKey("expected 32 byte secret key".to_string())
     })?;
-    SecretKey::from_bytes(&sk).map_err(SignatureError::EllipticCurveError)
+    SecretKey::from_bytes(&secret_key).map_err(SignatureError::EllipticCurveError)
 }
 
 /// An error involving a signature.

--- a/crates/rethnet_eth/src/signature.rs
+++ b/crates/rethnet_eth/src/signature.rs
@@ -54,7 +54,7 @@ pub fn secret_key_from_str(secret_key: &str) -> Result<SecretKey, SignatureError
     let sk = FieldBytes::from_exact_iter(sk.into_iter()).ok_or_else(|| {
         SignatureError::InvalidSecretKey("expected 32 byte secret key".to_string())
     })?;
-    Ok(SecretKey::from_bytes(&sk).map_err(SignatureError::EllipticCurveError)?)
+    SecretKey::from_bytes(&sk).map_err(SignatureError::EllipticCurveError)
 }
 
 /// An error involving a signature.

--- a/crates/rethnet_eth/src/transaction/request/legacy.rs
+++ b/crates/rethnet_eth/src/transaction/request/legacy.rs
@@ -1,11 +1,11 @@
 use std::sync::OnceLock;
 
 use bytes::Bytes;
+use k256::SecretKey;
 use revm_primitives::{keccak256, B256, U256};
-use secp256k1::SecretKey;
 
 use crate::{
-    signature::Signature,
+    signature::{Signature, SignatureError},
     transaction::{kind::TransactionKind, signed::LegacySignedTransaction},
 };
 
@@ -25,13 +25,13 @@ impl LegacyTransactionRequest {
         keccak256(&rlp::encode(self))
     }
 
-    /// Signs the transaction with the provided private key.
-    pub fn sign(self, private_key: &SecretKey) -> LegacySignedTransaction {
+    /// Signs the transaction with the provided secret key.
+    pub fn sign(self, secret_key: &SecretKey) -> Result<LegacySignedTransaction, SignatureError> {
         let hash = self.hash();
 
-        let signature = Signature::new(hash, private_key);
+        let signature = Signature::new(hash, secret_key)?;
 
-        LegacySignedTransaction {
+        Ok(LegacySignedTransaction {
             nonce: self.nonce,
             gas_price: self.gas_price,
             gas_limit: self.gas_limit,
@@ -40,7 +40,7 @@ impl LegacyTransactionRequest {
             input: self.input,
             signature,
             hash: OnceLock::new(),
-        }
+        })
     }
 }
 

--- a/crates/rethnet_eth/src/transaction/signed/eip155.rs
+++ b/crates/rethnet_eth/src/transaction/signed/eip155.rs
@@ -100,10 +100,11 @@ impl rlp::Decodable for EIP155SignedTransaction {
 mod tests {
     use std::str::FromStr;
 
+    use k256::SecretKey;
     use revm_primitives::Address;
-    use secp256k1::SecretKey;
 
     use super::*;
+    use crate::signature::secret_key_from_str;
 
     fn dummy_request() -> EIP155TransactionRequest {
         let to = Address::from_str("0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e").unwrap();
@@ -119,8 +120,8 @@ mod tests {
         }
     }
 
-    fn dummy_private_key() -> SecretKey {
-        SecretKey::from_str("e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109")
+    fn dummy_secret_key() -> SecretKey {
+        secret_key_from_str("e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109")
             .unwrap()
     }
 
@@ -132,7 +133,7 @@ mod tests {
                 .unwrap();
 
         let request = dummy_request();
-        let signed = request.sign(&dummy_private_key());
+        let signed = request.sign(&dummy_secret_key()).unwrap();
 
         let encoded = rlp::encode(&signed);
         assert_eq!(expected, encoded.to_vec());
@@ -147,7 +148,7 @@ mod tests {
         );
 
         let request = dummy_request();
-        let signed = request.sign(&dummy_private_key());
+        let signed = request.sign(&dummy_secret_key()).unwrap();
 
         assert_eq!(expected, *signed.hash());
     }
@@ -155,7 +156,7 @@ mod tests {
     #[test]
     fn test_eip155_signed_transaction_rlp() {
         let request = dummy_request();
-        let signed = request.sign(&dummy_private_key());
+        let signed = request.sign(&dummy_secret_key()).unwrap();
 
         let encoded = rlp::encode(&signed);
         assert_eq!(signed, rlp::decode(&encoded).unwrap());

--- a/crates/rethnet_eth/src/transaction/signed/eip2930.rs
+++ b/crates/rethnet_eth/src/transaction/signed/eip2930.rs
@@ -123,10 +123,11 @@ impl rlp::Decodable for EIP2930SignedTransaction {
 mod tests {
     use std::str::FromStr;
 
+    use k256::SecretKey;
     use revm_primitives::Address;
-    use secp256k1::SecretKey;
 
     use crate::access_list::AccessListItem;
+    use crate::signature::secret_key_from_str;
 
     use super::*;
 
@@ -148,8 +149,8 @@ mod tests {
         }
     }
 
-    fn dummy_private_key() -> SecretKey {
-        SecretKey::from_str("e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109")
+    fn dummy_secret_key() -> SecretKey {
+        secret_key_from_str("e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109")
             .unwrap()
     }
 
@@ -161,7 +162,7 @@ mod tests {
                 .unwrap();
 
         let request = dummy_request();
-        let signed = request.sign(&dummy_private_key());
+        let signed = request.sign(&dummy_secret_key()).unwrap();
 
         let encoded = rlp::encode(&signed);
         assert_eq!(expected, encoded.to_vec());
@@ -176,7 +177,7 @@ mod tests {
         );
 
         let request = dummy_request();
-        let signed = request.sign(&dummy_private_key());
+        let signed = request.sign(&dummy_secret_key()).unwrap();
 
         assert_eq!(expected, *signed.hash());
     }
@@ -184,7 +185,7 @@ mod tests {
     #[test]
     fn test_eip2930_signed_transaction_rlp() {
         let request = dummy_request();
-        let signed = request.sign(&dummy_private_key());
+        let signed = request.sign(&dummy_secret_key()).unwrap();
 
         let encoded = rlp::encode(&signed);
         assert_eq!(signed, rlp::decode(&encoded).unwrap());

--- a/crates/rethnet_eth/src/transaction/signed/legacy.rs
+++ b/crates/rethnet_eth/src/transaction/signed/legacy.rs
@@ -98,12 +98,13 @@ impl rlp::Decodable for LegacySignedTransaction {
 
 #[cfg(test)]
 mod tests {
+    use k256::SecretKey;
     use std::str::FromStr;
 
     use revm_primitives::Address;
-    use secp256k1::SecretKey;
 
     use super::*;
+    use crate::signature::secret_key_from_str;
 
     fn dummy_request() -> LegacyTransactionRequest {
         let to = Address::from_str("0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e").unwrap();
@@ -118,8 +119,8 @@ mod tests {
         }
     }
 
-    fn dummy_private_key() -> SecretKey {
-        SecretKey::from_str("e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109")
+    fn dummy_secret_key() -> SecretKey {
+        secret_key_from_str("e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109")
             .unwrap()
     }
 
@@ -130,7 +131,7 @@ mod tests {
             hex::decode("f85f01020394c014ba5ec014ba5ec014ba5ec014ba5ec014ba5e048212341ca0c62d73a484ff7c53a0cfdf8eaa5e5896491b70971e9ce4a3e8750772b7c0203fa00562866909572aee9ab72df7470c1dd7aa29b056597be57c17e06f1ee303e7eb").unwrap();
 
         let request = dummy_request();
-        let signed = request.sign(&dummy_private_key());
+        let signed = request.sign(&dummy_secret_key()).unwrap();
 
         let encoded = rlp::encode(&signed);
         assert_eq!(expected, encoded.to_vec());
@@ -145,7 +146,7 @@ mod tests {
         );
 
         let request = dummy_request();
-        let signed = request.sign(&dummy_private_key());
+        let signed = request.sign(&dummy_secret_key()).unwrap();
 
         assert_eq!(expected, *signed.hash());
     }
@@ -153,7 +154,7 @@ mod tests {
     #[test]
     fn test_legacy_signed_transaction_rlp() {
         let request = dummy_request();
-        let signed = request.sign(&dummy_private_key());
+        let signed = request.sign(&dummy_secret_key()).unwrap();
 
         let encoded = rlp::encode(&signed);
         assert_eq!(signed, rlp::decode(&encoded).unwrap());

--- a/crates/rethnet_evm/Cargo.toml
+++ b/crates/rethnet_evm/Cargo.toml
@@ -21,7 +21,7 @@ once_cell = { version = "1.18.0", default-features = false, features = ["alloc",
 parking_lot = { version = "0.12.1", default-features = false }
 rethnet_defaults = { version = "0.1.0-dev", path = "../rethnet_defaults" }
 rethnet_eth = { version = "0.1.0-dev", path = "../rethnet_eth", features = ["serde"] }
-revm = { git = "https://github.com/Wodann/revm", rev = "20df365", version = "3.3", default-features = false, features = ["dev", "secp256k1", "serde", "std"] }
+revm = { git = "https://github.com/Wodann/revm", rev = "20df365", version = "3.3", default-features = false, features = ["dev", "serde", "std"] }
 # revm = { path = "../../../revm/crates/revm", version = "3.3", default-features = false, features = ["dev", "serde", "std"] }
 rlp = { version = "0.5.2", default-features = false }
 serde = { version = "1.0.158", default-features = false, features = ["std"] }

--- a/crates/rethnet_evm/tests/blockchain.rs
+++ b/crates/rethnet_evm/tests/blockchain.rs
@@ -126,9 +126,9 @@ fn create_dummy_block_with_header(partial_header: PartialHeader) -> LocalBlock {
 fn create_dummy_transaction() -> SignedTransaction {
     const DUMMY_INPUT: &[u8] = b"124";
 
-    // TODO: Consolidate DEFAULT_PRIVATE_KEYS in a centralised place
+    // TODO: Consolidate DEFAULT_SECRET_KEYS in a centralised place
     // these were taken from the standard output of a run of `hardhat node`
-    const DUMMY_PRIVATE_KEY: &str =
+    const DUMMY_SECRET_KEY: &str =
         "e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109";
 
     let to = Address::from_str("0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e")
@@ -144,7 +144,7 @@ fn create_dummy_transaction() -> SignedTransaction {
         chain_id: 1,
     };
 
-    let secret_key = rethnet_eth::signature::secret_key_from_str(DUMMY_PRIVATE_KEY)
+    let secret_key = rethnet_eth::signature::secret_key_from_str(DUMMY_SECRET_KEY)
         .expect("Failed to parse secret key");
 
     SignedTransaction::PostEip155Legacy(transaction.sign(&secret_key).expect("signs transaction"))

--- a/crates/rethnet_evm/tests/blockchain.rs
+++ b/crates/rethnet_evm/tests/blockchain.rs
@@ -144,10 +144,10 @@ fn create_dummy_transaction() -> SignedTransaction {
         chain_id: 1,
     };
 
-    let private_key = rethnet_eth::secp256k1::SecretKey::from_str(DUMMY_PRIVATE_KEY)
-        .expect("Failed to parse private key");
+    let secret_key = rethnet_eth::signature::secret_key_from_str(DUMMY_PRIVATE_KEY)
+        .expect("Failed to parse secret key");
 
-    SignedTransaction::PostEip155Legacy(transaction.sign(&private_key))
+    SignedTransaction::PostEip155Legacy(transaction.sign(&secret_key).expect("signs transaction"))
 }
 
 #[tokio::test]

--- a/crates/rethnet_evm_napi/Cargo.toml
+++ b/crates/rethnet_evm_napi/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 async-trait = { version = "0.1.73", default-features = false }
 crossbeam-channel = { version = "0.5.6", default-features = false }
+k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "std"] }
 # when napi is pinned, be sure to pin napi-derive to the same version
 # The `async` feature ensures that a tokio runtime is available
 napi = { version = "2.12.4", default-features = false, features = ["async", "error_anyhow", "napi8", "serde-json"] }
@@ -17,7 +18,6 @@ rethnet = { version = "0.1.0-dev", path = "../rethnet" }
 rethnet_defaults = { version = "0.1.0-dev", path = "../rethnet_defaults" }
 rethnet_evm = { version = "0.1.0-dev", path = "../rethnet_evm" }
 rethnet_eth = { version = "0.1.0-dev", path = "../rethnet_eth" }
-secp256k1 = { version = "0.24.0", default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0.85", default-features = false, features = ["alloc"] }
 tracing = { version = "0.1.37", default-features = false, features = ["std"] }
 tracing-flame = { version = "0.2.0", default-features = false, features = ["smallvec"] }

--- a/crates/rethnet_evm_napi/index.d.ts
+++ b/crates/rethnet_evm_napi/index.d.ts
@@ -24,8 +24,8 @@ export interface Account {
 }
 /** An account that needs to be created during the genesis block. */
 export interface GenesisAccount {
-  /** Account private key */
-  privateKey: string
+  /** Account secret key */
+  secretKey: string
   /** Account balance */
   balance: bigint
 }

--- a/crates/rethnet_evm_napi/npm/win32-arm64-msvc/README.md
+++ b/crates/rethnet_evm_napi/npm/win32-arm64-msvc/README.md
@@ -1,0 +1,3 @@
+# `@ignored/edr-win32-arm64-msvc`
+
+This is the **aarch64-pc-windows-msvc** binary for `edr`

--- a/crates/rethnet_evm_napi/npm/win32-arm64-msvc/package.json
+++ b/crates/rethnet_evm_napi/npm/win32-arm64-msvc/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@ignored/edr-win32-arm64-msvc",
+  "repository": {
+    "url": "https://github.com/NomicFoundation/hardhat.git",
+    "type": "git"
+  },
+  "version": "0.1.0-alpha.1",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "edr.win32-arm64-msvc.node",
+  "files": [
+    "edr.win32-arm64-msvc.node"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  }
+}

--- a/crates/rethnet_evm_napi/package.json
+++ b/crates/rethnet_evm_napi/package.json
@@ -12,6 +12,7 @@
     "triples": {
       "additional": [
         "aarch64-apple-darwin",
+        "aarch64-pc-windows-msvc",
         "aarch64-unknown-linux-gnu",
         "aarch64-unknown-linux-musl",
         "x86_64-unknown-linux-musl",

--- a/crates/rethnet_rpc_server/Cargo.toml
+++ b/crates/rethnet_rpc_server/Cargo.toml
@@ -9,11 +9,11 @@ async-trait = { version = "0.1.73", default-features = false }
 axum = "0.6.18"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hyper = { version = "0.14.27", default-features = false, features = ["server"] }
+k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "std"] }
 parking_lot = { version = "0.12.1", default-features = false }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rethnet_eth = { version = "0.1.0-dev", path = "../rethnet_eth", features = ["serde"] }
 rethnet_evm = { version = "0.1.0-dev", path = "../rethnet_evm" }
-secp256k1 = { version = "0.24.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.147", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.89" }
 sha3 = { version = "0.10.6", default-features = false }

--- a/crates/rethnet_rpc_server/src/config.rs
+++ b/crates/rethnet_rpc_server/src/config.rs
@@ -2,8 +2,6 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-use secp256k1::SecretKey;
-
 use rethnet_eth::{Address, SpecId, U256};
 
 pub use crate::hardhat_methods::reset::{RpcForkConfig, RpcHardhatNetworkConfig};
@@ -27,8 +25,8 @@ pub struct Config {
 
 /// configuration input for a single account
 pub struct AccountConfig {
-    /// the private key of the account
-    pub private_key: SecretKey,
+    /// the secret key of the account
+    pub secret_key: k256::SecretKey,
     /// the balance of the account
     pub balance: U256,
 }

--- a/crates/rethnet_rpc_server/src/lib.rs
+++ b/crates/rethnet_rpc_server/src/lib.rs
@@ -996,7 +996,7 @@ impl Server {
                     event!(Level::INFO, "Account #{}: {address:?}", i + 1);
                     event!(
                         Level::INFO,
-                        "Private Key: 0x{}",
+                        "Secret Key: 0x{}",
                         hex::encode(secret_key.to_bytes())
                     );
                     let local_account = (address, secret_key.clone());

--- a/crates/rethnet_rpc_server/src/lib.rs
+++ b/crates/rethnet_rpc_server/src/lib.rs
@@ -33,7 +33,6 @@ use rethnet_evm::{
     AccountInfo, CfgEnv, HashMap, HashSet, MemPool, MineBlockResult, RandomHashGenerator,
     KECCAK_EMPTY,
 };
-use secp256k1::{Secp256k1, SecretKey};
 use sha3::{Digest, Keccak256};
 use tokio::sync::RwLock;
 use tracing::{event, Level};
@@ -68,7 +67,7 @@ struct AppData {
     filters: RwLock<HashMap<U256, Filter>>,
     impersonated_accounts: RwLock<HashSet<Address>>,
     last_filter_id: RwLock<U256>,
-    local_accounts: HashMap<Address, SecretKey>,
+    local_accounts: HashMap<Address, k256::SecretKey>,
     network_id: u64,
     node: Node,
 }
@@ -691,8 +690,9 @@ fn handle_sign(
 ) -> ResponseData<Signature> {
     event!(Level::INFO, "eth_sign({address:?}, {message:?})");
     match state.local_accounts.get(address) {
-        Some(private_key) => ResponseData::Success {
-            result: Signature::new(&Bytes::from(message.clone())[..], private_key),
+        Some(secret_key) => match Signature::new(&Bytes::from(message.clone())[..], secret_key) {
+            Ok(signature) => ResponseData::Success { result: signature },
+            Err(error) => ResponseData::new_error(-32000, &error.to_string(), None),
         },
         None => ResponseData::new_error(0, "{address} is not an account owned by this node", None),
     }
@@ -980,42 +980,37 @@ impl Server {
         event!(Level::INFO, "Listening on {}", config.address);
 
         let (local_accounts, genesis_accounts): (
-            HashMap<Address, SecretKey>,
+            HashMap<Address, k256::SecretKey>,
             HashMap<Address, AccountInfo>,
         ) = {
-            let secp256k1 = Secp256k1::signing_only();
             config
                 .accounts
                 .iter()
                 .enumerate()
-                .map(
-                    |(
-                        i,
-                        AccountConfig {
-                            private_key,
-                            balance,
+                .map(|(i, account_config)| {
+                    let AccountConfig {
+                        secret_key,
+                        balance,
+                    } = account_config;
+                    let address = public_key_to_address(secret_key.public_key());
+                    event!(Level::INFO, "Account #{}: {address:?}", i + 1);
+                    event!(
+                        Level::INFO,
+                        "Private Key: 0x{}",
+                        hex::encode(secret_key.to_bytes())
+                    );
+                    let local_account = (address, secret_key.clone());
+                    let genesis_account = (
+                        address,
+                        AccountInfo {
+                            balance: *balance,
+                            nonce: 0,
+                            code: None,
+                            code_hash: KECCAK_EMPTY,
                         },
-                    )| {
-                        let address = public_key_to_address(private_key.public_key(&secp256k1));
-                        event!(Level::INFO, "Account #{}: {address:?}", i + 1);
-                        event!(
-                            Level::INFO,
-                            "Private Key: 0x{}",
-                            hex::encode(private_key.secret_bytes())
-                        );
-                        let local_account = (address, *private_key);
-                        let genesis_account = (
-                            address,
-                            AccountInfo {
-                                balance: *balance,
-                                nonce: 0,
-                                code: None,
-                                code_hash: KECCAK_EMPTY,
-                            },
-                        );
-                        (local_account, genesis_account)
-                    },
-                )
+                    );
+                    (local_account, genesis_account)
+                })
                 .unzip()
         };
 

--- a/crates/rethnet_rpc_server/tests/integration_tests.rs
+++ b/crates/rethnet_rpc_server/tests/integration_tests.rs
@@ -4,7 +4,6 @@ use std::{
     time::SystemTime,
 };
 
-use secp256k1::{Secp256k1, SecretKey};
 use tempfile::TempDir;
 use tracing::Level;
 
@@ -17,7 +16,7 @@ use rethnet_eth::{
         BlockSpec,
     },
     serde::ZeroXPrefixedBytes,
-    signature::{private_key_to_address, Signature},
+    signature::{secret_key_from_str, secret_key_to_address, Signature},
     Address, Bytes, SpecId, B256, U256, U64,
 };
 use rethnet_evm::{AccountInfo, HashMap, KECCAK_EMPTY};
@@ -27,7 +26,7 @@ use rethnet_rpc_server::{
     Server,
 };
 
-const PRIVATE_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const SECRET_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
 struct TestFixture {
     server_address: SocketAddr,
@@ -55,8 +54,8 @@ async fn start_server() -> TestFixture {
         allow_unlimited_contract_size: false,
         rpc_hardhat_network_config: RpcHardhatNetworkConfig { forking: None },
         accounts: vec![AccountConfig {
-            private_key: SecretKey::from_str(PRIVATE_KEY)
-                .expect("should construct private key from string"),
+            secret_key: secret_key_from_str(SECRET_KEY)
+                .expect("should construct secret key from string"),
             balance: U256::ZERO,
         }],
         block_gas_limit: U256::from(30_000_000),
@@ -133,7 +132,7 @@ async fn test_accounts() {
     verify_response(
         &start_server().await,
         MethodInvocation::Eth(EthMethodInvocation::Accounts()),
-        vec![private_key_to_address(&Secp256k1::signing_only(), PRIVATE_KEY).unwrap()],
+        vec![secret_key_to_address(SECRET_KEY).unwrap()],
     )
     .await;
 }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/RethnetState.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/RethnetState.ts
@@ -21,7 +21,7 @@ export class RethnetStateManager {
       State.withGenesisAccounts(
         genesisAccounts.map((account) => {
           return {
-            privateKey: account.privateKey,
+            secretKey: account.privateKey,
             balance: BigInt(account.balance),
           };
         })
@@ -49,7 +49,7 @@ export class RethnetStateManager {
         blockNumber,
         genesisAccounts.map((account) => {
           return {
-            privateKey: account.privateKey,
+            secretKey: account.privateKey,
             balance: BigInt(account.balance),
           };
         })

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/context/rethnet.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/context/rethnet.ts
@@ -75,7 +75,7 @@ export class RethnetEthContext implements EthContextAdapter {
           config.forkCachePath,
           config.genesisAccounts.map((account) => {
             return {
-              privateKey: account.privateKey,
+              secretKey: account.privateKey,
               balance: BigInt(account.balance),
             };
           }),
@@ -123,7 +123,7 @@ export class RethnetEthContext implements EthContextAdapter {
           ethereumjsHeaderDataToRethnetBlockOptions(genesisBlockHeader),
           config.genesisAccounts.map((account) => {
             return {
-              privateKey: account.privateKey,
+              secretKey: account.privateKey,
               balance: BigInt(account.balance),
             };
           })


### PR DESCRIPTION
Fix EDR build and NPM release on Windows ARM. Resolves:

- https://github.com/NomicFoundation/edr/issues/199
- https://github.com/NomicFoundation/edr/issues/200

And there is a QOL improvement to only run the publish step of the EDR build workflow if the commit is a release commit (e.g. `edr-0.1.0`) so we don't get false positive "deploy" messages in PRs.

Notes:

- I changed the terminology from "private key" to "secret key" in EDR. I think this is important, because the abbreviation of private key is ambiguous (PK can mean both public key and private key) and confusing secret and public keys can have disastrous effects. The `k256` crate also calls it secret key, so it's better aligned there as well.
- The generated NAPI release workflow doesn't support testing a Windows ARM build and I haven't managed to manually test the built Windows ARM artifact in reasonable time (Docker and VM on my machine don't work).