### PR TITLE
fix: set ^0.1.0-alpha.1 as hardhat dependency

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -140,7 +140,7 @@
     "p-map": "^4.0.0",
     "raw-body": "^2.4.1",
     "resolve": "1.17.0",
-    "@ignored/edr": "^0.1.0-alpha",
+    "@ignored/edr": "^0.1.0-alpha.1",
     "semver": "^6.3.0",
     "solc": "0.7.3",
     "source-map-support": "^0.5.13",


### PR DESCRIPTION
Since we released a pre-release version with `0.1.0-alpha.0`, the caret version ^0.1.0-alpha` always installs `0.1.0-alpha.0`. Specifying `^0.1.0-alpha.1` instead seems to make caret versions work as intendend.