### PR TITLE
Fix compiler download

### DIFF
--- a/.changeset/unlucky-pens-melt.md
+++ b/.changeset/unlucky-pens-melt.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed the compiler download, which broke with the latest version of undici

--- a/packages/hardhat-core/src/internal/util/download.ts
+++ b/packages/hardhat-core/src/internal/util/download.ts
@@ -48,7 +48,7 @@ export async function download(
   });
 
   if (response.statusCode >= 200 && response.statusCode <= 299) {
-    const responseBody = await response.body.arrayBuffer();
+    const responseBody = Buffer.from(await response.body.arrayBuffer());
     const tmpFilePath = resolveTempFileName(filePath);
     await fsExtra.ensureDir(path.dirname(filePath));
 


### PR DESCRIPTION
The compiler downloader was broken because it was trying to write an `ArrayBuffer` to a file. This commit fixes it by converting the `ArrayBuffer` to a `Buffer` before writing it to the file.

This was working before because undici was returning a `Uint8Array` under the hood, but this was fixed in [the latest version](https://github.com/nodejs/undici/releases/tag/v5.26.4).