### PR TITLE
Fix hardhat-ledger to work with hardhat console

### DIFF
--- a/.changeset/poor-nails-walk.md
+++ b/.changeset/poor-nails-walk.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ledger": patch
+---
+
+Fixed a problem that made `hardhat-ledger` unusable in the Hardhat console (thanks @area!).

--- a/packages/hardhat-ledger/src/internal/with-spinners.ts
+++ b/packages/hardhat-ledger/src/internal/with-spinners.ts
@@ -33,7 +33,7 @@ function attachSpinner(
   }
 ): ora.Ora {
   const { startText, eventPrefix } = spinnerOptions;
-  const spinner = ora(startText);
+  const spinner = ora({ text: startText, discardStdin: false });
 
   emmiter.on(`${eventPrefix}_start`, () => spinner.start());
   emmiter.on(`${eventPrefix}_success`, () => spinner.succeed());


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

I am attempting to use `npx hardhat console` in conjunction with `hardhat-ledger`. When doing so, after sending any transaction, `hardhat console` exits. This behaviour is related, either unintentionally or not, to the [default value of `discardStdin`](https://github.com/sindresorhus/ora/issues/220). This PR changes the value used.

There is a slight behavioral change in the console, which is that, as you might expect, keyboard input while the spinner is running is not discarded. This feels more acceptable than exiting after every transaction.

It does not seem to me that additional tests are required here, but open to guidance on that front.
