### PR TITLE
[v-next] eslint config update rules

### DIFF
--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -94,7 +94,10 @@ function createConfig(configFilePath, packageEntryPoints = []) {
           minimumDescriptionLength: 3,
         },
       ],
-      "@typescript-eslint/consistent-type-assertions": "error",
+      "@typescript-eslint/consistent-type-assertions": [
+        "error",
+        { assertionStyle: "never" },
+      ],
       "@typescript-eslint/consistent-type-definitions": "error",
       "@typescript-eslint/dot-notation": "error",
       "@typescript-eslint/explicit-member-accessibility": [

--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -41,8 +41,13 @@ function createConfig(configFilePath, packageEntryPoints = []) {
       "no-only-tests",
       "@typescript-eslint",
       "@nomicfoundation/slow-imports",
+      "@eslint-community/eslint-comments",
     ],
     rules: {
+      "@eslint-community/eslint-comments/require-description": [
+        "error",
+        { ignore: ["eslint-enable"] },
+      ],
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/array-type": [
         "error",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1438,6 +1438,9 @@ importers:
         specifier: ^7.6.2
         version: 7.6.2
     devDependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.3.0
+        version: 4.3.0(eslint@8.57.0)
       '@microsoft/api-extractor':
         specifier: ^7.43.4
         version: 7.43.4(@types/node@20.12.10)
@@ -1526,6 +1529,9 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.3.0
+        version: 4.3.0(eslint@8.57.0)
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
         version: link:../../packages/eslint-plugin-hardhat-internal-rules
@@ -1635,6 +1641,9 @@ importers:
         specifier: ^6.16.1
         version: 6.16.1
     devDependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.3.0
+        version: 4.3.0(eslint@8.57.0)
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
         version: link:../../packages/eslint-plugin-hardhat-internal-rules
@@ -1726,6 +1735,9 @@ importers:
         specifier: workspace:^3.0.0
         version: link:../hardhat-utils
     devDependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.3.0
+        version: 4.3.0(eslint@8.57.0)
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
         version: link:../../packages/eslint-plugin-hardhat-internal-rules
@@ -1796,6 +1808,9 @@ importers:
         specifier: ^6.16.1
         version: 6.16.1
     devDependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.3.0
+        version: 4.3.0(eslint@8.57.0)
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
         version: link:../../packages/eslint-plugin-hardhat-internal-rules
@@ -1859,6 +1874,9 @@ importers:
 
   v-next/hardhat-zod-utils:
     devDependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.3.0
+        version: 4.3.0(eslint@8.57.0)
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
         version: link:../../packages/eslint-plugin-hardhat-internal-rules
@@ -1922,6 +1940,9 @@ importers:
 
   v-next/template-package:
     devDependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.3.0
+        version: 4.3.0(eslint@8.57.0)
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
         version: link:../../packages/eslint-plugin-hardhat-internal-rules
@@ -2290,6 +2311,12 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.3.0':
+    resolution: {integrity: sha512-6e93KtgsndNkvwCCa07LOQJSwzzLLxwrFll3+huyFoiiQXWG0KBcmo0Q1bVgYQQDLfWOOZl2VPBsXqZL6vHIBQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -7175,6 +7202,12 @@ snapshots:
 
   '@esbuild/win32-x64@0.19.12':
     optional: true
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.3.0(eslint@8.57.0)':
+    dependencies:
+      escape-string-regexp: 4.0.0
+      eslint: 8.57.0
+      ignore: 5.3.1
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
     dependencies:

--- a/v-next/core/package.json
+++ b/v-next/core/package.json
@@ -48,6 +48,7 @@
     "README.md"
   ],
   "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@microsoft/api-extractor": "^7.43.4",
     "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",

--- a/v-next/core/src/internal/async-mutex.ts
+++ b/v-next/core/src/internal/async-mutex.ts
@@ -23,7 +23,6 @@ export class AsyncMutex {
     try {
       /* eslint-disable-next-line @typescript-eslint/return-await, @typescript-eslint/await-thenable -- We want to make sure that we await the result if it's a promise, and that the finally is run after it */
       return await f();
-      /* eslint-enable @typescript-eslint/return-await, @typescript-eslint/await-thenable */
     } finally {
       await release();
     }

--- a/v-next/core/src/internal/async-mutex.ts
+++ b/v-next/core/src/internal/async-mutex.ts
@@ -21,8 +21,9 @@ export class AsyncMutex {
     const release = await this.#acquire();
 
     try {
-      // eslint-disable-next-line @typescript-eslint/return-await, @typescript-eslint/await-thenable
+      /* eslint-disable-next-line @typescript-eslint/return-await, @typescript-eslint/await-thenable -- We want to make sure that we await the result if it's a promise, and that the finally is run after it */
       return await f();
+      /* eslint-enable @typescript-eslint/return-await, @typescript-eslint/await-thenable */
     } finally {
       await release();
     }

--- a/v-next/core/src/internal/global-parameters.ts
+++ b/v-next/core/src/internal/global-parameters.ts
@@ -73,5 +73,6 @@ export function resolveGlobalArguments(
   // TODO: Validate the userProvidedGlobalArguments and get the remaining ones
   // from env variables
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TODO
   return userProvidedGlobalArguments as GlobalArguments;
 }

--- a/v-next/core/src/internal/hook-manager.ts
+++ b/v-next/core/src/internal/hook-manager.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions -- Typescript
+can handle the generic types in this file correctly. It can do it for function
+signatures, but not for function bodies. */
 import {
   ChainedHook,
   HookContext,

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -172,10 +172,10 @@ async function resolveUserConfig(
   sortedPlugins: HardhatPlugin[],
   config: HardhatUserConfig,
 ): Promise<HardhatConfig> {
-  const initialResolvedConfig = {
+  const initialResolvedConfig: HardhatConfig = {
     plugins: sortedPlugins,
     tasks: config.tasks ?? [],
-  } as HardhatConfig;
+  };
 
   return hooks.runHandlerChain(
     "config",

--- a/v-next/core/src/internal/user-interruptions.ts
+++ b/v-next/core/src/internal/user-interruptions.ts
@@ -1,3 +1,5 @@
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+
 import { HookContext, HookManager } from "../types/hooks.js";
 import { UserInterruptionManager } from "../types/user-interruptions.js";
 
@@ -116,22 +118,24 @@ async function defaultRequestSecretInput(
         initialMessage = out;
       }
 
+      assertHardhatInvariant(
+        rlAsAny.output,
+        "Espected readline output to be defined",
+      );
+
       // We shouw the initial message as is
       if (out.startsWith(initialMessage)) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        rlAsAny.output!.write(initialMessage);
+        rlAsAny.output.write(initialMessage);
         out = out.slice(initialMessage.length);
       } else if (out.trim() === "") {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        rlAsAny.output!.write(out);
+        rlAsAny.output.write(out);
         out = "";
       }
     }
 
     // We show the rest of the chars as "*"
     for (const _ of out) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      rlAsAny.output!.write("*");
+      rlAsAny.output.write("*");
     }
   };
 

--- a/v-next/core/src/internal/user-interruptions.ts
+++ b/v-next/core/src/internal/user-interruptions.ts
@@ -108,6 +108,8 @@ async function defaultRequestSecretInput(
     output: process.stdout,
   });
 
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- 
+  We need to access a private property of the readline interface. */
   const rlAsAny = rl as any;
 
   let initialMessage: string | undefined;

--- a/v-next/core/test/internal/tasks/builders.ts
+++ b/v-next/core/test/internal/tasks/builders.ts
@@ -618,6 +618,8 @@ describe("Task builders", () => {
             () =>
               builder[fnName]({
                 name: "param",
+                /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+                Intentionally testing an invalid type */
                 defaultValue: 123 as any,
                 type: ParameterType.STRING,
               }),
@@ -633,6 +635,8 @@ describe("Task builders", () => {
           () =>
             builder.addVariadicParameter({
               name: "param",
+              /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+              Intentionally testing an invalid type */
               defaultValue: [123, 456, 789] as any,
               type: ParameterType.STRING,
             }),
@@ -1042,6 +1046,8 @@ describe("Task builders", () => {
           () =>
             builder.addNamedParameter({
               name: "param",
+              /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+              Intentionally testing an invalid type */
               defaultValue: 123 as any,
               type: ParameterType.STRING,
             }),

--- a/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
+++ b/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
@@ -12,7 +12,19 @@ describe("UserInterruptionManager", () => {
       const userInterruptionManager = new UserInterruptionManagerImplementation(
         hookManager,
       );
-      hookManager.setContext({} as any);
+
+      // TODO: Setting the context like this is a bit fragile. If this test
+      // breaks we should probably switch to initializing an entire HRE in these
+      // tests.
+      hookManager.setContext({
+        config: {
+          tasks: [],
+          plugins: [],
+        },
+        globalArguments: {},
+        hooks: hookManager,
+        interruptions: userInterruptionManager,
+      });
 
       let called = false;
       let givenInterruptor: string = "";
@@ -45,7 +57,15 @@ describe("UserInterruptionManager", () => {
       const userInterruptionManager = new UserInterruptionManagerImplementation(
         hookManager,
       );
-      hookManager.setContext({} as any);
+      hookManager.setContext({
+        config: {
+          tasks: [],
+          plugins: [],
+        },
+        globalArguments: {},
+        hooks: hookManager,
+        interruptions: userInterruptionManager,
+      });
 
       let called = false;
       let givenInterruptor: string = "";
@@ -80,7 +100,15 @@ describe("UserInterruptionManager", () => {
       const userInterruptionManager = new UserInterruptionManagerImplementation(
         hookManager,
       );
-      hookManager.setContext({} as any);
+      hookManager.setContext({
+        config: {
+          tasks: [],
+          plugins: [],
+        },
+        globalArguments: {},
+        hooks: hookManager,
+        interruptions: userInterruptionManager,
+      });
 
       let called = false;
       let givenInterruptor: string = "";

--- a/v-next/hardhat-build-system/package.json
+++ b/v-next/hardhat-build-system/package.json
@@ -55,6 +55,7 @@
     "undici": "^6.16.1"
   },
   "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@reporters/github": "^1.7.0",

--- a/v-next/hardhat-build-system/src/internal/solidity/compilation-job.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compilation-job.ts
@@ -83,9 +83,9 @@ export async function createCompilationJobsFromConnectedComponent(
 
     if (isCompilationJobCreationError(compilationJobOrError)) {
       log(
-        `'${file.absolutePath}' couldn't be compiled. Reason: '${
-          compilationJobOrError as any
-        }'`,
+        `'${file.absolutePath}' couldn't be compiled. Reason: '${JSON.stringify(
+          compilationJobOrError,
+        )}'`,
       );
       errors.push(compilationJobOrError);
       continue;

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
@@ -51,6 +51,8 @@ export class Compiler implements ICompiler {
    * babel/register and hang the process.
    */
   #loadCompilerSources(compilerPath: string) {
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+    TODO: This was already replaced in `main`. */
     const Module = module.constructor as any;
 
     // if Hardhat is bundled (for example, in the vscode extension), then

--- a/v-next/hardhat-build-system/src/internal/solidity/parse.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/parse.ts
@@ -1,5 +1,3 @@
-import type SolidityAnalyzerT from "@nomicfoundation/solidity-analyzer";
-
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
@@ -31,9 +29,7 @@ export class Parser {
     }
 
     try {
-      const { analyze } = (await import(
-        "@nomicfoundation/solidity-analyzer"
-      )) as typeof SolidityAnalyzerT;
+      const { analyze } = await import("@nomicfoundation/solidity-analyzer");
       const result = analyze(fileContent);
 
       this.#cache.set(contentHash, result);

--- a/v-next/hardhat-build-system/src/internal/solidity/parse.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/parse.ts
@@ -50,7 +50,7 @@ export class Parser {
         throw new HardhatError(HardhatError.ERRORS.GENERAL.CORRUPTED_LOCKFILE);
       }
 
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw e;
     }
   }

--- a/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
@@ -297,7 +297,7 @@ export class Resolver {
         );
       }
 
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw error;
     }
   }
@@ -576,7 +576,7 @@ export class Resolver {
         );
       }
 
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw error;
     }
   }

--- a/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
@@ -5,6 +5,7 @@ import {
   HardhatError,
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import resolve from "resolve";
 
 import {
@@ -339,12 +340,14 @@ export class Resolver {
         const hardhatCoreDir = path.join(__dirname, "..", "..");
         packageJsonPath = path.join(hardhatCoreDir, "package.json");
       } else {
+        ensureError(error);
+
         throw new HardhatError(
           HardhatError.ERRORS.RESOLVER.LIBRARY_NOT_INSTALLED,
           {
             library: libraryName,
           },
-          error as Error,
+          error,
         );
       }
     }

--- a/v-next/hardhat-build-system/src/internal/tasks.ts
+++ b/v-next/hardhat-build-system/src/internal/tasks.ts
@@ -821,6 +821,8 @@ export async function taskCompileSolidityLogCompilationErrors(
       console.error(errorMessage.replace(/^\w+:/, (t) => chalk.red.bold(t)));
     } else {
       console.warn(
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+        This is not typed, but a string is returned by solidity */
         (error.formattedMessage as string).replace(/^\w+:/, (t) =>
           chalk.yellow.bold(t),
         ),
@@ -1174,8 +1176,9 @@ export async function taskCompileSolidityLogCompilationResult(
 // TASK_COMPILE_REMOVE_OBSOLETE_ARTIFACTS
 // TESTED
 export async function taskCompileRemoveObsoleteArtifacts(artifacts: Artifacts) {
-  // We know this is the actual implementation, so we use some
-  // non-public methods here.
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- 
+  We know this is the actual implementation, so we use some non-public methods 
+  here by downcasting */
   const artifactsImpl = artifacts as ArtifactsImpl;
   await artifactsImpl.removeObsoleteArtifacts();
 }
@@ -1333,8 +1336,9 @@ export async function taskCompileSolidity(
 
   const allArtifactsEmittedPerFile = solidityFilesCache.getEntries();
 
-  // We know this is the actual implementation, so we use some
-  // non-public methods here.
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- 
+  We know this is the actual implementation, so we use some non-public methods 
+  here by downcasting */
   const artifactsImpl = artifacts as ArtifactsImpl;
   artifactsImpl.addValidArtifacts(allArtifactsEmittedPerFile);
 

--- a/v-next/hardhat-build-system/src/internal/tasks.ts
+++ b/v-next/hardhat-build-system/src/internal/tasks.ts
@@ -127,7 +127,7 @@ export async function taskCompileSolidityReadFile(
       );
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw e;
   }
 }
@@ -1102,7 +1102,7 @@ export async function taskCompileSolidityCompileJobs(
     return { artifactsEmittedPerJob };
   } catch (e) {
     if (!(e instanceof AggregateError)) {
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw e;
     }
 
@@ -1113,7 +1113,7 @@ export async function taskCompileSolidityCompileJobs(
           HardhatError.ERRORS.BUILTIN_TASKS.COMPILE_FAILURE,
         )
       ) {
-        // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+        // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
         throw error;
       }
     }

--- a/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
@@ -612,7 +612,7 @@ export class Artifacts implements IArtifacts {
       case 0:
         return "";
       case 1:
-        return `Did you mean "${names[0] as string}"?`;
+        return `Did you mean "${names[0]}"?`;
       default:
         return `We found some that were similar:
 
@@ -683,14 +683,10 @@ Please replace "${contractName}" for the correct contract name wherever you are 
     similarNames: string[],
   ): string[] {
     const outputNames = [];
-    const groups = similarNames.reduce(
-      (obj, cur) => {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Re-throwing the error
-        obj[cur] = obj[cur] ? (obj[cur] as number) + 1 : 1;
-        return obj;
-      },
-      {} as { [k: string]: number },
-    );
+    const groups = similarNames.reduce<{ [k: string]: number }>((obj, cur) => {
+      obj[cur] = obj[cur] !== undefined ? obj[cur] + 1 : 1;
+      return obj;
+    }, {});
 
     for (const [name, occurrences] of Object.entries(groups)) {
       if (occurrences > 1) {

--- a/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
@@ -94,7 +94,7 @@ export class Artifacts implements IArtifacts {
         return false;
       }
 
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw e;
     }
 
@@ -590,7 +590,7 @@ export class Artifacts implements IArtifacts {
         );
       }
 
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw e;
     }
   }
@@ -685,7 +685,7 @@ Please replace "${contractName}" for the correct contract name wherever you are 
     const outputNames = [];
     const groups = similarNames.reduce(
       (obj, cur) => {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Re-throwing the error
         obj[cur] = obj[cur] ? (obj[cur] as number) + 1 : 1;
         return obj;
       },

--- a/v-next/hardhat-build-system/src/internal/utils/contract-names.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/contract-names.ts
@@ -154,8 +154,8 @@ export function findDistance(a: string, b: string): number {
     bx3 = b.charCodeAt(offset + (d3 = x + 3));
     dd = x += 4;
     for (y = 0; y < len; y += 2) {
-      dy = vector[y] as number;
-      ay = vector[y + 1] as number;
+      dy = vector[y];
+      ay = vector[y + 1];
       d0 = _min(dy, d0, d1, bx0, ay);
       d1 = _min(d0, d1, d2, bx1, ay);
       d2 = _min(d1, d2, d3, bx2, ay);
@@ -172,8 +172,8 @@ export function findDistance(a: string, b: string): number {
     bx0 = b.charCodeAt(offset + (d0 = x));
     dd = ++x;
     for (y = 0; y < len; y += 2) {
-      dy = vector[y] as number;
-      vector[y] = dd = _min(dy, d0, dd, bx0, vector[y + 1] as number);
+      dy = vector[y];
+      vector[y] = dd = _min(dy, d0, dd, bx0, vector[y + 1]);
       d0 = dy;
     }
   }

--- a/v-next/hardhat-build-system/src/internal/utils/fs-utils.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/fs-utils.ts
@@ -52,11 +52,11 @@ async function readdir(absolutePathToDir: string) {
     }
 
     if (e.code === "ENOTDIR") {
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw new InvalidDirectoryError(absolutePathToDir, e);
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw new FileSystemAccessError(e.message, e);
   }
 }
@@ -106,7 +106,7 @@ export async function getFileTrueCase(
     }
   }
 
-  // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+  // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
   throw new FileNotFoundError(path.join(from, relativePath));
 }
 
@@ -156,11 +156,11 @@ function readdirSync(absolutePathToDir: string) {
     }
 
     if (e.code === "ENOTDIR") {
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw new InvalidDirectoryError(absolutePathToDir, e);
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw new FileSystemAccessError(e.message, e);
   }
 }
@@ -201,7 +201,7 @@ export function getFileTrueCaseSync(
     }
   }
 
-  // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+  // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
   throw new FileNotFoundError(path.join(from, relativePath));
 }
 
@@ -222,11 +222,11 @@ export async function getRealPath(absolutePath: string): Promise<string> {
     }
 
     if (e.code === "ENOENT") {
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw new FileNotFoundError(absolutePath, e);
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw new FileSystemAccessError(e.message, e);
   }
 }
@@ -248,11 +248,11 @@ export function getRealPathSync(absolutePath: string): string {
     }
 
     if (e.code === "ENOENT") {
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw new FileNotFoundError(absolutePath, e);
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw new FileSystemAccessError(e.message, e);
   }
 }

--- a/v-next/hardhat-build-system/src/internal/utils/multi-process-mutex.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/multi-process-mutex.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @nomicfoundation/hardhat-internal-rules/only-hardhat-error */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/v-next/hardhat-build-system/src/internal/utils/source-names.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/source-names.ts
@@ -70,7 +70,7 @@ async function getSourceNameTrueCase(
       );
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw error;
   }
 }
@@ -157,7 +157,7 @@ export async function isLocalSourceName(
       return false;
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw error;
   }
 

--- a/v-next/hardhat-build-system/test/index.ts
+++ b/v-next/hardhat-build-system/test/index.ts
@@ -1,6 +1,4 @@
-// TODO: remove this TS rule?
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
+/* eslint-disable @typescript-eslint/no-non-null-assertion -- TODO: remove this */
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
@@ -366,7 +364,7 @@ describe("build-system", () => {
        * command operates as a separate process. To resolve this, the private
        * variable should be cleared after each run of the compile task.
        */
-      // eslint-disable-next-line @typescript-eslint/dot-notation
+      // eslint-disable-next-line @typescript-eslint/dot-notation -- TODO
       // (this.env.artifacts as any)["_validArtifacts"] = [];
 
       await buildSystem.build({
@@ -422,7 +420,7 @@ describe("build-system", () => {
        * command operates as a separate process. To resolve this, the private
        * variable should be cleared after each run of the compile task.
        */
-      // eslint-disable-next-line @typescript-eslint/dot-notation
+      // eslint-disable-next-line @typescript-eslint/dot-notation -- TODO
       // (this.env.artifacts as any)["_validArtifacts"] = [];
 
       await buildSystem.build({

--- a/v-next/hardhat-build-system/test/internal/utils/artifacts.ts
+++ b/v-next/hardhat-build-system/test/internal/utils/artifacts.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions -- TODO: Stop
+using invalid objects in tests */
 import assert from "node:assert/strict";
 import * as os from "node:os";
 import path from "node:path";

--- a/v-next/hardhat-errors/package.json
+++ b/v-next/hardhat-errors/package.json
@@ -36,6 +36,7 @@
     "README.md"
   ],
   "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@reporters/github": "^1.7.0",

--- a/v-next/hardhat-errors/src/errors.ts
+++ b/v-next/hardhat-errors/src/errors.ts
@@ -82,7 +82,7 @@ export class HardhatError<
       messageArgumentsOrParentError instanceof Error
     ) {
       /* eslint-disable @typescript-eslint/consistent-type-assertions -- 
-      Typescript infercente get's lost here, but we know that if we didn't get
+      Typescript inference get's lost here, but we know that if we didn't get
       arguments, it's because the error doesn't have any. */
       this.#arguments = {} as MessagetTemplateArguments<
         ErrorDescriptorT["messageTemplate"]

--- a/v-next/hardhat-errors/src/errors.ts
+++ b/v-next/hardhat-errors/src/errors.ts
@@ -81,6 +81,9 @@ export class HardhatError<
       messageArgumentsOrParentError === undefined ||
       messageArgumentsOrParentError instanceof Error
     ) {
+      /* eslint-disable @typescript-eslint/consistent-type-assertions -- 
+      Typescript infercente get's lost here, but we know that if we didn't get
+      arguments, it's because the error doesn't have any. */
       this.#arguments = {} as MessagetTemplateArguments<
         ErrorDescriptorT["messageTemplate"]
       >;

--- a/v-next/hardhat-errors/test/errors.ts
+++ b/v-next/hardhat-errors/test/errors.ts
@@ -162,6 +162,8 @@ describe("Error categories", () => {
 
 describe("Error descriptors", () => {
   it("Should have all errors inside their ranges", () => {
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+    We kwow that this is correct */
     for (const errorGroup of Object.keys(HardhatError.ERRORS) as Array<
       keyof typeof HardhatError.ERRORS
     >) {
@@ -184,6 +186,8 @@ describe("Error descriptors", () => {
   });
 
   it("Shouldn't repeat error numbers", () => {
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+    We kwow that this is correct */
     for (const errorGroup of Object.keys(HardhatError.ERRORS) as Array<
       keyof typeof HardhatError.ERRORS
     >) {
@@ -206,6 +210,8 @@ describe("Error descriptors", () => {
   });
 
   it("Should keep the numbers in order, without gaps", () => {
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+    We kwow that this is correct */
     for (const errorGroup of Object.keys(HardhatError.ERRORS) as Array<
       keyof typeof HardhatError.ERRORS
     >) {
@@ -394,7 +400,8 @@ describe("Type tests", () => {
     describe("Edge cases", () => {
       it("Should support {}", () => {
         expectTypeOf<MessagetTemplateArguments<"foo {} {}">>().toEqualTypeOf<{
-          // eslint-disable-next-line @typescript-eslint/naming-convention -- This test case is intentionally testing a weird variable name
+          /* eslint-disable-next-line @typescript-eslint/naming-convention -- 
+          This test case is intentionally testing a weird variable name */
           "": ErrorMessageTemplateValue;
         }>();
       });

--- a/v-next/hardhat-errors/test/errors.ts
+++ b/v-next/hardhat-errors/test/errors.ts
@@ -394,7 +394,7 @@ describe("Type tests", () => {
     describe("Edge cases", () => {
       it("Should support {}", () => {
         expectTypeOf<MessagetTemplateArguments<"foo {} {}">>().toEqualTypeOf<{
-          // eslint-disable-next-line @typescript-eslint/naming-convention
+          // eslint-disable-next-line @typescript-eslint/naming-convention -- This test case is intentionally testing a weird variable name
           "": ErrorMessageTemplateValue;
         }>();
       });

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -47,6 +47,7 @@
     "README.md"
   ],
   "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@reporters/github": "^1.7.0",

--- a/v-next/hardhat-utils/src/crypto.ts
+++ b/v-next/hardhat-utils/src/crypto.ts
@@ -9,13 +9,12 @@ import { createHash } from "node:crypto";
  * @returns The Keccak-256 hash of the input bytes.
  */
 export async function keccak256(bytes: Uint8Array): Promise<Uint8Array> {
-  /* eslint-disable @typescript-eslint/consistent-type-assertions -- We have to
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We have to
   typecast the import because the type definitions for the `keccak` package are
   incorrect. */
   const { default: createKeccakHash } = (await import("keccak")) as unknown as {
     default: (algorithm: KeccakT.KeccakAlgorithm) => KeccakT.Keccak;
   };
-  /* eslint-enable @typescript-eslint/consistent-type-assertions */
 
   return createKeccakHash("keccak256").update(Buffer.from(bytes)).digest();
 }

--- a/v-next/hardhat-utils/src/crypto.ts
+++ b/v-next/hardhat-utils/src/crypto.ts
@@ -9,11 +9,14 @@ import { createHash } from "node:crypto";
  * @returns The Keccak-256 hash of the input bytes.
  */
 export async function keccak256(bytes: Uint8Array): Promise<Uint8Array> {
-  // We have to typecast the import because the type definitions for the
-  // `keccak` package are incorrect.
+  /* eslint-disable @typescript-eslint/consistent-type-assertions -- We have to
+  typecast the import because the type definitions for the `keccak` package are
+  incorrect. */
   const { default: createKeccakHash } = (await import("keccak")) as unknown as {
     default: (algorithm: KeccakT.KeccakAlgorithm) => KeccakT.Keccak;
   };
+  /* eslint-enable @typescript-eslint/consistent-type-assertions */
+
   return createKeccakHash("keccak256").update(Buffer.from(bytes)).digest();
 }
 

--- a/v-next/hardhat-utils/src/fs.ts
+++ b/v-next/hardhat-utils/src/fs.ts
@@ -548,7 +548,7 @@ export async function emptyDir(absolutePath: string): Promise<void> {
 
   await remove(absolutePath);
   await mkdir(absolutePath);
-  // eslint-disable-next-line no-bitwise
+  // eslint-disable-next-line no-bitwise -- Bitwise as common in fs permissions
   await chmod(absolutePath, mode & 0o777);
 }
 

--- a/v-next/hardhat-utils/src/hex.ts
+++ b/v-next/hardhat-utils/src/hex.ts
@@ -106,7 +106,7 @@ export function normalizeHexString(hexString: string): PrefixedHexString {
   }
 
   return isHexStringPrefixed(normalizedHexString)
-    ? (normalizedHexString as PrefixedHexString)
+    ? normalizedHexString
     : `0x${normalizedHexString}`;
 }
 
@@ -117,7 +117,9 @@ export function normalizeHexString(hexString: string): PrefixedHexString {
  * @param hexString The string to check.
  * @returns True if the string starts with "0x", false otherwise.
  */
-export function isHexStringPrefixed(hexString: string): boolean {
+export function isHexStringPrefixed(
+  hexString: string,
+): hexString is PrefixedHexString {
   return hexString.toLowerCase().startsWith("0x");
 }
 

--- a/v-next/hardhat-utils/src/request.ts
+++ b/v-next/hardhat-utils/src/request.ts
@@ -159,6 +159,7 @@ export async function postFormRequest(
         ...headers,
         "Content-Type": "application/x-www-form-urlencoded",
       },
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TODO: Add a runtime check for body's type
       body: querystring.stringify(body as ParsedUrlQueryInput),
     });
   } catch (e) {

--- a/v-next/hardhat-utils/test/bigint.ts
+++ b/v-next/hardhat-utils/test/bigint.ts
@@ -72,6 +72,7 @@ describe("bigint", () => {
     });
 
     it("Should throw on unsupported types", async () => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Intentionally testing an type mismatch
       await assert.rejects(toBigInt(true as any), {
         name: "InvalidParameterError",
         message: "Unsupported type: boolean",

--- a/v-next/hardhat-utils/test/fs.ts
+++ b/v-next/hardhat-utils/test/fs.ts
@@ -885,7 +885,7 @@ describe("File system utils", () => {
 
       const stats = await fsPromises.stat(filePath);
 
-      // eslint-disable-next-line no-bitwise
+      // eslint-disable-next-line no-bitwise -- Bitwise is common in fs permissions
       assert.equal(stats.mode & 0o777, 0o666);
     });
 
@@ -1034,7 +1034,7 @@ describe("File system utils", () => {
 
       await emptyDir(dirPath);
 
-      // eslint-disable-next-line no-bitwise
+      // eslint-disable-next-line no-bitwise -- Bitwise is common in fs permissions
       assert.equal((await fsPromises.stat(dirPath)).mode & 0o777, 0o666);
     });
 

--- a/v-next/hardhat-utils/test/lang.ts
+++ b/v-next/hardhat-utils/test/lang.ts
@@ -103,7 +103,7 @@ describe("lang", () => {
 
       const expected: { [key: number]: number } = {};
       for (let i = 0; i < buffer.length; i++) {
-        expected[i] = buffer[i] as number;
+        expected[i] = buffer[i];
       }
 
       assert.deepEqual(clonedBuffer, expected);

--- a/v-next/hardhat-zod-utils/package.json
+++ b/v-next/hardhat-zod-utils/package.json
@@ -36,6 +36,7 @@
     "README.md"
   ],
   "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@nomicfoundation/hardhat-core": "workspace:^3.0.0",

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -50,6 +50,7 @@
     "README.md"
   ],
   "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@reporters/github": "^1.7.0",

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -40,7 +40,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newSubtaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true, true]);
         assert.deepEqual(res.taskArguments, {});
@@ -79,7 +79,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -95,7 +95,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
 
         assert.equal(res.task.id, newSubtaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true, true]);
@@ -112,7 +112,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
 
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true]);
@@ -127,7 +127,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, { flag: false });
@@ -142,7 +142,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, { optionFlag: "<value>" });
@@ -233,7 +233,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -250,7 +250,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -267,7 +267,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -284,7 +284,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newSubtaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -300,7 +300,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newSubtaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -330,7 +330,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -346,7 +346,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true]);
         assert.deepEqual(res.taskArguments, {});
@@ -394,7 +394,7 @@ describe("main", function () {
             hre,
           );
 
-          assert.ok(!Array.isArray(res));
+          assert.ok(!Array.isArray(res), "Result should be an array");
           assert.deepEqual(res.taskArguments, {
             param: BigInt(1234),
             param2: true,
@@ -448,7 +448,7 @@ describe("main", function () {
             hre,
           );
 
-          assert.ok(!Array.isArray(res));
+          assert.ok(!Array.isArray(res), "Result should be an array");
           assert.deepEqual(res.taskArguments, {
             param: BigInt(1234),
             param2: true,
@@ -510,7 +510,7 @@ describe("main", function () {
               hre,
             );
 
-            assert.ok(!Array.isArray(res));
+            assert.ok(!Array.isArray(res), "Result should be an array");
             assert.deepEqual(res.taskArguments, {
               param: [paramResults[i]],
             });
@@ -561,7 +561,7 @@ describe("main", function () {
 
         const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
-        assert.ok(!Array.isArray(res));
+        assert.ok(!Array.isArray(res), "Result should be an array");
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [
           true,

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -4,18 +4,10 @@ import { before, describe, it } from "node:test";
 import { createHardhatRuntimeEnvironment } from "@nomicfoundation/hardhat-core";
 import { ParameterType, task } from "@nomicfoundation/hardhat-core/config";
 import { HardhatRuntimeEnvironment } from "@nomicfoundation/hardhat-core/types/hre";
-import {
-  NewTaskDefinition,
-  Task,
-} from "@nomicfoundation/hardhat-core/types/tasks";
+import { NewTaskDefinition } from "@nomicfoundation/hardhat-core/types/tasks";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 
 import { parseTaskAndArguments } from "../../../src/internal/cli/main.js";
-
-interface TaskRes {
-  task: Task;
-  taskArguments: Record<string, any>;
-}
 
 describe("main", function () {
   let hre: HardhatRuntimeEnvironment;
@@ -46,12 +38,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, true, true, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newSubtaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true, true]);
         assert.deepEqual(res.taskArguments, {});
@@ -88,12 +77,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -107,11 +93,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false, false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
+
+        assert.ok(!Array.isArray(res));
 
         assert.equal(res.task.id, newSubtaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true, true]);
@@ -126,11 +110,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
+
+        assert.ok(!Array.isArray(res));
 
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true]);
@@ -143,12 +125,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, { flag: false });
@@ -161,12 +140,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, { optionFlag: "<value>" });
@@ -255,12 +231,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -275,12 +248,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -295,12 +265,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -315,12 +282,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newSubtaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -334,12 +298,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false, false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newSubtaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -367,12 +328,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false, false, false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true, true, true, true]);
         assert.deepEqual(res.taskArguments, {
@@ -386,12 +344,9 @@ describe("main", function () {
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [true]);
         assert.deepEqual(res.taskArguments, {});
@@ -437,8 +392,9 @@ describe("main", function () {
               false,
             ],
             hre,
-          ) as TaskRes;
+          );
 
+          assert.ok(!Array.isArray(res));
           assert.deepEqual(res.taskArguments, {
             param: BigInt(1234),
             param2: true,
@@ -490,8 +446,9 @@ describe("main", function () {
             command.split(" ").slice(2),
             [false, false, false, false, false, false, false],
             hre,
-          ) as TaskRes;
+          );
 
+          assert.ok(!Array.isArray(res));
           assert.deepEqual(res.taskArguments, {
             param: BigInt(1234),
             param2: true,
@@ -551,8 +508,9 @@ describe("main", function () {
               command.split(" ").slice(2),
               [false, false],
               hre,
-            ) as TaskRes;
+            );
 
+            assert.ok(!Array.isArray(res));
             assert.deepEqual(res.taskArguments, {
               param: [paramResults[i]],
             });
@@ -601,12 +559,9 @@ describe("main", function () {
           false,
         ];
 
-        const res = parseTaskAndArguments(
-          cliArguments,
-          usedCliArguments,
-          hre,
-        ) as TaskRes;
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
 
+        assert.ok(!Array.isArray(res));
         assert.equal(res.task.id, newTaskDefinition.id);
         assert.deepEqual(usedCliArguments, [
           true,

--- a/v-next/template-package/package.json
+++ b/v-next/template-package/package.json
@@ -38,6 +38,7 @@
     "README.md"
   ],
   "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
     "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@reporters/github": "^1.7.0",


### PR DESCRIPTION
This PR introduces two changes to our `eslint` config:

1) It enables the rule `@eslint-community/eslint-comments/require-description`. It forces you to explain why you used an `eslint-disable` directive in the same comment that uses it.
2) It changes the rule `@typescript-eslint/consistent-type-assertions` so type casts are now a linter error.

As this PR fixes a ton of new linter errors, it is better to review it one commit at the time. The first and third commits are the actual config changes, and the second and fourth commits just fix the new linter errors.