### PR TITLE
chore(hardhat-viem,hardhat-toolbox-viem): updated package.json with loosen version constraints for typescript

### DIFF
--- a/packages/hardhat-toolbox-viem/package.json
+++ b/packages/hardhat-toolbox-viem/package.json
@@ -73,7 +73,7 @@
   "peerDependencies": {
     "@nomicfoundation/hardhat-network-helpers": "workspace:^1.0.0",
     "@nomicfoundation/hardhat-verify": "workspace:^2.0.0",
-    "@nomicfoundation/hardhat-viem": "workspace:^1.0.0",
+    "@nomicfoundation/hardhat-viem": "workspace:^2.0.0",
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^7.1.6",
     "@types/mocha": ">=9.1.0",

--- a/packages/hardhat-toolbox-viem/package.json
+++ b/packages/hardhat-toolbox-viem/package.json
@@ -83,7 +83,7 @@
     "hardhat-gas-reporter": "^1.0.8",
     "solidity-coverage": "^0.8.1",
     "ts-node": ">=8.0.0",
-    "typescript": "~5.0.4",
+    "typescript": "^5.0.0",
     "viem": "^1.15.1"
   },
   "bugs": {

--- a/packages/hardhat-viem/package.json
+++ b/packages/hardhat-viem/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "hardhat": "workspace:^2.17.0",
-    "typescript": "~5.0.0",
+    "typescript": "^5.0.0",
     "viem": "^2.7.6"
   },
   "dependencies": {


### PR DESCRIPTION
### Problem

Once adding `hardhat-toolbox-viem` to my local project I've stumbled upon following error while running `npm install`.

<img width="1176" alt="image" src="https://github.com/NomicFoundation/hardhat/assets/20476300/2b2e0137-2af9-44aa-88f3-0e51f8d8163c">

I have following packages installed in my repo;
```json
  "@nomicfoundation/hardhat-viem": "^2.0.0",
  "@nomicfoundation/hardhat-toolbox-viem": "^2.0.0",
``` 

### Solution

I've took a look at two `package.json` files for `hardhat-viem` and `hardhat-toolbox-viem`. What I found out is that both of them do contain conflicting peerDependencies.

The first is `hardhat-toolbox-viem` package and I believe it supposed to already rely on latest `hardhat-viem` version. Where now it depends on `^1.0.0`, so what I did I bumped it by one major version, so now it's `hardhat-viem@workspace:^2.0.0`.

The second was `typescript@~5.0.0` as a peer dependency of `hardhat-viem`. As you can already it capped up to only latest patch updates, where in my project I already have version `5.3.2`. To avoid such conflicts I've changed typescript version constraint to accept any minor version as well by setting `typescript@^5.0.0` in both; `hardhat-viem` & `hardhat-toolkit-viem`.