### PR TITLE
Fix vyper downloader

### DIFF
--- a/.changeset/tough-geese-tie.md
+++ b/.changeset/tough-geese-tie.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-vyper": patch
+---
+
+Fixed a problem with the Vyper compilers downloader

--- a/packages/hardhat-vyper/src/downloader.ts
+++ b/packages/hardhat-vyper/src/downloader.ts
@@ -127,8 +127,10 @@ export class CompilerDownloader {
   }
 
   private _findVersionRelease(version: string): CompilerRelease | undefined {
-    return this.compilersList.find((release) =>
-      semver.eq(release.tag_name, version)
+    return this.compilersList.find(
+      (release) =>
+        semver.valid(release.tag_name) !== null &&
+        semver.eq(release.tag_name, version)
     );
   }
 


### PR DESCRIPTION
The latest releases of Vyper include tag names like "v0.3.10rc5" which are not valid semver strings. This was causing the downloder to fail when calling semver.eq. This fixes this by previously checking that the tag_name is a valid semver string.

EDIT: that kind of version string is valid for [PEP 440](https://peps.python.org/pep-0440/) but it's not for semver.

[PEP 440](https://peps.python.org/pep-0440/#pre-release-separators):

> Pre-releases should allow a ., -, or _ separator between the release segment and the pre-release segment. The normal form for this is without a separator.

[Semver](https://semver.org/#spec-item-9):

> A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers immediately following the patch version.