### PR TITLE
hardhat-verify: add apiUrl and browserUrl in sourcify options

### DIFF
--- a/.changeset/bright-plums-watch.md
+++ b/.changeset/bright-plums-watch.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Add apiUrl and browserUrl to Sourcify configuration.

--- a/packages/hardhat-verify/README.md
+++ b/packages/hardhat-verify/README.md
@@ -186,6 +186,10 @@ To verify a contract using Sourcify, you need to add to your Hardhat config:
 ```js
 sourcify: {
   enabled: true,
+  // Optional: specify a different Sourcify server
+  apiUrl: "https://sourcify.dev/server",
+  // Optional: specify a different Sourcify repository
+  browserUrl: "https://repo.sourcify.dev",
 }
 ```
 

--- a/packages/hardhat-verify/README.md
+++ b/packages/hardhat-verify/README.md
@@ -285,7 +285,11 @@ Both Etherscan and Sourcify classes can be imported from the plugin for direct u
   ```js
   import { Sourcify } from "@nomicfoundation/hardhat-verify/sourcify";
 
-  const instance = new Sourcify(1); // Set chainId
+  const instance = new Sourcify(
+    1,
+    "https://sourcify.dev/server",
+    "https://repo.sourcify.dev"
+  ); // Set chainId
 
   if (!instance.isVerified("0x123abc...")) {
     const sourcifyResponse = await instance.verify("0x123abc...", {

--- a/packages/hardhat-verify/src/internal/config.ts
+++ b/packages/hardhat-verify/src/internal/config.ts
@@ -37,6 +37,8 @@ export function sourcifyConfigExtender(
 ): void {
   const defaultSourcifyConfig: SourcifyConfig = {
     enabled: false,
+    apiUrl: "https://sourcify.dev/server",
+    browserUrl: "https://repo.sourcify.dev",
   };
   const cloneDeep = require("lodash.clonedeep") as typeof LodashCloneDeepT;
   const userSourcifyConfig = cloneDeep(userConfig.sourcify);

--- a/packages/hardhat-verify/src/internal/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/sourcify.ts
@@ -14,10 +14,10 @@ import { ValidationResponse } from "./utilities";
 export class Sourcify {
   public apiUrl: string = "https://sourcify.dev/server";
   public browserUrl: string = "https://repo.sourcify.dev";
-  private _chainId: number;
+  public chainId: number;
 
   constructor(chainId: number, apiUrl?: string, browserUrl?: string) {
-    this._chainId = chainId;
+    this.chainId = chainId;
     if (apiUrl !== undefined) {
       this.apiUrl = apiUrl;
     }
@@ -30,7 +30,7 @@ export class Sourcify {
   public async isVerified(address: string) {
     const parameters = new URLSearchParams({
       addresses: address,
-      chainIds: `${this._chainId}`,
+      chainIds: `${this.chainId}`,
     });
 
     const url = new URL(`${this.apiUrl}/check-all-by-addresses`);
@@ -94,7 +94,7 @@ export class Sourcify {
     const parameters: any = {
       address,
       files,
-      chain: `${this._chainId}`,
+      chain: `${this.chainId}`,
     };
 
     if (chosenContract !== undefined) {
@@ -139,7 +139,7 @@ export class Sourcify {
       contractStatus === ContractStatus.PERFECT
         ? "full_match"
         : "partial_match";
-    return `${this.browserUrl}/contracts/${matchType}/${this._chainId}/${address}/`;
+    return `${this.browserUrl}/contracts/${matchType}/${this.chainId}/${address}/`;
   }
 }
 

--- a/packages/hardhat-verify/src/internal/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/sourcify.ts
@@ -12,19 +12,11 @@ import { ContractStatus } from "./sourcify.types";
 import { ValidationResponse } from "./utilities";
 
 export class Sourcify {
-  public apiUrl: string = "https://sourcify.dev/server";
-  public browserUrl: string = "https://repo.sourcify.dev";
-  public chainId: number;
-
-  constructor(chainId: number, apiUrl?: string, browserUrl?: string) {
-    this.chainId = chainId;
-    if (apiUrl !== undefined) {
-      this.apiUrl = apiUrl;
-    }
-    if (browserUrl !== undefined) {
-      this.browserUrl = browserUrl;
-    }
-  }
+  constructor(
+    public chainId: number,
+    public apiUrl: string,
+    public browserUrl: string
+  ) {}
 
   // https://sourcify.dev/server/api-docs/#/Repository/get_check_all_by_addresses
   public async isVerified(address: string) {

--- a/packages/hardhat-verify/src/internal/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/sourcify.ts
@@ -14,8 +14,17 @@ import { ValidationResponse } from "./utilities";
 export class Sourcify {
   public apiUrl: string = "https://sourcify.dev/server";
   public browserUrl: string = "https://repo.sourcify.dev";
+  private chainId: number;
 
-  constructor(public chainId: number) {}
+  constructor(chainId: number, apiUrl?: string, browserUrl?: string) {
+    this.chainId = chainId;
+    if (apiUrl) {
+      this.apiUrl = apiUrl;
+    }
+    if (browserUrl) {
+      this.browserUrl = browserUrl;
+    }
+  }
 
   // https://sourcify.dev/server/api-docs/#/Repository/get_check_all_by_addresses
   public async isVerified(address: string) {

--- a/packages/hardhat-verify/src/internal/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/sourcify.ts
@@ -14,14 +14,14 @@ import { ValidationResponse } from "./utilities";
 export class Sourcify {
   public apiUrl: string = "https://sourcify.dev/server";
   public browserUrl: string = "https://repo.sourcify.dev";
-  private chainId: number;
+  private _chainId: number;
 
   constructor(chainId: number, apiUrl?: string, browserUrl?: string) {
-    this.chainId = chainId;
-    if (apiUrl) {
+    this._chainId = chainId;
+    if (apiUrl !== undefined) {
       this.apiUrl = apiUrl;
     }
-    if (browserUrl) {
+    if (browserUrl !== undefined) {
       this.browserUrl = browserUrl;
     }
   }
@@ -30,7 +30,7 @@ export class Sourcify {
   public async isVerified(address: string) {
     const parameters = new URLSearchParams({
       addresses: address,
-      chainIds: `${this.chainId}`,
+      chainIds: `${this._chainId}`,
     });
 
     const url = new URL(`${this.apiUrl}/check-all-by-addresses`);
@@ -94,7 +94,7 @@ export class Sourcify {
     const parameters: any = {
       address,
       files,
-      chain: `${this.chainId}`,
+      chain: `${this._chainId}`,
     };
 
     if (chosenContract !== undefined) {
@@ -139,7 +139,7 @@ export class Sourcify {
       contractStatus === ContractStatus.PERFECT
         ? "full_match"
         : "partial_match";
-    return `${this.browserUrl}/contracts/${matchType}/${this.chainId}/${address}/`;
+    return `${this.browserUrl}/contracts/${matchType}/${this._chainId}/${address}/`;
   }
 }
 

--- a/packages/hardhat-verify/src/internal/tasks/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/tasks/sourcify.ts
@@ -67,7 +67,11 @@ subtask(TASK_VERIFY_SOURCIFY)
       16
     );
 
-    const sourcify = new Sourcify(currentChainId);
+    const sourcify = new Sourcify(
+      currentChainId,
+      config.sourcify.apiUrl,
+      config.sourcify.browserUrl
+    );
 
     const status = await sourcify.isVerified(address);
     if (status !== false) {

--- a/packages/hardhat-verify/src/internal/tasks/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/tasks/sourcify.ts
@@ -69,8 +69,8 @@ subtask(TASK_VERIFY_SOURCIFY)
 
     const sourcify = new Sourcify(
       currentChainId,
-      config.sourcify.apiUrl,
-      config.sourcify.browserUrl
+      config.sourcify.apiUrl!,
+      config.sourcify.browserUrl!
     );
 
     const status = await sourcify.isVerified(address);

--- a/packages/hardhat-verify/src/types.ts
+++ b/packages/hardhat-verify/src/types.ts
@@ -15,6 +15,8 @@ export interface EtherscanConfig {
 
 export interface SourcifyConfig {
   enabled: boolean;
+  apiUrl?: string;
+  browserUrl?: string;
 }
 
 export type ApiKey = string | Record<string, string>;

--- a/packages/hardhat-verify/test/unit/config.ts
+++ b/packages/hardhat-verify/test/unit/config.ts
@@ -168,6 +168,8 @@ describe("Extend config", () => {
       const userConfig: HardhatUserConfig = {};
       const expected: SourcifyConfig = {
         enabled: false,
+        apiUrl: "https://sourcify.dev/server",
+        browserUrl: "https://repo.sourcify.dev",
       };
       sourcifyConfigExtender(hardhatConfig, userConfig);
 

--- a/packages/hardhat-verify/test/unit/sourcify.ts
+++ b/packages/hardhat-verify/test/unit/sourcify.ts
@@ -9,7 +9,11 @@ describe("Sourcify", () => {
     it("should return the contract url", () => {
       const expectedContractAddress =
         "https://repo.sourcify.dev/contracts/full_match/100/0xC4c622862a8F548997699bE24EA4bc504e5cA865/";
-      const sourcify = new Sourcify(chainId);
+      const sourcify = new Sourcify(
+        chainId,
+        "https://sourcify.dev/server",
+        "https://repo.sourcify.dev"
+      );
       const contractUrl = sourcify.getContractUrl(
         "0xC4c622862a8F548997699bE24EA4bc504e5cA865",
         ContractStatus.PERFECT


### PR DESCRIPTION
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.

---

Allow to pass `apiUrl` and `browserUrl` to override the default sourcify server and repo urls
