### PR TITLE
Enforce contract verification

### DIFF
--- a/.changeset/pink-goats-jam.md
+++ b/.changeset/pink-goats-jam.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Added 'force' flag to allow verification of partially verified contracts (thanks @rimrakhimov!)

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -52,6 +52,7 @@ export interface VerifyTaskArgs {
   constructorArgs?: string;
   libraries?: string;
   contract?: string;
+  force: boolean;
   listNetworks: boolean;
 }
 
@@ -114,6 +115,11 @@ task(TASK_VERIFY, "Verifies a contract on Etherscan or Sourcify")
     "contract",
     "Fully qualified name of the contract to verify. Skips automatic detection of the contract. " +
       "Use if the deployed bytecode matches more than one contract in your project"
+  )
+  .addFlag(
+    "force",
+    "Enforce contract verification even if the contract is already verified. " +
+      "Use to re-verify partially verified contracts on Blockscout"
   )
   .addFlag("listNetworks", "Print the list of supported networks")
   .setAction(async (taskArgs: VerifyTaskArgs, { run }) => {

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -62,6 +62,7 @@ interface VerifySubtaskArgs {
   constructorArguments: string[];
   libraries: LibraryToAddress;
   contract?: string;
+  force?: boolean;
 }
 
 export interface VerificationResponse {
@@ -272,9 +273,16 @@ subtask(TASK_VERIFY_VERIFY)
   .addOptionalParam("constructorArguments", undefined, [], types.any)
   .addOptionalParam("libraries", undefined, {}, types.any)
   .addOptionalParam("contract")
+  .addFlag("force")
   .setAction(
     async (
-      { address, constructorArguments, libraries, contract }: VerifySubtaskArgs,
+      {
+        address,
+        constructorArguments,
+        libraries,
+        contract,
+        force,
+      }: VerifySubtaskArgs,
       { run, config }
     ) => {
       // This can only happen if the subtask is invoked from within Hardhat by a user script or another task.
@@ -292,6 +300,7 @@ subtask(TASK_VERIFY_VERIFY)
           constructorArgsParams: constructorArguments,
           libraries,
           contract,
+          force,
         });
       }
 

--- a/packages/hardhat-verify/src/internal/errors.ts
+++ b/packages/hardhat-verify/src/internal/errors.ts
@@ -458,3 +458,12 @@ ${undetectableLibraries.map((x) => `  * ${x}`).join("\n")}`
 }`);
   }
 }
+
+export class ContractAlreadyVerifiedError extends HardhatVerifyError {
+  constructor(contractAddress: string) {
+    super(`The Etherecan API responded that the contract ${contractAddress} is already verified.
+This can happen if you used '--force' flag, but either the explorer does not support contracts' re-verification
+(e.g., Etherscan) or the contract has already been verified with a full match.`);
+    Object.setPrototypeOf(this, ContractAlreadyVerifiedError.prototype);
+  }
+}

--- a/packages/hardhat-verify/src/internal/errors.ts
+++ b/packages/hardhat-verify/src/internal/errors.ts
@@ -460,10 +460,9 @@ ${undetectableLibraries.map((x) => `  * ${x}`).join("\n")}`
 }
 
 export class ContractAlreadyVerifiedError extends HardhatVerifyError {
-  constructor(contractAddress: string) {
-    super(`The Etherecan API responded that the contract ${contractAddress} is already verified.
-This can happen if you used '--force' flag, but either the explorer does not support contracts' re-verification
-(e.g., Etherscan) or the contract has already been verified with a full match.`);
-    Object.setPrototypeOf(this, ContractAlreadyVerifiedError.prototype);
+  constructor(contractFQN: string, contractAddress: string) {
+    super(`The block explorer's API responded that the contract ${contractFQN} at ${contractAddress} is already verified.
+This can happen if you used the '--force' flag. However, re-verification of contracts might not be supported
+by the explorer (e.g., Etherscan), or the contract may have already been verified with a full match.`);
   }
 }

--- a/packages/hardhat-verify/src/internal/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/etherscan.ts
@@ -187,7 +187,7 @@ export class Etherscan {
       }
 
       if (etherscanResponse.isAlreadyVerified()) {
-        throw new ContractAlreadyVerifiedError(contractAddress);
+        throw new ContractAlreadyVerifiedError(contractName, contractAddress);
       }
 
       if (!etherscanResponse.isOk()) {

--- a/packages/hardhat-verify/src/internal/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/etherscan.ts
@@ -311,6 +311,7 @@ class EtherscanResponse implements ValidationResponse {
       // returned by blockscout
       this.message.startsWith("Smart-contract already verified") ||
       // returned by etherscan
+      this.message.startsWith("Contract source code already verified") ||
       this.message.startsWith("Already Verified")
     );
   }

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -106,7 +106,7 @@ subtask(TASK_VERIFY_ETHERSCAN)
     if (!force && isVerified) {
       const contractURL = etherscan.getContractUrl(address);
       console.log(`The contract ${address} has already been verified on Etherscan.
