### PR TITLE
fix: reduce state size cache

### DIFF
--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -75,7 +75,7 @@ use crate::{
 };
 
 const DEFAULT_INITIAL_BASE_FEE_PER_GAS: u64 = 1_000_000_000;
-const MAX_CACHED_STATES: usize = 2048;
+const MAX_CACHED_STATES: usize = 64;
 
 /// The result of executing an `eth_call`.
 #[derive(Clone)]


### PR DESCRIPTION
Reduce state size cache to avoid swapping when executing https://github.com/neptune-mutual-blue/protocol tests. Memory consumption remains below 8gb in that repo.

This change leads to a 20% slowdown on the Rocketpool scenario which is I think acceptable.