### PR TITLE
feat: collect solidity `console.log` messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "edr_rpc_hardhat",
  "indexmap 2.0.2",
  "k256",
+ "lazy_static",
  "log",
  "parking_lot 0.12.1",
  "rand",

--- a/crates/edr_evm/src/block/builder.rs
+++ b/crates/edr_evm/src/block/builder.rs
@@ -58,8 +58,8 @@ pub enum BlockTransactionError<BE, SE> {
 
 impl<BE, SE> From<EVMError<DatabaseComponentError<SE, BE>>> for BlockTransactionError<BE, SE>
 where
-    BE: Debug + Send + 'static,
-    SE: Debug + Send + 'static,
+    BE: Debug + Send,
+    SE: Debug + Send,
 {
     fn from(error: EVMError<DatabaseComponentError<SE, BE>>) -> Self {
         match error {
@@ -180,8 +180,8 @@ impl BlockBuilder {
         inspector: Option<&mut dyn SyncInspector<BlockchainErrorT, StateErrorT>>,
     ) -> Result<ExecutionResult, BlockTransactionError<BlockchainErrorT, StateErrorT>>
     where
-        BlockchainErrorT: Debug + Send + 'static,
-        StateErrorT: Debug + Send + 'static,
+        BlockchainErrorT: Debug + Send,
+        StateErrorT: Debug + Send,
     {
         //  transaction's gas limit cannot be greater than the remaining gas in the
         // block

--- a/crates/edr_evm/src/debug_trace.rs
+++ b/crates/edr_evm/src/debug_trace.rs
@@ -28,8 +28,8 @@ pub fn debug_trace_transaction<BlockchainErrorT, StateErrorT>(
     transaction_hash: &B256,
 ) -> Result<DebugTraceResult, DebugTraceError<BlockchainErrorT, StateErrorT>>
 where
-    BlockchainErrorT: Debug + Send + 'static,
-    StateErrorT: Debug + Send + 'static,
+    BlockchainErrorT: Debug + Send,
+    StateErrorT: Debug + Send,
 {
     if evm_config.spec_id < SpecId::SPURIOUS_DRAGON {
         // Matching Hardhat Network behaviour: https://github.com/NomicFoundation/hardhat/blob/af7e4ce6a18601ec9cd6d4aa335fa7e24450e638/packages/hardhat-core/src/internal/hardhat-network/provider/vm/ethereumjs.ts#L427

--- a/crates/edr_evm/src/evm.rs
+++ b/crates/edr_evm/src/evm.rs
@@ -11,16 +11,16 @@ use crate::{blockchain::SyncBlockchain, SyncDatabase};
 /// Super trait for an inspector of an `AsyncDatabase` that's debuggable.
 pub trait SyncInspector<BE, SE>: Inspector<DatabaseComponentError<SE, BE>> + Debug + Send
 where
-    BE: Debug + Send + 'static,
-    SE: Debug + Send + 'static,
+    BE: Debug + Send,
+    SE: Debug + Send,
 {
 }
 
 impl<I, BE, SE> SyncInspector<BE, SE> for I
 where
     I: Inspector<DatabaseComponentError<SE, BE>> + Debug + Send,
-    BE: Debug + Send + 'static,
-    SE: Debug + Send + 'static,
+    BE: Debug + Send,
+    SE: Debug + Send,
 {
 }
 

--- a/crates/edr_evm/src/inspector.rs
+++ b/crates/edr_evm/src/inspector.rs
@@ -166,8 +166,8 @@ where
 
 impl<BlockchainErrorT, StateErrorT> InspectorContainer<BlockchainErrorT, StateErrorT>
 where
-    BlockchainErrorT: Debug + Send + 'static,
-    StateErrorT: Debug + Send + 'static,
+    BlockchainErrorT: Debug + Send,
+    StateErrorT: Debug + Send,
 {
     /// Constructs a new instance.
     pub fn new(

--- a/crates/edr_evm/src/inspector.rs
+++ b/crates/edr_evm/src/inspector.rs
@@ -143,7 +143,7 @@ where
 }
 
 /// Container for storing inspector and tracer.
-pub enum InspectorContainer<BlockchainErrorT, StateErrorT>
+pub enum InspectorContainer<'inspector, BlockchainErrorT, StateErrorT>
 where
     BlockchainErrorT: Debug,
     StateErrorT: Debug,
@@ -156,15 +156,16 @@ where
     Dual(
         DualInspector<
             TraceCollector,
-            Box<dyn SyncInspector<BlockchainErrorT, StateErrorT>>,
+            &'inspector mut dyn SyncInspector<BlockchainErrorT, StateErrorT>,
             DatabaseComponentError<StateErrorT, BlockchainErrorT>,
         >,
     ),
     /// Only an inspector.
-    Inspector(Box<dyn SyncInspector<BlockchainErrorT, StateErrorT>>),
+    Inspector(&'inspector mut dyn SyncInspector<BlockchainErrorT, StateErrorT>),
 }
 
-impl<BlockchainErrorT, StateErrorT> InspectorContainer<BlockchainErrorT, StateErrorT>
+impl<'inspector, BlockchainErrorT, StateErrorT>
+    InspectorContainer<'inspector, BlockchainErrorT, StateErrorT>
 where
     BlockchainErrorT: Debug + Send,
     StateErrorT: Debug + Send,
@@ -172,7 +173,7 @@ where
     /// Constructs a new instance.
     pub fn new(
         with_trace: bool,
-        tracer: Option<Box<dyn SyncInspector<BlockchainErrorT, StateErrorT>>>,
+        tracer: Option<&'inspector mut dyn SyncInspector<BlockchainErrorT, StateErrorT>>,
     ) -> Self {
         if with_trace {
             if let Some(tracer) = tracer {

--- a/crates/edr_evm/src/miner.rs
+++ b/crates/edr_evm/src/miner.rs
@@ -91,8 +91,8 @@ pub fn mine_block<BlockchainErrorT, StateErrorT>(
     inspector: Option<Box<dyn SyncInspector<BlockchainErrorT, StateErrorT>>>,
 ) -> Result<MineBlockResultAndState<StateErrorT>, MineBlockError<BlockchainErrorT, StateErrorT>>
 where
-    BlockchainErrorT: Debug + Send + 'static,
-    StateErrorT: Debug + Send + 'static,
+    BlockchainErrorT: Debug + Send,
+    StateErrorT: Debug + Send,
 {
     let parent_block = blockchain
         .last_block()

--- a/crates/edr_evm/src/miner.rs
+++ b/crates/edr_evm/src/miner.rs
@@ -88,7 +88,7 @@ pub fn mine_block<BlockchainErrorT, StateErrorT>(
     reward: U256,
     base_fee: Option<U256>,
     prevrandao: Option<B256>,
-    inspector: Option<Box<dyn SyncInspector<BlockchainErrorT, StateErrorT>>>,
+    inspector: Option<&mut dyn SyncInspector<BlockchainErrorT, StateErrorT>>,
 ) -> Result<MineBlockResultAndState<StateErrorT>, MineBlockError<BlockchainErrorT, StateErrorT>>
 where
     BlockchainErrorT: Debug + Send,

--- a/crates/edr_evm/src/runtime.rs
+++ b/crates/edr_evm/src/runtime.rs
@@ -30,8 +30,8 @@ pub fn dry_run<BlockchainErrorT, StateErrorT>(
     inspector: Option<&mut dyn SyncInspector<BlockchainErrorT, StateErrorT>>,
 ) -> Result<ResultAndState, TransactionError<BlockchainErrorT, StateErrorT>>
 where
-    BlockchainErrorT: Debug + Send + 'static,
-    StateErrorT: Debug + Send + 'static,
+    BlockchainErrorT: Debug + Send,
+    StateErrorT: Debug + Send,
 {
     if cfg.spec_id > SpecId::MERGE && block.prevrandao.is_none() {
         return Err(TransactionError::MissingPrevrandao);
@@ -68,8 +68,8 @@ pub fn guaranteed_dry_run<BlockchainErrorT, StateErrorT>(
     inspector: Option<&mut dyn SyncInspector<BlockchainErrorT, StateErrorT>>,
 ) -> Result<ResultAndState, TransactionError<BlockchainErrorT, StateErrorT>>
 where
-    BlockchainErrorT: Debug + Send + 'static,
-    StateErrorT: Debug + Send + 'static,
+    BlockchainErrorT: Debug + Send,
+    StateErrorT: Debug + Send,
 {
     cfg.disable_balance_check = true;
     dry_run(
@@ -94,8 +94,8 @@ pub fn run<BlockchainErrorT, StateErrorT>(
     inspector: Option<&mut dyn SyncInspector<BlockchainErrorT, StateErrorT>>,
 ) -> Result<ExecutionResult, TransactionError<BlockchainErrorT, StateErrorT>>
 where
-    BlockchainErrorT: Debug + Send + 'static,
-    StateErrorT: Debug + Send + 'static,
+    BlockchainErrorT: Debug + Send,
+    StateErrorT: Debug + Send,
 {
     let ResultAndState {
         result,

--- a/crates/edr_evm/src/transaction.rs
+++ b/crates/edr_evm/src/transaction.rs
@@ -33,8 +33,8 @@ pub enum TransactionError<BE, SE> {
 
 impl<BE, SE> From<EVMError<DatabaseComponentError<SE, BE>>> for TransactionError<BE, SE>
 where
-    BE: Debug + Send + 'static,
-    SE: Debug + Send + 'static,
+    BE: Debug + Send,
+    SE: Debug + Send,
 {
     fn from(error: EVMError<DatabaseComponentError<SE, BE>>) -> Self {
         match error {

--- a/crates/edr_napi/index.d.ts
+++ b/crates/edr_napi/index.d.ts
@@ -682,7 +682,7 @@ export class MineBlockResult {
 /** A JSON-RPC provider for Ethereum. */
 export class Provider {
   /**Constructs a new provider with the provided configuration. */
-  static withConfig(config: ProviderConfig): Promise<Provider>
+  static withConfig(config: ProviderConfig, consoleLogCallback: (message: Buffer) => void): Promise<Provider>
   /**Handles a JSON-RPC request and returns a JSON-RPC response. */
   handleRequest(jsonRequest: string): Promise<string>
 }

--- a/crates/edr_napi/src/miner.rs
+++ b/crates/edr_napi/src/miner.rs
@@ -56,8 +56,7 @@ pub async fn mine_block(
         let mut blockchain = blockchain.write();
         let mut state = state.write();
         let mut mem_pool = mem_pool.write();
-        
-        
+
         let result = edr_evm::mine_block(
             &*blockchain,
             state.clone(),

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -2,11 +2,15 @@ mod config;
 
 use std::sync::Arc;
 
-use edr_eth::remote::jsonrpc;
-use napi::{tokio::runtime, Env, JsObject, Status};
+use edr_eth::{remote::jsonrpc, Bytes};
+use edr_provider::InspectorCallbacks;
+use napi::{tokio::runtime, Env, JsFunction, JsObject, NapiRaw, Status};
 use napi_derive::napi;
 
 use self::config::ProviderConfig;
+use crate::threadsafe_function::{
+    ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
+};
 
 /// A JSON-RPC provider for Ethereum.
 #[napi]
@@ -18,13 +22,19 @@ pub struct Provider {
 impl Provider {
     #[doc = "Constructs a new provider with the provided configuration."]
     #[napi(ts_return_type = "Promise<Provider>")]
-    pub fn with_config(env: Env, config: ProviderConfig) -> napi::Result<JsObject> {
+    pub fn with_config(
+        env: Env,
+        config: ProviderConfig,
+        #[napi(ts_arg_type = "(message: Buffer) => void")] console_log_callback: JsFunction,
+    ) -> napi::Result<JsObject> {
         let config = edr_provider::ProviderConfig::try_from(config)?;
         let runtime = runtime::Handle::current();
 
+        let callbacks = Arc::new(InspectorCallback::new(&env, console_log_callback)?);
+
         let (deferred, promise) = env.create_deferred()?;
         runtime.clone().spawn(async move {
-            let result = edr_provider::Provider::new(&runtime, &config)
+            let result = edr_provider::Provider::new(&runtime, callbacks, &config)
                 .await
                 .map_or_else(
                     |error| Err(napi::Error::new(Status::GenericFailure, error.to_string())),
@@ -61,5 +71,41 @@ impl Provider {
 
         serde_json::to_string(&response)
             .map_err(|e| napi::Error::new(Status::GenericFailure, e.to_string()))
+    }
+}
+
+#[derive(Debug)]
+struct InspectorCallback {
+    console_log_callback: ThreadsafeFunction<Bytes>,
+}
+
+impl InspectorCallback {
+    fn new(env: &Env, console_log_callback_js: JsFunction) -> napi::Result<Self> {
+        let console_log_callback = ThreadsafeFunction::create(
+            env.raw(),
+            // SAFETY: The callback is guaranteed to be valid for the lifetime of the inspector.
+            unsafe { console_log_callback_js.raw() },
+            0,
+            |ctx: ThreadSafeCallContext<Bytes>| {
+                let call_input = ctx
+                    .env
+                    .create_buffer_with_data(ctx.value.to_vec())?
+                    .into_raw();
+                ctx.callback.call(None, &[call_input])?;
+                Ok(())
+            },
+        )?;
+
+        Ok(Self {
+            console_log_callback,
+        })
+    }
+}
+
+impl InspectorCallbacks for InspectorCallback {
+    fn console(&self, call_input: Bytes) {
+        // TODO do we want this async?
+        self.console_log_callback
+            .call(call_input, ThreadsafeFunctionCallMode::Blocking);
     }
 }

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -30,7 +30,7 @@ impl Provider {
         let config = edr_provider::ProviderConfig::try_from(config)?;
         let runtime = runtime::Handle::current();
 
-        let callbacks = Arc::new(InspectorCallback::new(&env, console_log_callback)?);
+        let callbacks = Box::new(InspectorCallback::new(&env, console_log_callback)?);
 
         let (deferred, promise) = env.create_deferred()?;
         runtime.clone().spawn(async move {

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -104,7 +104,8 @@ impl InspectorCallback {
 
 impl InspectorCallbacks for InspectorCallback {
     fn console(&self, call_input: Bytes) {
-        // TODO do we want this async?
+        // This is blocking because it's important that the console log messages are
+        // passed on in the order they're received.
         self.console_log_callback
             .call(call_input, ThreadsafeFunctionCallMode::Blocking);
     }

--- a/crates/edr_napi/src/threadsafe_function.rs
+++ b/crates/edr_napi/src/threadsafe_function.rs
@@ -91,6 +91,7 @@ impl From<ThreadsafeFunctionCallMode> for sys::napi_threadsafe_function_call_mod
 ///   ctx.env.get_undefined()
 /// }
 /// ```
+#[derive(Debug)]
 pub struct ThreadsafeFunction<T: 'static> {
     raw_tsfn: sys::napi_threadsafe_function,
     aborted: Arc<AtomicBool>,

--- a/crates/edr_provider/Cargo.toml
+++ b/crates/edr_provider/Cargo.toml
@@ -10,6 +10,7 @@ edr_evm = { version = "0.2.0-dev", path = "../edr_evm" }
 rpc_hardhat = { package = "edr_rpc_hardhat", version = "0.2.0-dev", path = "../edr_rpc_hardhat" }
 indexmap = { version = "2.0.0", default-features = false, features = ["std"] }
 k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "std"] }
+lazy_static = { version = "1.4.0", default-features = false }
 log = { version = "0.4.20", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 rand = { version = "0.8.5", default-features = false }

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -107,7 +107,7 @@ pub trait InspectorCallbacks {
 
 pub trait SendInspectorCallbacks: InspectorCallbacks + Debug + Send + Sync {}
 
-impl<I> SendInspectorCallbacks for I where I: InspectorCallbacks + Debug + Send + Sync {}
+impl<T> SendInspectorCallbacks for T where T: InspectorCallbacks + Debug + Send + Sync {}
 
 impl ProviderData {
     pub async fn new(
@@ -1426,7 +1426,10 @@ impl<DatabaseErrorT> Inspector<DatabaseErrorT> for EvmInspector {
 #[cfg(test)]
 mod tests {
     use anyhow::Context;
-    use edr_eth::transaction::{Eip155TransactionRequest, TransactionKind, TransactionRequest};
+    use edr_eth::transaction::{
+        Eip1559TransactionRequest, Eip155TransactionRequest, TransactionKind, TransactionRequest,
+    };
+    use edr_evm::hex;
     use parking_lot::Mutex;
     use tempfile::TempDir;
 
@@ -1469,8 +1472,78 @@ mod tests {
             })
         }
 
-        fn callbacks(&self) -> Vec<Bytes> {
-            self.callbacks.calls.lock().clone()
+        fn console_log_calls(&self) -> Vec<Bytes> {
+            self.callbacks.console_log_calls.lock().clone()
+        }
+
+        fn deploy_console_log_contract(&mut self) -> anyhow::Result<ConsoleLogTransaction> {
+            // Compiled with solc 0.8.17, without optimizations
+            /*
+            // SPDX-License-Identifier: MIT
+            pragma solidity ^0.8.0;
+
+            import "hardhat/console.sol";
+
+            contract Foo {
+              function f() public pure {
+                console.log("hello");
+              }
+            }
+            */
+            let byte_code = hex::decode("608060405234801561001057600080fd5b5061027a806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c806326121ff014610030575b600080fd5b61003861003a565b005b6100786040518060400160405280600581526020017f68656c6c6f00000000000000000000000000000000000000000000000000000081525061007a565b565b6101108160405160240161008e91906101f3565b6040516020818303038152906040527f41304fac000000000000000000000000000000000000000000000000000000007bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19166020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff8381831617835250505050610113565b50565b61012a8161012261012d61014e565b63ffffffff16565b50565b60006a636f6e736f6c652e6c6f679050600080835160208501845afa505050565b610159819050919050565b610161610215565b565b600081519050919050565b600082825260208201905092915050565b60005b8381101561019d578082015181840152602081019050610182565b60008484015250505050565b6000601f19601f8301169050919050565b60006101c582610163565b6101cf818561016e565b93506101df81856020860161017f565b6101e8816101a9565b840191505092915050565b6000602082019050818103600083015261020d81846101ba565b905092915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052605160045260246000fdfea26469706673582212201e965281cb15cf946ada70867e2acb07debad82404e574500944a7b3e0b799ac64736f6c63430008110033")?;
+
+            let deploy_tx = TransactionRequest::Eip1559(Eip1559TransactionRequest {
+                kind: TransactionKind::Create,
+                gas_limit: 10_000_000,
+                value: U256::ZERO,
+                input: byte_code.into(),
+                nonce: 0,
+                max_priority_fee_per_gas: U256::from(42_000_000_000_u64),
+                chain_id: 1,
+                max_fee_per_gas: U256::from(42_000_000_000_u64),
+                access_list: vec![],
+            });
+
+            let deploy_tx_hash =
+                self.provider_data
+                    .send_transaction(TransactionRequestAndSender {
+                        request: deploy_tx,
+                        sender: self.first_local_account(),
+                    })?;
+
+            let deploy_receipt = self
+                .provider_data
+                .transaction_receipt(&deploy_tx_hash)?
+                .context("deploy receipt should exist")?;
+            let contract_address = deploy_receipt
+                .contract_address
+                .context("contract address should exist")?;
+
+            // Call f()
+            let call_data = hex::decode("26121ff0")?;
+
+            // Expected call data for `console.log("hello")`
+            let expected_call_data = hex::decode("41304fac0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000")?.into();
+
+            let transaction_request = TransactionRequest::Eip1559(Eip1559TransactionRequest {
+                kind: TransactionKind::Call(contract_address),
+                gas_limit: 10_000_000,
+                value: U256::ZERO,
+                input: call_data.into(),
+                nonce: 1,
+                max_priority_fee_per_gas: U256::from(42_000_000_000_u64),
+                chain_id: 1,
+                max_fee_per_gas: U256::from(42_000_000_000_u64),
+                access_list: vec![],
+            });
+
+            Ok(ConsoleLogTransaction {
+                transaction: TransactionRequestAndSender {
+                    request: transaction_request,
+                    sender: self.first_local_account(),
+                },
+                expected_call_data,
+            })
         }
 
         fn dummy_transaction_request(&self, nonce: Option<u64>) -> TransactionRequestAndSender {
@@ -1484,19 +1557,19 @@ mod tests {
                 chain_id: 1,
             });
 
-            let sender = *self
+            TransactionRequestAndSender {
+                request,
+                sender: self.first_local_account(),
+            }
+        }
+
+        fn first_local_account(&self) -> Address {
+            *self
                 .provider_data
                 .local_accounts
                 .keys()
                 .next()
-                .expect("there are local accounts");
-
-            TransactionRequestAndSender { request, sender }
-        }
-
-        fn signed_dummy_transaction(&self) -> anyhow::Result<PendingTransaction> {
-            let transaction = self.dummy_transaction_request(None);
-            Ok(self.provider_data.sign_transaction_request(transaction)?)
+                .expect("there are local accounts")
         }
 
         fn impersonated_dummy_transaction(&self) -> anyhow::Result<PendingTransaction> {
@@ -1505,16 +1578,26 @@ mod tests {
 
             Ok(self.provider_data.sign_transaction_request(transaction)?)
         }
+
+        fn signed_dummy_transaction(&self) -> anyhow::Result<PendingTransaction> {
+            let transaction = self.dummy_transaction_request(None);
+            Ok(self.provider_data.sign_transaction_request(transaction)?)
+        }
+    }
+
+    struct ConsoleLogTransaction {
+        transaction: TransactionRequestAndSender,
+        expected_call_data: Bytes,
     }
 
     #[derive(Debug, Default)]
     struct InspectorCallbacksStub {
-        calls: Mutex<Vec<Bytes>>,
+        console_log_calls: Mutex<Vec<Bytes>>,
     }
 
     impl InspectorCallbacks for InspectorCallbacksStub {
         fn console(&self, call_input: Bytes) {
-            self.calls.lock().push(call_input);
+            self.console_log_calls.lock().push(call_input);
         }
     }
 
@@ -1654,18 +1737,51 @@ mod tests {
         Ok(())
     }
 
-    // TODO change this to deploy a contract with console.log
     #[tokio::test]
     async fn console_log_mine_block() -> anyhow::Result<()> {
         let mut fixture = ProviderTestFixture::new().await?;
+        let ConsoleLogTransaction {
+            transaction,
+            expected_call_data,
+        } = fixture.deploy_console_log_contract()?;
 
-        let transaction = fixture.signed_dummy_transaction()?;
-        let _transaction_hash = fixture.provider_data.add_pending_transaction(transaction)?;
-        let block = fixture.provider_data.mine_pending_block()?;
+        assert_eq!(fixture.console_log_calls().len(), 0);
 
-        assert_ne!(block.transaction_results.len(), 0);
-        assert_ne!(block.transaction_traces.len(), 0);
-        assert_eq!(fixture.callbacks().len(), 0);
+        fixture.provider_data.set_auto_mining(false);
+        fixture.provider_data.send_transaction(transaction)?;
+        let (block_timestamp, _) = fixture.provider_data.next_block_timestamp(None)?;
+        let prevrandao = fixture.provider_data.prev_randao_generator.next_value();
+        fixture
+            .provider_data
+            .mine_block(block_timestamp, Some(prevrandao))?;
+
+        let console_log_calls = fixture.console_log_calls();
+        assert_eq!(console_log_calls.len(), 1);
+        assert_eq!(console_log_calls[0], expected_call_data);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn console_log_run_call() -> anyhow::Result<()> {
+        let mut fixture = ProviderTestFixture::new().await?;
+        let ConsoleLogTransaction {
+            transaction,
+            expected_call_data,
+        } = fixture.deploy_console_log_contract()?;
+
+        assert_eq!(fixture.console_log_calls().len(), 0);
+
+        let pending_transaction = fixture
+            .provider_data
+            .sign_transaction_request(transaction)?;
+        fixture
+            .provider_data
+            .run_call(pending_transaction, None, &StateOverrides::default())?;
+
+        let console_log_calls = fixture.console_log_calls();
+        assert_eq!(console_log_calls.len(), 1);
+        assert_eq!(console_log_calls[0], expected_call_data);
 
         Ok(())
     }

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -97,7 +97,7 @@ pub struct ProviderData {
     last_filter_id: U256,
     logger: Logger,
     impersonated_accounts: HashSet<Address>,
-    callbacks: Arc<dyn SendInspectorCallbacks>,
+    callbacks: Arc<dyn SyncInspectorCallbacks>,
 }
 
 pub trait InspectorCallbacks {
@@ -105,14 +105,14 @@ pub trait InspectorCallbacks {
     fn console(&self, call_input: Bytes);
 }
 
-pub trait SendInspectorCallbacks: InspectorCallbacks + Debug + Send + Sync {}
+pub trait SyncInspectorCallbacks: InspectorCallbacks + Debug + Send + Sync {}
 
-impl<T> SendInspectorCallbacks for T where T: InspectorCallbacks + Debug + Send + Sync {}
+impl<T> SyncInspectorCallbacks for T where T: InspectorCallbacks + Debug + Send + Sync {}
 
 impl ProviderData {
     pub async fn new(
         runtime: &runtime::Handle,
-        callbacks: Arc<dyn SendInspectorCallbacks>,
+        callbacks: Arc<dyn SyncInspectorCallbacks>,
         config: &ProviderConfig,
     ) -> Result<Self, CreationError> {
         let InitialAccounts {
@@ -1396,11 +1396,11 @@ lazy_static! {
 
 #[derive(Debug)]
 struct EvmInspector {
-    callbacks: Arc<dyn SendInspectorCallbacks>,
+    callbacks: Arc<dyn SyncInspectorCallbacks>,
 }
 
 impl EvmInspector {
-    fn new(callbacks: Arc<dyn SendInspectorCallbacks>) -> Self {
+    fn new(callbacks: Arc<dyn SyncInspectorCallbacks>) -> Self {
         Self { callbacks }
     }
 }

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -1,4 +1,5 @@
 mod account;
+mod inspector;
 
 use std::{
     cmp::Ordering,
@@ -32,12 +33,14 @@ use edr_evm::{
         AccountModifierFn, IrregularState, StateDiff, StateError, StateOverride, StateOverrides,
         SyncState,
     },
-    Account, AccountInfo, BlobExcessGasAndPrice, Block, BlockEnv, Bytecode, CallInputs, CfgEnv,
-    EVMData, ExecutionResult, Gas, HashMap, HashSet, Inspector, InstructionResult, MemPool,
-    MineBlockResult, MineBlockResultAndState, MineOrdering, PendingTransaction,
-    RandomHashGenerator, StorageSlot, SyncBlock, TransactionCreationError, KECCAK_EMPTY,
+    Account, AccountInfo, BlobExcessGasAndPrice, Block, BlockEnv, Bytecode, CfgEnv,
+    ExecutionResult, HashMap, HashSet, MemPool, MineBlockResult, MineBlockResultAndState,
+    MineOrdering, PendingTransaction, RandomHashGenerator, StorageSlot, SyncBlock,
+    TransactionCreationError, KECCAK_EMPTY,
 };
 use indexmap::IndexMap;
+use inspector::EvmInspector;
+pub use inspector::{InspectorCallbacks, SyncInspectorCallbacks};
 use lazy_static::lazy_static;
 use rpc_hardhat::ForkMetadata;
 use tokio::runtime;
@@ -99,15 +102,6 @@ pub struct ProviderData {
     impersonated_accounts: HashSet<Address>,
     callbacks: Arc<dyn SyncInspectorCallbacks>,
 }
-
-pub trait InspectorCallbacks {
-    /// Calls to `console.*` from Solidity
-    fn console(&self, call_input: Bytes);
-}
-
-pub trait SyncInspectorCallbacks: InspectorCallbacks + Debug + Send + Sync {}
-
-impl<T> SyncInspectorCallbacks for T where T: InspectorCallbacks + Debug + Send + Sync {}
 
 impl ProviderData {
     pub async fn new(
@@ -1394,47 +1388,20 @@ lazy_static! {
         .expect("static ok");
 }
 
-#[derive(Debug)]
-struct EvmInspector {
-    callbacks: Arc<dyn SyncInspectorCallbacks>,
-}
-
-impl EvmInspector {
-    fn new(callbacks: Arc<dyn SyncInspectorCallbacks>) -> Self {
-        Self { callbacks }
-    }
-}
-
-impl<DatabaseErrorT> Inspector<DatabaseErrorT> for EvmInspector {
-    fn call(
-        &mut self,
-        _data: &mut dyn EVMData<DatabaseErrorT>,
-        inputs: &mut CallInputs,
-    ) -> (InstructionResult, Gas, Bytes) {
-        if inputs.contract == *CONSOLE_ADDRESS {
-            self.callbacks.console(inputs.input.clone());
-        }
-
-        (
-            InstructionResult::Continue,
-            Gas::new(inputs.gas_limit),
-            Bytes::new(),
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use anyhow::Context;
-    use edr_eth::transaction::{
-        Eip1559TransactionRequest, Eip155TransactionRequest, TransactionKind, TransactionRequest,
-    };
-    use edr_evm::hex;
-    use parking_lot::Mutex;
+    use edr_eth::transaction::{Eip155TransactionRequest, TransactionKind, TransactionRequest};
     use tempfile::TempDir;
 
     use super::*;
-    use crate::{test_utils::create_test_config_with_impersonated_accounts, ProviderConfig};
+    use crate::{
+        data::inspector::tests::{
+            deploy_console_log_contract, ConsoleLogTransaction, InspectorCallbacksStub,
+        },
+        test_utils::create_test_config_with_impersonated_accounts,
+        ProviderConfig,
+    };
 
     struct ProviderTestFixture {
         // We need to keep the tempdir alive for the duration of the test
@@ -1476,76 +1443,6 @@ mod tests {
             self.callbacks.console_log_calls.lock().clone()
         }
 
-        fn deploy_console_log_contract(&mut self) -> anyhow::Result<ConsoleLogTransaction> {
-            // Compiled with solc 0.8.17, without optimizations
-            /*
-            // SPDX-License-Identifier: MIT
-            pragma solidity ^0.8.0;
-
-            import "hardhat/console.sol";
-
-            contract Foo {
-              function f() public pure {
-                console.log("hello");
-              }
-            }
-            */
-            let byte_code = hex::decode("608060405234801561001057600080fd5b5061027a806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c806326121ff014610030575b600080fd5b61003861003a565b005b6100786040518060400160405280600581526020017f68656c6c6f00000000000000000000000000000000000000000000000000000081525061007a565b565b6101108160405160240161008e91906101f3565b6040516020818303038152906040527f41304fac000000000000000000000000000000000000000000000000000000007bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19166020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff8381831617835250505050610113565b50565b61012a8161012261012d61014e565b63ffffffff16565b50565b60006a636f6e736f6c652e6c6f679050600080835160208501845afa505050565b610159819050919050565b610161610215565b565b600081519050919050565b600082825260208201905092915050565b60005b8381101561019d578082015181840152602081019050610182565b60008484015250505050565b6000601f19601f8301169050919050565b60006101c582610163565b6101cf818561016e565b93506101df81856020860161017f565b6101e8816101a9565b840191505092915050565b6000602082019050818103600083015261020d81846101ba565b905092915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052605160045260246000fdfea26469706673582212201e965281cb15cf946ada70867e2acb07debad82404e574500944a7b3e0b799ac64736f6c63430008110033")?;
-
-            let deploy_tx = TransactionRequest::Eip1559(Eip1559TransactionRequest {
-                kind: TransactionKind::Create,
-                gas_limit: 10_000_000,
-                value: U256::ZERO,
-                input: byte_code.into(),
-                nonce: 0,
-                max_priority_fee_per_gas: U256::from(42_000_000_000_u64),
-                chain_id: 1,
-                max_fee_per_gas: U256::from(42_000_000_000_u64),
-                access_list: vec![],
-            });
-
-            let deploy_tx_hash =
-                self.provider_data
-                    .send_transaction(TransactionRequestAndSender {
-                        request: deploy_tx,
-                        sender: self.first_local_account(),
-                    })?;
-
-            let deploy_receipt = self
-                .provider_data
-                .transaction_receipt(&deploy_tx_hash)?
-                .context("deploy receipt should exist")?;
-            let contract_address = deploy_receipt
-                .contract_address
-                .context("contract address should exist")?;
-
-            // Call f()
-            let call_data = hex::decode("26121ff0")?;
-
-            // Expected call data for `console.log("hello")`
-            let expected_call_data = hex::decode("41304fac0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000")?.into();
-
-            let transaction_request = TransactionRequest::Eip1559(Eip1559TransactionRequest {
-                kind: TransactionKind::Call(contract_address),
-                gas_limit: 10_000_000,
-                value: U256::ZERO,
-                input: call_data.into(),
-                nonce: 1,
-                max_priority_fee_per_gas: U256::from(42_000_000_000_u64),
-                chain_id: 1,
-                max_fee_per_gas: U256::from(42_000_000_000_u64),
-                access_list: vec![],
-            });
-
-            Ok(ConsoleLogTransaction {
-                transaction: TransactionRequestAndSender {
-                    request: transaction_request,
-                    sender: self.first_local_account(),
-                },
-                expected_call_data,
-            })
-        }
-
         fn dummy_transaction_request(&self, nonce: Option<u64>) -> TransactionRequestAndSender {
             let request = TransactionRequest::Eip155(Eip155TransactionRequest {
                 kind: TransactionKind::Call(Address::zero()),
@@ -1582,22 +1479,6 @@ mod tests {
         fn signed_dummy_transaction(&self) -> anyhow::Result<PendingTransaction> {
             let transaction = self.dummy_transaction_request(None);
             Ok(self.provider_data.sign_transaction_request(transaction)?)
-        }
-    }
-
-    struct ConsoleLogTransaction {
-        transaction: TransactionRequestAndSender,
-        expected_call_data: Bytes,
-    }
-
-    #[derive(Debug, Default)]
-    struct InspectorCallbacksStub {
-        console_log_calls: Mutex<Vec<Bytes>>,
-    }
-
-    impl InspectorCallbacks for InspectorCallbacksStub {
-        fn console(&self, call_input: Bytes) {
-            self.console_log_calls.lock().push(call_input);
         }
     }
 
@@ -1743,7 +1624,7 @@ mod tests {
         let ConsoleLogTransaction {
             transaction,
             expected_call_data,
-        } = fixture.deploy_console_log_contract()?;
+        } = deploy_console_log_contract(&mut fixture.provider_data)?;
 
         assert_eq!(fixture.console_log_calls().len(), 0);
 
@@ -1768,7 +1649,7 @@ mod tests {
         let ConsoleLogTransaction {
             transaction,
             expected_call_data,
-        } = fixture.deploy_console_log_contract()?;
+        } = deploy_console_log_contract(&mut fixture.provider_data)?;
 
         assert_eq!(fixture.console_log_calls().len(), 0);
 

--- a/crates/edr_provider/src/data/inspector.rs
+++ b/crates/edr_provider/src/data/inspector.rs
@@ -1,0 +1,150 @@
+use std::{fmt::Debug, sync::Arc};
+
+use edr_eth::Bytes;
+use edr_evm::{CallInputs, EVMData, Gas, Inspector, InstructionResult};
+
+use crate::data::CONSOLE_ADDRESS;
+
+pub trait InspectorCallbacks {
+    /// Calls to `console.*` from Solidity
+    fn console(&self, call_input: Bytes);
+}
+
+pub trait SyncInspectorCallbacks: InspectorCallbacks + Debug + Send + Sync {}
+
+impl<T> SyncInspectorCallbacks for T where T: InspectorCallbacks + Debug + Send + Sync {}
+
+#[derive(Debug)]
+pub(super) struct EvmInspector {
+    callbacks: Arc<dyn SyncInspectorCallbacks>,
+}
+
+impl EvmInspector {
+    pub fn new(callbacks: Arc<dyn SyncInspectorCallbacks>) -> Self {
+        Self { callbacks }
+    }
+}
+
+impl<DatabaseErrorT> Inspector<DatabaseErrorT> for EvmInspector {
+    fn call(
+        &mut self,
+        _data: &mut dyn EVMData<DatabaseErrorT>,
+        inputs: &mut CallInputs,
+    ) -> (InstructionResult, Gas, Bytes) {
+        if inputs.contract == *CONSOLE_ADDRESS {
+            self.callbacks.console(inputs.input.clone());
+        }
+
+        (
+            InstructionResult::Continue,
+            Gas::new(inputs.gas_limit),
+            Bytes::new(),
+        )
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use anyhow::Context;
+    use edr_eth::{
+        transaction::{
+            Eip1559TransactionRequest, TransactionKind, TransactionRequest,
+            TransactionRequestAndSender,
+        },
+        Bytes, U256,
+    };
+    use edr_evm::hex;
+    use parking_lot::Mutex;
+
+    use crate::data::{InspectorCallbacks, ProviderData};
+
+    #[derive(Debug, Default)]
+    pub struct InspectorCallbacksStub {
+        pub console_log_calls: Mutex<Vec<Bytes>>,
+    }
+
+    impl InspectorCallbacks for InspectorCallbacksStub {
+        fn console(&self, call_input: Bytes) {
+            self.console_log_calls.lock().push(call_input);
+        }
+    }
+
+    pub struct ConsoleLogTransaction {
+        pub transaction: TransactionRequestAndSender,
+        pub expected_call_data: Bytes,
+    }
+
+    pub fn deploy_console_log_contract(
+        provider_data: &mut ProviderData,
+    ) -> anyhow::Result<ConsoleLogTransaction> {
+        // Compiled with solc 0.8.17, without optimizations
+        /*
+        // SPDX-License-Identifier: MIT
+        pragma solidity ^0.8.0;
+
+        import "hardhat/console.sol";
+
+        contract Foo {
+          function f() public pure {
+            console.log("hello");
+          }
+        }
+        */
+        let byte_code = hex::decode("608060405234801561001057600080fd5b5061027a806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c806326121ff014610030575b600080fd5b61003861003a565b005b6100786040518060400160405280600581526020017f68656c6c6f00000000000000000000000000000000000000000000000000000081525061007a565b565b6101108160405160240161008e91906101f3565b6040516020818303038152906040527f41304fac000000000000000000000000000000000000000000000000000000007bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19166020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff8381831617835250505050610113565b50565b61012a8161012261012d61014e565b63ffffffff16565b50565b60006a636f6e736f6c652e6c6f679050600080835160208501845afa505050565b610159819050919050565b610161610215565b565b600081519050919050565b600082825260208201905092915050565b60005b8381101561019d578082015181840152602081019050610182565b60008484015250505050565b6000601f19601f8301169050919050565b60006101c582610163565b6101cf818561016e565b93506101df81856020860161017f565b6101e8816101a9565b840191505092915050565b6000602082019050818103600083015261020d81846101ba565b905092915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052605160045260246000fdfea26469706673582212201e965281cb15cf946ada70867e2acb07debad82404e574500944a7b3e0b799ac64736f6c63430008110033")?;
+
+        let deploy_tx = TransactionRequest::Eip1559(Eip1559TransactionRequest {
+            kind: TransactionKind::Create,
+            gas_limit: 10_000_000,
+            value: U256::ZERO,
+            input: byte_code.into(),
+            nonce: 0,
+            max_priority_fee_per_gas: U256::from(42_000_000_000_u64),
+            chain_id: 1,
+            max_fee_per_gas: U256::from(42_000_000_000_u64),
+            access_list: vec![],
+        });
+
+        let sender = *provider_data
+            .accounts()
+            .next()
+            .context("should have accounts")?;
+
+        let deploy_tx_hash = provider_data.send_transaction(TransactionRequestAndSender {
+            request: deploy_tx,
+            sender,
+        })?;
+
+        let deploy_receipt = provider_data
+            .transaction_receipt(&deploy_tx_hash)?
+            .context("deploy receipt should exist")?;
+        let contract_address = deploy_receipt
+            .contract_address
+            .context("contract address should exist")?;
+
+        // Call f()
+        let call_data = hex::decode("26121ff0")?;
+
+        // Expected call data for `console.log("hello")`
+        let expected_call_data = hex::decode("41304fac0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000")?.into();
+
+        let transaction_request = TransactionRequest::Eip1559(Eip1559TransactionRequest {
+            kind: TransactionKind::Call(contract_address),
+            gas_limit: 10_000_000,
+            value: U256::ZERO,
+            input: call_data.into(),
+            nonce: 1,
+            max_priority_fee_per_gas: U256::from(42_000_000_000_u64),
+            chain_id: 1,
+            max_fee_per_gas: U256::from(42_000_000_000_u64),
+            access_list: vec![],
+        });
+
+        Ok(ConsoleLogTransaction {
+            transaction: TransactionRequestAndSender {
+                request: transaction_request,
+                sender,
+            },
+            expected_call_data,
+        })
+    }
+}

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -23,7 +23,7 @@ use self::{
     interval::IntervalMiner,
     requests::{eth, hardhat, EthRequest, Request},
 };
-use crate::data::SendInspectorCallbacks;
+use crate::data::SyncInspectorCallbacks;
 
 /// A JSON-RPC provider for Ethereum.
 ///
@@ -65,7 +65,7 @@ impl Provider {
     /// Constructs a new instance.
     pub async fn new(
         runtime: &runtime::Handle,
-        callbacks: Arc<dyn SendInspectorCallbacks>,
+        callbacks: Arc<dyn SyncInspectorCallbacks>,
         config: &ProviderConfig,
     ) -> Result<Self, CreationError> {
         let data = ProviderData::new(runtime, callbacks, config).await?;

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -15,12 +15,15 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use tokio::runtime;
 
-pub use self::{config::*, error::ProviderError, requests::ProviderRequest};
+pub use self::{
+    config::*, data::InspectorCallbacks, error::ProviderError, requests::ProviderRequest,
+};
 use self::{
     data::{CreationError, ProviderData},
     interval::IntervalMiner,
     requests::{eth, hardhat, EthRequest, Request},
 };
+use crate::data::SendInspectorCallbacks;
 
 /// A JSON-RPC provider for Ethereum.
 ///
@@ -62,9 +65,10 @@ impl Provider {
     /// Constructs a new instance.
     pub async fn new(
         runtime: &runtime::Handle,
+        callbacks: Arc<dyn SendInspectorCallbacks>,
         config: &ProviderConfig,
     ) -> Result<Self, CreationError> {
-        let data = ProviderData::new(runtime, config).await?;
+        let data = ProviderData::new(runtime, callbacks, config).await?;
         let data = Arc::new(Mutex::new(data));
 
         let interval_miner = config

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -65,7 +65,7 @@ impl Provider {
     /// Constructs a new instance.
     pub async fn new(
         runtime: &runtime::Handle,
-        callbacks: Arc<dyn SyncInspectorCallbacks>,
+        callbacks: Box<dyn SyncInspectorCallbacks>,
         config: &ProviderConfig,
     ) -> Result<Self, CreationError> {
         let data = ProviderData::new(runtime, callbacks, config).await?;

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -28,6 +28,7 @@ import {
 import { isErrorResponse } from "../../core/providers/http";
 import { getHardforkName } from "../../util/hardforks";
 import { Mutex } from "../../vendor/await-semaphore";
+import { ConsoleLogger } from "../stack-traces/consoleLogger";
 import { FIRST_SOLC_VERSION_SUPPORTED } from "../stack-traces/constants";
 
 import { MiningTimer } from "./MiningTimer";
@@ -454,7 +455,11 @@ class EdrProviderWrapper extends EventEmitter implements EIP1193Provider {
           },
         },
       },
-      (message: Buffer) => console.log("console.log callback", message)
+      (message: Buffer) => {
+        const consoleLogger = new ConsoleLogger();
+
+        consoleLogger.log(message);
+      }
     );
 
     return new EdrProviderWrapper(provider);

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -421,38 +421,41 @@ class EdrProviderWrapper extends EventEmitter implements EIP1193Provider {
       };
     }
 
-    const provider = await Provider.withConfig({
-      bailOnCallFailure: config.throwOnCallFailures,
-      bailOnTransactionFailure: config.throwOnTransactionFailures,
-      chainId: BigInt(config.chainId),
-      cacheDir: config.forkCachePath,
-      coinbase: Buffer.from(coinbase.slice(2), "hex"),
-      fork,
-      hardfork: ethereumsjsHardforkToEdrSpecId(
-        getHardforkName(config.hardfork)
-      ),
-      networkId: BigInt(config.chainId),
-      blockGasLimit: BigInt(config.blockGasLimit),
-      genesisAccounts: config.genesisAccounts.map((account) => {
-        return {
-          secretKey: account.privateKey,
-          balance: BigInt(account.balance),
-        };
-      }),
-      allowUnlimitedContractSize: config.allowUnlimitedContractSize,
-      allowBlocksWithSameTimestamp:
-        config.allowBlocksWithSameTimestamp ?? false,
-      initialBaseFeePerGas: BigInt(
-        config.initialBaseFeePerGas ?? 1_000_000_000
-      ),
-      mining: {
-        autoMine: config.automine,
-        interval: ethereumjsIntervalMiningConfigToEdr(config.intervalMining),
-        memPool: {
-          order: ethereumjsMempoolOrderToEdrMineOrdering(config.mempoolOrder),
+    const provider = await Provider.withConfig(
+      {
+        bailOnCallFailure: config.throwOnCallFailures,
+        bailOnTransactionFailure: config.throwOnTransactionFailures,
+        chainId: BigInt(config.chainId),
+        cacheDir: config.forkCachePath,
+        coinbase: Buffer.from(coinbase.slice(2), "hex"),
+        fork,
+        hardfork: ethereumsjsHardforkToEdrSpecId(
+          getHardforkName(config.hardfork)
+        ),
+        networkId: BigInt(config.chainId),
+        blockGasLimit: BigInt(config.blockGasLimit),
+        genesisAccounts: config.genesisAccounts.map((account) => {
+          return {
+            secretKey: account.privateKey,
+            balance: BigInt(account.balance),
+          };
+        }),
+        allowUnlimitedContractSize: config.allowUnlimitedContractSize,
+        allowBlocksWithSameTimestamp:
+          config.allowBlocksWithSameTimestamp ?? false,
+        initialBaseFeePerGas: BigInt(
+          config.initialBaseFeePerGas ?? 1_000_000_000
+        ),
+        mining: {
+          autoMine: config.automine,
+          interval: ethereumjsIntervalMiningConfigToEdr(config.intervalMining),
+          memPool: {
+            order: ethereumjsMempoolOrderToEdrMineOrdering(config.mempoolOrder),
+          },
         },
       },
-    });
+      (message: Buffer) => console.log("console.log callback", message)
+    );
 
     return new EdrProviderWrapper(provider);
   }

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/consoleLogger.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/consoleLogger.ts
@@ -125,6 +125,38 @@ export class ConsoleLogger {
     }
   }
 
+  /**
+   * Temporary code to print console.sol messages that come from EDR
+   */
+  public log(message: Buffer): void {
+    const sig = bufferToInt(message.slice(0, 4));
+    const parameters = message.slice(4);
+
+    const types = this._consoleLogs[sig];
+    if (types === undefined) {
+      return;
+    }
+
+    const consoleLogs = [this._decode(parameters, types)];
+
+    this._replaceNumberFormatSpecifiers(consoleLogs);
+
+    for (const log of consoleLogs) {
+      if (log === undefined) {
+        console.log("");
+        return;
+      }
+
+      // special case for console.log()
+      if (log.length === 0) {
+        console.log("");
+        return;
+      }
+
+      console.log(util.format(log[0], ...log.slice(1)));
+    }
+  }
+
   private _maybeConsoleLog(call: CallMessageTrace): ConsoleLogs | undefined {
     const sig = bufferToInt(call.calldata.slice(0, 4));
     const parameters = call.calldata.slice(4);


### PR DESCRIPTION
- Supports collecting `console.log` calls from Solidity in the EDR provider when mining a block or running a call.
- The call data is passed as a buffer to a JS callback. Decoding, formatting and logging is handled on the JS side.
- There are automated tests on the Rust side to make sure that the `console.log` calls are recorded.
- We tested the JS side manually.