### PR TITLE
chore: add back EDR changesets

### DIFF
--- a/.changeset/friendly-papayas-drum.md
+++ b/.changeset/friendly-papayas-drum.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed mining of blocks when forking a chain that has non-Ethereum block headers

--- a/.changeset/twelve-ducks-exercise.md
+++ b/.changeset/twelve-ducks-exercise.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/edr": patch
+---
+
+Fixed panic when re-setting global default subscriber


### PR DESCRIPTION
These were removed temporarily to allow a Hardhat release.
