### PR TITLE
Add eslint rules to enforce `node:assert/strict`

### DIFF
--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -319,6 +319,24 @@ function createConfig(configFilePath, packageEntryPoints = []) {
                 "Use the 'node:' prefix to import built-in Node.js modules.",
             },
           ],
+          paths: [
+            {
+              // Due to an error in @types/node 20 you can't import AssertionError from node:assert/strict
+              name: "node:assert/strict",
+              importNames: ["AssertionError"],
+              message: "AssertionError must be imported from node:assert.",
+            },
+            {
+              name: "node:assert",
+              importNames: [
+                "default",
+                ...Object.keys(require("node:assert")).filter(
+                  (k) => k !== "AssertionError"
+                ),
+              ],
+              message: "Use node:assert/strict instead.",
+            },
+          ],
         },
       ],
     },

--- a/v-next/core/test/plugins/resolve-plugin-list.ts
+++ b/v-next/core/test/plugins/resolve-plugin-list.ts
@@ -1,4 +1,4 @@
-import assert from "node:assert";
+import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";

--- a/v-next/hardhat-build-system/test/helpers.ts
+++ b/v-next/hardhat-build-system/test/helpers.ts
@@ -1,4 +1,5 @@
-import assert, { AssertionError } from "node:assert";
+import { AssertionError } from "node:assert";
+import assert from "node:assert/strict";
 import { rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/v-next/hardhat-build-system/test/index.ts
+++ b/v-next/hardhat-build-system/test/index.ts
@@ -1,7 +1,7 @@
 // TODO: remove this TS rule?
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import assert from "node:assert";
+import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/v-next/hardhat-build-system/test/internal/utils/artifacts.ts
+++ b/v-next/hardhat-build-system/test/internal/utils/artifacts.ts
@@ -1,4 +1,4 @@
-import assert from "node:assert";
+import assert from "node:assert/strict";
 import * as os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, it } from "node:test";


### PR DESCRIPTION
This PR adds an eslint rule so that we use `node:assert/strict` and not `node:assert`. 

The one exception is when you import `AssertionError`, which needs to come from `node:assert`.