### PR TITLE
docs(ignition): include config option `maxFeePerGasLimit`

### DIFF
--- a/docs/src/content/ignition/docs/config/index.md
+++ b/docs/src/content/ignition/docs/config/index.md
@@ -1,5 +1,9 @@
 # Configuration
 
+Hardhat Ignition has configuration options at both the global and network level.
+
+## Configuration options
+
 You can use the `ignition` field in the Hardhat config to customize how Hardhat Ignition behaves:
 
 ```js
@@ -13,8 +17,6 @@ module.exports = {
   },
 };
 ```
-
-## Configuration options
 
 These are the different options you can add to your Hardhat config file.
 
@@ -41,3 +43,30 @@ Default value: 4.
 The number of confirmations Hardhat Ignition waits before considering a transaction as complete. This provides control over block re-org risk.
 
 Default value: 5
+
+## Network configuration options
+
+You can use the `ignition` field under specific network configurations to customize deployments on a per-network basis:
+
+```js
+// hardhat.config.js
+module.exports = {
+  networks: {
+    sepolia: {
+      // ...
+      ignition: {
+        maxFeePerGasLimit: 50_000_000_000n, // 50 gwei
+      },
+      // ...
+    },
+  },
+};
+```
+
+These are the different options you can add to the per-network `ignition` config.
+
+### `maxFeePerGasLimit`
+
+If set, places a limit on the maximum fee per gas that Hardhat Ignition will allow when sending transactions. If Hardhat Ignition's calculated max fee per gas is higher than the limit, the deployment will be stopped with an error. This is useful for preventing accidental high fees during busy periods.
+
+Default value: undefined


### PR DESCRIPTION
As this is a per-network config option the configuration page had to be restructured to support both global and per-network config.

