### PR TITLE
feat: plugin install validation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1435,8 +1435,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       semver:
-        specifier: ^6.3.0
-        version: 6.3.1
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.43.4
@@ -1454,8 +1454,8 @@ importers:
         specifier: ^20.0.0
         version: 20.12.10
       '@types/semver':
-        specifier: ^6.2.7
-        version: 6.2.7
+        specifier: ^7.5.8
+        version: 7.5.8
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.9.0(@typescript-eslint/parser@7.9.0)(eslint@8.57.0)(typescript@5.4.3)
@@ -1629,8 +1629,8 @@ importers:
         specifier: 1.17.0
         version: 1.17.0
       semver:
-        specifier: ^6.3.0
-        version: 6.3.1
+        specifier: ^7.6.2
+        version: 7.6.2
       undici:
         specifier: ^6.16.1
         version: 6.16.1
@@ -1666,8 +1666,8 @@ importers:
         specifier: ^1.17.1
         version: 1.20.6
       '@types/semver':
-        specifier: ^6.2.7
-        version: 6.2.7
+        specifier: ^7.5.8
+        version: 7.5.8
       '@types/sinon':
         specifier: ^9.0.8
         version: 9.0.11
@@ -2229,7 +2229,7 @@ packages:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.6.0
+      semver: 7.6.2
     dev: true
 
   /@changesets/assemble-release-plan@6.0.0:
@@ -2240,7 +2240,7 @@ packages:
       '@changesets/get-dependents-graph': 2.0.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.6.0
+      semver: 7.6.2
     dev: true
 
   /@changesets/changelog-git@0.2.0:
@@ -2281,7 +2281,7 @@ packages:
       p-limit: 2.3.0
       preferred-pm: 3.1.3
       resolve-from: 5.0.0
-      semver: 7.6.0
+      semver: 7.6.2
       spawndamnit: 2.0.0
       term-size: 2.2.1
       tty-table: 4.2.3
@@ -2312,7 +2312,7 @@ packages:
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
-      semver: 7.6.0
+      semver: 7.6.2
     dev: true
 
   /@changesets/get-release-plan@4.0.0:
@@ -3069,7 +3069,7 @@ packages:
       '@ledgerhq/errors': 6.16.2
       '@ledgerhq/logs': 6.12.0
       rxjs: 7.8.1
-      semver: 7.6.0
+      semver: 7.6.2
     dev: false
 
   /@ledgerhq/domain-service@1.1.18(debug@4.3.4):
@@ -4080,7 +4080,7 @@ packages:
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare-lite: 1.4.0
-      semver: 7.6.0
+      semver: 7.6.2
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -4109,7 +4109,7 @@ packages:
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
@@ -4138,7 +4138,7 @@ packages:
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -4464,7 +4464,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -4485,7 +4485,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -4505,7 +4505,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       tsutils: 3.21.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -4527,7 +4527,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
@@ -4549,7 +4549,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -4571,7 +4571,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
@@ -4592,7 +4592,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -4613,7 +4613,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.61.0(typescript@5.0.4)
       eslint: 8.57.0
       eslint-scope: 5.1.1
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4633,7 +4633,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
       eslint: 8.57.0
       eslint-scope: 5.1.1
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4651,7 +4651,7 @@ packages:
       '@typescript-eslint/types': 7.7.1
       '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.3)
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4670,7 +4670,7 @@ packages:
       '@typescript-eslint/types': 7.7.1
       '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.5)
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5245,7 +5245,7 @@ packages:
   /builtins@5.1.0:
     resolution: {integrity: sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==}
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
     dev: true
 
   /bytes@3.1.2:
@@ -6267,7 +6267,7 @@ packages:
       eslint: '>=6.0.0'
     dependencies:
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.2
     dev: true
 
   /eslint-config-prettier@8.3.0(eslint@8.57.0):
@@ -6521,7 +6521,7 @@ packages:
       is-core-module: 2.13.1
       minimatch: 3.1.2
       resolve: 1.22.8
