### PR TITLE
refactor: pass spec id instead of data to transaction to rpc result

### DIFF
--- a/crates/edr_provider/src/requests/eth/blocks.rs
+++ b/crates/edr_provider/src/requests/eth/blocks.rs
@@ -119,7 +119,9 @@ fn block_to_rpc_output(
                     transaction_index: i.try_into().expect("usize fits into u64"),
                 }),
             })
-            .map(|tx| transaction_to_rpc_result(data, tx).map(HashOrTransaction::Transaction))
+            .map(|tx| {
+                transaction_to_rpc_result(tx, data.spec_id()).map(HashOrTransaction::Transaction)
+            })
             .collect::<Result<_, _>>()?
     } else {
         block

--- a/crates/edr_provider/src/requests/eth/transactions.rs
+++ b/crates/edr_provider/src/requests/eth/transactions.rs
@@ -27,7 +27,7 @@ pub fn handle_get_transaction_by_block_hash_and_index(
 
     data.block_by_hash(&block_hash)?
         .and_then(|block| transaction_from_block(block, index))
-        .map(|tx| transaction_to_rpc_result(data, tx))
+        .map(|tx| transaction_to_rpc_result(tx, data.spec_id()))
         .transpose()
 }
 
@@ -51,7 +51,7 @@ pub fn handle_get_transaction_by_block_spec_and_index(
         Err(err) => return Err(err),
     }
     .and_then(|block| transaction_from_block(block, index))
-    .map(|tx| transaction_to_rpc_result(data, tx))
+    .map(|tx| transaction_to_rpc_result(tx, data.spec_id()))
     .transpose()
 }
 
@@ -66,7 +66,7 @@ pub fn handle_get_transaction_by_hash(
     transaction_hash: B256,
 ) -> Result<Option<remote::eth::Transaction>, ProviderError> {
     data.transaction_by_hash(&transaction_hash)?
-        .map(|tx| transaction_to_rpc_result(data, tx))
+        .map(|tx| transaction_to_rpc_result(tx, data.spec_id()))
         .transpose()
 }
 
@@ -94,8 +94,8 @@ fn transaction_from_block(
 }
 
 pub fn transaction_to_rpc_result(
-    data: &ProviderData,
     transaction_and_block: TransactionAndBlock,
+    spec_id: SpecId,
 ) -> Result<remote::eth::Transaction, ProviderError> {
     fn gas_price_for_post_eip1559(
         signed_transaction: &SignedTransaction,
@@ -147,7 +147,7 @@ pub fn transaction_to_rpc_result(
         SignedTransaction::Eip4844(tx) => Some(tx.chain_id),
     };
 
-    let show_transaction_type = data.spec_id() >= FIRST_HARDFORK_WITH_TRANSACTION_TYPE;
+    let show_transaction_type = spec_id >= FIRST_HARDFORK_WITH_TRANSACTION_TYPE;
     let is_typed_transaction = signed_transaction.transaction_type() > 0;
     let transaction_type = if show_transaction_type || is_typed_transaction {
         Some(signed_transaction.transaction_type())


### PR DESCRIPTION
There is no point of passing the entire `data` anymore to `transaction_to_rpc_result` so just pass the spec id.