### PR TITLE
Allow for input instead of data in eth_call and eth_sendTransaction

### DIFF
--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/input/callRequest.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/input/callRequest.ts
@@ -20,6 +20,7 @@ export const rpcCallRequest = t.type(
     gasPrice: optionalOrNullable(rpcQuantity),
     value: optionalOrNullable(rpcQuantity),
     data: optionalOrNullable(rpcData),
+    input: optionalOrNullable(rpcData),
     accessList: optionalOrNullable(rpcAccessList),
     maxFeePerGas: optionalOrNullable(rpcQuantity),
     maxPriorityFeePerGas: optionalOrNullable(rpcQuantity),

--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/input/transactionRequest.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/input/transactionRequest.ts
@@ -14,6 +14,7 @@ export const rpcTransactionRequest = t.type(
     value: optionalOrNullable(rpcQuantity),
     nonce: optionalOrNullable(rpcQuantity),
     data: optionalOrNullable(rpcData),
+    input: optionalOrNullable(rpcData),
     accessList: optionalOrNullable(rpcAccessList),
     chainId: optionalOrNullable(rpcQuantity),
     maxFeePerGas: optionalOrNullable(rpcQuantity),

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/base.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/base.ts
@@ -88,13 +88,22 @@ export class Base {
   public async rpcCallRequestToNodeCallParams(
     rpcCall: RpcCallRequest
   ): Promise<CallParams> {
+    let data: Buffer;
+    if (rpcCall.input !== undefined) {
+      data = rpcCall.input;
+    } else if (rpcCall.data !== undefined) {
+      data = rpcCall.data;
+    } else {
+      data = toBuffer([]);
+    }
+
     return {
       to: rpcCall.to,
       from:
         rpcCall.from !== undefined
           ? rpcCall.from
           : await this._getDefaultCallFrom(),
-      data: rpcCall.data !== undefined ? rpcCall.data : toBuffer([]),
+      data,
       gasLimit:
         rpcCall.gas !== undefined ? rpcCall.gas : this._node.getBlockGasLimit(),
       value: rpcCall.value !== undefined ? rpcCall.value : 0n,

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/modules/eth.ts
@@ -1260,13 +1260,20 @@ export class EthModule extends Base {
   private async _rpcTransactionRequestToNodeTransactionParams(
     rpcTx: RpcTransactionRequest
   ): Promise<TransactionParams> {
+    let data: Buffer = toBuffer([]);
+    if (rpcTx.input !== undefined) {
+      data = rpcTx.input;
+    } else if (rpcTx.data !== undefined) {
+      data = rpcTx.data;
+    }
+
     const baseParams = {
       to: rpcTx.to,
       from: rpcTx.from,
       gasLimit:
         rpcTx.gas !== undefined ? rpcTx.gas : this._node.getBlockGasLimit(),
       value: rpcTx.value !== undefined ? rpcTx.value : 0n,
-      data: rpcTx.data !== undefined ? rpcTx.data : toBuffer([]),
+      data,
       nonce:
         rpcTx.nonce !== undefined
           ? rpcTx.nonce

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/node-types.ts
@@ -89,7 +89,8 @@ interface BaseTransactionParams {
   from: Buffer;
   gasLimit: bigint;
   value: bigint;
-  data: Buffer;
+  data?: Buffer;
+  input?: Buffer;
   nonce: bigint;
 }
 

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/assertions.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/assertions.ts
@@ -220,7 +220,11 @@ function assertTransaction(
   assert.equal(tx.from, bufferToHex(txParams.from));
   assertQuantity(tx.gas, txParams.gasLimit);
   assert.equal(tx.hash, txHash);
-  assert.equal(tx.input, bufferToHex(txParams.data));
+  assert.isTrue(txParams.data !== undefined || txParams.input !== undefined);
+  assert.equal(
+    tx.input,
+    bufferToHex(txParams.data !== undefined ? txParams.data : txParams.input!)
+  );
   assertQuantity(tx.nonce, txParams.nonce);
   assert.equal(
     tx.to,

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/transactions.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/transactions.ts
@@ -62,9 +62,16 @@ export async function sendTransactionFromTxParams(
   provider: EthereumProvider,
   txParams: TransactionParams
 ) {
+  let data: Buffer = toBuffer([]);
+  if (txParams.input !== undefined) {
+    data = txParams.input;
+  } else if (txParams.data !== undefined) {
+    data = txParams.data;
+  }
+
   const rpcTxParams: RpcTransactionRequestInput = {
     from: bufferToHex(txParams.from),
-    data: bufferToHex(txParams.data),
+    data: bufferToHex(data),
     nonce: numberToRpcQuantity(txParams.nonce),
     value: numberToRpcQuantity(txParams.value),
     gas: numberToRpcQuantity(txParams.gasLimit),

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/call.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/call.ts
@@ -91,6 +91,39 @@ describe("Eth module", function () {
             );
           });
 
+          it("Should accept an input param instead of a data param", async function () {
+            const contractAddress = await deployContract(
+              this.provider,
+              `0x${EXAMPLE_CONTRACT.bytecode.object}`
+            );
+
+            const result = await this.provider.send("eth_call", [
+              { to: contractAddress, input: EXAMPLE_CONTRACT.selectors.i },
+            ]);
+
+            assert.equal(
+              result,
+              "0x0000000000000000000000000000000000000000000000000000000000000000"
+            );
+
+            await this.provider.send("eth_sendTransaction", [
+              {
+                to: contractAddress,
+                from: DEFAULT_ACCOUNTS_ADDRESSES[0],
+                input: `${EXAMPLE_CONTRACT.selectors.modifiesState}000000000000000000000000000000000000000000000000000000000000000a`,
+              },
+            ]);
+
+            const result2 = await this.provider.send("eth_call", [
+              { to: contractAddress, input: EXAMPLE_CONTRACT.selectors.i },
+            ]);
+
+            assert.equal(
+              result2,
+              "0x000000000000000000000000000000000000000000000000000000000000000a"
+            );
+          });
+
           it("Should return the value returned by the contract using an unknown account as from", async function () {
             const from = "0x1234567890123456789012345678901234567890";
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByHash.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByHash.ts
@@ -165,7 +165,7 @@ describe("Eth module", function () {
             this.provider,
             {
               from: bufferToHex(txParams.from),
-              data: bufferToHex(txParams.data),
+              data: bufferToHex(txParams.data!),
               nonce: numberToRpcQuantity(txParams.nonce),
               value: numberToRpcQuantity(txParams.value),
               gas: numberToRpcQuantity(txParams.gasLimit),

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionReceipt.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionReceipt.ts
@@ -194,7 +194,7 @@ describe("Eth module", function () {
             this.provider,
             {
               from: bufferToHex(txParams.from),
-              data: bufferToHex(txParams.data),
+              data: bufferToHex(txParams.data!),
               nonce: numberToRpcQuantity(txParams.nonce),
               value: numberToRpcQuantity(txParams.value),
               gas: numberToRpcQuantity(txParams.gasLimit),


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

A hardhat node only accepts a `data` param in inbound `eth_call` and `eth_sendTransaction`. This behavior is not according to [spec defined here](https://ethereum.github.io/execution-apis/api-documentation/), so I'd file it as a bug.
Most RPCs I've tested so far support both `input` and `data`.

This behavior creates a problem when one tries to use a hardhat node together with go-ethereum, because the latter sends data as `input`.

This PR adds support for an `input` param while retaining support for the `data` param. If both `input` and `data` are provided `input` takes precedence, because it's aligned with the spec.