### PR TITLE
use absolute path for foundry sources

### DIFF
--- a/.changeset/cyan-cheetahs-add.md
+++ b/.changeset/cyan-cheetahs-add.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-foundry": patch
+---
+
+Use absolute rather than relative path when overriding sources configuration

--- a/packages/hardhat-foundry/src/index.ts
+++ b/packages/hardhat-foundry/src/index.ts
@@ -59,7 +59,7 @@ extendConfig((config, userConfig) => {
   }
 
   // Set sources path
-  config.paths.sources = foundrySourcesPath;
+  config.paths.sources = path.resolve(config.paths.root, foundrySourcesPath);
 
   // Change hardhat's cache path if it clashes with foundry's
   const foundryCachePath = path.resolve(


### PR DESCRIPTION
closes #5043

Not sure how to test this because the plugin directory is not a Hardhat project.