### PR TITLE
fix: remove api keys from RPC error messages

### DIFF
--- a/.changeset/brave-scissors-train.md
+++ b/.changeset/brave-scissors-train.md
@@ -1,5 +1,5 @@
 ---
-
+"@nomicfoundation/edr": patch
 ---
 
 fix: remove api keys from RPC error messages

--- a/.changeset/brave-scissors-train.md
+++ b/.changeset/brave-scissors-train.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+fix: remove api keys from RPC error messages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "log",
  "mockito",
  "paste",
+ "regex",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",

--- a/crates/edr_eth/Cargo.toml
+++ b/crates/edr_eth/Cargo.toml
@@ -4,15 +4,17 @@ version = "0.2.0-dev"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.75"
 alloy-primitives = { version = "0.6", default-features = false, features = ["rand", "rlp"] }
 alloy-rlp = { version = "0.3", default-features = false, features = ["derive"] }
-futures = {version = "0.3.28", default-features = false}
+futures = { version = "0.3.28", default-features = false }
 hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-hyper = {version = "0.14.27", default-features = false}
+hyper = { version = "0.14.27", default-features = false }
 itertools = { version = "0.10.5", default-features = false, features = ["use_alloc"] }
-k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8",] }
+k256 = { version = "0.13.1", default-features = false, features = ["arithmetic", "ecdsa", "pkcs8", ] }
+lazy_static = { version = "1.4.0", default-features = false }
 log = { version = "0.4.17", default-features = false }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 reqwest-middleware = { version = "0.2.4", default-features = false }
@@ -26,8 +28,9 @@ thiserror = { version = "1.0.37", default-features = false }
 tokio = { version = "1.21.2", default-features = false, features = ["fs", "sync"] }
 tracing = { version = "0.1.37", features = ["attributes", "std"], optional = true }
 triehash = { version = "0.8.4", default-features = false }
-uuid = { version = "1.4.1", default-features = false, features = ["v4"]}
+uuid = { version = "1.4.1", default-features = false, features = ["v4"] }
 url = "2.4.1"
+regex = "1.10.0"
 
 [dev-dependencies]
 anyhow = "1.0.75"
@@ -40,7 +43,7 @@ edr_test_utils = { version = "0.2.0-dev", path = "../edr_test_utils" }
 serial_test = "2.0.0"
 tempfile = { version = "3.7.1", default-features = false }
 tokio = { version = "1.23.0", features = ["macros"] }
