### PR TITLE
Normalize version when finding version

### DIFF
--- a/packages/hardhat-vyper/src/downloader.ts
+++ b/packages/hardhat-vyper/src/downloader.ts
@@ -127,11 +127,15 @@ export class CompilerDownloader {
   }
 
   private _findVersionRelease(version: string): CompilerRelease | undefined {
-    return this.compilersList.find(
-      (release) =>
-        semver.valid(release.tag_name) !== null &&
-        semver.eq(semver.coerce(release.tag_name).version, version)
-    );
+    return this.compilersList.find((release) => {
+      const valid = semver.valid(release.tag_name);
+      const normalized = semver.coerce(release.tag_name);
+      return (
+        valid !== null &&
+        normalized !== null &&
+        semver.eq(normalized.version, version)
+      );
+    });
   }
 
   private async _downloadCompilersList(): Promise<void> {

--- a/packages/hardhat-vyper/src/downloader.ts
+++ b/packages/hardhat-vyper/src/downloader.ts
@@ -130,7 +130,7 @@ export class CompilerDownloader {
     return this.compilersList.find(
       (release) =>
         semver.valid(release.tag_name) !== null &&
-        semver.eq(release.tag_name, version)
+        semver.eq(semver.coerce(release.tag_name).version, version)
     );
   }
 


### PR DESCRIPTION
Normalizes the release tag names in order to properly test for equal versions. Fixes https://github.com/NomicFoundation/hardhat/issues/4615