### PR TITLE
fix: block timestamp calculation

### DIFF
--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -1847,7 +1847,7 @@ impl<LoggerErrorT: Debug> ProviderData<LoggerErrorT> {
             i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs())
                 .expect("timestamp too large");
 
-        let (mut block_timestamp, new_offset) = if let Some(timestamp) = timestamp {
+        let (mut block_timestamp, mut new_offset) = if let Some(timestamp) = timestamp {
             timestamp.checked_sub(latest_block_header.timestamp).ok_or(
                 ProviderError::TimestampLowerThanPrevious {
                     proposed: timestamp,
@@ -1873,6 +1873,9 @@ impl<LoggerErrorT: Debug> ProviderData<LoggerErrorT> {
             && !self.allow_blocks_with_same_timestamp;
         if timestamp_needs_increase {
             block_timestamp += 1;
+            if new_offset.is_none() {
+                new_offset = Some(self.block_time_offset_seconds + 1);
+            }
         }
 
         Ok((block_timestamp, new_offset))

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -403,8 +403,8 @@ fn revert_error(output: &Bytes) -> String {
             | alloy_sol_types::Error::UnknownSelector { .. } => {
                 format!("VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x{})", hex::encode(output))
             }
-            _ => unreachable!(
-                "Since we are not validating, no other error can occur: {decode_error:?}"
+            _ => format!(
+                "Internal: Since we are not validating, this error should not occur: {decode_error:?}"
             ),
         },
     }

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -399,10 +399,13 @@ fn revert_error(output: &Bytes) -> String {
             }
         }
         Err(decode_error) => match decode_error {
-            alloy_sol_types::Error::TypeCheckFail { .. } => {
+            alloy_sol_types::Error::TypeCheckFail { .. }
+            | alloy_sol_types::Error::UnknownSelector { .. } => {
                 format!("VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x{})", hex::encode(output))
             }
-            _ => unreachable!("Since we are not validating, no other error can occur"),
+            _ => unreachable!(
+                "Since we are not validating, no other error can occur: {decode_error:?}"
+            ),
         },
     }
 }

--- a/crates/edr_provider/src/error.rs
+++ b/crates/edr_provider/src/error.rs
@@ -295,7 +295,7 @@ impl Display for EstimateGasFailure {
 #[serde(rename_all = "camelCase")]
 pub struct TransactionFailure {
     pub reason: TransactionFailureReason,
-    pub data: Option<String>,
+    pub data: String,
     #[serde(skip)]
     pub trace: Trace,
     pub transaction_hash: B256,
@@ -324,7 +324,7 @@ impl TransactionFailure {
         let data = format!("0x{}", hex::encode(output.as_ref()));
         Self {
             reason: TransactionFailureReason::Revert(output),
-            data: Some(data),
+            data,
             trace,
             transaction_hash,
         }
@@ -341,7 +341,7 @@ impl TransactionFailure {
 
         Self {
             reason,
-            data: None,
+            data: "0x".to_string(),
             trace,
             transaction_hash: tx_hash,
         }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -609,9 +609,8 @@ export class EdrProviderWrapper
         error = encodeSolidityStackTrace(response.error.message, stackTrace);
         // Pass data and transaction hash from the original error
         (error as any).data = {
-          data: response.error.data?.data,
-          transactionHash: response.error.data?.transactionHash,
-          ...(error as any).data,
+          data: response.error.data?.data ?? undefined,
+          transactionHash: response.error.data?.transactionHash ?? undefined,
         };
       } else {
         if (response.error.code === InvalidArgumentsError.CODE) {


### PR DESCRIPTION
When block timestamps were equal, we weren't incrementing the offset by.

The corresponding code in Hardhat is here:

https://github.com/NomicFoundation/hardhat/blob/edr/main/packages/hardhat-core/src/internal/hardhat-network/provider/node.ts#L382-L384