### PR TITLE
Fixes related to the pnpm migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"

--- a/.github/workflows/check-docs-site.yml
+++ b/.github/workflows/check-docs-site.yml
@@ -31,5 +31,3 @@ jobs:
         run: cd docs && pnpm lint
       - name: Build
         run: cd docs && pnpm build
-      - name: Storybook
-        run: cd docs && pnpm build-storybook

--- a/.github/workflows/check-docs-site.yml
+++ b/.github/workflows/check-docs-site.yml
@@ -3,7 +3,7 @@ name: Check Docs Site
 on:
   push:
     branches:
-      - "fr/**"
+      - "**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/compile-with-typescript-v4.yml
+++ b/.github/workflows/compile-with-typescript-v4.yml
@@ -21,13 +21,12 @@ jobs:
         with:
           node-version: 16
           cache: "pnpm"
+      - name: Remove packages that can't be compiled with TypeScript v4
+        run: rm -fr packages/hardhat-viem packages/hardhat-toolbox-viem packages/hardhat-web3-v4
+      - name: Remove packages that can't be compiled with TypeScript v4 from the build script
+        run: sed -i 's/packages\/\(hardhat-viem\|hardhat-toolbox-viem\|hardhat-web3-v4\) *//g' package.json
       - name: Install typescript v4 in all packages
         run: |
           sed -i 's/"typescript": "~5.0.0"/"typescript": "^4.0.0"/' package.json packages/*/package.json && pnpm install --no-frozen-lockfile
-      # hardhat-viem is the only package that requires TypeScript v5
-      - name: Remove hardhat-viem directory
-        run: rm -fr packages/hardhat-viem
-      - name: Remove hardhat-viem from the build script
-        run: sed -i 's/packages\/hardhat-viem packages\/hardhat-toolbox-viem//' package.json
       - name: Build
         run: pnpm build

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts=true

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,9 +10,7 @@
     "postbuild": "next-sitemap",
     "build:test": "ANALYZE=true next build",
     "start": "next start",
-    "lint": "eslint src -f unix",
-    "storybook": "NODE_OPTIONS='--openssl-legacy-provider' start-storybook -p 6006 --ci",
-    "build-storybook": "NODE_OPTIONS='--openssl-legacy-provider' build-storybook"
+    "lint": "eslint src -f unix"
   },
   "dependencies": {
     "@callstack/react-theme-provider": "^3.0.7",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "preinstall": "npx -y only-allow pnpm",
     "prebuild": "ts-node --transpileOnly --skipProject scripts/prepare-error-list.ts",
     "dev": "next-remote-watch ./src/content",
     "dev:debug": "NODE_OPTIONS='--inspect' next dev",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "typescript": "~5.0.0"
   },
   "scripts": {
-    "preinstall": "npx -y only-allow pnpm",
     "build": "tsc --build packages/hardhat-core packages/hardhat-ethers packages/hardhat-verify packages/hardhat-solhint packages/hardhat-solpp packages/hardhat-truffle4 packages/hardhat-truffle5 packages/hardhat-vyper packages/hardhat-web3 packages/hardhat-web3-v4 packages/hardhat-web3-legacy packages/hardhat-chai-matchers packages/hardhat-network-helpers packages/hardhat-toolbox packages/hardhat-foundry packages/hardhat-ledger packages/hardhat-viem packages/hardhat-toolbox-viem",
     "watch": "tsc --build --watch packages/hardhat-core/src packages/hardhat-ethers packages/hardhat-verify packages/hardhat-solhint packages/hardhat-solpp packages/hardhat-truffle4 packages/hardhat-truffle5 packages/hardhat-vyper packages/hardhat-web3 packages/hardhat-web3-v4 packages/hardhat-web3-legacy packages/hardhat-chai-matchers packages/hardhat-network-helpers packages/hardhat-toolbox packages/hardhat-foundry packages/hardhat-ledger packages/hardhat-viem packages/hardhat-toolbox-viem",
     "clean": "pnpm run --recursive clean",


### PR DESCRIPTION
Some things we missed when we migrated to pnpm.

Some comments:
- I removed the `only-allow` script because it adds 6 seconds to each installation. This can be improved by adding `only-allow` as a dev dependency itself, so that this cost is only paid the first time... but I'd rather just remove it; I don't think it's worth it.
- Dependabot supports pnpm, but (as far as I understand) it auto-detects it; the setting has to be `npm` anyway because the setting is about the ecosystem, not about the package manager.