### PR TITLE
fix: use custom address recovery for fake signature

### DIFF
--- a/crates/edr_eth/src/transaction.rs
+++ b/crates/edr_eth/src/transaction.rs
@@ -4,6 +4,7 @@
 
 //! transaction related data
 
+mod fake_signature;
 mod kind;
 mod request;
 mod signed;

--- a/crates/edr_eth/src/transaction/request.rs
+++ b/crates/edr_eth/src/transaction/request.rs
@@ -2,7 +2,6 @@ mod eip155;
 mod eip1559;
 mod eip2930;
 mod eip4844;
-mod fake_signature;
 mod legacy;
 
 use k256::SecretKey;

--- a/crates/edr_eth/src/transaction/request/eip155.rs
+++ b/crates/edr_eth/src/transaction/request/eip155.rs
@@ -7,8 +7,7 @@ use revm_primitives::keccak256;
 use crate::{
     signature::{Signature, SignatureError},
     transaction::{
-        kind::TransactionKind, request::fake_signature::make_fake_signature,
-        signed::Eip155SignedTransaction,
+        fake_signature::make_fake_signature, kind::TransactionKind, signed::Eip155SignedTransaction,
     },
     Address, Bytes, B256, U256,
 };
@@ -47,6 +46,7 @@ impl Eip155TransactionRequest {
             input: self.input,
             signature,
             hash: OnceLock::new(),
+            is_fake: false,
         })
     }
 
@@ -64,6 +64,7 @@ impl Eip155TransactionRequest {
             input: self.input,
             signature,
             hash: OnceLock::new(),
+            is_fake: true,
         }
     }
 
@@ -132,7 +133,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::transaction::request::fake_signature::tests::test_fake_sign_properties;
+    use crate::transaction::fake_signature::tests::test_fake_sign_properties;
 
     fn dummy_request() -> Eip155TransactionRequest {
         let to = Address::from_str("0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e").unwrap();

--- a/crates/edr_eth/src/transaction/request/eip1559.rs
+++ b/crates/edr_eth/src/transaction/request/eip1559.rs
@@ -8,7 +8,7 @@ use crate::{
     access_list::AccessListItem,
     signature::{Signature, SignatureError},
     transaction::{
-        kind::TransactionKind, request::fake_signature::make_fake_signature,
+        fake_signature::make_fake_signature, kind::TransactionKind,
         signed::Eip1559SignedTransaction,
     },
     utils::envelop_bytes,
@@ -56,6 +56,7 @@ impl Eip1559TransactionRequest {
             r: signature.r,
             s: signature.s,
             hash: OnceLock::new(),
+            is_fake: false,
         })
     }
 
@@ -76,6 +77,7 @@ impl Eip1559TransactionRequest {
             r: signature.r,
             s: signature.s,
             hash: OnceLock::new(),
+            is_fake: true,
         }
     }
 }
@@ -101,7 +103,7 @@ pub(crate) mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::transaction::request::fake_signature::tests::test_fake_sign_properties;
+    use crate::transaction::fake_signature::tests::test_fake_sign_properties;
 
     fn dummy_request() -> Eip1559TransactionRequest {
         let to = Address::from_str("0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e").unwrap();

--- a/crates/edr_eth/src/transaction/request/eip2930.rs
+++ b/crates/edr_eth/src/transaction/request/eip2930.rs
@@ -8,7 +8,7 @@ use crate::{
     access_list::AccessListItem,
     signature::{Signature, SignatureError},
     transaction::{
-        kind::TransactionKind, request::fake_signature::make_fake_signature,
+        fake_signature::make_fake_signature, kind::TransactionKind,
         signed::Eip2930SignedTransaction,
     },
     utils::envelop_bytes,
@@ -55,6 +55,7 @@ impl Eip2930TransactionRequest {
             r: signature.r,
             s: signature.s,
             hash: OnceLock::new(),
+            is_fake: false,
         })
     }
 
@@ -75,6 +76,7 @@ impl Eip2930TransactionRequest {
             r: signature.r,
             s: signature.s,
             hash: OnceLock::new(),
+            is_fake: true,
         }
     }
 }
@@ -99,7 +101,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::transaction::request::fake_signature::tests::test_fake_sign_properties;
+    use crate::transaction::fake_signature::tests::test_fake_sign_properties;
 
     fn dummy_request() -> Eip2930TransactionRequest {
         let to = Address::from_str("0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e").unwrap();

--- a/crates/edr_eth/src/transaction/request/eip4844.rs
+++ b/crates/edr_eth/src/transaction/request/eip4844.rs
@@ -7,7 +7,7 @@ use k256::SecretKey;
 use crate::{
     access_list::AccessListItem,
     signature::{Signature, SignatureError},
-    transaction::{request::fake_signature::make_fake_signature, Eip4844SignedTransaction},
+    transaction::{fake_signature::make_fake_signature, Eip4844SignedTransaction},
     utils::envelop_bytes,
     Address, Bytes, B256, U256,
 };
@@ -57,6 +57,7 @@ impl Eip4844TransactionRequest {
             r: signature.r,
             s: signature.s,
             hash: OnceLock::new(),
+            is_fake: false,
         })
     }
 
