### PR TITLE
Upgrade hardhat-viem to support viem@2

### DIFF
--- a/.changeset/proud-peas-sort.md
+++ b/.changeset/proud-peas-sort.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": major
+---
+
+Upgraded hardhat-viem to support viem@2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "bump"
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"

--- a/packages/hardhat-viem/README.md
+++ b/packages/hardhat-viem/README.md
@@ -154,7 +154,7 @@ const contractA = await hre.viem.deployContract(
   "contractName",
   ["arg1", 50, "arg3"],
   {
-    walletClient: secondWalletClient,
+    client: { wallet: secondWalletClient }
     gas: 1000000,
     value: parseEther("0.0001"),
     confirmations: 5, // 1 by default
@@ -185,7 +185,7 @@ const [_, secondWalletClient] = await hre.viem.getWalletClients();
 const contract = await hre.viem.getContractAt(
   "contractName",
   "0x1234567890123456789012345678901234567890",
-  { walletClient: secondWalletClient }
+  { client: { wallet: secondWalletClient } }
 );
 ```
 
@@ -210,7 +210,7 @@ const { contract: contractName, deploymentTransaction } =
     "contractName",
     ["arg1", 50, "arg3"],
     {
-      walletClient: secondWalletClient,
+      client: { wallet: secondWalletClient },
       gas: 1000000,
       value: parseEther("0.0001"),
     }

--- a/packages/hardhat-viem/package.json
+++ b/packages/hardhat-viem/package.json
@@ -66,12 +66,12 @@
     "sinon": "^9.0.0",
     "ts-node": "^10.8.0",
     "typescript": "~5.0.0",
-    "viem": "^1.15.1"
+    "viem": "^2.7.6"
   },
   "peerDependencies": {
     "hardhat": "workspace:^2.17.0",
     "typescript": "~5.0.0",
-    "viem": "^1.15.1"
+    "viem": "^2.7.6"
   },
   "dependencies": {
     "abitype": "^0.9.8",

--- a/packages/hardhat-viem/src/internal/contracts.ts
+++ b/packages/hardhat-viem/src/internal/contracts.ts
@@ -225,8 +225,10 @@ async function innerGetContractAt(
   const viem = await import("viem");
   const contract = viem.getContract({
     address,
-    publicClient,
-    walletClient,
+    client: {
+      public: publicClient,
+      wallet: walletClient,
+    },
     abi: contractAbi,
   });
 

--- a/packages/hardhat-viem/src/internal/contracts.ts
+++ b/packages/hardhat-viem/src/internal/contracts.ts
@@ -27,16 +27,10 @@ export async function deployContract(
   constructorArgs: any[] = [],
   config: DeployContractConfig = {}
 ): Promise<GetContractReturnType> {
-  const {
-    walletClient: configWalletClient,
-    publicClient: configPublicClient,
-    confirmations,
-    ...deployContractParameters
-  } = config;
+  const { client, confirmations, ...deployContractParameters } = config;
   const [publicClient, walletClient, contractArtifact] = await Promise.all([
-    configPublicClient ?? getPublicClient(network.provider),
-    configWalletClient ??
-      getDefaultWalletClient(network.provider, network.name),
+    client?.public ?? getPublicClient(network.provider),
+    client?.wallet ?? getDefaultWalletClient(network.provider, network.name),
     artifacts.readArtifact(contractName),
   ]);
 
@@ -120,15 +114,10 @@ export async function sendDeploymentTransaction(
   contract: GetContractReturnType;
   deploymentTransaction: GetTransactionReturnType;
 }> {
-  const {
-    walletClient: configWalletClient,
-    publicClient: configPublicClient,
-    ...deployContractParameters
-  } = config;
+  const { client, ...deployContractParameters } = config;
   const [publicClient, walletClient, contractArtifact] = await Promise.all([
-    configPublicClient ?? getPublicClient(network.provider),
-    configWalletClient ??
-      getDefaultWalletClient(network.provider, network.name),
+    client?.public ?? getPublicClient(network.provider),
+    client?.wallet ?? getDefaultWalletClient(network.provider, network.name),
     artifacts.readArtifact(contractName),
   ]);
 
@@ -202,8 +191,8 @@ export async function getContractAt(
   config: GetContractAtConfig = {}
 ): Promise<GetContractReturnType> {
   const [publicClient, walletClient, contractArtifact] = await Promise.all([
-    config.publicClient ?? getPublicClient(network.provider),
-    config.walletClient ??
+    config.client?.public ?? getPublicClient(network.provider),
+    config.client?.wallet ??
       getDefaultWalletClient(network.provider, network.name),
     artifacts.readArtifact(contractName),
   ]);

--- a/packages/hardhat-viem/src/types.ts
+++ b/packages/hardhat-viem/src/types.ts
@@ -42,8 +42,10 @@ export type GetContractReturnType<
   TAbi extends viemT.Abi | readonly unknown[] = viemT.Abi
 > = viemT.GetContractReturnType<
   TAbi,
-  PublicClient,
-  WalletClient,
+  {
+    public: PublicClient;
+    wallet: WalletClient;
+  },
   viemT.Address
 >;
 

--- a/packages/hardhat-viem/src/types.ts
+++ b/packages/hardhat-viem/src/types.ts
@@ -13,13 +13,22 @@ export type TestClient = viemT.TestClient<
   viemT.Chain
 >;
 
+export type KeyedClient =
+  | {
+      public?: PublicClient;
+      wallet: WalletClient;
+    }
+  | {
+      public: PublicClient;
+      wallet?: WalletClient;
+    };
+
 export type TestClientMode = Parameters<
   typeof viemT.createTestClient
 >[0]["mode"];
 
 export interface SendTransactionConfig {
-  walletClient?: WalletClient;
-  publicClient?: PublicClient;
+  client?: KeyedClient;
   gas?: bigint;
   gasPrice?: bigint;
   maxFeePerGas?: bigint;
@@ -34,20 +43,12 @@ export interface DeployContractConfig extends SendTransactionConfig {
 export type SendDeploymentTransactionConfig = SendTransactionConfig;
 
 export interface GetContractAtConfig {
-  walletClient?: WalletClient;
-  publicClient?: PublicClient;
+  client?: KeyedClient;
 }
 
 export type GetContractReturnType<
   TAbi extends viemT.Abi | readonly unknown[] = viemT.Abi
-> = viemT.GetContractReturnType<
-  TAbi,
-  {
-    public: PublicClient;
-    wallet: WalletClient;
-  },
-  viemT.Address
->;
+> = viemT.GetContractReturnType<TAbi, Required<KeyedClient>, viemT.Address>;
 
 export type GetTransactionReturnType = viemT.GetTransactionReturnType<
   viemT.Chain,

--- a/packages/hardhat-viem/test/integration.ts
+++ b/packages/hardhat-viem/test/integration.ts
@@ -64,10 +64,10 @@ describe("Integration tests", function () {
         const fromAddress = fromWalletClient.account.address;
         const toAddress = toWalletClient.account.address;
 
-        const fromBalanceBefore: bigint = await publicClient.getBalance({
+        const fromBalanceBefore = await publicClient.getBalance({
           address: fromAddress,
         });
-        const toBalanceBefore: bigint = await publicClient.getBalance({
+        const toBalanceBefore = await publicClient.getBalance({
           address: toAddress,
         });
 
@@ -79,10 +79,10 @@ describe("Integration tests", function () {
         const receipt = await publicClient.waitForTransactionReceipt({ hash });
         const transactionFee = receipt.gasUsed * receipt.effectiveGasPrice;
 
-        const fromBalanceAfter: bigint = await publicClient.getBalance({
+        const fromBalanceAfter = await publicClient.getBalance({
           address: fromAddress,
         });
-        const toBalanceAfter: bigint = await publicClient.getBalance({
+        const toBalanceAfter = await publicClient.getBalance({
           address: toAddress,
         });
 

--- a/packages/hardhat-viem/test/integration.ts
+++ b/packages/hardhat-viem/test/integration.ts
@@ -141,7 +141,7 @@ describe("Integration tests", function () {
         const contract = await this.hre.viem.deployContract(
           "WithoutConstructorArgs",
           [],
-          { walletClient: secondWalletClient }
+          { client: { wallet: secondWalletClient } }
         );
 
         const owner = await contract.read.getOwner();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1585,8 +1585,8 @@ importers:
         specifier: ~5.0.0
         version: 5.0.4
       viem:
-        specifier: ^1.15.1
-        version: 1.15.1(typescript@5.0.4)
+        specifier: ^2.7.6
+        version: 2.7.10(typescript@5.0.4)
 
   packages/hardhat-vyper:
     dependencies:
@@ -1889,6 +1889,10 @@ packages:
   /@aashutoshrathi/word-wrap@1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+
+  /@adraffy/ens-normalize@1.10.0:
+    resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
+    dev: true
 
   /@adraffy/ens-normalize@1.9.2:
     resolution: {integrity: sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==}
@@ -4031,6 +4035,20 @@ packages:
         optional: true
     dependencies:
       typescript: 5.0.4
+
+  /abitype@1.0.0(typescript@5.0.4):
+    resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.0.4
+    dev: true
 
   /abortcontroller-polyfill@1.7.5:
     resolution: {integrity: sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==}
@@ -7590,6 +7608,14 @@ packages:
       ws: 8.13.0
     dev: true
 
+  /isows@1.0.3(ws@8.13.0):
+    resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
+    peerDependencies:
+      ws: '*'
+    dependencies:
+      ws: 8.13.0
+    dev: true
+
   /isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
@@ -10755,6 +10781,29 @@ packages:
       '@types/ws': 8.5.9
       abitype: 0.9.8(typescript@5.0.4)
       isomorphic-ws: 5.0.0(ws@8.13.0)
+      typescript: 5.0.4
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: true
+
+  /viem@2.7.10(typescript@5.0.4):
+    resolution: {integrity: sha512-mpm/A3Rbq6hhRovOw6btkrLeDe0DlEGLoCmO2LCbH/MuTQgLNd0cWJSIov9TL/8/Pz+qC2e+bh9zohQnKA+6PQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.0
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/bip32': 1.3.2
+      '@scure/bip39': 1.2.1
+      abitype: 1.0.0(typescript@5.0.4)
+      isows: 1.0.3(ws@8.13.0)
       typescript: 5.0.4
       ws: 8.13.0
     transitivePeerDependencies:


### PR DESCRIPTION
This PR represents the first part of adding support for `viem@2`. A subsequent PR will update `hardhat-toolbox-viem` and the dependencies in `packages/hardhat-core/src/internal/cli/project-creation.ts`.

[Link to second PR](https://github.com/NomicFoundation/hardhat/pull/4876).