### PR TITLE
ci: pin napi-rs docker images

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -40,14 +40,14 @@ jobs:
             target: i686-pc-windows-msvc
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:4b2638c0987845c4ab3488574a215a2a866b99fb28588788786f2b8cbcb40e71
             build: |-
               set -e &&
               pnpm run build --target x86_64-unknown-linux-gnu &&
               strip *.node
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:2003f7f7027adaab2c97bf576ce6bb87640a77c62a6898ed2359c050c49872a5
             build: |-
               apk add perl;
               set -e &&
@@ -60,7 +60,7 @@ jobs:
               strip -x *.node
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:08cb2c8326ae78cf8ffd58f81523dd9592a4778c2c5f314251f5773ea204f289
             build: |-
               set -e &&
               sudo apt-get update &&
@@ -74,7 +74,7 @@ jobs:
               aarch64-unknown-linux-gnu-strip *.node
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:2003f7f7027adaab2c97bf576ce6bb87640a77c62a6898ed2359c050c49872a5
             build: |-
               apk add perl;
               set -e &&


### PR DESCRIPTION
Pin NAPI-rs Docker images to avoid failures if the images are upgraded.