### PR TITLE
fix: tests with async fn in describe

### DIFF
--- a/packages/hardhat-core/test/internal/context.ts
+++ b/packages/hardhat-core/test/internal/context.ts
@@ -7,7 +7,7 @@ import { useEnvironment } from "../helpers/environment";
 import { expectHardhatError } from "../helpers/errors";
 import { useFixtureProject } from "../helpers/project";
 
-describe("Hardhat context", async function () {
+describe("Hardhat context", function () {
   describe("no context", () => {
     it("context is not defined", async function () {
       assert.isFalse(HardhatContext.isCreated());
@@ -21,7 +21,7 @@ describe("Hardhat context", async function () {
     });
   });
 
-  describe("create context but no environment", async function () {
+  describe("create context but no environment", function () {
     afterEach("reset context", function () {
       resetHardhatContext();
     });
@@ -63,7 +63,7 @@ describe("Hardhat context", async function () {
     });
   });
 
-  describe("environment creates context", async function () {
+  describe("environment creates context", function () {
     useFixtureProject("config-project");
     useEnvironment();
     it("should create context and set HRE into context", async function () {

--- a/packages/hardhat-core/test/internal/core/providers/construction.ts
+++ b/packages/hardhat-core/test/internal/core/providers/construction.ts
@@ -21,7 +21,7 @@ import { expectHardhatErrorAsync } from "../../../helpers/errors";
 
 import { MockedProvider } from "./mocks";
 
-describe("Network config typeguards", async () => {
+describe("Network config typeguards", () => {
   it("Should recognize HDAccountsConfig", () => {
     assert.isTrue(isHDAccountsConfig({ mnemonic: "asdads" } as any));
     assert.isFalse(isHDAccountsConfig({ initialIndex: 1 } as any));

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/error-object.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/error-object.ts
@@ -36,7 +36,7 @@ describe("error object in JSON-RPC response", function () {
     describe(`${name} provider`, function () {
       setCWD();
 
-      describe("should have the right fields", async function () {
+      describe("should have the right fields", function () {
         useProvider();
         useHelpers();
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/hardhat-network-options.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/hardhat-network-options.ts
@@ -171,7 +171,7 @@ describe("Hardhat Network special options", function () {
   });
 
   describe("accounts", function () {
-    describe("mnemonic without passphrase", async function () {
+    describe("mnemonic without passphrase", function () {
       useFixtureProject("mnemonic-without-passphrase");
       useEnvironment();
 
@@ -189,7 +189,7 @@ describe("Hardhat Network special options", function () {
       });
     });
 
-    describe("mnemonic with a passphrase", async function () {
+    describe("mnemonic with a passphrase", function () {
       useFixtureProject("mnemonic-with-passphrase");
       useEnvironment();
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/blockNumber.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/blockNumber.ts
@@ -26,7 +26,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_blockNumber", async function () {
+      describe("eth_blockNumber", function () {
         let firstBlockNumber: number;
 
         beforeEach(async function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/call.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/call.ts
@@ -57,7 +57,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_call", async function () {
+      describe("eth_call", function () {
         describe("when called without blockTag param", () => {
           it("Should return the value returned by the contract", async function () {
             const contractAddress = await deployContract(

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/estimateGas.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/estimateGas.ts
@@ -31,7 +31,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_estimateGas", async function () {
+      describe("eth_estimateGas", function () {
         it("should estimate the gas for a transfer", async function () {
           const estimation = await this.provider.send("eth_estimateGas", [
             {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/feeHistory.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/feeHistory.ts
@@ -21,7 +21,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_feeHistory", async function () {
+      describe("eth_feeHistory", function () {
         describe("Params validation", function () {
           it("Should validate that block count is in [1, 1024]", async function () {
             await assertInvalidInputError(

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/gasPrice.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/gasPrice.ts
@@ -14,7 +14,7 @@ describe("Eth module", function () {
     describe(`${name} provider`, function () {
       setCWD();
 
-      describe("eth_gasPrice", async function () {
+      describe("eth_gasPrice", function () {
         describe("with eip-1559", function () {
           useProvider();
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBalance.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBalance.ts
@@ -33,7 +33,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getBalance", async function () {
+      describe("eth_getBalance", function () {
         it("Should return 0 for empty accounts", async function () {
           if (!isFork) {
             assertQuantity(

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByHash.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByHash.ts
@@ -24,7 +24,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getBlockByHash", async function () {
+      describe("eth_getBlockByHash", function () {
         it("should return null for non-existing blocks", async function () {
           assert.isNull(
             await this.provider.send("eth_getBlockByHash", [

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByNumber.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockByNumber.ts
@@ -29,7 +29,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider({ hardfork: "london" });
 
-      describe("eth_getBlockByNumber", async function () {
+      describe("eth_getBlockByNumber", function () {
         it("Should return the genesis block for number 0", async function () {
           const block = await this.provider.send("eth_getBlockByNumber", [
             numberToRpcQuantity(0),

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockTransactionCountByHash.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockTransactionCountByHash.ts
@@ -23,7 +23,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getBlockTransactionCountByHash", async function () {
+      describe("eth_getBlockTransactionCountByHash", function () {
         it("should return null for non-existing blocks", async function () {
           assert.isNull(
             await this.provider.send("eth_getBlockTransactionCountByHash", [

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockTransactionCountByNumber.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getBlockTransactionCountByNumber.ts
@@ -22,7 +22,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getBlockTransactionCountByNumber", async function () {
+      describe("eth_getBlockTransactionCountByNumber", function () {
         it("should return null for non-existing blocks", async function () {
           const firstBlockNumber = rpcQuantityToNumber(
             await this.provider.send("eth_blockNumber")

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getCode.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getCode.ts
@@ -31,7 +31,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getCode", async function () {
+      describe("eth_getCode", function () {
         it("Should return an empty buffer for non-contract accounts", async function () {
           assert.equal(
             await this.provider.send("eth_getCode", [zeroAddress()]),

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getFilterLogs.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getFilterLogs.ts
@@ -25,7 +25,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getFilterLogs", async function () {
+      describe("eth_getFilterLogs", function () {
         let firstBlockNumber: number;
 
         beforeEach(async function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getLogs.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getLogs.ts
@@ -25,7 +25,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getLogs", async function () {
+      describe("eth_getLogs", function () {
         let firstBlockNumber: number;
 
         beforeEach(async function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getStorageAt.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getStorageAt.ts
@@ -28,7 +28,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getStorageAt", async function () {
+      describe("eth_getStorageAt", function () {
         describe("Imitating Ganache", function () {
           describe("When a slot has not been written into", function () {
             it("Should return `0x0000000000000000000000000000000000000000000000000000000000000000`", async function () {

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByBlockHashAndIndex.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByBlockHashAndIndex.ts
@@ -45,7 +45,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getTransactionByBlockHashAndIndex", async function () {
+      describe("eth_getTransactionByBlockHashAndIndex", function () {
         it("should return null for non-existing blocks", async function () {
           assert.isNull(
             await this.provider.send("eth_getTransactionByBlockHashAndIndex", [

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByBlockNumberAndIndex.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByBlockNumberAndIndex.ts
@@ -44,7 +44,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getTransactionByBlockNumberAndIndex", async function () {
+      describe("eth_getTransactionByBlockNumberAndIndex", function () {
         it("should return null for non-existing blocks", async function () {
           assert.isNull(
             await this.provider.send(

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByHash.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionByHash.ts
@@ -56,7 +56,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getTransactionByHash", async function () {
+      describe("eth_getTransactionByHash", function () {
         it("should return null for unknown txs", async function () {
           assert.isNull(
             await this.provider.send("eth_getTransactionByHash", [

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionCount.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionCount.ts
@@ -29,7 +29,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getTransactionCount", async function () {
+      describe("eth_getTransactionCount", function () {
         it("Should return 0 for random accounts", async function () {
           assertQuantity(
             await this.provider.send("eth_getTransactionCount", [

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionReceipt.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/getTransactionReceipt.ts
@@ -46,7 +46,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_getTransactionReceipt", async function () {
+      describe("eth_getTransactionReceipt", function () {
         it("should return null for unknown txs", async function () {
           const receipt = await this.provider.send(
             "eth_getTransactionReceipt",

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/index.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/index.ts
@@ -28,7 +28,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_accounts", async function () {
+      describe("eth_accounts", function () {
         it("should return the genesis accounts in lower case", async function () {
           const accounts = await this.provider.send("eth_accounts");
 
@@ -36,13 +36,13 @@ describe("Eth module", function () {
         });
       });
 
-      describe("eth_chainId", async function () {
+      describe("eth_chainId", function () {
         it("should return the chain id as QUANTITY", async function () {
           assertQuantity(await this.provider.send("eth_chainId"), chainId);
         });
       });
 
-      describe("eth_coinbase", async function () {
+      describe("eth_coinbase", function () {
         it("should return the default coinbase address", async function () {
           assert.equal(
             await this.provider.send("eth_coinbase"),
@@ -51,37 +51,37 @@ describe("Eth module", function () {
         });
       });
 
-      describe("eth_compileLLL", async function () {
+      describe("eth_compileLLL", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_compileLLL");
         });
       });
 
-      describe("eth_compileSerpent", async function () {
+      describe("eth_compileSerpent", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_compileSerpent");
         });
       });
 
-      describe("eth_compileSolidity", async function () {
+      describe("eth_compileSolidity", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_compileSolidity");
         });
       });
 
-      describe("eth_getCompilers", async function () {
+      describe("eth_getCompilers", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_getCompilers");
         });
       });
 
-      describe("eth_getProof", async function () {
+      describe("eth_getProof", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_getProof");
         });
       });
 
-      describe("eth_getUncleByBlockHashAndIndex", async function () {
+      describe("eth_getUncleByBlockHashAndIndex", function () {
         it("is not supported", async function () {
           await assertNotSupported(
             this.provider,
@@ -90,7 +90,7 @@ describe("Eth module", function () {
         });
       });
 
-      describe("eth_getUncleByBlockNumberAndIndex", async function () {
+      describe("eth_getUncleByBlockNumberAndIndex", function () {
         it("is not supported", async function () {
           await assertNotSupported(
             this.provider,
@@ -99,7 +99,7 @@ describe("Eth module", function () {
         });
       });
 
-      describe("eth_getUncleCountByBlockHash", async function () {
+      describe("eth_getUncleCountByBlockHash", function () {
         it("is not supported", async function () {
           await assertNotSupported(
             this.provider,
@@ -108,7 +108,7 @@ describe("Eth module", function () {
         });
       });
 
-      describe("eth_getUncleCountByBlockNumber", async function () {
+      describe("eth_getUncleCountByBlockNumber", function () {
         it("is not supported", async function () {
           await assertNotSupported(
             this.provider,
@@ -117,36 +117,36 @@ describe("Eth module", function () {
         });
       });
 
-      describe("eth_getWork", async function () {
+      describe("eth_getWork", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_getWork");
         });
       });
 
-      describe("eth_hashrate", async function () {
+      describe("eth_hashrate", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_hashrate");
         });
       });
 
-      describe("eth_mining", async function () {
+      describe("eth_mining", function () {
         it("should return false", async function () {
           assert.deepEqual(await this.provider.send("eth_mining"), false);
         });
       });
 
-      describe("eth_protocolVersion", async function () {
+      describe("eth_protocolVersion", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_protocolVersion");
         });
       });
 
-      describe("eth_sign", async function () {
+      describe("eth_sign", function () {
         // TODO: Test this. Note that it's implementation is tested in one of
         // our provider wrappers, but re-test it here anyway.
       });
 
-      describe("eth_signTransaction", async function () {
+      describe("eth_signTransaction", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_signTransaction");
         });
@@ -164,19 +164,19 @@ describe("Eth module", function () {
         });
       });
 
-      describe("eth_submitHashrate", async function () {
+      describe("eth_submitHashrate", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_submitHashrate");
         });
       });
 
-      describe("eth_submitWork", async function () {
+      describe("eth_submitWork", function () {
         it("is not supported", async function () {
           await assertNotSupported(this.provider, "eth_submitWork");
         });
       });
 
-      describe("eth_syncing", async function () {
+      describe("eth_syncing", function () {
         it("Should return false", async function () {
           assert.deepEqual(await this.provider.send("eth_syncing"), false);
         });

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/newPendingTransactionFilter.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/newPendingTransactionFilter.ts
@@ -18,7 +18,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_newPendingTransactionFilter", async function () {
+      describe("eth_newPendingTransactionFilter", function () {
         it("Supports pending transaction filter", async function () {
           assert.isString(
             await this.provider.send("eth_newPendingTransactionFilter")

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/pendingTransactions.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/pendingTransactions.ts
@@ -20,7 +20,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_pendingTransactions", async function () {
+      describe("eth_pendingTransactions", function () {
         it("should return an empty array if there are no pending transactions", async function () {
           assert.deepEqual(
             await this.provider.send("eth_pendingTransactions"),

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/sendRawTransaction.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/sendRawTransaction.ts
@@ -31,7 +31,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider({ hardfork: "london" });
 
-      describe("eth_sendRawTransaction", async function () {
+      describe("eth_sendRawTransaction", function () {
         it("Should throw if the data isn't a proper transaction", async function () {
           await assertInvalidArgumentsError(
             this.provider,

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/sendTransaction.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/sendTransaction.ts
@@ -51,7 +51,7 @@ describe("Eth module", function () {
     describe(`${name} provider`, function () {
       setCWD();
 
-      describe("eth_sendTransaction", async function () {
+      describe("eth_sendTransaction", function () {
         useProvider({ hardfork: "london" });
         useHelpers();
 

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/unsubscribe.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/eth/methods/unsubscribe.ts
@@ -16,7 +16,7 @@ describe("Eth module", function () {
       setCWD();
       useProvider();
 
-      describe("eth_unsubscribe", async function () {
+      describe("eth_unsubscribe", function () {
         it("Supports unsubscribe", async function () {
           const filterId = await this.provider.send("eth_subscribe", [
             "newHeads",

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/evm.ts
@@ -55,7 +55,7 @@ describe("Evm module", function () {
         );
       };
 
-      describe("evm_increaseTime", async function () {
+      describe("evm_increaseTime", function () {
         it("should increase the offset of time used for block timestamps", async function () {
           const blockNumber = rpcQuantityToNumber(
             await this.provider.send("eth_blockNumber")
@@ -148,7 +148,7 @@ describe("Evm module", function () {
         });
       });
 
-      describe("evm_setNextBlockTimestamp", async function () {
+      describe("evm_setNextBlockTimestamp", function () {
         for (const { description, prepare } of [
           {
             description: "without any special preparation",
@@ -487,7 +487,7 @@ describe("Evm module", function () {
         });
       });
 
-      describe("evm_mine", async function () {
+      describe("evm_mine", function () {
         it("should mine empty blocks", async function () {
           const firstBlockNumber = rpcQuantityToNumber(
             await this.provider.send("eth_blockNumber")
@@ -921,7 +921,7 @@ describe("Evm module", function () {
         });
       });
 
-      describe("evm_snapshot", async function () {
+      describe("evm_snapshot", function () {
         it("returns the snapshot id starting at 1", async function () {
           const id1: string = await this.provider.send("evm_snapshot", []);
           const id2: string = await this.provider.send("evm_snapshot", []);
@@ -945,7 +945,7 @@ describe("Evm module", function () {
         });
       });
 
-      describe("evm_revert", async function () {
+      describe("evm_revert", function () {
         it("Returns false for non-existing ids", async function () {
           const reverted1: boolean = await this.provider.send("evm_revert", [
             "0x1",
@@ -1440,7 +1440,7 @@ describe("Evm module", function () {
       setCWD();
       useProvider({ allowBlocksWithSameTimestamp: true });
 
-      describe("evm_setNextBlockTimestamp", async function () {
+      describe("evm_setNextBlockTimestamp", function () {
         it("should allow using the same timestamp as the previous block", async function () {
           const timestamp = getCurrentTimestamp() + 70;
           await this.provider.send("evm_mine", [timestamp]);

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/hardhat.ts
@@ -473,7 +473,7 @@ describe("Hardhat module", function () {
           );
         });
 
-        describe("should increment the block number", async function () {
+        describe("should increment the block number", function () {
           it("when not given any arguments", async function () {
             const latestBlockNumber = await getLatestBlockNumber();
             await this.provider.send("hardhat_mine");

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/net.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/net.ts
@@ -17,13 +17,13 @@ describe("Net module", function () {
       setCWD();
       useProvider();
 
-      describe("net_listening", async function () {
+      describe("net_listening", function () {
         it("Should return true", async function () {
           assert.isTrue(await this.provider.send("net_listening"));
         });
       });
 
-      describe("net_peerCount", async function () {
+      describe("net_peerCount", function () {
         it("Should return 0", async function () {
           assert.strictEqual(
             await this.provider.send("net_peerCount"),
@@ -32,7 +32,7 @@ describe("Net module", function () {
         });
       });
 
-      describe("net_version", async function () {
+      describe("net_version", function () {
         it("Should return the network id as a decimal string, not QUANTITY", async function () {
           assert.strictEqual(
             await this.provider.send("net_version"),

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/personal.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/personal.ts
@@ -16,7 +16,7 @@ describe("Personal module", function () {
       setCWD();
       useProvider();
 
-      describe("personal_sign", async function () {
+      describe("personal_sign", function () {
         it("Should be compatible with geth's implementation", async function () {
           // This test was created by using Geth 1.10.12-unstable and calling personal_sign
           const result = await this.provider.request({

--- a/packages/hardhat-core/test/internal/hardhat-network/provider/modules/web3.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/provider/modules/web3.ts
@@ -23,7 +23,7 @@ describe("Web3 module", function () {
       setCWD();
       useProvider();
 
-      describe("web3_clientVersion", async function () {
+      describe("web3_clientVersion", function () {
         it("Should return the right value", async function () {
           const res = await this.provider.send("web3_clientVersion");
           const expectedEDRVersion =
@@ -32,7 +32,7 @@ describe("Web3 module", function () {
         });
       });
 
-      describe("web3_sha3", async function () {
+      describe("web3_sha3", function () {
         it("Should return the keccak256 of the input", async function () {
           const data = "0x123a1b238123";
           const hashed = bufferToRpcData(keccak256(toBuffer(data)));


### PR DESCRIPTION
Every now and then, Hardhat tests with fail on one system for non-obvious reasons and I can't reproduce the problem (e.g. [this](https://github.com/NomicFoundation/hardhat/actions/runs/8568834063/job/23483577220?pr=5085#step:11:3020)).

I'm hoping that removing these erroneous usages of `async function`s in tests will avoid any issues due to race conditions