-${contractURL}`);
+${contractURL}. If you're trying to verify a partially verified contract, please use the --force flag.`);
       return;
     }
 

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -105,7 +105,7 @@ subtask(TASK_VERIFY_ETHERSCAN)
     const isVerified = await etherscan.isVerified(address);
     if (!force && isVerified) {
       const contractURL = etherscan.getContractUrl(address);
-      console.log(`The contract ${address} has already been verified on Etherscan.
+      console.log(`The contract ${address} has already been verified on the block explorer.
 ${contractURL}. If you're trying to verify a partially verified contract, please use the --force flag.`);
       return;
     }

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -301,16 +301,17 @@ subtask(TASK_VERIFY_ETHERSCAN_ATTEMPT_VERIFICATION)
       // Ensure the linking information is present in the compiler input;
       compilerInput.settings.libraries = contractInformation.libraries;
 
+      const contractFQN = `${contractInformation.sourceName}:${contractInformation.contractName}`;
       const { message: guid } = await verificationInterface.verify(
         address,
         JSON.stringify(compilerInput),
-        `${contractInformation.sourceName}:${contractInformation.contractName}`,
+        contractFQN,
         `v${contractInformation.solcLongVersion}`,
         encodedConstructorArguments
       );
 
       console.log(`Successfully submitted source code for contract
-${contractInformation.sourceName}:${contractInformation.contractName} at ${address}
+${contractFQN} at ${address}
 for verification on the block explorer. Waiting for verification result...
 `);
 
@@ -321,7 +322,7 @@ for verification on the block explorer. Waiting for verification result...
 
       // Etherscan answers with already verified message only when checking returned guid
       if (verificationStatus.isAlreadyVerified()) {
-        throw new ContractAlreadyVerifiedError(address);
+        throw new ContractAlreadyVerifiedError(contractFQN, address);
       }
 
       if (!(verificationStatus.isFailure() || verificationStatus.isSuccess())) {

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -26,6 +26,7 @@ import {
   InvalidContractNameError,
   UnexpectedNumberOfFilesError,
   VerificationAPIUnexpectedMessageError,
+  ContractAlreadyVerifiedError,
 } from "../errors";
 import { Etherscan } from "../etherscan";
 import { Bytecode } from "../solc/bytecode";
@@ -50,6 +51,7 @@ interface VerificationArgs {
   constructorArgs: string[];
   libraries: LibraryToAddress;
   contractFQN?: string;
+  force: boolean;
 }
 
 interface GetMinimalInputArgs {
@@ -76,12 +78,14 @@ subtask(TASK_VERIFY_ETHERSCAN)
   .addOptionalParam("constructorArgs")
   .addOptionalParam("libraries", undefined, undefined, types.any)
   .addOptionalParam("contract")
+  .addFlag("force")
   .setAction(async (taskArgs: VerifyTaskArgs, { config, network, run }) => {
     const {
       address,
       constructorArgs,
       libraries,
       contractFQN,
+      force,
     }: VerificationArgs = await run(
       TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS,
       taskArgs
@@ -99,7 +103,7 @@ subtask(TASK_VERIFY_ETHERSCAN)
     );
 
     const isVerified = await etherscan.isVerified(address);
-    if (isVerified) {
+    if (!force && isVerified) {
       const contractURL = etherscan.getContractUrl(address);
       console.log(`The contract ${address} has already been verified on Etherscan.
 ${contractURL}`);
@@ -200,6 +204,7 @@ subtask(TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS)
   .addOptionalParam("constructorArgs", undefined, undefined, types.inputFile)
   .addOptionalParam("libraries", undefined, undefined, types.any)
   .addOptionalParam("contract")
+  .addFlag("force")
   .setAction(
     async ({
       address,
@@ -207,6 +212,7 @@ subtask(TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS)
       constructorArgs: constructorArgsModule,
       contract,
       libraries: librariesModule,
+      force,
     }: VerifyTaskArgs): Promise<VerificationArgs> => {
       if (address === undefined) {
         throw new MissingAddressError();
@@ -238,6 +244,7 @@ subtask(TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS)
         constructorArgs,
         libraries,
         contractFQN: contract,
+        force,
       };
     }
   );
@@ -311,6 +318,11 @@ for verification on the block explorer. Waiting for verification result...
       await sleep(700);
       const verificationStatus =
         await verificationInterface.getVerificationStatus(guid);
+
+      // Etherscan answers with already verified message only when checking returned guid
+      if (verificationStatus.isAlreadyVerified()) {
+        throw new ContractAlreadyVerifiedError(address);
+      }
 
       if (!(verificationStatus.isFailure() || verificationStatus.isSuccess())) {
         // Reaching this point shouldn't be possible unless the API is behaving in a new way.

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -105,8 +105,8 @@ subtask(TASK_VERIFY_ETHERSCAN)
     const isVerified = await etherscan.isVerified(address);
     if (!force && isVerified) {
       const contractURL = etherscan.getContractUrl(address);
-      console.log(`The contract ${address} has already been verified on the block explorer.
-${contractURL}. If you're trying to verify a partially verified contract, please use the --force flag.`);
+      console.log(`The contract ${address} has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
+${contractURL}`);
       return;
     }
 

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -91,7 +91,7 @@ describe("verify task integration tests", () => {
       });
 
       expect(logStub).to.be.calledOnceWith(
-        `The contract ${address} has already been verified on Etherscan.
+        `The contract ${address} has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
 https://hardhat.etherscan.io/address/${address}#code`
       );
       logStub.restore();

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -629,6 +629,132 @@ https://hardhat.etherscan.io/address/${bothLibsContractAddress}#code\n`);
       await this.hre.run(TASK_CLEAN);
     });
   });
+
+  describe("with a verified contract and '--force' flag", () => {
+    let simpleContractAddress: string;
+    before(async function () {
+      await this.hre.run(TASK_COMPILE, { force: true, quiet: true });
+      simpleContractAddress = await deployContract(
+        "SimpleContract",
+        [],
+        this.hre
+      );
+    });
+
+    beforeEach(() => {
+      interceptIsVerified({ message: "OK", result: [{ SourceCode: "code" }] });
+    });
+
+    it("should validate a partially verified contract", async function () {
+      interceptVerify({
+        status: 1,
+        result: "ezq878u486pzijkvvmerl6a9mzwhv6sefgvqi5tkwceejc7tvn",
+      });
+      interceptGetStatus(() => {
+        return {
+          status: 1,
+          result: "Pass - Verified",
+        };
+      });
+      const logStub = sinon.stub(console, "log");
+
+      const taskResponse = await this.hre.run(TASK_VERIFY, {
+        address: simpleContractAddress,
+        constructorArgsParams: [],
+        force: true,
+      });
+
+      assert.equal(logStub.callCount, 2);
+      expect(logStub.getCall(0)).to.be
+        .calledWith(`Successfully submitted source code for contract
+contracts/SimpleContract.sol:SimpleContract at ${simpleContractAddress}
+for verification on the block explorer. Waiting for verification result...
+`);
+      expect(logStub.getCall(1)).to.be
+        .calledWith(`Successfully verified contract SimpleContract on the block explorer.
+https://hardhat.etherscan.io/address/${simpleContractAddress}#code\n`);
+      logStub.restore();
+      assert.isUndefined(taskResponse);
+    });
+
+    it("should throw if the verification response status is 'already verified' (blockscout full matched)", async function () {
+      interceptVerify({
+        status: 0,
+        result: "Smart-contract already verified.",
+      });
+
+      await expect(
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
+          address: simpleContractAddress,
+          constructorArgsParams: [],
+          force: true,
+        })
+      ).to.be.rejectedWith(
+        new RegExp(
+          `The block explorer's API responded that the contract contracts/SimpleContract.sol:SimpleContract at ${simpleContractAddress} is already verified.`
+        )
+      );
+    });
+
+    // If contract was actually verified, Etherscan returns an error on the verification request.
+    it("should throw if the verification response status is 'already verified' (etherscan manually verified)", async function () {
+      interceptVerify({
+        status: 0,
+        result: "Contract source code already verified",
+      });
+
+      await expect(
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
+          address: simpleContractAddress,
+          constructorArgsParams: [],
+          force: true,
+        })
+      ).to.be.rejectedWith(
+        new RegExp(
+          `The block explorer's API responded that the contract contracts/SimpleContract.sol:SimpleContract at ${simpleContractAddress} is already verified.`
+        )
+      );
+    });
+
+    // If contract was verified via matching a deployed bytecode of another contract,
+    // Etherscan returns an error only on ve get verification status response.
+    it("should throw if the get verification status is 'already verified' (etherscan automatically verified)", async function () {
+      interceptVerify({
+        status: 1,
+        result: "ezq878u486pzijkvvmerl6a9mzwhv6sefgvqi5tkwceejc7tvn",
+      });
+      interceptGetStatus(() => {
+        return {
+          status: 0,
+          result: "Already Verified",
+        };
+      });
+      const logStub = sinon.stub(console, "log");
+
+      await expect(
+        this.hre.run(TASK_VERIFY_ETHERSCAN, {
+          address: simpleContractAddress,
+          constructorArgsParams: [],
+          force: true,
+        })
+      ).to.be.rejectedWith(
+        new RegExp(
+          `The block explorer's API responded that the contract contracts/SimpleContract.sol:SimpleContract at ${simpleContractAddress} is already verified.`
+        )
+      );
+
+      expect(logStub).to.be
+        .calledOnceWith(`Successfully submitted source code for contract
+contracts/SimpleContract.sol:SimpleContract at ${simpleContractAddress}
+for verification on the block explorer. Waiting for verification result...
+`);
+      logStub.restore();
+    });
+
+    after(async function () {
+      await this.hre.run(TASK_CLEAN);
+    });
+  });
 });
 
 describe("verify task Sourcify's integration tests", () => {

--- a/packages/hardhat-verify/test/unit/index.ts
+++ b/packages/hardhat-verify/test/unit/index.ts
@@ -67,6 +67,7 @@ describe("verify task", () => {
           ConstructorLib: "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
         },
         contractFQN: "contracts/TestContract.sol:TestContract",
+        force: false,
       };
       const processedArgs = await this.hre.run(
         TASK_VERIFY_ETHERSCAN_RESOLVE_ARGUMENTS,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

That PR adds the `--force` verification flag described in https://github.com/NomicFoundation/hardhat/issues/5122, which allows the re-verification of already verified contracts (for blockscout-based explorers).

Notice that sometimes, an underlying explorer may return an error saying that the contract has already been verified. For blockscout-based explorers that happens if the contract is already verified with a [full match](https://docs.sourcify.dev/docs/full-vs-partial-match/), while for etherscan that is the only possible option for verified contracts. The PR considers those cases as errors and fails with a corresponding error message. I don't know if that is what is expected, though.

Also I plan to add some test cases, but would be glad to get some suggestions to start with