### PR TITLE
fix: unmatched edr exceptional halt

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/exit.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/exit.ts
@@ -150,9 +150,10 @@ export class Exit {
         return ExceptionalHalt.OpcodeNotFound;
       case ExitCode.CODESIZE_EXCEEDS_MAXIMUM:
         return ExceptionalHalt.CreateContractSizeLimit;
+      case ExitCode.CREATE_COLLISION:
+        return ExceptionalHalt.CreateCollision;
 
       default:
-        // TODO temporary, should be removed in production
         // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
         throw new Error(`Unmatched edr exceptional halt: ${this.kind}`);
     }


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/edr/issues/205 and all outstanding test failures in the `openzeppelin-contracts` repo when ran against `rethnet/main` except for: https://github.com/NomicFoundation/edr/issues/206.

Co-authored with @Wodann .