### PR TITLE
fix: use correct hardfork for calls in pre-fork context

### DIFF
--- a/crates/edr_evm/src/block/builder.rs
+++ b/crates/edr_evm/src/block/builder.rs
@@ -90,11 +90,13 @@ where
                 }
                 _ => Self::InvalidTransaction(e),
             },
-            EVMError::Header(
-                InvalidHeader::ExcessBlobGasNotSet | InvalidHeader::PrevrandaoNotSet,
-            ) => unreachable!("error: {error:?}"),
             EVMError::Database(DatabaseComponentError::State(e)) => Self::State(e),
             EVMError::Database(DatabaseComponentError::BlockHash(e)) => Self::BlockHash(e),
+            // This case is a bug in our codebase for local blockchains, but it can happen that the
+            // remote returns incorrect block data in which case we should return a custom error.
+            EVMError::Header(
+                error @ (InvalidHeader::ExcessBlobGasNotSet | InvalidHeader::PrevrandaoNotSet),
+            ) => Self::Custom(error.to_string()),
             EVMError::Custom(error) => Self::Custom(error),
         }
     }

--- a/crates/edr_provider/src/requests/debug.rs
+++ b/crates/edr_provider/src/requests/debug.rs
@@ -9,7 +9,10 @@ use serde::{Deserialize, Deserializer};
 
 use crate::{
     data::ProviderData,
-    requests::{eth::resolve_call_request, validation::validate_call_request},
+    requests::{
+        eth::{resolve_block_spec_for_call_request, resolve_call_request},
+        validation::validate_call_request,
+    },
     ProviderError,
 };
 
@@ -36,17 +39,14 @@ pub fn handle_debug_trace_call<LoggerErrorT: Debug>(
     block_spec: Option<BlockSpec>,
     config: Option<DebugTraceConfig>,
 ) -> Result<DebugTraceResult, ProviderError<LoggerErrorT>> {
+    let block_spec = resolve_block_spec_for_call_request(block_spec);
     validate_call_request(data.spec_id(), &call_request, &block_spec)?;
 
-    let transaction = resolve_call_request(
-        data,
-        call_request,
-        block_spec.as_ref(),
-        &StateOverrides::default(),
-    )?;
+    let transaction =
+        resolve_call_request(data, call_request, &block_spec, &StateOverrides::default())?;
     data.debug_trace_call(
         transaction,
-        block_spec.as_ref(),
+        &block_spec,
         config.map(Into::into).unwrap_or_default(),
     )
 }

--- a/crates/edr_provider/src/requests/eth/gas.rs
+++ b/crates/edr_provider/src/requests/eth/gas.rs
@@ -22,11 +22,11 @@ pub fn handle_estimate_gas<LoggerErrorT: Debug>(
     call_request: CallRequest,
     block_spec: Option<BlockSpec>,
 ) -> Result<(U64, Vec<Trace>), ProviderError<LoggerErrorT>> {
-    validate_call_request(data.spec_id(), &call_request, &block_spec)?;
-
     // Matching Hardhat behavior in defaulting to "pending" instead of "latest" for
     // estimate gas.
     let block_spec = block_spec.unwrap_or_else(BlockSpec::pending);
+
+    validate_call_request(data.spec_id(), &call_request, &block_spec)?;
 
     let transaction =
         resolve_estimate_gas_request(data, call_request, &block_spec, &StateOverrides::default())?;
@@ -109,7 +109,7 @@ fn resolve_estimate_gas_request<LoggerErrorT: Debug>(
     resolve_call_request_inner(
         data,
         request,
-        Some(block_spec),
+        block_spec,
         state_overrides,
         ProviderData::gas_price,
         |data, max_fee_per_gas, max_priority_fee_per_gas| {

--- a/crates/edr_provider/src/requests/validation.rs
+++ b/crates/edr_provider/src/requests/validation.rs
@@ -155,11 +155,9 @@ pub fn validate_transaction_spec<LoggerErrorT: Debug>(
 pub fn validate_call_request<LoggerErrorT: Debug>(
     spec_id: SpecId,
     call_request: &CallRequest,
-    block_spec: &Option<BlockSpec>,
+    block_spec: &BlockSpec,
 ) -> Result<(), ProviderError<LoggerErrorT>> {
-    if let Some(ref block_spec) = block_spec {
-        validate_post_merge_block_tags(spec_id, block_spec)?;
-    }
+    validate_post_merge_block_tags(spec_id, block_spec)?;
 
     validate_transaction_and_call_request(
         spec_id,

--- a/crates/edr_provider/tests/issue_356.rs
+++ b/crates/edr_provider/tests/issue_356.rs
@@ -1,0 +1,58 @@
+use std::str::FromStr;
+
+use anyhow::Context;
+use edr_eth::{remote::eth::CallRequest, Address, Bytes, SpecId};
+use edr_provider::{
+    hardhat_rpc_types::ForkConfig, test_utils::create_test_config_with_fork, MethodInvocation,
+    NoopLogger, Provider, ProviderRequest,
+};
+use edr_test_utils::env::get_alchemy_url;
+use sha3::{Digest, Keccak256};
+use tokio::runtime;
+
+// Check that there is no panic when calling a forked blockchain where the
+// hardfork is specified as Cancun, but the block number is before the Cancun
+// hardfork. https://github.com/NomicFoundation/edr/issues/356
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_324() -> anyhow::Result<()> {
+    // ERC-20 contract
+    const TEST_CONTRACT_ADDRESS: &str = "0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0";
+
+    let contract_address = Address::from_str(TEST_CONTRACT_ADDRESS).context("Invalid address")?;
+
+    let logger = Box::new(NoopLogger);
+    let subscriber = Box::new(|_event| {});
+
+    let mut config = create_test_config_with_fork(Some(ForkConfig {
+        json_rpc_url: get_alchemy_url().replace("mainnet", "sepolia"),
+        // Pre-cancun Sepolia block
+        block_number: Some(4243456),
+        http_headers: None,
+    }));
+    config.hardfork = SpecId::CANCUN;
+
+    let provider = Provider::new(runtime::Handle::current(), logger, subscriber, config)?;
+
+    let selector = Bytes::copy_from_slice(
+        &Keccak256::new_with_prefix("decimals()")
+            .finalize()
+            .as_slice()[..4],
+    );
+
+    let response = provider.handle_request(ProviderRequest::Single(MethodInvocation::Call(
+        CallRequest {
+            to: Some(contract_address),
+            data: Some(selector),
+            ..CallRequest::default()
+        },
+        None,
+        None,
+    )))?;
+
+    assert_eq!(
+        response.result,
+        "0x0000000000000000000000000000000000000000000000000000000000000006"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This PR resolves https://github.com/NomicFoundation/edr/issues/356 by fixing two things:

1. When in fork mode and executing a call in the block immediately preceding the fork, make sure that the hardfork for EVM execution is derived from the block number as opposed to the provider config. This is achieved by explicitly specifying the latest block when creating the REVM block context if the block spec is `None` for calls. `None` in this method was meant to mean we're mining a new block.
2. Avoid panicking when REVM block context validation fails due to missing fields. Previously we panicked here, because we assumed that the fields were already validated. It is not validated however for remote blocks, so it's better to return an error.