### PR TITLE
fix: change panics to errors in forked blockchain

### DIFF
--- a/crates/edr_evm/src/block.rs
+++ b/crates/edr_evm/src/block.rs
@@ -13,7 +13,7 @@ use edr_eth::{
 pub use self::{
     builder::{BlockBuilder, BlockBuilderCreationError, BlockTransactionError, BuildBlockResult},
     local::LocalBlock,
-    remote::RemoteBlock,
+    remote::{CreationError as RemoteBlockCreationError, RemoteBlock},
 };
 
 /// Trait for implementations of an Ethereum block.


### PR DESCRIPTION
I went over `expect`s in the forked blockchain implementation to change panics to errors to avoid panicking if the remote responds with unexpected data. 

I introduced a new `ForkedBlockchainError` error type as I didn't want to add errors that can only occur for a forked blockchain to the `BlockchainError` type. I also moved errors from `BlockchainError` that can only occur for a forked blockchain to `ForkedBlockchainError`.