-      semver: 7.6.0
+      semver: 7.6.2
     dev: true
 
   /eslint-plugin-no-only-tests@3.1.0:
@@ -8214,6 +8214,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
 
   /lru_map@0.3.3:
     resolution: {integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==}
@@ -8258,7 +8259,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
     dev: true
 
   /make-error@1.3.6:
@@ -8530,7 +8531,7 @@ packages:
     resolution: {integrity: sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
     dev: false
 
   /node-addon-api@2.0.2:
@@ -9561,12 +9562,10 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /semver@7.6.0:
-    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
+  /semver@7.6.2:
+    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
     engines: {node: '>=10'}
     hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
 
   /serialize-javascript@6.0.0:
     resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
@@ -9772,7 +9771,7 @@ packages:
       pify: 4.0.1
       recursive-readdir: 2.2.3
       sc-istanbul: 0.4.6
-      semver: 7.6.0
+      semver: 7.6.2
       shelljs: 0.8.5
       web3-utils: 1.10.4
     dev: true
@@ -11257,6 +11256,7 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
 
   /yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1434,6 +1434,9 @@ importers:
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
+      semver:
+        specifier: ^6.3.0
+        version: 6.3.1
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.43.4
@@ -1450,6 +1453,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.12.10
+      '@types/semver':
+        specifier: ^6.2.7
+        version: 6.2.7
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.9.0(@typescript-eslint/parser@7.9.0)(eslint@8.57.0)(typescript@5.4.3)

--- a/v-next/core/package.json
+++ b/v-next/core/package.json
@@ -53,6 +53,7 @@
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@reporters/github": "^1.7.0",
     "@types/node": "^20.0.0",
+    "@types/semver": "^6.2.7",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
     "c8": "^9.1.0",
@@ -73,6 +74,7 @@
   "dependencies": {
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0",
     "@nomicfoundation/hardhat-utils": "workspace:^3.0.0",
-    "chalk": "^5.3.0"
+    "chalk": "^5.3.0",
+    "semver": "^6.3.0"
   }
 }

--- a/v-next/core/package.json
+++ b/v-next/core/package.json
@@ -53,7 +53,7 @@
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@reporters/github": "^1.7.0",
     "@types/node": "^20.0.0",
-    "@types/semver": "^6.2.7",
+    "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
     "c8": "^9.1.0",
@@ -75,6 +75,6 @@
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0",
     "@nomicfoundation/hardhat-utils": "workspace:^3.0.0",
     "chalk": "^5.3.0",
-    "semver": "^6.3.0"
+    "semver": "^7.6.2"
   }
 }

--- a/v-next/core/src/internal/plugins/plugin-validation.ts
+++ b/v-next/core/src/internal/plugins/plugin-validation.ts
@@ -3,19 +3,10 @@ import path from "node:path";
 import process from "node:process";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { PackageJson } from "@nomicfoundation/hardhat-utils/package";
 import semver from "semver";
 
 import { HardhatPlugin } from "../../types/plugins.js";
-
-/**
- * A simplified version of the package.json object
- */
-interface PackageJson {
-  version: string;
-  peerDependencies: {
-    [name: string]: string;
-  };
-}
 
 /**
  * Validate that a plugin is installed and that its peer dependencies are installed and satisfy the version constraints.

--- a/v-next/core/src/internal/plugins/plugin-validation.ts
+++ b/v-next/core/src/internal/plugins/plugin-validation.ts
@@ -26,7 +26,7 @@ export async function validatePluginNpmDependencies(
     return;
   }
 
-  const pluginPackageJson = readPackageJson(
+  const pluginPackageJson = readPackageJsonViaNodeRequire(
     plugin.npmPackage,
     basePathForNpmResolution,
   );
@@ -44,7 +44,7 @@ export async function validatePluginNpmDependencies(
   for (const [dependencyName, versionSpec] of Object.entries(
     pluginPackageJson.peerDependencies,
   )) {
-    const dependencyPackageJson = readPackageJson(
+    const dependencyPackageJson = readPackageJsonViaNodeRequire(
       dependencyName,
       basePathForNpmResolution,
     );
@@ -83,7 +83,7 @@ export async function validatePluginNpmDependencies(
  * @param baseRequirePath - the directory path to use for resolution, defaults to `process.cwd()`
  * @returns the package.json object or undefined if the package is not found
  */
