### PR TITLE
feat: add max cached states env var

### DIFF
--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -7,6 +7,7 @@ use std::{
     cmp,
     cmp::Ordering,
     collections::BTreeMap,
+    ffi::OsString,
     fmt::Debug,
     num::NonZeroUsize,
     sync::Arc,
@@ -76,7 +77,8 @@ use crate::{
 };
 
 const DEFAULT_INITIAL_BASE_FEE_PER_GAS: u64 = 1_000_000_000;
-const MAX_CACHED_STATES: usize = 10;
+const EDR_MAX_CACHED_STATES_ENV_VAR: &str = "__EDR_MAX_CACHED_STATES";
+const DEFAULT_MAX_CACHED_STATES: usize = 10;
 
 /// The result of executing an `eth_call`.
 #[derive(Clone, Debug)]
@@ -112,6 +114,8 @@ pub enum CreationError {
     /// Invalid initial date
     #[error("The initial date configuration value {0:?} is before the UNIX epoch")]
     InvalidInitialDate(SystemTime),
+    #[error("Invalid max cached states environment variable value: '{0:?}'. Please provide a non-zero integer!")]
+    InvalidMaxCachedStates(OsString),
     /// An error that occurred while constructing a local blockchain.
     #[error(transparent)]
     LocalBlockchainCreation(#[from] LocalCreationError),
@@ -183,8 +187,19 @@ impl<LoggerErrorT: Debug> ProviderData<LoggerErrorT> {
             next_block_base_fee_per_gas,
         } = create_blockchain_and_state(runtime_handle.clone(), &config, genesis_accounts)?;
 
-        let mut block_state_cache =
-            LruCache::new(NonZeroUsize::new(MAX_CACHED_STATES).expect("constant is non-zero"));
+        let max_cached_states = std::env::var(EDR_MAX_CACHED_STATES_ENV_VAR).map_or_else(
+            |err| match err {
+                std::env::VarError::NotPresent => {
+                    Ok(NonZeroUsize::new(DEFAULT_MAX_CACHED_STATES).expect("constant is non-zero"))
+                }
+                std::env::VarError::NotUnicode(s) => Err(CreationError::InvalidMaxCachedStates(s)),
+            },
+            |s| {
+                s.parse()
+                    .map_err(|_err| CreationError::InvalidMaxCachedStates(s.into()))
+            },
+        )?;
+        let mut block_state_cache = LruCache::new(max_cached_states);
         let mut block_number_to_state_id = BTreeMap::new();
 
         let current_state_id = StateId::default();


### PR DESCRIPTION
Add `__EDR_MAX_CACHED_STATES` environment variable to allow changing the default value of 10. Increasing the value causes higher memory usage and may lead to slow downs if the machine runs out of memory and starts swapping.

| Repo                   | Improvement over HH2.20 with cache size = 10 | Improvement over HH2.20 with cache size = 2048 | RAM usage with cache size = 2048 |
|------------------------|----------------------------------------------|------------------------------------------------|----------------------------------|
| openzeppelin-contracts | 10%                                          | 28%                                            | 6GB                              |
| rocketpool             | 51%                                          | 60%                                            | 6GB                              |
| uniswap-v3-core        | 3.5%                                         | 10%                                            | 4GB                              |