### PR TITLE
Fix 404 supported chains link

### DIFF
--- a/.changeset/modern-pugs-watch.md
+++ b/.changeset/modern-pugs-watch.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Fixed broken link in network error message (thanks @sunsetlover36!).

--- a/packages/hardhat-viem/src/internal/errors.ts
+++ b/packages/hardhat-viem/src/internal/errors.ts
@@ -24,7 +24,7 @@ const client = await hre.viem.getPublicClient({
   ...
 });
 
-You can find a list of supported networks here: https://viem.sh/docs/clients/chains.html`
+You can find a list of supported networks here: https://github.com/wevm/viem/blob/main/src/chains/index.ts`
     );
   }
 }
@@ -40,7 +40,7 @@ const client = await hre.viem.getPublicClient({
   ...
 });
 
-You can find a list of supported networks here: https://viem.sh/docs/clients/chains.html`
+You can find a list of supported networks here: https://github.com/wevm/viem/blob/main/src/chains/index.ts`
     );
   }
 }


### PR DESCRIPTION
Fixed broken viem link to supported networks in the error text related to unsupported networks with a valid link from [docs](https://viem.sh/docs/chains/introduction)