### PR TITLE
Fix some grammatical mistakes

### DIFF
--- a/docs/src/content/tutorial/writing-and-compiling-contracts.md
+++ b/docs/src/content/tutorial/writing-and-compiling-contracts.md
@@ -1,12 +1,12 @@
 # 4. Writing and compiling smart contracts
 
-We're going to create a simple smart contract that implements a token that can be transferred. Token contracts are most frequently used to exchange or store value. We won't go in depth into the Solidity code of the contract on this tutorial, but there's some logic we implemented that you should know:
+We're going to create a simple smart contract that implements a token that can be transferred. Token contracts are most frequently used to exchange or store value. We won't go in depth into the Solidity code of the contract in this tutorial, but there's some logic we implemented that you should know:
 
 - There is a fixed total supply of tokens that can't be changed.
 - The entire supply is assigned to the address that deploys the contract.
 - Anyone can receive tokens.
 - Anyone with at least one token can transfer tokens.
-- The token is non-divisible. You can transfer 1, 2, 3 or 37 tokens but not 2.5.
+- The token is non-divisible. You can transfer 1, 2, 3, or 37 tokens but not 2.5.
 
 :::tip
 
@@ -71,7 +71,7 @@ contract Token {
      */
     function transfer(address to, uint256 amount) external {
         // Check if the transaction sender has enough tokens.
-        // If `require`'s first argument evaluates to `false` then the
+        // If `require`'s first argument evaluates to `false`, the
         // transaction will revert.
         require(balances[msg.sender] >= amount, "Not enough tokens");
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
This PR proposes three grammatical enhancements:

1. `on tutorial` -> `in tutorial`. [reference](https://textranch.com/c/in-the-tutorial-or-on-the-tutorial/#:~:text=in%20the%20tutorial%27-,when%20referring%20to%20the%20content%20or%20material%20covered%20within%20the%20tutorial,-.).
2. Oxford comma.
3. Unnecessary use of `then`,  and missing `,`.