### PR TITLE
Disable compilation errors on unused variables

### DIFF
--- a/config-v-next/tsconfig.json
+++ b/config-v-next/tsconfig.json
@@ -7,8 +7,6 @@
     "isolatedModules": true,
     "noEmitOnError": true,
     "noImplicitOverride": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "skipDefaultLibCheck": true,
     "sourceMap": true
   }


### PR DESCRIPTION
This PR disables these compilation settings. It doesn't modify the linter config, as the rule to forbid unused variables was already enabled 😅