### PR TITLE
fix: cache block contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ Brewfile.lock.json
 
 # Performance profiling application
 .clinic
+
+benchmark-scenarios/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "itertools 0.12.0",
  "k256",
  "lazy_static",
+ "log",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
  "k256",
  "lazy_static",
  "log",
+ "lru",
  "parking_lot 0.12.1",
  "paste",
  "rand",
@@ -1940,6 +1941,15 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
+dependencies = [
+ "hashbrown 0.14.1",
+]
 
 [[package]]
 name = "matchers"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,7 @@ name = "edr_evm"
 version = "0.2.0-dev"
 dependencies = [
  "alloy-rlp",
+ "anyhow",
  "async-rwlock",
  "auto_impl",
  "cita_trie",

--- a/crates/edr_evm/Cargo.toml
+++ b/crates/edr_evm/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.21.2", default-features = false, features = ["macros", "r
 tracing = { version = "0.1.37", features = ["attributes", "std"], optional = true }
 
 [dev-dependencies]
+anyhow = "1.0.75"
 criterion = { version = "0.4.0", default-features = false, features = ["cargo_bench_support", "html_reports", "plotters"] }
 lazy_static = "1.4.0"
 edr_test_utils = { version = "0.2.0-dev", path = "../edr_test_utils" }

--- a/crates/edr_evm/src/block/builder.rs
+++ b/crates/edr_evm/src/block/builder.rs
@@ -310,24 +310,22 @@ impl BlockBuilder {
         StateErrorT: Debug + Send,
     {
         for (address, reward) in rewards {
-            state.modify_account(
-                address,
-                AccountModifierFn::new(Box::new(move |balance, _nonce, _code| {
-                    *balance += reward;
-                })),
-                &|| {
-                    Ok(AccountInfo {
-                        code: None,
-                        ..AccountInfo::default()
-                    })
-                },
-            )?;
+            if reward > U256::ZERO {
+                let account_info = state.modify_account(
+                    address,
+                    AccountModifierFn::new(Box::new(move |balance, _nonce, _code| {
+                        *balance += reward;
+                    })),
+                    &|| {
+                        Ok(AccountInfo {
+                            code: None,
+                            ..AccountInfo::default()
+                        })
+                    },
+                )?;
 
-            let account_info = state
-                .basic(address)?
-                .expect("Account must exist after modification");
-
-            self.state_diff.apply_account_change(address, account_info);
+                self.state_diff.apply_account_change(address, account_info);
+            }
         }
 
         if let Some(gas_limit) = self.parent_gas_limit {

--- a/crates/edr_evm/src/blockchain/storage/reservable.rs
+++ b/crates/edr_evm/src/blockchain/storage/reservable.rs
@@ -150,7 +150,7 @@ impl<BlockT: Block + Clone> ReservableSparseBlockchainStorage<BlockT> {
             previous_base_fee_per_gas: previous_base_fee,
             previous_state_root,
             previous_total_difficulty,
-            previous_diff_index: self.state_diffs.len(),
+            previous_diff_index: self.state_diffs.len() - 1,
             spec_id,
         };
 

--- a/crates/edr_evm/src/upcast.rs
+++ b/crates/edr_evm/src/upcast.rs
@@ -1,5 +1,0 @@
-/// Trait for upcasting a super trait object to a sub trait object.
-pub trait Upcast<T: ?Sized> {
-    /// Upcasts the trait object.
-    fn upcast(&self) -> &T;
-}

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -11,6 +11,7 @@ ansi_term = { version = "0.12.1", default-features = false }
 crossbeam-channel = { version = "0.5.6", default-features = false }
 itertools = { version = "0.12.0", default-features = false }
 k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", "precomputed-tables", "std"] }
+log = { version = "0.4.20", default-features = false }
 # when napi is pinned, be sure to pin napi-derive to the same version
 # The `async` feature ensures that a tokio runtime is available
 napi = { version = "2.12.4", default-features = false, features = ["async", "error_anyhow", "napi8", "serde-json"] }

--- a/crates/edr_napi/src/provider.rs
+++ b/crates/edr_napi/src/provider.rs
@@ -73,14 +73,12 @@ impl Provider {
                 if let Some((method_name, provider_error)) = reason.provider_error() {
                     // Ignore potential failure of logging, as returning the original error is more
                     // important
-                    let _result = runtime::Handle::current()
-                        .spawn_blocking(move || {
-                            provider.log_failed_deserialization(&method_name, &provider_error)
-                        })
+                    if let Err(error) = provider
+                        .log_failed_deserialization(&method_name, &provider_error)
                         .await
-                        .map_err(|error| {
-                            napi::Error::new(Status::GenericFailure, error.to_string())
-                        })?;
+                    {
+                        log::error!("Failed to log deserialization error: {error}");
+                    }
                 }
 
                 let data = serde_json::from_str(&json_request).ok();
@@ -107,7 +105,7 @@ impl Provider {
         };
 
         let response = runtime::Handle::current()
-            .spawn_blocking(move || provider.handle_request(request))
+            .spawn(async move { provider.handle_request(request).await })
             .await
             .map_err(|e| napi::Error::new(Status::GenericFailure, e.to_string()))?;
 

--- a/crates/edr_provider/Cargo.toml
+++ b/crates/edr_provider/Cargo.toml
@@ -23,6 +23,7 @@ sha3 = { version = "0.10.6", default-features = false }
 thiserror = { version = "1.0.37", default-features = false }
 tokio = { version = "1.21.2", default-features = false, features = ["macros"] }
 tracing = { version = "0.1.37", features = ["attributes", "std"] }
+lru = "0.12.2"
 
 [dev-dependencies]
 anyhow = "1.0.75"

--- a/crates/edr_provider/src/config.rs
+++ b/crates/edr_provider/src/config.rs
@@ -25,14 +25,17 @@ impl IntervalConfig {
     }
 }
 
-impl From<OneUsizeOrTwo> for IntervalConfig {
-    fn from(value: OneUsizeOrTwo) -> Self {
+impl TryFrom<OneUsizeOrTwo> for IntervalConfig {
+    type Error = ();
+
+    fn try_from(value: OneUsizeOrTwo) -> Result<Self, Self::Error> {
         match value {
-            OneUsizeOrTwo::One(value) => Self::Fixed(value as u64),
-            OneUsizeOrTwo::Two([min, max]) => Self::Range {
+            OneUsizeOrTwo::One(0) => Err(()),
+            OneUsizeOrTwo::One(value) => Ok(Self::Fixed(value as u64)),
+            OneUsizeOrTwo::Two([min, max]) => Ok(Self::Range {
                 min: min as u64,
                 max: max as u64,
-            },
+            }),
         }
     }
 }

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -70,7 +70,7 @@ use crate::{
     pending::BlockchainWithPending,
     requests::hardhat::rpc_types::{ForkConfig, ForkMetadata},
     snapshot::Snapshot,
-    ProviderConfig, ProviderError, SubscriptionEvent, SubscriptionEventData,
+    MiningConfig, ProviderConfig, ProviderError, SubscriptionEvent, SubscriptionEventData,
     SyncSubscriberCallback,
 };
 
@@ -1869,6 +1869,10 @@ impl<LoggerErrorT: Debug> ProviderData<LoggerErrorT> {
         let prevrandao = None;
 
         self.mine_block(block_timestamp, prevrandao)
+    }
+
+    pub fn mining_config(&self) -> &MiningConfig {
+        &self.initial_config.mining
     }
 
     /// Get the timestamp for the next block.

--- a/crates/edr_provider/src/lib.rs
+++ b/crates/edr_provider/src/lib.rs
@@ -86,7 +86,8 @@ lazy_static! {
 pub struct Provider<LoggerErrorT: Debug> {
     data: Arc<AsyncMutex<ProviderData<LoggerErrorT>>>,
     /// Interval miner runs in the background, if enabled. It holds the data
-    /// mutex, so
+    /// mutex, so it needs to internally check for cancellation/self-destruction
+    /// while async-awaiting the lock to avoid a deadlock.
     interval_miner: Arc<Mutex<Option<IntervalMiner<LoggerErrorT>>>>,
     runtime: runtime::Handle,
 }

--- a/crates/edr_provider/src/requests/debug.rs
+++ b/crates/edr_provider/src/requests/debug.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 pub fn handle_debug_trace_transaction<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     transaction_hash: B256,
     config: Option<DebugTraceConfig>,
 ) -> Result<DebugTraceResult, ProviderError<LoggerErrorT>> {
@@ -31,7 +31,7 @@ pub fn handle_debug_trace_transaction<LoggerErrorT: Debug>(
 }
 
 pub fn handle_debug_trace_call<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     call_request: CallRequest,
     block_spec: Option<BlockSpec>,
     config: Option<DebugTraceConfig>,

--- a/crates/edr_provider/src/requests/eth/blockchain.rs
+++ b/crates/edr_provider/src/requests/eth/blockchain.rs
@@ -19,7 +19,7 @@ pub fn handle_chain_id_request<LoggerErrorT: Debug>(
 }
 
 pub fn handle_get_transaction_count_request<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     address: Address,
     block_spec: Option<BlockSpec>,
 ) -> Result<U256, ProviderError<LoggerErrorT>> {

--- a/crates/edr_provider/src/requests/eth/blocks.rs
+++ b/crates/edr_provider/src/requests/eth/blocks.rs
@@ -41,7 +41,7 @@ pub fn handle_get_block_by_hash_request<LoggerErrorT: Debug>(
 }
 
 pub fn handle_get_block_by_number_request<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     block_spec: PreEip1898BlockSpec,
     transaction_detail_flag: bool,
 ) -> Result<Option<eth::Block<HashOrTransaction>>, ProviderError<LoggerErrorT>> {
@@ -74,7 +74,7 @@ pub fn handle_get_block_transaction_count_by_hash_request<LoggerErrorT: Debug>(
 }
 
 pub fn handle_get_block_transaction_count_by_block_number<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     block_spec: PreEip1898BlockSpec,
 ) -> Result<Option<U64>, ProviderError<LoggerErrorT>> {
     Ok(block_by_number(data, &block_spec.into())?
@@ -93,7 +93,7 @@ struct BlockByNumberResult {
 }
 
 fn block_by_number<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     block_spec: &BlockSpec,
 ) -> Result<Option<BlockByNumberResult>, ProviderError<LoggerErrorT>> {
     validate_post_merge_block_tags(data.spec_id(), block_spec)?;

--- a/crates/edr_provider/src/requests/eth/call.rs
+++ b/crates/edr_provider/src/requests/eth/call.rs
@@ -48,7 +48,7 @@ pub fn handle_call_request<LoggerErrorT: Debug>(
 }
 
 pub(crate) fn resolve_call_request<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     request: CallRequest,
     block_spec: Option<&BlockSpec>,
     state_overrides: &StateOverrides,

--- a/crates/edr_provider/src/requests/eth/gas.rs
+++ b/crates/edr_provider/src/requests/eth/gas.rs
@@ -54,7 +54,7 @@ pub fn handle_estimate_gas<LoggerErrorT: Debug>(
 }
 
 pub fn handle_fee_history<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     block_count: U256,
     newest_block: BlockSpec,
     reward_percentiles: Option<Vec<f64>>,

--- a/crates/edr_provider/src/requests/eth/state.rs
+++ b/crates/edr_provider/src/requests/eth/state.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 pub fn handle_get_balance_request<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     address: Address,
     block_spec: Option<BlockSpec>,
 ) -> Result<U256, ProviderError<LoggerErrorT>> {
@@ -19,7 +19,7 @@ pub fn handle_get_balance_request<LoggerErrorT: Debug>(
 }
 
 pub fn handle_get_code_request<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     address: Address,
     block_spec: Option<BlockSpec>,
 ) -> Result<Bytes, ProviderError<LoggerErrorT>> {
@@ -31,7 +31,7 @@ pub fn handle_get_code_request<LoggerErrorT: Debug>(
 }
 
 pub fn handle_get_storage_at_request<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     address: Address,
     index: U256,
     block_spec: Option<BlockSpec>,

--- a/crates/edr_provider/src/requests/eth/transactions.rs
+++ b/crates/edr_provider/src/requests/eth/transactions.rs
@@ -40,7 +40,7 @@ pub fn handle_get_transaction_by_block_hash_and_index<LoggerErrorT: Debug>(
 }
 
 pub fn handle_get_transaction_by_block_spec_and_index<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     block_spec: PreEip1898BlockSpec,
     index: U256,
 ) -> Result<Option<remote::eth::Transaction>, ProviderError<LoggerErrorT>> {
@@ -264,7 +264,7 @@ pub fn handle_send_raw_transaction_request<LoggerErrorT: Debug>(
 }
 
 fn resolve_transaction_request<LoggerErrorT: Debug>(
-    data: &ProviderData<LoggerErrorT>,
+    data: &mut ProviderData<LoggerErrorT>,
     transaction_request: EthTransactionRequest,
 ) -> Result<TransactionRequestAndSender, ProviderError<LoggerErrorT>> {
     const DEFAULT_MAX_PRIORITY_FEE_PER_GAS: u64 = 1_000_000_000;

--- a/crates/edr_provider/src/requests/hardhat/state.rs
+++ b/crates/edr_provider/src/requests/hardhat/state.rs
@@ -2,15 +2,7 @@ use core::fmt::Debug;
 
 use edr_eth::{Address, Bytes, U256};
 
-use crate::{data::ProviderData, requests::hardhat::rpc_types::ResetProviderConfig, ProviderError};
-
-pub fn handle_reset<LoggerErrorT: Debug>(
-    data: &mut ProviderData<LoggerErrorT>,
-    config: Option<ResetProviderConfig>,
-) -> Result<bool, ProviderError<LoggerErrorT>> {
-    data.reset(config.and_then(|c| c.forking))?;
-    Ok(true)
-}
+use crate::{data::ProviderData, ProviderError};
 
 pub fn handle_set_balance<LoggerErrorT: Debug>(
     data: &mut ProviderData<LoggerErrorT>,

--- a/crates/edr_provider/src/snapshot.rs
+++ b/crates/edr_provider/src/snapshot.rs
@@ -5,9 +5,11 @@ use edr_evm::{
     state::{IrregularState, StateError, SyncState},
     MemPool, RandomHashGenerator,
 };
+use lru::LruCache;
 
 pub struct Snapshot {
     pub block_number: u64,
+    pub block_state_cache: LruCache<u64, Box<dyn SyncState<StateError>>>,
     pub block_time_offset_seconds: i64,
     pub coinbase: Address,
     pub irregular_state: IrregularState,

--- a/crates/edr_provider/src/snapshot.rs
+++ b/crates/edr_provider/src/snapshot.rs
@@ -1,15 +1,13 @@
-use std::time::Instant;
+use std::{collections::BTreeMap, time::Instant};
 
 use edr_eth::{Address, U256};
-use edr_evm::{
-    state::{IrregularState, StateError, SyncState},
-    MemPool, RandomHashGenerator,
-};
-use lru::LruCache;
+use edr_evm::{state::IrregularState, MemPool, RandomHashGenerator};
 
-pub struct Snapshot {
+use crate::data::StateId;
+
+pub(crate) struct Snapshot {
     pub block_number: u64,
-    pub block_state_cache: LruCache<u64, Box<dyn SyncState<StateError>>>,
+    pub block_number_to_state_id: BTreeMap<u64, StateId>,
     pub block_time_offset_seconds: i64,
     pub coinbase: Address,
     pub irregular_state: IrregularState,
@@ -17,6 +15,5 @@ pub struct Snapshot {
     pub next_block_base_fee_per_gas: Option<U256>,
     pub next_block_timestamp: Option<u64>,
     pub prev_randao_generator: RandomHashGenerator,
-    pub state: Box<dyn SyncState<StateError>>,
     pub time: Instant,
 }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = { version = "1.0.63" }
+anyhow = { version = "1.0.75" }
 cfg-if = "1.0.0"
 clap = { version = "3.2.20", features = ["derive"] }
 difference = { version = "2.0.0", default-features = false }

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/interval-mining-provider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/interval-mining-provider.ts
@@ -1,7 +1,6 @@
 import { assert } from "chai";
 
 import { rpcQuantityToNumber } from "../../../../src/internal/core/jsonrpc/types/base-types";
-import { ALCHEMY_URL } from "../../../setup";
 import { workaroundWindowsCiFailures } from "../../../utils/workaround-windows-ci-failures";
 import { setCWD } from "../helpers/cwd";
 import { INTERVAL_MINING_PROVIDERS } from "../helpers/providers";
@@ -12,7 +11,6 @@ describe("Interval mining provider", function () {
     workaroundWindowsCiFailures.call(this, { isFork });
 
     describe(`${name} provider`, function () {
-      const safeBlockInThePast = 11_200_000;
       const blockTime = 100;
       const blockWaitTime = blockTime + 10;
 
@@ -45,38 +43,8 @@ describe("Interval mining provider", function () {
       });
 
       describe("hardhat_reset", function () {
-        if (isFork) {
-          testForkedProviderBehaviour();
-        } else {
+        if (!isFork) {
           testNormalProviderBehaviour();
-        }
-
-        function testForkedProviderBehaviour() {
-          it("starts interval mining", async function () {
-            const firstBlock = await getBlockNumber();
-
-            await sleep(blockWaitTime);
-            const secondBlockBeforeReset = await getBlockNumber();
-
-            await this.provider.send("hardhat_reset", [
-              {
-                forking: {
-                  jsonRpcUrl: ALCHEMY_URL,
-                  blockNumber: safeBlockInThePast,
-                },
-              },
-            ]);
-
-            await sleep(blockWaitTime);
-            const secondBlockAfterReset = await getBlockNumber();
-
-            await sleep(blockWaitTime);
-            const thirdBlock = await getBlockNumber();
-
-            assert.equal(secondBlockBeforeReset, firstBlock + 1);
-            assert.equal(secondBlockAfterReset, safeBlockInThePast + 1);
-            assert.equal(thirdBlock, safeBlockInThePast + 2);
-          });
         }
 
         function testNormalProviderBehaviour() {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/interval-mining-provider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/interval-mining-provider.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 
 import { rpcQuantityToNumber } from "../../../../src/internal/core/jsonrpc/types/base-types";
+import { ALCHEMY_URL } from "../../../setup";
 import { workaroundWindowsCiFailures } from "../../../utils/workaround-windows-ci-failures";
 import { setCWD } from "../helpers/cwd";
 import { INTERVAL_MINING_PROVIDERS } from "../helpers/providers";
@@ -11,6 +12,7 @@ describe("Interval mining provider", function () {
     workaroundWindowsCiFailures.call(this, { isFork });
 
     describe(`${name} provider`, function () {
+      const safeBlockInThePast = 11_200_000;
       const blockTime = 100;
       const blockWaitTime = blockTime + 10;
 
@@ -43,8 +45,38 @@ describe("Interval mining provider", function () {
       });
 
       describe("hardhat_reset", function () {
-        if (!isFork) {
+        if (isFork) {
+          testForkedProviderBehaviour();
+        } else {
           testNormalProviderBehaviour();
+        }
+
+        function testForkedProviderBehaviour() {
+          it("starts interval mining", async function () {
+            const firstBlock = await getBlockNumber();
+
+            await sleep(blockWaitTime);
+            const secondBlockBeforeReset = await getBlockNumber();
+
+            await this.provider.send("hardhat_reset", [
+              {
+                forking: {
+                  jsonRpcUrl: ALCHEMY_URL,
+                  blockNumber: safeBlockInThePast,
+                },
+              },
+            ]);
+
+            await sleep(blockWaitTime);
+            const secondBlockAfterReset = await getBlockNumber();
+
+            await sleep(blockWaitTime);
+            const thirdBlock = await getBlockNumber();
+
+            assert.equal(secondBlockBeforeReset, firstBlock + 1);
+            assert.equal(secondBlockAfterReset, safeBlockInThePast + 1);
+            assert.equal(thirdBlock, safeBlockInThePast + 2);
+          });
         }
 
         function testNormalProviderBehaviour() {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByHash.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByHash.ts
@@ -350,6 +350,35 @@ describe("Eth module", function () {
           assert.equal(tx.from, "0x84467283e3663522a02574288291a9d0f9c968c2");
         });
 
+        it("should get a blob transaction from goerli", async function () {
+          if (!isFork || ALCHEMY_URL === undefined) {
+            this.skip();
+          }
+          const goerliUrl = ALCHEMY_URL.replace("mainnet", "goerli");
+
+          // If "mainnet" is not present the replacement failed so we skip the test
+          if (goerliUrl === ALCHEMY_URL) {
+            this.skip();
+          }
+
+          await this.provider.send("hardhat_reset", [
+            {
+              forking: {
+                jsonRpcUrl: goerliUrl,
+                // Cancun block
+                blockNumber: 10527489,
+              },
+            },
+          ]);
+
+          const tx = await this.provider.send("eth_getTransactionByHash", [
+            // blob transaction
+            "0x0190ab719774b0ed612789072e399157537845383c2d2445a9929784a098a5c9",
+          ]);
+
+          assert.equal(tx.from, "0xa1d6cf9ed782555a0572cc08380ee3b68a1df449");
+        });
+
         it("should return access list transactions", async function () {
           const firstBlockNumber = rpcQuantityToNumber(
             await this.provider.send("eth_blockNumber")


### PR DESCRIPTION
Avoid recomputing states by caching them for later use. 

This change brings a 100x improvement on the Rocketpool scenario that makes heavy use of snapshots.