### PR TITLE
fix: bench compilation without `test-remote` feature

### DIFF
--- a/crates/edr_evm/benches/state/util.rs
+++ b/crates/edr_evm/benches/state/util.rs
@@ -3,7 +3,9 @@ use std::clone::Clone;
 use std::sync::Arc;
 
 use criterion::{BatchSize, BenchmarkId, Criterion};
-use edr_eth::{remote::PreEip1898BlockSpec, Address, Bytes, U256};
+#[cfg(all(test, feature = "test-remote"))]
+use edr_eth::remote::PreEip1898BlockSpec;
+use edr_eth::{Address, Bytes, U256};
 #[cfg(all(test, feature = "test-remote"))]
 use edr_evm::state::ForkState;
 use edr_evm::state::{StateError, SyncState, TrieState};


### PR DESCRIPTION
Without this change, the pre-commit hook is failing when the Alchemy/Infura url environment variables are not set.

If we want to catch issues like this in the CI, we would have to add an extra step for it, as the Cargo hack step in the CI is not ran for test code and if I enable it, there are lots of other failures due to tests assuming the default features. Note that issues like this won’t affect external users.





