### PR TITLE
Exclude artifacts/package.json from artifacts in getArtifactPaths

### DIFF
--- a/.changeset/dry-moose-draw.md
+++ b/.changeset/dry-moose-draw.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Modified the artifacts cleanup logic to avoid removing a `package.json` file under the artifacts directory

--- a/packages/hardhat-core/src/internal/artifacts.ts
+++ b/packages/hardhat-core/src/internal/artifacts.ts
@@ -154,14 +154,8 @@ export class Artifacts implements IArtifacts {
       return cached;
     }
 
-    const buildInfosDir = path.join(this._artifactsPath, BUILD_INFO_DIR_NAME);
-
-    const paths = await getAllFilesMatching(
-      this._artifactsPath,
-      (f) =>
-        f.endsWith(".json") &&
-        !f.startsWith(buildInfosDir) &&
-        !f.endsWith(".dbg.json")
+    const paths = await getAllFilesMatching(this._artifactsPath, (f) =>
+      this._isArtifactPath(f)
     );
 
     const result = paths.sort();
@@ -563,14 +557,8 @@ export class Artifacts implements IArtifacts {
       return cached;
     }
 
-    const buildInfosDir = path.join(this._artifactsPath, BUILD_INFO_DIR_NAME);
-
-    const paths = getAllFilesMatchingSync(
-      this._artifactsPath,
-      (f) =>
-        f.endsWith(".json") &&
-        !f.startsWith(buildInfosDir) &&
-        !f.endsWith(".dbg.json")
+    const paths = getAllFilesMatchingSync(this._artifactsPath, (f) =>
+      this._isArtifactPath(f)
     );
 
     const result = paths.sort();
@@ -933,6 +921,15 @@ Please replace "${contractName}" for the correct contract name wherever you are 
     }
 
     return undefined;
+  }
+
+  private _isArtifactPath(file: string) {
+    return (
+      file.endsWith(".json") &&
+      file !== path.join(this._artifactsPath, "package.json") &&
+      !file.startsWith(path.join(this._artifactsPath, BUILD_INFO_DIR_NAME)) &&
+      !file.endsWith(".dbg.json")
+    );
   }
 }
 


### PR DESCRIPTION
Resolved an issue where `artifacts/package.json` was mistakenly identified and pruned as an artifact in the `TASK_COMPILE_REMOVE_OBSOLETE_ARTIFACTS` subtask. This update ensures the file is preserved, as it is required to provide ESM support in `hardhat-viem`.