### PR TITLE
Use explicit content-type header in RPC requests

### DIFF
--- a/crates/edr_eth/src/remote/client.rs
+++ b/crates/edr_eth/src/remote/client.rs
@@ -11,7 +11,7 @@ use std::{
 use futures::stream::StreamExt;
 pub use hyper::{http::Error as HttpError, HeaderMap};
 use itertools::{izip, Itertools};
-use reqwest::Client as HttpClient;
+use reqwest::{self, Client as HttpClient};
 use reqwest_middleware::{ClientBuilder as HttpClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 #[cfg(feature = "tracing")]
@@ -473,6 +473,7 @@ impl RpcClient {
         self.client
             .post(self.url.clone())
             .body(request_body.to_json_string())
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
             .send()
             .await
             .map_err(RpcClientError::FailedToSend)?


### PR DESCRIPTION
Closes https://github.com/NomicFoundation/edr/issues/323

EDIT: turning this into a draft because, while this lets the node start with that network, it can't mine a block after doing it.

The problem is that a `BlockchainError::InvalidParentHash` is thrown. I couldn't figure out why that happens with this network but not with mainnet. It might be related to faster mining times in that network. My guess is that there is a race condition where the "latest" block is fetched twice at different points, with different results. Not sure though.