### PR TITLE
fix: bump EDR version to 0.3.3

### DIFF
--- a/.changeset/neat-readers-beam.md
+++ b/.changeset/neat-readers-beam.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Upgrade EDR to version to [0.3.3](https://github.com/NomicFoundation/hardhat/blob/f0b18441bc4a482c37026b7d4a56783d5ce0a749/crates/edr_napi/CHANGELOG.md#033)

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.1.2",
     "@metamask/eth-sig-util": "^4.0.0",
-    "@nomicfoundation/edr": "workspace:^0.3.1",
+    "@nomicfoundation/edr": "workspace:^0.3.3",
     "@nomicfoundation/ethereumjs-common": "4.0.4",
     "@nomicfoundation/ethereumjs-tx": "5.0.4",
     "@nomicfoundation/ethereumjs-util": "9.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,7 +246,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
       '@nomicfoundation/edr':
-        specifier: workspace:^0.3.1
+        specifier: workspace:^0.3.3
         version: link:../../crates/edr_napi
       '@nomicfoundation/ethereumjs-common':
         specifier: 4.0.4
@@ -2723,7 +2723,7 @@ packages:
       '@ethersproject/bignumber': 5.7.0
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/constants': 5.7.0
-      '@ethersproject/logger': 5.7.0
+      '@ethersproject/logger': 5.0.6
       '@ethersproject/properties': 5.7.0
       '@ethersproject/transactions': 5.7.0
 
@@ -2778,6 +2778,9 @@ packages:
     dependencies:
       '@ethersproject/bytes': 5.7.0
       js-sha3: 0.8.0
+
+  /@ethersproject/logger@5.0.6:
+    resolution: {integrity: sha512-FrX0Vnb3JZ1md/7GIZfmJ06XOAA8r3q9Uqt9O5orr4ZiksnbpXKlyDzQtlZ5Yv18RS8CAUbiKH9vwidJg1BPmQ==}
 
   /@ethersproject/logger@5.7.0:
     resolution: {integrity: sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==}


### PR DESCRIPTION
Bump EDR version to 0.3.3 which includes some bug fixes: https://github.com/NomicFoundation/hardhat/blob/main/crates/edr_napi/CHANGELOG.md#033