### PR TITLE
Fix compilation error with latest @types/node

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-errors.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/solidity-errors.ts
@@ -391,7 +391,7 @@ class SolidityCallSite implements NodeJS.CallSite {
   }
 
   public getScriptNameOrSourceURL() {
-    return null;
+    return "";
   }
 
   public getThis() {
@@ -424,5 +424,21 @@ class SolidityCallSite implements NodeJS.CallSite {
 
   public isToplevel() {
     return false;
+  }
+
+  public getScriptHash(): string {
+    return "";
+  }
+
+  public getEnclosingColumnNumber(): number {
+    return 0;
+  }
+
+  public getEnclosingLineNumber(): number {
+    return 0;
+  }
+
+  public toString(): string {
+    return "[SolidityCallSite]";
   }
 }


### PR DESCRIPTION
Adapt the `SolidityCallSite` class to properly implement the latest version of `NodeJS.CallSite`.

Notice that there are three different changes here:
- A change in the return value of `getScriptNameOrSourceURL`. This function wasn't even present in the type definition of `@types/node@16` so I'm not sure why it was there. Maybe it was removed and re-added with a different return type? Anyway, I think we can assume no one was using it.
- New methods (`getScriptHash`, `getEnclosingColumnNumber` and `getEnclosingLineNumber`). If some consumer was calling those methods, then that would've resulted in an error, so we can assume that they were not being used. (You could argue that maybe someone was checking if they existed, but that's a long shot, especially for such an internal object.)
- An implementation of `.toString`. The default result for a class that doesn't implement it is `[object Object]`, so I think this is also safe enough.