### PR TITLE
refactor: replace vm stub in adapters with vm proxy in node

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/context/edr.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/context/edr.ts
@@ -1,5 +1,4 @@
 import { Blockchain, EdrContext, SpecId } from "@ignored/edr";
-import { AsyncEventEmitter } from "@nomicfoundation/ethereumjs-util";
 import { BlockchainAdapter } from "../blockchain";
 import { EdrBlockchain } from "../blockchain/edr";
 import { EthContextAdapter } from "../context";
@@ -7,7 +6,7 @@ import { MemPoolAdapter } from "../mem-pool";
 import { BlockMinerAdapter } from "../miner";
 import { VMAdapter } from "../vm/vm-adapter";
 import { EdrMiner } from "../miner/edr";
-import { EdrAdapter, VMStub } from "../vm/edr";
+import { EdrAdapter } from "../vm/edr";
 import { NodeConfig, isForkedNodeConfig } from "../node-types";
 import {
   ethereumjsHeaderDataToEdrBlockOptions,
@@ -140,20 +139,13 @@ export class EdrEthContext implements EthContextAdapter {
         ? UNLIMITED_CONTRACT_SIZE_VALUE
         : undefined;
 
-    const vmStub: VMStub = {
-      evm: {
-        events: new AsyncEventEmitter(),
-      },
-    };
-
     const vm = new EdrAdapter(
       blockchain.asInner(),
       state,
       common,
       limitContractCodeSize,
       limitInitcodeSize,
-      config.enableTransientStorage,
-      vmStub
+      config.enableTransientStorage
     );
 
     const memPool = new EdrMemPool(BigInt(config.blockGasLimit), state, specId);
@@ -165,8 +157,7 @@ export class EdrEthContext implements EthContextAdapter {
       common,
       limitContractCodeSize,
       ethereumjsMempoolOrderToEdrMineOrdering(config.mempoolOrder),
-      prevRandaoGenerator,
-      vmStub
+      prevRandaoGenerator
     );
 
     return new EdrEthContext(blockchain, memPool, miner, vm);

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/miner.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/miner.ts
@@ -1,3 +1,5 @@
+import type { MinimalInterpreterStep } from "./vm/proxy-vm";
+
 import { Block } from "@nomicfoundation/ethereumjs-block";
 import { Address } from "@nomicfoundation/ethereumjs-util";
 import { PartialTrace, RunBlockResult } from "./vm/vm-adapter";
@@ -27,4 +29,6 @@ export interface BlockMinerAdapter {
   prevRandaoGeneratorSeed(): Buffer;
 
   setPrevRandaoGeneratorNextValue(nextValue: Buffer): void;
+
+  onStep(cb: (step: MinimalInterpreterStep, next?: any) => Promise<void>): void;
 }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/miner/dual.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/miner/dual.ts
@@ -1,3 +1,5 @@
+import type { MinimalInterpreterStep } from "../vm/proxy-vm";
+
 import { Address } from "@nomicfoundation/ethereumjs-util";
 import { keccak256 } from "../../../util/keccak";
 import { globalEdrContext } from "../context/edr";
@@ -92,5 +94,12 @@ export class DualBlockMiner implements BlockMinerAdapter {
   public setPrevRandaoGeneratorNextValue(nextValue: Buffer): void {
     this._hardhatMiner.setPrevRandaoGeneratorNextValue(nextValue);
     this._edrMiner.setPrevRandaoGeneratorNextValue(nextValue);
+  }
+
+  public onStep(
+    _cb: (step: MinimalInterpreterStep, next?: any) => Promise<void>
+  ) {
+    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+    throw new Error("Not implemented");
   }
 }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/miner/hardhat.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/miner/hardhat.ts
@@ -1,3 +1,5 @@
+import type { MinimalInterpreterStep } from "../vm/proxy-vm";
+
 import { HeaderData } from "@nomicfoundation/ethereumjs-block";
 import { Common } from "@nomicfoundation/ethereumjs-common";
 import { TypedTransaction } from "@nomicfoundation/ethereumjs-tx";
@@ -149,6 +151,12 @@ export class HardhatBlockMiner implements BlockMinerAdapter {
 
   public setPrevRandaoGeneratorNextValue(nextValue: Buffer): void {
     this._prevRandaoGenerator.setNext(nextValue);
+  }
+
+  public onStep(
+    _cb: (step: MinimalInterpreterStep, next?: any) => Promise<void>
+  ) {
+    // not necessary
   }
 
   private _isTxMinable(

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts
@@ -105,6 +105,7 @@ import { PartialMineBlockResult } from "./miner";
 import { EthContextAdapter } from "./context";
 import { hasTransactions } from "./mem-pool";
 import { makeForkClient } from "./utils/makeForkClient";
+import { getMinimalEthereumJsVm, MinimalEthereumJsVm } from "./vm/proxy-vm";
 
 const log = debug("hardhat:core:hardhat-network:node");
 
@@ -233,6 +234,9 @@ export class HardhatNode extends EventEmitter {
   // blockNumber => state root
   private _irregularStatesByBlockNumber: Map<bigint, Buffer> = new Map();
 
+  // temporarily added for backwards compatibility
+  private _vm: MinimalEthereumJsVm;
+
   private constructor(
     private readonly _context: EthContextAdapter,
     private readonly _instanceId: bigint,
@@ -264,6 +268,8 @@ export class HardhatNode extends EventEmitter {
     const contractsIdentifier = new ContractsIdentifier();
     this._vmTraceDecoder = new VmTraceDecoder(contractsIdentifier);
     this._solidityTracer = new SolidityTracer();
+
+    this._vm = getMinimalEthereumJsVm(this._context);
 
     if (tracingConfig === undefined || tracingConfig.buildInfos === undefined) {
       return;

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/dual.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/dual.ts
@@ -1,3 +1,5 @@
+import type { InterpreterStep } from "@nomicfoundation/ethereumjs-evm";
+
 import { Block } from "@nomicfoundation/ethereumjs-block";
 import { Common } from "@nomicfoundation/ethereumjs-common";
 import { TypedTransaction } from "@nomicfoundation/ethereumjs-tx";
@@ -521,6 +523,10 @@ export class DualModeAdapter implements VMAdapter {
     ]);
 
     return new DualModeBlockBuilder(ethereumJSBlockBuilder, edrBlockBuilder);
+  }
+
+  public onStep(_cb: (step: InterpreterStep, next?: any) => Promise<void>) {
+    throw new Error("Method not implemented.");
   }
 }
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/edr.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/edr.ts
@@ -489,12 +489,14 @@ export class EdrAdapter implements VMAdapter {
 
     // For solidity-coverage compatibility
     for (const step of this._vmTracer.tracingSteps) {
-      this._vm.evm.events.emit("step", {
-        pc: Number(step.pc),
-        depth: step.depth,
-        opcode: { name: step.opcode },
-        stackTop: step.stackTop,
-      });
+      for (const listener of this._stepListeners) {
+        await listener({
+          pc: Number(step.pc),
+          depth: step.depth,
+          opcode: { name: step.opcode },
+          stack: step.stackTop !== undefined ? [step.stackTop] : [],
+        });
+      }
     }
 
     try {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/edr.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/edr.ts
@@ -1,11 +1,11 @@
+import type { MinimalInterpreterStep } from "./proxy-vm";
+
 import { Block } from "@nomicfoundation/ethereumjs-block";
 import { Common } from "@nomicfoundation/ethereumjs-common";
-import { InterpreterStep } from "@nomicfoundation/ethereumjs-evm";
 import {
   Account,
   Address,
   bufferToBigInt,
-  AsyncEventEmitter,
   KECCAK256_NULL,
   toBuffer,
 } from "@nomicfoundation/ethereumjs-util";
@@ -59,6 +59,9 @@ import { EdrBlockBuilder } from "./block-builder/edr";
 export class EdrAdapter implements VMAdapter {
   private _vmTracer: VMTracer;
   private _stateRootToState: Map<Buffer, State> = new Map();
+  private _stepListeners: Array<
+    (step: MinimalInterpreterStep, next?: any) => Promise<void>
+  > = [];
 
   constructor(
     private _blockchain: Blockchain,
@@ -66,9 +69,7 @@ export class EdrAdapter implements VMAdapter {
     private readonly _common: Common,
     private readonly _limitContractCodeSize: bigint | undefined,
     private readonly _limitInitcodeSize: bigint | undefined,
-    private readonly _enableTransientStorage: boolean,
-    // For solidity-coverage compatibility. Name cannot be changed.
-    private _vm: VMStub
+    private readonly _enableTransientStorage: boolean
   ) {
     this._vmTracer = new VMTracer(_common, false);
   }
@@ -102,20 +103,13 @@ export class EdrAdapter implements VMAdapter {
         ? UNLIMITED_CONTRACT_SIZE_VALUE
         : undefined;
 
-    const vmStub: VMStub = {
-      evm: {
-        events: new AsyncEventEmitter(),
-      },
-    };
-
     return new EdrAdapter(
       blockchain,
       state,
       common,
       limitContractCodeSize,
       limitInitcodeSize,
-      config.enableTransientStorage,
-      vmStub
+      config.enableTransientStorage
     );
   }
 
@@ -252,12 +246,14 @@ export class EdrAdapter implements VMAdapter {
 
     // For solidity-coverage compatibility
     for (const step of this._vmTracer.tracingSteps) {
-      this._vm.evm.events.emit("step", {
-        pc: Number(step.pc),
-        depth: step.depth,
-        opcode: { name: step.opcode },
-        stackTop: step.stackTop,
-      });
+      for (const listener of this._stepListeners) {
+        await listener({
+          pc: Number(step.pc),
+          depth: step.depth,
+          opcode: { name: step.opcode },
+          stack: step.stackTop !== undefined ? [step.stackTop] : [],
+        });
+      }
     }
 
     try {
@@ -675,6 +671,12 @@ export class EdrAdapter implements VMAdapter {
     );
   }
 
+  public onStep(
+    cb: (step: MinimalInterpreterStep, next?: any) => Promise<void>
+  ) {
+    this._stepListeners.push(cb);
+  }
+
   private _getBlockEnvDifficulty(
     difficulty: bigint | undefined
   ): bigint | undefined {
@@ -708,20 +710,4 @@ export class EdrAdapter implements VMAdapter {
 
     return undefined;
   }
-}
-
-type InterpreterStepStub = Pick<InterpreterStep, "pc" | "depth"> & {
-  opcode: { name: string };
-  stackTop?: bigint;
-};
-
-interface EVMStub {
-  events: AsyncEventEmitter<{
-    step: (data: InterpreterStepStub, resolve?: (result?: any) => void) => void;
-  }>;
-}
-
-// For compatibility with solidity-coverage that attaches a listener to the step event.
-export interface VMStub {
-  evm: EVMStub;
 }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/proxy-vm.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/proxy-vm.ts
@@ -1,0 +1,113 @@
+import type { EVMResult, Message } from "@nomicfoundation/ethereumjs-evm";
+import type { Address } from "@nomicfoundation/ethereumjs-util";
+import type { EthContextAdapter } from "../context";
+
+import { assertHardhatInvariant } from "../../../core/errors";
+
+export interface MinimalInterpreterStep {
+  pc: number;
+  depth: number;
+  opcode: {
+    name: string;
+  };
+  stack: bigint[];
+}
+
+declare function onEvent(
+  event: "step",
+  cb: (step: MinimalInterpreterStep, next: any) => Promise<void>
+): void;
+declare function onEvent(
+  event: "beforeMessage",
+  cb: (step: Message, next: any) => Promise<void>
+): void;
+declare function onEvent(
+  event: "afterMessage",
+  cb: (step: EVMResult, next: any) => Promise<void>
+): void;
+
+/**
+ * Used by the node to keep the `_vm` variable used by some plugins. This
+ * interface only has the things used by those plugins.
+ */
+export interface MinimalEthereumJsVm {
+  evm: {
+    events: {
+      on: typeof onEvent;
+    };
+  };
+  stateManager: {
+    putContractCode: (address: Address, code: Buffer) => Promise<void>;
+    getContractStorage: (address: Address, slotHash: Buffer) => Promise<Buffer>;
+    putContractStorage: (
+      address: Address,
+      slotHash: Buffer,
+      slotValue: Buffer
+    ) => Promise<void>;
+  };
+}
+
+/**
+ * Creates a proxy for the given object that throws if a property is accessed
+ * that is not in the original object. It also works for nested objects.
+ */
+function createVmProxy<T>(obj: T, prefix?: string): T {
+  if (typeof obj !== "object" || obj === null) {
+    return obj;
+  }
+
+  return new Proxy(obj, {
+    get(target, prop): any {
+      if (prop in target) {
+        return createVmProxy(
+          (target as any)[prop],
+          `${prefix ?? ""}${String(prop)}.`
+        );
+      }
+
+      assertHardhatInvariant(
+        false,
+        `Property ${prefix ?? ""}${String(prop)} cannot be used in node._vm`
+      );
+    },
+
+    set() {
+      assertHardhatInvariant(false, "Properties cannot be changed in node._vm");
+    },
+  });
+}
+
+export function getMinimalEthereumJsVm(
+  context: EthContextAdapter
+): MinimalEthereumJsVm {
+  const minimalEthereumJsVm: MinimalEthereumJsVm = {
+    evm: {
+      events: {
+        on: (event, cb) => {
+          assertHardhatInvariant(
+            event === "step",
+            `Event ${event} is not supported in node._vm`
+          );
+
+          if (event === "step") {
+            context.vm().onStep(cb as any);
+            context.blockMiner().onStep(cb as any);
+          }
+        },
+      },
+    },
+    stateManager: {
+      putContractCode: async (address, code) => {
+        return context.vm().putContractCode(address, code);
+      },
+      getContractStorage: async (address, slotHash) => {
+        return context.vm().getContractStorage(address, slotHash);
+      },
+      putContractStorage: async (address, slotHash, slotValue) => {
+        return context.vm().putContractStorage(address, slotHash, slotValue);
+      },
+    },
+  };
+
+  return createVmProxy(minimalEthereumJsVm);
+}

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/vm-adapter.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/vm-adapter.ts
@@ -6,6 +6,7 @@ import type { TxReceipt } from "@nomicfoundation/ethereumjs-vm";
 import type { StateOverrideSet } from "../../../core/jsonrpc/types/input/callRequest";
 import type { RpcDebugTracingConfig } from "../../../core/jsonrpc/types/input/debugTraceTransaction";
 import type { RpcDebugTraceOutput } from "../output";
+import type { MinimalInterpreterStep } from "./proxy-vm";
 
 import { MessageTrace } from "../../stack-traces/message-trace";
 import { Bloom } from "../utils/bloom";
@@ -94,4 +95,6 @@ export interface VMAdapter {
     common: Common,
     opts: BuildBlockOpts
   ): Promise<BlockBuilderAdapter>;
+
+  onStep(cb: (step: MinimalInterpreterStep, next?: any) => Promise<void>): void;
 }


### PR DESCRIPTION
WIP. I implemented the step handler for both ethereumjs and edr modes, and verified that it works. I also implemented the `_vm.stateManager` part of this, which smock needs.

Pending here is the `beforeMessage`/`afterMessage` handlers, for both ethereumjs and edr modes.