### PR TITLE
Update hardhat-verify: add holesky & arbitrumSepolia, remove arbitrumTestnet & Goerli

### DIFF
--- a/.changeset/modern-clocks-leave.md
+++ b/.changeset/modern-clocks-leave.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Added holesky and arbitrumSepolia, and removed arbitrumTestnet and arbitrumGoerli from hardhat-verify chains.

--- a/packages/hardhat-verify/src/internal/chain-config.ts
+++ b/packages/hardhat-verify/src/internal/chain-config.ts
@@ -171,6 +171,14 @@ export const builtinChains: ChainConfig[] = [
     },
   },
   {
+    network: "holesky",
+    chainId: 17000,
+    urls: {
+      apiURL: "https://api-holesky.etherscan.io/api",
+      browserURL: "https://holesky.etherscan.io",
+    },
+  },
+  {
     network: "arbitrumOne",
     chainId: 42161,
     urls: {
@@ -211,19 +219,11 @@ export const builtinChains: ChainConfig[] = [
     },
   },
   {
-    network: "arbitrumTestnet",
-    chainId: 421611,
+    network: "arbitrumSepolia",
+    chainId: 421614,
     urls: {
-      apiURL: "https://api-testnet.arbiscan.io/api",
-      browserURL: "https://testnet.arbiscan.io/",
-    },
-  },
-  {
-    network: "arbitrumGoerli",
-    chainId: 421613,
-    urls: {
-      apiURL: "https://api-goerli.arbiscan.io/api",
-      browserURL: "https://goerli.arbiscan.io/",
+      apiURL: "https://api-sepolia.arbiscan.io/api",
+      browserURL: "https://sepolia.arbiscan.io/",
     },
   },
   {


### PR DESCRIPTION
Closes https://github.com/NomicFoundation/hardhat/issues/4582
Closes https://github.com/NomicFoundation/hardhat/issues/4473

> ⚠️ Important note: Ethereum Goerli was deprecated in Q1 2023 but will be supported until Q1 2024. We are currently phasing out the usage of Arbitrum Goerli. Support for Arbitrum Goerli will cease prior to the conclusion of Ethereum Goerli.
> ⚠️` The old testnet RinkArby was deprecated on December 20th, 2022.

https://docs.arbitrum.io/for-devs/concepts/public-chains#arbitrum-goerli