### PR TITLE
Update chain-config.ts : Replace Mumbai by Amoy

### DIFF
--- a/.changeset/new-books-marry.md
+++ b/.changeset/new-books-marry.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Added Polygon Amoy testnet (thanks @FournyP!)

--- a/packages/hardhat-verify/src/internal/chain-config.ts
+++ b/packages/hardhat-verify/src/internal/chain-config.ts
@@ -203,11 +203,11 @@ export const builtinChains: ChainConfig[] = [
     },
   },
   {
-    network: "polygonMumbai",
-    chainId: 80001,
+    network: "polygonAmoy",
+    chainId: 80002,
     urls: {
-      apiURL: "https://api-testnet.polygonscan.com/api",
-      browserURL: "https://mumbai.polygonscan.com/",
+      apiURL: "https://api-amoy.polygonscan.com/api",
+      browserURL: "https://amoy.polygonscan.com/",
     },
   },
   {

--- a/packages/hardhat-verify/src/internal/chain-config.ts
+++ b/packages/hardhat-verify/src/internal/chain-config.ts
@@ -203,6 +203,14 @@ export const builtinChains: ChainConfig[] = [
     },
   },
   {
+    network: "polygonMumbai",
+    chainId: 80001,
+    urls: {
+      apiURL: "https://api-testnet.polygonscan.com/api",
+      browserURL: "https://mumbai.polygonscan.com/",
+    },
+  },
+  {
     network: "polygonAmoy",
     chainId: 80002,
     urls: {


### PR DESCRIPTION
With the deprecation of Polygon Mumbai to Polygon Amoy, I've done this little PR because I need it for one of my projects.

### PR adds following changes

- [x]  Replace `Mumbai` testnet into `Amoy` to verify smart contract