### PR TITLE
Viem 2 in toolbox in ethereumjs/main

### DIFF
--- a/.changeset/silver-waves-cough.md
+++ b/.changeset/silver-waves-cough.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-toolbox-viem": major
+"hardhat": patch
+---
+
+Upgraded hardhat-toolbox-viem and project creation to support viem@2

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -46,7 +46,7 @@ const ETHERS_PROJECT_DEPENDENCIES: Dependencies = {
 };
 
 const VIEM_PROJECT_DEPENDENCIES: Dependencies = {
-  "@nomicfoundation/hardhat-toolbox-viem": "^2.0.0",
+  "@nomicfoundation/hardhat-toolbox-viem": "^3.0.0",
 };
 
 const PEER_DEPENDENCIES: Dependencies = {
@@ -68,8 +68,8 @@ const ETHERS_PEER_DEPENDENCIES: Dependencies = {
 };
 
 const VIEM_PEER_DEPENDENCIES: Dependencies = {
-  "@nomicfoundation/hardhat-viem": "^1.0.0",
-  viem: "^1.15.1",
+  "@nomicfoundation/hardhat-viem": "^2.0.0",
+  viem: "^2.7.6",
 };
 
 const TYPESCRIPT_DEPENDENCIES: Dependencies = {};

--- a/packages/hardhat-toolbox-viem/package.json
+++ b/packages/hardhat-toolbox-viem/package.json
@@ -47,7 +47,7 @@
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@nomicfoundation/hardhat-network-helpers": "workspace:^1.0.0",
     "@nomicfoundation/hardhat-verify": "workspace:^2.0.0",
-    "@nomicfoundation/hardhat-viem": "workspace:^1.0.0",
+    "@nomicfoundation/hardhat-viem": "workspace:^2.0.0",
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^7.1.6",
     "@types/mocha": ">=9.1.0",
@@ -68,12 +68,12 @@
     "solidity-coverage": "^0.8.1",
     "ts-node": "^10.8.0",
     "typescript": "~5.0.4",
-    "viem": "^1.15.1"
+    "viem": "^2.7.6"
   },
   "peerDependencies": {
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "@nomicfoundation/hardhat-verify": "^2.0.0",
-    "@nomicfoundation/hardhat-viem": "^1.0.0",
+    "@nomicfoundation/hardhat-viem": "^2.0.0",
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^7.1.6",
     "@types/mocha": ">=9.1.0",
@@ -84,7 +84,7 @@
     "solidity-coverage": "^0.8.1",
     "ts-node": ">=8.0.0",
     "typescript": "~5.0.4",
-    "viem": "^1.15.1"
+    "viem": "^2.7.6"
   },
   "bugs": {
     "url": "https://github.com/nomicfoundation/hardhat/issues"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,7 +1125,7 @@ importers:
         specifier: workspace:^2.0.0
         version: link:../hardhat-verify
       '@nomicfoundation/hardhat-viem':
-        specifier: workspace:^1.0.0
+        specifier: workspace:^2.0.0
         version: link:../hardhat-viem
       '@types/chai':
         specifier: ^4.2.0
@@ -1188,8 +1188,8 @@ importers:
         specifier: ~5.0.4
         version: 5.0.4
       viem:
-        specifier: ^1.15.1
-        version: 1.15.1(typescript@5.0.4)
+        specifier: ^2.7.6
+        version: 2.7.6(typescript@5.0.4)
 
   packages/hardhat-truffle4:
     dependencies:
@@ -1881,10 +1881,6 @@ packages:
 
   /@adraffy/ens-normalize@1.9.2:
     resolution: {integrity: sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==}
-
-  /@adraffy/ens-normalize@1.9.4:
-    resolution: {integrity: sha512-UK0bHA7hh9cR39V+4gl2/NnBBjoXIxkuWAPCaY4X7fbH4L/azIi7ilWOCjMUYfpJgraLUAqkRi2BqrjME8Rynw==}
-    dev: true
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -3813,12 +3809,6 @@ packages:
       '@types/node': 16.18.40
     dev: true
 
-  /@types/ws@8.5.10:
-    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
-    dependencies:
-      '@types/node': 16.18.40
-    dev: true
-
   /@types/ws@8.5.3:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
@@ -4039,6 +4029,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.0.4
+    dev: false
 
   /abitype@1.0.0(typescript@5.0.4):
     resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
@@ -10735,22 +10726,21 @@ packages:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  /viem@1.15.1(typescript@5.0.4):
-    resolution: {integrity: sha512-lxk8wwUK7ZivYAUZ6pH+9Y6jjrfXXjafCOoASa4lw3ULUCT2BajU4SELarlxJQimpsFd7OZD4m4iEXYLF/bt6w==}
+  /viem@2.7.10(typescript@5.0.4):
+    resolution: {integrity: sha512-mpm/A3Rbq6hhRovOw6btkrLeDe0DlEGLoCmO2LCbH/MuTQgLNd0cWJSIov9TL/8/Pz+qC2e+bh9zohQnKA+6PQ==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@adraffy/ens-normalize': 1.9.4
+      '@adraffy/ens-normalize': 1.10.0
       '@noble/curves': 1.2.0
       '@noble/hashes': 1.3.2
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
-      '@types/ws': 8.5.10
-      abitype: 0.9.8(typescript@5.0.4)
-      isomorphic-ws: 5.0.0(ws@8.13.0)
+      abitype: 1.0.0(typescript@5.0.4)
+      isows: 1.0.3(ws@8.13.0)
       typescript: 5.0.4
       ws: 8.13.0
     transitivePeerDependencies:
@@ -10759,8 +10749,8 @@ packages:
       - zod
     dev: true
 
-  /viem@2.7.10(typescript@5.0.4):
-    resolution: {integrity: sha512-mpm/A3Rbq6hhRovOw6btkrLeDe0DlEGLoCmO2LCbH/MuTQgLNd0cWJSIov9TL/8/Pz+qC2e+bh9zohQnKA+6PQ==}
+  /viem@2.7.6(typescript@5.0.4):
+    resolution: {integrity: sha512-43TF0VYcTeNef9dax1/BhqlRLXpAo6HAiQ68hrJ8XRhDOou73nHZEjeFl8Eai4UFFodKhu+PbRUFzuuoixOUfg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:


### PR DESCRIPTION
Apply the follow on changes to the viem toolbox now that `hardhat-viem` support for `viem@2` has been released.
