### PR TITLE
feat: add Cancun activation block number

### DIFF
--- a/.changeset/perfect-insects-hide.md
+++ b/.changeset/perfect-insects-hide.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixes detection of Cancun blocks on mainnet

--- a/crates/edr_eth/src/spec.rs
+++ b/crates/edr_eth/src/spec.rs
@@ -80,6 +80,7 @@ const MAINNET_HARDFORKS: &[(u64, SpecId)] = &[
     (15_050_000, SpecId::GRAY_GLACIER),
     (15_537_394, SpecId::MERGE),
     (17_034_870, SpecId::SHANGHAI),
+    (19_426_589, SpecId::CANCUN),
 ];
 
 fn mainnet_config() -> &'static ChainConfig {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/baseFeePerGas.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/baseFeePerGas.ts
@@ -122,7 +122,12 @@ describe("Block's baseFeePerGas", function () {
                 );
               });
 
-              for (const hardfork of ["london", "arrowGlacier", "shanghai"]) {
+              for (const hardfork of [
+                "london",
+                "arrowGlacier",
+                "shanghai",
+                "cancun",
+              ]) {
                 it(`should compute the next base fee correctly when ${hardfork} is activated`, async function () {
                   const latestBlockRpc = await this.provider.send(
                     "eth_getBlockByNumber",
@@ -132,6 +137,12 @@ describe("Block's baseFeePerGas", function () {
                   if (hardfork !== "shanghai") {
                     delete latestBlockRpc.withdrawals;
                     delete latestBlockRpc.withdrawalsRoot;
+                  }
+
+                  if (hardfork !== "cancun") {
+                    delete latestBlockRpc.blobGasUsed;
+                    delete latestBlockRpc.excessBlobGas;
+                    delete latestBlockRpc.parentBeaconBlockRoot;
                   }
 
                   const latestBlockData = rpcToBlockData({


### PR DESCRIPTION
This adds detection of `Cancun` blocks on mainnet, when using the default hardfork activation detection.