### PR TITLE
add Sourcify example in "Advanced Usage" in readme

### DIFF
--- a/packages/hardhat-verify/README.md
+++ b/packages/hardhat-verify/README.md
@@ -234,44 +234,66 @@ hre.run("verify:verify", {
 }
 ```
 
-#### Advanced Usage: Using the Etherscan class from another plugin
+#### Advanced Usage: Using the Etherscan and Sourcify classes from another plugin
 
-The Etherscan class used for contract verification can be imported from the plugin, allowing its direct usage:
+- The **Etherscan** class used for contract verification can be imported from the plugin, allowing its direct usage:
 
-```js
-import { Etherscan } from "@nomicfoundation/hardhat-verify/etherscan";
+  ```js
+  import { Etherscan } from "@nomicfoundation/hardhat-verify/etherscan";
 
-const instance = new Etherscan(
-  "abc123def123", // Etherscan API key
-  "https://api.etherscan.io/api", // Etherscan API URL
-  "https://etherscan.io" // Etherscan browser URL
-);
-
-if (!instance.isVerified("0x123abc...")) {
-  const { message: guid } = await instance.verify(
-    // Contract address
-    "0x123abc...",
-    // Contract source code
-    '{"language":"Solidity","sources":{"contracts/Sample.sol":{"content":"// SPDX-Lic..."}},"settings":{ ... }}',
-    // Contract name
-    "contracts/Sample.sol:MyContract",
-    // Compiler version
-    "v0.8.19+commit.7dd6d404",
-    // Encoded constructor arguments
-    "0000000000000000000000000000000000000000000000000000000000000032"
+  const instance = new Etherscan(
+    "abc123def123", // Etherscan API key
+    "https://api.etherscan.io/api", // Etherscan API URL
+    "https://etherscan.io" // Etherscan browser URL
   );
 
-  await sleep(1000);
-  const verificationStatus = await instance.getVerificationStatus(guid);
-
-  if (verificationStatus.isSuccess()) {
-    const contractURL = instance.getContractUrl("0x123abc...");
-    console.log(
-      `Successfully verified contract "MyContract" on Etherscan: ${contractURL}`
+  if (!instance.isVerified("0x123abc...")) {
+    const { message: guid } = await instance.verify(
+      // Contract address
+      "0x123abc...",
+      // Contract source code
+      '{"language":"Solidity","sources":{"contracts/Sample.sol":{"content":"// SPDX-Lic..."}},"settings":{ ... }}',
+      // Contract name
+      "contracts/Sample.sol:MyContract",
+      // Compiler version
+      "v0.8.19+commit.7dd6d404",
+      // Encoded constructor arguments
+      "0000000000000000000000000000000000000000000000000000000000000032"
     );
+
+    await sleep(1000);
+    const verificationStatus = await instance.getVerificationStatus(guid);
+
+    if (verificationStatus.isSuccess()) {
+      const contractURL = instance.getContractUrl("0x123abc...");
+      console.log(
+        `Successfully verified contract "MyContract" on Etherscan: ${contractURL}`
+      );
+    }
   }
-}
-```
+  ```
+
+- The **Sourcify** class used for contract verification can be imported from the plugin, allowing its direct usage:
+
+  ```js
+  import { Sourcify } from "@nomicfoundation/hardhat-verify/sourcify";
+
+  const instance = new Sourcify(1); // Set chainId
+
+  if (!instance.isVerified("0x123abc...")) {
+    const sourcifyResponse = await instance.verify("0x123abc...", {
+      "metadata.json": "{...}",
+      "otherFile.sol": "...",
+    });
+    if (sourcifyResponse.isOk()) {
+      const contractURL = instance.getContractUrl(
+        "0x123abc...",
+        sourcifyResponse.status
+      );
+      console.log(`Successfully verified contract on Sourcify: ${contractURL}`);
+    }
+  }
+  ```
 
 ## How it works
 

--- a/packages/hardhat-verify/README.md
+++ b/packages/hardhat-verify/README.md
@@ -57,7 +57,7 @@ module.exports = {
   },
   sourcify: {
     // Disabled by default
-    // Does not need API Key
+    // Doesn't need an API key
     enabled: true
   }
 };

--- a/packages/hardhat-verify/README.md
+++ b/packages/hardhat-verify/README.md
@@ -6,7 +6,7 @@
 
 ## What
 
-This plugin helps you verify the source code for your Solidity contracts. At the moment, it supports [Etherscan](https://etherscan.io)-based explorers and explorers compatible with its API like [Blockscout](https://www.blockscout.com/).
+This plugin helps you verify the source code for your Solidity contracts. At the moment, it supports [Etherscan](https://etherscan.io)-based explorers, explorers compatible with its API like [Blockscout](https://www.blockscout.com/) and [Sourcify](https://sourcify.dev/).
 
 It's smart and it tries to do as much as possible to facilitate the process:
 
@@ -35,7 +35,7 @@ import "@nomicfoundation/hardhat-verify";
 
 ## Tasks
 
-This plugin provides the `verify` task, which allows you to verify contracts through Etherscan's service.
+This plugin provides the `verify` task, which allows you to verify contracts through Sourcify and Etherscan's service.
 
 ## Environment extensions
 
@@ -43,7 +43,7 @@ This plugin does not extend the environment.
 
 ## Usage
 
-You need to add the following Etherscan config to your `hardhat.config.js` file:
+You need to add the following Etherscan and Sourcify configs to your `hardhat.config.js` file:
 
 ```js
 module.exports = {
@@ -54,6 +54,11 @@ module.exports = {
     // Your API key for Etherscan
     // Obtain one at https://etherscan.io/
     apiKey: "YOUR_ETHERSCAN_API_KEY"
+  },
+  sourcify: {
+    // Disabled by default
+    // Does not need API Key
+    enabled: true
   }
 };
 ```
@@ -236,7 +241,9 @@ hre.run("verify:verify", {
 
 #### Advanced Usage: Using the Etherscan and Sourcify classes from another plugin
 
-- The **Etherscan** class used for contract verification can be imported from the plugin, allowing its direct usage:
+Both Etherscan and Sourcify classes can be imported from the plugin for direct use.
+
+- **Etherscan Class Usage**
 
   ```js
   import { Etherscan } from "@nomicfoundation/hardhat-verify/etherscan";
@@ -273,7 +280,7 @@ hre.run("verify:verify", {
   }
   ```
 
-- The **Sourcify** class used for contract verification can be imported from the plugin, allowing its direct usage:
+- **Sourcify Class Usage**
 
   ```js
   import { Sourcify } from "@nomicfoundation/hardhat-verify/sourcify";


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Add the Sourcify snippet example in "Advanced Usage: Using the Etherscan and Sourcify classes from another plugin" into the `hardhat-verify`'s readme