-export function readPackageJson(
+function readPackageJsonViaNodeRequire(
   packageName: string,
   baseRequirePath?: string,
 ): PackageJson | undefined {

--- a/v-next/core/src/internal/plugins/plugin-validation.ts
+++ b/v-next/core/src/internal/plugins/plugin-validation.ts
@@ -13,6 +13,10 @@ import { HardhatPlugin } from "../../types/plugins.js";
  *
  * @param plugin - the plugin to be validated
  * @param basePathForNpmResolution - the directory path to use for node module resolution, defaulting to `process.cwd()`
+ * @throws {HardhatError} with descriptor:
+ * - {@link ERRORS.ARTIFACTS.PLUGIN_NOT_INSTALLED} if the plugin is not installed as an npm package
+ * - {@link ERRORS.ARTIFACTS.PLUGIN_MISSING_DEPENDENCY} if the plugin's package peer dependency is not installed
+ * - {@link ERRORS.ARTIFACTS.DEPENDENCY_VERSION_MISMATCH} if the plugin's package peer dependency is installed but has the wrong version
  */
 export async function validatePluginNpmDependencies(
   plugin: HardhatPlugin,

--- a/v-next/core/src/internal/plugins/plugin-validation.ts
+++ b/v-next/core/src/internal/plugins/plugin-validation.ts
@@ -1,6 +1,110 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import semver from "semver";
+
 import { HardhatPlugin } from "../../types/plugins.js";
 
-export async function validatePluginNpmDependencies(_plugin: HardhatPlugin) {
-  // TODO: If it has an npm package, validate their peer dependencies
-  // If any is missing, throw
+/**
+ * A simplified version of the package.json object
+ */
+interface PackageJson {
+  version: string;
+  peerDependencies: {
+    [name: string]: string;
+  };
+}
+
+/**
+ * Validate that a plugin is installed and that its peer dependencies are installed and satisfy the version constraints.
+ *
+ * @param plugin - the plugin to be validated
+ * @param basePathForNpmResolution - the directory path to use for node module resolution, defaulting to `process.cwd()`
+ */
+export async function validatePluginNpmDependencies(
+  plugin: HardhatPlugin,
+  // TODO: When all loads where based on a hardhat config file
+  // on disk we used the config file's directory as the base path
+  // We need to decide if the current working directory is the right
+  // option for module resolution now
+  basePathForNpmResolution?: string,
+): Promise<void> {
+  if (plugin.npmPackage === undefined) {
+    return;
+  }
+
+  const pluginPackageJson = readPackageJson(
+    plugin.npmPackage,
+    basePathForNpmResolution,
+  );
+
+  if (pluginPackageJson === undefined) {
+    throw new HardhatError(HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED, {
+      pluginId: plugin.id,
+    });
+  }
+
+  if (pluginPackageJson.peerDependencies === undefined) {
+    return;
+  }
+
+  for (const [dependencyName, versionSpec] of Object.entries(
+    pluginPackageJson.peerDependencies,
+  )) {
+    const dependencyPackageJson = readPackageJson(
+      dependencyName,
+      basePathForNpmResolution,
+    );
+
+    if (dependencyPackageJson === undefined) {
+      throw new HardhatError(
+        HardhatError.ERRORS.PLUGINS.PLUGIN_MISSING_DEPENDENCY,
+        {
+          pluginId: plugin.id,
+          peerDependencyName: dependencyName,
+        },
+      );
+    }
+
+    const installedVersion = dependencyPackageJson.version;
+
+    if (!semver.satisfies(installedVersion, versionSpec)) {
+      throw new HardhatError(
+        HardhatError.ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH,
+        {
+          pluginId: plugin.id,
+          peerDependencyName: dependencyName,
+          installedVersion,
+          expectedVersion: versionSpec,
+        },
+      );
+    }
+  }
+}
+
+/**
+ * Read the package.json of a named package resolved through the node
+ * require system.
+ *
+ * @param packageName - the package name i.e. "@nomiclabs/hardhat-waffle"
+ * @param baseRequirePath - the directory path to use for resolution, defaults to `process.cwd()`
+ * @returns the package.json object or undefined if the package is not found
+ */
+export function readPackageJson(
+  packageName: string,
+  baseRequirePath?: string,
+): PackageJson | undefined {
+  try {
+    const require = createRequire(baseRequirePath ?? process.cwd());
+
+    const packageJsonPath = require.resolve(
+      path.join(packageName, "package.json"),
+    );
+
+    return require(packageJsonPath);
+  } catch (error) {
+    return undefined;
+  }
 }

--- a/v-next/core/test/plugins/fixture-projects/installed-package/README.md
+++ b/v-next/core/test/plugins/fixture-projects/installed-package/README.md
@@ -1,0 +1,3 @@
+# Installed Package Example
+
+This is part of the plugin validation tests. We have checked in a `node_modules` folder to simulate an installed example package.

--- a/v-next/core/test/plugins/fixture-projects/installed-package/node_modules/example/package.json
+++ b/v-next/core/test/plugins/fixture-projects/installed-package/node_modules/example/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "devDependencies": {},
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/README.md
+++ b/v-next/core/test/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/README.md
@@ -1,0 +1,3 @@
+# Installed Peer Dependencies as in the the `node_modules` of the package
+
+This is part of the plugin validation tests. We have checked in a `node_modules` folder to simulate an installed `example` package. Inside the example package is a further `node_modules` with both peer deps: `peer1` and `peer2`.

--- a/v-next/core/test/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/node_modules/example/node_modules/peer1/package.json
+++ b/v-next/core/test/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/node_modules/example/node_modules/peer1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "peer1",
+  "version": "1.0.0",
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/node_modules/example/node_modules/peer2/package.json
+++ b/v-next/core/test/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/node_modules/example/node_modules/peer2/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "peer2",
+  "version": "1.0.0",
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/node_modules/example/package.json
+++ b/v-next/core/test/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/node_modules/example/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "peer1": "1.0.0",
+    "peer2": "1.0.0"
+  },
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/installed-peer-deps/README.md
+++ b/v-next/core/test/plugins/fixture-projects/installed-peer-deps/README.md
@@ -1,0 +1,3 @@
+# Installed Peer Deps
+
+This is part of the plugin validation tests. We have checked in a `node_modules` folder to simulate an installed `example` package with an installed set of peer dependencies: `peer1` and `peer2`.

--- a/v-next/core/test/plugins/fixture-projects/installed-peer-deps/node_modules/example/package.json
+++ b/v-next/core/test/plugins/fixture-projects/installed-peer-deps/node_modules/example/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "peer1": "1.0.0",
+    "peer2": "1.0.0"
+  },
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/installed-peer-deps/node_modules/peer1/package.json
+++ b/v-next/core/test/plugins/fixture-projects/installed-peer-deps/node_modules/peer1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "peer1",
+  "version": "1.0.0",
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/installed-peer-deps/node_modules/peer2/package.json
+++ b/v-next/core/test/plugins/fixture-projects/installed-peer-deps/node_modules/peer2/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "peer2",
+  "version": "1.0.0",
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/not-installed-package/README.md
+++ b/v-next/core/test/plugins/fixture-projects/not-installed-package/README.md
@@ -1,0 +1,3 @@
+# Not installed Package Example
+
+This is part of the plugin validation tests. We have an empty `node_modules`.

--- a/v-next/core/test/plugins/fixture-projects/not-installed-peer-dep/README.md
+++ b/v-next/core/test/plugins/fixture-projects/not-installed-peer-dep/README.md
@@ -1,0 +1,3 @@
+# Not installed Peer Dep
+
+This is part of the plugin validation tests. We have checked in a `node_modules` folder to simulate an installed `example` package with one peer dep `peer1` that is installed and another `peer2` that is not.

--- a/v-next/core/test/plugins/fixture-projects/not-installed-peer-dep/node_modules/example/package.json
+++ b/v-next/core/test/plugins/fixture-projects/not-installed-peer-dep/node_modules/example/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "peer1": "1.0.0",
+    "peer2": "1.0.0"
+  },
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/not-installed-peer-dep/node_modules/peer1/package.json
+++ b/v-next/core/test/plugins/fixture-projects/not-installed-peer-dep/node_modules/peer1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "peer1",
+  "version": "1.0.0",
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/peer-dep-with-wrong-version/README.md
+++ b/v-next/core/test/plugins/fixture-projects/peer-dep-with-wrong-version/README.md
@@ -1,0 +1,3 @@
+# Peer dependency with the wrong version
+
+This is part of the plugin validation tests. We have checked in a `node_modules` folder to simulate an installed `example` package with an installed set of peer dependencies: `peer1` and `peer2`. However `peer2@2.0.0` is outside the version range of `^1.0.0` in `example`.

--- a/v-next/core/test/plugins/fixture-projects/peer-dep-with-wrong-version/node_modules/example/package.json
+++ b/v-next/core/test/plugins/fixture-projects/peer-dep-with-wrong-version/node_modules/example/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "peer1": "1.0.0",
+    "peer2": "^1.0.0"
+  },
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/peer-dep-with-wrong-version/node_modules/peer1/package.json
+++ b/v-next/core/test/plugins/fixture-projects/peer-dep-with-wrong-version/node_modules/peer1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "peer1",
+  "version": "1.0.0",
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/fixture-projects/peer-dep-with-wrong-version/node_modules/peer2/package.json
+++ b/v-next/core/test/plugins/fixture-projects/peer-dep-with-wrong-version/node_modules/peer2/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "peer2",
+  "version": "2.0.0",
+  "license": "ISC"
+}

