### PR TITLE
feat: add `eth_estimateGas` support

### DIFF
--- a/crates/edr_evm/src/transaction/pending.rs
+++ b/crates/edr_evm/src/transaction/pending.rs
@@ -50,7 +50,7 @@ impl PendingTransaction {
             return Err(TransactionCreationError::ContractMissingData);
         }
 
-        let initial_cost = Self::initial_cost(spec_id, &transaction);
+        let initial_cost = initial_cost(spec_id, &transaction);
         if transaction.gas_limit() < initial_cost {
             return Err(TransactionCreationError::InsufficientGas {
                 initial_gas_cost: U256::from(initial_cost),
@@ -69,6 +69,11 @@ impl PendingTransaction {
         &self.caller
     }
 
+    /// The minimum gas required to include the transaction in a block.
+    pub fn initial_cost(&self, spec_id: SpecId) -> u64 {
+        initial_cost(spec_id, &self.transaction)
+    }
+
     /// Returns the inner [`SignedTransaction`]
     pub fn transaction(&self) -> &SignedTransaction {
         &self.transaction
@@ -77,81 +82,6 @@ impl PendingTransaction {
     /// Returns the inner transaction and caller
     pub fn into_inner(self) -> (SignedTransaction, Address) {
         (self.transaction, self.caller)
-    }
-
-    fn initial_cost(spec_id: SpecId, transaction: &SignedTransaction) -> u64 {
-        let access_list: Option<Vec<(Address, Vec<U256>)>> =
-            transaction.access_list().cloned().map(Into::into);
-
-        match spec_id {
-            SpecId::FRONTIER | SpecId::FRONTIER_THAWING => initial_tx_gas::<FrontierSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::HOMESTEAD | SpecId::DAO_FORK => initial_tx_gas::<HomesteadSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::TANGERINE => initial_tx_gas::<TangerineSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::SPURIOUS_DRAGON => initial_tx_gas::<SpuriousDragonSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::BYZANTIUM => initial_tx_gas::<ByzantiumSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::PETERSBURG | SpecId::CONSTANTINOPLE => initial_tx_gas::<PetersburgSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::ISTANBUL | SpecId::MUIR_GLACIER => initial_tx_gas::<IstanbulSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::BERLIN => initial_tx_gas::<BerlinSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::LONDON | SpecId::ARROW_GLACIER | SpecId::GRAY_GLACIER => {
-                initial_tx_gas::<LondonSpec>(
-                    transaction.data(),
-                    transaction.kind() == TransactionKind::Create,
-                    access_list.as_ref().map_or(&[], |access_list| access_list),
-                )
-            }
-            SpecId::MERGE => initial_tx_gas::<MergeSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::SHANGHAI => initial_tx_gas::<ShanghaiSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::CANCUN => initial_tx_gas::<LatestSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-            SpecId::LATEST => initial_tx_gas::<LatestSpec>(
-                transaction.data(),
-                transaction.kind() == TransactionKind::Create,
-                access_list.as_ref().map_or(&[], |access_list| access_list),
-            ),
-        }
     }
 }
 
@@ -279,5 +209,80 @@ impl From<PendingTransaction> for TxEnv {
                 max_fee_per_blob_gas: Some(max_fee_per_blob_gas),
             },
         }
+    }
+}
+
+fn initial_cost(spec_id: SpecId, transaction: &SignedTransaction) -> u64 {
+    let access_list: Option<Vec<(Address, Vec<U256>)>> =
+        transaction.access_list().cloned().map(Into::into);
+
+    match spec_id {
+        SpecId::FRONTIER | SpecId::FRONTIER_THAWING => initial_tx_gas::<FrontierSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::HOMESTEAD | SpecId::DAO_FORK => initial_tx_gas::<HomesteadSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::TANGERINE => initial_tx_gas::<TangerineSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::SPURIOUS_DRAGON => initial_tx_gas::<SpuriousDragonSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::BYZANTIUM => initial_tx_gas::<ByzantiumSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::PETERSBURG | SpecId::CONSTANTINOPLE => initial_tx_gas::<PetersburgSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::ISTANBUL | SpecId::MUIR_GLACIER => initial_tx_gas::<IstanbulSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::BERLIN => initial_tx_gas::<BerlinSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::LONDON | SpecId::ARROW_GLACIER | SpecId::GRAY_GLACIER => {
+            initial_tx_gas::<LondonSpec>(
+                transaction.data(),
+                transaction.kind() == TransactionKind::Create,
+                access_list.as_ref().map_or(&[], |access_list| access_list),
+            )
+        }
+        SpecId::MERGE => initial_tx_gas::<MergeSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::SHANGHAI => initial_tx_gas::<ShanghaiSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::CANCUN => initial_tx_gas::<LatestSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
+        SpecId::LATEST => initial_tx_gas::<LatestSpec>(
+            transaction.data(),
+            transaction.kind() == TransactionKind::Create,
+            access_list.as_ref().map_or(&[], |access_list| access_list),
+        ),
     }
 }

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -1,4 +1,6 @@
 mod account;
+mod call;
+mod gas;
 mod inspector;
 
 use std::{
@@ -10,7 +12,6 @@ use std::{
 };
 
 use edr_eth::{
-    block::BlobGas,
     log::FilterLog,
     receipt::BlockReceipt,
     remote::{
@@ -28,15 +29,14 @@ use edr_evm::{
     },
     calculate_next_base_fee,
     db::StateRef,
-    guaranteed_dry_run, mempool, mine_block,
+    mempool, mine_block,
     state::{
         AccountModifierFn, IrregularState, StateDiff, StateError, StateOverride, StateOverrides,
         SyncState,
     },
-    Account, AccountInfo, BlobExcessGasAndPrice, Block, BlockEnv, Bytecode, CfgEnv,
-    ExecutionResult, HashMap, HashSet, MemPool, MineBlockResult, MineBlockResultAndState,
-    MineOrdering, OrderedTransaction, PendingTransaction, RandomHashGenerator, StorageSlot,
-    SyncBlock, KECCAK_EMPTY,
+    Account, AccountInfo, Block, Bytecode, CfgEnv, ExecutionResult, HashMap, HashSet, MemPool,
+    MineBlockResult, MineBlockResultAndState, MineOrdering, OrderedTransaction, PendingTransaction,
+    RandomHashGenerator, StorageSlot, SyncBlock, TxEnv, KECCAK_EMPTY,
 };
 use indexmap::IndexMap;
 use inspector::EvmInspector;
@@ -46,6 +46,10 @@ use tokio::runtime;
 
 use self::account::{create_accounts, InitialAccounts};
 use crate::{
+    data::{
+        call::RunCallArgs,
+        gas::{BinarySearchEstimationArgs, CheckGasLimitArgs},
+    },
     error::TransactionFailure,
     filter::{bloom_contains_log_filter, filter_logs, Filter, FilterData, LogFilter},
     logger::Logger,
@@ -415,6 +419,79 @@ impl ProviderData {
 
     pub fn coinbase(&self) -> Address {
         self.beneficiary
+    }
+
+    /// Estimate the gas cost of a transaction. Matches Hardhat behavior.
+    pub fn estimate_gas(
+        &self,
+        transaction: PendingTransaction,
+        block_spec: &BlockSpec,
+    ) -> Result<u64, ProviderError> {
+        let cfg_env = self.create_evm_config(Some(block_spec))?;
+        // Minimum gas cost that is required for transaction to be included in
+        // a block
+        let minimum_cost = transaction.initial_cost(self.spec_id());
+        let transaction_hash = *transaction.hash();
+        let tx_env: TxEnv = transaction.into();
+
+        let state_overrides = StateOverrides::default();
+
+        self.execute_in_block_context(Some(block_spec), |blockchain, block, state| {
+            let header = block.header();
+
+            // Measure the gas used by the transaction with optional limit from call request
+            // defaulting to block limit. Report errors from initial call as if from
+            // `eth_call`.
+            let (mut initial_estimation, _) = call::run_call_and_handle_errors(
+                RunCallArgs {
+                    blockchain,
+                    header,
+                    state: &state,
+                    state_overrides: &state_overrides,
+                    cfg_env: cfg_env.clone(),
+                    tx_env: tx_env.clone(),
+                    inspector: None,
+                },
+                &transaction_hash,
+            )?;
+
+            // Ensure that the initial estimation is at least the minimum cost + 1.
+            if initial_estimation <= minimum_cost {
+                initial_estimation = minimum_cost + 1;
+            }
+
+            // Test if the transaction would be successful with the initial estimation
+            let result = gas::check_gas_limit(CheckGasLimitArgs {
+                blockchain,
+                header,
+                state: &state,
+                state_overrides: &state_overrides,
+                cfg_env: cfg_env.clone(),
+                tx_env: tx_env.clone(),
+                transaction_hash: &transaction_hash,
+                gas_limit: initial_estimation,
+            })?;
+
+            // Return the initial estimation if it was successful
+            if result {
+                return Ok(initial_estimation);
+            }
+
+            // Correct the initial estimation if the transaction failed with the actually
+            // used gas limit. This can happen if the execution logic is based
+            // on the available gas.
+            gas::binary_search_estimation(BinarySearchEstimationArgs {
+                blockchain,
+                header,
+                state: &state,
+                state_overrides: &state_overrides,
+                cfg_env: cfg_env.clone(),
+                tx_env: tx_env.clone(),
+                transaction_hash: &transaction_hash,
+                lower_bound: initial_estimation,
+                upper_bound: header.gas_limit,
+            })
+        })?
     }
 
     pub fn gas_price(&self) -> Result<U256, ProviderError> {
@@ -876,52 +953,27 @@ impl ProviderData {
         block_spec: Option<&BlockSpec>,
         state_overrides: &StateOverrides,
     ) -> Result<Bytes, ProviderError> {
-        let cfg = self.create_evm_config(block_spec)?;
+        let cfg_env = self.create_evm_config(block_spec)?;
         let transaction_hash = *transaction.hash();
-        let transaction = transaction.into();
+        let tx_env = transaction.into();
 
         self.execute_in_block_context(block_spec, |blockchain, block, state| {
-            let header = block.header();
-            let block = BlockEnv {
-                number: U256::from(header.number),
-                coinbase: header.beneficiary,
-                timestamp: U256::from(header.timestamp),
-                gas_limit: U256::from(header.gas_limit),
-                basefee: U256::from(0),
-                difficulty: header.difficulty,
-                prevrandao: if cfg.spec_id >= SpecId::MERGE {
-                    Some(header.mix_hash)
-                } else {
-                    None
-                },
-                blob_excess_gas_and_price: header
-                    .blob_gas
-                    .as_ref()
-                    .map(|BlobGas { excess_gas, .. }| BlobExcessGasAndPrice::new(*excess_gas)),
-            };
-
             let mut inspector = self.evm_inspector();
 
-            let result = guaranteed_dry_run(
-                blockchain,
-                &state,
-                state_overrides,
-                cfg,
-                transaction,
-                block,
-                Some(&mut inspector),
-            )
-            .map_err(ProviderError::RunTransaction)?;
+            let (_, output) = call::run_call_and_handle_errors(
+                RunCallArgs {
+                    blockchain,
+                    header: block.header(),
+                    state: &state,
+                    state_overrides,
+                    cfg_env,
+                    tx_env,
+                    inspector: Some(&mut inspector),
+                },
+                &transaction_hash,
+            )?;
 
-            match result.result {
-                ExecutionResult::Success { output, .. } => Ok(output.into_data()),
-                ExecutionResult::Revert { output, .. } => {
-                    Err(TransactionFailure::revert(output, transaction_hash).into())
-                }
-                ExecutionResult::Halt { reason, .. } => {
-                    Err(TransactionFailure::halt(reason, transaction_hash).into())
-                }
-            }
+            Ok(output)
         })?
     }
 

--- a/crates/edr_provider/src/data/call.rs
+++ b/crates/edr_provider/src/data/call.rs
@@ -1,0 +1,84 @@
+use edr_eth::{
+    block::{BlobGas, Header},
+    Bytes, SpecId, B256, U256,
+};
+use edr_evm::{
+    blockchain::{BlockchainError, SyncBlockchain},
+    guaranteed_dry_run,
+    state::{StateError, StateOverrides, SyncState},
+    BlobExcessGasAndPrice, BlockEnv, CfgEnv, ExecutionResult, ResultAndState, SyncInspector, TxEnv,
+};
+
+use crate::{error::TransactionFailure, ProviderError};
+
+pub(super) struct RunCallArgs<'a> {
+    pub blockchain: &'a dyn SyncBlockchain<BlockchainError, StateError>,
+    pub header: &'a Header,
+    pub state: &'a dyn SyncState<StateError>,
+    pub state_overrides: &'a StateOverrides,
+    pub cfg_env: CfgEnv,
+    pub tx_env: TxEnv,
+    pub inspector: Option<&'a mut dyn SyncInspector<BlockchainError, StateError>>,
+}
+
+/// Execute a transaction as a call. Returns the gas used and the output.
+pub(super) fn run_call(args: RunCallArgs<'_>) -> Result<ResultAndState, ProviderError> {
+    let RunCallArgs {
+        blockchain,
+        header,
+        state,
+        state_overrides,
+        cfg_env,
+        tx_env,
+        inspector,
+    } = args;
+
+    let block = BlockEnv {
+        number: U256::from(header.number),
+        coinbase: header.beneficiary,
+        timestamp: U256::from(header.timestamp),
+        gas_limit: U256::from(header.gas_limit),
+        basefee: U256::ZERO,
+        difficulty: header.difficulty,
+        prevrandao: if cfg_env.spec_id >= SpecId::MERGE {
+            Some(header.mix_hash)
+        } else {
+            None
+        },
+        blob_excess_gas_and_price: header
+            .blob_gas
+            .as_ref()
+            .map(|BlobGas { excess_gas, .. }| BlobExcessGasAndPrice::new(*excess_gas)),
+    };
+
+    guaranteed_dry_run(
+        blockchain,
+        state,
+        state_overrides,
+        cfg_env,
+        tx_env,
+        block,
+        inspector,
+    )
+    .map_err(ProviderError::RunTransaction)
+}
+
+/// Execute a transaction as a call. Returns the gas used and the output.
+pub(super) fn run_call_and_handle_errors(
+    run_call_args: RunCallArgs<'_>,
+    transaction_hash: &B256,
+) -> Result<(u64, Bytes), ProviderError> {
+    let result = run_call(run_call_args)?;
+
+    match result.result {
+        ExecutionResult::Success {
+            gas_used, output, ..
+        } => Ok((gas_used, output.into_data())),
+        ExecutionResult::Revert { output, .. } => {
+            Err(TransactionFailure::revert(output, *transaction_hash).into())
+        }
+        ExecutionResult::Halt { reason, .. } => {
+            Err(TransactionFailure::halt(reason, *transaction_hash).into())
+        }
+    }
+}

--- a/crates/edr_provider/src/data/gas.rs
+++ b/crates/edr_provider/src/data/gas.rs
@@ -1,0 +1,146 @@
+use std::cmp;
+
+use edr_eth::{block::Header, B256};
+use edr_evm::{
+    blockchain::{BlockchainError, SyncBlockchain},
+    state::{StateError, StateOverrides, SyncState},
+    CfgEnv, ExecutionResult, Halt, ResultAndState, TxEnv,
+};
+
+use crate::{
+    data::{call, call::RunCallArgs},
+    error::TransactionFailure,
+    ProviderError,
+};
+
+pub(super) struct CheckGasLimitArgs<'a> {
+    pub blockchain: &'a dyn SyncBlockchain<BlockchainError, StateError>,
+    pub header: &'a Header,
+    pub state: &'a dyn SyncState<StateError>,
+    pub state_overrides: &'a StateOverrides,
+    pub cfg_env: CfgEnv,
+    pub tx_env: TxEnv,
+    pub transaction_hash: &'a B256,
+    pub gas_limit: u64,
+}
+
+/// Test if the transaction successfully executes with the given gas limit.
+/// Returns true on success and return false if the transaction runs out of gas
+/// or funds or reverts. Returns an error for any other halt reason.
+pub(super) fn check_gas_limit(args: CheckGasLimitArgs<'_>) -> Result<bool, ProviderError> {
+    let CheckGasLimitArgs {
+        blockchain,
+        header,
+        state,
+        state_overrides,
+        cfg_env,
+        mut tx_env,
+        transaction_hash,
+        gas_limit,
+    } = args;
+
+    tx_env.gas_limit = gas_limit;
+
+    let ResultAndState { result, .. } = call::run_call(RunCallArgs {
+        blockchain,
+        header,
+        state,
+        state_overrides,
+        cfg_env,
+        tx_env,
+        inspector: None,
+    })?;
+
+    match result {
+        ExecutionResult::Success { .. } => Ok(true),
+        ExecutionResult::Halt { reason, .. } => match reason {
+            Halt::OutOfFund | Halt::OutOfGas(_) => Ok(false),
+            _ => Err(TransactionFailure::halt(reason, *transaction_hash).into()),
+        },
+        ExecutionResult::Revert { .. } => Ok(false),
+    }
+}
+
+pub(super) struct BinarySearchEstimationArgs<'a> {
+    pub blockchain: &'a dyn SyncBlockchain<BlockchainError, StateError>,
+    pub header: &'a Header,
+    pub state: &'a dyn SyncState<StateError>,
+    pub state_overrides: &'a StateOverrides,
+    pub cfg_env: CfgEnv,
+    pub tx_env: TxEnv,
+    pub transaction_hash: &'a B256,
+    pub lower_bound: u64,
+    pub upper_bound: u64,
+}
+
+/// Search for a tight upper bound on the gas limit that will allow the
+/// transaction to execute. Matches Hardhat logic, except it's iterative, not
+/// recursive.
+pub(super) fn binary_search_estimation(
+    args: BinarySearchEstimationArgs<'_>,
+) -> Result<u64, ProviderError> {
+    const MAX_ITERATIONS: usize = 20;
+
+    let BinarySearchEstimationArgs {
+        blockchain,
+        header,
+        state,
+        state_overrides,
+        cfg_env,
+        tx_env,
+        transaction_hash,
+        mut lower_bound,
+        mut upper_bound,
+    } = args;
+
+    let mut i = 0;
+
+    while upper_bound - lower_bound > min_difference(lower_bound) && i < MAX_ITERATIONS {
+        let mut mid = lower_bound + (upper_bound - lower_bound) / 2;
+        if i == 0 {
+            // Start close to the lower bound as it's assumed to be derived from the gas
+            // used by the transaction.
+            let initial_mid = 3 * lower_bound;
+            mid = cmp::min(mid, initial_mid);
+        }
+
+        let success = check_gas_limit(CheckGasLimitArgs {
+            blockchain,
+            header,
+            state,
+            state_overrides,
+            cfg_env: cfg_env.clone(),
+            tx_env: tx_env.clone(),
+            transaction_hash,
+            gas_limit: mid,
+        })?;
+
+        if success {
+            upper_bound = mid;
+        } else {
+            lower_bound = mid + 1;
+        }
+
+        i += 1;
+    }
+
+    Ok(upper_bound)
+}
+
+// Matches Hardhat
+#[inline]
+fn min_difference(lower_bound: u64) -> u64 {
+    if lower_bound >= 4_000_000 {
+        50_000
+    } else if lower_bound >= 1_000_000 {
+        10_000
+    } else if lower_bound >= 100_000 {
+        1_000
+    } else if lower_bound >= 50_000 {
+        500
+    } else if lower_bound >= 30_000 {
+        300
+    } else {
+        200
+    }
+}

--- a/crates/edr_provider/src/requests/eth/call.rs
+++ b/crates/edr_provider/src/requests/eth/call.rs
@@ -25,7 +25,7 @@ pub fn handle_call_request(
     data.run_call(transaction, block_spec.as_ref(), &state_overrides)
 }
 
-fn resolve_call_request(
+pub(crate) fn resolve_call_request(
     data: &ProviderData,
     request: CallRequest,
     block_spec: Option<&BlockSpec>,

--- a/crates/edr_provider/src/requests/eth/gas.rs
+++ b/crates/edr_provider/src/requests/eth/gas.rs
@@ -2,10 +2,14 @@ use edr_eth::{
     remote::{eth::CallRequest, BlockSpec},
     SpecId, U256,
 };
+use edr_evm::state::StateOverrides;
 
 use crate::{
     data::ProviderData,
-    requests::validation::{validate_call_request, validate_post_merge_block_tags},
+    requests::{
+        eth::resolve_call_request,
+        validation::{validate_call_request, validate_post_merge_block_tags},
+    },
     ProviderError,
 };
 
@@ -16,9 +20,20 @@ pub fn handle_estimate_gas(
 ) -> Result<U256, ProviderError> {
     validate_call_request(data.spec_id(), &call_request, &block_spec)?;
 
-    // TODO implement logic
-    // https://github.com/NomicFoundation/edr/issues/227
-    Ok(U256::ZERO)
+    // Matching Hardhat behavior in defaulting to "pending" instead of "latest" for
+    // estimate gas.
+    let block_spec = block_spec.unwrap_or_else(BlockSpec::pending);
+
+    let transaction = resolve_call_request(
+        data,
+        call_request,
+        Some(&block_spec),
+        &StateOverrides::default(),
+    )?;
+
+    let gas_limit = data.estimate_gas(transaction, &block_spec)?;
+
+    Ok(U256::from(gas_limit))
 }
 
 pub fn handle_fee_history(

--- a/crates/edr_provider/src/requests/eth/gas.rs
+++ b/crates/edr_provider/src/requests/eth/gas.rs
@@ -1,6 +1,6 @@
 use edr_eth::{
     remote::{eth::CallRequest, BlockSpec},
-    SpecId, U256,
+    SpecId, U256, U64,
 };
 use edr_evm::state::StateOverrides;
 
@@ -17,7 +17,7 @@ pub fn handle_estimate_gas(
     data: &ProviderData,
     call_request: CallRequest,
     block_spec: Option<BlockSpec>,
-) -> Result<U256, ProviderError> {
+) -> Result<U64, ProviderError> {
     validate_call_request(data.spec_id(), &call_request, &block_spec)?;
 
     // Matching Hardhat behavior in defaulting to "pending" instead of "latest" for
@@ -33,7 +33,7 @@ pub fn handle_estimate_gas(
 
     let gas_limit = data.estimate_gas(transaction, &block_spec)?;
 
-    Ok(U256::from(gas_limit))
+    Ok(U64::from(gas_limit))
 }
 
 pub fn handle_fee_history(

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/estimateGas.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/estimateGas.ts
@@ -281,9 +281,13 @@ describe("Eth module", function () {
               });
 
               afterEach(function () {
-                if (spy) {
-                  spy.restore();
+                if (
+                  process.env.HARDHAT_EXPERIMENTAL_VM_MODE === "edr" ||
+                  process.env.HARDHAT_EXPERIMENTAL_VM_MODE === "dual"
+                ) {
+                  return;
                 }
+                spy.restore();
               });
 
               it("Should use a gasPrice if provided", async function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/estimateGas.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/estimateGas.ts
@@ -267,6 +267,13 @@ describe("Eth module", function () {
               let spy: SinonSpy;
 
               beforeEach(function () {
+                if (
+                  process.env.HARDHAT_EXPERIMENTAL_VM_MODE === "edr" ||
+                  process.env.HARDHAT_EXPERIMENTAL_VM_MODE === "dual"
+                ) {
+                  this.skip();
+                }
+
                 spy = sinon.spy(
                   HardhatNode.prototype as any,
                   "_runTxAndRevertMutations"
@@ -274,7 +281,9 @@ describe("Eth module", function () {
               });
 
               afterEach(function () {
-                spy.restore();
+                if (spy) {
+                  spy.restore();
+                }
               });
 
               it("Should use a gasPrice if provided", async function () {


### PR DESCRIPTION
Add `eth_estimateGas` support for EDR provider and enable relevant tests. 

Implementation matches Hardhat behavior, except for logging as that's blocked by https://github.com/NomicFoundation/edr/issues/129. 

Follow up issue: https://github.com/NomicFoundation/edr/issues/267