### PR TITLE
Upgrade the viem toolbox and project creation to viem@2

### DIFF
--- a/.changeset/proud-peas-sort.md
+++ b/.changeset/proud-peas-sort.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": major
+---
+
+Upgraded hardhat-viem to support viem@2

--- a/.changeset/silver-waves-cough.md
+++ b/.changeset/silver-waves-cough.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-toolbox-viem": major
+"hardhat": patch
+---
+
+Upgraded hardhat-toolbox-viem and project creation to support viem@2

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -46,7 +46,7 @@ const ETHERS_PROJECT_DEPENDENCIES: Dependencies = {
 };
 
 const VIEM_PROJECT_DEPENDENCIES: Dependencies = {
-  "@nomicfoundation/hardhat-toolbox-viem": "^2.0.0",
+  "@nomicfoundation/hardhat-toolbox-viem": "^3.0.0",
 };
 
 const PEER_DEPENDENCIES: Dependencies = {
@@ -68,8 +68,8 @@ const ETHERS_PEER_DEPENDENCIES: Dependencies = {
 };
 
 const VIEM_PEER_DEPENDENCIES: Dependencies = {
-  "@nomicfoundation/hardhat-viem": "^1.0.0",
-  viem: "^1.15.1",
+  "@nomicfoundation/hardhat-viem": "^2.0.0",
+  viem: "^2.7.6",
 };
 
 const TYPESCRIPT_DEPENDENCIES: Dependencies = {};

--- a/packages/hardhat-toolbox-viem/package.json
+++ b/packages/hardhat-toolbox-viem/package.json
@@ -47,7 +47,7 @@
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@nomicfoundation/hardhat-network-helpers": "workspace:^1.0.0",
     "@nomicfoundation/hardhat-verify": "workspace:^2.0.0",
-    "@nomicfoundation/hardhat-viem": "workspace:^1.0.0",
+    "@nomicfoundation/hardhat-viem": "workspace:^2.0.0",
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^7.1.6",
     "@types/mocha": ">=9.1.0",
@@ -68,12 +68,12 @@
     "solidity-coverage": "^0.8.1",
     "ts-node": "^10.8.0",
     "typescript": "~5.0.4",
-    "viem": "^1.15.1"
+    "viem": "^2.7.6"
   },
   "peerDependencies": {
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "@nomicfoundation/hardhat-verify": "^2.0.0",
-    "@nomicfoundation/hardhat-viem": "^1.0.0",
+    "@nomicfoundation/hardhat-viem": "^2.0.0",
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^7.1.6",
     "@types/mocha": ">=9.1.0",
@@ -84,7 +84,7 @@
     "solidity-coverage": "^0.8.1",
     "ts-node": ">=8.0.0",
     "typescript": "~5.0.4",
-    "viem": "^1.15.1"
+    "viem": "^2.7.6"
   },
   "bugs": {
     "url": "https://github.com/nomicfoundation/hardhat/issues"

--- a/packages/hardhat-viem/package.json
+++ b/packages/hardhat-viem/package.json
@@ -66,12 +66,12 @@
     "sinon": "^9.0.0",
     "ts-node": "^10.8.0",
     "typescript": "~5.0.0",
-    "viem": "^1.15.1"
+    "viem": "^2.7.6"
   },
   "peerDependencies": {
     "hardhat": "^2.17.0",
     "typescript": "~5.0.0",
-    "viem": "^1.15.1"
+    "viem": "^2.7.6"
   },
   "dependencies": {
     "abitype": "^0.9.8",

--- a/packages/hardhat-viem/src/internal/contracts.ts
+++ b/packages/hardhat-viem/src/internal/contracts.ts
@@ -225,8 +225,10 @@ async function innerGetContractAt(
   const viem = await import("viem");
   const contract = viem.getContract({
     address,
-    publicClient,
-    walletClient,
+    client: {
+      public: publicClient,
+      wallet: walletClient,
+    },
     abi: contractAbi,
   });
 

--- a/packages/hardhat-viem/src/types.ts
+++ b/packages/hardhat-viem/src/types.ts
@@ -42,8 +42,10 @@ export type GetContractReturnType<
   TAbi extends viemT.Abi | readonly unknown[] = viemT.Abi
 > = viemT.GetContractReturnType<
   TAbi,
-  PublicClient,
-  WalletClient,
+  {
+    public: PublicClient;
+    wallet: WalletClient;
+  },
   viemT.Address
 >;
 

--- a/packages/hardhat-viem/test/integration.ts
+++ b/packages/hardhat-viem/test/integration.ts
@@ -64,10 +64,10 @@ describe("Integration tests", function () {
         const fromAddress = fromWalletClient.account.address;
         const toAddress = toWalletClient.account.address;
 
-        const fromBalanceBefore: bigint = await publicClient.getBalance({
+        const fromBalanceBefore = await publicClient.getBalance({
           address: fromAddress,
         });
-        const toBalanceBefore: bigint = await publicClient.getBalance({
+        const toBalanceBefore = await publicClient.getBalance({
           address: toAddress,
         });
 
@@ -79,10 +79,10 @@ describe("Integration tests", function () {
         const receipt = await publicClient.waitForTransactionReceipt({ hash });
         const transactionFee = receipt.gasUsed * receipt.effectiveGasPrice;
 
-        const fromBalanceAfter: bigint = await publicClient.getBalance({
+        const fromBalanceAfter = await publicClient.getBalance({
           address: fromAddress,
         });
-        const toBalanceAfter: bigint = await publicClient.getBalance({
+        const toBalanceAfter = await publicClient.getBalance({
           address: toAddress,
         });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1570,8 +1570,8 @@ importers:
         specifier: ~5.0.0
         version: 5.0.4
       viem:
-        specifier: ^1.15.1
-        version: 1.21.4(typescript@5.0.4)
+        specifier: ^2.7.6
+        version: 2.7.9(typescript@5.0.4)
 
   packages/hardhat-vyper:
     dependencies:
@@ -3271,7 +3271,7 @@ packages:
     resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
     dependencies:
       '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.3.3
       '@scure/base': 1.1.5
     dev: true
 
@@ -3291,7 +3291,7 @@ packages:
   /@scure/bip39@1.2.1:
     resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
     dependencies:
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.3.3
       '@scure/base': 1.1.5
     dev: true
 
@@ -4039,6 +4039,20 @@ packages:
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.19.1
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      typescript: 5.0.4
+    dev: true
+
+  /abitype@1.0.0(typescript@5.0.4):
+    resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -10572,6 +10586,29 @@ packages:
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
       abitype: 0.9.8(typescript@5.0.4)
+      isows: 1.0.3(ws@8.13.0)
+      typescript: 5.0.4
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+    dev: true
+
+  /viem@2.7.9(typescript@5.0.4):
+    resolution: {integrity: sha512-iDfc8TwaZFp1K95zlsxYh6Cs0OWCt35Tqs8uYgXKSxtz7w075mZ0H5SJ8zSyJGoEaticVDhtdmRRX6TtcW9EeQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.0
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/bip32': 1.3.2
+      '@scure/bip39': 1.2.1
+      abitype: 1.0.0(typescript@5.0.4)
       isows: 1.0.3(ws@8.13.0)
       typescript: 5.0.4
       ws: 8.13.0


### PR DESCRIPTION
This PR represents the second part of adding support for viem@2. Tests won't succeed as the CI won't be able to install the newer versions of the dependencies. Closes https://github.com/NomicFoundation/hardhat/issues/4749

[Link to first PR](https://github.com/NomicFoundation/hardhat/pull/4875).