### PR TITLE
Add configurable public client to getContractAt, deployContract and sendDeploymentTransaction

### DIFF
--- a/.changeset/odd-cooks-wait.md
+++ b/.changeset/odd-cooks-wait.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Add configurable public client to getContractAt, deployContract and sendDeploymentTransaction

--- a/packages/hardhat-viem/src/internal/contracts.ts
+++ b/packages/hardhat-viem/src/internal/contracts.ts
@@ -120,12 +120,11 @@ export async function sendDeploymentTransaction(
   contract: GetContractReturnType;
   deploymentTransaction: GetTransactionReturnType;
 }> {
-  const { 
-    walletClient: configWalletClient, 
-    publicClient: configPublicClient, 
-    ...deployContractParameters 
-  } =
-    config;
+  const {
+    walletClient: configWalletClient,
+    publicClient: configPublicClient,
+    ...deployContractParameters
+  } = config;
   const [publicClient, walletClient, contractArtifact] = await Promise.all([
     configPublicClient ?? getPublicClient(network.provider),
     configWalletClient ??

--- a/packages/hardhat-viem/src/internal/contracts.ts
+++ b/packages/hardhat-viem/src/internal/contracts.ts
@@ -198,7 +198,7 @@ export async function getContractAt(
   config: GetContractAtConfig = {}
 ): Promise<GetContractReturnType> {
   const [publicClient, walletClient, contractArtifact] = await Promise.all([
-    getPublicClient(network.provider),
+    config.publicClient ?? getPublicClient(network.provider),
     config.walletClient ??
       getDefaultWalletClient(network.provider, network.name),
     artifacts.readArtifact(contractName),

--- a/packages/hardhat-viem/src/internal/contracts.ts
+++ b/packages/hardhat-viem/src/internal/contracts.ts
@@ -29,11 +29,12 @@ export async function deployContract(
 ): Promise<GetContractReturnType> {
   const {
     walletClient: configWalletClient,
+    publicClient: configPublicClient,
     confirmations,
     ...deployContractParameters
   } = config;
   const [publicClient, walletClient, contractArtifact] = await Promise.all([
-    getPublicClient(network.provider),
+    configPublicClient ?? getPublicClient(network.provider),
     configWalletClient ??
       getDefaultWalletClient(network.provider, network.name),
     artifacts.readArtifact(contractName),
@@ -119,10 +120,14 @@ export async function sendDeploymentTransaction(
   contract: GetContractReturnType;
   deploymentTransaction: GetTransactionReturnType;
 }> {
-  const { walletClient: configWalletClient, ...deployContractParameters } =
+  const { 
+    walletClient: configWalletClient, 
+    publicClient: configPublicClient, 
+    ...deployContractParameters 
+  } =
     config;
   const [publicClient, walletClient, contractArtifact] = await Promise.all([
-    getPublicClient(network.provider),
+    configPublicClient ?? getPublicClient(network.provider),
     configWalletClient ??
       getDefaultWalletClient(network.provider, network.name),
     artifacts.readArtifact(contractName),

--- a/packages/hardhat-viem/src/types.ts
+++ b/packages/hardhat-viem/src/types.ts
@@ -19,6 +19,7 @@ export type TestClientMode = Parameters<
 
 export interface SendTransactionConfig {
   walletClient?: WalletClient;
+  publicClient?: PublicClient;
   gas?: bigint;
   gasPrice?: bigint;
   maxFeePerGas?: bigint;

--- a/packages/hardhat-viem/src/types.ts
+++ b/packages/hardhat-viem/src/types.ts
@@ -34,6 +34,7 @@ export type SendDeploymentTransactionConfig = SendTransactionConfig;
 
 export interface GetContractAtConfig {
   walletClient?: WalletClient;
+  publicClient?: PublicClient;
 }
 
 export type GetContractReturnType<


### PR DESCRIPTION
## Problem

This PR fixes this issue - https://github.com/NomicFoundation/hardhat/issues/4624

I want to configure client with `hre.viem.getWalletClient` and then get contract API with `hre.viem.getContractAt` by passing `GetContractAtConfig` from `@nomicfoundation/hardhat-viem/src/types`

It's possible to configure only `walletClient` in `GetContractAtConfig` but for `watchEvent` method it's required to have `publicClient` configured.

If you are trying to use hardhat without specifying `--network` - you won't get any events

## Solution

Add `publicClient` to `getContractAtConfig` and use this client in `getContractAt` function. This would allow to use read methods of the contract with any configuration.