### PR TITLE
Add eslint rule to forbid describes with async functions

### DIFF
--- a/config/eslint/eslintrc.js
+++ b/config/eslint/eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
   plugins: [
     "@nomicfoundation/hardhat-internal-rules",
     "import",
-    "no-only-tests",
+    "mocha",
     "@typescript-eslint",
     "@nomicfoundation/slow-imports",
   ],
@@ -206,7 +206,6 @@ module.exports = {
     "no-extra-bind": "error",
     "no-new-func": "error",
     "no-new-wrappers": "error",
-    "no-only-tests/no-only-tests": "error",
     "no-return-await": "off",
     "@typescript-eslint/return-await": "error",
     "no-sequences": "error",
@@ -238,5 +237,7 @@ module.exports = {
         patterns: ["hardhat/src", "@nomiclabs/*/src"],
       },
     ],
+    "mocha/no-exclusive-tests": "error",
+    "mocha/no-async-describe": "error",
   },
 };

--- a/packages/hardhat-chai-matchers/package.json
+++ b/packages/hardhat-chai-matchers/package.json
@@ -55,7 +55,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "ethers": "^6.1.0",
     "get-port": "^5.1.1",

--- a/packages/hardhat-chai-matchers/test/bigNumber.ts
+++ b/packages/hardhat-chai-matchers/test/bigNumber.ts
@@ -860,7 +860,7 @@ describe("BigNumber matchers", function () {
       });
     });
 