@@ -79,6 +80,7 @@ impl Eip4844TransactionRequest {
             r: signature.r,
             s: signature.s,
             hash: OnceLock::new(),
+            is_fake: true,
         }
     }
 }
@@ -106,7 +108,7 @@ pub(crate) mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::transaction::request::fake_signature::tests::test_fake_sign_properties;
+    use crate::transaction::fake_signature::tests::test_fake_sign_properties;
 
     fn dummy_request() -> Eip4844TransactionRequest {
         // From https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/test/eip4844.spec.ts#L68

--- a/crates/edr_eth/src/transaction/request/legacy.rs
+++ b/crates/edr_eth/src/transaction/request/legacy.rs
@@ -7,8 +7,7 @@ use k256::SecretKey;
 use crate::{
     signature::{Signature, SignatureError},
     transaction::{
-        kind::TransactionKind, request::fake_signature::make_fake_signature,
-        signed::LegacySignedTransaction,
+        fake_signature::make_fake_signature, kind::TransactionKind, signed::LegacySignedTransaction,
     },
     Address, Bytes, B256, U256,
 };
@@ -45,6 +44,7 @@ impl LegacyTransactionRequest {
             input: self.input,
             signature,
             hash: OnceLock::new(),
+            is_fake: false,
         })
     }
 
@@ -61,6 +61,7 @@ impl LegacyTransactionRequest {
             input: self.input,
             signature,
             hash: OnceLock::new(),
+            is_fake: true,
         }
     }
 }
@@ -83,7 +84,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::transaction::request::fake_signature::tests::test_fake_sign_properties;
+    use crate::transaction::fake_signature::tests::test_fake_sign_properties;
 
     fn dummy_request() -> LegacyTransactionRequest {
         let to = Address::from_str("0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e").unwrap();

--- a/crates/edr_eth/src/transaction/signed.rs
+++ b/crates/edr_eth/src/transaction/signed.rs
@@ -438,6 +438,7 @@ mod tests {
                     v: 1,
                 },
                 hash: OnceLock::new(),
+                is_fake: false
             }),
             post_eip155 => SignedTransaction::PostEip155Legacy(Eip155SignedTransaction {
                 nonce: 0,
@@ -452,6 +453,7 @@ mod tests {
                     v: 37,
                 },
                 hash: OnceLock::new(),
+                is_fake: false
             }),
             eip2930 => SignedTransaction::Eip2930(Eip2930SignedTransaction {
                 chain_id: 1,
@@ -466,6 +468,7 @@ mod tests {
                 s: U256::default(),
                 access_list: vec![].into(),
                 hash: OnceLock::new(),
+                is_fake: false
             }),
             eip1559 => SignedTransaction::Eip1559(Eip1559SignedTransaction {
                 chain_id: 1,
@@ -481,6 +484,7 @@ mod tests {
                 r: U256::default(),
                 s: U256::default(),
                 hash: OnceLock::new(),
+                is_fake: false
             }),
             eip4844 => SignedTransaction::Eip4844(Eip4844SignedTransaction {
                 chain_id: 1,
@@ -498,6 +502,7 @@ mod tests {
                 r: U256::default(),
                 s: U256::default(),
                 hash: OnceLock::new(),
+                is_fake: false
             }),
     }
 
@@ -527,6 +532,7 @@ mod tests {
                 .unwrap(),
             },
             hash: OnceLock::new(),
+            is_fake: false,
         });
         assert_eq!(
             expected,
@@ -555,6 +561,7 @@ mod tests {
                 .unwrap(),
             },
             hash: OnceLock::new(),
+            is_fake: false,
         });
         assert_eq!(
             expected,
@@ -583,6 +590,7 @@ mod tests {
                 .unwrap(),
             },
             hash: OnceLock::new(),
+            is_fake: false,
         });
         assert_eq!(
             expected,
@@ -608,6 +616,7 @@ mod tests {
             s: U256::from_str("0x016b83f4f980694ed2eee4d10667242b1f40dc406901b34125b008d334d47469")
                 .unwrap(),
             hash: OnceLock::new(),
+            is_fake: false,
         });
         assert_eq!(
             expected,
@@ -636,6 +645,7 @@ mod tests {
                 .unwrap(),
             },
             hash: OnceLock::new(),
+            is_fake: false,
         });
         assert_eq!(
             expected,

--- a/crates/edr_eth/src/transaction/signed/eip2930.rs
+++ b/crates/edr_eth/src/transaction/signed/eip2930.rs
@@ -6,7 +6,10 @@ use alloy_rlp::{RlpDecodable, RlpEncodable};
 use crate::{
     access_list::AccessList,
     signature::{Signature, SignatureError},
-    transaction::{kind::TransactionKind, request::Eip2930TransactionRequest},
+    transaction::{
+        fake_signature::recover_fake_signature, kind::TransactionKind,
+        request::Eip2930TransactionRequest,
+    },
     utils::envelop_bytes,
     Address, Bytes, B256, U256,
 };
@@ -34,6 +37,11 @@ pub struct Eip2930SignedTransaction {
     #[rlp(skip)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub hash: OnceLock<B256>,
+    /// Whether the signed transaction is from an impersonated account.
+    #[rlp(default)]
+    #[rlp(skip)]
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub is_fake: bool,
 }
 
 impl Eip2930SignedTransaction {
@@ -53,6 +61,10 @@ impl Eip2930SignedTransaction {
             s: self.s,
             v: u64::from(self.odd_y_parity),
         };
+
+        if self.is_fake {
+            return Ok(recover_fake_signature(&signature));
+        }
 
         signature.recover(Eip2930TransactionRequest::from(self).hash())
     }

--- a/crates/edr_evm/src/transaction/executable.rs
+++ b/crates/edr_evm/src/transaction/executable.rs
@@ -284,6 +284,7 @@ impl TryFrom<Transaction> for ExecutableTransaction {
                             v: value.v,
                         },
                         hash: OnceLock::from(value.hash),
+                        is_fake: false,
                     })
                 } else {
                     SignedTransaction::PostEip155Legacy(Eip155SignedTransaction {
@@ -299,6 +300,7 @@ impl TryFrom<Transaction> for ExecutableTransaction {
                             v: value.v,
                         },
                         hash: OnceLock::from(value.hash),
+                        is_fake: false,
                     })
                 }
             }
