### PR TITLE
TaskManagerImplementation improvements

### DIFF
--- a/v-next/core/src/internal/tasks/builders.ts
+++ b/v-next/core/src/internal/tasks/builders.ts
@@ -35,6 +35,12 @@ export class NewTaskDefinitionBuilderImplementation
   #action?: NewTaskActionFunction | string;
 
   constructor(id: string | string[], description: string = "") {
+    if (id.length === 0) {
+      throw new HardhatError(
+        HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID,
+      );
+    }
+
     this.#id = Array.isArray(id) ? id : [id];
     this.#description = description;
   }
@@ -288,6 +294,12 @@ export class TaskOverrideDefinitionBuilderImplementation
   #action?: TaskOverrideActionFunction | string;
 
   constructor(id: string | string[]) {
+    if (id.length === 0) {
+      throw new HardhatError(
+        HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID,
+      );
+    }
+
     this.#id = Array.isArray(id) ? id : [id];
   }
 

--- a/v-next/core/src/internal/tasks/task-manager.ts
+++ b/v-next/core/src/internal/tasks/task-manager.ts
@@ -1,3 +1,8 @@
+import {
+  HardhatError,
+  assertHardhatInvariant,
+} from "@nomicfoundation/hardhat-errors";
+
 import { GlobalParameterMap } from "../../types/global-parameters.js";
 import { HardhatRuntimeEnvironment } from "../../types/hre.js";
 import {
@@ -10,7 +15,7 @@ import {
 } from "../../types/tasks.js";
 
 import { ResolvedTask } from "./resolved-task.js";
-import { formatTaskId } from "./utils.js";
+import { formatTaskId, getActorFragment } from "./utils.js";
 
 export class TaskManagerImplementation implements TaskManager {
   readonly #hre: HardhatRuntimeEnvironment;
@@ -22,6 +27,7 @@ export class TaskManagerImplementation implements TaskManager {
   ) {
     this.#hre = hre;
 
+    // reduce plugin tasks
     for (const plugin of this.#hre.config.plugins) {
       if (plugin.tasks === undefined) {
         continue;
@@ -36,6 +42,7 @@ export class TaskManagerImplementation implements TaskManager {
       }
     }
 
+    // reduce global user defined tasks
     for (const taskDefinition of this.#hre.config.tasks) {
       this.#reduceTaskDefinition(globalParameterIndex, taskDefinition);
     }
@@ -43,22 +50,26 @@ export class TaskManagerImplementation implements TaskManager {
 
   public getTask(taskId: string | string[]): Task {
     taskId = Array.isArray(taskId) ? taskId : [taskId];
-
     if (taskId.length === 0) {
-      throw new Error(`Invalid task id "${formatTaskId(taskId)}"`);
+      throw new HardhatError(
+        HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND,
+        {
+          id: formatTaskId(taskId),
+        },
+      );
     }
 
     let tasks = this.#rootTasks;
-    let task: Task;
-
+    let task: Task | undefined;
     for (let i = 0; i < taskId.length; i++) {
       const idFragment = taskId[i];
-
       const currentTask = tasks.get(idFragment);
-
       if (currentTask === undefined) {
-        throw new Error(
-          `Task "${formatTaskId(taskId.slice(0, i + 1))}" not found.`,
+        throw new HardhatError(
+          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND,
+          {
+            id: formatTaskId(taskId.slice(0, i + 1)),
+          },
         );
       }
 
@@ -66,52 +77,55 @@ export class TaskManagerImplementation implements TaskManager {
       tasks = task.subtasks;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Can't be undefined as we set it in the non-empty loop.
-    return task!;
+    // task can't be undefined as we set it in the non-empty loop
+    assertHardhatInvariant(task !== undefined, "Task not found");
+
+    return task;
   }
 
   #insertTask(taskId: string[], task: Task, pluginId?: string) {
     if (taskId.length === 0) {
-      throw new Error(`Invalid task id "${formatTaskId(taskId)}"`);
+      throw new HardhatError(
+        HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID,
+      );
     }
 
+    // Traverse all the parent tasks to check that they exist
     let tasks = this.#rootTasks;
-
     for (let i = 0; i < taskId.length - 1; i++) {
       const idFragment = taskId[i];
-
       const currentTask = tasks.get(idFragment);
-
       if (currentTask === undefined) {
-        throw new Error(
-          `Task "${formatTaskId(taskId.slice(0, i + 1))}" not found and trying to define subtask "${formatTaskId(taskId)}". Define an empty task if you just want to define subtasks`,
+        throw new HardhatError(
+          HardhatError.ERRORS.TASK_DEFINITIONS.SUBTASK_WITHOUT_PARENT,
+          {
+            task: formatTaskId(taskId.slice(0, i + 1)),
+            subtask: formatTaskId(taskId),
+          },
         );
       }
 
       tasks = currentTask.subtasks;
     }
 
-    const existingTask = tasks.get(taskId[taskId.length - 1]);
-
-    if (existingTask === undefined) {
-      tasks.set(taskId[taskId.length - 1], task);
-      return;
-    }
-
-    const definedByMessage =
-      existingTask.pluginId !== undefined
-        ? ` by plugin ${existingTask.pluginId}`
-        : "";
-
-    if (pluginId !== undefined) {
-      throw new Error(
-        `Plugin ${pluginId} is trying to define the task "${formatTaskId(taskId)}" but it is already defined${definedByMessage}`,
+    // Check that the task doesn't already exist
+    const lastIdFragment = taskId[taskId.length - 1];
+    const existingTask = tasks.get(lastIdFragment);
+    if (existingTask !== undefined) {
+      const exPluginId = existingTask.pluginId;
+      throw new HardhatError(
+        HardhatError.ERRORS.TASK_DEFINITIONS.TASK_ALREADY_DEFINED,
+        {
+          actorFragment: getActorFragment(pluginId),
+          task: formatTaskId(taskId),
+          definedByFragment:
+            exPluginId !== undefined ? ` by plugin ${exPluginId}` : "",
+        },
       );
     }
 
-    throw new Error(
-      `You are trying to defined the task "${formatTaskId(taskId)}" is already defined${definedByMessage}`,
-    );
+    // Insert the task
+    tasks.set(lastIdFragment, task);
   }
 
   #reduceTaskDefinition(
@@ -159,6 +173,7 @@ export class TaskManagerImplementation implements TaskManager {
         );
 
         this.#processTaskOverride(taskDefinition);
+        break;
       }
     }
   }
@@ -170,17 +185,16 @@ export class TaskManagerImplementation implements TaskManager {
   ) {
     for (const namedParamName of Object.keys(taskDefinition.namedParameters)) {
       const globalParamEntry = globalParameterIndex.get(namedParamName);
-
       if (globalParamEntry !== undefined) {
-        if (pluginId === undefined) {
-          throw new Error(
-            `Trying to define task "${formatTaskId(taskDefinition.id)}" with the named parameter ${namedParamName} but it is already defined as a global parameter by plugin ${globalParamEntry.pluginId}`,
-          );
-        } else {
-          throw new Error(
-            `Plugin ${pluginId} trying to define task "${formatTaskId(taskDefinition.id)}" with the named parameter ${namedParamName} but it is already defined as a global parameter by plugin ${globalParamEntry.pluginId}`,
-          );
-        }
+        throw new HardhatError(
+          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_PARAMETER_ALREADY_DEFINED,
+          {
+            actorFragment: getActorFragment(pluginId),
+            task: formatTaskId(taskDefinition.id),
+            namedParamName,
+            globalParamPluginId: globalParamEntry.pluginId,
+          },
+        );
       }
     }
   }
@@ -190,34 +204,21 @@ export class TaskManagerImplementation implements TaskManager {
     pluginId?: string,
   ) {
     const task = this.getTask(taskDefinition.id);
-    if (task === undefined) {
-      if (pluginId !== undefined) {
-        throw new Error(
-          `Plugin ${pluginId} is trying to override the task "${formatTaskId(taskDefinition.id)}" but it hasn't been defined`,
-        );
-      } else {
-        throw new Error(
-          `Trying to override the task "${formatTaskId(taskDefinition.id)}" but it hasn't been defined`,
+    for (const [namedParamName, namedParamValue] of Object.entries(
+      taskDefinition.namedParameters,
+    )) {
+      if (task.namedParameters.has(namedParamName)) {
+        throw new HardhatError(
+          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OVERRIDE_PARAMETER_ALREADY_DEFINED,
+          {
+            actorFragment: getActorFragment(pluginId),
+            namedParamName,
+            task: formatTaskId(taskDefinition.id),
+          },
         );
       }
-    }
 
-    for (const paramName of Object.keys(taskDefinition.namedParameters)) {
-      if (task.namedParameters.has(paramName)) {
-        if (pluginId !== undefined) {
-          throw new Error(
-            `Plugin ${pluginId} is trying to override the named parameter ${paramName} of the task "${formatTaskId(taskDefinition.id)}" but it is already defined`,
-          );
-        } else {
-          throw new Error(
-            `Trying to override the named parameter ${paramName} of the task "${formatTaskId(taskDefinition.id)}" but it is already defined`,
-          );
-        }
-      }
-    }
-
-    for (const namedParam of Object.values(taskDefinition.namedParameters)) {
-      task.namedParameters.set(namedParam.name, namedParam);
+      task.namedParameters.set(namedParamName, namedParamValue);
     }
 
     if (taskDefinition.description !== undefined) {

--- a/v-next/core/src/internal/tasks/task-manager.ts
+++ b/v-next/core/src/internal/tasks/task-manager.ts
@@ -206,7 +206,10 @@ export class TaskManagerImplementation implements TaskManager {
     for (const [namedParamName, namedParamValue] of Object.entries(
       taskDefinition.namedParameters,
     )) {
-      if (task.namedParameters.has(namedParamName)) {
+      const hasArgument =
+        task.namedParameters.has(namedParamName) ||
+        task.positionalParameters.some((p) => p.name === namedParamName);
+      if (hasArgument) {
         throw new HardhatError(
           HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OVERRIDE_PARAMETER_ALREADY_DEFINED,
           {

--- a/v-next/core/src/internal/tasks/task-manager.ts
+++ b/v-next/core/src/internal/tasks/task-manager.ts
@@ -77,8 +77,7 @@ export class TaskManagerImplementation implements TaskManager {
       tasks = task.subtasks;
     }
 
-    // task can't be undefined as we set it in the non-empty loop
-    assertHardhatInvariant(task !== undefined, "Task not found");
+    assertHardhatInvariant(task !== undefined, "Task is undefined despite it being always set by a non-empty loop");
 
     return task;
   }

--- a/v-next/core/src/internal/tasks/task-manager.ts
+++ b/v-next/core/src/internal/tasks/task-manager.ts
@@ -77,7 +77,10 @@ export class TaskManagerImplementation implements TaskManager {
       tasks = task.subtasks;
     }
 
-    assertHardhatInvariant(task !== undefined, "Task is undefined despite it being always set by a non-empty loop");
+    assertHardhatInvariant(
+      task !== undefined,
+      "Task is undefined despite it being always set by a non-empty loop",
+    );
 
     return task;
   }

--- a/v-next/core/src/internal/tasks/task-manager.ts
+++ b/v-next/core/src/internal/tasks/task-manager.ts
@@ -54,7 +54,7 @@ export class TaskManagerImplementation implements TaskManager {
       throw new HardhatError(
         HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND,
         {
-          id: formatTaskId(taskId),
+          task: formatTaskId(taskId),
         },
       );
     }
@@ -68,7 +68,7 @@ export class TaskManagerImplementation implements TaskManager {
         throw new HardhatError(
           HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND,
           {
-            id: formatTaskId(taskId.slice(0, i + 1)),
+            task: formatTaskId(taskId.slice(0, i + 1)),
           },
         );
       }

--- a/v-next/core/src/internal/tasks/utils.ts
+++ b/v-next/core/src/internal/tasks/utils.ts
@@ -6,6 +6,10 @@ export function formatTaskId(taskId: string | string[]): string {
   return taskId.join(" ");
 }
 
+export function getActorFragment(pluginId: string | undefined): string {
+  return pluginId !== undefined ? `Plugin ${pluginId} is` : "You are";
+}
+
 const FILE_PROTOCOL_PATTERN = /^file:\/\/.+/;
 
 export function isValidActionUrl(action: string): boolean {

--- a/v-next/core/test/internal/tasks/builders.ts
+++ b/v-next/core/test/internal/tasks/builders.ts
@@ -42,6 +42,26 @@ describe("Task builders", () => {
       });
     });
 
+    describe("Task id validation", () => {
+      it("should throw if the id is an empty string", () => {
+        assert.throws(() => new NewTaskDefinitionBuilderImplementation(""), {
+          name: "HardhatError",
+          message:
+            "HHE208: Task id cannot be an empty string or an empty array",
+        });
+      });
+
+      it("should throw if the array of ids is empty", () => {
+        const ids: string[] = [];
+
+        assert.throws(() => new NewTaskDefinitionBuilderImplementation(ids), {
+          name: "HardhatError",
+          message:
+            "HHE208: Task id cannot be an empty string or an empty array",
+        });
+      });
+    });
+
     describe("Adding an action", () => {
       it("should create a new task definition builder with an async function action", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
@@ -721,6 +741,32 @@ describe("Task builders", () => {
         description: undefined,
         action: taskAction,
         namedParameters: {},
+      });
+    });
+
+    describe("Task id validation", () => {
+      it("should throw if the id is an empty string", () => {
+        assert.throws(
+          () => new TaskOverrideDefinitionBuilderImplementation(""),
+          {
+            name: "HardhatError",
+            message:
+              "HHE208: Task id cannot be an empty string or an empty array",
+          },
+        );
+      });
+
+      it("should throw if the array of ids is empty", () => {
+        const ids: string[] = [];
+
+        assert.throws(
+          () => new TaskOverrideDefinitionBuilderImplementation(ids),
+          {
+            name: "HardhatError",
+            message:
+              "HHE208: Task id cannot be an empty string or an empty array",
+          },
+        );
       });
     });
 

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -197,6 +197,51 @@ Please ensure that an action is defined for each task.`,
       websiteDescription:
         "Required positional parameters must be defined before optional ones in a task definition.",
     },
+    TASK_NOT_FOUND: {
+      number: 205,
+      messageTemplate: "Task %task% not found",
+      websiteTitle: "Task not found",
+      websiteDescription: "The provided task name does not match any task.",
+    },
+    SUBTASK_WITHOUT_PARENT: {
+      number: 206,
+      messageTemplate:
+        "Task %task% not found when attempting to define subtask %subtask%. If you intend to only define subtasks, please first define %task% as an empty task",
+      websiteTitle: "Subtask without parent",
+      websiteDescription:
+        "The parent task of the subtask being defined was not found. If you intend to only define subtasks, please first define the parent task as an empty task.",
+    },
+    TASK_ALREADY_DEFINED: {
+      number: 207,
+      messageTemplate:
+        "%actorFragment% trying to define the task %task% but it is already defined%definedByFragment%",
+      websiteTitle: "Task already defined",
+      websiteDescription:
+        "The task is already defined. Please ensure that tasks are uniquely named to avoid conflicts.",
+    },
+    EMPTY_TASK_ID: {
+      number: 208,
+      messageTemplate: "Task id cannot be an empty string or an empty array",
+      websiteTitle: "Empty task id",
+      websiteDescription:
+        "The task id cannot be an empty string or an empty array. Please ensure that the array of task names is not empty.",
+    },
+    TASK_PARAMETER_ALREADY_DEFINED: {
+      number: 209,
+      messageTemplate:
+        "%actorFragment% trying to define task %task% with the named parameter %namedParamName% but it is already defined as a global parameter by plugin %globalParamPluginId%",
+      websiteTitle: "Task parameter already defined",
+      websiteDescription:
+        "The task named parameter is already defined as a global parameter by another plugin. Please ensure that task parameters are uniquely named to avoid conflicts.",
+    },
+    TASK_OVERRIDE_PARAMETER_ALREADY_DEFINED: {
+      number: 210,
+      messageTemplate:
+        "%actorFragment% trying to override the named parameter %namedParamName% of the task %task% but it is already defined",
+      websiteTitle: "Task override parameter already defined",
+      websiteDescription:
+        "An attempt is being made to override a named parameter that has already been defined. Please ensure that the parameter is not defined before trying to override it.",
+    },
   },
   ARGUMENTS: {
     INVALID_VALUE_FOR_TYPE: {

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -237,10 +237,10 @@ Please ensure that an action is defined for each task.`,
     TASK_OVERRIDE_PARAMETER_ALREADY_DEFINED: {
       number: 210,
       messageTemplate:
-        "{actorFragment} trying to override the named parameter {namedParamName} of the task {task} but it is already defined",
+        "{actorFragment} trying to override the parameter {namedParamName} of the task {task} but it is already defined",
       websiteTitle: "Task override parameter already defined",
       websiteDescription:
-        "An attempt is being made to override a named parameter that has already been defined. Please ensure that the parameter is not defined before trying to override it.",
+        "An attempt is being made to override a parameter that has already been defined. Please ensure that the parameter is not defined before trying to override it.",
     },
   },
   ARGUMENTS: {

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -199,14 +199,14 @@ Please ensure that an action is defined for each task.`,
     },
     TASK_NOT_FOUND: {
       number: 205,
-      messageTemplate: "Task %task% not found",
+      messageTemplate: "Task {task} not found",
       websiteTitle: "Task not found",
       websiteDescription: "The provided task name does not match any task.",
     },
     SUBTASK_WITHOUT_PARENT: {
       number: 206,
       messageTemplate:
-        "Task %task% not found when attempting to define subtask %subtask%. If you intend to only define subtasks, please first define %task% as an empty task",
+        "Task {task} not found when attempting to define subtask {subtask}. If you intend to only define subtasks, please first define {task} as an empty task",
       websiteTitle: "Subtask without parent",
       websiteDescription:
         "The parent task of the subtask being defined was not found. If you intend to only define subtasks, please first define the parent task as an empty task.",
@@ -214,7 +214,7 @@ Please ensure that an action is defined for each task.`,
     TASK_ALREADY_DEFINED: {
       number: 207,
       messageTemplate:
-        "%actorFragment% trying to define the task %task% but it is already defined%definedByFragment%",
+        "{actorFragment} trying to define the task {task} but it is already defined{definedByFragment}",
       websiteTitle: "Task already defined",
       websiteDescription:
         "The task is already defined. Please ensure that tasks are uniquely named to avoid conflicts.",
@@ -229,7 +229,7 @@ Please ensure that an action is defined for each task.`,
     TASK_PARAMETER_ALREADY_DEFINED: {
       number: 209,
       messageTemplate:
-        "%actorFragment% trying to define task %task% with the named parameter %namedParamName% but it is already defined as a global parameter by plugin %globalParamPluginId%",
+        "{actorFragment} trying to define task {task} with the named parameter {namedParamName} but it is already defined as a global parameter by plugin {globalParamPluginId}",
       websiteTitle: "Task parameter already defined",
       websiteDescription:
         "The task named parameter is already defined as a global parameter by another plugin. Please ensure that task parameters are uniquely named to avoid conflicts.",
@@ -237,7 +237,7 @@ Please ensure that an action is defined for each task.`,
     TASK_OVERRIDE_PARAMETER_ALREADY_DEFINED: {
       number: 210,
       messageTemplate:
-        "%actorFragment% trying to override the named parameter %namedParamName% of the task %task% but it is already defined",
+        "{actorFragment} trying to override the named parameter {namedParamName} of the task {task} but it is already defined",
       websiteTitle: "Task override parameter already defined",
       websiteDescription:
         "An attempt is being made to override a named parameter that has already been defined. Please ensure that the parameter is not defined before trying to override it.",


### PR DESCRIPTION
This PR may be hard to read as there are a bunch of changes to the same file and the diff doesn't look good. Here's a summary of the most important changes:

- Replaced all Errors with HardhatErrors. Added error descriptors for each error.
- Added validation to the task builders to account for empty IDs (either empty string or empty array), along with tests.
- Added comments to make the code more legible.
- Since most errors can be thrown by a task added by the user or by a plugin, I've added a `getActorFragment` helper to avoid some of the branching and to prevent having different descriptors for the same error type.
- Used `assertHardhatInvariant` to avoid the non-null assertion in `getTask`.
- Updated `#insertTask` by moving the successful case to the end and handling errors first if there's an `existingTask`.
- Removed the check for an `undefined` task in `#processTaskOverride` as the call to `getTask` will throw an error if the task can't be found.
- Used `Object.entries` in `#processTaskOverride` to avoid looping over the named params twice.

Part of https://github.com/NomicFoundation/hardhat/issues/5229