### PR TITLE
fix: vyper downloader in `edr/main`

### DIFF
--- a/packages/hardhat-vyper/src/downloader.ts
+++ b/packages/hardhat-vyper/src/downloader.ts
@@ -127,8 +127,10 @@ export class CompilerDownloader {
   }
 
   private _findVersionRelease(version: string): CompilerRelease | undefined {
-    return this.compilersList.find((release) =>
-      semver.eq(release.tag_name, version)
+    return this.compilersList.find(
+      (release) =>
+        semver.valid(release.tag_name) !== null &&
+        semver.eq(release.tag_name, version)
     );
   }
 


### PR DESCRIPTION
Cherry picking the fix from https://github.com/NomicFoundation/hardhat/pull/4552 to `edr/main` to fix CI failures such as https://github.com/NomicFoundation/hardhat/actions/runs/6728124285/job/18294392642?pr=4553