### PR TITLE
feat: add `eth_getBlockByNumber` support

### DIFF
--- a/crates/edr_eth/src/remote.rs
+++ b/crates/edr_eth/src/remote.rs
@@ -94,37 +94,43 @@ pub enum BlockSpec {
     Eip1898(Eip1898BlockSpec),
 }
 
-impl BlockSpec {
-    /// Constructs an instance for the earliest block.
-    #[must_use]
-    pub fn earliest() -> Self {
-        Self::Tag(BlockTag::Earliest)
-    }
+macro_rules! impl_block_tags {
+    ($type_name:ident) => {
+        impl $type_name {
+            /// Constructs an instance for the earliest block.
+            #[must_use]
+            pub fn earliest() -> Self {
+                Self::Tag(BlockTag::Earliest)
+            }
 
-    /// Constructs an instance for the latest block.
-    #[must_use]
-    pub fn latest() -> Self {
-        Self::Tag(BlockTag::Latest)
-    }
+            /// Constructs an instance for the latest block.
+            #[must_use]
+            pub fn latest() -> Self {
+                Self::Tag(BlockTag::Latest)
+            }
 
-    /// Constructs an instance for the pending block.
-    #[must_use]
-    pub fn pending() -> Self {
-        Self::Tag(BlockTag::Pending)
-    }
+            /// Constructs an instance for the pending block.
+            #[must_use]
+            pub fn pending() -> Self {
+                Self::Tag(BlockTag::Pending)
+            }
 
-    /// Constructs an instance for the safe block.
-    #[must_use]
-    pub fn safe() -> Self {
-        Self::Tag(BlockTag::Safe)
-    }
+            /// Constructs an instance for the safe block.
+            #[must_use]
+            pub fn safe() -> Self {
+                Self::Tag(BlockTag::Safe)
+            }
 
-    /// Constructs an instance for the finalized block.
-    #[must_use]
-    pub fn finalized() -> Self {
-        Self::Tag(BlockTag::Finalized)
-    }
+            /// Constructs an instance for the finalized block.
+            #[must_use]
+            pub fn finalized() -> Self {
+                Self::Tag(BlockTag::Finalized)
+            }
+        }
+    };
 }
+
+impl_block_tags!(BlockSpec);
 
 impl Display for BlockSpec {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> Result<(), fmt::Error> {
@@ -154,6 +160,8 @@ impl From<PreEip1898BlockSpec> for BlockSpec {
         }
     }
 }
+
+impl_block_tags!(PreEip1898BlockSpec);
 
 #[cfg(test)]
 mod tests {

--- a/crates/edr_eth/src/remote/client.rs
+++ b/crates/edr_eth/src/remote/client.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 use super::{
     eth, jsonrpc,
     methods::{GetLogsInput, MethodInvocation},
-    BlockSpec,
+    BlockSpec, PreEip1898BlockSpec,
 };
 use crate::{
     block::{block_time, is_safe_block_number, IsSafeBlockNumberArgs},
@@ -719,7 +719,7 @@ impl RpcClient {
     /// Calls `eth_getBlockByNumber` and returns the transaction's hash.
     pub async fn get_block_by_number(
         &self,
-        spec: BlockSpec,
+        spec: PreEip1898BlockSpec,
     ) -> Result<Option<eth::Block<B256>>, RpcClientError> {
         self.call_with_resolver(
             MethodInvocation::GetBlockByNumber(spec, false),
@@ -731,7 +731,7 @@ impl RpcClient {
     /// Calls `eth_getBlockByNumber` and returns the transaction's data.
     pub async fn get_block_by_number_with_transaction_data(
         &self,
-        spec: BlockSpec,
+        spec: PreEip1898BlockSpec,
     ) -> Result<eth::Block<eth::Transaction>, RpcClientError> {
         self.call_with_resolver(
             MethodInvocation::GetBlockByNumber(spec, true),
@@ -1360,7 +1360,7 @@ mod tests {
             assert_eq!(client.files_in_cache().len(), 0);
 
             client
-                .get_block_by_number(BlockSpec::finalized())
+                .get_block_by_number(PreEip1898BlockSpec::finalized())
                 .await
                 .expect("should have succeeded");
 
@@ -1375,7 +1375,7 @@ mod tests {
             let block_number = 16222385;
 
             let block = TestRpcClient::new(&alchemy_url)
-                .get_block_by_number(BlockSpec::Number(block_number))
+                .get_block_by_number(PreEip1898BlockSpec::Number(block_number))
                 .await
                 .expect("should have succeeded")
                 .expect("Block must exist");
@@ -1401,7 +1401,7 @@ mod tests {
             assert_eq!(client.files_in_cache().len(), 0);
 
             let block = client
-                .get_block_by_number(BlockSpec::Number(block_number))
+                .get_block_by_number(PreEip1898BlockSpec::Number(block_number))
                 .await
                 .expect("should have succeeded")
                 .expect("Block must exist");
@@ -1417,7 +1417,7 @@ mod tests {
             let alchemy_url = get_alchemy_url();
             let client = TestRpcClient::new(&alchemy_url);
 
-            let block_spec = BlockSpec::Number(16220843);
+            let block_spec = PreEip1898BlockSpec::Number(16220843);
 
             assert_eq!(client.files_in_cache().len(), 0);
 
@@ -1444,7 +1444,7 @@ mod tests {
             assert_eq!(client.files_in_cache().len(), 0);
 
             client
-                .get_block_by_number_with_transaction_data(BlockSpec::earliest())
+                .get_block_by_number_with_transaction_data(PreEip1898BlockSpec::earliest())
                 .await
                 .expect("should have succeeded");
 
@@ -1457,7 +1457,7 @@ mod tests {
             let alchemy_url = get_alchemy_url();
 
             let _block = TestRpcClient::new(&alchemy_url)
-                .get_block_by_number(BlockSpec::latest())
+                .get_block_by_number(PreEip1898BlockSpec::latest())
                 .await
                 .expect("should have succeeded");
         }
@@ -1467,7 +1467,7 @@ mod tests {
             let alchemy_url = get_alchemy_url();
 
             let _block = TestRpcClient::new(&alchemy_url)
-                .get_block_by_number_with_transaction_data(BlockSpec::latest())
+                .get_block_by_number_with_transaction_data(PreEip1898BlockSpec::latest())
                 .await
                 .expect("should have succeeded");
         }
@@ -1477,7 +1477,7 @@ mod tests {
             let alchemy_url = get_alchemy_url();
 
             let _block = TestRpcClient::new(&alchemy_url)
-                .get_block_by_number(BlockSpec::pending())
+                .get_block_by_number(PreEip1898BlockSpec::pending())
                 .await
                 .expect("should have succeeded");
         }
@@ -1487,7 +1487,7 @@ mod tests {
             let alchemy_url = get_alchemy_url();
 
             let _block = TestRpcClient::new(&alchemy_url)
-                .get_block_by_number_with_transaction_data(BlockSpec::pending())
+                .get_block_by_number_with_transaction_data(PreEip1898BlockSpec::pending())
                 .await
                 .expect("should have succeeded");
         }

--- a/crates/edr_eth/src/remote/eth.rs
+++ b/crates/edr_eth/src/remote/eth.rs
@@ -307,7 +307,7 @@ pub struct Block<TX> {
     /// the "extra data" field of this block
     #[serde(with = "crate::serde::bytes")]
     pub extra_data: Bytes,
-    /// the bloom filter for the logs of the block. None when its pending block.
+    /// the bloom filter for the logs of the block
     pub logs_bloom: Bloom,
     /// the unix timestamp for when the block was collated
     #[serde(with = "crate::serde::u64")]

--- a/crates/edr_eth/src/remote/eth.rs
+++ b/crates/edr_eth/src/remote/eth.rs
@@ -323,8 +323,9 @@ pub struct Block<TX> {
     /// on the last given parameter
     #[serde(default)]
     pub transactions: Vec<TX>,
-    /// integer the size of this block in bytes
-    pub size: U256,
+    /// the length of the RLP encoding of this block in bytes
+    #[serde(with = "crate::serde::u64")]
+    pub size: u64,
     /// mix hash
     pub mix_hash: B256,
     /// hash of the generated proof-of-work. null when its pending block.

--- a/crates/edr_eth/src/remote/methods.rs
+++ b/crates/edr_eth/src/remote/methods.rs
@@ -104,7 +104,7 @@ pub enum MethodInvocation {
     /// eth_getBlockByNumber
     #[serde(rename = "eth_getBlockByNumber")]
     GetBlockByNumber(
-        BlockSpec,
+        PreEip1898BlockSpec,
         /// include transaction data
         bool,
     ),

--- a/crates/edr_eth/tests/integration_tests.rs
+++ b/crates/edr_eth/tests/integration_tests.rs
@@ -104,7 +104,7 @@ fn test_serde_eth_get_balance() {
 #[test]
 fn test_serde_eth_get_block_by_number() {
     help_test_method_invocation_serde(MethodInvocation::GetBlockByNumber(
-        BlockSpec::Number(100),
+        PreEip1898BlockSpec::Number(100),
         true,
     ));
 }
@@ -112,7 +112,7 @@ fn test_serde_eth_get_block_by_number() {
 #[test]
 fn test_serde_eth_get_block_by_tag() {
     help_test_method_invocation_serde(MethodInvocation::GetBlockByNumber(
-        BlockSpec::latest(),
+        PreEip1898BlockSpec::latest(),
         true,
     ));
 }

--- a/crates/edr_eth/tests/receipt.rs
+++ b/crates/edr_eth/tests/receipt.rs
@@ -18,13 +18,13 @@ mod remote {
                     #[tokio::test]
                     #[serial]
                     async fn [<test_remote_block_receipt_root_ $name>]() {
-                        use edr_eth::{remote::{RpcClient, BlockSpec}, trie::ordered_trie_root};
+                        use edr_eth::{remote::{RpcClient, PreEip1898BlockSpec}, trie::ordered_trie_root};
                         use edr_test_utils::env::get_alchemy_url;
 
                         let client = RpcClient::new(&get_alchemy_url(), CACHE_DIR.path().into());
 
                         let block = client
-                            .get_block_by_number_with_transaction_data(BlockSpec::Number($block_number))
+                            .get_block_by_number_with_transaction_data(PreEip1898BlockSpec::Number($block_number))
                             .await
                             .expect("Should succeed");
 

--- a/crates/edr_eth/tests/transaction.rs
+++ b/crates/edr_eth/tests/transaction.rs
@@ -9,7 +9,7 @@ mod alchemy {
                     #[tokio::test]
                     async fn [<test_transaction_remote_ $name _hash>]() {
                         use edr_eth::{
-                            remote::{RpcClient, BlockSpec},
+                            remote::{RpcClient, PreEip1898BlockSpec},
                             transaction::SignedTransaction,
                             Address
                         };
@@ -21,7 +21,7 @@ mod alchemy {
                         let client = RpcClient::new(&get_alchemy_url(), tempdir.path().into());
 
                         let block = client
-                            .get_block_by_number_with_transaction_data(BlockSpec::Number($block_number))
+                            .get_block_by_number_with_transaction_data(PreEip1898BlockSpec::Number($block_number))
                             .await
                             .expect("Should succeed");
 

--- a/crates/edr_evm/benches/state/util.rs
+++ b/crates/edr_evm/benches/state/util.rs
@@ -3,7 +3,7 @@ use std::clone::Clone;
 use std::sync::Arc;
 
 use criterion::{BatchSize, BenchmarkId, Criterion};
-use edr_eth::{Address, Bytes, U256};
+use edr_eth::{remote::PreEip1898BlockSpec, Address, Bytes, U256};
 #[cfg(all(test, feature = "test-remote"))]
 use edr_evm::state::ForkState;
 use edr_evm::state::{StateError, SyncState, TrieState};
@@ -41,7 +41,7 @@ impl EdrStates {
 
         #[cfg(all(test, feature = "test-remote"))]
         let fork = {
-            use edr_eth::remote::{BlockSpec, RpcClient};
+            use edr_eth::remote::RpcClient;
             use edr_evm::RandomHashGenerator;
             use parking_lot::Mutex;
 
@@ -54,7 +54,9 @@ impl EdrStates {
             ));
 
             let block = runtime
-                .block_on(rpc_client.get_block_by_number(BlockSpec::Number(fork_block_number)))
+                .block_on(
+                    rpc_client.get_block_by_number(PreEip1898BlockSpec::Number(fork_block_number)),
+                )
                 .expect("failed to retrieve block by number")
                 .expect("block should exist");
 

--- a/crates/edr_evm/src/block.rs
+++ b/crates/edr_evm/src/block.rs
@@ -28,11 +28,11 @@ pub trait Block: Debug {
     /// Returns the block's header.
     fn header(&self) -> &block::Header;
 
-    /// Uncle block hashes.
+    /// Ommer/uncle block hashes.
     fn ommer_hashes(&self) -> &[B256];
 
-    /// The size of this block in bytes.
-    fn size(&self) -> u64;
+    /// The length of the RLP encoding of this block in bytes.
+    fn rlp_size(&self) -> u64;
 
     /// Returns the block's transactions.
     fn transactions(&self) -> &[SignedTransaction];

--- a/crates/edr_evm/src/block.rs
+++ b/crates/edr_evm/src/block.rs
@@ -5,7 +5,10 @@ mod remote;
 use std::{fmt::Debug, sync::Arc};
 
 use auto_impl::auto_impl;
-use edr_eth::{block, receipt::BlockReceipt, transaction::SignedTransaction, Address, B256};
+use edr_eth::{
+    block, receipt::BlockReceipt, transaction::SignedTransaction, withdrawal::Withdrawal, Address,
+    B256,
+};
 
 pub use self::{
     builder::{BlockBuilder, BlockBuilderCreationError, BlockTransactionError, BuildBlockResult},
@@ -25,6 +28,12 @@ pub trait Block: Debug {
     /// Returns the block's header.
     fn header(&self) -> &block::Header;
 
+    /// Uncle block hashes.
+    fn ommer_hashes(&self) -> &[B256];
+
+    /// The size of this block in bytes.
+    fn size(&self) -> u64;
+
     /// Returns the block's transactions.
     fn transactions(&self) -> &[SignedTransaction];
 
@@ -33,6 +42,9 @@ pub trait Block: Debug {
 
     /// Returns the receipts of the block's transactions.
     fn transaction_receipts(&self) -> Result<Vec<Arc<BlockReceipt>>, Self::Error>;
+
+    /// Withdrawals
+    fn withdrawals(&self) -> Option<&[Withdrawal]>;
 }
 
 /// Trait that meets all requirements for a synchronous block.

--- a/crates/edr_evm/src/block/local.rs
+++ b/crates/edr_evm/src/block/local.rs
@@ -107,7 +107,7 @@ impl Block for LocalBlock {
         &self.header
     }
 
-    fn size(&self) -> u64 {
+    fn rlp_size(&self) -> u64 {
         rlp::encode(self)
             .len()
             .try_into()

--- a/crates/edr_evm/src/block/local.rs
+++ b/crates/edr_evm/src/block/local.rs
@@ -22,6 +22,7 @@ pub struct LocalBlock {
     transaction_callers: Vec<Address>,
     transaction_receipts: Vec<Arc<BlockReceipt>>,
     ommers: Vec<block::Header>,
+    ommer_hashes: Vec<B256>,
     withdrawals: Option<Vec<Withdrawal>>,
     hash: B256,
 }
@@ -48,6 +49,7 @@ impl LocalBlock {
         ommers: Vec<Header>,
         withdrawals: Option<Vec<Withdrawal>>,
     ) -> Self {
+        let ommer_hashes = ommers.iter().map(Header::hash).collect::<Vec<_>>();
         let ommers_hash = keccak256(&rlp::encode_list(&ommers)[..]);
         let transactions_root =
             trie::ordered_trie_root(transactions.iter().map(|r| rlp::encode(r).freeze()));
@@ -70,6 +72,7 @@ impl LocalBlock {
             transaction_callers,
             transaction_receipts,
             ommers,
+            ommer_hashes,
             withdrawals,
             hash,
         }
@@ -104,6 +107,13 @@ impl Block for LocalBlock {
         &self.header
     }
 
+    fn size(&self) -> u64 {
+        rlp::encode(self)
+            .len()
+            .try_into()
+            .expect("usize fits into u64")
+    }
+
     fn transactions(&self) -> &[SignedTransaction] {
         &self.transactions
     }
@@ -114,6 +124,33 @@ impl Block for LocalBlock {
 
     fn transaction_receipts(&self) -> Result<Vec<Arc<BlockReceipt>>, Self::Error> {
         Ok(self.transaction_receipts.clone())
+    }
+
+    fn ommer_hashes(&self) -> &[B256] {
+        self.ommer_hashes.as_slice()
+    }
+
+    fn withdrawals(&self) -> Option<&[Withdrawal]> {
+        self.withdrawals.as_deref()
+    }
+}
+
+impl rlp::Encodable for LocalBlock {
+    fn rlp_append(&self, s: &mut rlp::RlpStream) {
+        let mut num_fields = 3;
+        if self.withdrawals.is_some() {
+            num_fields += 1;
+        }
+
+        s.begin_list(num_fields);
+
+        s.append(&self.header);
+        s.append_list(&self.transactions);
+        s.append_list(&self.ommers);
+
+        if let Some(withdrawals) = self.withdrawals.as_ref() {
+            s.append_list(withdrawals);
+        }
     }
 }
 

--- a/crates/edr_evm/src/block/remote.rs
+++ b/crates/edr_evm/src/block/remote.rs
@@ -9,7 +9,7 @@ use edr_eth::{
     },
     transaction::SignedTransaction,
     withdrawal::Withdrawal,
-    Address, B256, B64, U256,
+    Address, B256, B64,
 };
 use tokio::runtime;
 
@@ -30,9 +30,6 @@ pub enum CreationError {
     /// Missing number
     #[error("Missing numbeer")]
     MissingNumber,
-    /// Size too large
-    #[error("Size too large: {0}")]
-    SizeTooLarge(U256),
     /// Transaction conversion error
     #[error(transparent)]
     TransactionConversionError(#[from] TransactionConversionError),

--- a/crates/edr_evm/src/block/remote.rs
+++ b/crates/edr_evm/src/block/remote.rs
@@ -53,7 +53,7 @@ pub struct RemoteBlock {
     withdrawals: Option<Vec<Withdrawal>>,
     /// The block's hash
     hash: B256,
-    /// Integer size of this block in bytes
+    /// The length of the RLP encoding of this block in bytes
     size: u64,
     // The RPC client is needed to lazily fetch receipts
     rpc_client: Arc<RpcClient>,
@@ -103,11 +103,6 @@ impl RemoteBlock {
 
         let hash = block.hash.ok_or(CreationError::MissingHash)?;
 
-        let size = block
-            .size
-            .try_into()
-            .map_err(|_err| CreationError::SizeTooLarge(block.size))?;
-
         Ok(Self {
             header,
             transactions,
@@ -117,7 +112,7 @@ impl RemoteBlock {
             withdrawals: block.withdrawals,
             hash,
             rpc_client,
-            size,
+            size: block.size,
             runtime,
         })
     }
@@ -138,7 +133,7 @@ impl Block for RemoteBlock {
         self.ommer_hashes.as_slice()
     }
 
-    fn size(&self) -> u64 {
+    fn rlp_size(&self) -> u64 {
         self.size
     }
 

--- a/crates/edr_evm/src/blockchain/remote.rs
+++ b/crates/edr_evm/src/blockchain/remote.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_rwlock::{RwLock, RwLockUpgradableReadGuard};
 use edr_eth::{
     receipt::BlockReceipt,
-    remote::{self, BlockSpec, RpcClient, RpcClientError},
+    remote::{self, PreEip1898BlockSpec, RpcClient, RpcClientError},
     B256, U256,
 };
 use tokio::runtime;
@@ -62,7 +62,7 @@ impl<BlockT: Block + Clone + From<RemoteBlock>, const FORCE_CACHING: bool>
         } else {
             let block = self
                 .client
-                .get_block_by_number_with_transaction_data(BlockSpec::Number(number))
+                .get_block_by_number_with_transaction_data(PreEip1898BlockSpec::Number(number))
                 .await?;
 
             self.fetch_and_cache_block(cache, block).await

--- a/crates/edr_evm/src/state/fork.rs
+++ b/crates/edr_evm/src/state/fork.rs
@@ -206,7 +206,7 @@ mod tests {
         str::FromStr,
     };
 
-    use edr_eth::remote::BlockSpec;
+    use edr_eth::remote::PreEip1898BlockSpec;
     use edr_test_utils::env::get_alchemy_url;
 
     use super::*;
@@ -234,7 +234,7 @@ mod tests {
             let rpc_client = RpcClient::new(&get_alchemy_url(), tempdir.path().to_path_buf());
 
             let block = rpc_client
-                .get_block_by_number(BlockSpec::Number(FORK_BLOCK))
+                .get_block_by_number(PreEip1898BlockSpec::Number(FORK_BLOCK))
                 .await
                 .expect("failed to retrieve block by number")
                 .expect("block should exist");

--- a/crates/edr_evm/src/state/remote.rs
+++ b/crates/edr_evm/src/state/remote.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 pub use cached::CachedRemoteState;
 use edr_eth::{
-    remote::{BlockSpec, RpcClient, RpcClientError},
+    remote::{BlockSpec, PreEip1898BlockSpec, RpcClient, RpcClientError},
     Address, B256, U256,
 };
 use revm::{
@@ -57,7 +57,7 @@ impl RemoteState {
         Ok(tokio::task::block_in_place(move || {
             self.runtime.block_on(
                 self.client
-                    .get_block_by_number(BlockSpec::Number(block_number)),
+                    .get_block_by_number(PreEip1898BlockSpec::Number(block_number)),
             )
         })?
         .map(|block| block.state_root))

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -165,8 +165,10 @@ impl ProviderData {
 
     /// Fetch a block by block spec.
     /// Returns `None` if the block spec is `pending`.
-    /// Returns `ProviderError::InvalidBlockSpec` if the block spec is a number
-    /// or a hash and the block isn't found.
+    /// Returns `ProviderError::InvalidBlockSpec` error if the block spec is a
+    /// number or a hash and the block isn't found.
+    /// Returns `ProviderError::InvalidBlockTag` error if the block tag is safe
+    /// or finalized and block spec is pre-merge.
     pub fn block_by_block_spec(
         &self,
         block_spec: &BlockSpec,
@@ -184,9 +186,17 @@ impl ProviderData {
             ),
             // Matching Hardhat behaviour by returning the last block for finalized and safe.
             // https://github.com/NomicFoundation/hardhat/blob/b84baf2d9f5d3ea897c06e0ecd5e7084780d8b6c/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts#L1395
-            BlockSpec::Tag(BlockTag::Finalized | BlockTag::Safe | BlockTag::Latest) => {
-                Some(self.blockchain.last_block()?)
+            BlockSpec::Tag(BlockTag::Finalized | BlockTag::Safe) => {
+                if self.spec_id() >= SpecId::MERGE {
+                    Some(self.blockchain.last_block()?)
+                } else {
+                    return Err(ProviderError::InvalidBlockTag {
+                        block_spec: block_spec.clone(),
+                        spec: self.spec_id(),
+                    });
+                }
             }
+            BlockSpec::Tag(BlockTag::Latest) => Some(self.blockchain.last_block()?),
             BlockSpec::Tag(BlockTag::Pending) => None,
             BlockSpec::Eip1898(Eip1898BlockSpec::Hash {
                 block_hash,
@@ -675,31 +685,47 @@ impl ProviderData {
         self.impersonated_accounts.remove(&address)
     }
 
+    pub fn total_difficulty_by_hash(&self, hash: &B256) -> Result<Option<U256>, ProviderError> {
+        self.blockchain
+            .total_difficulty_by_hash(hash)
+            .map_err(ProviderError::Blockchain)
+    }
+
     /// Get a transaction by hash from the blockchain or from the mempool if
     /// it's not mined yet.
     pub fn transaction_by_hash(
         &self,
         hash: &B256,
-    ) -> Result<Option<GetTransactionResult>, ProviderError> {
+    ) -> Result<Option<TransactionAndBlock>, ProviderError> {
         let transaction = if let Some(tx) = self.mem_pool.transaction_by_hash(hash) {
             let signed_transaction = tx.pending().transaction().clone();
 
-            Some(GetTransactionResult {
+            Some(TransactionAndBlock {
                 signed_transaction,
-                spec_id: self.blockchain.spec_id(),
-                block_metadata: None,
+                block_data: None,
             })
-        } else if let Some(tx_block) = self.blockchain.block_by_transaction_hash(hash)? {
-            let tx_index = self
+        } else if let Some(block) = self.blockchain.block_by_transaction_hash(hash)? {
+            let tx_index_u64 = self
                 .blockchain
                 .receipt_by_transaction_hash(hash)?
                 .expect("If the transaction was inserted in a block, it must have a receipt")
                 .transaction_index;
-
             let tx_index =
-                usize::try_from(tx_index).expect("Indices cannot be larger than usize::MAX");
+                usize::try_from(tx_index_u64).expect("Indices cannot be larger than usize::MAX");
 
-            transaction_from_block(&tx_block, tx_index, self.spec_id())
+            let signed_transaction = block
+                .transactions()
+                .get(tx_index)
+                .expect("Transaction index must be valid, since it's from the receipt.")
+                .clone();
+
+            Some(TransactionAndBlock {
+                signed_transaction,
+                block_data: Some(BlockDataForTransaction {
+                    block,
+                    transaction_index: tx_index_u64,
+                }),
+            })
         } else {
             None
         };
@@ -904,27 +930,6 @@ impl ProviderData {
     }
 }
 
-pub fn transaction_from_block(
-    block: &Arc<dyn SyncBlock<Error = BlockchainError>>,
-    index: usize,
-    spec_id: SpecId,
-) -> Option<GetTransactionResult> {
-    block.transactions().get(index).map(|tx| {
-        let block_metadata = BlockMetadataForTransaction {
-            base_fee_per_gas: block.header().base_fee_per_gas,
-            block_hash: *block.hash(),
-            block_number: block.header().number,
-            transaction_index: index.try_into().expect("usize fits into u64"),
-        };
-
-        GetTransactionResult {
-            signed_transaction: tx.clone(),
-            spec_id,
-            block_metadata: Some(block_metadata),
-        }
-    })
-}
-
 fn block_time_offset_seconds(config: &ProviderConfig) -> Result<u64, CreationError> {
     config.initial_date.map_or(Ok(0), |initial_date| {
         Ok(SystemTime::now()
@@ -1028,23 +1033,18 @@ async fn create_blockchain_and_state(
 }
 
 /// The result returned by requesting a transaction.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GetTransactionResult {
+#[derive(Debug, Clone)]
+pub struct TransactionAndBlock {
     /// The signed transaction.
     pub signed_transaction: SignedTransaction,
-    /// Information about the active hardforks.
-    pub spec_id: SpecId,
-    /// The block metadata for the transaction. None if the transaction is
-    /// pending.
-    pub block_metadata: Option<BlockMetadataForTransaction>,
+    /// Block data in which the transaction is found if it has been mined.
+    pub block_data: Option<BlockDataForTransaction>,
 }
 
 /// Block metadata for a transaction.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BlockMetadataForTransaction {
-    pub base_fee_per_gas: Option<U256>,
-    pub block_hash: B256,
-    pub block_number: u64,
+#[derive(Debug, Clone)]
+pub struct BlockDataForTransaction {
+    pub block: Arc<dyn SyncBlock<Error = BlockchainError>>,
     pub transaction_index: u64,
 }
 
@@ -1360,7 +1360,7 @@ mod tests {
 
         let non_existing_tx = fixture.provider_data.transaction_by_hash(&B256::zero())?;
 
-        assert_eq!(non_existing_tx, None);
+        assert!(non_existing_tx.is_none());
 
         Ok(())
     }

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -17,6 +17,10 @@ pub enum ProviderError {
     /// Block number or hash doesn't exist in blockchain
     #[error("Block number or block hash doesn't exist: '{0}'")]
     InvalidBlockNumberOrHash(BlockSpec),
+    /// The block tag is not allowed in pre-merge hardforks.
+    /// https://github.com/NomicFoundation/hardhat/blob/b84baf2d9f5d3ea897c06e0ecd5e7084780d8b6c/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts#L1820
+    #[error("The '{block_spec}' block tag is not allowed in pre-merge hardforks. You are using the '{spec:?}' hardfork.")]
+    InvalidBlockTag { block_spec: BlockSpec, spec: SpecId },
     /// Invalid filter subscription type
     #[error("Subscription {filter_id} is not a {expected:?} subscription, but a {actual:?} subscription")]
     InvalidFilterSubscriptionType {

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -138,7 +138,10 @@ fn handle_eth_request(
         EthRequest::GetBalance(address, block_spec) => {
             eth::handle_get_balance_request(data, address, block_spec).and_then(to_json)
         }
-        EthRequest::GetBlockByNumber(_, _) => Err(ProviderError::Unimplemented("".to_string())),
+        EthRequest::GetBlockByNumber(block_spec, transaction_detail_flag) => {
+            eth::handle_get_block_by_number_request(data, block_spec, transaction_detail_flag)
+                .and_then(to_json)
+        }
         EthRequest::GetBlockByHash(_, _) => Err(ProviderError::Unimplemented("".to_string())),
         EthRequest::GetBlockTransactionCountByHash(_) => {
             Err(ProviderError::Unimplemented("".to_string()))

--- a/crates/edr_provider/src/requests/eth.rs
+++ b/crates/edr_provider/src/requests/eth.rs
@@ -1,5 +1,6 @@
 mod accounts;
 mod blockchain;
+mod blocks;
 mod config;
 mod evm;
 mod filter;
@@ -9,6 +10,6 @@ mod transactions;
 mod web3;
 
 pub use self::{
-    accounts::*, blockchain::*, config::*, evm::*, filter::*, sign::*, state::*, transactions::*,
-    web3::*,
+    accounts::*, blockchain::*, blocks::*, config::*, evm::*, filter::*, sign::*, state::*,
+    transactions::*, web3::*,
 };

--- a/crates/edr_provider/src/requests/eth/blocks.rs
+++ b/crates/edr_provider/src/requests/eth/blocks.rs
@@ -1,0 +1,120 @@
+use std::sync::Arc;
+
+use edr_eth::{
+    remote::{eth, PreEip1898BlockSpec},
+    B256, U256,
+};
+use edr_evm::{blockchain::BlockchainError, SyncBlock};
+
+use crate::{
+    data::{BlockDataForTransaction, ProviderData, TransactionAndBlock},
+    requests::eth::transaction_to_rpc_result,
+    ProviderError,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(untagged)]
+pub enum HashOrTransaction {
+    Hash(B256),
+    Transaction(eth::Transaction),
+}
+
+pub fn handle_get_block_by_number_request(
+    data: &ProviderData,
+    block_spec: PreEip1898BlockSpec,
+    transaction_detail_flag: bool,
+) -> Result<Option<eth::Block<HashOrTransaction>>, ProviderError> {
+    match data.block_by_block_spec(&block_spec.into()) {
+        Ok(Some(block)) => {
+            let total_difficulty = data.total_difficulty_by_hash(block.hash())?;
+            Ok(Some(block_to_rpc_output(
+                data,
+                block,
+                total_difficulty,
+                transaction_detail_flag,
+            )?))
+        }
+        // Pending block
+        Ok(None) => {
+            let result = data.mine_pending_block()?;
+            let block: Arc<dyn SyncBlock<Error = BlockchainError>> = Arc::new(result.block);
+
+            let last_block = data.last_block()?;
+            let previous_total_difficulty = data
+                .total_difficulty_by_hash(last_block.hash())?
+                .expect("last block has total difficulty");
+            let total_difficulty = previous_total_difficulty + block.header().difficulty;
+
+            Ok(Some(block_to_rpc_output(
+                data,
+                block,
+                Some(total_difficulty),
+                transaction_detail_flag,
+            )?))
+        }
+        Err(ProviderError::InvalidBlockNumberOrHash(_)) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+fn block_to_rpc_output(
+    data: &ProviderData,
+    block: Arc<dyn SyncBlock<Error = BlockchainError>>,
+    total_difficulty: Option<U256>,
+    transaction_detail_flag: bool,
+) -> Result<eth::Block<HashOrTransaction>, ProviderError> {
+    let header = block.header();
+
+    let transactions: Vec<HashOrTransaction> = if transaction_detail_flag {
+        block
+            .transactions()
+            .iter()
+            .enumerate()
+            .map(|(i, tx)| TransactionAndBlock {
+                signed_transaction: tx.clone(),
+                block_data: Some(BlockDataForTransaction {
+                    block: block.clone(),
+                    transaction_index: i.try_into().expect("usize fits into u64"),
+                }),
+            })
+            .map(|tx| transaction_to_rpc_result(data, tx).map(HashOrTransaction::Transaction))
+            .collect::<Result<_, _>>()?
+    } else {
+        block
+            .transactions()
+            .iter()
+            .map(|tx| HashOrTransaction::Hash(*tx.hash()))
+            .collect()
+    };
+
+    Ok(eth::Block {
+        hash: Some(*block.hash()),
+        parent_hash: header.parent_hash,
+        sha3_uncles: header.ommers_hash,
+        state_root: header.state_root,
+        transactions_root: header.transactions_root,
+        receipts_root: header.receipts_root,
+        number: Some(header.number),
+        gas_used: header.gas_used,
+        gas_limit: header.gas_limit,
+        extra_data: header.extra_data.clone(),
+        logs_bloom: header.logs_bloom,
+        timestamp: header.timestamp,
+        difficulty: header.difficulty,
+        total_difficulty,
+        uncles: block.ommer_hashes().to_vec(),
+        transactions,
+        size: U256::from(block.size()),
+        mix_hash: header.mix_hash,
+        nonce: Some(header.nonce.as_limbs()[0]),
+        base_fee_per_gas: header.base_fee_per_gas,
+        miner: Some(header.beneficiary),
+        withdrawals: block
+            .withdrawals()
+            .map(<[edr_eth::withdrawal::Withdrawal]>::to_vec),
+        withdrawals_root: header.withdrawals_root,
+        blob_gas_used: header.blob_gas.as_ref().map(|bg| bg.gas_used),
+        excess_blob_gas: header.blob_gas.as_ref().map(|bg| bg.excess_gas),
+        parent_beacon_block_root: header.parent_beacon_block_root,
+    })
+}

--- a/crates/edr_provider/src/requests/eth/blocks.rs
+++ b/crates/edr_provider/src/requests/eth/blocks.rs
@@ -104,7 +104,7 @@ fn block_to_rpc_output(
         total_difficulty,
         uncles: block.ommer_hashes().to_vec(),
         transactions,
-        size: U256::from(block.size()),
+        size: block.rlp_size(),
         mix_hash: header.mix_hash,
         nonce: Some(header.nonce.as_limbs()[0]),
         base_fee_per_gas: header.base_fee_per_gas,

--- a/crates/edr_provider/src/requests/eth/transactions.rs
+++ b/crates/edr_provider/src/requests/eth/transactions.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use edr_eth::{
+    block::Header,
     receipt::BlockReceipt,
     remote,
     remote::PreEip1898BlockSpec,
@@ -11,9 +12,7 @@ use edr_eth::{
 use edr_evm::{blockchain::BlockchainError, SyncBlock};
 
 use crate::{
-    data::{
-        transaction_from_block, BlockMetadataForTransaction, GetTransactionResult, ProviderData,
-    },
+    data::{BlockDataForTransaction, ProviderData, TransactionAndBlock},
     ProviderError,
 };
 
@@ -27,8 +26,8 @@ pub fn handle_get_transaction_by_block_hash_and_index(
     let index = rpc_index_to_usize(&index)?;
 
     data.block_by_hash(&block_hash)?
-        .and_then(|block| transaction_from_block(&block, index, data.spec_id()))
-        .map(get_transaction_result_to_rpc_result)
+        .and_then(|block| transaction_from_block(block, index))
+        .map(|tx| transaction_to_rpc_result(data, tx))
         .transpose()
 }
 
@@ -51,8 +50,8 @@ pub fn handle_get_transaction_by_block_spec_and_index(
         Err(ProviderError::InvalidBlockNumberOrHash(_)) => None,
         Err(err) => return Err(err),
     }
-    .and_then(|block| transaction_from_block(&block, index, data.spec_id()))
-    .map(get_transaction_result_to_rpc_result)
+    .and_then(|block| transaction_from_block(block, index))
+    .map(|tx| transaction_to_rpc_result(data, tx))
     .transpose()
 }
 
@@ -67,7 +66,7 @@ pub fn handle_get_transaction_by_hash(
     transaction_hash: B256,
 ) -> Result<Option<remote::eth::Transaction>, ProviderError> {
     data.transaction_by_hash(&transaction_hash)?
-        .map(get_transaction_result_to_rpc_result)
+        .map(|tx| transaction_to_rpc_result(data, tx))
         .transpose()
 }
 
@@ -78,12 +77,29 @@ pub fn handle_get_transaction_receipt(
     data.transaction_receipt(&transaction_hash)
 }
 
-fn get_transaction_result_to_rpc_result(
-    result: GetTransactionResult,
+fn transaction_from_block(
+    block: Arc<dyn SyncBlock<Error = BlockchainError>>,
+    transaction_index: usize,
+) -> Option<TransactionAndBlock> {
+    block
+        .transactions()
+        .get(transaction_index)
+        .map(|transaction| TransactionAndBlock {
+            signed_transaction: transaction.clone(),
+            block_data: Some(BlockDataForTransaction {
+                block: block.clone(),
+                transaction_index: transaction_index.try_into().expect("usize fits into u64"),
+            }),
+        })
+}
+
+pub fn transaction_to_rpc_result(
+    data: &ProviderData,
+    transaction_and_block: TransactionAndBlock,
 ) -> Result<remote::eth::Transaction, ProviderError> {
     fn gas_price_for_post_eip1559(
         signed_transaction: &SignedTransaction,
-        block_metadata: Option<&BlockMetadataForTransaction>,
+        block: Option<&Arc<dyn SyncBlock<Error = BlockchainError>>>,
     ) -> U256 {
         let max_fee_per_gas = signed_transaction
             .max_fee_per_gas()
@@ -92,8 +108,8 @@ fn get_transaction_result_to_rpc_result(
             .max_priority_fee_per_gas()
             .expect("Transaction must be post EIP-1559 transaction.");
 
-        if let Some(block_metadata) = block_metadata {
-            let base_fee_per_gas = block_metadata.base_fee_per_gas.expect(
+        if let Some(block) = block {
+            let base_fee_per_gas = block.header().base_fee_per_gas.expect(
                 "Transaction must have base fee per gas in block metadata if EIP-1559 is active.",
             );
             let priority_fee_per_gas =
@@ -106,18 +122,19 @@ fn get_transaction_result_to_rpc_result(
         }
     }
 
-    let GetTransactionResult {
+    let TransactionAndBlock {
         signed_transaction,
-        spec_id,
-        block_metadata,
-    } = result;
+        block_data,
+    } = transaction_and_block;
+    let block = block_data.as_ref().map(|b| &b.block);
+    let header = block.map(|b| b.header());
 
     let gas_price = match &signed_transaction {
         SignedTransaction::PreEip155Legacy(tx) => tx.gas_price,
         SignedTransaction::PostEip155Legacy(tx) => tx.gas_price,
         SignedTransaction::Eip2930(tx) => tx.gas_price,
         SignedTransaction::Eip1559(_) | SignedTransaction::Eip4844(_) => {
-            gas_price_for_post_eip1559(&signed_transaction, block_metadata.as_ref())
+            gas_price_for_post_eip1559(&signed_transaction, block)
         }
     };
 
@@ -130,7 +147,7 @@ fn get_transaction_result_to_rpc_result(
         SignedTransaction::Eip4844(tx) => Some(tx.chain_id),
     };
 
-    let show_transaction_type = spec_id >= FIRST_HARDFORK_WITH_TRANSACTION_TYPE;
+    let show_transaction_type = data.spec_id() >= FIRST_HARDFORK_WITH_TRANSACTION_TYPE;
     let is_typed_transaction = signed_transaction.transaction_type() > 0;
     let transaction_type = if show_transaction_type || is_typed_transaction {
         Some(signed_transaction.transaction_type())
@@ -143,9 +160,9 @@ fn get_transaction_result_to_rpc_result(
     Ok(remote::eth::Transaction {
         hash: *signed_transaction.hash(),
         nonce: signed_transaction.nonce(),
-        block_hash: block_metadata.as_ref().map(|m| m.block_hash),
-        block_number: block_metadata.as_ref().map(|m| U256::from(m.block_number)),
-        transaction_index: block_metadata.map(|m| m.transaction_index),
+        block_hash: header.map(Header::hash),
+        block_number: header.map(|h| U256::from(h.number)),
+        transaction_index: block_data.as_ref().map(|bd| bd.transaction_index),
         from: signed_transaction.recover()?,
         to: signed_transaction.to(),
         value: signed_transaction.value(),


### PR DESCRIPTION
Adds `eth_getBlockByNumber` support to the EDR provider, matching the Hardhat implementation. 

Hardhat integration tests are passing up to the point where they need `eth_sendTransaction`.