### PR TITLE
feat: add `eth_getTransactionByHash` support

### DIFF
--- a/crates/edr_eth/src/access_list.rs
+++ b/crates/edr_eth/src/access_list.rs
@@ -30,6 +30,12 @@ impl From<Vec<AccessListItem>> for AccessList {
     }
 }
 
+impl From<AccessList> for Vec<AccessListItem> {
+    fn from(src: AccessList) -> Vec<AccessListItem> {
+        src.0
+    }
+}
+
 /// Access list item
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(

--- a/crates/edr_eth/src/transaction/signed.rs
+++ b/crates/edr_eth/src/transaction/signed.rs
@@ -94,6 +94,17 @@ impl SignedTransaction {
     }
 
     /// Retrieves the max fee per gas of the transaction, if any.
+    pub fn max_fee_per_gas(&self) -> Option<U256> {
+        match self {
+            SignedTransaction::PreEip155Legacy(_)
+            | SignedTransaction::PostEip155Legacy(_)
+            | SignedTransaction::Eip2930(_) => None,
+            SignedTransaction::Eip1559(tx) => Some(tx.max_priority_fee_per_gas),
+            SignedTransaction::Eip4844(tx) => Some(tx.max_priority_fee_per_gas),
+        }
+    }
+
+    /// Retrieves the max priority fee per gas of the transaction, if any.
     pub fn max_priority_fee_per_gas(&self) -> Option<U256> {
         match self {
             SignedTransaction::PreEip155Legacy(_)
@@ -101,6 +112,28 @@ impl SignedTransaction {
             | SignedTransaction::Eip2930(_) => None,
             SignedTransaction::Eip1559(tx) => Some(tx.max_priority_fee_per_gas),
             SignedTransaction::Eip4844(tx) => Some(tx.max_priority_fee_per_gas),
+        }
+    }
+
+    /// Retrieves the max fee per blob gas of the transaction, if any.
+    pub fn max_fee_per_blob_gas(&self) -> Option<U256> {
+        match self {
+            SignedTransaction::PreEip155Legacy(_)
+            | SignedTransaction::PostEip155Legacy(_)
+            | SignedTransaction::Eip2930(_)
+            | SignedTransaction::Eip1559(_) => None,
+            SignedTransaction::Eip4844(tx) => Some(tx.max_fee_per_blob_gas),
+        }
+    }
+
+    /// Retrieves the blob hashes of the transaction, if any.
+    pub fn blob_hashes(&self) -> Option<Vec<B256>> {
+        match self {
+            SignedTransaction::PreEip155Legacy(_)
+            | SignedTransaction::PostEip155Legacy(_)
+            | SignedTransaction::Eip2930(_)
+            | SignedTransaction::Eip1559(_) => None,
+            SignedTransaction::Eip4844(tx) => Some(tx.blob_hashes.clone()),
         }
     }
 
@@ -206,6 +239,15 @@ impl SignedTransaction {
                 s: tx.s,
                 v: u64::from(tx.odd_y_parity),
             },
+        }
+    }
+
+    pub fn transaction_type(&self) -> u64 {
+        match self {
+            SignedTransaction::PreEip155Legacy(_) | SignedTransaction::PostEip155Legacy(_) => 0,
+            SignedTransaction::Eip2930(_) => 1,
+            SignedTransaction::Eip1559(_) => 2,
+            SignedTransaction::Eip4844(_) => 3,
         }
     }
 }

--- a/crates/edr_evm/src/transaction/pending.rs
+++ b/crates/edr_evm/src/transaction/pending.rs
@@ -91,6 +91,11 @@ impl PendingTransaction {
         &self.caller
     }
 
