### PR TITLE
fix: bump EDR to 0.3.4

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.1.2",
     "@metamask/eth-sig-util": "^4.0.0",
-    "@nomicfoundation/edr": "workspace:^0.3.3",
+    "@nomicfoundation/edr": "workspace:^0.3.4",
     "@nomicfoundation/ethereumjs-common": "4.0.4",
     "@nomicfoundation/ethereumjs-tx": "5.0.4",
     "@nomicfoundation/ethereumjs-util": "9.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,7 +246,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
       '@nomicfoundation/edr':
-        specifier: workspace:^0.3.3
+        specifier: workspace:^0.3.4
         version: link:../../crates/edr_napi
       '@nomicfoundation/ethereumjs-common':
         specifier: 4.0.4


### PR DESCRIPTION
Bump EDR to [0.3.4](https://github.com/NomicFoundation/hardhat/blob/main/crates/edr_napi/CHANGELOG.md#034)