### PR TITLE
Relax EDR dependency range

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.1.2",
     "@metamask/eth-sig-util": "^4.0.0",
-    "@nomicfoundation/edr": "workspace:^0.3.1",
+    "@nomicfoundation/edr": "workspace:<1.0.0",
     "@nomicfoundation/ethereumjs-common": "4.0.4",
     "@nomicfoundation/ethereumjs-tx": "5.0.4",
     "@nomicfoundation/ethereumjs-util": "9.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,7 +246,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
       '@nomicfoundation/edr':
-        specifier: workspace:^0.3.1
+        specifier: workspace:<1.0.0
         version: link:../../crates/edr_napi
       '@nomicfoundation/ethereumjs-common':
         specifier: 4.0.4


### PR DESCRIPTION
The `^0.3.0` range won't install versions like `0.4.0`. This, plus the fact that we won't be introducing breaking changes in new minor 0.x versions, makes me thing that it's simpler for Hardhat to just accept any 0.x version.

We might also want to include a `>=` part in this range, if we add something to the EDR API that's then used by Hardhat. But we can think about that when it happens.