### PR TITLE
fix: Stack Trace Source Maps - corrected typo in indexing

### DIFF
--- a/.changeset/happy-mails-impress.md
+++ b/.changeset/happy-mails-impress.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix an issue that was present in the solidity source map decoding module.

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/source-maps.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/source-maps.ts
@@ -76,12 +76,11 @@ function uncompressSourcemaps(compressedSourcemap: string): SourceMap[] {
 function addUnmappedInstructions(
   instructions: Instruction[],
   bytecode: Buffer,
-  bytesIndex: number
 ) {
   const lastInstrPc = instructions[instructions.length - 1].pc;
-  let nextPc = lastInstrPc + 1;
+  let bytesIndex = lastInstrPc + 1;
 
-  while (bytecode[nextPc] !== Opcode.INVALID) {
+  while (bytecode[bytesIndex] !== Opcode.INVALID) {
     const opcode = bytecode[nextPc];
     let pushData: Buffer | undefined;
 
@@ -95,10 +94,10 @@ function addUnmappedInstructions(
       ? JumpType.INTERNAL_JUMP
       : JumpType.NOT_JUMP;
 
-    const instruction = new Instruction(nextPc, opcode, jumpType, pushData);
+    const instruction = new Instruction(bytesIndex, opcode, jumpType, pushData);
     instructions.push(instruction);
 
-    nextPc += 1 + pushDataLenth;
+    bytesIndex += getOpcodeLength(opcode);
   }
 }
 
@@ -161,7 +160,7 @@ export function decodeInstructions(
 
   // See: https://github.com/ethereum/solidity/issues/9133
   if (isDeployment) {
-    addUnmappedInstructions(instructions, bytecode, bytesIndex);
+    addUnmappedInstructions(instructions, bytecode);
   }
 
   return instructions;

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/source-maps.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/source-maps.ts
@@ -75,13 +75,13 @@ function uncompressSourcemaps(compressedSourcemap: string): SourceMap[] {
 
 function addUnmappedInstructions(
   instructions: Instruction[],
-  bytecode: Buffer,
+  bytecode: Buffer
 ) {
   const lastInstrPc = instructions[instructions.length - 1].pc;
   let bytesIndex = lastInstrPc + 1;
 
   while (bytecode[bytesIndex] !== Opcode.INVALID) {
-    const opcode = bytecode[nextPc];
+    const opcode = bytecode[bytesIndex];
     let pushData: Buffer | undefined;
 
     let pushDataLenth = 0;


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.

---


If we compile the following function with solcx version: `'0.8.14'`
```solidity
pragma solidity ^0.8.14;

contract FunctionSelector {
    /*
    "transfer(address,uint256)"
    0xa9059cbb
    "transferFrom(address,address,uint256)"
    0x23b872dd
    */
    function getSelector(string calldata _func) external pure returns (bytes4) {
        return bytes4(keccak256(bytes(_func)));
    }
}
```

We will get the following:
- bytecode
  ```
  0x608060405234801561001057600080fd5b506004361061002b5760003560e01c806380a003ff14610030575b600080fd5b61004a600480360381019061004591906100f1565b610060565b6040516100579190610179565b60405180910390f35b600082826040516100729291906101d3565b6040518091039020905092915050565b600080fd5b600080fd5b600080fd5b600080fd5b600080fd5b60008083601f8401126100b1576100b061008c565b5b8235905067ffffffffffffffff8111156100ce576100cd610091565b5b6020830191508360018202830111156100ea576100e9610096565b5b9250929050565b6000806020838503121561010857610107610082565b5b600083013567ffffffffffffffff81111561012657610125610087565b5b6101328582860161009b565b92509250509250929050565b60007fffffffff0000000000000000000000000000000000000000000000000000000082169050919050565b6101738161013e565b82525050565b600060208201905061018e600083018461016a565b92915050565b600081905092915050565b82818337600083830152505050565b60006101ba8385610194565b93506101c783858461019f565b82840190509392505050565b60006101e08284866101ae565b9150819050939250505056fea2646970667358221220935c1bb5ffc254a6d918bcaa929aed4522afbd2b7e7754b231713d06ab223cb464736f6c634300080e0033
  ```
- compressed source-map
  ```
  '26:164:0:-:0;;;;;;;;;;;;;;;;;;;'
  ```
 - selector
  ```json
  {"getSelector": "0x80a003ff"}
  ``` 

We have a `PUSH4` at `pc=33` so at index `33+1: 33 + 1 + 4` we have the function descriptor `80a003ff`

Unfortunately because the `nextPc` was never iterated (possibly due to the deviation from naming conventions) it stays at the last instruction to have a valid sourcemap entry (`28`) meaning the `nextPc=29` throughout this function call.

This means that incorrectly the `PUSH4` data is assigned to the range `29 + 1: 29 + 1 + 4` giving `e01c8063`.