-    describe("deep equal", async function () {
+    describe("deep equal", function () {
       checkAll(1, 1, (a, b) => {
         it(`should work with ${typestr(a)} and ${typestr(b)}`, function () {
           // successful assertions

--- a/packages/hardhat-chai-matchers/test/events.ts
+++ b/packages/hardhat-chai-matchers/test/events.ts
@@ -405,7 +405,7 @@ describe(".to.emit (contract events)", () => {
           );
         });
 
-        describe("nested predicate", async function () {
+        describe("nested predicate", function () {
           it("Should succeed when predicate passes", async function () {
             await expect(contract.emitUintArray(1, 2))
               .to.emit(contract, "WithUintArray")
@@ -630,7 +630,7 @@ describe(".to.emit (contract events)", () => {
           "WithStringArg"
         );
       });
-      describe("When detecting two events from one call (chaining)", async function () {
+      describe("When detecting two events from one call (chaining)", function () {
         it("Should succeed when both expected events are indeed emitted", async function () {
           await expect(contract.emitUintAndString(1, "a string"))
             .to.emit(contract, "WithUintArg")
@@ -663,7 +663,7 @@ describe(".to.emit (contract events)", () => {
             );
           });
         });
-        describe("When specifying .withArgs()", async function () {
+        describe("When specifying .withArgs()", function () {
           it("Should pass when expecting the correct args from the first event", async function () {
             await expect(contract.emitUintAndString(1, "a string"))
               .to.emit(contract, "WithUintArg")

--- a/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-chai-matchers/test/reverted/revertedWithCustomError.ts
@@ -223,7 +223,7 @@ describe("INTEGRATION: Reverted with custom error", function () {
     });
 
     describe("with args", function () {
-      describe("one argument", async function () {
+      describe("one argument", function () {
         it("Should match correct argument", async function () {
           await expect(matchers.revertWithCustomErrorWithUint(1))
             .to.be.revertedWithCustomError(matchers, "CustomErrorWithUint")
@@ -348,7 +348,7 @@ describe("INTEGRATION: Reverted with custom error", function () {
         });
       });
 
-      describe("array of different lengths", async function () {
+      describe("array of different lengths", function () {
         it("Should fail if the expected array is bigger", async function () {
           await expect(
             expect(matchers.revertWithCustomErrorWithPair(1, 2))

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -92,7 +92,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "ethers": "^6.1.0",
     "ethers-v5": "npm:ethers@5",

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -153,7 +153,7 @@ function defineTest(
   ) {
     it.skip(desc, func);
   } else if (testDefinition.only !== undefined && testDefinition.only) {
-    // eslint-disable-next-line no-only-tests/no-only-tests
+    // eslint-disable-next-line mocha/no-exclusive-tests
     it.only(desc, func);
   } else {
     it(desc, func);
@@ -773,7 +773,7 @@ describe("Stack traces", function () {
       process.exit(1);
     }
 
-    // eslint-disable-next-line no-only-tests/no-only-tests
+    // eslint-disable-next-line mocha/no-exclusive-tests
     describe.only(`Use compiler at ${customSolcPath} with version ${customSolcVersion}`, function () {
       const compilerOptions = {
         solidityVersion: customSolcVersion,
@@ -867,7 +867,7 @@ function defineTestForSolidityMajorVersion(
   testsPath: string
 ) {
   for (const compilerOptions of solcVersionsCompilerOptions) {
-    // eslint-disable-next-line no-only-tests/no-only-tests
+    // eslint-disable-next-line mocha/no-exclusive-tests
     const describeFn = compilerOptions.only === true ? describe.only : describe;
 
     describeFn(`Use compiler ${compilerOptions.compilerPath}`, function () {

--- a/packages/hardhat-ethers/package.json
+++ b/packages/hardhat-ethers/package.json
@@ -61,7 +61,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "ethers": "^6.1.0",
     "hardhat": "workspace:^2.0.0",

--- a/packages/hardhat-foundry/package.json
+++ b/packages/hardhat-foundry/package.json
@@ -48,6 +48,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.17.2",
     "mocha": "^10.0.0",

--- a/packages/hardhat-ledger/package.json
+++ b/packages/hardhat-ledger/package.json
@@ -63,7 +63,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.16.0",
     "mocha": "^10.0.0",

--- a/packages/hardhat-network-helpers/package.json
+++ b/packages/hardhat-network-helpers/package.json
@@ -55,7 +55,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "ethers-v5": "npm:ethers@5",
     "hardhat": "workspace:^2.9.5",

--- a/packages/hardhat-shorthand/package.json
+++ b/packages/hardhat-shorthand/package.json
@@ -49,7 +49,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.0.0",
     "mocha": "^10.0.0",

--- a/packages/hardhat-solhint/package.json
+++ b/packages/hardhat-solhint/package.json
@@ -52,7 +52,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "fs-extra": "^7.0.1",
     "hardhat": "workspace:^2.0.0",

--- a/packages/hardhat-solpp/package.json
+++ b/packages/hardhat-solpp/package.json
@@ -52,7 +52,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.0.0",
     "mocha": "^10.0.0",

--- a/packages/hardhat-solpp/test/tests.ts
+++ b/packages/hardhat-solpp/test/tests.ts
@@ -19,8 +19,8 @@ export async function expectErrorAsync(
   }
 }
 
-describe("Solpp plugin", async function () {
-  describe("js-config-project", async function () {
+describe("Solpp plugin", function () {
+  describe("js-config-project", function () {
     useEnvironment("js-config-project");
 
     it("should evaluate symbols as javascript functions", async function () {
@@ -36,7 +36,7 @@ describe("Solpp plugin", async function () {
     });
   });
 
-  describe("json-config-project", async function () {
+  describe("json-config-project", function () {
     useEnvironment("json-config-project");
 
     it("should load definitions from json", async function () {
@@ -54,7 +54,7 @@ describe("Solpp plugin", async function () {
     });
   });
 
-  describe("hardhat-project", async function () {
+  describe("hardhat-project", function () {
     useEnvironment("hardhat-project");
 
     it("should create processed contracts in the cache directory", async function () {
@@ -102,7 +102,7 @@ describe("Solpp plugin", async function () {
     });
 
     // This test skipped because solpp won't fail if a contract has an non-defined symbol.
-    describe.skip("fail-project", async function () {
+    describe.skip("fail-project", function () {
       useEnvironment("fail-project");
 
       it("should fail when symbol does not exist", async function () {

--- a/packages/hardhat-toolbox-viem/package.json
+++ b/packages/hardhat-toolbox-viem/package.json
@@ -59,7 +59,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.11.0",
     "hardhat-gas-reporter": "^1.0.8",

--- a/packages/hardhat-toolbox/package.json
+++ b/packages/hardhat-toolbox/package.json
@@ -58,7 +58,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "ethers": "^6.4.0",
     "hardhat": "workspace:^2.11.0",

--- a/packages/hardhat-truffle4/package.json
+++ b/packages/hardhat-truffle4/package.json
@@ -55,7 +55,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.6.4",
     "mocha": "^10.0.0",

--- a/packages/hardhat-truffle5/package.json
+++ b/packages/hardhat-truffle5/package.json
@@ -55,7 +55,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.6.4",
     "mocha": "^10.0.0",

--- a/packages/hardhat-verify/package.json
+++ b/packages/hardhat-verify/package.json
@@ -70,7 +70,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "ethers": "^5.0.0",
     "hardhat": "workspace:^2.0.4",

--- a/packages/hardhat-viem/package.json
+++ b/packages/hardhat-viem/package.json
@@ -55,7 +55,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.17.0",
     "jest-diff": "^29.7.0",

--- a/packages/hardhat-vyper/package.json
+++ b/packages/hardhat-vyper/package.json
@@ -58,7 +58,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.8.3",
     "mocha": "^10.0.0",

--- a/packages/hardhat-vyper/test/tests.ts
+++ b/packages/hardhat-vyper/test/tests.ts
@@ -68,7 +68,7 @@ describe("Vyper plugin", function () {
     });
   });
 
-  describe("Mixed language", async function () {
+  describe("Mixed language", function () {
     useFixtureProject("mixed-language");
     useEnvironment();
 

--- a/packages/hardhat-web3-legacy/package.json
+++ b/packages/hardhat-web3-legacy/package.json
@@ -46,7 +46,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.0.0",
     "mocha": "^10.0.0",

--- a/packages/hardhat-web3-v4/package.json
+++ b/packages/hardhat-web3-v4/package.json
@@ -47,7 +47,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.0.0",
     "mocha": "^10.0.0",

--- a/packages/hardhat-web3/package.json
+++ b/packages/hardhat-web3/package.json
@@ -46,7 +46,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-no-only-tests": "3.0.0",
+    "eslint-plugin-mocha": "10.4.1",
     "eslint-plugin-prettier": "3.4.0",
     "hardhat": "workspace:^2.0.0",
     "mocha": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,9 +206,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -456,9 +456,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -547,9 +547,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -617,6 +617,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -717,9 +720,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -793,9 +796,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -875,9 +878,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -945,9 +948,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1021,9 +1024,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1102,9 +1105,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1193,9 +1196,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1281,9 +1284,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1363,9 +1366,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1478,9 +1481,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1572,9 +1575,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1678,9 +1681,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1742,9 +1745,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1808,9 +1811,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -1877,9 +1880,9 @@ importers:
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint@8.57.0)
-      eslint-plugin-no-only-tests:
-        specifier: 3.0.0
-        version: 3.0.0
+      eslint-plugin-mocha:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 3.4.0
         version: 3.4.0(eslint-config-prettier@8.3.0)(eslint@8.57.0)(prettier@2.4.1)
@@ -2723,7 +2726,7 @@ packages:
       '@ethersproject/bignumber': 5.7.0
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/constants': 5.7.0
-      '@ethersproject/logger': 5.0.6
+      '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
       '@ethersproject/transactions': 5.7.0
 
@@ -2778,9 +2781,6 @@ packages:
     dependencies:
       '@ethersproject/bytes': 5.7.0
       js-sha3: 0.8.0
-
-  /@ethersproject/logger@5.0.6:
-    resolution: {integrity: sha512-FrX0Vnb3JZ1md/7GIZfmJ06XOAA8r3q9Uqt9O5orr4ZiksnbpXKlyDzQtlZ5Yv18RS8CAUbiKH9vwidJg1BPmQ==}
 
   /@ethersproject/logger@5.7.0:
     resolution: {integrity: sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==}
@@ -6200,9 +6200,16 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-no-only-tests@3.0.0:
-    resolution: {integrity: sha512-I0PeXMs1vu21ap45hey4HQCJRqpcoIvGcNTPJe+UhUm8TwjQ6//mCrDqF8q0WS6LgmRDwQ4ovQej0AQsAHb5yg==}
-    engines: {node: '>=5.0.0'}
+  /eslint-plugin-mocha@10.4.1(eslint@8.57.0):
+    resolution: {integrity: sha512-G85ALUgKaLzuEuHhoW3HVRgPTmia6njQC3qCG6CEvA8/Ja9PDZnRZOuzekMki+HaViEQXINuYsmhp5WR5/4MfA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      eslint: 8.57.0
+      eslint-utils: 3.0.0(eslint@8.57.0)
+      globals: 13.24.0
+      rambda: 7.5.0
     dev: true
 
   /eslint-plugin-node@11.1.0(eslint@8.57.0):
@@ -9339,6 +9346,10 @@ packages:
   /quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  /rambda@7.5.0:
+    resolution: {integrity: sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==}
+    dev: true
 
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}


### PR DESCRIPTION
Continuation of https://github.com/NomicFoundation/hardhat/pull/5086

Using this plugin also lets us remove the `eslint-plugin-no-only-tests` package and replace it with a rule from `eslint-plugin-mocha`.