### PR TITLE
Fix cases where trace.step is empty

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/error-inferrer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/error-inferrer.ts
@@ -1000,7 +1000,7 @@ export class ErrorInferrer {
     }
 
     const lastStep = trace.steps[trace.steps.length - 1];
-    if (!isEvmStep(lastStep)) {
+    if (lastStep === undefined || !isEvmStep(lastStep)) {
       return false;
     }
 


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**,
  - [ ] relevant tests have been included.

---

[This unit test in the OpenZeppelin Contracts repository](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/test/utils/Create2.test.js#L112-L119) triggers an issue

```
  hardhat:core:hardhat-network:node Could not generate stack trace. Please report this to help us improve Hardhat.
  hardhat:core:hardhat-network:node  TypeError: Cannot use 'in' operator to search for 'pc' in undefined
    at isEvmStep (/home/amxx/Work/OZ/openzeppelin-contracts/node_modules/hardhat/src/internal/hardhat-network/stack-traces/message-trace.ts:88:14)
    at ErrorInferrer._isConstructorInvalidArgumentsError (/home/amxx/Work/OZ/openzeppelin-contracts/node_modules/hardhat/src/internal/hardhat-network/stack-traces/error-inferrer.ts:1003:19)
    at ErrorInferrer.inferBeforeTracingCreateMessage (/home/amxx/Work/OZ/openzeppelin-contracts/node_modules/hardhat/src/internal/hardhat-network/stack-traces/error-inferrer.ts:144:14)
    at SolidityTracer._getCreateMessageStackTrace (/home/amxx/Work/OZ/openzeppelin-contracts/node_modules/hardhat/src/internal/hardhat-network/stack-traces/solidityTracer.ts:136:27)
    at SolidityTracer.getStackTrace (/home/amxx/Work/OZ/openzeppelin-contracts/node_modules/hardhat/src/internal/hardhat-network/stack-traces/solidityTracer.ts:50:19)
    at SolidityTracer._rawTraceEvmExecution (/home/amxx/Work/OZ/openzeppelin-contracts/node_modules/hardhat/src/internal/hardhat-network/stack-traces/solidityTracer.ts:217:38)
    at SolidityTracer._traceEvmExecution (/home/amxx/Work/OZ/openzeppelin-contracts/node_modules/hardhat/src/internal/hardhat-network/stack-traces/solidityTracer.ts:159:29)
    at SolidityTracer._getCallMessageStackTrace (/home/amxx/Work/OZ/openzeppelin-contracts/node_modules/hardhat/src/internal/hardhat-network/stack-traces/solidityTracer.ts:70:17)
    at SolidityTracer.getStackTrace (/home/amxx/Work/OZ/openzeppelin-contracts/node_modules/hardhat/src/internal/hardhat-network/stack-traces/solidityTracer.ts:54:19)
    at HardhatNode._manageErrors (/home/amxx/Work/OZ/openzeppelin-contracts/node_modules/hardhat/src/internal/hardhat-network/provider/node.ts:1989:41) +0ms
```

The reason for this error is that `trace.steps` is empty, and thus 
```
const lastStep = trace.steps[trace.steps.length - 1];
```
is `undefined`
