### PR TITLE
Enable eslint rules to make catching errors safer

### DIFF
--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -200,6 +200,12 @@ function createConfig(configFilePath, packageEntryPoints = []) {
             ":matches(BinaryExpression[operator='instanceof']) > Identifier[name='HardhatError']",
           message: "Use HardhatError.isHardhatError instead of instanceof",
         },
+        // We forbid casting errors in favor of using ensureError or HardhatError.isHardhatError
+        {
+          selector: "CatchClause[param] > Identifier[typeAnnotation]",
+          message:
+            "Use ensureError() or HardhatError.isHardhatError instead of casting the error",
+        },
       ],
       "@typescript-eslint/restrict-plus-operands": "error",
       "@typescript-eslint/restrict-template-expressions": [
@@ -233,6 +239,7 @@ function createConfig(configFilePath, packageEntryPoints = []) {
         },
       ],
       "@typescript-eslint/unified-signatures": "error",
+      "@typescript-eslint/use-unknown-in-catch-callback-variable": "error",
       "constructor-super": "error",
       eqeqeq: ["error", "always"],
       "guard-for-in": "error",

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/downloader.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/downloader.ts
@@ -5,6 +5,7 @@ import { promisify } from "node:util";
 
 import { bytesToHexString } from "@nomicfoundation/hardhat-utils/bytes";
 import { keccak256 } from "@nomicfoundation/hardhat-utils/crypto";
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import {
   chmod,
   createFile,
@@ -193,7 +194,9 @@ export class CompilerDownloader implements ICompilerDownloader {
       if (build === undefined && (await this.#shouldDownloadCompilerList())) {
         try {
           await this.#downloadCompilerList();
-        } catch (e: any) {
+        } catch (e) {
+          ensureError(e);
+
           throw new HardhatError(
             ERRORS.SOLC.VERSION_LIST_DOWNLOAD_FAILED,
             {},
@@ -211,7 +214,9 @@ export class CompilerDownloader implements ICompilerDownloader {
       let downloadPath: string;
       try {
         downloadPath = await this.#downloadCompiler(build);
-      } catch (e: any) {
+      } catch (e) {
+        ensureError(e);
+
         throw new HardhatError(
           ERRORS.SOLC.DOWNLOAD_FAILED,
           {

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import * as semver from "semver";
 
 import { ERRORS } from "../../errors/errors-list.js";
@@ -122,7 +123,9 @@ export class NativeCompiler implements ICompiler {
 
         process.stdin.write(JSON.stringify(input));
         process.stdin.end();
-      } catch (e: any) {
+      } catch (e) {
+        ensureError(e);
+
         throw new HardhatError(ERRORS.SOLC.CANT_RUN_NATIVE_COMPILER, {}, e);
       }
     });

--- a/v-next/hardhat-build-system/src/internal/solidity/parse.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/parse.ts
@@ -1,5 +1,7 @@
 import type SolidityAnalyzerT from "@nomicfoundation/solidity-analyzer";
 
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
+
 import { SolidityFilesCache } from "../builtin-tasks/utils/solidity-files-cache.js";
 import { ERRORS } from "../errors/errors-list.js";
 import { HardhatError } from "../errors/errors.js";
@@ -38,8 +40,14 @@ export class Parser {
       this.#cache.set(contentHash, result);
 
       return result;
-    } catch (e: any) {
-      if (e.code === "MODULE_NOT_FOUND") {
+    } catch (e) {
+      ensureError(e);
+
+      if (
+        "code" in e &&
+        typeof e.code === "string" &&
+        e.code === "MODULE_NOT_FOUND"
+      ) {
         throw new HardhatError(ERRORS.GENERAL.CORRUPTED_LOCKFILE);
       }
 

--- a/v-next/hardhat-build-system/src/internal/utils/fs-utils.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/fs-utils.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
+
 import { CustomError, assertHardhatInvariant } from "../errors/errors.js";
 
 /**
@@ -40,7 +42,12 @@ export async function getAllFilesMatching(
 async function readdir(absolutePathToDir: string) {
   try {
     return await fsPromises.readdir(absolutePathToDir);
-  } catch (e: any) {
+  } catch (e) {
+    ensureError(e);
+    if (!("code" in e) || typeof e.code !== "string") {
+      throw e;
+    }
+
     if (e.code === "ENOENT") {
       return [];
     }
@@ -139,7 +146,12 @@ export function getAllFilesMatchingSync(
 function readdirSync(absolutePathToDir: string) {
   try {
     return fs.readdirSync(absolutePathToDir);
-  } catch (e: any) {
+  } catch (e) {
+    ensureError(e);
+    if (!("code" in e) || typeof e.code !== "string") {
+      throw e;
+    }
+
     if (e.code === "ENOENT") {
       return [];
     }
@@ -204,7 +216,12 @@ export async function getRealPath(absolutePath: string): Promise<string> {
     // This method returns the actual casing.
     // Please read Node.js' docs to learn more.
     return await fsPromises.realpath(path.normalize(absolutePath));
-  } catch (e: any) {
+  } catch (e) {
+    ensureError(e);
+    if (!("code" in e) || typeof e.code !== "string") {
+      throw e;
+    }
+
     if (e.code === "ENOENT") {
       // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
       throw new FileNotFoundError(absolutePath, e);
@@ -225,7 +242,12 @@ export function getRealPathSync(absolutePath: string): string {
     // This method returns the actual casing.
     // Please read Node.js' docs to learn more.
     return fs.realpathSync.native(path.normalize(absolutePath));
-  } catch (e: any) {
+  } catch (e) {
+    ensureError(e);
+    if (!("code" in e) || typeof e.code !== "string") {
+      throw e;
+    }
+
     if (e.code === "ENOENT") {
       // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
       throw new FileNotFoundError(absolutePath, e);

--- a/v-next/hardhat-build-system/test/helpers.ts
+++ b/v-next/hardhat-build-system/test/helpers.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { beforeEach } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { getRealPath, mkdir, remove } from "@nomicfoundation/hardhat-utils/fs";
 import semver from "semver";
 
@@ -96,7 +97,12 @@ export async function importCsjOrEsModule(filePath: string): Promise<any> {
   try {
     const imported = await import(pathToFileURL(filePath).toString());
     return imported.default !== undefined ? imported.default : imported;
-  } catch (e: any) {
+  } catch (e) {
+    ensureError(e);
+    if (!("code" in e) || typeof e.code !== "string") {
+      throw e;
+    }
+
     if (e.code === "ERR_REQUIRE_ESM") {
       throw new Error("Cannot find configuration file");
     }
@@ -213,7 +219,7 @@ export async function expectHardhatErrorAsync(
 
   try {
     await f();
-  } catch (err: unknown) {
+  } catch (err) {
     if (!HardhatError.isHardhatError(err)) {
       assert.fail();
     }

--- a/v-next/hardhat/src/cli.ts
+++ b/v-next/hardhat/src/cli.ts
@@ -4,7 +4,7 @@ process.setSourceMapsEnabled(true);
 
 const { main } = await import("./internal/cli/main.js");
 
-main(process.argv.slice(2)).catch((error) => {
+main(process.argv.slice(2)).catch((error: unknown) => {
   console.error(error);
   process.exitCode = 1;
 });


### PR DESCRIPTION
This PR introduces two new rules that:

1. Forbids doing `} catch (e: <Type>) {`, hinting you to use `ensureError()` or `HardhatError.isHardhatError()` instead.
2. Forces you to do `.catch((e : unknown) =>` instead of just `.catch(e =>`, as the latter is an `any`.