### PR TITLE
fix: lazy init global edr context

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/context/edr.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/context/edr.ts
@@ -23,8 +23,17 @@ import { RandomBufferGenerator } from "../utils/random";
 
 export const UNLIMITED_CONTRACT_SIZE_VALUE = 2n ** 64n - 1n;
 
-// Only one is allowed to exist
-export const globalEdrContext = new EdrContext();
+let _getGlobalEdrContext: EdrContext | undefined;
+
+// Lazy initialize the global EDR context.
+export function getGlobalEdrContext(): EdrContext {
+  if (_getGlobalEdrContext === undefined) {
+    // Only one is allowed to exist
+    _getGlobalEdrContext = new EdrContext();
+  }
+
+  return _getGlobalEdrContext;
+}
 
 export class EdrEthContext implements EthContextAdapter {
   constructor(
@@ -65,7 +74,7 @@ export class EdrEthContext implements EthContextAdapter {
 
       blockchain = new EdrBlockchain(
         await Blockchain.fork(
-          globalEdrContext,
+          getGlobalEdrContext(),
           specId,
           config.forkConfig.jsonRpcUrl,
           config.forkConfig.blockNumber !== undefined
@@ -91,7 +100,7 @@ export class EdrEthContext implements EthContextAdapter {
       config.forkConfig.blockNumber = Number(latestBlockNumber);
     } else {
       state = EdrStateManager.withGenesisAccounts(
-        globalEdrContext,
+        getGlobalEdrContext(),
         config.genesisAccounts
       );
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/context/edr.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/context/edr.ts
@@ -23,16 +23,16 @@ import { RandomBufferGenerator } from "../utils/random";
 
 export const UNLIMITED_CONTRACT_SIZE_VALUE = 2n ** 64n - 1n;
 
-let _getGlobalEdrContext: EdrContext | undefined;
+let _globalEdrContext: EdrContext | undefined;
 
 // Lazy initialize the global EDR context.
 export function getGlobalEdrContext(): EdrContext {
-  if (_getGlobalEdrContext === undefined) {
+  if (_globalEdrContext === undefined) {
     // Only one is allowed to exist
-    _getGlobalEdrContext = new EdrContext();
+    _globalEdrContext = new EdrContext();
   }
 
-  return _getGlobalEdrContext;
+  return _globalEdrContext;
 }
 
 export class EdrEthContext implements EthContextAdapter {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/miner/dual.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/miner/dual.ts
@@ -3,7 +3,7 @@ import type { MinimalInterpreterStep } from "../vm/proxy-vm";
 
 import { Address } from "@nomicfoundation/ethereumjs-util";
 import { keccak256 } from "../../../util/keccak";
-import { globalEdrContext } from "../context/edr";
+import { getGlobalEdrContext } from "../context/edr";
 import { randomHashSeed } from "../fork/ForkStateManager";
 import { BlockMinerAdapter, PartialMineBlockResult } from "../miner";
 import {
@@ -46,7 +46,7 @@ export class DualBlockMiner implements BlockMinerAdapter {
         nextStateRootSeed = keccak256(stateRootSeed);
       }
 
-      globalEdrContext.setStateRootGeneratorSeed(stateRootSeed);
+      getGlobalEdrContext().setStateRootGeneratorSeed(stateRootSeed);
 
       const edrResult = await this._edrMiner.mineBlock(
         blockTimestamp,
@@ -67,7 +67,7 @@ export class DualBlockMiner implements BlockMinerAdapter {
       return edrResult;
     } catch (error) {
       // Ensure that the state root generator seed is re-aligned upon an error
-      globalEdrContext.setStateRootGeneratorSeed(randomHashSeed());
+      getGlobalEdrContext().setStateRootGeneratorSeed(randomHashSeed());
 
       // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
       throw error;

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/block-builder/dual.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/block-builder/dual.ts
@@ -7,7 +7,7 @@ import {
   assertEqualRunTxResults,
 } from "../../utils/assertions";
 import { randomHashSeed } from "../../fork/ForkStateManager";
-import { globalEdrContext } from "../../context/edr";
+import { getGlobalEdrContext } from "../../context/edr";
 
 export class DualModeBlockBuilder implements BlockBuilderAdapter {
   constructor(
@@ -20,7 +20,7 @@ export class DualModeBlockBuilder implements BlockBuilderAdapter {
     const edrResult = await this._edrBuilder.addTransaction(tx);
 
     // Matches EthereumJS' runCall checkpoint call
-    globalEdrContext.setStateRootGeneratorSeed(randomHashSeed());
+    getGlobalEdrContext().setStateRootGeneratorSeed(randomHashSeed());
 
     assertEqualRunTxResults(ethereumJSResult, edrResult);
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/dual.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/dual.ts
@@ -23,7 +23,7 @@ import {
 import { opcodeName } from "../../stack-traces/opcodes";
 import { VMTracer } from "../../stack-traces/vm-tracer";
 import { RpcDebugTraceOutput } from "../output";
-import { globalEdrContext } from "../context/edr";
+import { getGlobalEdrContext } from "../context/edr";
 import { randomHashSeed } from "../fork/ForkStateManager";
 import { assertEqualRunTxResults } from "../utils/assertions";
 
@@ -88,13 +88,13 @@ export class DualModeAdapter implements VMAdapter {
       ]);
 
       // Matches EthereumJS' runCall checkpoint call
-      globalEdrContext.setStateRootGeneratorSeed(randomHashSeed());
+      getGlobalEdrContext().setStateRootGeneratorSeed(randomHashSeed());
 
       assertEqualRunTxResults(ethereumJSResult, edrResult);
       return edrResult;
     } catch (error) {
       // Ensure that the state root generator seed is re-aligned upon an error
-      globalEdrContext.setStateRootGeneratorSeed(randomHashSeed());
+      getGlobalEdrContext().setStateRootGeneratorSeed(randomHashSeed());
 
       throw error;
     }
@@ -218,7 +218,7 @@ export class DualModeAdapter implements VMAdapter {
       config
     );
 
-    globalEdrContext.setStateRootGeneratorSeed(randomHashSeed());
+    getGlobalEdrContext().setStateRootGeneratorSeed(randomHashSeed());
 
     return edrResult;
   }
@@ -256,7 +256,7 @@ export class DualModeAdapter implements VMAdapter {
       ]);
 
       // Matches EthereumJS' runCall checkpoint call
-      globalEdrContext.setStateRootGeneratorSeed(randomHashSeed());
+      getGlobalEdrContext().setStateRootGeneratorSeed(randomHashSeed());
 
       assertEqualRunTxResults(ethereumJSResult, edrResult);
 
@@ -266,7 +266,7 @@ export class DualModeAdapter implements VMAdapter {
       return edrResult;
     } catch (error) {
       // Ensure that the state root generator seed is re-aligned upon an error
-      globalEdrContext.setStateRootGeneratorSeed(randomHashSeed());
+      getGlobalEdrContext().setStateRootGeneratorSeed(randomHashSeed());
 
       throw error;
     }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/edr.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/edr.ts
@@ -54,7 +54,7 @@ import { MessageTrace } from "../../stack-traces/message-trace";
 import { VMTracer } from "../../stack-traces/vm-tracer";
 
 import {
-  globalEdrContext,
+  getGlobalEdrContext,
   UNLIMITED_CONTRACT_SIZE_VALUE,
 } from "../context/edr";
 import { RunTxResult, VMAdapter } from "./vm-adapter";
@@ -97,13 +97,13 @@ export class EdrAdapter implements VMAdapter {
 
     if (isForkedNodeConfig(config)) {
       state = await EdrStateManager.forkRemote(
-        globalEdrContext,
+        getGlobalEdrContext(),
         config.forkConfig,
         config.genesisAccounts
       );
     } else {
       state = EdrStateManager.withGenesisAccounts(
-        globalEdrContext,
+        getGlobalEdrContext(),
         config.genesisAccounts
       );
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1346,11 +1346,6 @@
   resolved "https://registry.yarnpkg.com/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.3.tgz#8d9147fbd0d49e8f4c5ce729d226694a8fe03eb8"
   integrity sha512-DZMzB/lqPK78T6MluyXqtlRmOMcsZbTTbbEyAjo0ncaff2mqu/k8a79PBcyvpgAhWD/R59Fjq/x3ro5Lof0AtA==
 
-"@nomicfoundation/ethereumjs-rlp@5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.2.tgz#4fee8dc58a53ac6ae87fb1fca7c15dc06c6b5dea"
-  integrity sha512-QwmemBc+MMsHJ1P1QvPl8R8p2aPvvVcKBbvHnQOKBpBztEo0omN0eaob6FeZS/e3y9NSe+mfu3nNFBHszqkjTA==
-
 "@nomicfoundation/ethereumjs-rlp@5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.3.tgz#9431390cee638f0dd2c8cdbce824cb5b575c1f74"
@@ -1389,15 +1384,6 @@
     "@nomicfoundation/ethereumjs-common" "4.0.3"
     "@nomicfoundation/ethereumjs-rlp" "5.0.3"
     "@nomicfoundation/ethereumjs-util" "9.0.3"
-    ethereum-cryptography "0.1.3"
-
-"@nomicfoundation/ethereumjs-util@9.0.2":
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.2.tgz#16bdc1bb36f333b8a3559bbb4b17dac805ce904d"
-  integrity sha512-4Wu9D3LykbSBWZo8nJCnzVIYGvGCuyiYLIJa9XXNVt1q1jUzHdB+sJvx95VGCpPkCT+IbLecW6yfzy3E1bQrwQ==
-  dependencies:
-    "@chainsafe/ssz" "^0.10.0"
-    "@nomicfoundation/ethereumjs-rlp" "5.0.2"
     ethereum-cryptography "0.1.3"
 
 "@nomicfoundation/ethereumjs-util@9.0.3":


### PR DESCRIPTION
I noticed while doing performance testing that the global EDR context is initialized even in `ethereumjs` mode. This is undesirable as we don't want to run Rust code unless the experimental VM flag is set to `edr`. I fixed it by making the global EDR context initialization lazy.