### PR TITLE
broken link for `@nomicfoundation/hardhat-web3-v4` 

### DIFF
--- a/docs/src/components/Navigation.mocks.json
+++ b/docs/src/components/Navigation.mocks.json
@@ -170,6 +170,10 @@
         "href": "/plugins/nomiclabs-hardhat-web3"
       },
       {
+        "label": "@nomiclabs/hardhat-web3-v4",
+        "href": "/plugins/nomiclabs-hardhat-web3-v4"
+      },
+      {
         "label": "@nomiclabs/hardhat-truffle5",
         "href": "/plugins/nomiclabs-hardhat-truffle5"
       },

--- a/docs/src/content/hardhat-runner/plugins/_dirinfo.yaml
+++ b/docs/src/content/hardhat-runner/plugins/_dirinfo.yaml
@@ -14,6 +14,7 @@ order:
   - "@nomiclabs/hardhat-solpp"
   - "@nomiclabs/hardhat-waffle"
   - "@nomiclabs/hardhat-web3"
+  - "@nomiclabs/hardhat-web3-v4"
   - "@nomiclabs/hardhat-truffle5"
   - "@nomiclabs/hardhat-web3-legacy"
   - "@nomiclabs/hardhat-truffle4"


### PR DESCRIPTION

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
Hi guys, pls let me know if this PR is good to show the [web3-v4 guide](https://github.com/NomicFoundation/hardhat/blob/8db6b3418e072dcadd7f6d27ce1109e75cb5881a/packages/hardhat-web3-v4/README.md?plain=1) in the website. Right now, the plugin is in the [plugins list](https://hardhat.org/hardhat-runner/plugins), but if you click on [@nomicfoundation/hardhat-web3-v4](https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-web3-v4), it just goes to a 404 screen. 
Let me know if it's clear or needs changes. Thanks!