### PR TITLE
feat: add support for tracing to scenario runner

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,8 @@
 [alias]
-gen-execution-api  = "run --bin tools -- gen-execution-api"
-replay-block       = "run --bin tools -- replay-block"
+gen-execution-api       = "run --bin tools -- gen-execution-api"
+scenario                = "run --release --bin tools -- scenario"
+scenario-with-tracing   = "run --release --features tracing --bin tools -- scenario"
+replay-block            = "run --release --bin tools -- replay-block"
 
 [target.'cfg(all())']
 rustflags = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,6 +3716,9 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.5.11",
+ "tracing",
+ "tracing-flame",
+ "tracing-subscriber",
  "walkdir",
 ]
 

--- a/crates/edr_napi/Cargo.toml
+++ b/crates/edr_napi/Cargo.toml
@@ -46,7 +46,7 @@ openssl-sys = { version = "0.9.93", features = ["vendored"] }
 napi-build = "2.0.1"
 
 [features]
-tracing = ["edr_evm/tracing"]
+tracing = ["edr_evm/tracing", "edr_provider/tracing"]
 scenarios = ["rand"]
 
 [profile.release]

--- a/crates/edr_provider/Cargo.toml
+++ b/crates/edr_provider/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = { version = "1.0.89" }
 sha3 = { version = "0.10.6", default-features = false }
 thiserror = { version = "1.0.37", default-features = false }
 tokio = { version = "1.21.2", default-features = false, features = ["macros"] }
-tracing = { version = "0.1.37", features = ["attributes", "std"] }
+tracing = { version = "0.1.37", features = ["attributes", "std"], optional = true }
 lru = "0.12.2"
 
 [dev-dependencies]
@@ -39,3 +39,4 @@ toml = { version = "0.5.9", default-features = false }
 
 [features]
 test-utils = ["anyhow"]
+tracing = ["dep:tracing", "edr_eth/tracing", "edr_evm/tracing"]

--- a/crates/edr_provider/src/data.rs
+++ b/crates/edr_provider/src/data.rs
@@ -526,7 +526,7 @@ impl<LoggerErrorT: Debug> ProviderData<LoggerErrorT> {
         self.beneficiary
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip(self)))]
     pub fn debug_trace_transaction(
         &mut self,
         transaction_hash: &B256,

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -19,5 +19,11 @@ serde_json = "1.0.107"
 serde = { version = "1.0.189", features = ["derive"] }
 tempfile = "3.7.1"
 tokio = "1.33.0"
+tracing = { version = "0.1.37", features = ["attributes", "std"], optional = true }
+tracing-flame = { version = "0.2.0", default-features = false, features = ["smallvec"], optional = true }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["ansi", "env-filter", "fmt", "parking_lot", "smallvec", "std"], optional = true }
 toml = { version = "0.5.9", default-features = false }
 walkdir = { version = "2.4.0", features = [] }
+
+[features]
+tracing = ["dep:tracing", "dep:tracing-flame", "dep:tracing-subscriber", "edr_eth/tracing", "edr_evm/tracing", "edr_provider/tracing"]


### PR DESCRIPTION
This PR:
- adds the `cargo scenario` and `cargo scenario-with-tracing` shortcuts, to make it easier to execute those tools.
- sets the `cargo replay-block` command to build in release mode