### PR TITLE
Fixing hardhat-foundry combined setup page

### DIFF
--- a/docs/src/content/hardhat-runner/docs/advanced/hardhat-and-foundry.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/hardhat-and-foundry.md
@@ -78,14 +78,14 @@ If you have an existing Foundry project and you want to use Hardhat in it, follo
 
 First, if you don't have a `package.json` already in your project, create one with `npm init`.
 
-Then install Hardhat and the [`@nomicfoundation/hardhat-foundry`](/hardhat-runner/plugins/nomicfoundation-hardhat-foundry) plugin:
+Then install Hardhat and the [`@nomicfoundation/hardhat-foundry`](/hardhat-runner/plugins/nomicfoundation-hardhat-foundry) and [`@nomicfoundation/hardhat-toolbox`](/hardhat-runner/plugins/nomicfoundation-hardhat-toolbox) plugins:
 
 ::::tabsgroup{options="npm 7+,npm 6,yarn"}
 
 :::tab{value="npm 7+"}
 
 ```
-npm install --save-dev hardhat @nomicfoundation/hardhat-foundry
+npm install --save-dev @nomicfoundation/hardhat-foundry @nomicfoundation/hardhat-toolbox
 ```
 
 :::
@@ -93,7 +93,7 @@ npm install --save-dev hardhat @nomicfoundation/hardhat-foundry
 :::tab{value="npm 6"}
 
 ```
-npm install --save-dev hardhat @nomicfoundation/hardhat-foundry
+npm install --save-dev @nomicfoundation/hardhat-foundry @nomicfoundation/hardhat-toolbox
 ```
 
 :::
@@ -101,7 +101,7 @@ npm install --save-dev hardhat @nomicfoundation/hardhat-foundry
 :::tab{value=yarn}
 
 ```
-yarn add --dev hardhat @nomicfoundation/hardhat-foundry
+yarn add --dev hardhat @nomicfoundation/hardhat-foundry @nomicfoundation/hardhat-toolbox
 ```
 
 :::
@@ -111,6 +111,7 @@ yarn add --dev hardhat @nomicfoundation/hardhat-foundry
 After that, initialize a Hardhat project with `npx hardhat init`. Choose the "Create an empty hardhat.config.js" option, and then import the plugin in `hardhat.config.js`:
 
 ```javascript
+require("@nomicfoundation/hardhat-toolbox");
 require("@nomicfoundation/hardhat-foundry");
 ```
 


### PR DESCRIPTION
Hey @fvictorio apologies for being so delayed, but I am pushing a PR to fix an error at the docs as acknowledged in issue #4606 .

I came across this issue while writing this article for the official foundry book, which is now merged:
https://book.getfoundry.sh/config/hardhat

The second section of the article inside Hardhat's docs should now work out of the box.
