### PR TITLE
Compile message output update

### DIFF
--- a/docs/src/content/tutorial/writing-and-compiling-contracts.md
+++ b/docs/src/content/tutorial/writing-and-compiling-contracts.md
@@ -107,8 +107,7 @@ To compile the contract run `npx hardhat compile` in your terminal. The `compile
 
 ```
 $ npx hardhat compile
-Compiling 1 file with {RECOMMENDED_SOLC_VERSION}
-Compilation finished successfully
+Compiled 1 Solidity file successfully (evm target: paris).
 ```
 
 The contract has been successfully compiled and it's ready to be used.


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->



---

<!-- Add a description of your PR here -->
Earlier the output from console was "Compiling 1 file with 0.8.19
Compilation finished successfully".
But with update in hardhat, now console output is showing this message:
"Compiled 1 Solidity file successfully (evm target: paris)."