### PR TITLE
fix: don't build edr_napi before testing in CI

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -37,7 +37,7 @@ jobs:
           - host: windows-latest
             build: |
               pnpm build --target i686-pc-windows-msvc
-              pnpm test
+              pnpm testNoBuild
             target: i686-pc-windows-msvc
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -202,7 +202,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: pnpm test
+        run: pnpm testNoBuild
   test-linux-x64-gnu-binding:
     name: Test bindings on Linux-x64-gnu - node@${{ matrix.node }}
     needs:
@@ -236,7 +236,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: docker run --rm -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }} bash -c "wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node; pnpm test"
+        run: docker run --rm -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }} bash -c "wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node; pnpm testNoBuild"
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
@@ -272,7 +272,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: docker run --rm -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }}-alpine sh -c "wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node; pnpm test"
+        run: docker run --rm -v $(pwd):/build -w /build/crates/edr_napi node:${{ matrix.node }}-alpine sh -c "wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node; pnpm testNoBuild"
   test-linux-aarch64-gnu-binding:
     name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
     needs:
@@ -315,7 +315,7 @@ jobs:
           run: |
             wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node
             set -e
-            pnpm test
+            pnpm testNoBuild
             ls -la
   test-linux-aarch64-musl-binding:
     name: Test bindings on aarch64-unknown-linux-musl - node@lts
@@ -353,7 +353,7 @@ jobs:
           run: |
             wget -qO- 'https://unpkg.com/@pnpm/self-installer' | node
             set -e
-            pnpm test
+            pnpm testNoBuild
   check_commit:
     name: Check commit
     runs-on: ubuntu-latest

--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -45,6 +45,7 @@
     "version": "napi version",
     "pretest": "pnpm build",
     "test": "pnpm tsc && mocha --recursive \"test/**/*.ts\" --exit",
+    "testNoBuild": "pnpm tsc && mocha --recursive \"test/**/*.ts\" --exit",
     "clean": "rm -rf @ignored/edr.node"
   }
 }


### PR DESCRIPTION
After we build NAPI binaries in the CI, we test them on their respective platforms using the `node` Docker image.

In https://github.com/NomicFoundation/hardhat/pull/4831 we made a change to make `pnpm test` trigger `pnpm build`. This caused testing to fail in `node` Docker containers as the Rust toolchain is not available there.

This PR fixes this by adding a `testNoBuild` command that is executed in the CI.

Closes https://github.com/NomicFoundation/edr/issues/293