### PR TITLE
Add redirect for hh-waffle guide

### DIFF
--- a/docs/redirects.config.js
+++ b/docs/redirects.config.js
@@ -89,6 +89,11 @@ const customRedirects = [
     permanent: false,
   },
   {
+    source: "/hardhat-runner/docs/guides/migrating-from-hardhat-waffle",
+    destination: "/hardhat-runner/docs/advanced/migrating-from-hardhat-waffle",
+    permanent: false,
+  },
+  {
     source: "/custom-hardfork-history",
     destination:
       "/hardhat-network/docs/guides/forking-other-networks.html#using-a-custom-hardfork-history",


### PR DESCRIPTION
Closes https://github.com/NomicFoundation/hardhat/issues/4623

This broke after I moved the guide from the normal guides to the advanced guides.