### PR TITLE
ci: enable web3 module tests

### DIFF
--- a/packages/hardhat-core/.prettierignore
+++ b/packages/hardhat-core/.prettierignore
@@ -11,6 +11,7 @@
 /*.js.map
 /test/fixture-projects/**/artifacts
 /test/fixture-projects/**/cache
+edr-cache
 /test/internal/hardhat-network/provider/.hardhat_node_test_cache
 /test/internal/hardhat-network/stack-traces/compilers
 /test/internal/hardhat-network/stack-traces/test-files/**/artifacts

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -31,6 +31,7 @@ import { Mutex } from "../../vendor/await-semaphore";
 import { ConsoleLogger } from "../stack-traces/consoleLogger";
 import { FIRST_SOLC_VERSION_SUPPORTED } from "../stack-traces/constants";
 
+import { getPackageJson } from "../../util/packageInfo";
 import { MiningTimer } from "./MiningTimer";
 import { DebugModule } from "./modules/debug";
 import { EthModule } from "./modules/eth";
@@ -509,8 +510,20 @@ export class EdrProviderWrapper
       throw error;
     }
 
+    // Override EDR version string with Hardhat version string with EDR backend,
+    // e.g. `HardhatNetwork/2.19.0/@nomicfoundation/edr/0.2.0-dev`
+    if (args.method === "web3_clientVersion") {
+      return clientVersion(response.result);
+    }
+
     return response.result;
   }
+}
+
+async function clientVersion(edrClientVersion: string): Promise<string> {
+  const hardhatPackage = await getPackageJson();
+  const edrVersion = edrClientVersion.split("/")[1];
+  return `HardhatNetwork/${hardhatPackage.version}/@nomicfoundation/edr/${edrVersion}`;
 }
 
 export async function createHardhatNetworkProvider(

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/isEdrProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/isEdrProvider.ts
@@ -1,0 +1,9 @@
+/* eslint-disable dot-notation,@typescript-eslint/dot-notation */
+import { EdrProviderWrapper } from "../../../../src/internal/hardhat-network/provider/provider";
+
+export function isEdrProvider(provider: any): boolean {
+  return (
+    provider instanceof EdrProviderWrapper ||
+    provider["_provider"] instanceof EdrProviderWrapper
+  );
+}

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/retrieveCommon.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/retrieveCommon.ts
@@ -1,9 +1,9 @@
 /* eslint-disable dot-notation,@typescript-eslint/dot-notation */
 import { Common } from "@nomicfoundation/ethereumjs-common";
-import { EdrProviderWrapper } from "../../../../src/internal/hardhat-network/provider/provider";
+import { isEdrProvider } from "./isEdrProvider";
 
 export async function retrieveCommon(provider: any): Promise<Common> {
-  if (provider instanceof EdrProviderWrapper) {
+  if (isEdrProvider(provider)) {
     return provider["_common"];
   }
 

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -28,6 +28,7 @@ import {
 } from "./providers";
 import { sleep } from "./sleep";
 import { spawnEdrProvider } from "./spawnEdrProvider";
+import { isEdrProvider } from "./isEdrProvider";
 
 declare module "mocha" {
   interface Context {
@@ -105,9 +106,11 @@ export function useProvider({
       },
       this.logger
     );
-    this.provider = new BackwardsCompatibilityProviderAdapter(
+
+    const provider = new BackwardsCompatibilityProviderAdapter(
       this.hardhatNetworkProvider
     );
+    this.provider = provider;
 
     if (useJsonRpc) {
       this.server = new JsonRpcServer({
@@ -137,6 +140,10 @@ export function useProvider({
 
       await isReady;
     }
+
+    this.isEdr = () => {
+      return this.edrProcess !== undefined || isEdrProvider(provider);
+    };
   });
 
   afterEach("Remove provider", async function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/web3.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/web3.ts
@@ -22,13 +22,14 @@ describe("Web3 module", function () {
       describe("web3_clientVersion", async function () {
         it("Should return the right value", async function () {
           const res = await this.provider.send("web3_clientVersion");
-          const expectedHardhatVersion =
+          const expectedEthereumJSVersion =
             /^HardhatNetwork\/.*\/@nomicfoundation\/ethereumjs-vm/;
-          const expectedEDRVersion = /^edr\/.*\/revm\/.*$/;
+          const expectedEDRVersion =
+            /^HardhatNetwork\/.*\/@nomicfoundation\/edr/;
           const expected =
-            this.edrProcess === undefined
-              ? expectedHardhatVersion
-              : expectedEDRVersion;
+            this.isEdr() === true
+              ? expectedEDRVersion
+              : expectedEthereumJSVersion;
           assert.match(res, expected);
         });
       });


### PR DESCRIPTION
Enable Web3 module tests. After discussion with @fvictorio we settled on returning version strings of this format for the EDR provider: `HardhatNetwork/2.19.0/@nomicfoundation/edr/0.2.0-dev`