### PR TITLE
Temporarily remove EDR changeset

### DIFF
--- a/.changeset/cold-cobras-carry.md
+++ b/.changeset/cold-cobras-carry.md
@@ -1,5 +1,0 @@
----
-"hardhat": minor
----
-
-Refactored Hardhat Network to use EDR instead of ethereumjs


### PR DESCRIPTION
Removing EDR changeset so we can release hardhat-viem without releasing hardhat.