### PR TITLE
feat: set cancun as default hardfork

### DIFF
--- a/.changeset/gold-comics-do.md
+++ b/.changeset/gold-comics-do.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Set cancun as the default hardfork in Hardhat network

--- a/.changeset/gold-comics-do.md
+++ b/.changeset/gold-comics-do.md
@@ -1,5 +1,5 @@
 ---
-"hardhat": patch
+"hardhat": minor
 ---
 
 Set cancun as the default hardfork in Hardhat network

--- a/docs/src/content/hardhat-network/docs/reference/index.md
+++ b/docs/src/content/hardhat-network/docs/reference/index.md
@@ -66,7 +66,7 @@ The block gas limit to use in Hardhat Network's blockchain. Default value: `30_0
 
 #### `hardfork`
 
-This setting changes how Hardhat Network works, to mimic Ethereum's mainnet at a given hardfork. It must be one of `"byzantium"`, `"constantinople"`, `"petersburg"`, `"istanbul"`, `"muirGlacier"`, `"berlin"`, `"london"`, `"arrowGlacier"`, `"grayGlacier"`, `"merge"`, `"shanghai"` and `"cancun"`. Default value: `"shanghai"`
+This setting changes how Hardhat Network works, to mimic Ethereum's mainnet at a given hardfork. It must be one of `"byzantium"`, `"constantinople"`, `"petersburg"`, `"istanbul"`, `"muirGlacier"`, `"berlin"`, `"london"`, `"arrowGlacier"`, `"grayGlacier"`, `"merge"`, `"shanghai"` and `"cancun"`. Default value: `"cancun"`
 
 #### `throwOnTransactionFailures`
 

--- a/packages/hardhat-core/src/internal/core/config/default-config.ts
+++ b/packages/hardhat-core/src/internal/core/config/default-config.ts
@@ -36,7 +36,7 @@ export const defaultHardhatNetworkParams: Omit<
   HardhatNetworkConfig,
   "gas" | "initialDate"
 > = {
-  hardfork: HardforkName.SHANGHAI,
+  hardfork: HardforkName.CANCUN,
   blockGasLimit: 30_000_000,
   gasPrice: HARDHAT_NETWORK_DEFAULT_GAS_PRICE,
   chainId: 31337,
@@ -76,6 +76,7 @@ export const defaultHardhatNetworkParams: Omit<
           [HardforkName.GRAY_GLACIER, 15_050_000],
           [HardforkName.MERGE, 15_537_394],
           [HardforkName.SHANGHAI, 17_034_870],
+          [HardforkName.CANCUN, 19_426_589],
         ]),
       },
     ],

