### PR TITLE
Type-safe `HardhatError`

### DIFF
--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/downloader.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/downloader.ts
@@ -201,7 +201,6 @@ export class CompilerDownloader implements ICompilerDownloader {
 
           throw new HardhatError(
             HardhatError.ERRORS.SOLC.VERSION_LIST_DOWNLOAD_FAILED,
-            {},
             e,
           );
         }

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
@@ -130,7 +130,6 @@ export class NativeCompiler implements ICompiler {
 
         throw new HardhatError(
           HardhatError.ERRORS.SOLC.CANT_RUN_NATIVE_COMPILER,
-          {},
           e,
         );
       }

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -103,7 +103,7 @@ Note that you don't need to do this every time you install a new dependency, but
     INVALID_READ_OF_DIRECTORY: {
       number: 3,
       messageTemplate:
-        "Invalid file path %absolutePath%. Attempting to read a directory instead of a file.",
+        "Invalid file path {absolutePath}. Attempting to read a directory instead of a file.",
       websiteTitle: "Invalid read: a directory cannot be read",
       websiteDescription: `An attempt was made to read a file, but a path to a directory was provided.
 
@@ -112,7 +112,7 @@ Please double check the file path.`,
     DUPLICATED_PLUGIN_ID: {
       number: 4,
       messageTemplate:
-        'Duplicated plugin id "%id%" found. Did you install multiple versions of the same plugin?',
+        'Duplicated plugin id "{id}" found. Did you install multiple versions of the same plugin?',
       websiteTitle: "Duplicated plugin id",
       websiteDescription: `While loading the plugins, two different plugins where found with the same id.
 
@@ -148,7 +148,7 @@ Please double check whether you have multiple versions of the same plugin instal
   INTERNAL: {
     ASSERTION_ERROR: {
       number: 100,
-      messageTemplate: "An internal invariant was violated: %message%",
+      messageTemplate: "An internal invariant was violated: {message}",
       websiteTitle: "Invariant violation",
       websiteDescription: `An internal invariant was violated. This is probably caused by a programming error in Hardhat or in one of the used plugins.
 
@@ -202,7 +202,7 @@ Please ensure that an action is defined for each task.`,
     INVALID_VALUE_FOR_TYPE: {
       number: 300,
       messageTemplate:
-        "Invalid value %value% for argument %name% of type %type%",
+        "Invalid value {value} for argument {name} of type {type}",
       websiteTitle: "Invalid argument type",
       websiteDescription: `One of your Hardhat or task arguments has an invalid type.
 
@@ -236,13 +236,13 @@ Please double check your arguments.`,
   RESOLVER: {
     FILE_NOT_FOUND: {
       number: 400,
-      messageTemplate: "File %file% doesn't exist.",
+      messageTemplate: "File {file} doesn't exist.",
       websiteTitle: "Solidity file not found",
       websiteDescription: `Tried to resolve a nonexistent Solidity file as an entry-point.`,
     },
     LIBRARY_NOT_INSTALLED: {
       number: 401,
-      messageTemplate: "Library %library% is not installed.",
+      messageTemplate: "Library {library} is not installed.",
       websiteTitle: "Solidity library not installed",
       websiteDescription: `One of your Solidity sources imports a library that is not installed.
 
@@ -250,7 +250,7 @@ Please double check your imports or install the missing dependency.`,
     },
     LIBRARY_FILE_NOT_FOUND: {
       number: 402,
-      messageTemplate: "File %file% doesn't exist.",
+      messageTemplate: "File {file} doesn't exist.",
       websiteTitle: "Missing library file",
       websiteDescription: `One of your libraries' files was imported but doesn't exist.
 
@@ -258,7 +258,7 @@ Please double check your imports or update your libraries.`,
     },
     ILLEGAL_IMPORT: {
       number: 403,
-      messageTemplate: "Illegal import %imported% from %from%",
+      messageTemplate: "Illegal import {imported} from {from}",
       websiteTitle: "Illegal Solidity import",
       websiteDescription: `One of your libraries tried to use a relative import to import a file outside of its scope.
 
@@ -266,7 +266,7 @@ This is disabled for security reasons.`,
     },
     IMPORTED_FILE_NOT_FOUND: {
       number: 404,
-      messageTemplate: "File %imported%, imported from %from%, not found.",
+      messageTemplate: "File {imported}, imported from {from}, not found.",
       websiteTitle: "Imported file not found",
       websiteDescription: `One of your source files imported a nonexistent file.
 
@@ -275,7 +275,7 @@ Please double check your imports.`,
     INVALID_IMPORT_BACKSLASH: {
       number: 405,
       messageTemplate:
-        "Invalid import %imported% from %from%. Imports must use / instead of \\, even in Windows",
+        "Invalid import {imported} from {from}. Imports must use / instead of \\, even in Windows",
       websiteTitle: "Invalid import: use / instead of \\",
       websiteDescription: `A Solidity file is trying to import another file via relative path and is using backslashes (\\\\) instead of slashes (/).
 
@@ -284,7 +284,7 @@ You must always use slashes (/) in Solidity imports.`,
     INVALID_IMPORT_PROTOCOL: {
       number: 406,
       messageTemplate:
-        "Invalid import %imported% from %from%. Hardhat doesn't support imports via %protocol%.",
+        "Invalid import {imported} from {from}. Hardhat doesn't support imports via {protocol}.",
       websiteTitle: "Invalid import: trying to use an unsupported protocol",
       websiteDescription: `A Solidity file is trying to import a file using an unsupported protocol, like http.
 
@@ -293,7 +293,7 @@ You can only import files that are available locally or installed through npm.`,
     INVALID_IMPORT_ABSOLUTE_PATH: {
       number: 407,
       messageTemplate:
-        "Invalid import %imported% from %from%. Hardhat doesn't support imports with absolute paths.",
+        "Invalid import {imported} from {from}. Hardhat doesn't support imports with absolute paths.",
       websiteTitle: "Invalid import: absolute paths unsupported",
       websiteDescription: `A Solidity file is trying to import a file using its absolute path.
 
@@ -302,7 +302,7 @@ This is not supported, as it would lead to hard-to-reproduce compilations.`,
     INVALID_IMPORT_OUTSIDE_OF_PROJECT: {
       number: 408,
       messageTemplate:
-        "Invalid import %imported% from %from%. The file being imported is outside of the project",
+        "Invalid import {imported} from {from}. The file being imported is outside of the project",
       websiteTitle: "Invalid import: file outside of the project",
       websiteDescription: `A Solidity file is trying to import a file that is outside of the project.
 
@@ -311,7 +311,7 @@ This is not supported by Hardhat.`,
     INVALID_IMPORT_WRONG_CASING: {
       number: 409,
       messageTemplate:
-        "Trying to import %imported% from %from%, but it has an incorrect casing.",
+        "Trying to import {imported} from {from}, but it has an incorrect casing.",
       websiteTitle: "Invalid import: wrong file casing",
       websiteDescription: `A Solidity file is trying to import a file but its source name casing was wrong.
 
@@ -320,7 +320,7 @@ Hardhat's compiler is case sensitive to ensure projects are portable across diff
     WRONG_SOURCE_NAME_CASING: {
       number: 410,
       messageTemplate:
-        "Trying to resolve the file %incorrect% but its correct case-sensitive name is %correct%",
+        "Trying to resolve the file {incorrect} but its correct case-sensitive name is {correct}",
       websiteTitle: "Incorrect source name casing",
       websiteDescription: `You tried to resolve a Solidity file with an incorrect casing.
 
@@ -329,7 +329,7 @@ Hardhat's compiler is case sensitive to ensure projects are portable across diff
     IMPORTED_LIBRARY_NOT_INSTALLED: {
       number: 411,
       messageTemplate:
-        "The library %library%, imported from %from%, is not installed. Try installing it using npm.",
+        "The library {library}, imported from {from}, is not installed. Try installing it using npm.",
       websiteTitle: "Invalid import: library not installed",
       websiteDescription: `A Solidity file is trying to import another which belongs to a library that is not installed.
 
@@ -338,7 +338,7 @@ Try installing the library using npm.`,
     INCLUDES_OWN_PACKAGE_NAME: {
       number: 412,
       messageTemplate:
-        "Invalid import %imported% from %from%. Trying to import file using the own package's name.",
+        "Invalid import {imported} from {from}. Trying to import file using the own package's name.",
       websiteTitle: "Invalid import: includes own package's name",
       websiteDescription: `A Solidity file is trying to import another using its own package name. This is most likely caused by an existing symlink for the package in your node_modules.
 
@@ -347,7 +347,7 @@ Use a relative import instead of referencing the package's name.`,
     IMPORTED_MAPPED_FILE_NOT_FOUND: {
       number: 413,
       messageTemplate:
-        "File %importName% => %imported%, imported from %from%, not found.",
+        "File {importName} => {imported}, imported from {from}, not found.",
       websiteTitle: "Imported mapped file not found",
       websiteDescription: `One of your source files imported a nonexistent or not installed file.
 
@@ -356,7 +356,7 @@ Please double check your imports and installed libraries.`,
     INVALID_IMPORT_OF_DIRECTORY: {
       number: 414,
       messageTemplate:
-        "Invalid import %imported% from %from%. Attempting to import a directory. Directories cannot be imported.",
+        "Invalid import {imported} from {from}. Attempting to import a directory. Directories cannot be imported.",
       websiteTitle: "Invalid import: a directory cannot be imported",
       websiteDescription: `A Solidity file is attempting to import a directory, which is not possible.
 
@@ -365,7 +365,7 @@ Please double check your imports.`,
     AMBIGUOUS_SOURCE_NAMES: {
       number: 415,
       messageTemplate:
-        "Two different source names (%sourcenames%) resolve to the same file (%file%).",
+        "Two different source names ({sourcenames}) resolve to the same file ({file}).",
       websiteTitle: "Ambiguous source names",
       websiteDescription: `Two different source names map to the same file.
 
@@ -375,7 +375,7 @@ This is probably caused by multiple remappings pointing to the same source file.
   SOLC: {
     INVALID_VERSION: {
       number: 500,
-      messageTemplate: `Solidity version %version% is invalid or hasn't been released yet.
+      messageTemplate: `Solidity version {version} is invalid or hasn't been released yet.
 
 If you are certain it has been released, run "npx hardhat clean --global" and try again`,
       websiteTitle: "Invalid or unreleased `solc` version",
@@ -386,7 +386,7 @@ If you are certain it has been released, run \`npx hardhat clean --global\` and 
     DOWNLOAD_FAILED: {
       number: 501,
       messageTemplate:
-        "Couldn't download compiler version %remoteVersion%. Please check your internet connection and try again.",
+        "Couldn't download compiler version {remoteVersion}. Please check your internet connection and try again.",
       websiteTitle: "`solc` download failed",
       websiteDescription: `Couldn't download \`solc\`.
 
@@ -403,7 +403,7 @@ Please check your internet connection and try again.`,
     },
     INVALID_DOWNLOAD: {
       number: 503,
-      messageTemplate: `Couldn't download compiler version %remoteVersion%: Checksum verification failed.
+      messageTemplate: `Couldn't download compiler version {remoteVersion}: Checksum verification failed.
 
 Please check your internet connection and try again.
 
@@ -443,15 +443,15 @@ Please check Hardhat's output for more details.`,
       number: 601,
       messageTemplate: `The project cannot be compiled, see reasons below.
 
-%reasons%`,
+{reasons}`,
       websiteTitle: "The project cannot be compiled",
       websiteDescription: `The project cannot be compiled with the current settings.`,
     },
     COMPILE_TASK_UNSUPPORTED_SOLC_VERSION: {
       number: 602,
-      messageTemplate: `Version %version% is not supported by Hardhat.
+      messageTemplate: `Version {version} is not supported by Hardhat.
 
-The first supported version is %firstSupportedVersion%`,
+The first supported version is {firstSupportedVersion}`,
       websiteTitle: "Unsupported solc version",
       websiteDescription: `This version of solidity is not supported by Hardhat.
 Please use a newer, supported version.`,
@@ -462,7 +462,7 @@ Please use a newer, supported version.`,
     NOT_FOUND: {
       number: 700,
       messageTemplate:
-        'Artifact for contract "%contractName%" not found. %suggestion%',
+        'Artifact for contract "{contractName}" not found. {suggestion}',
       websiteTitle: "Artifact not found",
       websiteDescription: `Tried to import a nonexistent artifact.
 
@@ -470,11 +470,11 @@ Please double check that your contracts have been compiled and double check your
     },
     MULTIPLE_FOUND: {
       number: 701,
-      messageTemplate: `There are multiple artifacts for contract "%contractName%", please use a fully qualified name.
+      messageTemplate: `There are multiple artifacts for contract "{contractName}", please use a fully qualified name.
 
-Please replace %contractName% for one of these options wherever you are trying to read its artifact:
+Please replace {contractName} for one of these options wherever you are trying to read its artifact:
 
-%candidates%
+{candidates}
 `,
       websiteTitle: "Multiple artifacts found",
       websiteDescription: `There are multiple artifacts that match the given contract name, and Hardhat doesn't know which one to use.
@@ -484,7 +484,7 @@ Please use the fully qualified name of the contract to disambiguate it.`,
     WRONG_CASING: {
       number: 702,
       messageTemplate:
-        "Invalid artifact path %incorrect%, its correct case-sensitive path is %correct%",
+        "Invalid artifact path {incorrect}, its correct case-sensitive path is {correct}",
       websiteTitle: "Incorrect artifact path casing",
       websiteDescription: `You tried to get an artifact file with an incorrect casing.
 
@@ -496,7 +496,7 @@ Hardhat's artifact resolution is case sensitive to ensure projects are portable 
     INVALID_SOURCE_NAME_ABSOLUTE_PATH: {
       number: 1000,
       messageTemplate:
-        "Invalid source name %name%. Expected source name but found an absolute path.",
+        "Invalid source name {name}. Expected source name but found an absolute path.",
       websiteTitle: "Invalid source name: absolute path",
       websiteDescription: `A Solidity source name was expected, but an absolute path was given.
 
@@ -506,7 +506,7 @@ If you aren't overriding compilation-related tasks, please report this as a bug.
     INVALID_SOURCE_NAME_RELATIVE_PATH: {
       number: 1001,
       messageTemplate:
-        "Invalid source name %name%. Expected source name but found a relative path.",
+        "Invalid source name {name}. Expected source name but found a relative path.",
       websiteTitle: "Invalid source name: relative path",
       websiteDescription: `A Solidity source name was expected, but a relative path was given.
 
@@ -516,7 +516,7 @@ If you aren't overriding compilation-related tasks, please report this as a bug.
     INVALID_SOURCE_NAME_BACKSLASHES: {
       number: 1002,
       messageTemplate:
-        "Invalid source %name%. The source name uses backslashes (\\) instead of slashes (/).",
+        "Invalid source {name}. The source name uses backslashes (\\) instead of slashes (/).",
       websiteTitle: "Invalid source name: backslashes",
       websiteDescription: `A Solidity source name was invalid because it uses backslashes (\\\\) instead of slashes (/).
 
@@ -526,7 +526,7 @@ If you aren't overriding compilation-related tasks, please report this as a bug.
     INVALID_SOURCE_NOT_NORMALIZED: {
       number: 1003,
       messageTemplate:
-        "Invalid source name %name%. Source names must be normalized",
+        "Invalid source name {name}. Source names must be normalized",
       websiteTitle: "Invalid source name: not normalized",
       websiteDescription: `A Solidity source name was invalid because it wasn't normalized. It probably contains some "." or "..".
 
@@ -536,7 +536,7 @@ If you aren't overriding compilation-related tasks, please report this as a bug.
     WRONG_CASING: {
       number: 1004,
       messageTemplate:
-        "Invalid source map %incorrect%, its correct case-sensitive source name is %correct%",
+        "Invalid source map {incorrect}, its correct case-sensitive source name is {correct}",
       websiteTitle: "Incorrect source name casing",
       websiteDescription: `You tried to resolve a Solidity file with an incorrect casing.
 
@@ -545,7 +545,7 @@ Hardhat's compiler is case sensitive to ensure projects are portable across diff
     },
     FILE_NOT_FOUND: {
       number: 1005,
-      messageTemplate: "Solidity source file %name% not found",
+      messageTemplate: "Solidity source file {name} not found",
       websiteTitle: "Solidity source file not found",
       websiteDescription: `A source name should correspond to an existing Solidity file but it doesn't.
 
@@ -555,7 +555,7 @@ Hardhat's compiler is case sensitive to ensure projects are portable across diff
     NODE_MODULES_AS_LOCAL: {
       number: 1006,
       messageTemplate:
-        "The file %path% is treated as local but is inside a node_modules directory",
+        "The file {path} is treated as local but is inside a node_modules directory",
       websiteTitle: "File from node_modules treated as local",
       websiteDescription: `A file was treated as local but is inside a node_modules directory.
 
@@ -565,7 +565,7 @@ If you aren't overriding compilation-related tasks, please report this as a bug.
     EXTERNAL_AS_LOCAL: {
       number: 1007,
       messageTemplate:
-        "The file %path% is treated as local but is outside the project",
+        "The file {path} is treated as local but is outside the project",
       websiteTitle: "File from outside the project treated as local",
       websiteDescription: `A file was treated as local but is outside the project.
 
@@ -576,7 +576,7 @@ If you aren't overriding compilation-related tasks, please report this as a bug.
   CONTRACT_NAMES: {
     INVALID_FULLY_QUALIFIED_NAME: {
       number: 1100,
-      messageTemplate: "Invalid fully qualified contract name %name%.",
+      messageTemplate: "Invalid fully qualified contract name {name}.",
       websiteTitle: "Invalid fully qualified contract name",
       websiteDescription: `A contract name was expected to be in fully qualified form, but it's not.
 
@@ -586,27 +586,27 @@ A fully qualified name should look like file.sol:Contract`,
   PLUGINS: {
     PLUGIN_NOT_INSTALLED: {
       number: 1200,
-      messageTemplate: 'Plugin "%pluginId%" is not installed.',
+      messageTemplate: 'Plugin "{pluginId}" is not installed.',
       websiteTitle: "Plugin not installed",
       websiteDescription: `A plugin was included in the Hardhat config but has not been installed.`,
     },
     PLUGIN_MISSING_DEPENDENCY: {
       number: 1201,
       messageTemplate:
-        'Plugin "%pluginId%" is missing a peer dependency "%peerDependencyName%".',
+        'Plugin "{pluginId}" is missing a peer dependency "{peerDependencyName}".',
       websiteTitle: "Plugin missing peer dependency",
       websiteDescription: `A plugin's peer dependency has not been installed.`,
     },
     DEPENDENCY_VERSION_MISMATCH: {
       number: 1202,
       messageTemplate:
-        'Plugin "%pluginId%" has a peer dependency "%peerDependencyName%" with version "%installedVersion%" but version "%expectedVersion%" is needed.',
+        'Plugin "{pluginId}" has a peer dependency "{peerDependencyName}" with version "{installedVersion}" but version "{expectedVersion}" is needed.',
       websiteTitle: "Dependency version mismatch",
       websiteDescription: `A plugin's peer dependency version does not match the expected version.`,
     },
     PLUGIN_DEPENDENCY_FAILED_LOAD: {
       number: 1203,
-      messageTemplate: 'Plugin "%pluginId%" dependency could not be loaded.',
+      messageTemplate: 'Plugin "{pluginId}" dependency could not be loaded.',
       websiteTitle: "Plugin dependency could not be loaded",
       websiteDescription: `A plugin's dependent plugin could not be lazily loaded.`,
     },

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -127,19 +127,19 @@ Please double check whether you have multiple versions of the same plugin instal
     },
     INVALID_CONFIG_PATH: {
       number: 6,
-      messageTemplate: "Config file %configPath% not found",
+      messageTemplate: "Config file {configPath} not found",
       websiteTitle: "Invalid config path",
       websiteDescription: "The config file doesn't exist at the provided path.",
     },
     NO_CONFIG_EXPORTED: {
       number: 7,
-      messageTemplate: "No config exported in %configPath%",
+      messageTemplate: "No config exported in {configPath}",
       websiteTitle: "No config exported",
       websiteDescription: "There is nothing exported from the config file.",
     },
     INVALID_CONFIG_OBJECT: {
       number: 8,
-      messageTemplate: "Invalid config exported in %configPath%",
+      messageTemplate: "Invalid config exported in {configPath}",
       websiteTitle: "Invalid config object",
       websiteDescription:
         "The config file doesn't export a valid configuration object.",
@@ -167,7 +167,7 @@ Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us i
     },
     INVALID_FILE_ACTION: {
       number: 201,
-      messageTemplate: "Invalid file action: %action% is not a valid file URL",
+      messageTemplate: "Invalid file action: {action} is not a valid file URL",
       websiteTitle: "Invalid file action",
       websiteDescription: `The setAction function was called with a string parameter that is not a valid file URL. A valid file URL must start with 'file://'.
 
@@ -175,7 +175,7 @@ Please ensure that you are providing a correct file URL.`,
     },
     NO_ACTION: {
       number: 202,
-      messageTemplate: "The task %task% doesn't have an action",
+      messageTemplate: "The task {task} doesn't have an action",
       websiteTitle: "Task missing action",
       websiteDescription: `A task was defined without an action.
 
@@ -184,7 +184,7 @@ Please ensure that an action is defined for each task.`,
     POSITIONAL_PARAM_AFTER_VARIADIC: {
       number: 203,
       messageTemplate:
-        "Cannot add the positional param %name% after a variadic one",
+        "Cannot add the positional param {name} after a variadic one",
       websiteTitle: "Invalid task definition",
       websiteDescription:
         "A variadic parameter must always be the last positional parameter in a task definition.",
@@ -192,7 +192,7 @@ Please ensure that an action is defined for each task.`,
     REQUIRED_PARAM_AFTER_OPTIONAL: {
       number: 204,
       messageTemplate:
-        "Cannot add required positional param %name% after an optional one",
+        "Cannot add required positional param {name} after an optional one",
       websiteTitle: "Invalid task definition",
       websiteDescription:
         "Required positional parameters must be defined before optional ones in a task definition.",
@@ -210,7 +210,7 @@ Please double check your arguments.`,
     },
     RESERVED_NAME: {
       number: 301,
-      messageTemplate: "Argument name %name% is reserved",
+      messageTemplate: "Argument name {name} is reserved",
       websiteTitle: "Reserved argument name",
       websiteDescription: `One of your Hardhat or task arguments has a reserved name.
 
@@ -218,7 +218,7 @@ Please double check your arguments.`,
     },
     DUPLICATED_NAME: {
       number: 302,
-      messageTemplate: "Argument name %name% is already in use",
+      messageTemplate: "Argument name {name} is already in use",
       websiteTitle: "Argument name already in use",
       websiteDescription: `One of your Hardhat or task argument names is already in use.
 
@@ -226,7 +226,7 @@ Please double check your arguments.`,
     },
     INVALID_NAME: {
       number: 303,
-      messageTemplate: "Argument name %name% is invalid",
+      messageTemplate: "Argument name {name} is invalid",
       websiteTitle: "Invalid argument name",
       websiteDescription: `One of your Hardhat or task argument names is invalid.
 

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -611,8 +611,4 @@ A fully qualified name should look like file.sol:Contract`,
       websiteDescription: `A plugin's dependent plugin could not be lazily loaded.`,
     },
   },
-} satisfies {
-  [category in keyof typeof ERROR_CATEGORIES]: {
-    [name: string]: ErrorDescriptor;
-  };
-};
+} as const;

--- a/v-next/hardhat-errors/src/errors.ts
+++ b/v-next/hardhat-errors/src/errors.ts
@@ -9,6 +9,7 @@ export type ErrorMessageTemplateValue =
   | bigint
   | undefined
   | null
+  | ErrorMessageTemplateValue[]
   | { toString(): string };
 
 export type MessagetTemplateArguments<MessageTemplateT extends string> =
@@ -193,8 +194,17 @@ export function applyErrorMessageTemplate(
     if (rawValue === undefined) {
       return "undefined";
     }
+
     if (rawValue === null) {
       return "null";
+    }
+
+    if (typeof rawValue === "bigint") {
+      return `${rawValue}n`;
+    }
+
+    if (Array.isArray(rawValue)) {
+      return JSON.stringify(rawValue);
     }
 
     return rawValue.toString();

--- a/v-next/hardhat-errors/src/errors.ts
+++ b/v-next/hardhat-errors/src/errors.ts
@@ -2,10 +2,6 @@ import { CustomError } from "@nomicfoundation/hardhat-utils/error";
 
 import { ERRORS, ErrorDescriptor } from "./descriptors.js";
 
-export const ERROR_PREFIX = "HHE";
-
-const IS_HARDHAT_ERROR_PROPERTY_NAME = "_isHardhatError";
-
 export type ErrorMessageTemplateValue =
   | string
   | number
@@ -15,31 +11,81 @@ export type ErrorMessageTemplateValue =
   | null
   | { toString(): string };
 
-export type ErrorMessageTemplateArguments = Record<
-  string,
-  ErrorMessageTemplateValue
->;
+export type MessagetTemplateArguments<MessageTemplateT extends string> =
+  MessageTemplateT extends `${string}{${infer Tag}}${infer Rest}`
+    ? {
+        [K in
+          | Tag
+          | keyof MessagetTemplateArguments<Rest>]: ErrorMessageTemplateValue;
+      }
+    : {};
 
-export class HardhatError extends CustomError {
+export type HardhatErrorConstructorArguments<
+  ErrorDescriptorT extends ErrorDescriptor,
+> = keyof MessagetTemplateArguments<
+  ErrorDescriptorT["messageTemplate"]
+> extends never
+  ? [ErrorDescriptorT, Error?]
+  : [
+      ErrorDescriptorT,
+      MessagetTemplateArguments<ErrorDescriptorT["messageTemplate"]>,
+      Error?,
+    ];
+
+export const ERROR_PREFIX = "HHE";
+
+const IS_HARDHAT_ERROR_PROPERTY_NAME = "_isHardhatError";
+
+export class HardhatError<
+  ErrorDescriptorT extends ErrorDescriptor,
+> extends CustomError {
   public static readonly ERRORS = ERRORS;
 
-  readonly #descriptor: ErrorDescriptor;
+  readonly #descriptor: ErrorDescriptorT;
+
+  readonly #arguments: MessagetTemplateArguments<
+    ErrorDescriptorT["messageTemplate"]
+  >;
 
   constructor(
-    errorDescriptor: ErrorDescriptor,
-    messageArguments: ErrorMessageTemplateArguments = {},
-    parentError?: Error,
+    ...[
+      errorDescriptor,
+      messageArgumentsOrParentError,
+      parentError,
+    ]: HardhatErrorConstructorArguments<ErrorDescriptorT>
   ) {
     const prefix = `${getErrorCode(errorDescriptor)}: `;
 
-    const formattedMessage = applyErrorMessageTemplate(
-      errorDescriptor.messageTemplate,
-      messageArguments,
+    const formattedMessage =
+      messageArgumentsOrParentError === undefined ||
+      messageArgumentsOrParentError instanceof Error
+        ? errorDescriptor.messageTemplate
+        : applyErrorMessageTemplate(
+            errorDescriptor.messageTemplate,
+            messageArgumentsOrParentError,
+          );
+
+    super(
+      prefix + formattedMessage,
+      parentError instanceof Error
+        ? parentError
+        : messageArgumentsOrParentError instanceof Error
+          ? messageArgumentsOrParentError
+          : undefined,
     );
 
-    super(prefix + formattedMessage, parentError);
-
     this.#descriptor = errorDescriptor;
+
+    if (
+      messageArgumentsOrParentError === undefined ||
+      messageArgumentsOrParentError instanceof Error
+    ) {
+      this.#arguments = {} as MessagetTemplateArguments<
+        ErrorDescriptorT["messageTemplate"]
+      >;
+    } else {
+      this.#arguments = messageArgumentsOrParentError;
+    }
 
     // As this package is going to be used from most of our packages, there's a
     // change of users having multiple versions of it. If that happens, they may
@@ -57,8 +103,15 @@ export class HardhatError extends CustomError {
 
   public static isHardhatError(
     other: unknown,
+  ): other is HardhatError<ErrorDescriptor>;
+  public static isHardhatError<ErrorDescriptorT extends ErrorDescriptor>(
+    other: unknown,
+    descriptor?: ErrorDescriptorT,
+  ): other is HardhatError<ErrorDescriptorT>;
+  public static isHardhatError(
+    other: unknown,
     descriptor?: ErrorDescriptor,
-  ): other is HardhatError {
+  ): other is HardhatError<ErrorDescriptor> {
     if (typeof other !== "object" || other === null) {
       return false;
     }
@@ -73,7 +126,7 @@ export class HardhatError extends CustomError {
       // If an error descriptor is provided, check if its number matches the Hardhat error number
       (descriptor === undefined
         ? true
-        : (other as HardhatError).number === descriptor.number)
+        : (other as HardhatError<ErrorDescriptor>).number === descriptor.number)
     );
   }
 
@@ -89,8 +142,10 @@ export class HardhatError extends CustomError {
     return this.#descriptor;
   }
 
-  public get messageArguments(): Record<string, ErrorMessageTemplateValue> {
-    return this.messageArguments;
+  public get messageArguments(): MessagetTemplateArguments<
+    ErrorDescriptorT["messageTemplate"]
+  > {
+    return this.#arguments;
   }
 }
 
@@ -130,68 +185,18 @@ function getErrorCode(errorDescriptor: ErrorDescriptor): string {
  */
 export function applyErrorMessageTemplate(
   template: string,
-  values: ErrorMessageTemplateArguments,
+  values: Record<string, ErrorMessageTemplateValue>,
 ): string {
-  return _applyErrorMessageTemplate(template, values, false);
-}
-
-function _applyErrorMessageTemplate(
-  template: string,
-  values: ErrorMessageTemplateArguments,
-  isRecursiveCall: boolean,
-): string {
-  if (!isRecursiveCall) {
-    for (const variableName of Object.keys(values)) {
-      assertHardhatInvariant(
-        /^[a-zA-Z][a-zA-Z0-9]*$/.test(variableName),
-        `Trying to apply error template but variable "${variableName}" is invalid. Variable names can only include ascii letters and numbers, and start with a letter.`,
-      );
-
-      const variableTag = `%${variableName}%`;
-
-      assertHardhatInvariant(
-        template.includes(variableTag),
-        `Trying to apply error template but variable "${variableName}" is not present in the template.`,
-      );
-    }
-  }
-
-  if (template.includes("%%")) {
-    return template
-      .split("%%")
-      .map((part) => _applyErrorMessageTemplate(part, values, true))
-      .join("%");
-  }
-
-  for (const variableName of Object.keys(values)) {
-    let value: string;
-
+  return template.replaceAll(/{(.*?)}/g, (_match, variableName) => {
     const rawValue = values[variableName];
 
     if (rawValue === undefined) {
-      value = "undefined";
-    } else if (rawValue === null) {
-      value = "null";
-    } else if (typeof rawValue === "bigint") {
-      value = `${rawValue}n`;
-    } else if (
-      typeof rawValue === "object" &&
-      !rawValue.hasOwnProperty("toString")
-    ) {
-      value = JSON.stringify(rawValue);
-    } else {
-      value = rawValue.toString();
+      return "undefined";
+    }
+    if (rawValue === null) {
+      return "null";
     }
 
-    const variableTag = `%${variableName}%`;
-
-    assertHardhatInvariant(
-      !/%([a-zA-Z][a-zA-Z0-9]*)?%/.test(value),
-      `Trying to apply an error template but variable "${variableName}" has a value that contains a variable tag.`,
-    );
-
-    template = template.replaceAll(variableTag, value);
-  }
-
-  return template;
+    return rawValue.toString();
+  });
 }

--- a/v-next/hardhat-errors/test/errors.ts
+++ b/v-next/hardhat-errors/test/errors.ts
@@ -302,13 +302,11 @@ describe("applyErrorMessageTemplate", () => {
 describe("Type tests", () => {
   describe("ErrorDescriptor types", () => {
     it("should have the right type", () => {
-      const descriptors: {
+      const _descriptors: {
         [category in keyof typeof ERROR_CATEGORIES]: {
           [name: string]: ErrorDescriptor;
         };
       } = ERRORS;
-
-      void descriptors;
     });
   });
 
@@ -385,12 +383,12 @@ describe("Type tests", () => {
 
   describe("Hardhat error constructor", () => {
     it("Should be constructable without arguments if there aren't any", () => {
-      void new HardhatError(mockErrorDescriptor);
-      void new HardhatError(mockErrorDescriptor, new Error());
+      const _e = new HardhatError(mockErrorDescriptor);
+      const _e2 = new HardhatError(mockErrorDescriptor, new Error());
     });
 
     it("Should be constructable with the right arguments", () => {
-      void new HardhatError(
+      const _e = new HardhatError(
         {
           ...mockErrorDescriptor,
           messageTemplate: "{asd}",
@@ -398,7 +396,7 @@ describe("Type tests", () => {
         { asd: 123 },
       );
 
-      void new HardhatError(
+      const _e2 = new HardhatError(
         {
           ...mockErrorDescriptor,
           messageTemplate: "{asd}",

--- a/v-next/hardhat-errors/test/errors.ts
+++ b/v-next/hardhat-errors/test/errors.ts
@@ -296,6 +296,17 @@ describe("applyErrorMessageTemplate", () => {
         );
       });
     });
+
+    describe("Edge cases", () => {
+      it("Should support {}", () => {
+        assert.equal(
+          applyErrorMessageTemplate("foo {} {}", {
+            [""]: "bar",
+          }),
+          "foo bar bar",
+        );
+      });
+    });
   });
 });
 
@@ -378,6 +389,15 @@ describe("Type tests", () => {
         hello: ErrorMessageTemplateValue;
         hola: ErrorMessageTemplateValue;
       }>();
+    });
+
+    describe("Edge cases", () => {
+      it("Should support {}", () => {
+        expectTypeOf<MessagetTemplateArguments<"foo {} {}">>().toEqualTypeOf<{
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          "": ErrorMessageTemplateValue;
+        }>();
+      });
     });
   });
 

--- a/v-next/hardhat-errors/test/errors.ts
+++ b/v-next/hardhat-errors/test/errors.ts
@@ -409,7 +409,7 @@ describe("Type tests", () => {
     });
   });
 
-  describe("messageArguments propery types", () => {
+  describe("messageArguments property types", () => {
     it("Should have the right type", () => {
       expectTypeOf(
         new HardhatError(mockErrorDescriptor).messageArguments,


### PR DESCRIPTION
This PR modifies `HardhatError` so that its constructor and its `messageArguments` property are type-safe.

This introduces two extra changes:

1. The error message template system now uses `{variable}` instead of `%variable%`, as that dramatically simplified this PR.
2. The constructor only takes two parameters now if the message template doesn't use any variable. Those are the descriptor and the optional cause.