### PR TITLE
docs(ignition): add `maxPriorityFeePerGas` to config

### DIFF
--- a/docs/src/content/ignition/docs/config/index.md
+++ b/docs/src/content/ignition/docs/config/index.md
@@ -56,6 +56,7 @@ module.exports = {
       // ...
       ignition: {
         maxFeePerGasLimit: 50_000_000_000n, // 50 gwei
+        maxPriorityFeePerGas: 2_000_000_000n, // 2 gwei
       },
       // ...
     },
@@ -68,5 +69,11 @@ These are the different options you can add to the per-network `ignition` config
 ### `maxFeePerGasLimit`
 
 If set, places a limit on the maximum fee per gas that Hardhat Ignition will allow when sending transactions. If Hardhat Ignition's calculated max fee per gas is higher than the limit, the deployment will be stopped with an error. This is useful for preventing accidental high fees during busy periods.
+
+Default value: undefined
+
+### `maxPriorityFeePerGas`
+
+The maximum priority fee per gas, in wei, that Hardhat Ignition will use for gas fee calculations when sending transactions. If not set then Hardhat Ignition will try to use `eth_maxPriorityFeePerGas` if available, or default to 1 gwei.
 
 Default value: undefined


### PR DESCRIPTION
Documents the `maxPriorityFeePerGas` as a config value for network configuration.