--- a/v-next/core/test/plugins/plugin-validation.ts
+++ b/v-next/core/test/plugins/plugin-validation.ts
@@ -1,8 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
-
 import { validatePluginNpmDependencies } from "../../src/internal/plugins/plugin-validation.js";
 import { HardhatPlugin } from "../../src/types/plugins.js";
 
@@ -43,16 +41,10 @@ describe("Plugins - plugin validation", () => {
             plugin,
             nonInstalledPackageProjectFixture,
           ),
-        (err) => {
-          assert(HardhatError.isHardhatError(err), "Expected a HardhatError");
-          assert.equal(
-            err.message,
-            'HHE1200: Plugin "example-plugin" is not installed.',
-          );
-
-          return true;
+        {
+          name: "HardhatError",
+          message: 'HHE1200: Plugin "example-plugin" is not installed.',
         },
-        "Expected a plugin not installed error",
       );
     });
   });
@@ -76,9 +68,10 @@ describe("Plugins - plugin validation", () => {
       await assert.rejects(
         validatePluginNpmDependencies(plugin, notInstalledPeerDepFixture),
         {
-          name: "HardhatError"
-          message: 'HHE1201: Plugin "example-plugin" is missing a peer dependency "peer2".',
-        }
+          name: "HardhatError",
+          message:
+            'HHE1201: Plugin "example-plugin" is missing a peer dependency "peer2".',
+        },
       );
     });
   });
