### PR TITLE
fix: use `eth_maxPriorityFeePerGas` for determing gas

### DIFF
--- a/.changeset/smart-hotels-fold.md
+++ b/.changeset/smart-hotels-fold.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Use `eth_maxPriorityFeePerGas` for the max fee per gas calculation if available

--- a/packages/hardhat-ethers/src/internal/hardhat-ethers-provider.ts
+++ b/packages/hardhat-ethers/src/internal/hardhat-ethers-provider.ts
@@ -153,7 +153,16 @@ export class HardhatEthersProvider implements ethers.Provider {
     const latestBlock = await this.getBlock("latest");
     const baseFeePerGas = latestBlock?.baseFeePerGas;
     if (baseFeePerGas !== undefined && baseFeePerGas !== null) {
-      maxPriorityFeePerGas = 1_000_000_000n;
+      try {
+        maxPriorityFeePerGas = BigInt(
+          await this._hardhatProvider.send("eth_maxPriorityFeePerGas")
+        );
+      } catch {
+        // the max priority fee RPC call is not supported by
+        // this chain
+      }
+
+      maxPriorityFeePerGas = maxPriorityFeePerGas ?? 1_000_000_000n;
       maxFeePerGas = 2n * baseFeePerGas + maxPriorityFeePerGas;
     }
 


### PR DESCRIPTION
Update `getFeeData` to match the `ethers` algorithm, specifically don't just assume `1_000_000_000n` as the `maxPriorityFeePerGas`. Instead call `eth_maxPriorityFeePerGas`, and only fall back to `1_000_000_000n`, if there is no response.

Fixes #5093


