### PR TITLE
refactor: add client request type

### DIFF
--- a/crates/edr_eth/src/remote.rs
+++ b/crates/edr_eth/src/remote.rs
@@ -10,6 +10,7 @@ pub mod jsonrpc;
 /// RPC methods
 pub mod methods;
 mod r#override;
+mod request_methods;
 
 use std::{
     fmt,

--- a/crates/edr_eth/src/remote/cacheable_method_invocation.rs
+++ b/crates/edr_eth/src/remote/cacheable_method_invocation.rs
@@ -4,27 +4,27 @@ use sha3::{digest::FixedOutput, Digest, Sha3_256};
 use crate::{
     block::{is_safe_block_number, IsSafeBlockNumberArgs},
     remote::{
-        methods::{GetLogsInput, MethodInvocation},
-        BlockSpec, BlockTag, Eip1898BlockSpec, PreEip1898BlockSpec,
+        eth::GetLogsInput, request_methods::RequestMethod, BlockSpec, BlockTag, Eip1898BlockSpec,
+        PreEip1898BlockSpec,
     },
     U256,
 };
 
-pub(super) fn try_read_cache_key(method_invocation: &MethodInvocation) -> Option<ReadCacheKey> {
-    CacheableMethodInvocation::try_from(method_invocation)
+pub(super) fn try_read_cache_key(method: &RequestMethod) -> Option<ReadCacheKey> {
+    CacheableRequestMethod::try_from(method)
         .ok()
-        .and_then(CacheableMethodInvocation::read_cache_key)
+        .and_then(CacheableRequestMethod::read_cache_key)
 }
 
-pub(super) fn try_write_cache_key(method_invocation: &MethodInvocation) -> Option<WriteCacheKey> {
-    CacheableMethodInvocation::try_from(method_invocation)
+pub(super) fn try_write_cache_key(method: &RequestMethod) -> Option<WriteCacheKey> {
+    CacheableRequestMethod::try_from(method)
         .ok()
-        .and_then(CacheableMethodInvocation::write_cache_key)
+        .and_then(CacheableRequestMethod::write_cache_key)
 }
 
-/// Potentially cacheable Ethereum JSON-RPC method invocation.
+/// Potentially cacheable Ethereum JSON-RPC methods.
 #[derive(Clone, Debug)]
-enum CacheableMethodInvocation<'a> {
+enum CacheableRequestMethod<'a> {
     /// eth_chainId
     ChainId,
     /// eth_getBalance
@@ -46,10 +46,6 @@ enum CacheableMethodInvocation<'a> {
         /// include transaction data
         include_tx_data: bool,
     },
-    /// eth_getBlockTransactionCountByHash
-    GetBlockTransactionCountByHash { block_hash: &'a B256 },
-    /// eth_getBlockTransactionCountByNumber
-    GetBlockTransactionCountByNumber { block_spec: CacheableBlockSpec<'a> },
     /// eth_getCode
     GetCode {
         address: &'a Address,
@@ -62,16 +58,6 @@ enum CacheableMethodInvocation<'a> {
         address: &'a Address,
         position: &'a U256,
         block_spec: CacheableBlockSpec<'a>,
-    },
-    /// eth_getTransactionByBlockHashAndIndex
-    GetTransactionByBlockHashAndIndex {
-        block_hash: &'a B256,
-        index: &'a U256,
-    },
-    /// eth_getTransactionByBlockNumberAndIndex
-    GetTransactionByBlockNumberAndIndex {
-        block_spec: CacheableBlockSpec<'a>,
-        index: &'a U256,
     },
     /// eth_getTransactionByHash
     GetTransactionByHash { transaction_hash: &'a B256 },
@@ -86,193 +72,127 @@ enum CacheableMethodInvocation<'a> {
     NetVersion,
 }
 
-impl<'a> CacheableMethodInvocation<'a> {
+impl<'a> CacheableRequestMethod<'a> {
     fn read_cache_key(self) -> Option<ReadCacheKey> {
-        let cache_key = Hasher::new().hash_method_invocation(&self).ok()?.finalize();
+        let cache_key = Hasher::new().hash_method(&self).ok()?.finalize();
         Some(ReadCacheKey(cache_key))
     }
 
     #[allow(clippy::match_same_arms)]
     fn write_cache_key(self) -> Option<WriteCacheKey> {
-        match Hasher::new().hash_method_invocation(&self) {
+        match Hasher::new().hash_method(&self) {
             Err(SymbolicBlogTagError) => WriteCacheKey::needs_block_number(self),
             Ok(hasher) => match self {
-                CacheableMethodInvocation::ChainId => Some(WriteCacheKey::finalize(hasher)),
-                CacheableMethodInvocation::GetBalance {
+                CacheableRequestMethod::ChainId => Some(WriteCacheKey::finalize(hasher)),
+                CacheableRequestMethod::GetBalance {
                     address: _,
                     block_spec,
                 } => WriteCacheKey::needs_safety_check(hasher, block_spec),
-                CacheableMethodInvocation::GetBlockByNumber {
+                CacheableRequestMethod::GetBlockByNumber {
                     block_spec,
                     include_tx_data: _,
                 } => WriteCacheKey::needs_safety_check(hasher, block_spec),
-                CacheableMethodInvocation::GetBlockByHash {
+                CacheableRequestMethod::GetBlockByHash {
                     block_hash: _,
                     include_tx_data: _,
                 } => Some(WriteCacheKey::finalize(hasher)),
-                CacheableMethodInvocation::GetBlockTransactionCountByHash { block_hash: _ } => {
-                    Some(WriteCacheKey::finalize(hasher))
-                }
-                CacheableMethodInvocation::GetBlockTransactionCountByNumber { block_spec } => {
-                    WriteCacheKey::needs_safety_check(hasher, block_spec)
-                }
-                CacheableMethodInvocation::GetCode {
+                CacheableRequestMethod::GetCode {
                     address: _,
                     block_spec,
                 } => WriteCacheKey::needs_safety_check(hasher, block_spec),
-                CacheableMethodInvocation::GetLogs {
+                CacheableRequestMethod::GetLogs {
                     params,
                     // TODO should we check that to < from?
                 } => WriteCacheKey::needs_safety_check(hasher, params.to_block),
-                CacheableMethodInvocation::GetStorageAt {
+                CacheableRequestMethod::GetStorageAt {
                     address: _,
                     position: _,
                     block_spec,
                 } => WriteCacheKey::needs_safety_check(hasher, block_spec),
-                CacheableMethodInvocation::GetTransactionByBlockHashAndIndex {
-                    block_hash: _,
-                    index: _,
-                } => Some(WriteCacheKey::finalize(hasher)),
-                CacheableMethodInvocation::GetTransactionByBlockNumberAndIndex {
-                    block_spec: _,
-                    index: _,
-                } => Some(WriteCacheKey::finalize(hasher)),
-                CacheableMethodInvocation::GetTransactionByHash {
+                CacheableRequestMethod::GetTransactionByHash {
                     transaction_hash: _,
                 } => Some(WriteCacheKey::finalize(hasher)),
-                CacheableMethodInvocation::GetTransactionCount {
+                CacheableRequestMethod::GetTransactionCount {
                     address: _,
                     block_spec,
                 } => WriteCacheKey::needs_safety_check(hasher, block_spec),
-                CacheableMethodInvocation::GetTransactionReceipt {
+                CacheableRequestMethod::GetTransactionReceipt {
                     transaction_hash: _,
                 } => Some(WriteCacheKey::finalize(hasher)),
-                CacheableMethodInvocation::NetVersion => Some(WriteCacheKey::finalize(hasher)),
+                CacheableRequestMethod::NetVersion => Some(WriteCacheKey::finalize(hasher)),
             },
         }
     }
 }
 
-/// Error type for [`CacheableMethodInvocation::try_from`].
+/// Error type for [`CacheableRequestMethod::try_from`].
 #[derive(thiserror::Error, Debug)]
 enum MethodNotCacheableError {
     #[error(transparent)]
     BlockSpec(#[from] BlockSpecNotCacheableError),
     #[error("Method is not cacheable: {0:?}")]
-    MethodInvocation(MethodInvocation),
+    RequestMethod(RequestMethod),
     #[error("Get logs input is not cacheable: {0:?}")]
     GetLogsInput(#[from] GetLogsInputNotCacheableError),
     #[error(transparent)]
     PreEip18989BlockSpec(#[from] PreEip1898BlockSpecNotCacheableError),
 }
 
-impl<'a> TryFrom<&'a MethodInvocation> for CacheableMethodInvocation<'a> {
+impl<'a> TryFrom<&'a RequestMethod> for CacheableRequestMethod<'a> {
     type Error = MethodNotCacheableError;
 
-    fn try_from(value: &'a MethodInvocation) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a RequestMethod) -> Result<Self, Self::Error> {
         match value {
-            MethodInvocation::ChainId(_) => Ok(CacheableMethodInvocation::ChainId),
-            MethodInvocation::GetBalance(address, block_spec) => {
-                Ok(CacheableMethodInvocation::GetBalance {
+            RequestMethod::ChainId(_) => Ok(CacheableRequestMethod::ChainId),
+            RequestMethod::GetBalance(address, block_spec) => {
+                Ok(CacheableRequestMethod::GetBalance {
                     address,
                     block_spec: block_spec.try_into()?,
                 })
             }
-            MethodInvocation::GetBlockByNumber(block_spec, include_tx_data) => {
-                Ok(CacheableMethodInvocation::GetBlockByNumber {
+            RequestMethod::GetBlockByNumber(block_spec, include_tx_data) => {
+                Ok(CacheableRequestMethod::GetBlockByNumber {
                     block_spec: block_spec.try_into()?,
                     include_tx_data: *include_tx_data,
                 })
             }
-            MethodInvocation::GetBlockByHash(block_hash, include_tx_data) => {
-                Ok(CacheableMethodInvocation::GetBlockByHash {
+            RequestMethod::GetBlockByHash(block_hash, include_tx_data) => {
+                Ok(CacheableRequestMethod::GetBlockByHash {
                     block_hash,
                     include_tx_data: *include_tx_data,
                 })
             }
-            MethodInvocation::GetBlockTransactionCountByHash(block_hash) => {
-                Ok(CacheableMethodInvocation::GetBlockTransactionCountByHash { block_hash })
-            }
-            MethodInvocation::GetBlockTransactionCountByNumber(block_spec) => Ok(
-                CacheableMethodInvocation::GetBlockTransactionCountByNumber {
-                    block_spec: block_spec.try_into()?,
-                },
-            ),
-            MethodInvocation::GetCode(address, block_spec) => {
-                Ok(CacheableMethodInvocation::GetCode {
-                    address,
-                    block_spec: block_spec.try_into()?,
-                })
-            }
-            MethodInvocation::GetLogs(params) => Ok(CacheableMethodInvocation::GetLogs {
+            RequestMethod::GetCode(address, block_spec) => Ok(CacheableRequestMethod::GetCode {
+                address,
+                block_spec: block_spec.try_into()?,
+            }),
+            RequestMethod::GetLogs(params) => Ok(CacheableRequestMethod::GetLogs {
                 params: params.try_into()?,
             }),
-            MethodInvocation::GetStorageAt(address, position, block_spec) => {
-                Ok(CacheableMethodInvocation::GetStorageAt {
+            RequestMethod::GetStorageAt(address, position, block_spec) => {
+                Ok(CacheableRequestMethod::GetStorageAt {
                     address,
                     position,
                     block_spec: block_spec.try_into()?,
                 })
             }
-            MethodInvocation::GetTransactionByBlockHashAndIndex(block_hash, index) => Ok(
-                CacheableMethodInvocation::GetTransactionByBlockHashAndIndex { block_hash, index },
-            ),
-            MethodInvocation::GetTransactionByBlockNumberAndIndex(block_spec, index) => Ok(
-                CacheableMethodInvocation::GetTransactionByBlockNumberAndIndex {
-                    block_spec: block_spec.try_into()?,
-                    index,
-                },
-            ),
-            MethodInvocation::GetTransactionByHash(transaction_hash) => {
-                Ok(CacheableMethodInvocation::GetTransactionByHash { transaction_hash })
+            RequestMethod::GetTransactionByHash(transaction_hash) => {
+                Ok(CacheableRequestMethod::GetTransactionByHash { transaction_hash })
             }
-            MethodInvocation::GetTransactionCount(address, block_spec) => {
-                Ok(CacheableMethodInvocation::GetTransactionCount {
+            RequestMethod::GetTransactionCount(address, block_spec) => {
+                Ok(CacheableRequestMethod::GetTransactionCount {
                     address,
                     block_spec: block_spec.try_into()?,
                 })
             }
-            MethodInvocation::GetTransactionReceipt(transaction_hash) => {
-                Ok(CacheableMethodInvocation::GetTransactionReceipt { transaction_hash })
+            RequestMethod::GetTransactionReceipt(transaction_hash) => {
+                Ok(CacheableRequestMethod::GetTransactionReceipt { transaction_hash })
             }
-            MethodInvocation::NetVersion(_) => Ok(CacheableMethodInvocation::NetVersion),
+            RequestMethod::NetVersion(_) => Ok(CacheableRequestMethod::NetVersion),
 
             // Explicit to make sure if a new method is added, it is not forgotten here.
-            MethodInvocation::Accounts(_)
-            | MethodInvocation::BlockNumber(_)
-            | MethodInvocation::Call(_, _, _)
-            | MethodInvocation::Coinbase(_)
-            | MethodInvocation::EstimateGas(_, _)
-            | MethodInvocation::FeeHistory(_, _, _)
-            | MethodInvocation::GasPrice(_)
-            | MethodInvocation::GetFilterChanges(_)
-            | MethodInvocation::GetFilterLogs(_)
-            | MethodInvocation::Mining(_)
-            | MethodInvocation::NetListening(_)
-            | MethodInvocation::NetPeerCount(_)
-            | MethodInvocation::NewBlockFilter(_)
-            | MethodInvocation::NewFilter(_)
-            | MethodInvocation::NewPendingTransactionFilter(_)
-            | MethodInvocation::PendingTransactions(_)
-            | MethodInvocation::SendRawTransaction(_)
-            | MethodInvocation::SendTransaction(_)
-            | MethodInvocation::Sign(_, _)
-            | MethodInvocation::SignTypedDataV4(_, _)
-            | MethodInvocation::Subscribe(_)
-            | MethodInvocation::Syncing(_)
-            | MethodInvocation::UninstallFilter(_)
-            | MethodInvocation::Unsubscribe(_)
-            | MethodInvocation::Web3ClientVersion(_)
-            | MethodInvocation::Web3Sha3(_)
-            | MethodInvocation::EvmIncreaseTime(_)
-            | MethodInvocation::EvmMine(_)
-            | MethodInvocation::EvmRevert(_)
-            | MethodInvocation::EvmSetAutomine(_)
-            | MethodInvocation::EvmSetBlockGasLimit(_)
-            | MethodInvocation::EvmSetIntervalMining(_)
-            | MethodInvocation::EvmSetNextBlockTimestamp(_)
-            | MethodInvocation::EvmSnapshot(_) => {
-                Err(MethodNotCacheableError::MethodInvocation(value.clone()))
+            RequestMethod::BlockNumber(_) => {
+                Err(MethodNotCacheableError::RequestMethod(value.clone()))
             }
         }
     }
@@ -435,9 +355,9 @@ impl WriteCacheKey {
         }
     }
 
-    fn needs_block_number(method_invocation: CacheableMethodInvocation<'_>) -> Option<Self> {
+    fn needs_block_number(method: CacheableRequestMethod<'_>) -> Option<Self> {
         Some(Self::NeedsBlockNumber(CacheKeyForSymbolicBlockTag {
-            method_invocation: MethodWithResolvableSymbolicBlockSpec::new(method_invocation)?,
+            method: MethodWithResolvableSymbolicBlockSpec::new(method)?,
         }))
     }
 }
@@ -477,7 +397,7 @@ pub(super) enum ResolvedSymbolicTag {
 
 #[derive(Debug, Clone)]
 pub(super) struct CacheKeyForSymbolicBlockTag {
-    method_invocation: MethodWithResolvableSymbolicBlockSpec,
+    method: MethodWithResolvableSymbolicBlockSpec,
 }
 
 impl CacheKeyForSymbolicBlockTag {
@@ -486,26 +406,24 @@ impl CacheKeyForSymbolicBlockTag {
     pub(super) fn resolve_symbolic_tag(self, block_number: u64) -> Option<ResolvedSymbolicTag> {
         let resolved_block_spec = CacheableBlockSpec::Number { block_number };
 
-        let resolved_method_invocation = match self.method_invocation {
+        let resolved_method = match self.method {
             MethodWithResolvableSymbolicBlockSpec::GetBlockByNumber {
                 include_tx_data, ..
-            } => CacheableMethodInvocation::GetBlockByNumber {
+            } => CacheableRequestMethod::GetBlockByNumber {
                 block_spec: resolved_block_spec,
                 include_tx_data,
             },
         };
 
-        resolved_method_invocation
-            .write_cache_key()
-            .map(|key| match key {
-                WriteCacheKey::NeedsSafetyCheck(cache_key) => {
-                    ResolvedSymbolicTag::NeedsSafetyCheck(cache_key)
-                }
-                WriteCacheKey::Resolved(cache_key) => ResolvedSymbolicTag::Resolved(cache_key),
-                WriteCacheKey::NeedsBlockNumber(_) => {
-                    unreachable!("resolved block spec should not need block number")
-                }
-            })
+        resolved_method.write_cache_key().map(|key| match key {
+            WriteCacheKey::NeedsSafetyCheck(cache_key) => {
+                ResolvedSymbolicTag::NeedsSafetyCheck(cache_key)
+            }
+            WriteCacheKey::Resolved(cache_key) => ResolvedSymbolicTag::Resolved(cache_key),
+            WriteCacheKey::NeedsBlockNumber(_) => {
+                unreachable!("resolved block spec should not need block number")
+            }
+        })
     }
 }
 
@@ -517,9 +435,9 @@ pub(super) enum MethodWithResolvableSymbolicBlockSpec {
 }
 
 impl<'a> MethodWithResolvableSymbolicBlockSpec {
-    fn new(method_invocation: CacheableMethodInvocation<'a>) -> Option<Self> {
-        match method_invocation {
-            CacheableMethodInvocation::GetBlockByNumber {
+    fn new(method: CacheableRequestMethod<'a>) -> Option<Self> {
+        match method {
+            CacheableRequestMethod::GetBlockByNumber {
                 include_tx_data,
                 block_spec: _,
             } => Some(Self::GetBlockByNumber { include_tx_data }),
@@ -651,40 +569,34 @@ impl Hasher {
         Ok(this)
     }
 
-    // Allow to keep same structure as other MethodInvocation and other methods.
+    // Allow to keep same structure as other RequestMethod and other methods.
     #[allow(clippy::match_same_arms)]
-    fn hash_method_invocation(
+    fn hash_method(
         self,
-        method: &CacheableMethodInvocation<'_>,
+        method: &CacheableRequestMethod<'_>,
     ) -> Result<Self, SymbolicBlogTagError> {
         let this = self.hash_u8(method.cache_key_variant());
 
         let this = match method {
-            CacheableMethodInvocation::ChainId => this,
-            CacheableMethodInvocation::GetBalance {
+            CacheableRequestMethod::ChainId => this,
+            CacheableRequestMethod::GetBalance {
                 address,
                 block_spec,
             } => this.hash_address(address).hash_block_spec(block_spec)?,
-            CacheableMethodInvocation::GetBlockByNumber {
+            CacheableRequestMethod::GetBlockByNumber {
                 block_spec,
                 include_tx_data,
             } => this.hash_block_spec(block_spec)?.hash_bool(include_tx_data),
-            CacheableMethodInvocation::GetBlockByHash {
+            CacheableRequestMethod::GetBlockByHash {
                 block_hash,
                 include_tx_data,
             } => this.hash_b256(block_hash).hash_bool(include_tx_data),
-            CacheableMethodInvocation::GetBlockTransactionCountByHash { block_hash } => {
-                this.hash_b256(block_hash)
-            }
-            CacheableMethodInvocation::GetBlockTransactionCountByNumber { block_spec } => {
-                this.hash_block_spec(block_spec)?
-            }
-            CacheableMethodInvocation::GetCode {
+            CacheableRequestMethod::GetCode {
                 address,
                 block_spec,
             } => this.hash_address(address).hash_block_spec(block_spec)?,
-            CacheableMethodInvocation::GetLogs { params } => this.hash_get_logs_input(params)?,
-            CacheableMethodInvocation::GetStorageAt {
+            CacheableRequestMethod::GetLogs { params } => this.hash_get_logs_input(params)?,
+            CacheableRequestMethod::GetStorageAt {
                 address,
                 position,
                 block_spec,
@@ -692,24 +604,17 @@ impl Hasher {
                 .hash_address(address)
                 .hash_u256(position)
                 .hash_block_spec(block_spec)?,
-            CacheableMethodInvocation::GetTransactionByBlockHashAndIndex { block_hash, index } => {
-                this.hash_b256(block_hash).hash_u256(index)
-            }
-            CacheableMethodInvocation::GetTransactionByBlockNumberAndIndex {
-                block_spec,
-                index,
-            } => this.hash_block_spec(block_spec)?.hash_u256(index),
-            CacheableMethodInvocation::GetTransactionByHash { transaction_hash } => {
+            CacheableRequestMethod::GetTransactionByHash { transaction_hash } => {
                 this.hash_b256(transaction_hash)
             }
-            CacheableMethodInvocation::GetTransactionCount {
+            CacheableRequestMethod::GetTransactionCount {
                 address,
                 block_spec,
             } => this.hash_address(address).hash_block_spec(block_spec)?,
-            CacheableMethodInvocation::GetTransactionReceipt { transaction_hash } => {
+            CacheableRequestMethod::GetTransactionReceipt { transaction_hash } => {
                 this.hash_b256(transaction_hash)
             }
-            CacheableMethodInvocation::NetVersion => this,
+            CacheableRequestMethod::NetVersion => this,
         };
 
         Ok(this)
@@ -740,24 +645,26 @@ impl<T> CacheKeyVariant for Option<T> {
     }
 }
 
-impl<'a> CacheKeyVariant for &'a CacheableMethodInvocation<'a> {
+impl<'a> CacheKeyVariant for &'a CacheableRequestMethod<'a> {
     fn cache_key_variant(&self) -> u8 {
         match self {
-            CacheableMethodInvocation::ChainId => 0,
-            CacheableMethodInvocation::GetBalance { .. } => 1,
-            CacheableMethodInvocation::GetBlockByNumber { .. } => 2,
-            CacheableMethodInvocation::GetBlockByHash { .. } => 3,
-            CacheableMethodInvocation::GetBlockTransactionCountByHash { .. } => 4,
-            CacheableMethodInvocation::GetBlockTransactionCountByNumber { .. } => 5,
-            CacheableMethodInvocation::GetCode { .. } => 6,
-            CacheableMethodInvocation::GetLogs { .. } => 7,
-            CacheableMethodInvocation::GetStorageAt { .. } => 8,
-            CacheableMethodInvocation::GetTransactionByBlockHashAndIndex { .. } => 9,
-            CacheableMethodInvocation::GetTransactionByBlockNumberAndIndex { .. } => 10,
-            CacheableMethodInvocation::GetTransactionByHash { .. } => 11,
-            CacheableMethodInvocation::GetTransactionCount { .. } => 12,
-            CacheableMethodInvocation::GetTransactionReceipt { .. } => 13,
-            CacheableMethodInvocation::NetVersion => 14,
+            CacheableRequestMethod::ChainId => 0,
+            CacheableRequestMethod::GetBalance { .. } => 1,
+            CacheableRequestMethod::GetBlockByNumber { .. } => 2,
+            CacheableRequestMethod::GetBlockByHash { .. } => 3,
+            // These methods have been removed as they're not currently in use by the RPC client.
+            // If they're added back, they should keep their old variant number.
+            // CacheableRequestMethod::GetBlockTransactionCountByHash { .. } => 4,
+            // CacheableRequestMethod::GetBlockTransactionCountByNumber { .. } => 5,
+            CacheableRequestMethod::GetCode { .. } => 6,
+            CacheableRequestMethod::GetLogs { .. } => 7,
+            CacheableRequestMethod::GetStorageAt { .. } => 8,
+            // CacheableRequestMethod::GetTransactionByBlockHashAndIndex { .. } => 9,
+            // CacheableRequestMethod::GetTransactionByBlockNumberAndIndex { .. } => 10,
+            CacheableRequestMethod::GetTransactionByHash { .. } => 11,
+            CacheableRequestMethod::GetTransactionCount { .. } => 12,
+            CacheableRequestMethod::GetTransactionReceipt { .. } => 13,
+            CacheableRequestMethod::NetVersion => 14,
         }
     }
 }
@@ -834,10 +741,8 @@ mod test {
 
     #[test]
     fn test_no_arguments_keys_not_equal() {
-        let key_one = CacheableMethodInvocation::ChainId.read_cache_key().unwrap();
-        let key_two = CacheableMethodInvocation::NetVersion
-            .read_cache_key()
-            .unwrap();
+        let key_one = CacheableRequestMethod::ChainId.read_cache_key().unwrap();
+        let key_two = CacheableRequestMethod::NetVersion.read_cache_key().unwrap();
 
         assert_ne!(key_one, key_two);
     }
@@ -845,12 +750,12 @@ mod test {
     #[test]
     fn test_same_arguments_keys_not_equal() {
         let value = B256::default();
-        let key_one = CacheableMethodInvocation::GetTransactionByHash {
+        let key_one = CacheableRequestMethod::GetTransactionByHash {
             transaction_hash: &value,
         }
         .read_cache_key()
         .unwrap();
-        let key_two = CacheableMethodInvocation::GetTransactionReceipt {
+        let key_two = CacheableRequestMethod::GetTransactionReceipt {
             transaction_hash: &value,
         }
         .read_cache_key()
@@ -864,7 +769,7 @@ mod test {
         let address = Address::default();
         let position = U256::default();
 
-        let key_one = CacheableMethodInvocation::GetStorageAt {
+        let key_one = CacheableRequestMethod::GetStorageAt {
             address: &address,
             position: &position,
             block_spec: CacheableBlockSpec::Hash {
@@ -875,7 +780,7 @@ mod test {
         .read_cache_key()
         .unwrap();
 
-        let key_two = CacheableMethodInvocation::GetStorageAt {
+        let key_two = CacheableRequestMethod::GetStorageAt {
             address: &address,
             position: &position,
             block_spec: CacheableBlockSpec::Number {
@@ -895,7 +800,7 @@ mod test {
         let block_number = u64::default();
         let block_spec = CacheableBlockSpec::Number { block_number };
 
-        let key_one = CacheableMethodInvocation::GetStorageAt {
+        let key_one = CacheableRequestMethod::GetStorageAt {
             address: &address,
             position: &position,
             block_spec: block_spec.clone(),
@@ -903,7 +808,7 @@ mod test {
         .read_cache_key()
         .unwrap();
 
-        let key_two = CacheableMethodInvocation::GetStorageAt {
+        let key_two = CacheableRequestMethod::GetStorageAt {
             address: &address,
             position: &position,
             block_spec,

--- a/crates/edr_eth/src/remote/cacheable_method_invocation.rs
+++ b/crates/edr_eth/src/remote/cacheable_method_invocation.rs
@@ -191,7 +191,7 @@ impl<'a> TryFrom<&'a RequestMethod> for CacheableRequestMethod<'a> {
             RequestMethod::NetVersion(_) => Ok(CacheableRequestMethod::NetVersion),
 
             // Explicit to make sure if a new method is added, it is not forgotten here.
-            RequestMethod::BlockNumber(_) => {
+            RequestMethod::BlockNumber(_) | RequestMethod::FeeHistory(_, _, _) => {
                 Err(MethodNotCacheableError::RequestMethod(value.clone()))
             }
         }

--- a/crates/edr_eth/src/remote/client.rs
+++ b/crates/edr_eth/src/remote/client.rs
@@ -22,11 +22,7 @@ use sha3::{digest::FixedOutput, Digest, Sha3_256};
 use tokio::sync::{OnceCell, RwLock};
 use uuid::Uuid;
 
-use super::{
-    eth, jsonrpc,
-    methods::{GetLogsInput, MethodInvocation},
-    BlockSpec, PreEip1898BlockSpec,
-};
+use super::{eth, jsonrpc, request_methods::RequestMethod, BlockSpec, PreEip1898BlockSpec};
 use crate::{
     block::{block_time, is_safe_block_number, IsSafeBlockNumberArgs},
     log::FilterLog,
@@ -36,6 +32,7 @@ use crate::{
             try_read_cache_key, try_write_cache_key, CacheKeyForSymbolicBlockTag,
             CacheKeyForUncheckedBlockNumber, ReadCacheKey, ResolvedSymbolicTag, WriteCacheKey,
         },
+        eth::GetLogsInput,
         jsonrpc::Id,
     },
     serde::ZeroXPrefixedBytes,
@@ -89,10 +86,10 @@ pub enum RpcClientError {
     },
 
     /// A response is missing from a batch request.
-    #[error("Missing response for method: '{method_invocation:?}' for request id: '{id:?}' in batch request")]
+    #[error("Missing response for method: '{method:?}' for request id: '{id:?}' in batch request")]
     MissingResponse {
         /// The method invocation for which the response is missing.
-        method_invocation: MethodInvocation,
+        method: Box<RequestMethod>,
         /// The id of the request iwth the missing response
         id: Id,
         /// The response text
@@ -135,15 +132,15 @@ pub enum CacheError {
     Json(#[from] serde_json::Error),
 }
 
-/// a JSON-RPC method invocation request
+/// A JSON-RPC request
 #[derive(Deserialize, Serialize)]
-pub struct Request<MethodInvocation> {
+pub struct Request<RequestMethod> {
     /// JSON-RPC version
     #[serde(rename = "jsonrpc")]
     pub version: jsonrpc::Version,
     /// the method to invoke, with its parameters
     #[serde(flatten)]
-    pub method: MethodInvocation,
+    pub method: RequestMethod,
     /// the request ID, to be correlated via the response's ID
     pub id: Id,
 }
@@ -327,11 +324,11 @@ impl RpcClient {
 
     async fn resolve_write_key<T>(
         &self,
-        method_invocation: &MethodInvocation,
+        method: &RequestMethod,
         result: T,
         resolve_block_number: impl Fn(T) -> Option<u64>,
     ) -> Result<Option<String>, RpcClientError> {
-        let write_cache_key = try_write_cache_key(method_invocation);
+        let write_cache_key = try_write_cache_key(method);
 
         if let Some(cache_key) = write_cache_key {
             match cache_key {
@@ -351,12 +348,12 @@ impl RpcClient {
 
     async fn try_write_response_to_cache<T: Serialize>(
         &self,
-        method_invocation: &MethodInvocation,
+        method: &RequestMethod,
         result: &T,
         resolve_block_number: impl Fn(&T) -> Option<u64>,
     ) -> Result<(), RpcClientError> {
         if let Some(cache_key) = self
-            .resolve_write_key(method_invocation, result, resolve_block_number)
+            .resolve_write_key(method, result, resolve_block_number)
             .await?
         {
             self.write_response_to_cache(&cache_key, result).await?;
@@ -453,14 +450,14 @@ impl RpcClient {
 
     fn serialize_request(
         &self,
-        input: &MethodInvocation,
+        input: &RequestMethod,
     ) -> Result<SerializedRequest, RpcClientError> {
         let id = Id::Num(self.next_id.fetch_add(1, Ordering::Relaxed));
         Self::serialize_request_with_id(input, id)
     }
 
     fn serialize_request_with_id(
-        method: &MethodInvocation,
+        method: &RequestMethod,
         id: Id,
     ) -> Result<SerializedRequest, RpcClientError> {
         let request = serde_json::to_value(Request {
@@ -475,19 +472,19 @@ impl RpcClient {
 
     async fn call<T: DeserializeOwned + Serialize>(
         &self,
-        method_invocation: MethodInvocation,
+        method: RequestMethod,
     ) -> Result<T, RpcClientError> {
-        self.call_with_resolver(method_invocation, |_| None).await
+        self.call_with_resolver(method, |_| None).await
     }
 
     async fn call_with_resolver<T: DeserializeOwned + Serialize>(
         &self,
-        method_invocation: MethodInvocation,
+        method: RequestMethod,
         resolve_block_number: impl Fn(&T) -> Option<u64>,
     ) -> Result<T, RpcClientError> {
-        let read_cache_key = try_read_cache_key(&method_invocation);
+        let read_cache_key = try_read_cache_key(&method);
 
-        let request = self.serialize_request(&method_invocation)?;
+        let request = self.serialize_request(&method)?;
 
         if let Some(cached_response) = self.try_from_cache(read_cache_key.as_ref()).await? {
             match cached_response.parse().await {
@@ -514,7 +511,7 @@ impl RpcClient {
             .await
             .and_then(|response| Self::extract_result(request, response))?;
 
-        self.try_write_response_to_cache(&method_invocation, &result, &resolve_block_number)
+        self.try_write_response_to_cache(&method, &result, &resolve_block_number)
             .await?;
 
         Ok(result)
@@ -524,9 +521,9 @@ impl RpcClient {
     // functions as the cached path calls `eth_chainId` without caching.
     async fn call_without_cache<T: DeserializeOwned>(
         &self,
-        method_invocation: MethodInvocation,
+        method: RequestMethod,
     ) -> Result<T, RpcClientError> {
-        let request = self.serialize_request(&method_invocation)?;
+        let request = self.serialize_request(&method)?;
 
         self.send_request_body(&request)
             .await
@@ -536,23 +533,19 @@ impl RpcClient {
     /// Returns the results of the given method invocations.
     async fn batch_call(
         &self,
-        method_invocations: &[MethodInvocation],
+        methods: &[RequestMethod],
     ) -> Result<VecDeque<ResponseValue>, RpcClientError> {
-        self.batch_call_with_resolver(method_invocations, |_| None)
-            .await
+        self.batch_call_with_resolver(methods, |_| None).await
     }
 
     async fn batch_call_with_resolver(
         &self,
-        method_invocations: &[MethodInvocation],
+        methods: &[RequestMethod],
         resolve_block_number: impl Fn(&serde_json::Value) -> Option<u64>,
     ) -> Result<VecDeque<ResponseValue>, RpcClientError> {
-        let ids = self.get_ids(method_invocations.len() as u64);
+        let ids = self.get_ids(methods.len() as u64);
 
-        let cache_keys = method_invocations
-            .iter()
-            .map(try_read_cache_key)
-            .collect::<Vec<_>>();
+        let cache_keys = methods.iter().map(try_read_cache_key).collect::<Vec<_>>();
 
         let mut results: Vec<Option<ResponseValue>> = Vec::with_capacity(cache_keys.len());
 
@@ -562,11 +555,9 @@ impl RpcClient {
 
         let mut requests: Vec<SerializedRequest> = Vec::new();
         let mut id_to_index = HashMap::<&Id, usize>::new();
-        for (index, (id, method_invocation, cache_response)) in
-            izip!(&ids, method_invocations, &results).enumerate()
-        {
+        for (index, (id, method, cache_response)) in izip!(&ids, methods, &results).enumerate() {
             if cache_response.is_none() {
-                let request = Self::serialize_request_with_id(method_invocation, id.clone())?;
+                let request = Self::serialize_request_with_id(method, id.clone())?;
                 requests.push(request);
                 id_to_index.insert(id, index);
             }
@@ -597,12 +588,8 @@ impl RpcClient {
                         request: request_body.to_json_string(),
                     })?;
 
-            self.try_write_response_to_cache(
-                &method_invocations[index],
-                &result,
-                &resolve_block_number,
-            )
-            .await?;
+            self.try_write_response_to_cache(&methods[index], &result, &resolve_block_number)
+                .await?;
 
             results[index] = Some(ResponseValue::Remote(result));
         }
@@ -612,7 +599,7 @@ impl RpcClient {
             .enumerate()
             .map(|(index, result)| {
                 result.ok_or_else(|| RpcClientError::MissingResponse {
-                    method_invocation: method_invocations[index].clone(),
+                    method: Box::new(methods[index].clone()),
                     id: ids[index].clone(),
                     response: remote_response.clone(),
                 })
@@ -623,7 +610,7 @@ impl RpcClient {
     /// Calls `eth_blockNumber` and returns the block number.
     pub async fn block_number(&self) -> Result<u64, RpcClientError> {
         let block_number = self
-            .call_without_cache::<U64>(MethodInvocation::BlockNumber(()))
+            .call_without_cache::<U64>(RequestMethod::BlockNumber(()))
             .await?
             .as_limbs()[0];
 
@@ -654,7 +641,7 @@ impl RpcClient {
         let chain_id = *self
             .chain_id
             .get_or_try_init(|| async {
-                self.call_without_cache::<U64>(MethodInvocation::ChainId(()))
+                self.call_without_cache::<U64>(RequestMethod::ChainId(()))
                     .await
                     .map(|chain_id| chain_id.as_limbs()[0])
             })
@@ -682,13 +669,13 @@ impl RpcClient {
         addresses: &[Address],
         block: Option<BlockSpec>,
     ) -> Result<Vec<AccountInfo>, RpcClientError> {
-        let inputs: Vec<MethodInvocation> = addresses
+        let inputs: Vec<RequestMethod> = addresses
             .iter()
             .flat_map(|address| {
                 [
-                    MethodInvocation::GetBalance(*address, block.clone()),
-                    MethodInvocation::GetTransactionCount(*address, block.clone()),
-                    MethodInvocation::GetCode(*address, block.clone()),
+                    RequestMethod::GetBalance(*address, block.clone()),
+                    RequestMethod::GetTransactionCount(*address, block.clone()),
+                    RequestMethod::GetCode(*address, block.clone()),
                 ]
             })
             .collect();
@@ -723,8 +710,7 @@ impl RpcClient {
         &self,
         hash: &B256,
     ) -> Result<Option<eth::Block<B256>>, RpcClientError> {
-        self.call(MethodInvocation::GetBlockByHash(*hash, false))
-            .await
+        self.call(RequestMethod::GetBlockByHash(*hash, false)).await
     }
 
     /// Calls `eth_getBlockByHash` and returns the transaction's data.
@@ -732,8 +718,7 @@ impl RpcClient {
         &self,
         hash: &B256,
     ) -> Result<Option<eth::Block<eth::Transaction>>, RpcClientError> {
-        self.call(MethodInvocation::GetBlockByHash(*hash, true))
-            .await
+        self.call(RequestMethod::GetBlockByHash(*hash, true)).await
     }
 
     /// Calls `eth_getBlockByNumber` and returns the transaction's hash.
@@ -742,7 +727,7 @@ impl RpcClient {
         spec: PreEip1898BlockSpec,
     ) -> Result<Option<eth::Block<B256>>, RpcClientError> {
         self.call_with_resolver(
-            MethodInvocation::GetBlockByNumber(spec, false),
+            RequestMethod::GetBlockByNumber(spec, false),
             |block: &Option<eth::Block<B256>>| block.as_ref().and_then(|block| block.number),
         )
         .await
@@ -754,7 +739,7 @@ impl RpcClient {
         spec: PreEip1898BlockSpec,
     ) -> Result<eth::Block<eth::Transaction>, RpcClientError> {
         self.call_with_resolver(
-            MethodInvocation::GetBlockByNumber(spec, true),
+            RequestMethod::GetBlockByNumber(spec, true),
             |block: &eth::Block<eth::Transaction>| block.number,
         )
         .await
@@ -767,7 +752,7 @@ impl RpcClient {
         to_block: BlockSpec,
         address: &Address,
     ) -> Result<Vec<FilterLog>, RpcClientError> {
-        self.call(MethodInvocation::GetLogs(GetLogsInput {
+        self.call(RequestMethod::GetLogs(GetLogsInput {
             from_block,
             to_block,
             address: *address,
@@ -780,7 +765,7 @@ impl RpcClient {
         &self,
         tx_hash: &B256,
     ) -> Result<Option<eth::Transaction>, RpcClientError> {
-        self.call(MethodInvocation::GetTransactionByHash(*tx_hash))
+        self.call(RequestMethod::GetTransactionByHash(*tx_hash))
             .await
     }
 
@@ -790,7 +775,7 @@ impl RpcClient {
         address: &Address,
         block: Option<BlockSpec>,
     ) -> Result<U256, RpcClientError> {
-        self.call(MethodInvocation::GetTransactionCount(*address, block))
+        self.call(RequestMethod::GetTransactionCount(*address, block))
             .await
     }
 
@@ -799,7 +784,7 @@ impl RpcClient {
         &self,
         tx_hash: &B256,
     ) -> Result<Option<BlockReceipt>, RpcClientError> {
-        self.call(MethodInvocation::GetTransactionReceipt(*tx_hash))
+        self.call(RequestMethod::GetTransactionReceipt(*tx_hash))
             .await
     }
 
@@ -808,9 +793,9 @@ impl RpcClient {
         &self,
         hashes: impl IntoIterator<Item = &B256>,
     ) -> Result<Option<Vec<BlockReceipt>>, RpcClientError> {
-        let requests: Vec<MethodInvocation> = hashes
+        let requests: Vec<RequestMethod> = hashes
             .into_iter()
-            .map(|transaction_hash| MethodInvocation::GetTransactionReceipt(*transaction_hash))
+            .map(|transaction_hash| RequestMethod::GetTransactionReceipt(*transaction_hash))
             .collect();
 
         let responses = self.batch_call(&requests).await?;
@@ -832,13 +817,13 @@ impl RpcClient {
         position: U256,
         block: Option<BlockSpec>,
     ) -> Result<Option<U256>, RpcClientError> {
-        self.call(MethodInvocation::GetStorageAt(*address, position, block))
+        self.call(RequestMethod::GetStorageAt(*address, position, block))
             .await
     }
 
     /// Calls `net_version`.
     pub async fn network_id(&self) -> Result<u64, RpcClientError> {
-        self.call::<U64>(MethodInvocation::NetVersion(()))
+        self.call::<U64>(RequestMethod::NetVersion(()))
             .await
             .map(|network_id| network_id.as_limbs()[0])
     }
@@ -1114,7 +1099,7 @@ mod tests {
                 .expect("failed to parse hash from string");
 
         let error = TestRpcClient::new(&server.url())
-            .call::<Option<eth::Transaction>>(MethodInvocation::GetTransactionByHash(hash))
+            .call::<Option<eth::Transaction>>(RequestMethod::GetTransactionByHash(hash))
             .await
             .expect_err("should have failed to due to a HTTP status error");
 
@@ -1177,7 +1162,7 @@ mod tests {
             .expect("failed to parse hash from string");
 
             let error = TestRpcClient::new(alchemy_url)
-                .call::<Option<eth::Transaction>>(MethodInvocation::GetTransactionByHash(hash))
+                .call::<Option<eth::Transaction>>(RequestMethod::GetTransactionByHash(hash))
                 .await
                 .expect_err("should have failed to interpret response as a Transaction");
 
@@ -1198,7 +1183,7 @@ mod tests {
             .expect("failed to parse hash from string");
 
             let error = TestRpcClient::new(alchemy_url)
-                .call::<Option<eth::Transaction>>(MethodInvocation::GetTransactionByHash(hash))
+                .call::<Option<eth::Transaction>>(RequestMethod::GetTransactionByHash(hash))
                 .await
                 .expect_err("should have failed to connect due to a garbage domain name");
 

--- a/crates/edr_eth/src/remote/eth.rs
+++ b/crates/edr_eth/src/remote/eth.rs
@@ -6,10 +6,16 @@
 // - https://github.com/gakonst/ethers-rs/blob/7e6c3ba98363bdf6131e8284f186cc2c70ff48c3/LICENSE-MIT
 // For the original context, see https://github.com/gakonst/ethers-rs/tree/7e6c3ba98363bdf6131e8284f186cc2c70ff48c3
 
-/// input types for EIP-712 message signing
+/// Input type for `eth_call` and `eth_estimateGas`
+mod call_request;
+/// Input types for EIP-712 message signing
 pub mod eip712;
+mod get_logs;
 
 use std::{fmt::Debug, sync::OnceLock};
+
+pub use call_request::CallRequest;
+pub use get_logs::GetLogsInput;
 
 use crate::{
     access_list::AccessListItem,

--- a/crates/edr_eth/src/remote/eth/call_request.rs
+++ b/crates/edr_eth/src/remote/eth/call_request.rs
@@ -1,0 +1,30 @@
+use revm_primitives::Address;
+
+use crate::{access_list::AccessListItem, serde::ZeroXPrefixedBytes, U256};
+
+/// For specifying input to methods requiring a transaction object, like
+/// `eth_call` and `eth_estimateGas`
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct CallRequest {
+    /// the address from which the transaction should be sent
+    pub from: Option<Address>,
+    /// the address to which the transaction should be sent
+    pub to: Option<Address>,
+    #[cfg_attr(feature = "serde", serde(default, with = "crate::serde::optional_u64"))]
+    /// gas
+    pub gas: Option<u64>,
+    /// gas price
+    pub gas_price: Option<U256>,
+    /// max base fee per gas sender is willing to pay
+    pub max_fee_per_gas: Option<U256>,
+    /// miner tip
+    pub max_priority_fee_per_gas: Option<U256>,
+    /// transaction value
+    pub value: Option<U256>,
+    /// transaction data
+    pub data: Option<ZeroXPrefixedBytes>,
+    /// warm storage access pre-payment
+    pub access_list: Option<Vec<AccessListItem>>,
+}

--- a/crates/edr_eth/src/remote/eth/get_logs.rs
+++ b/crates/edr_eth/src/remote/eth/get_logs.rs
@@ -1,0 +1,15 @@
+use revm_primitives::Address;
+
+use crate::remote::BlockSpec;
+
+/// for specifying the inputs to `eth_getLogs`
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetLogsInput {
+    /// starting block for get_logs request
+    pub from_block: BlockSpec,
+    /// ending block for get_logs request
+    pub to_block: BlockSpec,
+    /// address for get_logs request
+    pub address: Address,
+}

--- a/crates/edr_eth/src/remote/methods.rs
+++ b/crates/edr_eth/src/remote/methods.rs
@@ -2,9 +2,8 @@ use revm_primitives::ruint::aliases::U64;
 
 use super::StateOverrideOptions;
 use crate::{
-    access_list::AccessListItem,
     remote::{
-        eth::eip712,
+        eth::{eip712, CallRequest, GetLogsInput},
         filter::{FilterOptions, SubscriptionType},
         BlockSpec, PreEip1898BlockSpec,
     },
@@ -12,33 +11,6 @@ use crate::{
     transaction::EthTransactionRequest,
     Address, B256, U256,
 };
-
-/// for specifying input to methods requiring a transaction object, like
-/// `eth_call`, `eth_sendTransaction` and `eth_estimateGas`
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct CallRequest {
-    /// the address from which the transaction should be sent
-    pub from: Option<Address>,
-    /// the address to which the transaction should be sent
-    pub to: Option<Address>,
-    #[cfg_attr(feature = "serde", serde(default, with = "crate::serde::optional_u64"))]
-    /// gas
-    pub gas: Option<u64>,
-    /// gas price
-    pub gas_price: Option<U256>,
-    /// max base fee per gas sender is willing to pay
-    pub max_fee_per_gas: Option<U256>,
-    /// miner tip
-    pub max_priority_fee_per_gas: Option<U256>,
-    /// transaction value
-    pub value: Option<U256>,
-    /// transaction data
-    pub data: Option<ZeroXPrefixedBytes>,
-    /// warm storage access pre-payment
-    pub access_list: Option<Vec<AccessListItem>>,
-}
 
 mod optional_block_spec {
     use super::BlockSpec;
@@ -311,18 +283,6 @@ impl From<U64OrUsize> for u64 {
             U64OrUsize::Usize(u) => u as u64,
         }
     }
-}
-
-/// for specifying the inputs to `eth_getLogs`
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GetLogsInput {
-    /// starting block for get_logs request
-    pub from_block: BlockSpec,
-    /// ending block for get_logs request
-    pub to_block: BlockSpec,
-    /// address for get_logs request
-    pub address: Address,
 }
 
 #[cfg(test)]

--- a/crates/edr_eth/src/remote/request_methods.rs
+++ b/crates/edr_eth/src/remote/request_methods.rs
@@ -13,6 +13,16 @@ pub enum RequestMethod {
     /// eth_blockNumber
     #[serde(rename = "eth_blockNumber", with = "crate::serde::empty_params")]
     BlockNumber(()),
+    /// eth_feeHistory
+    #[serde(rename = "eth_feeHistory")]
+    FeeHistory(
+        /// block count
+        U256,
+        /// newest block
+        BlockSpec,
+        /// reward percentiles
+        Vec<f64>,
+    ),
     /// eth_chainId
     #[serde(rename = "eth_chainId", with = "crate::serde::empty_params")]
     ChainId(()),

--- a/crates/edr_eth/src/remote/request_methods.rs
+++ b/crates/edr_eth/src/remote/request_methods.rs
@@ -1,0 +1,88 @@
+use revm_primitives::{Address, B256};
+
+use crate::{
+    remote::{eth::GetLogsInput, BlockSpec, PreEip1898BlockSpec},
+    U256,
+};
+
+/// Methods for requests to a remote Ethereum node. Only contains methods
+/// supported by the [`crate::remote::client::RpcClient`].
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(tag = "method", content = "params")]
+pub enum RequestMethod {
+    /// eth_blockNumber
+    #[serde(rename = "eth_blockNumber", with = "crate::serde::empty_params")]
+    BlockNumber(()),
+    /// eth_chainId
+    #[serde(rename = "eth_chainId", with = "crate::serde::empty_params")]
+    ChainId(()),
+    /// eth_getBalance
+    #[serde(rename = "eth_getBalance")]
+    GetBalance(
+        Address,
+        #[serde(
+            skip_serializing_if = "Option::is_none",
+            default = "optional_block_spec::latest"
+        )]
+        Option<BlockSpec>,
+    ),
+    /// eth_getBlockByNumber
+    #[serde(rename = "eth_getBlockByNumber")]
+    GetBlockByNumber(
+        PreEip1898BlockSpec,
+        /// include transaction data
+        bool,
+    ),
+    /// eth_getBlockByHash
+    #[serde(rename = "eth_getBlockByHash")]
+    GetBlockByHash(
+        /// hash
+        B256,
+        /// include transaction data
+        bool,
+    ),
+    /// eth_getCode
+    #[serde(rename = "eth_getCode")]
+    GetCode(
+        Address,
+        #[serde(
+            skip_serializing_if = "Option::is_none",
+            default = "optional_block_spec::latest"
+        )]
+        Option<BlockSpec>,
+    ),
+    /// eth_getLogs
+    #[serde(rename = "eth_getLogs", with = "crate::serde::sequence")]
+    GetLogs(GetLogsInput),
+    /// eth_getStorageAt
+    #[serde(rename = "eth_getStorageAt")]
+    GetStorageAt(
+        Address,
+        /// position
+        U256,
+        #[serde(
+            skip_serializing_if = "Option::is_none",
+            default = "optional_block_spec::latest"
+        )]
+        Option<BlockSpec>,
+    ),
+    /// eth_getTransactionByHash
+    #[serde(rename = "eth_getTransactionByHash", with = "crate::serde::sequence")]
+    GetTransactionByHash(B256),
+    /// eth_getTransactionCount
+    #[serde(rename = "eth_getTransactionCount")]
+    GetTransactionCount(
+        Address,
+        #[serde(
+            skip_serializing_if = "Option::is_none",
+            default = "optional_block_spec::latest"
+        )]
+        Option<BlockSpec>,
+    ),
+    /// eth_getTransactionReceipt
+    #[serde(rename = "eth_getTransactionReceipt", with = "crate::serde::sequence")]
+    GetTransactionReceipt(B256),
+    /// net_version
+    #[serde(rename = "net_version", with = "crate::serde::empty_params")]
+    NetVersion(()),
+}

--- a/crates/edr_eth/tests/integration_tests.rs
+++ b/crates/edr_eth/tests/integration_tests.rs
@@ -1,10 +1,10 @@
 use edr_eth::{
     remote::{
-        eth::eip712,
+        eth::{eip712, CallRequest, GetLogsInput},
         filter::{
             FilterBlockTarget, FilterOptions, LogOutput, OneOrMoreAddresses, SubscriptionType,
         },
-        methods::{CallRequest, GetLogsInput, MethodInvocation, OneUsizeOrTwo, U64OrUsize},
+        methods::{MethodInvocation, OneUsizeOrTwo, U64OrUsize},
         BlockSpec, BlockTag, PreEip1898BlockSpec,
     },
     transaction::EthTransactionRequest,

--- a/crates/edr_provider/src/requests/eth/call.rs
+++ b/crates/edr_provider/src/requests/eth/call.rs
@@ -1,5 +1,5 @@
 use edr_eth::{
-    remote::{methods::CallRequest, BlockSpec, StateOverrideOptions},
+    remote::{eth::CallRequest, BlockSpec, StateOverrideOptions},
     serde::ZeroXPrefixedBytes,
     transaction::{Eip1559TransactionRequest, Eip155TransactionRequest, TransactionRequest},
     Bytes, SpecId, U256,

--- a/crates/edr_provider/src/requests/validation.rs
+++ b/crates/edr_provider/src/requests/validation.rs
@@ -1,5 +1,5 @@
 use edr_eth::{
-    access_list::AccessListItem, remote::methods::CallRequest, transaction::EthTransactionRequest,
+    access_list::AccessListItem, remote::eth::CallRequest, transaction::EthTransactionRequest,
     SpecId, U256,
 };
 


### PR DESCRIPTION
Add client request type as the first step towards https://github.com/NomicFoundation/edr/issues/256

I ended up naming the client request type `RequestMethod` instead of the discussed `Request`, as the latter conflicts with the name of the struct that represents a JSON-RPC request (version + method + id) in the client.