### PR TITLE
fix: avoid inserting transactions twice

### DIFF
--- a/crates/edr_evm/src/blockchain.rs
+++ b/crates/edr_evm/src/blockchain.rs
@@ -34,6 +34,9 @@ pub enum BlockchainError {
     /// Forked blockchain error
     #[error(transparent)]
     Forked(#[from] ForkedBlockchainError),
+    /// An error that occurs when trying to insert a block into storage.
+    #[error(transparent)]
+    Insert(#[from] storage::InsertError),
     /// Invalid block number
     #[error("Invalid block number: {actual}. Expected: {expected}.")]
     InvalidBlockNumber {

--- a/crates/edr_evm/src/blockchain/local.rs
+++ b/crates/edr_evm/src/blockchain/local.rs
@@ -222,7 +222,7 @@ impl Blockchain for LocalBlockchain {
         number: u64,
     ) -> Result<Option<Arc<dyn SyncBlock<Error = Self::BlockchainError>>>, Self::BlockchainError>
     {
-        Ok(self.storage.block_by_number(number))
+        Ok(self.storage.block_by_number(number)?)
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
@@ -245,7 +245,7 @@ impl Blockchain for LocalBlockchain {
     ) -> Result<Arc<dyn SyncBlock<Error = Self::BlockchainError>>, Self::BlockchainError> {
         Ok(self
             .storage
-            .block_by_number(self.storage.last_block_number())
+            .block_by_number(self.storage.last_block_number())?
             .expect("Block must exist"))
     }
 
@@ -331,12 +331,9 @@ impl BlockchainMut for LocalBlockchain {
 
         let total_difficulty = previous_total_difficulty + block.header().difficulty;
 
-        // SAFETY: The block number is guaranteed to be unique, so the block hash must
-        // be too.
-        let block = unsafe {
-            self.storage
-                .insert_block_unchecked(block, state_diff, total_difficulty)
-        };
+        let block = self
+            .storage
+            .insert_block(block, state_diff, total_difficulty)?;
 
         Ok(BlockAndTotalDifficulty {
             block: block.clone(),
@@ -390,7 +387,7 @@ impl BlockHashRef for LocalBlockchain {
             u64::try_from(number).map_err(|_error| BlockchainError::BlockNumberTooLarge)?;
 
         self.storage
-            .block_by_number(number)
+            .block_by_number(number)?
             .map(|block| *block.hash())
             .ok_or(BlockchainError::UnknownBlockNumber)
     }

--- a/crates/edr_evm/src/blockchain/remote.rs
+++ b/crates/edr_evm/src/blockchain/remote.rs
@@ -171,8 +171,7 @@ impl<BlockT: Block + Clone + From<RemoteBlock>, const FORCE_CACHING: bool>
         {
             Ok(Some({
                 let mut cache = RwLockUpgradableReadGuard::upgrade(cache).await;
-                // SAFETY: the receipt with this hash didn't exist yet, so it must be unique
-                unsafe { cache.insert_receipt_unchecked(receipt) }.clone()
+                cache.insert_receipt(receipt)?.clone()
             }))
         } else {
             Ok(None)
@@ -235,8 +234,7 @@ impl<BlockT: Block + Clone + From<RemoteBlock>, const FORCE_CACHING: bool>
         if is_cacheable {
             let mut remote_cache = RwLockUpgradableReadGuard::upgrade(cache).await;
 
-            // SAFETY: the block with this number didn't exist yet, so it must be unique
-            Ok(unsafe { remote_cache.insert_block_unchecked(block, total_difficulty) }.clone())
+            Ok(remote_cache.insert_block(block, total_difficulty)?.clone())
         } else {
             Ok(block)
         }

--- a/crates/edr_evm/src/blockchain/storage.rs
+++ b/crates/edr_evm/src/blockchain/storage.rs
@@ -16,6 +16,12 @@ pub enum InsertError {
         /// The block's number
         block_number: u64,
     },
+    /// Receipt already exists
+    #[error("A receipt with transaction hash {transaction_hash} already exists.")]
+    DuplicateReceipt {
+        /// Transaction hash of duplicated receipt
+        transaction_hash: B256,
+    },
     /// Transaction already exists
     #[error("A transaction with hash {hash} already exists.")]
     DuplicateTransaction {


### PR DESCRIPTION
This PR fixes a bug where we were inserting twice into `SparseBlockchainStorage::transaction_hash_to_block`. I also made the unsafe unchecked insertions fallible to help us when debugging sporadic failures in third-party repos. 