### PR TITLE
Add get block by hash and block transaction count methods

### DIFF
--- a/crates/edr_eth/src/remote/methods.rs
+++ b/crates/edr_eth/src/remote/methods.rs
@@ -127,7 +127,7 @@ pub enum MethodInvocation {
         rename = "eth_getBlockTransactionCountByNumber",
         with = "crate::serde::sequence"
     )]
-    GetBlockTransactionCountByNumber(BlockSpec),
+    GetBlockTransactionCountByNumber(PreEip1898BlockSpec),
     /// eth_getCode
     #[serde(rename = "eth_getCode")]
     GetCode(

--- a/crates/edr_eth/tests/integration_tests.rs
+++ b/crates/edr_eth/tests/integration_tests.rs
@@ -150,7 +150,7 @@ fn test_serde_eth_get_transaction() {
 #[test]
 fn test_serde_eth_get_transaction_count_by_number() {
     help_test_method_invocation_serde(MethodInvocation::GetBlockTransactionCountByNumber(
-        BlockSpec::Number(100),
+        PreEip1898BlockSpec::Number(100),
     ));
 }
 

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -225,39 +225,6 @@ impl ProviderData {
             .map_err(ProviderError::Blockchain)
     }
 
-    pub fn block_by_number(
-        &self,
-        block_spec: &BlockSpec,
-    ) -> Result<Option<BlockAndTotalDifficulty>, ProviderError> {
-        match self.block_by_block_spec(block_spec) {
-            Ok(Some(block)) => {
-                let total_difficulty = self.total_difficulty_by_hash(block.hash())?;
-                Ok(Some(BlockAndTotalDifficulty {
-                    block,
-                    total_difficulty,
-                }))
-            }
-            // Pending block
-            Ok(None) => {
-                let result = self.mine_pending_block()?;
-                let block: Arc<dyn SyncBlock<Error = BlockchainError>> = Arc::new(result.block);
-
-                let last_block = self.last_block()?;
-                let previous_total_difficulty = self
-                    .total_difficulty_by_hash(last_block.hash())?
-                    .expect("last block has total difficulty");
-                let total_difficulty = previous_total_difficulty + block.header().difficulty;
-
-                Ok(Some(BlockAndTotalDifficulty {
-                    block,
-                    total_difficulty: Some(total_difficulty),
-                }))
-            }
-            Err(ProviderError::InvalidBlockNumberOrHash(_)) => Ok(None),
-            Err(err) => Err(err),
-        }
-    }
-
     pub fn chain_id(&self) -> u64 {
         self.blockchain.chain_id()
     }

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -142,12 +142,17 @@ fn handle_eth_request(
             eth::handle_get_block_by_number_request(data, block_spec, transaction_detail_flag)
                 .and_then(to_json)
         }
-        EthRequest::GetBlockByHash(_, _) => Err(ProviderError::Unimplemented("".to_string())),
-        EthRequest::GetBlockTransactionCountByHash(_) => {
-            Err(ProviderError::Unimplemented("".to_string()))
+        EthRequest::GetBlockByHash(block_hash, transaction_detail_flag) => {
+            eth::handle_get_block_by_hash_request(data, block_hash, transaction_detail_flag)
+                .and_then(to_json)
         }
-        EthRequest::GetBlockTransactionCountByNumber(_) => {
-            Err(ProviderError::Unimplemented("".to_string()))
+        EthRequest::GetBlockTransactionCountByHash(block_hash) => {
+            eth::handle_get_block_transaction_count_by_hash_request(data, block_hash)
+                .and_then(to_json)
+        }
+        EthRequest::GetBlockTransactionCountByNumber(block_spec) => {
+            eth::handle_get_block_transaction_count_by_block_number(data, block_spec)
+                .and_then(to_json)
         }
         EthRequest::GetCode(address, block_spec) => {
             eth::handle_get_code_request(data, address, block_spec).and_then(to_json)


### PR DESCRIPTION
Add support for 
- eth_getBlockByHash ([source](https://github.com/NomicFoundation/hardhat/blob/7dd2586cf5be393492f70adb176ab85a6e79b792/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts#L500))
- eth_getBlockTransactionCountByHash ([source](https://github.com/NomicFoundation/hardhat/blob/7dd2586cf5be393492f70adb176ab85a6e79b792/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts#L564))
- eth_getBlockTransactionCountByNumber ([source](https://github.com/NomicFoundation/hardhat/blob/7dd2586cf5be393492f70adb176ab85a6e79b792/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts#L583))