### PR TITLE
Bug in compilation when multiple versions are used with many contracts 

### DIFF
--- a/.changeset/small-crews-kiss.md
+++ b/.changeset/small-crews-kiss.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added logic to avoid downloading the same compiler version multiple times

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -580,25 +580,25 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD)
         compilersCache
       );
 
-      const isCompilerDownloaded = await downloader.isCompilerDownloaded(
-        solcVersion
+      await downloader.downloadCompiler(
+        solcVersion,
+        // downloadStartedCb
+        async (isCompilerDownloaded: boolean) => {
+          await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_START, {
+            solcVersion,
+            isCompilerDownloaded,
+            quiet,
+          });
+        },
+        // downloadEndedCb
+        async (isCompilerDownloaded: boolean) => {
+          await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_END, {
+            solcVersion,
+            isCompilerDownloaded,
+            quiet,
+          });
+        }
       );
-
-      if (!isCompilerDownloaded) {
-        await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_START, {
-          solcVersion,
-          isCompilerDownloaded,
-          quiet,
-        });
-
-        await downloader.downloadCompiler(solcVersion);
-
-        await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_END, {
-          solcVersion,
-          isCompilerDownloaded,
-          quiet,
-        });
-      }
 
       const compiler = await downloader.getCompiler(solcVersion);
 
@@ -615,24 +615,25 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD)
         compilersCache
       );
 
-      const isWasmCompilerDownloader =
-        await wasmDownloader.isCompilerDownloaded(solcVersion);
-
-      if (!isWasmCompilerDownloader) {
-        await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_START, {
-          solcVersion,
-          isCompilerDownloaded,
-          quiet,
-        });
-
-        await wasmDownloader.downloadCompiler(solcVersion);
-
-        await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_END, {
-          solcVersion,
-          isCompilerDownloaded,
-          quiet,
-        });
-      }
+      await wasmDownloader.downloadCompiler(
+        solcVersion,
+        async (isCompilerDownloaded: boolean) => {
+          // downloadStartedCb
+          await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_START, {
+            solcVersion,
+            isCompilerDownloaded,
+            quiet,
+          });
+        },
+        // downloadEndedCb
+        async (isCompilerDownloaded: boolean) => {
+          await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_END, {
+            solcVersion,
+            isCompilerDownloaded,
+            quiet,
+          });
+        }
+      );
 
       const wasmCompiler = await wasmDownloader.getCompiler(solcVersion);
 

--- a/packages/hardhat-core/src/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/src/builtin-tasks/compile.ts
@@ -582,7 +582,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD)
 
       await downloader.downloadCompiler(
         solcVersion,
-        // downloadStartedCb
+        // callback called before compiler download
         async (isCompilerDownloaded: boolean) => {
           await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_START, {
             solcVersion,
@@ -590,7 +590,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD)
             quiet,
           });
         },
