### PR TITLE
Hardhat verify fixes

### DIFF
--- a/.changeset/clever-hairs-happen.md
+++ b/.changeset/clever-hairs-happen.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Improved error handling and messaging

--- a/.changeset/clever-hairs-happen.md
+++ b/.changeset/clever-hairs-happen.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-verify": patch
 ---
 
-Improved error handling and messaging
+Improved error handling and messaging for errors from the block explorer

--- a/packages/hardhat-verify/src/internal/errors.ts
+++ b/packages/hardhat-verify/src/internal/errors.ts
@@ -9,6 +9,7 @@ import { TASK_VERIFY_VERIFY } from "./task-names";
 export class HardhatVerifyError extends NomicLabsHardhatPluginError {
   constructor(message: string, parent?: Error) {
     super("@nomicfoundation/hardhat-verify", message, parent);
+    Object.setPrototypeOf(this, this.constructor.prototype);
   }
 }
 
@@ -421,12 +422,27 @@ Encoder error reason: ${reason} fault in ${operation}`,
   }
 }
 
+/**
+ * `VerificationAPIUnexpectedMessageError` is thrown when the block explorer API
+ * does not behave as expected, such as when it returns an unexpected response message.
+ *
+ * This error is intended to be reported to the Hardhat team for further investigation
+ * and potential updates to the plugin to handle the new behavior.
+ */
 export class VerificationAPIUnexpectedMessageError extends HardhatVerifyError {
   constructor(message: string) {
     super(`The API responded with an unexpected message.
 Please report this issue to the Hardhat team.
 Contract verification may have succeeded and should be checked manually.
 Message: ${message}`);
+  }
+}
+
+export class NetworkRequestError extends HardhatVerifyError {
+  constructor(e: Error) {
+    super(
+      `A network request failed. This error is not related to Hardhat. Original error: ${e.message}`
+    );
   }
 }
 

--- a/packages/hardhat-verify/src/internal/errors.ts
+++ b/packages/hardhat-verify/src/internal/errors.ts
@@ -437,7 +437,7 @@ Message: ${message}`);
 export class NetworkRequestError extends HardhatVerifyError {
   constructor(e: Error) {
     super(
-      `A network request failed. This error is not related to Hardhat. Original error: ${e.message}`
+      `A network request failed. This is an error from the block explorer, not Hardhat. Error: ${e.message}`
     );
   }
 }

--- a/packages/hardhat-verify/src/internal/errors.ts
+++ b/packages/hardhat-verify/src/internal/errors.ts
@@ -425,14 +425,10 @@ Encoder error reason: ${reason} fault in ${operation}`,
 /**
  * `VerificationAPIUnexpectedMessageError` is thrown when the block explorer API
  * does not behave as expected, such as when it returns an unexpected response message.
- *
- * This error is intended to be reported to the Hardhat team for further investigation
- * and potential updates to the plugin to handle the new behavior.
  */
 export class VerificationAPIUnexpectedMessageError extends HardhatVerifyError {
   constructor(message: string) {
     super(`The API responded with an unexpected message.
-Please report this issue to the Hardhat team.
 Contract verification may have succeeded and should be checked manually.
 Message: ${message}`);
   }
@@ -443,19 +439,6 @@ export class NetworkRequestError extends HardhatVerifyError {
     super(
       `A network request failed. This error is not related to Hardhat. Original error: ${e.message}`
     );
-  }
-}
-
-export class UnexpectedError extends HardhatVerifyError {
-  constructor(e: unknown, functionName: string) {
-    const defaultErrorDetails = `Unexpected error in ${functionName}`;
-    const errorDetails =
-      e instanceof Error
-        ? e.message ?? defaultErrorDetails
-        : defaultErrorDetails;
-    super(`An unexpected error occurred during the verification process.
-Please report this issue to the Hardhat team.
-Error Details: ${errorDetails}`);
   }
 }
 

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -106,7 +106,8 @@ subtask(TASK_VERIFY_ETHERSCAN)
     if (!force && isVerified) {
       const contractURL = etherscan.getContractUrl(address);
       console.log(`The contract ${address} has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