@@ -92,16 +85,11 @@ describe("Plugins - plugin validation", () => {
       await assert.rejects(
         async () =>
           validatePluginNpmDependencies(plugin, peerDepWithWrongVersionFixture),
-        (err) => {
-          assert(HardhatError.isHardhatError(err), "Expected a HardhatError");
-          assert.equal(
-            err.message,
+        {
+          name: "HardhatError",
+          message:
             'HHE1202: Plugin "example-plugin" has a peer dependency "peer2" with version "2.0.0" but version "^1.0.0" is needed.',
-          );
-
-          return true;
         },
-        "Expected a peer dependency version mismatch error",
       );
     });
   });

--- a/v-next/core/test/plugins/plugin-validation.ts
+++ b/v-next/core/test/plugins/plugin-validation.ts
@@ -74,18 +74,11 @@ describe("Plugins - plugin validation", () => {
       );
 
       await assert.rejects(
-        async () =>
-          validatePluginNpmDependencies(plugin, notInstalledPeerDepFixture),
-        (err) => {
-          assert(HardhatError.isHardhatError(err), "Expected a HardhatError");
-          assert.equal(
-            err.message,
-            'HHE1201: Plugin "example-plugin" is missing a peer dependency "peer2".',
-          );
-
-          return true;
-        },
-        "Expected a missing peer dependency error",
+        validatePluginNpmDependencies(plugin, notInstalledPeerDepFixture),
+        {
+          name: "HardhatError"
+          message: 'HHE1201: Plugin "example-plugin" is missing a peer dependency "peer2".',
+        }
       );
     });
   });

