### PR TITLE
Add missing brackets to "after" example

### DIFF
--- a/docs/src/content/ignition/docs/guides/creating-modules.md
+++ b/docs/src/content/ignition/docs/guides/creating-modules.md
@@ -203,7 +203,7 @@ You also have the option to set explicit dependencies between `Future` objects. 
 const token = m.contract("Token", ["My Token", "TKN", 18]);
 
 const receiver = m.contract("Receiver", [], {
-  after: token, // `receiver` is deployed after `token`
+  after: [token], // `receiver` is deployed after `token`
 });
 ```
 


### PR DESCRIPTION
Added missing brackets around `after` params in an ignition example. 