### PR TITLE
doc: update Verdaccio docs

### DIFF
--- a/book/src/02_development/02_verdaccio.md
+++ b/book/src/02_development/02_verdaccio.md
@@ -10,9 +10,11 @@ It’s useful to test things related to publishing without actually publishing, 
 ## Usage
 
 1. In one terminal, run `verdaccio`
-2. In another terminal login with `npm login --registry=http://localhost:4873/`. Any user and password will do.
-3. Publish your package by passing the verdaccio registry as a parameter: `npm publish --registry=http://localhost:4873/`.
+2. In another terminal login with `pnpm login --registry=http://localhost:4873/`. Any user and password will do.
+3. Publish your package by passing the verdaccio registry as a parameter: `pnpm publish --registry=http://localhost:4873/`.
 4. Go to the project where you want to test and install the package with `npm i your-package --registry=http://localhost:4873/`.
+
+> Note: Read [Local Release](./03_local_release.md) on special instructions for publishing EDR NPM packages using Verdaccio.
 
 ## Updating a package
 

--- a/book/src/02_development/03_local_release.md
+++ b/book/src/02_development/03_local_release.md
@@ -4,7 +4,7 @@ These are instructions for releasing the [EDR NPM package](../../crates/edr_napi
 
 1. Install and start [Verdaccio](./02_verdaccio.md).
 2. Go to the [edr_napi](../../crates/edr_napi/) directory.
-3. Run `yarn build`.
+3. Run `pnpm build`.
 4. Look for the NAPI binary that was built for your platform. It has the format `edr.<PLATFORM>.node`. For example on Apple Silicon Macs, it's called `edr.darwin-arm64.node`.
 5. Move the NAPI binary to the appropriate platform-specifc package in the [npm](../../crates/edr_napi/npm) directory. For example, on Apple Silicon Macs: `mv edr.darwin-arm64.node npm/darwin-arm64`.
 6. Complete the Verdaccio [publish steps](./02_verdaccio.md#usage) in the [edr_napi](../../crates/edr_napi/) directory. You can ignore the warnings about not finding NAPI binaries for other platforms.

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -403,8 +403,8 @@ fn revert_error(output: &Bytes) -> String {
             | alloy_sol_types::Error::UnknownSelector { .. } => {
                 format!("VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x{})", hex::encode(output))
             }
-            _ => unreachable!(
-                "Since we are not validating, no other error can occur: {decode_error:?}"
+            _ => format!(
+                "Internal: Since we are not validating, this error should not occur: {decode_error:?}"
             ),
         },
     }

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -399,10 +399,13 @@ fn revert_error(output: &Bytes) -> String {
             }
         }
         Err(decode_error) => match decode_error {
-            alloy_sol_types::Error::TypeCheckFail { .. } => {
+            alloy_sol_types::Error::TypeCheckFail { .. }
+            | alloy_sol_types::Error::UnknownSelector { .. } => {
                 format!("VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x{})", hex::encode(output))
             }
-            _ => unreachable!("Since we are not validating, no other error can occur"),
+            _ => unreachable!(
+                "Since we are not validating, no other error can occur: {decode_error:?}"
+            ),
         },
     }
 }


### PR DESCRIPTION
Should be merged after https://github.com/NomicFoundation/hardhat/pull/4811

Updates the docs to reflect usage of `pnpm` and notes that publishing EDR NPM packages has special instructions (to avoid confusion)