@@ -320,6 +322,7 @@ impl TryFrom<Transaction> for ExecutableTransaction {
                 r: value.r,
                 s: value.s,
                 hash: OnceLock::from(value.hash),
+                is_fake: false,
             }),
             Some(2) => SignedTransaction::Eip1559(Eip1559SignedTransaction {
                 odd_y_parity: value.odd_y_parity(),
@@ -344,6 +347,7 @@ impl TryFrom<Transaction> for ExecutableTransaction {
                 r: value.r,
                 s: value.s,
                 hash: OnceLock::from(value.hash),
+                is_fake: false,
             }),
             Some(3) => SignedTransaction::Eip4844(Eip4844SignedTransaction {
                 odd_y_parity: value.odd_y_parity(),
@@ -376,6 +380,7 @@ impl TryFrom<Transaction> for ExecutableTransaction {
                 r: value.r,
                 s: value.s,
                 hash: OnceLock::from(value.hash),
+                is_fake: false,
             }),
             Some(r#type) => {
                 return Err(TransactionConversionError::UnsupportedType(r#type));

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -2535,7 +2535,6 @@ mod tests {
     use edr_eth::{
         remote::{eth::CallRequest, PreEip1898BlockSpec},
         spec::chain_hardfork_activations,
-        transaction::{Eip155TransactionRequest, TransactionKind, TransactionRequest},
     };
     use edr_evm::{hex, MineOrdering, RemoteBlock, TransactionError};
     use edr_test_utils::env::get_alchemy_url;
@@ -3399,56 +3398,6 @@ mod tests {
             .is_success());
         // Sanity check that the mempool is empty.
         assert_eq!(fixture.provider_data.mem_pool.transactions().count(), 0);
-
-        let transaction_result = fixture
-            .provider_data
-            .transaction_by_hash(&transaction_hash)?
-            .context("transaction not found")?;
-
-        assert_eq!(
-            transaction_result.signed_transaction.hash(),
-            &transaction_hash
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn transaction_by_hash_for_impersonated_account() -> anyhow::Result<()> {
-        let mut fixture = ProviderTestFixture::new_local()?;
-
-        let impersonated_account: Address = "0x67091a7dd65bf4f1e95af0a479fbc782b61c129a".parse()?;
-        fixture
-            .provider_data
-            .impersonate_account(impersonated_account);
-
-        fixture
-            .provider_data
-            .set_balance(impersonated_account, one_ether())?;
-
-        let request = TransactionRequest::Eip155(Eip155TransactionRequest {
-            kind: TransactionKind::Call(Address::ZERO),
-            gas_limit: 30_000,
-            gas_price: U256::from(42_000_000_000_u64),
-            value: U256::from(1),
-            input: Bytes::default(),
-            nonce: 0,
-            chain_id: fixture.provider_data.chain_id(),
-        })
-        .fake_sign(&impersonated_account);
-        let transaction = ExecutableTransaction::with_caller(
-            fixture.provider_data.spec_id(),
-            request,
-            impersonated_account,
-        )?;
-
-        fixture.provider_data.set_auto_mining(true);
-        let SendTransactionResult {
-            transaction_hash,
-            transaction_result,
-            ..
-        } = fixture.provider_data.send_transaction(transaction)?;
-        assert!(transaction_result.is_some());
 
         let transaction_result = fixture
             .provider_data


### PR DESCRIPTION
Make sure we're not trying to recover the address from fake signatures. Fixes https://github.com/NomicFoundation/edr/issues/294