### PR TITLE
fix: remove `deny_unknown_fields` from RPC types

### DIFF
--- a/crates/edr_eth/src/remote/eth.rs
+++ b/crates/edr_eth/src/remote/eth.rs
@@ -120,7 +120,6 @@ pub enum ReceiptConversionError {
 
 /// block object returned by `eth_getBlockBy*`
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct Block<TX> {
     /// Hash of the block

--- a/crates/edr_eth/src/remote/eth/call_request.rs
+++ b/crates/edr_eth/src/remote/eth/call_request.rs
@@ -6,7 +6,6 @@ use crate::{access_list::AccessListItem, U256};
 /// For specifying input to methods requiring a transaction object, like
 /// `eth_call` and `eth_estimateGas`
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct CallRequest {
     /// the address from which the transaction should be sent

--- a/crates/edr_eth/src/remote/jsonrpc.rs
+++ b/crates/edr_eth/src/remote/jsonrpc.rs
@@ -96,7 +96,6 @@ impl<SuccessT: Serialize, ErrorT: Into<Error>> From<Result<SuccessT, ErrorT>>
 /// included. This member is used to correlate the context between the two
 /// objects.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum Id {
     /// Numeric id

--- a/crates/edr_eth/src/transaction.rs
+++ b/crates/edr_eth/src/transaction.rs
@@ -14,7 +14,6 @@ use crate::{access_list::AccessListItem, Address, Bytes, U256};
 /// Represents _all_ transaction requests received from RPC
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct EthTransactionRequest {
     /// from address


### PR DESCRIPTION
Remove `deny_unknown_fields` from RPC types to match Hardhat behavior of accepting additional fields.