### PR TITLE
Add experimental support for using ESM modules with TypeScript

### DIFF
--- a/.changeset/friendly-dryers-mix.md
+++ b/.changeset/friendly-dryers-mix.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added support for ESM test files

--- a/.changeset/friendly-dryers-mix.md
+++ b/.changeset/friendly-dryers-mix.md
@@ -1,5 +1,0 @@
----
-"hardhat": patch
----
-
-Added support for ESM test files

--- a/.changeset/shaggy-hornets-exercise.md
+++ b/.changeset/shaggy-hornets-exercise.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Added support for using ESM modules with TypeScript
+Added experimental support for using ESM modules with TypeScript

--- a/.changeset/shaggy-hornets-exercise.md
+++ b/.changeset/shaggy-hornets-exercise.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Added support for using the .cts file extension in the Hardhat configuration file
+Added support for using ESM modules with TypeScript

--- a/.changeset/shaggy-hornets-exercise.md
+++ b/.changeset/shaggy-hornets-exercise.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added support for using the .cts file extension in the Hardhat configuration file

--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -7,7 +7,11 @@ import { HARDHAT_NETWORK_NAME } from "../internal/constants";
 import { subtask, task } from "../internal/core/config/config-env";
 import { HardhatError } from "../internal/core/errors";
 import { ERRORS } from "../internal/core/errors-list";
-import { isRunningWithTypescript } from "../internal/core/typescript-support";
+import {
+  isJavascriptFile,
+  isRunningWithTypescript,
+  isTypescriptFile,
+} from "../internal/core/typescript-support";
 import { getForkCacheDirPath } from "../internal/hardhat-network/provider/utils/disk-cache";
 import { showForkRecommendationsBannerIfNecessary } from "../internal/hardhat-network/provider/utils/fork-recomendations-banner";
 import { pluralize } from "../internal/util/strings";
@@ -40,7 +44,7 @@ subtask(TASK_TEST_GET_TEST_FILES)
 
     const jsFiles = await getAllFilesMatching(
       config.paths.tests,
-      (f) => f.endsWith(".js") || f.endsWith(".cjs") || f.endsWith(".mjs")
+      isJavascriptFile
     );
 
     if (!isRunningWithTypescript(config)) {
@@ -49,7 +53,7 @@ subtask(TASK_TEST_GET_TEST_FILES)
 
     const tsFiles = await getAllFilesMatching(
       config.paths.tests,
-      (f) => f.endsWith(".ts") || f.endsWith(".cts")
+      isTypescriptFile
     );
 
     return [...jsFiles, ...tsFiles];

--- a/packages/hardhat-core/src/builtin-tasks/test.ts
+++ b/packages/hardhat-core/src/builtin-tasks/test.ts
@@ -47,8 +47,9 @@ subtask(TASK_TEST_GET_TEST_FILES)
       return jsFiles;
     }
 
-    const tsFiles = await getAllFilesMatching(config.paths.tests, (f) =>
-      f.endsWith(".ts")
+    const tsFiles = await getAllFilesMatching(
+      config.paths.tests,
+      (f) => f.endsWith(".ts") || f.endsWith(".cts")
     );
 
     return [...jsFiles, ...tsFiles];

--- a/packages/hardhat-core/src/internal/core/project-structure.ts
+++ b/packages/hardhat-core/src/internal/core/project-structure.ts
@@ -10,10 +10,12 @@ import { ERRORS } from "./errors-list";
 const JS_CONFIG_FILENAME = "hardhat.config.js";
 const CJS_CONFIG_FILENAME = "hardhat.config.cjs";
 const TS_CONFIG_FILENAME = "hardhat.config.ts";
+const CTS_CONFIG_FILENAME = "hardhat.config.cts";
 
 export function isCwdInsideProject() {
   return (
     findUp.sync(TS_CONFIG_FILENAME) !== null ||
+    findUp.sync(CTS_CONFIG_FILENAME) !== null ||
     findUp.sync(CJS_CONFIG_FILENAME) !== null ||
     findUp.sync(JS_CONFIG_FILENAME) !== null
   );
@@ -23,6 +25,11 @@ export function getUserConfigPath() {
   const tsConfigPath = findUp.sync(TS_CONFIG_FILENAME);
   if (tsConfigPath !== null) {
     return tsConfigPath;
+  }
+
+  const ctsConfigPath = findUp.sync(CTS_CONFIG_FILENAME);
+  if (ctsConfigPath !== null) {
+    return ctsConfigPath;
   }
 
   const cjsConfigPath = findUp.sync(CJS_CONFIG_FILENAME);

--- a/packages/hardhat-core/src/internal/core/typescript-support.ts
+++ b/packages/hardhat-core/src/internal/core/typescript-support.ts
@@ -13,14 +13,14 @@ let cachedIsTypescriptSupported: boolean | undefined;
  */
 export function willRunWithTypescript(configPath?: string): boolean {
   const config = resolveConfigPath(configPath);
-  return isTypescriptFile(config);
+  return isNonEsmTypescriptFile(config);
 }
 
 /**
  * Returns true if an Hardhat is already running with typescript.
  */
 export function isRunningWithTypescript(config: HardhatConfig): boolean {
-  return isTypescriptFile(config.paths.configFile);
+  return isNonEsmTypescriptFile(config.paths.configFile);
 }
 
 export function isTypescriptSupported() {
@@ -80,6 +80,14 @@ export function loadTsNode(
   require(tsNodeRequirement);
 }
 
-function isTypescriptFile(path: string): boolean {
-  return path.endsWith(".ts") || path.endsWith(".cts");
+function isNonEsmTypescriptFile(path: string): boolean {
+  return /\.(ts|cts)$/i.test(path);
+}
+
+export function isTypescriptFile(path: string): boolean {
+  return /\.(ts|cts|mts)$/i.test(path);
+}
+
+export function isJavascriptFile(path: string): boolean {
+  return /\.(js|cjs|mjs)$/i.test(path);
 }

--- a/packages/hardhat-core/src/internal/core/typescript-support.ts
+++ b/packages/hardhat-core/src/internal/core/typescript-support.ts
@@ -81,5 +81,5 @@ export function loadTsNode(
 }
 
 function isTypescriptFile(path: string): boolean {
-  return path.endsWith(".ts");
+  return path.endsWith(".ts") || path.endsWith(".cts");
 }


### PR DESCRIPTION
This is part of the effort to support ESM in TypeScript projects. As the Hardhat config file needs to be a CommonJS module, users will need to change the extension to `.cts`. This PR enables Hardhat to read the config from a `.cts` file.