### PR TITLE
edr-0.2.0

### DIFF
--- a/crates/edr_napi/package.json
+++ b/crates/edr_napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/edr",
-  "version": "0.2.0-alpha.2",
+  "version": "0.2.0",
   "main": "index.js",
   "types": "index.d.ts",
   "repository": {

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.1.2",
     "@metamask/eth-sig-util": "^4.0.0",
-    "@nomicfoundation/edr": "workspace:^0.2.0-alpha.2",
+    "@nomicfoundation/edr": "workspace:^0.2.0",
     "@nomicfoundation/ethereumjs-common": "4.0.4",
     "@nomicfoundation/ethereumjs-tx": "5.0.4",
     "@nomicfoundation/ethereumjs-util": "9.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,7 +231,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
       '@nomicfoundation/edr':
-        specifier: workspace:^0.2.0-alpha.2
+        specifier: workspace:^0.2.0
         version: link:../../crates/edr_napi
       '@nomicfoundation/ethereumjs-common':
         specifier: 4.0.4


### PR DESCRIPTION
Publish `@nomicfoundation/edr@0.2.0` in npm

The e2e workflow will fail here because this version is not published yet.