### PR TITLE
ci: allow trailing space in EDR release commit

### DIFF
--- a/.github/workflows/edr-npm-release.yml
+++ b/.github/workflows/edr-npm-release.yml
@@ -417,12 +417,12 @@ jobs:
         run: pnpm artifacts
       - name: Publish
         run: |
-          if git log -1 --pretty=%B | grep "^edr-[0-9]\+\.[0-9]\+\.[0-9]\+$";
+          if git log -1 --pretty=%B | grep "^edr-[0-9]\+\.[0-9]\+\.[0-9]\+\s*";
           then
             echo "Publishing release"
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             pnpm publish --no-git-checks --provenance --access public
-          elif git log -1 --pretty=%B | grep "^edr-[0-9]\+\.[0-9]\+\.[0-9]\+";
+          elif git log -1 --pretty=%B | grep "^edr-[0-9]\+\.[0-9]\+\.[0-9]\+-";
           then
             echo "Publishing pre-release"
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc


### PR DESCRIPTION
Previously the EDR NPM release tagged the package as `next` if there is anything after the version in the release commit, e.g. commit message `edr-0.1.2` gets tagged as `latest`, but `edr-0.1.2-alpha` gets tagged as `next`. But this lead to `edr-0.3.4 (#5088)` getting tagged as `next` which is undesirable.

This PR changes the regexes to allow white space after the version triplet for `latest` release commits and require a hyphen after the version triplet to be tagged as `next`. This is in line with the semver [spec.](https://semver.org/#spec-item-9)