-${contractURL}`);
+${contractURL}
+`);
       return;
     }
 

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -92,7 +92,8 @@ describe("verify task integration tests", () => {
 
       expect(logStub).to.be.calledOnceWith(
         `The contract ${address} has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
-https://hardhat.etherscan.io/address/${address}#code`
+https://hardhat.etherscan.io/address/${address}#code
+`
       );
       logStub.restore();
       assert.isUndefined(taskResponse);

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -10,6 +10,7 @@ import {
   TASK_VERIFY_VERIFY,
   TASK_VERIFY_SOURCIFY,
 } from "../../src/internal/task-names";
+import { UnexpectedError } from "../../src/internal/errors";
 import { deployContract, getRandomAddress, useEnvironment } from "../helpers";
 import {
   interceptGetStatus,
@@ -308,7 +309,7 @@ This can occur if the library is only called in the contract constructor. The mi
           constructorArgsParams: [],
         })
       ).to.be.rejectedWith(
-        /An unexpected error occurred during the verification process\.\nPlease report this issue to the Hardhat team\.\nError Details: getaddrinfo ENOTFOUND api-hardhat\.etherscan\.io/
+        /A network request failed\. This error is not related to Hardhat\. Original error: getaddrinfo ENOTFOUND api-hardhat\.etherscan\.io/
       );
     });
 
@@ -331,16 +332,25 @@ This can occur if the library is only called in the contract constructor. The mi
         result: "Unable to locate ContractCode at 0x...",
       });
 
-      await expect(
-        this.hre.run(TASK_VERIFY_ETHERSCAN, {
+      try {
+        await this.hre.run(TASK_VERIFY_ETHERSCAN, {
           address: simpleContractAddress,
           constructorArgsParams: [],
-        })
-      ).to.be.rejectedWith(
-        new RegExp(
-          `The Etherscan API responded that the address ${simpleContractAddress} does not have bytecode.`
-        )
-      );
+        });
+        assert.fail("Expected error was not thrown");
+      } catch (e: any) {
+        assert.notInstanceOf(
+          e,
+          UnexpectedError,
+          "Error should not be an instance of UnexpectedError"
+        );
+        assert.match(
+          e.message,
+          new RegExp(
+            `The Etherscan API responded that the address ${simpleContractAddress} does not have bytecode.`
+          )
+        );
+      }
     });
 
     it("should throw if the verification response status is not ok", async function () {
@@ -371,7 +381,7 @@ This can occur if the library is only called in the contract constructor. The mi
           constructorArgsParams: [],
         })
       ).to.be.rejectedWith(
-        /An unexpected error occurred during the verification process\.\nPlease report this issue to the Hardhat team\.\nError Details: getaddrinfo ENOTFOUND api-hardhat\.etherscan\.io/
+        /A network request failed\. This error is not related to Hardhat\. Original error: getaddrinfo ENOTFOUND api-hardhat\.etherscan\.io/
       );
 
       expect(logStub).to.be

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -309,7 +309,7 @@ This can occur if the library is only called in the contract constructor. The mi
           constructorArgsParams: [],
         })
       ).to.be.rejectedWith(
-        /A network request failed\. This error is not related to Hardhat\. Original error: getaddrinfo ENOTFOUND api-hardhat\.etherscan\.io/
+        /A network request failed\. This is an error from the block explorer, not Hardhat\. Error: getaddrinfo ENOTFOUND api-hardhat\.etherscan\.io/
       );
     });
 
@@ -376,7 +376,7 @@ This can occur if the library is only called in the contract constructor. The mi
           constructorArgsParams: [],
         })
       ).to.be.rejectedWith(
-        /A network request failed\. This error is not related to Hardhat\. Original error: getaddrinfo ENOTFOUND api-hardhat\.etherscan\.io/
+        /A network request failed\. This is an error from the block explorer, not Hardhat\. Error: getaddrinfo ENOTFOUND api-hardhat\.etherscan\.io/
       );
 
       expect(logStub).to.be

--- a/packages/hardhat-verify/test/integration/index.ts
+++ b/packages/hardhat-verify/test/integration/index.ts
@@ -10,7 +10,6 @@ import {
   TASK_VERIFY_VERIFY,
   TASK_VERIFY_SOURCIFY,
 } from "../../src/internal/task-names";
-import { UnexpectedError } from "../../src/internal/errors";
 import { deployContract, getRandomAddress, useEnvironment } from "../helpers";
 import {
   interceptGetStatus,
@@ -339,11 +338,6 @@ This can occur if the library is only called in the contract constructor. The mi
         });
         assert.fail("Expected error was not thrown");
       } catch (e: any) {
-        assert.notInstanceOf(
-          e,
-          UnexpectedError,
-          "Error should not be an instance of UnexpectedError"
-        );
         assert.match(
           e.message,
           new RegExp(


### PR DESCRIPTION
**Changes in this PR:**

  - Removed `UnexpectedError` from `hardhat-verify`.
  - Functions that make API calls are no longer enclosed in a broad try/catch block. Instead, calls to `undici` are specifically wrapped, and now throw a new `NetworkRequestError`.
  - Replaced generic `Error` instances with `VerificationAPIUnexpectedMessageError` to better indicate API-related issues. The error message no longer instruct users to report issues to the Hardhat team.
  - Added a correction in `HardhatVerifyError` to address an problem introduced by `NomicLabsHardhatPluginError`. This fix resolves an issue causing the `instanceof` operator to work incorrectly.

Closes https://github.com/NomicFoundation/hardhat/issues/5166
