### PR TITLE
added @dgma/hardhat-sol-bundler plugin

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -867,10 +867,9 @@ const communityPlugins: IPlugin[] = [
     name: "@dgma/hardhat-sol-bundler",
     author: "Dogma Labs",
     authorUrl: "https://github.com/dgma",
-    description:
-      "Build and deploy only changed smartcontracts",
+    description: "Build and deploy only changed smartcontracts",
     tags: ["deployment", "diff deployment", "ethers.js", "proxy"],
-  }
+  },
 ];
 
 const officialPlugins: IPlugin[] = [

--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -863,6 +863,14 @@ const communityPlugins: IPlugin[] = [
       "Display different signatures that have the methods, events and errors of your contracts by console",
     tags: ["functions", "errors", "events", "tooling", "selectorss"],
   },
+  {
+    name: "@dgma/hardhat-sol-bundler",
+    author: "Dogma Labs",
+    authorUrl: "https://github.com/dgma",
+    description:
+      "Build and deploy only changed smartcontracts",
+    tags: ["deployment", "diff deployment", "ethers.js", "proxy"],
+  }
 ];
 
 const officialPlugins: IPlugin[] = [


### PR DESCRIPTION
A new @dgma/hardhat-sol-bundler plugin has been added to the community plugins list. We use this plugin internally in Dogma Labs and would like to open-source it. 