--- a/packages/hardhat-core/test/internal/core/config/default-config.ts
+++ b/packages/hardhat-core/test/internal/core/config/default-config.ts
@@ -12,11 +12,6 @@ describe("Default config", function () {
     }
 
     for (const hardfork of Object.values(HardforkName)) {
-      if (hardfork === HardforkName.CANCUN) {
-        // temporarily skipped until Cancun is enabled in mainnet
-        continue;
-      }
-
       const hardforkHistoryEntry =
         mainnetChainConfig.hardforkHistory.get(hardfork);
       assert.isDefined(

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/baseFeePerGas.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/baseFeePerGas.ts
@@ -134,6 +134,12 @@ describe("Block's baseFeePerGas", function () {
                     delete latestBlockRpc.withdrawalsRoot;
                   }
 
+                  if (hardfork !== "cancun") {
+                    delete latestBlockRpc.blobGasUsed;
+                    delete latestBlockRpc.excessBlobGas;
+                    delete latestBlockRpc.parentBeaconBlockRoot;
+                  }
+
                   const latestBlockData = rpcToBlockData({
                     ...latestBlockRpc,
                     transactions: [],

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/forking-different-hardfork.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/forking-different-hardfork.ts
@@ -15,7 +15,7 @@ import {
 const TOTAL_SUPPLY_SELECTOR = "0x18160ddd";
 
 // mainnet hardforks
-const CANCUN_HARDFORK_BLOCK_NUMBER = -1; // TBD
+const CANCUN_HARDFORK_BLOCK_NUMBER = 19_426_589;
 const SHANGHAI_HARDFORK_BLOCK_NUMBER = 17_034_870;
 const MERGE_HARDFORK_BLOCK_NUMBER = 15_537_394;
 
@@ -336,7 +336,7 @@ describe("Forking a block with a different hardfork", function () {
         });
       });
 
-      describe.skip("before and after cancun", function () {
+      describe("before and after cancun", function () {
         describe("cancun hardfork", function () {
           const hardfork = "cancun";
 
@@ -369,7 +369,7 @@ describe("Forking a block with a different hardfork", function () {
 
               assert.equal(
                 rpcDataToBigInt(daiSupply),
-                78634811100000031000021500n
+                3199311553579684551316799022n
               );
             });
 
@@ -385,7 +385,7 @@ describe("Forking a block with a different hardfork", function () {
 
               assert.equal(
                 rpcDataToBigInt(daiSupply),
-                78634811100000031000021500n
+                3199311553579684551316799022n
               );
             });
 
@@ -405,17 +405,17 @@ describe("Forking a block with a different hardfork", function () {
 
               assert.equal(
                 blockBeforeFork.parentBeaconBlockRoot,
-                "0xaa1c8fd7476ed6519cbb694784df5038ed7b008f05e2ad40585efc6c790d69de"
+                "0xff1a9fb2f5412756e7302c1662e8ee815e41f11da51da5471c57782a5ac6139a"
               );
-              assert.equal(blockBeforeFork.blobGasUsed, "0xa0000");
-              assert.equal(blockBeforeFork.excessBlobGas, "0x13a0000");
+              assert.equal(blockBeforeFork.blobGasUsed, "0x80000");
+              assert.equal(blockBeforeFork.excessBlobGas, "0x0");
 
               assert.equal(
                 blockAfterFork.parentBeaconBlockRoot,
                 "0xdd8876ba5af271ae9d93ececb192d6a7b4e6094ca5999756336279fd796b8619"
               );
               assert.equal(blockAfterFork.blobGasUsed, "0x0");
-              assert.equal(blockAfterFork.excessBlobGas, "0x1400000");
+              assert.equal(blockAfterFork.excessBlobGas, "0x0");
             });
 
             it("should have code in the beacon root contract", async function () {
@@ -456,7 +456,7 @@ describe("Forking a block with a different hardfork", function () {
 
               assert.equal(
                 rpcDataToBigInt(daiSupply),
-                78634811100000031000021500n
+                5022305384218217259061852351n
               );
             });
 
@@ -472,7 +472,7 @@ describe("Forking a block with a different hardfork", function () {
 
               assert.equal(
                 rpcDataToBigInt(daiSupply),
-                78634811100000031000021500n
+                5022305384218217259061852351n
               );
             });
 
@@ -544,7 +544,7 @@ describe("Forking a block with a different hardfork", function () {
 
               assert.equal(
                 rpcDataToBigInt(daiSupply),
-                78634811100000031000021500n
+                3199311553579684551316799022n
               );
             });
 
@@ -560,7 +560,7 @@ describe("Forking a block with a different hardfork", function () {
 
               assert.equal(
                 rpcDataToBigInt(daiSupply),
-                78634811100000031000021500n
+                3199311553579684551316799022n
               );
             });
 
@@ -580,10 +580,10 @@ describe("Forking a block with a different hardfork", function () {
 
               assert.equal(
                 blockBeforeFork.parentBeaconBlockRoot,
-                "0xaa1c8fd7476ed6519cbb694784df5038ed7b008f05e2ad40585efc6c790d69de"
+                "0xff1a9fb2f5412756e7302c1662e8ee815e41f11da51da5471c57782a5ac6139a"
               );
-              assert.equal(blockBeforeFork.blobGasUsed, "0xa0000");
-              assert.equal(blockBeforeFork.excessBlobGas, "0x13a0000");
+              assert.equal(blockBeforeFork.blobGasUsed, "0x80000");
+              assert.equal(blockBeforeFork.excessBlobGas, "0x0");
 
               assert.isUndefined(blockAfterFork.parentBeaconBlockRoot);
               assert.isUndefined(blockAfterFork.blobGasUsed);
@@ -620,7 +620,7 @@ describe("Forking a block with a different hardfork", function () {
 
               assert.equal(
                 rpcDataToBigInt(daiSupply),
-                78634811100000031000021500n
+                5022305384218217259061852351n
               );
             });
 
@@ -636,7 +636,7 @@ describe("Forking a block with a different hardfork", function () {
 
               assert.equal(
                 rpcDataToBigInt(daiSupply),
-                78634811100000031000021500n
+                5022305384218217259061852351n
               );
             });
 


### PR DESCRIPTION
Set cancun as the default config for the hardfork used in Hardhat network.