### PR TITLE
refactor: rename from validation to detection

### DIFF
--- a/v-next/core/src/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/src/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -17,7 +17,7 @@ import { HardhatPlugin } from "../../types/plugins.js";
  * - {@link ERRORS.ARTIFACTS.PLUGIN_MISSING_DEPENDENCY} if the plugin's package peer dependency is not installed
  * - {@link ERRORS.ARTIFACTS.DEPENDENCY_VERSION_MISMATCH} if the plugin's package peer dependency is installed but has the wrong version
  */
-export async function validatePluginNpmDependencies(
+export async function detectPluginNpmDependencyProblems(
   plugin: HardhatPlugin,
   basePathForNpmResolution: string,
 ): Promise<void> {

--- a/v-next/core/src/internal/plugins/resolve-plugin-list.ts
+++ b/v-next/core/src/internal/plugins/resolve-plugin-list.ts
@@ -3,7 +3,7 @@ import type { HardhatPlugin } from "../../types/plugins.js";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
-import { validatePluginNpmDependencies } from "./plugin-validation.js";
+import { detectPluginNpmDependencyProblems } from "./detect-plugin-npm-dependency-problems.js";
 
 /**
  * Resolves the plugin list, returning them in the right order.
@@ -87,7 +87,7 @@ async function loadDependency(
   } catch (error) {
     ensureError(error);
 
-    await validatePluginNpmDependencies(plugin, basePathForNpmResolution);
+    await detectPluginNpmDependencyProblems(plugin, basePathForNpmResolution);
 
     throw new HardhatError(
       HardhatError.ERRORS.PLUGINS.PLUGIN_DEPENDENCY_FAILED_LOAD,

--- a/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -115,7 +115,7 @@ describe("Plugins - detect npm dependency problems", () => {
         {
           name: "HardhatError",
           message:
-            'HHE1202: Plugin "example-plugin" has a peer dependency "peer2" with version "2.0.0" but version "^1.0.0" is needed.',
+            'HHE1202: Plugin "example-plugin" has a peer dependency "peer2" with expected version "^1.0.0" but the installed version is "2.0.0".',
         },
       );
     });

--- a/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { validatePluginNpmDependencies } from "../../../src/internal/plugins/plugin-validation.js";
+import { detectPluginNpmDependencyProblems } from "../../../src/internal/plugins/detect-plugin-npm-dependency-problems.js";
 import { HardhatPlugin } from "../../../src/types/plugins.js";
 
-describe("Plugins - plugin validation", () => {
+describe("Plugins - detect npm dependency problems", () => {
   const plugin: HardhatPlugin = {
     id: "example-plugin",
     npmPackage: "example",
@@ -16,7 +16,7 @@ describe("Plugins - plugin validation", () => {
     );
 
     await assert.doesNotReject(async () =>
-      validatePluginNpmDependencies(
+      detectPluginNpmDependencyProblems(
         {
           ...plugin,
           npmPackage: undefined,
@@ -33,7 +33,10 @@ describe("Plugins - plugin validation", () => {
       );
 
       await assert.doesNotReject(async () =>
-        validatePluginNpmDependencies(plugin, installedPackageProjectFixture),
+        detectPluginNpmDependencyProblems(
+          plugin,
+          installedPackageProjectFixture,
+        ),
       );
     });
 
@@ -44,7 +47,7 @@ describe("Plugins - plugin validation", () => {
 
       await assert.rejects(
         async () =>
-          validatePluginNpmDependencies(
+          detectPluginNpmDependencyProblems(
             plugin,
             nonInstalledPackageProjectFixture,
           ),
@@ -64,7 +67,7 @@ describe("Plugins - plugin validation", () => {
         );
 
         await assert.doesNotReject(async () =>
-          validatePluginNpmDependencies(plugin, installedPeerDepsFixture),
+          detectPluginNpmDependencyProblems(plugin, installedPeerDepsFixture),
         );
       });
 
@@ -74,7 +77,7 @@ describe("Plugins - plugin validation", () => {
         );
 
         await assert.rejects(
-          validatePluginNpmDependencies(plugin, notInstalledPeerDepFixture),
+          detectPluginNpmDependencyProblems(plugin, notInstalledPeerDepFixture),
           {
             name: "HardhatError",
             message:
@@ -91,7 +94,7 @@ describe("Plugins - plugin validation", () => {
         );
 
         await assert.doesNotReject(async () =>
-          validatePluginNpmDependencies(plugin, installedPeerDepsFixture),
+          detectPluginNpmDependencyProblems(plugin, installedPeerDepsFixture),
         );
       });
     });
@@ -105,7 +108,10 @@ describe("Plugins - plugin validation", () => {
 
       await assert.rejects(
         async () =>
-          validatePluginNpmDependencies(plugin, peerDepWithWrongVersionFixture),
+          detectPluginNpmDependencyProblems(
+            plugin,
+            peerDepWithWrongVersionFixture,
+          ),
         {
           name: "HardhatError",
           message:

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -588,7 +588,7 @@ A fully qualified name should look like file.sol:Contract`,
       number: 1200,
       messageTemplate: 'Plugin "{pluginId}" is not installed.',
       websiteTitle: "Plugin not installed",
-      websiteDescription: `A plugin was included in the Hardhat config but has not been installed.`,
+      websiteDescription: `A plugin was included in the Hardhat config but has not been installed into "node_modules".`,
     },
     PLUGIN_MISSING_DEPENDENCY: {
       number: 1201,
@@ -600,15 +600,17 @@ A fully qualified name should look like file.sol:Contract`,
     DEPENDENCY_VERSION_MISMATCH: {
       number: 1202,
       messageTemplate:
-        'Plugin "{pluginId}" has a peer dependency "{peerDependencyName}" with version "{installedVersion}" but version "{expectedVersion}" is needed.',
+        'Plugin "{pluginId}" has a peer dependency "{peerDependencyName}" with expected version "{expectedVersion}" but the installed version is "{installedVersion}".',
       websiteTitle: "Dependency version mismatch",
-      websiteDescription: `A plugin's peer dependency version does not match the expected version.`,
+      websiteDescription: `A plugin's peer dependency expected version does not match the version of the installed package.
+
+Please install a version of the peer dependency that meets the plugin's requirements.`,
     },
     PLUGIN_DEPENDENCY_FAILED_LOAD: {
       number: 1203,
       messageTemplate: 'Plugin "{pluginId}" dependency could not be loaded.',
       websiteTitle: "Plugin dependency could not be loaded",
-      websiteDescription: `A plugin's dependent plugin could not be lazily loaded.`,
+      websiteDescription: `The loading of a plugin's dependent plugin failed.`,
     },
   },
 } as const;


### PR DESCRIPTION
This is a follow up PR on the npm plugin dependency validation.

It does two things:

1. Renames the plugin installation validation function to `detectPluginNpmDependencyProblems`
2. Expands some of the related error messages to provide more details.

Resolves #5287 
