### PR TITLE
Update chain-config.ts : Added Base Sepolia chain

### DIFF
--- a/.changeset/large-phones-relax.md
+++ b/.changeset/large-phones-relax.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Added baseSepolia (thanks @hironate)

--- a/packages/hardhat-verify/src/internal/chain-config.ts
+++ b/packages/hardhat-verify/src/internal/chain-config.ts
@@ -219,6 +219,14 @@ export const builtinChains: ChainConfig[] = [
     },
   },
   {
+    network: "baseSepolia",
+    chainId: 84532,
+    urls: {
+      apiURL: "https://api-sepolia.basescan.org/api",
+      browserURL: "https://sepolia.basescan.org/",
+    },
+  },
+  {
     network: "arbitrumSepolia",
     chainId: 421614,
     urls: {


### PR DESCRIPTION
Currently, Base Sepolia is not in the list of chains for the hardhat verify plugin. This PR adds support for verifying smart contracts on the Base Sepolia network.

### PR adds following changes

- [x]  Base Sepolia support to verify smart contract