--- a/v-next/core/test/plugins/plugin-validation.ts
+++ b/v-next/core/test/plugins/plugin-validation.ts
@@ -50,29 +50,43 @@ describe("Plugins - plugin validation", () => {
   });
 
   describe("when the plugin has peer deps", () => {
-    it("should pass validation if the peer deps have been installed", async () => {
-      const installedPeerDepsFixture = import.meta.resolve(
-        "./fixture-projects/installed-peer-deps",
-      );
+    describe("and the peer deps are installed in the top level `node_modules`", () => {
+      it("should pass validation if the peer deps have been installed", async () => {
+        const installedPeerDepsFixture = import.meta.resolve(
+          "./fixture-projects/installed-peer-deps",
+        );
 
-      await assert.doesNotReject(async () =>
-        validatePluginNpmDependencies(plugin, installedPeerDepsFixture),
-      );
+        await assert.doesNotReject(async () =>
+          validatePluginNpmDependencies(plugin, installedPeerDepsFixture),
+        );
+      });
+
+      it("should fail validation if a peer dependency is not installed", async () => {
+        const notInstalledPeerDepFixture = import.meta.resolve(
+          "./fixture-projects/not-installed-peer-dep",
+        );
+
+        await assert.rejects(
+          validatePluginNpmDependencies(plugin, notInstalledPeerDepFixture),
+          {
+            name: "HardhatError",
+            message:
+              'HHE1201: Plugin "example-plugin" is missing a peer dependency "peer2".',
+          },
+        );
+      });
     });
 
-    it("should fail validation if a peer dependency is not installed", async () => {
-      const notInstalledPeerDepFixture = import.meta.resolve(
-        "./fixture-projects/not-installed-peer-dep",
-      );
+    describe("and the peer deps are installed in the `node_modules` of the plugin package", () => {
+      it("should pass validation if the peer deps have been installed", async () => {
+        const installedPeerDepsFixture = import.meta.resolve(
+          "./fixture-projects/installed-peer-deps-as-sub-node-modules",
+        );
 
-      await assert.rejects(
-        validatePluginNpmDependencies(plugin, notInstalledPeerDepFixture),
-        {
-          name: "HardhatError",
-          message:
-            'HHE1201: Plugin "example-plugin" is missing a peer dependency "peer2".',
-        },
-      );
+        await assert.doesNotReject(async () =>
+          validatePluginNpmDependencies(plugin, installedPeerDepsFixture),
+        );
+      });
     });
   });
 

--- a/v-next/core/test/plugins/plugin-validation.ts
+++ b/v-next/core/test/plugins/plugin-validation.ts
@@ -33,7 +33,7 @@ describe("Plugins - plugin validation", () => {
     });
 
     it("should fail validation if the npm package has not been installed", async () => {
-      const noninstalledPackageProjectFixture = import.meta.resolve(
+      const nonInstalledPackageProjectFixture = import.meta.resolve(
         "./fixture-projects/not-installed-package",
       );
 
@@ -41,7 +41,7 @@ describe("Plugins - plugin validation", () => {
         async () =>
           validatePluginNpmDependencies(
             plugin,
-            noninstalledPackageProjectFixture,
+            nonInstalledPackageProjectFixture,
           ),
         (err) => {
           assert(HardhatError.isHardhatError(err), "Expected a HardhatError");

--- a/v-next/core/test/plugins/plugin-validation.ts
+++ b/v-next/core/test/plugins/plugin-validation.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+
+import { validatePluginNpmDependencies } from "../../src/internal/plugins/plugin-validation.js";
+import { HardhatPlugin } from "../../src/types/plugins.js";
+
+describe("Plugins - plugin validation", () => {
+  const plugin: HardhatPlugin = {
+    id: "example-plugin",
+    npmPackage: "example",
+  };
+
+  it("should skip validation if the plugin is not from an npm package", async () => {
+    await assert.doesNotReject(async () =>
+      validatePluginNpmDependencies({
+        ...plugin,
+        npmPackage: undefined,
+      }),
+    );
+  });
+
+  describe("when the plugin has no peer deps", () => {
+    it("should pass validation if the npm package has been installed", async () => {
+      const installedPackageProjectFixture = import.meta.resolve(
+        "./fixture-projects/installed-package",
+      );
+
+      await assert.doesNotReject(async () =>
+        validatePluginNpmDependencies(plugin, installedPackageProjectFixture),
+      );
+    });
+
+    it("should fail validation if the npm package has not been installed", async () => {
+      const noninstalledPackageProjectFixture = import.meta.resolve(
+        "./fixture-projects/not-installed-package",
+      );
+
+      await assert.rejects(
+        async () =>
+          validatePluginNpmDependencies(
+            plugin,
+            noninstalledPackageProjectFixture,
+          ),
+        (err) => {
+          assert(HardhatError.isHardhatError(err), "Expected a HardhatError");
+          assert.equal(
+            err.message,
+            'HHE1200: Plugin "example-plugin" is not installed.',
+          );
+
+          return true;
+        },
+        "Expected a plugin not installed error",
+      );
+    });
+  });
+
+  describe("when the plugin has peer deps", () => {
+    it("should pass validation if the peer deps have been installed", async () => {
+      const installedPeerDepsFixture = import.meta.resolve(
+        "./fixture-projects/installed-peer-deps",
+      );
+
+      await assert.doesNotReject(async () =>
+        validatePluginNpmDependencies(plugin, installedPeerDepsFixture),
+      );
+    });
+
+    it("should fail validation if a peer dependency is not installed", async () => {
+      const notInstalledPeerDepFixture = import.meta.resolve(
+        "./fixture-projects/not-installed-peer-dep",
+      );
+
+      await assert.rejects(
+        async () =>
+          validatePluginNpmDependencies(plugin, notInstalledPeerDepFixture),
+        (err) => {
+          assert(HardhatError.isHardhatError(err), "Expected a HardhatError");
+          assert.equal(
+            err.message,
+            'HHE1201: Plugin "example-plugin" is missing a peer dependency "peer2".',
+          );
+
+          return true;
+        },
+        "Expected a missing peer dependency error",
+      );
+    });
+  });
+
+  describe("when the plugin has a peer dep installed but it is the wrong version", () => {
+    it("should fail validation if a peer dependency is outside of the semver range", async () => {
+      const peerDepWithWrongVersionFixture = import.meta.resolve(
+        "./fixture-projects/peer-dep-with-wrong-version",
+      );
+
+      await assert.rejects(
+        async () =>
+          validatePluginNpmDependencies(plugin, peerDepWithWrongVersionFixture),
+        (err) => {
+          assert(HardhatError.isHardhatError(err), "Expected a HardhatError");
+          assert.equal(
+            err.message,
+            'HHE1202: Plugin "example-plugin" has a peer dependency "peer2" with version "2.0.0" but version "^1.0.0" is needed.',
+          );
+
+          return true;
+        },
+        "Expected a peer dependency version mismatch error",
+      );
+    });
+  });
+});

--- a/v-next/core/test/plugins/resolve-plugin-list.ts
+++ b/v-next/core/test/plugins/resolve-plugin-list.ts
@@ -114,7 +114,6 @@ describe("Plugins - resolve plugin list", () => {
 
     assert.throws(
       () => resolvePluginList([a, copy]),
-
       (err) => {
         assert(HardhatError.isHardhatError(err), "Expected a HardhatError");
         assert(

--- a/v-next/hardhat-build-system/package.json
+++ b/v-next/hardhat-build-system/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.11",
     "p-map": "^4.0.0",
     "resolve": "1.17.0",
-    "semver": "^6.3.0",
+    "semver": "^7.6.2",
     "undici": "^6.16.1"
   },
   "devDependencies": {
@@ -65,7 +65,7 @@
     "@types/lodash": "^4.14.123",
     "@types/node": "^20.0.0",
     "@types/resolve": "^1.17.1",
-    "@types/semver": "^6.2.7",
+    "@types/semver": "^7.5.8",
     "@types/sinon": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -69,6 +69,11 @@ export const ERROR_CATEGORIES: {
     max: 1199,
     websiteTitle: "Contract name errors",
   },
+  PLUGINS: {
+    min: 1200,
+    max: 1299,
+    websiteTitle: "Plugin errors",
+  },
 };
 
 export const ERRORS = {
@@ -494,6 +499,28 @@ If you aren't overriding compilation-related tasks, please report this as a bug.
       websiteDescription: `A contract name was expected to be in fully qualified form, but it's not.
 
 A fully qualified name should look like file.sol:Contract`,
+    },
+  },
+  PLUGINS: {
+    PLUGIN_NOT_INSTALLED: {
+      number: 1200,
+      messageTemplate: 'Plugin "%pluginId%" is not installed.',
+      websiteTitle: "Plugin not installed",
+      websiteDescription: `A plugin was included in the Hardhat config but has not been installed.`,
+    },
+    PLUGIN_MISSING_DEPENDENCY: {
+      number: 1201,
+      messageTemplate:
+        'Plugin "%pluginId%" is missing a peer dependency "%peerDependencyName%".',
+      websiteTitle: "Plugin missing peer dependency",
+      websiteDescription: `A plugin's peer dependency has not been installed.`,
+    },
+    DEPENDENCY_VERSION_MISMATCH: {
+      number: 1202,
+      messageTemplate:
+        'Plugin "%pluginId%" has a peer dependency "%peerDependencyName%" with version "%installedVersion%" but version "%expectedVersion%" is needed.',
+      websiteTitle: "Dependency version mismatch",
+      websiteDescription: `A plugin's peer dependency version does not match the expected version.`,
     },
   },
 } satisfies {


### PR DESCRIPTION
Validates the plugins provided through the initial config object.

If the plugin comes from an npm package check that the package has been installed.

If the plugin is present further confirm that peer dependencies have been installed. It then checks that the installed version falls within the range of the originating package.

This leverages the node require mechanism based on `process.cwd()` as the starting directory.

Resolves #5256

## Review Notes

While 21 files are changed, most of these are fixture files for the small number of tests. The core change is in:

* `v-next/core/src/internal/plugins/plugin-validation.ts`
* `v-next/core/test/plugins/plugin-validation.ts`