### PR TITLE
Remove EDR changesets

### DIFF
--- a/.changeset/friendly-papayas-drum.md
+++ b/.changeset/friendly-papayas-drum.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-Fixed mining of blocks when forking a chain that has non-Ethereum block headers

--- a/.changeset/new-coins-eat.md
+++ b/.changeset/new-coins-eat.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-fix: avoid ecrecover for known sender

--- a/.changeset/tough-students-compare.md
+++ b/.changeset/tough-students-compare.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-perf: changed internal data structures to achieve to constant time checkpointing for significant performance improvements on large test suites

--- a/.changeset/twelve-ducks-exercise.md
+++ b/.changeset/twelve-ducks-exercise.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-Fixed panic when re-setting global default subscriber

--- a/.changeset/two-suits-admire.md
+++ b/.changeset/two-suits-admire.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/edr": patch
----
-
-fix: avoid cloning transaction traces for improved performance

--- a/.changeset/wicked-walls-itch.md
+++ b/.changeset/wicked-walls-itch.md
@@ -1,5 +1,5 @@
 ---
-"@nomicfoundation/ed": patch
+"hardhat": patch
 ---
 
-fix: avoid transferring traces to JS if there are no plugins that need them to improve performance
+Improved performance by reducing back-and-forth with EDR when it's not necessary


### PR DESCRIPTION
These were added before the repo migration, and they were already released.

The one that is modified comes from an optimization on the Hardhat side, which hasn't been released yet.