### PR TITLE
fix: add type field to call request

### DIFF
--- a/crates/edr_eth/src/remote/eth/call_request.rs
+++ b/crates/edr_eth/src/remote/eth/call_request.rs
@@ -28,4 +28,7 @@ pub struct CallRequest {
     pub data: Option<Bytes>,
     /// warm storage access pre-payment
     pub access_list: Option<Vec<AccessListItem>>,
+    /// EIP-2718 type
+    #[cfg_attr(feature = "serde", serde(default, rename = "type"))]
+    pub transaction_type: Option<U256>,
 }

--- a/crates/edr_provider/src/requests/eth/call.rs
+++ b/crates/edr_provider/src/requests/eth/call.rs
@@ -63,6 +63,7 @@ pub(crate) fn resolve_call_request<LoggerErrorT: Debug>(
         value,
         data: input,
         access_list,
+        ..
     } = request;
 
     let chain_id = data.chain_id();

--- a/crates/edr_provider/tests/eth_request_serialization.rs
+++ b/crates/edr_provider/tests/eth_request_serialization.rs
@@ -38,6 +38,7 @@ fn test_serde_eth_call() {
         value: Some(U256::from(123568919)),
         data: Some(Bytes::from(&b"whatever"[..])),
         access_list: None,
+        transaction_type: None,
     };
     help_test_method_invocation_serde(MethodInvocation::Call(
         tx.clone(),
@@ -72,6 +73,7 @@ fn test_serde_eth_estimate_gas() {
         value: Some(U256::from(123568919)),
         data: Some(Bytes::from(&b"whatever"[..])),
         access_list: None,
+        transaction_type: None,
     };
     help_test_method_invocation_serde(MethodInvocation::EstimateGas(
         tx.clone(),


### PR DESCRIPTION
Needed to make https://github.com/ProjectOpenSea/seaport/ tests pass in EDR mode.