### PR TITLE
fix typo of ignition

### DIFF
--- a/docs/src/content/ignition/docs/guides/deploy.md
+++ b/docs/src/content/ignition/docs/guides/deploy.md
@@ -3,7 +3,7 @@
 To execute your deployments, you need to use the `ignition deploy` task. It takes a path to a module file as an argument:
 
 ```sh
-npx hardhat igntion deploy ignition/modules/MyModule.js
+npx hardhat ignition deploy ignition/modules/MyModule.js
 ```
 
 Hardhat Ignition will load the Ignition Module exported by the file you provided, and deploy it.


### PR DESCRIPTION
there is a small typo (igntion) in this command "npx hardhat igntion deploy ignition/modules/MyModule.js"

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
