### PR TITLE
Assert .revertedWithCustomError and .emit only receives 2 arguments

### DIFF
--- a/.changeset/rare-boats-fetch.md
+++ b/.changeset/rare-boats-fetch.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-chai-matchers": patch
+---
+
+Improved how `.revertedWithCustomError` handles wrong number of arguments (thanks @RenanSouza2!)

--- a/packages/hardhat-chai-matchers/src/internal/emit.ts
+++ b/packages/hardhat-chai-matchers/src/internal/emit.ts
@@ -41,7 +41,12 @@ export function supportEmit(
 ) {
   Assertion.addMethod(
     EMIT_MATCHER,
-    function (this: any, contract: Contract, eventName: string) {
+    function (
+      this: any,
+      contract: Contract,
+      eventName: string,
+      ...args: any[]
+    ) {
       // capture negated flag before async code executes; see buildAssert's jsdoc
       const negated = this.__flags.negate;
       const tx = this._obj;
@@ -79,6 +84,13 @@ export function supportEmit(
             `The contract target should be a string`
           );
         }
+
+        if (args.length > 0) {
+          throw new Error(
+            "`.emit` expects only two arguments: the contract and the event name. Arguments should be asserted with the `.withArgs` helper."
+          );
+        }
+
         this.logs = receipt.logs
           .filter((log) => log.topics.includes(topic))
           .filter(

--- a/packages/hardhat-chai-matchers/src/internal/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/src/internal/reverted/revertedWithCustomError.ts
@@ -180,7 +180,7 @@ function validateInput(
 
     if (args.length > 0) {
       throw new Error(
-        ".revertedWithCustomError expcts only 2 arguments, the contract and the error name, arguments should be asserted in .withArgs"
+        "`.revertedWithCustomError` expects only two arguments: the contract and the error name. Arguments should be asserted with the `.withArgs` helper."
       );
     }
 

--- a/packages/hardhat-chai-matchers/src/internal/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/src/internal/reverted/revertedWithCustomError.ts
@@ -32,7 +32,8 @@ export function supportRevertedWithCustomError(
     function (
       this: any,
       contract: EthersT.BaseContract,
-      expectedCustomErrorName: string
+      expectedCustomErrorName: string,
+      ...args: any[]
     ) {
       // capture negated flag before async code executes; see buildAssert's jsdoc
       const negated = this.__flags.negate;
@@ -40,7 +41,8 @@ export function supportRevertedWithCustomError(
       const { iface, expectedCustomError } = validateInput(
         this._obj,
         contract,
-        expectedCustomErrorName
+        expectedCustomErrorName,
+        args
       );
 
       preventAsyncMatcherChaining(
@@ -148,7 +150,8 @@ export function supportRevertedWithCustomError(
 function validateInput(
   obj: any,
   contract: EthersT.BaseContract,
-  expectedCustomErrorName: string
+  expectedCustomErrorName: string,
+  args: any[]
 ): { iface: EthersT.Interface; expectedCustomError: EthersT.ErrorFragment } {
   try {
     // check the case where users forget to pass the contract as the first
@@ -172,6 +175,12 @@ function validateInput(
     if (expectedCustomError === null) {
       throw new Error(
         `The given contract doesn't have a custom error named '${expectedCustomErrorName}'`
+      );
+    }
+
+    if (args.length > 0) {
+      throw new Error(
+        ".revertedWithCustomError expcts only 2 arguments, the contract and the error name, arguments should be asserted in .withArgs"
       );
     }
 

--- a/packages/hardhat-chai-matchers/test/events.ts
+++ b/packages/hardhat-chai-matchers/test/events.ts
@@ -65,6 +65,16 @@ describe(".to.emit (contract events)", () => {
       );
     });
 
+    it("Should fail when matcher is called with too many arguments", async function () {
+      await expect(
+        // @ts-expect-error
+        expect(contract.emitUint(1)).not.to.emit(contract, "WithoutArgs", 1)
+      ).to.be.eventually.rejectedWith(
+        Error,
+        "`.emit` expects only two arguments: the contract and the event name. Arguments should be asserted with the `.withArgs` helper."
+      );
+    });
+
     it("Should detect events without arguments", async function () {
       await expect(contract.emitWithoutArgs()).to.emit(contract, "WithoutArgs");
     });

--- a/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
@@ -456,6 +456,18 @@ describe("INTEGRATION: Reverted with custom error", function () {
           "sender doesn't have enough funds to send tx"
         );
       });
+
+      it("extra arguments", async function () {
+        expect(() => {
+          const assertExtraArguments = expect(
+            matchers.revertWithSomeCustomError()
+          ).to.be.revertedWithCustomError as (...args: any[]) => any;
+          assertExtraArguments(matchers, "SomeCustomError", "extraArgument");
+        }).to.throw(
+          Error,
+          ".revertedWithCustomError expcts only 2 arguments, the contract and the error name, arguments should be asserted in .withArgs"
+        );
+      });
     });
 
     describe("stack traces", function () {

--- a/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
@@ -458,14 +458,18 @@ describe("INTEGRATION: Reverted with custom error", function () {
       });
 
       it("extra arguments", async function () {
-        expect(() => {
-          const assertExtraArguments = expect(
+        expect(() =>
+          expect(
             matchers.revertWithSomeCustomError()
-          ).to.be.revertedWithCustomError as (...args: any[]) => any;
-          assertExtraArguments(matchers, "SomeCustomError", "extraArgument");
-        }).to.throw(
+          ).to.be.revertedWithCustomError(
+            matchers,
+            "SomeCustomError",
+            // @ts-expect-error
+            "extraArgument"
+          )
+        ).to.throw(
           Error,
-          ".revertedWithCustomError expcts only 2 arguments, the contract and the error name, arguments should be asserted in .withArgs"
+          "`.revertedWithCustomError` expects only two arguments: the contract and the error name. Arguments should be asserted with the `.withArgs` helper."
         );
       });
     });


### PR DESCRIPTION
Resolves: #3603

- [X] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.


This PR asserts that .revertedWithCustomError only receives 2 arguments