### PR TITLE
fix: flatten 2d array

### DIFF
--- a/.changeset/little-bananas-thank.md
+++ b/.changeset/little-bananas-thank.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+fix: flatten 2d array

--- a/.changeset/little-bananas-thank.md
+++ b/.changeset/little-bananas-thank.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-fix: flatten 2d array
+Fix an issue with solc version selection

--- a/packages/hardhat-core/src/internal/solidity/compilation-job.ts
+++ b/packages/hardhat-core/src/internal/solidity/compilation-job.ts
@@ -234,9 +234,9 @@ function getCompilerConfigForFile(
   transitiveDependencies: taskTypes.TransitiveDependency[],
   solidityConfig: SolidityConfig
 ): SolcConfig | CompilationJobCreationError {
-  const transitiveDependenciesVersionPragmas = transitiveDependencies.map(
-    ({ dependency }) => dependency.content.versionPragmas
-  );
+  const transitiveDependenciesVersionPragmas = transitiveDependencies
+    .map(({ dependency }) => dependency.content.versionPragmas)
+    .flat();
   const versionRange = Array.from(
     new Set([
       ...file.content.versionPragmas,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] It's a very small fix

---

<!-- Add a description of your PR here -->
`transitiveDependenciesVersionPragmas` is a 2d array of strings. When you add it in a Set to dedup the values on the following lines, the dedup doesn't work because the Set is evaluating arrays and not their underlying string. Flattening 
 `transitiveDependenciesVersionPragmas` to make it a regular string array allows for the intended behavior, which is for the Set to dedup all repetitive pragma versions.

No other part of the code than the following Set is relying on `transitiveDependenciesVersionPragmas`.

before
```js
const transitiveDependenciesVersionPragmas = [
  [ '^0.8.20' ],
  [ '^0.8.20' ],
  [ '^0.8.20' ],
  [ '^0.8.20' ],
  [ '^0.8.20' ],
  [ '^0.8.20' ],
  [ '^0.8.20' ]
]

const versionRange = "^0.8.20 ^0.8.20 ^0.8.20 ^0.8.20 ^0.8.20 ^0.8.20"
```

after
```js
const transitiveDependenciesVersionPragmas = [
  '^0.8.20',
  '^0.8.20',
  '^0.8.20',
  '^0.8.20',
  '^0.8.20',
  '^0.8.20',
  '^0.8.20'
]

const versionRange = "^0.8.20"
```