### PR TITLE
chore: remove edr changesets

### DIFF
--- a/.changeset/friendly-papayas-drum.md
+++ b/.changeset/friendly-papayas-drum.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-Fixed mining of blocks when forking a chain that has non-Ethereum block headers

--- a/.changeset/tall-cats-learn.md
+++ b/.changeset/tall-cats-learn.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Upgrade EDR to version [0.3.5](https://github.com/NomicFoundation/hardhat/blob/3b36d76a88915de6bb5efd0eb110cc1782c461ca/crates/edr_napi/CHANGELOG.md#035)

--- a/.changeset/twelve-ducks-exercise.md
+++ b/.changeset/twelve-ducks-exercise.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-Fixed panic when re-setting global default subscriber


### PR DESCRIPTION
To avoid releasing EDR while doing a more general Hardhat release we are turning off two changesets. These will be added back in after the release.

Also add in a changeset to document the `0.3.5` upgrade.