-walkdir = { version = "2.3.3", default-features =  false }
+walkdir = { version = "2.3.3", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/edr_eth/src/remote/client.rs
+++ b/crates/edr_eth/src/remote/client.rs
@@ -1206,7 +1206,7 @@ mod tests {
 
         if let RpcClientError::HttpStatus(error) = error {
             assert_eq!(
-                <ReqwestError as Into<reqwest::Error>>::into(error).status(),
+                reqwest::Error::from(error).status(),
                 Some(StatusCode::from_u16(STATUS_CODE).unwrap())
             );
         } else {
@@ -1265,7 +1265,7 @@ mod tests {
 
             if let RpcClientError::HttpStatus(error) = error {
                 assert_eq!(
-                    <ReqwestError as Into<reqwest::Error>>::into(error).status(),
+                    reqwest::Error::from(error).status(),
                     Some(StatusCode::from_u16(401).unwrap())
                 );
             } else {

--- a/crates/edr_eth/src/remote/client.rs
+++ b/crates/edr_eth/src/remote/client.rs
@@ -1,3 +1,5 @@
+mod reqwest_error;
+
 use std::{
     collections::{HashMap, VecDeque},
     fmt::Debug,
@@ -29,6 +31,7 @@ use super::{
     request_methods::RequestMethod,
     BlockSpec, PreEip1898BlockSpec,
 };
+pub use crate::remote::client::reqwest_error::{MiddlewareError, ReqwestError};
 use crate::{
     block::{block_time, is_safe_block_number, IsSafeBlockNumberArgs},
     log::FilterLog,
@@ -59,15 +62,15 @@ const MAX_RETRIES: u32 = 7;
 pub enum RpcClientError {
     /// The message could not be sent to the remote node
     #[error(transparent)]
-    FailedToSend(reqwest_middleware::Error),
+    FailedToSend(MiddlewareError),
 
     /// The remote node failed to reply with the body of the response
     #[error("The response text was corrupted: {0}.")]
-    CorruptedResponse(reqwest::Error),
+    CorruptedResponse(ReqwestError),
 
     /// The server returned an error code.
     #[error("The Http server returned error status code: {0}")]
-    HttpStatus(reqwest::Error),
+    HttpStatus(ReqwestError),
 
     /// The request cannot be serialized as JSON.
     #[error(transparent)]
@@ -484,12 +487,12 @@ impl RpcClient {
             .body(request_body.to_json_string())
             .send()
             .await
-            .map_err(RpcClientError::FailedToSend)?
+            .map_err(|err| RpcClientError::FailedToSend(err.into()))?
             .error_for_status()
-            .map_err(RpcClientError::HttpStatus)?
+            .map_err(|err| RpcClientError::HttpStatus(err.into()))?
             .text()
             .await
-            .map_err(RpcClientError::CorruptedResponse)
+            .map_err(|err| RpcClientError::CorruptedResponse(err.into()))
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip_all))]
@@ -1203,7 +1206,7 @@ mod tests {
 
         if let RpcClientError::HttpStatus(error) = error {
             assert_eq!(
-                error.status(),
+                <ReqwestError as Into<reqwest::Error>>::into(error).status(),
                 Some(StatusCode::from_u16(STATUS_CODE).unwrap())
             );
         } else {
@@ -1245,20 +1248,26 @@ mod tests {
 
         #[tokio::test]
         async fn call_bad_api_key() {
-            let alchemy_url = "https://eth-mainnet.g.alchemy.com/v2/abcdefg";
+            let api_key = "invalid-api-key";
+            let alchemy_url = format!("https://eth-mainnet.g.alchemy.com/v2/{api_key}");
 
             let hash = B256::from_str(
                 "0xc008e9f9bb92057dd0035496fbf4fb54f66b4b18b370928e46d6603933022222",
             )
             .expect("failed to parse hash from string");
 
-            let error = TestRpcClient::new(alchemy_url)
+            let error = TestRpcClient::new(&alchemy_url)
                 .call::<Option<eth::Transaction>>(RequestMethod::GetTransactionByHash(hash))
                 .await
                 .expect_err("should have failed to interpret response as a Transaction");
 
+            assert!(!error.to_string().contains(api_key));
+
             if let RpcClientError::HttpStatus(error) = error {
-                assert_eq!(error.status(), Some(StatusCode::from_u16(401).unwrap()));
+                assert_eq!(
+                    <ReqwestError as Into<reqwest::Error>>::into(error).status(),
+                    Some(StatusCode::from_u16(401).unwrap())
+                );
             } else {
                 unreachable!("Invalid error: {error}");
             }
@@ -1279,7 +1288,7 @@ mod tests {
                 .expect_err("should have failed to connect due to a garbage domain name");
 
             if let RpcClientError::FailedToSend(error) = error {
-                assert!(error.to_string().contains(&format!("error sending request for url ({alchemy_url}): error trying to connect: dns error: ")));
+                assert!(error.to_string().contains("dns error"));
             } else {
                 unreachable!("Invalid error: {error}");
             }

--- a/crates/edr_eth/src/remote/client/reqwest_error.rs
+++ b/crates/edr_eth/src/remote/client/reqwest_error.rs
@@ -1,0 +1,138 @@
+use std::error::Error;
+
+use lazy_static::lazy_static;
+use regex::{Captures, Regex, Replacer};
+use url::Url;
+
+/// Custom wrapper for `reqwest::Error` to avoid displaying the url in error
+/// message that could contain sensitive information such as API keys.
+#[derive(thiserror::Error, Debug)]
+pub struct ReqwestError(#[from] reqwest::Error);
+
+impl From<ReqwestError> for reqwest::Error {
+    fn from(value: ReqwestError) -> Self {
+        value.0
+    }
+}
+
+// Matches the `Display` implementation for `reqwest::Error` except where noted
+impl std::fmt::Display for ReqwestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_builder() {
+            f.write_str("builder self")?;
+        } else if self.0.is_request() {
+            f.write_str("self sending request")?;
+        } else if self.0.is_body() {
+            f.write_str("request or response body self")?;
+        } else if self.0.is_decode() {
+            f.write_str("self decoding response body")?;
+        } else if self.0.is_redirect() {
+            f.write_str("self following redirect")?;
+        } else if self.0.is_status() {
+            let code = self.0.status().expect("Error is status");
+            let prefix = if code.is_client_error() {
+                "HTTP status client self"
+            } else {
+                debug_assert!(code.is_server_error());
+                "HTTP status server self"
+            };
+            write!(f, "{prefix} ({code})")?;
+        } else {
+            // It might be an upgrade, but `reqwest` doesn't expose checking that on the
+            // self type.
+            f.write_str("unknown self")?;
+        }
+
+        // This is changed from the original code
+        if let Some(host) = self.0.url().and_then(|url| url.host_str()) {
+            write!(f, " for host ({host})")?;
+        }
+
+        if let Some(e) = self.0.source() {
+            write!(f, ": {e}")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Custom wrapper for `reqwest_middleware::Error` to avoid displaying the url
+/// in error message that could contain sensitive information such as API keys.
+#[derive(thiserror::Error, Debug)]
+pub enum MiddlewareError {
+    /// There was an error running some middleware
+    Middleware(#[from] anyhow::Error),
+    /// Error from the underlying reqwest client
+    Reqwest(#[from] ReqwestError),
+}
+
+impl From<reqwest_middleware::Error> for MiddlewareError {
+    fn from(value: reqwest_middleware::Error) -> Self {
+        match value {
+            reqwest_middleware::Error::Middleware(middleware) => {
+                MiddlewareError::Middleware(middleware)
+            }
+            reqwest_middleware::Error::Reqwest(reqwest) => MiddlewareError::Reqwest(reqwest.into()),
+        }
+    }
+}
+
+impl std::fmt::Display for MiddlewareError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MiddlewareError::Middleware(e) => {
+                let s = e.to_string();
+                let replaced = URL_REGEX.replace_all(&s, UrlReplacer);
+                f.write_str(&replaced)
+            }
+            MiddlewareError::Reqwest(e) => e.fmt(f),
+        }
+    }
+}
+
+lazy_static! {
+    static ref URL_REGEX: Regex = Regex::new(r"(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)").expect("Test checks panic");
+}
+
+/// Replaces urls in strings with the host part only.
+struct UrlReplacer;
+
+impl Replacer for UrlReplacer {
+    fn replace_append(&mut self, caps: &Captures<'_>, dst: &mut String) {
+        if let Some(host) = caps.get(0).and_then(|url| {
+            Url::parse(url.as_str())
+                .ok()
+                .and_then(|url| url.host_str().map(ToString::to_string))
+        }) {
+            dst.push_str(&host);
+        } else {
+            dst.push_str("<unknown host>");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_middleware_error() -> anyhow::Result<()> {
+        let error = MiddlewareError::Middleware(anyhow::anyhow!(
+            "Some middleware error occurred for url: http://subdomain.example.com:1234/secret something else"
+        ));
+        assert_eq!(
+            error.to_string(),
+            "Some middleware error occurred for url: subdomain.example.com something else"
+        );
+
+        let error = MiddlewareError::Middleware(anyhow::anyhow!(
+            "Some middleware error occurred for url: https://subdomain.example.com/path?query=secret something else"
+        ));
+        assert_eq!(
+            error.to_string(),
+            "Some middleware error occurred for url: subdomain.example.com something else"
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Only log the host instead of the full URL in RPC errors to avoid leaking api keys in CI.