### PR TITLE
Add custom rpc method to toggle ledger feedback

### DIFF
--- a/.changeset/itchy-walls-suffer.md
+++ b/.changeset/itchy-walls-suffer.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ledger": patch
+---
+
+Internal restructuing to better support cli UI updates from other Hardhat plugins

--- a/packages/hardhat-ledger/src/provider.ts
+++ b/packages/hardhat-ledger/src/provider.ts
@@ -35,6 +35,7 @@ export class LedgerProvider extends ProviderWrapperWithChainId {
 
   public readonly paths: Paths = {}; // { address: path }
   public name: string = "LedgerProvider";
+  public isOutputEnabled: boolean = true;
 
   protected _eth: EthWrapper | undefined;
 
@@ -113,6 +114,10 @@ export class LedgerProvider extends ProviderWrapperWithChainId {
 
   public async request(args: RequestArguments): Promise<unknown> {
     const params = this._getParams(args);
+
+    if (args.method === "hardhat_setLedgerOutputEnabled") {
+      return this._setOutputEnabled(params);
+    }
 
     if (args.method === "eth_accounts") {
       const accounts = (await this._wrappedProvider.request(args)) as string[];
@@ -427,5 +432,15 @@ export class LedgerProvider extends ProviderWrapperWithChainId {
         hexAddress
       );
     }
+  }
+
+  /**
+   * Toggles the provider's output. Use to suppress default feedback and
+   * manage it via events.
+   */
+  private _setOutputEnabled(params: any[]): void {
+    const [enabled] = validateParams(params, t.boolean);
+
+    this.isOutputEnabled = enabled;
   }
 }

--- a/packages/hardhat-ledger/test/internal/with-spinners.ts
+++ b/packages/hardhat-ledger/test/internal/with-spinners.ts
@@ -1,17 +1,19 @@
+import type { OutputControlledEmitter } from "../../src/internal/with-spinners";
+
 import { assert } from "chai";
 import sinon from "sinon";
 import EventEmitter from "events";
-import * as spinners from "../../src/internal/with-spinners";
+import { withSpinners } from "../../src/internal/with-spinners";
 
 describe("withSpinners", () => {
-  let eventEmitter: EventEmitter;
+  let eventEmitter: OutputControlledEmitter;
 
   function containsArray(baseArray: Array<string | symbol>, values: string[]) {
     return values.every((value) => baseArray.includes(value));
   }
 
   beforeEach(() => {
-    eventEmitter = new EventEmitter();
+    eventEmitter = new EventEmitter() as OutputControlledEmitter;
   });
 
   afterEach(() => {
@@ -19,7 +21,7 @@ describe("withSpinners", () => {
   });
 
   it("should attach the connection events", () => {
-    const emitter = spinners.withSpinners(eventEmitter);
+    const emitter = withSpinners(eventEmitter);
     assert.isTrue(
       containsArray(emitter.eventNames(), [
         "connection_start",
@@ -30,7 +32,7 @@ describe("withSpinners", () => {
   });
 
   it("should attach the derivation events", () => {
-    const emitter = spinners.withSpinners(eventEmitter);
+    const emitter = withSpinners(eventEmitter);
     assert.isTrue(
       containsArray(emitter.eventNames(), [
         "derivation_start",
@@ -42,7 +44,7 @@ describe("withSpinners", () => {
   });
 
   it("should attach the confirmation events", () => {
-    const emitter = spinners.withSpinners(eventEmitter);
+    const emitter = withSpinners(eventEmitter);
     assert.isTrue(
       containsArray(emitter.eventNames(), [
         "confirmation_start",


### PR DESCRIPTION
Note: This RPC method is intended for internal usage and may change without notice.

Usage:

```javascript
try {
  // Disable the default ledger output by calling `hardhat_setLedgerOutputEnabled`
  await hre.network.provider.send("hardhat_setLedgerOutputEnabled", [false]);

  // Subscribe to hardhat-ledger events and manually handle the output
  hre.network.provider.once("connection_start", () => console.log("IGNITION: [hardhat-ledger] Connecting wallet"));
  hre.network.provider.once("connection_success", () => console.log("[🗸] IGNITION: [hardhat-ledger] Connecting wallet"));
  hre.network.provider.once("connection_failure", () => console.log("[x] IGNITION: [hardhat-ledger] Connecting wallet"));
  // confirmation_start
  // confirmation_success
  // confirmation_failure
  // derivation_start
  // derivation_progress
  // derivation_success
  // derivation_failure
  
  // Placeholder for contract deployment logic

  // Re-enable the default ledger output after deployment
  await hre.network.provider.send("hardhat_setLedgerOutputEnabled", [true]);
} catch (error) {
  if (/Unsupported method/.test(error.message)) {
    // The current provider does not support the hardhat-ledger method
    console.error("The method hardhat_setLedgerOutputEnabled is not supported by the current provider.");
  }
}
```

Closes https://github.com/NomicFoundation/hardhat/issues/4844