### PR TITLE
edr-0.2.0-alpha.2

### DIFF
--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/edr",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.0-alpha.2",
   "main": "index.js",
   "types": "index.d.ts",
   "repository": {

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.1.2",
     "@metamask/eth-sig-util": "^4.0.0",
-    "@nomicfoundation/edr": "workspace:^0.2.0-alpha.1",
+    "@nomicfoundation/edr": "workspace:^0.2.0-alpha.2",
     "@nomicfoundation/ethereumjs-common": "4.0.4",
     "@nomicfoundation/ethereumjs-tx": "5.0.4",
     "@nomicfoundation/ethereumjs-util": "9.0.4",


### PR DESCRIPTION
The previous attempt didn't work because GitHub ignored the commit during the rebase? Maybe because it was empty.

But I hadn't bumped the version on the `package.json` so it was not going to work anyway.