### PR TITLE
v-next/lazy-plugin-loading

### DIFF
--- a/v-next/core/src/internal/hook-manager.ts
+++ b/v-next/core/src/internal/hook-manager.ts
@@ -9,11 +9,7 @@ import {
 import { HardhatPlugin } from "../types/plugins.js";
 import { LastParameter, Return } from "../types/utils.js";
 
-import { validatePluginNpmDependencies } from "./plugins/plugin-validation.js";
-
 export class HookManagerImplementation implements HookManager {
-  readonly #validatedPlugins = new Set<string>();
-
   readonly #pluginsInReverseOrder: HardhatPlugin[];
 
   /**
@@ -242,11 +238,6 @@ export class HookManagerImplementation implements HookManager {
 
         if (hookHandlerCategoryFactory === undefined) {
           return;
-        }
-
-        if (!this.#validatedPlugins.has(plugin.id)) {
-          await validatePluginNpmDependencies(plugin);
-          this.#validatedPlugins.add(plugin.id);
         }
 
         let hookCategory: Partial<HardhatHooks[HookCategoryNameT]>;

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -39,7 +39,7 @@ export class HardhatRuntimeEnvironmentImplementation
 
     const resolvedPlugins =
       unsafeOptions?.resolvedPlugins ??
-      resolvePluginList(clonedUserConfig.plugins);
+      (await resolvePluginList(clonedUserConfig.plugins));
 
     const hooks = new HookManagerImplementation(resolvedPlugins);
 

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -37,9 +37,18 @@ export class HardhatRuntimeEnvironmentImplementation
     // TODO: Or maybe don't clone at all
     const clonedUserConfig = inputUserConfig;
 
+    // TODO: When all loads where based on a hardhat config file
+    // on disk we used the config file's directory as the base path
+    // We need to decide if the current working directory is the right
+    // option for module resolution now
+    const basePathForNpmResolution = process.cwd();
+
     const resolvedPlugins =
       unsafeOptions?.resolvedPlugins ??
-      (await resolvePluginList(clonedUserConfig.plugins));
+      (await resolvePluginList(
+        clonedUserConfig.plugins,
+        basePathForNpmResolution,
+      ));
 
     const hooks = new HookManagerImplementation(resolvedPlugins);
 

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -37,10 +37,7 @@ export class HardhatRuntimeEnvironmentImplementation
     // TODO: Or maybe don't clone at all
     const clonedUserConfig = inputUserConfig;
 
-    // TODO: When all loads where based on a hardhat config file
-    // on disk we used the config file's directory as the base path
-    // We need to decide if the current working directory is the right
-    // option for module resolution now
+    // Resolve plugins from node modules relative to the current working directory
     const basePathForNpmResolution = process.cwd();
 
     const resolvedPlugins =

--- a/v-next/core/src/internal/plugins/plugin-validation.ts
+++ b/v-next/core/src/internal/plugins/plugin-validation.ts
@@ -1,6 +1,5 @@
 import { createRequire } from "node:module";
 import path from "node:path";
-import process from "node:process";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { PackageJson } from "@nomicfoundation/hardhat-utils/package";
@@ -20,11 +19,7 @@ import { HardhatPlugin } from "../../types/plugins.js";
  */
 export async function validatePluginNpmDependencies(
   plugin: HardhatPlugin,
-  // TODO: When all loads where based on a hardhat config file
-  // on disk we used the config file's directory as the base path
-  // We need to decide if the current working directory is the right
-  // option for module resolution now
-  basePathForNpmResolution?: string,
+  basePathForNpmResolution: string,
 ): Promise<void> {
   if (plugin.npmPackage === undefined) {
     return;
@@ -91,10 +86,10 @@ export async function validatePluginNpmDependencies(
  */
 function readPackageJsonViaNodeRequire(
   packageName: string,
-  baseRequirePath?: string,
+  baseRequirePath: string,
 ): { packageJson: PackageJson; packagePath: string } | undefined {
   try {
-    const require = createRequire(baseRequirePath ?? process.cwd());
+    const require = createRequire(baseRequirePath);
 
     const packagePath = require.resolve(path.join(packageName, "package.json"));
 

--- a/v-next/core/src/types/plugins.ts
+++ b/v-next/core/src/types/plugins.ts
@@ -33,7 +33,7 @@ export interface HardhatPlugin {
   /**
    * An arary of plugins that this plugins depends on.
    */
-  dependencies?: HardhatPlugin[];
+  dependencies?: Array<() => Promise<HardhatPlugin>>;
 
   /**
    * An object with the different hook handlers that this plugin defines.

--- a/v-next/core/test/plugins/plugin-validation.ts
+++ b/v-next/core/test/plugins/plugin-validation.ts
@@ -11,11 +11,18 @@ describe("Plugins - plugin validation", () => {
   };
 
   it("should skip validation if the plugin is not from an npm package", async () => {
+    const peerDepWithWrongVersionFixture = import.meta.resolve(
+      "./fixture-projects/peer-dep-with-wrong-version",
+    );
+
     await assert.doesNotReject(async () =>
-      validatePluginNpmDependencies({
-        ...plugin,
-        npmPackage: undefined,
-      }),
+      validatePluginNpmDependencies(
+        {
+          ...plugin,
+          npmPackage: undefined,
+        },
+        peerDepWithWrongVersionFixture,
+      ),
     );
   });
 

--- a/v-next/core/test/plugins/resolve-plugin-list.ts
+++ b/v-next/core/test/plugins/resolve-plugin-list.ts
@@ -1,83 +1,87 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
-
 import { resolvePluginList } from "../../src/internal/plugins/resolve-plugin-list.js";
 import { HardhatPlugin } from "../../src/types/plugins.js";
 
 describe("Plugins - resolve plugin list", () => {
-  it("should return empty on an empty plugin list", () => {
-    assert.deepStrictEqual(resolvePluginList([]), []);
+  it("should return empty on an empty plugin list", async () => {
+    assert.deepStrictEqual(await resolvePluginList([]), []);
   });
 
-  it("should return empty on an undefined plugin list", () => {
-    assert.deepStrictEqual(resolvePluginList(), []);
+  it("should return empty on an undefined plugin list", async () => {
+    assert.deepStrictEqual(await resolvePluginList(), []);
   });
 
-  it("should return a single plugin", () => {
+  it("should return a single plugin", async () => {
     const plugin: HardhatPlugin = {
       id: "example-plugin",
     };
 
-    assert.deepStrictEqual(resolvePluginList([plugin]), [plugin]);
+    assert.deepStrictEqual(await resolvePluginList([plugin]), [plugin]);
   });
 
-  it("should support nested dependencies", () => {
+  it("should support nested dependencies", async () => {
     // A -> B -> C
-    const c = { id: "c" };
-    const b = { id: "b", dependencies: [c] };
-    const a = { id: "a", dependencies: [b] };
+    const c: HardhatPlugin = { id: "c" };
+    const b: HardhatPlugin = { id: "b", dependencies: [async () => c] };
+    const a: HardhatPlugin = { id: "a", dependencies: [async () => b] };
 
-    assert.deepStrictEqual(resolvePluginList([a]), [c, b, a]);
+    assert.deepStrictEqual(await resolvePluginList([a]), [c, b, a]);
   });
 
-  it("should break ties by honouring array order", () => {
+  it("should break ties by honouring array order", async () => {
     // A / B / C
-    const c = { id: "c" };
-    const b = { id: "b" };
-    const a = { id: "a" };
+    const c: HardhatPlugin = { id: "c" };
+    const b: HardhatPlugin = { id: "b" };
+    const a: HardhatPlugin = { id: "a" };
 
-    assert.deepStrictEqual(resolvePluginList([a, b, c]), [a, b, c]);
+    assert.deepStrictEqual(await resolvePluginList([a, b, c]), [a, b, c]);
   });
 
-  it("should break ties by honouring subdependency array order", () => {
+  it("should break ties by honouring subdependency array order", async () => {
     //   A
     //  / \
     // B   C
-    const c = { id: "c" };
-    const b = { id: "b" };
-    const a = { id: "a", dependencies: [b, c] };
+    const c: HardhatPlugin = { id: "c" };
+    const b: HardhatPlugin = { id: "b" };
+    const a: HardhatPlugin = {
+      id: "a",
+      dependencies: [async () => b, async () => c],
+    };
 
-    assert.deepStrictEqual(resolvePluginList([a]), [b, c, a]);
+    assert.deepStrictEqual(await resolvePluginList([a]), [b, c, a]);
   });
 
-  it("should support shared dependencies", () => {
+  it("should support shared dependencies", async () => {
     // A   B
     //  \ /
     //   C
-    const c = { id: "c" };
-    const b = { id: "b", dependencies: [c] };
-    const a = { id: "a", dependencies: [c] };
+    const c: HardhatPlugin = { id: "c" };
+    const b: HardhatPlugin = { id: "b", dependencies: [async () => c] };
+    const a: HardhatPlugin = { id: "a", dependencies: [async () => c] };
 
-    assert.deepStrictEqual(resolvePluginList([a, b]), [c, a, b]);
+    assert.deepStrictEqual(await resolvePluginList([a, b]), [c, a, b]);
   });
 
-  it("should support shared subdependencies", () => {
+  it("should support shared subdependencies", async () => {
     //   A
     //  / \
     // B   C
     //  \ /
     //   D
-    const d = { id: "d" };
-    const c = { id: "c", dependencies: [d] };
-    const b = { id: "b", dependencies: [d] };
-    const a = { id: "a", dependencies: [b, c] };
+    const d: HardhatPlugin = { id: "d" };
+    const c: HardhatPlugin = { id: "c", dependencies: [async () => d] };
+    const b: HardhatPlugin = { id: "b", dependencies: [async () => d] };
+    const a: HardhatPlugin = {
+      id: "a",
+      dependencies: [async () => b, async () => c],
+    };
 
-    assert.deepStrictEqual(resolvePluginList([a]), [d, b, c, a]);
+    assert.deepStrictEqual(await resolvePluginList([a]), [d, b, c, a]);
   });
 
-  it("should deal with a complicated dependency graph", () => {
+  it("should deal with a complicated dependency graph", async () => {
     //   A    B
     //  / \  / \ \
     // C   D    E F
@@ -85,17 +89,23 @@ describe("Plugins - resolve plugin list", () => {
     //   G      H
     //    \    /
     //      I
-    const i = { id: "i" };
-    const h = { id: "h", dependencies: [i] };
-    const g = { id: "g", dependencies: [i] };
-    const f = { id: "f", dependencies: [h] };
-    const e = { id: "e", dependencies: [h] };
-    const d = { id: "d", dependencies: [g] };
-    const c = { id: "c", dependencies: [g] };
-    const b = { id: "b", dependencies: [d, e, f] };
-    const a = { id: "a", dependencies: [c, d] };
+    const i: HardhatPlugin = { id: "i" };
+    const h: HardhatPlugin = { id: "h", dependencies: [async () => i] };
+    const g: HardhatPlugin = { id: "g", dependencies: [async () => i] };
+    const f: HardhatPlugin = { id: "f", dependencies: [async () => h] };
+    const e: HardhatPlugin = { id: "e", dependencies: [async () => h] };
+    const d: HardhatPlugin = { id: "d", dependencies: [async () => g] };
+    const c: HardhatPlugin = { id: "c", dependencies: [async () => g] };
+    const b: HardhatPlugin = {
+      id: "b",
+      dependencies: [async () => d, async () => e, async () => f],
+    };
+    const a: HardhatPlugin = {
+      id: "a",
+      dependencies: [async () => c, async () => d],
+    };
 
-    assert.deepStrictEqual(resolvePluginList([a, b]), [
+    assert.deepStrictEqual(await resolvePluginList([a, b]), [
       i,
       g,
       c,
@@ -108,23 +118,14 @@ describe("Plugins - resolve plugin list", () => {
     ]);
   });
 
-  it("should throw a HardhatError on finding different plugins with the same id", () => {
+  it("should throw a HardhatError on finding different plugins with the same id", async () => {
     const a = { id: "dup" };
     const copy = { id: "dup" };
 
-    assert.throws(
-      () => resolvePluginList([a, copy]),
-      (err) => {
-        assert(HardhatError.isHardhatError(err), "Expected a HardhatError");
-        assert(
-          /Duplicated plugin id "dup" found. Did you install multiple versions of the same plugin\?/.test(
-            err.message,
-          ),
-        );
-
-        return true;
-      },
-      "Expected a duplicate to be detected",
-    );
+    assert.rejects(async () => resolvePluginList([a, copy]), {
+      name: "HardhatError",
+      message:
+        'HHE4: Duplicated plugin id "dup" found. Did you install multiple versions of the same plugin?',
+    });
   });
 });

--- a/v-next/core/test/plugins/resolve-plugin-list.ts
+++ b/v-next/core/test/plugins/resolve-plugin-list.ts
@@ -5,12 +5,22 @@ import { resolvePluginList } from "../../src/internal/plugins/resolve-plugin-lis
 import { HardhatPlugin } from "../../src/types/plugins.js";
 
 describe("Plugins - resolve plugin list", () => {
+  const installedPackageFixture = import.meta.resolve(
+    "./fixture-projects/installed-package",
+  );
+
   it("should return empty on an empty plugin list", async () => {
-    assert.deepStrictEqual(await resolvePluginList([]), []);
+    assert.deepStrictEqual(
+      await resolvePluginList([], installedPackageFixture),
+      [],
+    );
   });
 
   it("should return empty on an undefined plugin list", async () => {
-    assert.deepStrictEqual(await resolvePluginList(), []);
+    assert.deepStrictEqual(
+      await resolvePluginList(undefined, installedPackageFixture),
+      [],
+    );
   });
 
   it("should return a single plugin", async () => {
@@ -18,7 +28,10 @@ describe("Plugins - resolve plugin list", () => {
       id: "example-plugin",
     };
 
-    assert.deepStrictEqual(await resolvePluginList([plugin]), [plugin]);
+    assert.deepStrictEqual(
+      await resolvePluginList([plugin], installedPackageFixture),
+      [plugin],
+    );
   });
 
   it("should support nested dependencies", async () => {
@@ -27,7 +40,10 @@ describe("Plugins - resolve plugin list", () => {
     const b: HardhatPlugin = { id: "b", dependencies: [async () => c] };
     const a: HardhatPlugin = { id: "a", dependencies: [async () => b] };
 
-    assert.deepStrictEqual(await resolvePluginList([a]), [c, b, a]);
+    assert.deepStrictEqual(
+      await resolvePluginList([a], installedPackageFixture),
+      [c, b, a],
+    );
   });
 
   it("should break ties by honouring array order", async () => {
@@ -36,7 +52,10 @@ describe("Plugins - resolve plugin list", () => {
     const b: HardhatPlugin = { id: "b" };
     const a: HardhatPlugin = { id: "a" };
 
-    assert.deepStrictEqual(await resolvePluginList([a, b, c]), [a, b, c]);
+    assert.deepStrictEqual(
+      await resolvePluginList([a, b, c], installedPackageFixture),
+      [a, b, c],
+    );
   });
 
   it("should break ties by honouring subdependency array order", async () => {
@@ -50,7 +69,10 @@ describe("Plugins - resolve plugin list", () => {
       dependencies: [async () => b, async () => c],
     };
 
-    assert.deepStrictEqual(await resolvePluginList([a]), [b, c, a]);
+    assert.deepStrictEqual(
+      await resolvePluginList([a], installedPackageFixture),
+      [b, c, a],
+    );
   });
 
   it("should support shared dependencies", async () => {
@@ -61,7 +83,10 @@ describe("Plugins - resolve plugin list", () => {
     const b: HardhatPlugin = { id: "b", dependencies: [async () => c] };
     const a: HardhatPlugin = { id: "a", dependencies: [async () => c] };
 
-    assert.deepStrictEqual(await resolvePluginList([a, b]), [c, a, b]);
+    assert.deepStrictEqual(
+      await resolvePluginList([a, b], installedPackageFixture),
+      [c, a, b],
+    );
   });
 
   it("should support shared subdependencies", async () => {
@@ -78,7 +103,10 @@ describe("Plugins - resolve plugin list", () => {
       dependencies: [async () => b, async () => c],
     };
 
-    assert.deepStrictEqual(await resolvePluginList([a]), [d, b, c, a]);
+    assert.deepStrictEqual(
+      await resolvePluginList([a], installedPackageFixture),
+      [d, b, c, a],
+    );
   });
 
   it("should deal with a complicated dependency graph", async () => {
@@ -105,27 +133,69 @@ describe("Plugins - resolve plugin list", () => {
       dependencies: [async () => c, async () => d],
     };
 
-    assert.deepStrictEqual(await resolvePluginList([a, b]), [
-      i,
-      g,
-      c,
-      d,
-      a,
-      h,
-      e,
-      f,
-      b,
-    ]);
+    assert.deepStrictEqual(
+      await resolvePluginList([a, b], installedPackageFixture),
+      [i, g, c, d, a, h, e, f, b],
+    );
   });
 
   it("should throw a HardhatError on finding different plugins with the same id", async () => {
     const a = { id: "dup" };
     const copy = { id: "dup" };
 
-    assert.rejects(async () => resolvePluginList([a, copy]), {
-      name: "HardhatError",
-      message:
-        'HHE4: Duplicated plugin id "dup" found. Did you install multiple versions of the same plugin?',
+    assert.rejects(
+      async () => resolvePluginList([a, copy], installedPackageFixture),
+      {
+        name: "HardhatError",
+        message:
+          'HHE4: Duplicated plugin id "dup" found. Did you install multiple versions of the same plugin?',
+      },
+    );
+  });
+
+  describe("dependency loading errors", () => {
+    it("should throw a general HardhatError on a dependency loading failing for unknown reasons", async () => {
+      const plugin: HardhatPlugin = {
+        id: "plugin",
+        npmPackage: "example",
+        dependencies: [
+          async () => {
+            throw new Error("Unknown reaons");
+          },
+        ],
+      };
+
+      assert.rejects(
+        async () => resolvePluginList([plugin], installedPackageFixture),
+        {
+          name: "HardhatError",
+          message: 'HHE1203: Plugin "plugin" dependency could not be loaded.',
+        },
+      );
+    });
+
+    it("should throw a plugin installation validation error if there is a dependency load failure", async () => {
+      const notInstalledPackageFixture = import.meta.resolve(
+        "./fixture-projects/not-installed-package",
+      );
+
+      const plugin: HardhatPlugin = {
+        id: "example",
+        npmPackage: "example",
+        dependencies: [
+          async () => {
+            throw new Error("Not installed");
+          },
+        ],
+      };
+
+      assert.rejects(
+        async () => resolvePluginList([plugin], notInstalledPackageFixture),
+        {
+          name: "HardhatError",
+          message: 'HHE1200: Plugin "example" is not installed.',
+        },
+      );
     });
   });
 });

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -522,6 +522,12 @@ A fully qualified name should look like file.sol:Contract`,
       websiteTitle: "Dependency version mismatch",
       websiteDescription: `A plugin's peer dependency version does not match the expected version.`,
     },
+    PLUGIN_DEPENDENCY_FAILED_LOAD: {
+      number: 1203,
+      messageTemplate: 'Plugin "%pluginId%" dependency could not be loaded.',
+      websiteTitle: "Plugin dependency could not be loaded",
+      websiteDescription: `A plugin's dependent plugin could not be lazily loaded.`,
+    },
   },
 } satisfies {
   [category in keyof typeof ERROR_CATEGORIES]: {

--- a/v-next/hardhat/src/hre.ts
+++ b/v-next/hardhat/src/hre.ts
@@ -21,7 +21,13 @@ export async function createHardhatRuntimeEnvironment(
   userProvidedGlobalArguments: Partial<GlobalArguments> = {},
 ): Promise<HardhatRuntimeEnvironment> {
   const plugins = [...builtinPlugins, ...(config.plugins ?? [])];
-  const resolvedPlugins = resolvePluginList(plugins);
+
+  // We resolve the plugins within npm modules relative to the current working
+  const basePathForNpmResolution = process.cwd();
+  const resolvedPlugins = await resolvePluginList(
+    plugins,
+    basePathForNpmResolution,
+  );
 
   return originalCreateHardhatRuntimeEnvironment(
     config,

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -75,7 +75,7 @@ export async function main(cliArguments: string[]) {
     const userConfig = await importUserConfig(configPath);
 
     const plugins = [...builtinPlugins, ...(userConfig.plugins ?? [])];
-    const resolvedPlugins = resolvePluginList(plugins);
+    const resolvedPlugins = await resolvePluginList(plugins, configPath);
 
     const globalParameterMap = buildGlobalParameterMap(resolvedPlugins);
     const userProvidedGlobalArguments = parseGlobalArguments(


### PR DESCRIPTION
Alter `HardhatPlugin` to use lazily loaded dependencies. This guards against failed installs as deps can have the form:

```ts
{
  id: "example",
  npmPackage: "my-plugin",
  dependencies: [
    () => import("another-plugin")
  ]
}
```

Several moves were made to support this:

1. The `HardhatPlugin` type was updated
2. Validation of plugin installs was moved into the plugin resolution logic. The dependency load is tried first, on exception a validation of the plugin installation is attempted. If there are no installation issue a generic dependency loading failed error is thrown.
3. The base path for npm resolution (the directory of the hardhat config file in v2) is now exposed through the `resolvePluginList` signature.