-        // downloadEndedCb
+        // callback called after compiler download
         async (isCompilerDownloaded: boolean) => {
           await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_END, {
             solcVersion,
@@ -618,14 +618,14 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD)
       await wasmDownloader.downloadCompiler(
         solcVersion,
         async (isCompilerDownloaded: boolean) => {
-          // downloadStartedCb
+          // callback called before compiler download
           await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_START, {
             solcVersion,
             isCompilerDownloaded,
             quiet,
           });
         },
-        // downloadEndedCb
+        // callback called after compiler download
         async (isCompilerDownloaded: boolean) => {
           await run(TASK_COMPILE_SOLIDITY_LOG_DOWNLOAD_COMPILER_END, {
             solcVersion,

--- a/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts
@@ -155,6 +155,10 @@ export class CompilerDownloader implements ICompilerDownloader {
     downloadStartedCb: (isCompilerDownloaded: boolean) => Promise<any>,
     downloadEndedCb: (isCompilerDownloaded: boolean) => Promise<any>
   ): Promise<void> {
+    // Since only one process at a time can acquire the mutex, we avoid the risk of downloading the same compiler multiple times.
+    // This is because the mutex blocks access until a compiler has been fully downloaded, preventing any new process
+    // from checking whether that version of the compiler exists. Without mutex it might incorrectly
+    // return false, indicating that the compiler isn't present, even though it is currently being downloaded.
     await this._mutex.use(async () => {
       const isCompilerDownloaded = await this.isCompilerDownloaded(version);
 

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts
@@ -190,6 +190,10 @@ export async function downloadCompiler(solidityVersion: string) {
 
   if (!isCompilerDownloaded) {
     console.log("Downloading solc", solidityVersion);
-    await downloader.downloadCompiler(solidityVersion);
+    await downloader.downloadCompiler(
+      solidityVersion,
+      async () => {},
+      async () => {}
+    );
   }
 }

--- a/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
@@ -249,11 +249,11 @@ describe("Compiler downloader", function () {
           promises.push(
             downloader.downloadCompiler(
               VERSION,
-              // downloadStartedCb
+              // callback called before compiler download
               async () => {
                 value++;
               },
-              // downloadEndedCb
+              // callback called after compiler download
               async () => {}
             )
           );
@@ -275,11 +275,11 @@ describe("Compiler downloader", function () {
           promises.push(
             downloader.downloadCompiler(
               version,
-              // downloadStartedCb
+              // callback called before compiler download
               async () => {
                 value++;
               },
-              // downloadEndedCb
+              // callback called after compiler download
               async () => {}
             )
           );

--- a/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
@@ -209,6 +209,31 @@ describe("Compiler downloader", function () {
       assert.isTrue(await mockDownloader.isCompilerDownloaded("0.4.12"));
     });
 
+    it("should execute both the callback before downloading the compiler and the callback after downloading the compiler", async function () {
+      const VERSION = "0.4.12";
+
+      let value = 0;
+
+      await downloader.downloadCompiler(
+        VERSION,
+        // downloadStartedCb
+        async () => {
+          // Check that the callback is executed before downloading the compiler
+          value++;
+          assert.isFalse(await downloader.isCompilerDownloaded(VERSION));
+        },
+        // downloadEndedCb
+        async () => {
+          // Check that the callback is executed after downloading the compiler
+          value++;
+          assert.isDefined(downloader.getCompiler(VERSION));
+        }
+      );
+
+      // Check that both callbacks have been called
+      assert(value === 2);
+    });
+
     describe("multiple downloads", function () {
       it("should not download multiple times the same compiler", async function () {
         // The intention is for the value to be 1 if the compiler is downloaded only once.

--- a/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
+++ b/packages/hardhat-core/test/internal/solidity/compiler/downloader.ts
@@ -217,7 +217,7 @@ describe("Compiler downloader", function () {
 
         const VERSION = "0.4.12";
 
-        const value = [0];
+        let value = 0;
 
         const promises = [];
         for (let i = 0; i < 10; i++) {
@@ -226,7 +226,7 @@ describe("Compiler downloader", function () {
               VERSION,
               // downloadStartedCb
               async () => {
-                value[0]++;
+                value++;
               },
               // downloadEndedCb
               async () => {}
@@ -237,13 +237,13 @@ describe("Compiler downloader", function () {
         await Promise.all(promises);
 
         assert.isDefined(downloader.getCompiler(VERSION));
-        assert(value[0] === 1);
+        assert(value === 1);
       });
 
       it("should download multiple different compilers", async function () {
         const VERSIONS = ["0.5.1", "0.5.2", "0.5.3", "0.5.4", "0.5.5"];
 
-        const value = [0];
+        let value = 0;
 
         const promises = [];
         for (const version of VERSIONS) {
@@ -252,7 +252,7 @@ describe("Compiler downloader", function () {
               version,
               // downloadStartedCb
               async () => {
-                value[0]++;
+                value++;
               },
               // downloadEndedCb
               async () => {}
@@ -266,7 +266,7 @@ describe("Compiler downloader", function () {
           assert.isDefined(downloader.getCompiler(version));
         }
 
-        assert(value[0] === VERSIONS.length);
+        assert(value === VERSIONS.length);
       });
     });
   });

--- a/packages/hardhat-core/test/internal/solidity/compiler/index.ts
+++ b/packages/hardhat-core/test/internal/solidity/compiler/index.ts
@@ -33,7 +33,11 @@ describe("Compiler", () => {
         CompilerDownloader.getCompilerPlatform(),
         this.tmpDir
       );
-      await downloader.downloadCompiler(solcVersion);
+      await downloader.downloadCompiler(
+        solcVersion,
+        async () => {},
+        async () => {}
+      );
       const compilerPathResult = await downloader.getCompiler(solcVersion);
       solcPath = compilerPathResult!.compilerPath;
     });
@@ -126,7 +130,11 @@ contract A {}
 
     beforeEach(async function () {
       downloader = new CompilerDownloader(CompilerPlatform.WASM, this.tmpDir);
-      await downloader.downloadCompiler(solcVersion);
+      await downloader.downloadCompiler(
+        solcVersion,
+        async () => {},
+        async () => {}
+      );
       const compilerPathResult = await downloader.getCompiler(solcVersion);
       solcPath = compilerPathResult!.compilerPath;
     });


### PR DESCRIPTION
See issue: https://github.com/NomicFoundation/hardhat/issues/4490

PROBLEM
If multiple requests to download the same version of a compiler are sent, the download occurs multiple times.

SOLUTION
Modify the existing mutex logic to check if a compiler of a specific version has already been downloaded or is currently being downloaded.