### PR TITLE
feat: check check constructor args type

### DIFF
--- a/.changeset/thick-beers-tie.md
+++ b/.changeset/thick-beers-tie.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Improved validation of contructor arguments

--- a/.changeset/thick-beers-tie.md
+++ b/.changeset/thick-beers-tie.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-verify": patch
 ---
 
-Improved validation of contructor arguments
+Improved validation of contructor arguments (thanks @fwx5618177!)

--- a/packages/hardhat-verify/test/unit/utilities.ts
+++ b/packages/hardhat-verify/test/unit/utilities.ts
@@ -537,6 +537,39 @@ but 2 arguments were provided instead.`);
       );
     });
 
+    it("should throw if a parameter type does not match its expected type: number instead of string", async () => {
+      const abi: JsonFragment[] = [
+        {
+          inputs: [
+            {
+              name: "amount",
+              type: "uint256",
+            },
+            {
+              name: "amount",
+              type: "string",
+            },
+            {
+              name: "amount",
+              type: "address",
+            },
+          ],
+          stateMutability: "nonpayable",
+          type: "constructor",
+        },
+      ];
+      const constructorArguments: any[] = [
+        50,
+        50, // Invalid string
+        "0x752C8191E6b1Db38B41A8c8921F7a703F2969d18",
+      ];
+      await expect(
+        encodeArguments(abi, sourceName, contractName, constructorArguments)
+      ).to.be.rejectedWith(
+        /Value 50 cannot be encoded for the parameter amount./
+      );
+    });
+
     it("should throw if an unsafe integer is provided as an argument", async () => {
       const abi: JsonFragment[] = [
         {


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

1. Added detection of parameters when passing arguments to the constructor. Currently, the detection is done on the backend, which makes it difficult to distinguish between strings and numbers in the tool. Therefore, a new feature has been submitted to address this issue.

This is the contract code:
```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.20;

contract MyContract {

    string public url;
    uint256 public add;

    constructor(string memory _url, uint256 _add) {
        url = _url;
        add = _add;
    }

    function setUrl(string memory _url) public {
        url = _url;
    }
}
```

Parameter passing file:
```js
module.exports = [
    123,
    123
];
```

Using the command:
```bash
npx hardhat verify --contract contracts/MyToken.sol:MyContract [ADDRESS] --constructor-args scripts/arguments.js
```
