### PR TITLE
docs: add new plugin for verifying contracts on evm chains and xlayer…

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -966,6 +966,13 @@ const communityPlugins: IPlugin[] = [
     description: "Ui extensions for the ethernaut-wallet package",
     tags: ["ethernaut-cli", "ui", "wallet"],
   },
+  {
+    name: "@okxweb3/hardhat-explorer-verify",
+    author: "okx",
+    authorUrl: "https://github.com/okx",
+    description: "Hardhat plugin for verifying smart contracts deployed on the EVM chains including X Layer",
+    tags: ["OKX Explorer", "Verification", "X Layer"],
+  }
 ];
 
 const officialPlugins: IPlugin[] = [

--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -970,9 +970,10 @@ const communityPlugins: IPlugin[] = [
     name: "@okxweb3/hardhat-explorer-verify",
     author: "okx",
     authorUrl: "https://github.com/okx",
-    description: "Hardhat plugin for verifying smart contracts deployed on the EVM chains including X Layer",
+    description:
+      "Hardhat plugin for verifying smart contracts deployed on the EVM chains including X Layer",
     tags: ["OKX Explorer", "Verification", "X Layer"],
-  }
+  },
 ];
 
 const officialPlugins: IPlugin[] = [


### PR DESCRIPTION
This PR simply adds a new plugin named @okxweb3/hardhat-explorer-verify which is used to verify smart contracts deployed on EVM chains including XLayer of OKX.

It can be found on this: https://github.com/okx/hardhat-explorer-verify.
It's npm repo: https://www.npmjs.com/package/@okxweb3/hardhat-explorer-verify