### PR TITLE
Throw CORRUPTED_LOCKFILE error when requiring EDR fails

### DIFF
--- a/.changeset/tame-apples-admire.md
+++ b/.changeset/tame-apples-admire.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Throw CORRUPTED_LOCKFILE error when requiring EDR fails

--- a/.changeset/tame-apples-admire.md
+++ b/.changeset/tame-apples-admire.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Throw CORRUPTED_LOCKFILE error when requiring EDR fails
+A proper error is now thrown when requiring EDR fails

--- a/packages/hardhat-core/src/common/napi-rs.ts
+++ b/packages/hardhat-core/src/common/napi-rs.ts
@@ -1,0 +1,15 @@
+import { HardhatError } from "../internal/core/errors";
+import { ERRORS } from "../internal/core/errors-list";
+
+export function requireNapiRsModule(id: string): unknown {
+  try {
+    return require(id);
+  } catch (e: any) {
+    if (e.code === "MODULE_NOT_FOUND") {
+      throw new HardhatError(ERRORS.GENERAL.CORRUPTED_LOCKFILE);
+    }
+
+    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+    throw e;
+  }
+}

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -9,7 +9,7 @@ import type {
   RequestArguments,
 } from "../../../types";
 
-import {
+import type {
   EdrContext,
   Provider as EdrProviderT,
   ExecutionResult,
@@ -27,6 +27,7 @@ import fsExtra from "fs-extra";
 import * as t from "io-ts";
 import semver from "semver";
 
+import { requireNapiRsModule } from "../../../common/napi-rs";
 import {
   HARDHAT_NETWORK_RESET_EVENT,
   HARDHAT_NETWORK_REVERT_SNAPSHOT_EVENT,
@@ -87,6 +88,10 @@ let _globalEdrContext: EdrContext | undefined;
 
 // Lazy initialize the global EDR context.
 export function getGlobalEdrContext(): EdrContext {
+  const { EdrContext } = requireNapiRsModule(
+    "@nomicfoundation/edr"
+  ) as typeof import("@nomicfoundation/edr");
+
   if (_globalEdrContext === undefined) {
     // Only one is allowed to exist
     _globalEdrContext = new EdrContext();
@@ -197,8 +202,9 @@ export class EdrProviderWrapper
     rawTraceCallbacks: RawTraceCallbacks,
     tracingConfig?: TracingConfig
   ): Promise<EdrProviderWrapper> {
-    const { Provider } =
-      require("@nomicfoundation/edr") as typeof import("@nomicfoundation/edr");
+    const { Provider } = requireNapiRsModule(
+      "@nomicfoundation/edr"
+    ) as typeof import("@nomicfoundation/edr");
 
     const coinbase = config.coinbase ?? DEFAULT_COINBASE;
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/convertToEdr.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/convertToEdr.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SpecId,
   MineOrdering,
   IntervalRange,
@@ -9,6 +9,7 @@ import {
 } from "@nomicfoundation/edr";
 import { Address } from "@nomicfoundation/ethereumjs-util";
 
+import { requireNapiRsModule } from "../../../../common/napi-rs";
 import { HardforkName } from "../../../util/hardforks";
 import { IntervalMiningConfig, MempoolOrder } from "../node-types";
 import { RpcDebugTraceOutput, RpcStructLog } from "../output";
@@ -21,6 +22,10 @@ import {
 /* eslint-disable @nomicfoundation/hardhat-internal-rules/only-hardhat-error */
 
 export function ethereumsjsHardforkToEdrSpecId(hardfork: HardforkName): SpecId {
+  const { SpecId } = requireNapiRsModule(
+    "@nomicfoundation/edr"
+  ) as typeof import("@nomicfoundation/edr");
+
   switch (hardfork) {
     case HardforkName.FRONTIER:
       return SpecId.Frontier;
@@ -65,6 +70,10 @@ export function ethereumsjsHardforkToEdrSpecId(hardfork: HardforkName): SpecId {
 }
 
 export function edrSpecIdToEthereumHardfork(specId: SpecId): HardforkName {
+  const { SpecId } = requireNapiRsModule(
+    "@nomicfoundation/edr"
+  ) as typeof import("@nomicfoundation/edr");
+
   switch (specId) {
     case SpecId.Frontier:
       return HardforkName.FRONTIER;
@@ -128,6 +137,10 @@ export function ethereumjsIntervalMiningConfigToEdr(
 export function ethereumjsMempoolOrderToEdrMineOrdering(
   mempoolOrder: MempoolOrder
 ): MineOrdering {
+  const { MineOrdering } = requireNapiRsModule(
+    "@nomicfoundation/edr"
+  ) as typeof import("@nomicfoundation/edr");
+
   switch (mempoolOrder) {
     case "fifo":
       return MineOrdering.Fifo;

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/exit.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/exit.ts
@@ -1,4 +1,6 @@
-import { ExceptionalHalt, SuccessReason } from "@nomicfoundation/edr";
+import type { ExceptionalHalt, SuccessReason } from "@nomicfoundation/edr";
+
+import { requireNapiRsModule } from "../../../../common/napi-rs";
 
 export enum ExitCode {
   SUCCESS,
@@ -14,6 +16,10 @@ export enum ExitCode {
 
 export class Exit {
   public static fromEdrSuccessReason(reason: SuccessReason): Exit {
+    const { SuccessReason } = requireNapiRsModule(
+      "@nomicfoundation/edr"
+    ) as typeof import("@nomicfoundation/edr");
+
     switch (reason) {
       case SuccessReason.Stop:
       case SuccessReason.Return:
@@ -25,6 +31,10 @@ export class Exit {
   }
 
   public static fromEdrExceptionalHalt(halt: ExceptionalHalt): Exit {
+    const { ExceptionalHalt } = requireNapiRsModule(
+      "@nomicfoundation/edr"
+    ) as typeof import("@nomicfoundation/edr");
+
     switch (halt) {
       case ExceptionalHalt.OutOfGas:
         return new Exit(ExitCode.OUT_OF_GAS);
@@ -83,6 +93,10 @@ export class Exit {
   }
 
   public getEdrExceptionalHalt(): ExceptionalHalt {
+    const { ExceptionalHalt } = requireNapiRsModule(
+      "@nomicfoundation/edr"
+    ) as typeof import("@nomicfoundation/edr");
+
     switch (this.kind) {
       case ExitCode.OUT_OF_GAS:
         return ExceptionalHalt.OutOfGas;

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-tracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-tracer.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CreateOutput,
   ExecutionResult,
   TracingMessage,

--- a/packages/hardhat-core/src/internal/solidity/parse.ts
+++ b/packages/hardhat-core/src/internal/solidity/parse.ts
@@ -1,8 +1,7 @@
 import type SolidityAnalyzerT from "@nomicfoundation/solidity-analyzer";
 
 import { SolidityFilesCache } from "../../builtin-tasks/utils/solidity-files-cache";
-import { HardhatError } from "../core/errors";
-import { ERRORS } from "../core/errors-list";
+import { requireNapiRsModule } from "../../common/napi-rs";
 
 interface ParsedData {
   imports: string[];
@@ -29,22 +28,14 @@ export class Parser {
       return cacheResult;
     }
 
-    try {
-      const { analyze } =
-        require("@nomicfoundation/solidity-analyzer") as typeof SolidityAnalyzerT;
-      const result = analyze(fileContent);
+    const { analyze } = requireNapiRsModule(
+      "@nomicfoundation/solidity-analyzer"
+    ) as typeof SolidityAnalyzerT;
+    const result = analyze(fileContent);
 
-      this._cache.set(contentHash, result);
+    this._cache.set(contentHash, result);
 
-      return result;
-    } catch (e: any) {
-      if (e.code === "MODULE_NOT_FOUND") {
-        throw new HardhatError(ERRORS.GENERAL.CORRUPTED_LOCKFILE);
-      }
-
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
-      throw e;
-    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
I created a `requireNapiRsModule` wrapper function to use both when requiring `solidity-analyzer` and EDR. The rest of the changes should be self-explanatory.