### PR TITLE
hh-viem: handle devnets with custom chain ids

### DIFF
--- a/packages/hardhat-viem/src/internal/chains.ts
+++ b/packages/hardhat-viem/src/internal/chains.ts
@@ -30,9 +30,15 @@ export async function getChain(provider: EthereumProvider): Promise<Chain> {
 
   if (matchingChains.length === 0) {
     if (await isHardhatNetwork(provider)) {
-      return chains.hardhat;
+      return {
+        ...chains.hardhat,
+        id: chainId,
+      };
     } else if (await isFoundryNetwork(provider)) {
-      return chains.foundry;
+      return {
+        ...chains.foundry,
+        id: chainId,
+      };
     } else {
       throw new NetworkNotFoundError(chainId);
     }

--- a/packages/hardhat-viem/test/chains.ts
+++ b/packages/hardhat-viem/test/chains.ts
@@ -135,5 +135,31 @@ Please report this issue if you're using Hardhat or Foundry.`
 Please report this issue if you're using Hardhat or Foundry.`
       );
     });
+
+    it("should return a hardhat chain with the custom chainId", async function () {
+      const provider: EthereumProvider = new EthereumMockedProvider();
+      const sendStub = sinon.stub(provider, "send");
+      sendStub.withArgs("eth_chainId").returns(Promise.resolve("0x3039")); // 12345 in hex
+      sendStub.withArgs("hardhat_metadata").returns(Promise.resolve({}));
+      sendStub.withArgs("anvil_nodeInfo").throws();
+
+      const chain = await getChain(provider);
+
+      expect(chain.id).to.equal(12345);
+      expect(chain.name).to.equal("Hardhat");
+    });
+
+    it("should return a foundry chain with the custom chainId", async function () {
+      const provider: EthereumProvider = new EthereumMockedProvider();
+      const sendStub = sinon.stub(provider, "send");
+      sendStub.withArgs("eth_chainId").returns(Promise.resolve("0x3039")); // 12345 in hex
+      sendStub.withArgs("anvil_nodeInfo").returns(Promise.resolve({}));
+      sendStub.withArgs("hardhat_metadata").throws();
+
+      const chain = await getChain(provider);
+
+      expect(chain.id).to.equal(12345);
+      expect(chain.name).to.equal("Foundry");
+    });
   });
 });


### PR DESCRIPTION
Closes #4599.

The underlying problem can be easily reproduced in two ways after creating a viem-based sample project:

1. Modify `networks.hardhat` to have a custom chain id and then run `hh scripts/deploy.ts`
2. Start anvil with a custom chain id and then run `hh --network localhost scripts/deploy.ts`