### PR TITLE
feat(package): provenance support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 enable-pre-post-scripts=true
+provenance=true

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -144,6 +144,9 @@
     "uuid": "^8.3.2",
     "ws": "^7.4.6"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "peerDependencies": {
     "ts-node": "*",
     "typescript": "*"


### PR DESCRIPTION
# Support Provenance Statement 

A provenance statement is displayed in a packages' registry page, as shown here:

<img width="856" alt="Screenshot 2024-05-25 at 3 58 29 PM" src="https://github.com/NomicFoundation/hardhat/assets/32783916/7da59b30-a65f-404b-8ee2-576317003872">

For more information regarding provenance statements and the requirements as defined by npmjs, see <https://docs.npmjs.com/generating-provenance-statements#prerequisites>

The `id-token` permission is required to publish to SigStore via OpenID Connect. You can read more about GitHub's attestation program here: <https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds>

## GitHub Action CI Support

You can use PNPM, just be sure to use the latest npm client for the actual publishing part of the release process. Yarn is *not* supported.

```diff
jobs:
  build:
    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
    steps:
      - uses: actions/checkout@v3
# 
#
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
```

### Scoped Publishing

Seeing as Hardhat is *not* scoped under the @nomicfoundation org, packages that are scoped should adjust their configuration in the manifest:

```jsonc
"publishConfig": {
  "@nomicfoundation:registry": "https://registry.npmjs.org",
  "provenance": true
  }
```

### `npm audit signatures`

> Example response showing the count of verified registry signatures and verified attestations for all of the packages in a project:

````console
audited 1267 packages in 6s

1267 packages have verified registry signatures

74 packages have verified attestations
```

