### PR TITLE
Avoid using a maxPriorityFeePerGas of 0

### DIFF
--- a/.changeset/old-phones-live.md
+++ b/.changeset/old-phones-live.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed an issue in low-traffic chains that resulted in txs using a `maxPriorityFeePerGas` of 0

--- a/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
+++ b/packages/hardhat-core/src/internal/core/providers/gas-providers.ts
@@ -254,6 +254,25 @@ export class AutomaticGasPriceProvider extends ProviderWrapper {
         ],
       })) as { baseFeePerGas: string[]; reward: string[][] };
 
+      let maxPriorityFeePerGas = rpcQuantityToBigInt(response.reward[0][0]);
+
+      if (maxPriorityFeePerGas === 0n) {
+        try {
+          const suggestedMaxPriorityFeePerGas =
+            (await this._wrappedProvider.request({
+              method: "eth_maxPriorityFeePerGas",
+              params: [],
+            })) as string;
+
+          maxPriorityFeePerGas = rpcQuantityToBigInt(
+            suggestedMaxPriorityFeePerGas
+          );
+        } catch {
+          // if eth_maxPriorityFeePerGas does not exist, use 1 wei
+          maxPriorityFeePerGas = 1n;
+        }
+      }
+
       return {
         // Each block increases the base fee by 1/8 at most, when full.
         // We have the next block's base fee, so we compute a cap for the
@@ -268,7 +287,7 @@ export class AutomaticGasPriceProvider extends ProviderWrapper {
             (AutomaticGasPriceProvider.EIP1559_BASE_FEE_MAX_FULL_BLOCKS_PREFERENCE -
               1n),
 
-        maxPriorityFeePerGas: rpcQuantityToBigInt(response.reward[0][0]),
+        maxPriorityFeePerGas,
       };
     } catch {
       this._nodeHasFeeHistory = false;

--- a/packages/hardhat-core/test/internal/core/providers/gas-providers.ts
+++ b/packages/hardhat-core/test/internal/core/providers/gas-providers.ts
@@ -256,6 +256,98 @@ describe("AutomaticGasPriceProvider", () => {
       });
     });
 
+    describe("When the eth_feeHistory result causes maxPriorityFeePerGas to be 0 and eth_maxPriorityFeePerGas doesn't exist", function () {
+      const latestBaseFeeInMockedProvider = 80;
+
+      beforeEach(function () {
+        mockedProvider.setReturnValue("eth_feeHistory", {
+          baseFeePerGas: [
+            numberToRpcQuantity(latestBaseFeeInMockedProvider),
+            numberToRpcQuantity(
+              Math.floor((latestBaseFeeInMockedProvider * 9) / 8)
+            ),
+          ],
+          reward: [["0x0"]],
+        });
+
+        mockedProvider.setReturnValue("eth_getBlockByNumber", {
+          baseFeePerGas: "0x1",
+        });
+      });
+
+      it("should use the reward return value as default maxPriorityFeePerGas", async function () {
+        await provider.request({
+          method: "eth_sendTransaction",
+          params: [
+            {
+              from: "0x0000000000000000000000000000000000000011",
+              to: "0x0000000000000000000000000000000000000011",
+              value: 1,
+            },
+          ],
+        });
+
+        const expectedBaseFee = Math.floor(
+          latestBaseFeeInMockedProvider *
+            (9 / 8) **
+              Number(
+                AutomaticGasPriceProvider.EIP1559_BASE_FEE_MAX_FULL_BLOCKS_PREFERENCE
+              )
+        );
+
+        const [tx] = mockedProvider.getLatestParams("eth_sendTransaction");
+        assert.equal(tx.maxFeePerGas, expectedBaseFee);
+        assert.equal(tx.maxPriorityFeePerGas, "0x1");
+      });
+    });
+
+    describe("When the eth_feeHistory result causes maxPriorityFeePerGas to be 0 and eth_maxPriorityFeePerGas exists", function () {
+      const latestBaseFeeInMockedProvider = 80;
+
+      beforeEach(function () {
+        mockedProvider.setReturnValue("eth_feeHistory", {
+          baseFeePerGas: [
+            numberToRpcQuantity(latestBaseFeeInMockedProvider),
+            numberToRpcQuantity(
+              Math.floor((latestBaseFeeInMockedProvider * 9) / 8)
+            ),
+          ],
+          reward: [["0x0"]],
+        });
+
+        mockedProvider.setReturnValue("eth_getBlockByNumber", {
+          baseFeePerGas: "0x1",
+        });
+
+        mockedProvider.setReturnValue("eth_maxPriorityFeePerGas", "0x12");
+      });
+
+      it("should use the reward return value as default maxPriorityFeePerGas", async function () {
+        await provider.request({
+          method: "eth_sendTransaction",
+          params: [
+            {
+              from: "0x0000000000000000000000000000000000000011",
+              to: "0x0000000000000000000000000000000000000011",
+              value: 1,
+            },
+          ],
+        });
+
+        const expectedBaseFee = Math.floor(
+          latestBaseFeeInMockedProvider *
+            (9 / 8) **
+              Number(
+                AutomaticGasPriceProvider.EIP1559_BASE_FEE_MAX_FULL_BLOCKS_PREFERENCE
+              )
+        );
+
+        const [tx] = mockedProvider.getLatestParams("eth_sendTransaction");
+        assert.equal(tx.maxFeePerGas, expectedBaseFee);
+        assert.equal(tx.maxPriorityFeePerGas, "0x12");
+      });
+    });
+
     describe("When eth_feeHistory is available and EIP1559 is not supported", function () {
       const latestBaseFeeInMockedProvider = 80;
 

--- a/packages/hardhat-core/test/internal/core/providers/gas-providers.ts
+++ b/packages/hardhat-core/test/internal/core/providers/gas-providers.ts
@@ -275,7 +275,7 @@ describe("AutomaticGasPriceProvider", () => {
         });
       });
 
-      it("should use the reward return value as default maxPriorityFeePerGas", async function () {
+      it("should use a non-zero maxPriorityFeePerGas", async function () {
         await provider.request({
           method: "eth_sendTransaction",
           params: [
@@ -322,7 +322,7 @@ describe("AutomaticGasPriceProvider", () => {
         mockedProvider.setReturnValue("eth_maxPriorityFeePerGas", "0x12");
       });
 
-      it("should use the reward return value as default maxPriorityFeePerGas", async function () {
+      it("should use the the result of eth_maxPriorityFeePerGas as maxPriorityFeePerGas", async function () {
         await provider.request({
           method: "eth_sendTransaction",
           params: [


### PR DESCRIPTION
Closes #4190.

If the computation over the `eth_feeHistory` result results in a max priority fee of 0, we try to use the result of `eth_maxPriorityFeePerGas`. If that method doesn't exist, we use 1.

I should mention that I _couldn't_ reproduce this issue, because right now Base goerli has enough activity to not trigger this. But this change is low-risk, since the new code is only executed when the inferred max priority fee is 0.

Another way in which this is not ideal is that we are only using `eth_maxPriorityFeePerGas` when the estimation is 0. Perhaps ideally we should always use it? But this is a way bigger change that I can't investigate right now. I'm going to create follow-up issues for this.