### PR TITLE
Update reference.md to correct mistakes in sample code.

### DIFF
--- a/docs/src/content/hardhat-chai-matchers/docs/reference.md
+++ b/docs/src/content/hardhat-chai-matchers/docs/reference.md
@@ -128,7 +128,7 @@ If the event has arguments, the `.withArgs` matcher can be added:
 
 ```ts
 await expect(token.transfer(address, 0))
-  .to.be.revertedWithCustomError(token, "InvalidTransferValue")
+  .to.be.emit(token, "Transfer")
   .withArgs(100);
 ```
 
@@ -203,7 +203,7 @@ Can be used after a `.emit` or a `.revertedWithCustomError` matcher to assert th
 ```ts
 // events
 await expect(token.transfer(address, 0))
-  .to.be.revertedWithCustomError(token, "InvalidTransferValue")
+  .to.be.emit(token, "Transfer")
   .withArgs(100);
 
 // errors

--- a/docs/src/content/hardhat-chai-matchers/docs/reference.md
+++ b/docs/src/content/hardhat-chai-matchers/docs/reference.md
@@ -128,7 +128,7 @@ If the event has arguments, the `.withArgs` matcher can be added:
 
 ```ts
 await expect(token.transfer(address, 0))
-  .to.be.emit(token, "Transfer")
+  .to.emit(token, "Transfer")
   .withArgs(100);
 ```
 
@@ -203,7 +203,7 @@ Can be used after a `.emit` or a `.revertedWithCustomError` matcher to assert th
 ```ts
 // events
 await expect(token.transfer(address, 0))
-  .to.be.emit(token, "Transfer")
+  .to.emit(token, "Transfer")
   .withArgs(100);
 
 // errors


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

The sample code for .emit that uses .withArgs was incorrect, so it has been corrected.
What should have been written as .emit was instead written as .revertedWithCustomError.

