### PR TITLE
Fix build with latest viem dependency

### DIFF
--- a/.changeset/short-pillows-march.md
+++ b/.changeset/short-pillows-march.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Fix to add guard for updated `TransactionReceipt` type in `viem`

--- a/packages/hardhat-viem/src/internal/contracts.ts
+++ b/packages/hardhat-viem/src/internal/contracts.ts
@@ -88,7 +88,7 @@ export async function innerDeployContract(
     confirmations,
   });
 
-  if (contractAddress === null) {
+  if (contractAddress === null || contractAddress === undefined) {
     const transaction = await publicClient.getTransaction({
       hash: deploymentTxHash,
     });


### PR DESCRIPTION
In the latest version of viem, the `contractAddress` field of the receipt can be both `null` or `undefined`, which causes our build to fail (and the latest dependencies workflow to fail). This fixes that.

I don't know in which cases this `undefined` can show up though.