### PR TITLE
Update creating-modules.md

### DIFF
--- a/docs/src/content/ignition/docs/guides/creating-modules.md
+++ b/docs/src/content/ignition/docs/guides/creating-modules.md
@@ -112,10 +112,10 @@ The first argument is the `Future` object for the contract you want to call, the
 
 In this example, the `m.call` returns a `Future` which we aren't assigning to any variable. This isn't a problem. Hardhat Ignition will execute every `Future` within a module, regardless of whether we store it or not.
 
-If you need to send ETH while calling a function, you can pass an object with options as the third argument to `m.contract`, and put in how much you want to send in the `value` field:
+If you need to send ETH while calling a function, you can pass an object with options as the fourth argument to `m.contract`, and put in how much you want to send in the `value` field:
 
 ```js
-m.call(myContract, "receivesEth" [], {
+m.call(myContract, "receivesEth", [], {
   value: 1_000_000_000n, // 1gwei
 });
 ```


### PR DESCRIPTION
When calling a function that receives ether, the options object should be the fourth argument. Missing comma between the function name and function arguments.

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
When calling a function that receives ether, the options object should be the fourth argument.
Missing comma between the function name and function arguments.