### PR TITLE
chore/update-triaging-rules

### DIFF
--- a/.github/workflows/autoassign-issues.yml
+++ b/.github/workflows/autoassign-issues.yml
@@ -15,7 +15,7 @@ jobs:
           script: |
             // each user has a chance of (p - (previousP ?? 0)) to be assigned
             const potentialAssignees = [
-              ["fvictorio", 1/3],
+              ["kanej", 1/3],
               ["schaable", 2/3],
               ["ChristopherDedominici", 1.0],
             ];

--- a/.github/workflows/autoassign-prs.yml
+++ b/.github/workflows/autoassign-prs.yml
@@ -1,0 +1,36 @@
+name: PR autoassignment
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-new-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const externalPrTriager = "kanej";
+
+            // Within the Github API PRs are issue objects
+            const pr = await github.rest.issues.get({
+              owner: context.issue.owner,
+              repo: context.issue.repo,
+              issue_number: context.issue.number
+            });
+
+            const isCollaborator = ["OWNER", "MEMBER", "COLLABORATOR"].includes(pr.data.author_association)
+
+            if (isCollaborator) {
+              return
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.issue.owner,
+              repo: context.issue.repo,
+              issue_number: context.issue.number,
+              assignees: [externalPrTriager],
+            });


### PR DESCRIPTION
Remove Franco from the issue triaging and replace with kanej.
Add a PR triaging assigner, where external PRs are assigned to kanej.
