### PR TITLE
Run gas report and coverage in e2e

### DIFF
--- a/e2e/test-project-initialization.sh
+++ b/e2e/test-project-initialization.sh
@@ -140,7 +140,7 @@ for pkg_manager in $pkg_managers; do
   assert_no_empty_files
   $pkg_runner hardhat compile
   $pkg_runner hardhat test
-  $pkg_runner hardhat coverage
+  SOLIDITY_COVERAGE=true $pkg_runner hardhat coverage
   REPORT_GAS=true $pkg_runner hardhat test
   cd -
 

--- a/e2e/test-project-initialization.sh
+++ b/e2e/test-project-initialization.sh
@@ -80,6 +80,8 @@ for pkg_manager in $pkg_managers; do
   assert_no_empty_files
   $pkg_runner hardhat compile
   $pkg_runner hardhat test
+  $pkg_runner hardhat coverage
+  REPORT_GAS=true $pkg_runner hardhat test
   cd -
 
   # pkg_manager, javascript, esm
@@ -94,6 +96,8 @@ for pkg_manager in $pkg_managers; do
   assert_no_empty_files
   $pkg_runner hardhat compile
   $pkg_runner hardhat test
+  $pkg_runner hardhat coverage
+  REPORT_GAS=true $pkg_runner hardhat test
   cd -
 
   # pkg_manager, typescript, cjs
@@ -106,6 +110,8 @@ for pkg_manager in $pkg_managers; do
   assert_no_empty_files
   $pkg_runner hardhat compile
   $pkg_runner hardhat test
+  $pkg_runner hardhat coverage
+  REPORT_GAS=true $pkg_runner hardhat test
   cd -
 
   # pkg_manager, typescript, esm
@@ -134,6 +140,8 @@ for pkg_manager in $pkg_managers; do
   assert_no_empty_files
   $pkg_runner hardhat compile
   $pkg_runner hardhat test
+  $pkg_runner hardhat coverage
+  REPORT_GAS=true $pkg_runner hardhat test
   cd -
 
   # pkg_manager, typescript-viem, esm


### PR DESCRIPTION
The e2e workflow should fail with this change. For some reason, `npx hardhat coverage` doesn't work with the viem-based sample project. As part of this PR, we should fix that.