+    /// Returns the inner [`SignedTransaction`]
+    pub fn transaction(&self) -> &SignedTransaction {
+        &self.transaction
+    }
+
     /// Returns the inner transaction and caller
     pub fn into_inner(self) -> (SignedTransaction, Address) {
         (self.transaction, self.caller)

--- a/crates/edr_provider/src/requests/eth/transactions.rs
+++ b/crates/edr_provider/src/requests/eth/transactions.rs
@@ -1,6 +1,117 @@
-use edr_eth::{serde::ZeroXPrefixedBytes, transaction::EthTransactionRequest, B256};
+use edr_eth::{
+    remote,
+    serde::ZeroXPrefixedBytes,
+    transaction::{EthTransactionRequest, SignedTransaction},
+    SpecId, B256, U256,
+};
 
-use crate::{data::ProviderData, ProviderError};
+use crate::{
+    data::{BlockMetadataForTransaction, GetTransactionResult, ProviderData},
+    ProviderError,
+};
+
+const FIRST_HARDFORK_WITH_TRANSACTION_TYPE: SpecId = SpecId::BERLIN;
+
+pub async fn handle_get_transaction_by_hash(
+    data: &ProviderData,
+    transaction_hash: B256,
+) -> Result<Option<remote::eth::Transaction>, ProviderError> {
+    data.transaction_by_hash(&transaction_hash)
+        .await?
+        .map(get_transaction_result_to_rpc_result)
+        .transpose()
+}
+
+fn get_transaction_result_to_rpc_result(
+    result: GetTransactionResult,
+) -> Result<remote::eth::Transaction, ProviderError> {
+    fn gas_price_for_post_eip1559(
+        signed_transaction: &SignedTransaction,
+        block_metadata: Option<&BlockMetadataForTransaction>,
+    ) -> U256 {
+        let max_fee_per_gas = signed_transaction
+            .max_fee_per_gas()
+            .expect("Transaction must be post EIP-1559 transaction.");
+        let max_priority_fee_per_gas = signed_transaction
+            .max_priority_fee_per_gas()
+            .expect("Transaction must be post EIP-1559 transaction.");
+
+        if let Some(block_metadata) = block_metadata {
+            let base_fee_per_gas = block_metadata.base_fee_per_gas.expect(
+                "Transaction must have base fee per gas in block metadata if EIP-1559 is active.",
+            );
+            let priority_fee_per_gas =
+                max_priority_fee_per_gas.min(max_fee_per_gas - base_fee_per_gas);
+            base_fee_per_gas + priority_fee_per_gas
+        } else {
+            // We are following Hardhat's behavior of returning the max fee per gas for
+            // pending transactions.
+            max_fee_per_gas
+        }
+    }
+
+    let GetTransactionResult {
+        signed_transaction,
+        spec_id,
+        block_metadata,
+    } = result;
+
+    let gas_price = match &signed_transaction {
+        SignedTransaction::PreEip155Legacy(tx) => tx.gas_price,
+        SignedTransaction::PostEip155Legacy(tx) => tx.gas_price,
+        SignedTransaction::Eip2930(tx) => tx.gas_price,
+        SignedTransaction::Eip1559(_) | SignedTransaction::Eip4844(_) => {
+            gas_price_for_post_eip1559(&signed_transaction, block_metadata.as_ref())
+        }
+    };
+
+    let chain_id = match &signed_transaction {
+        // Following Hardhat in not returning `chain_id` for `PostEip155Legacy` legacy transactions
+        // even though the chain id would be recoverable.
+        SignedTransaction::PreEip155Legacy(_) | SignedTransaction::PostEip155Legacy(_) => None,
+        SignedTransaction::Eip2930(tx) => Some(tx.chain_id),
+        SignedTransaction::Eip1559(tx) => Some(tx.chain_id),
+        SignedTransaction::Eip4844(tx) => Some(tx.chain_id),
+    };
+
+    let show_transaction_type = spec_id >= FIRST_HARDFORK_WITH_TRANSACTION_TYPE;
+    let is_typed_transaction = signed_transaction.transaction_type() > 0;
+    let transaction_type = if show_transaction_type || is_typed_transaction {
+        Some(signed_transaction.transaction_type())
+    } else {
+        None
+    };
+
+    let signature = signed_transaction.signature();
+
+    Ok(remote::eth::Transaction {
+        hash: *signed_transaction.hash(),
+        nonce: signed_transaction.nonce(),
+        block_hash: block_metadata.as_ref().map(|m| m.block_hash),
+        block_number: block_metadata.as_ref().map(|m| U256::from(m.block_number)),
+        transaction_index: block_metadata.map(|m| m.transaction_index),
+        from: signed_transaction.recover()?,
+        to: signed_transaction.to(),
+        value: signed_transaction.value(),
+        gas_price,
+        gas: U256::from(signed_transaction.gas_limit()),
+        input: signed_transaction.data().clone(),
+        v: signature.v,
+        // Following Hardhat in always returning `v` instead of `y_parity`.
+        y_parity: None,
+        r: signature.r,
+        s: signature.s,
+        chain_id,
+        transaction_type,
+        access_list: signed_transaction
+            .access_list()
+            .map(|access_list| access_list.clone().into()),
+        max_fee_per_gas: signed_transaction.max_fee_per_gas(),
+        max_priority_fee_per_gas: signed_transaction.max_priority_fee_per_gas(),
+        max_fee_per_blob_gas: signed_transaction.max_fee_per_blob_gas(),
+        blob_versioned_hashes: signed_transaction.blob_hashes(),
+    })
+}
 
 pub fn handle_send_transaction_request(
     data: &mut ProviderData,


### PR DESCRIPTION
Add `eth_getTransactionByHash` to the EDR provider:

- Follows Hardhat RPC logic.
- The provider implementation is tested, the RPC logic is waiting to be tested with Hardhat integration tests once those are wired in.
- Some tangential, but necessary changes included.
