### PR TITLE
Make the build-system work with solcjs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1637,6 +1637,9 @@ importers:
       semver:
         specifier: ^7.6.2
         version: 7.6.2
+      solc:
+        specifier: 0.7.3
+        version: 0.7.3(debug@4.3.4)
       undici:
         specifier: ^6.16.1
         version: 6.16.1

--- a/v-next/hardhat-build-system/package.json
+++ b/v-next/hardhat-build-system/package.json
@@ -52,6 +52,7 @@
     "p-map": "^4.0.0",
     "resolve": "1.17.0",
     "semver": "^7.6.2",
+    "solc": "0.7.3",
     "undici": "^6.16.1"
   },
   "devDependencies": {

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/solcjs-runner.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/solcjs-runner.ts
@@ -1,0 +1,39 @@
+async function readStream(
+  stream: NodeJS.ReadStream,
+  encoding: BufferEncoding = "utf8",
+) {
+  stream.setEncoding(encoding);
+
+  return new Promise((resolve, reject) => {
+    let data = "";
+
+    stream.on("data", (chunk) => (data += chunk.toString(encoding)));
+    stream.on("end", () => resolve(data));
+    stream.on("error", (error) => reject(error));
+  });
+}
+
+async function getSolcJs(solcJsPath: string) {
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+  We cast to string because it doesn't have types, and otherwise TS complains */
+  const { default: solcWrapper } = await import("solc/wrapper" as string);
+  const { default: solc } = await import(solcJsPath);
+
+  return solcWrapper(solc);
+}
+
+async function main() {
+  const input = await readStream(process.stdin);
+
+  const solcjsPath = process.argv[2];
+  const solc = await getSolcJs(solcjsPath);
+
+  const output = solc.compile(input);
+
+  console.log(output);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -500,6 +500,18 @@ If you are running MacOS, try installing Apple Rosetta.
 
 If this error persists, run "npx hardhat clean --global".`,
     },
+    CANT_RUN_SOLCJS_COMPILER: {
+      number: 504,
+      messageTemplate: `A wasm version of solc failed to run.
+
+If this error persists, run "npx hardhat clean --global".`,
+      websiteTitle: "Failed to run solcjs",
+      websiteDescription: `Hardhat successfully downloaded a WASM version of solc but it doesn't run.
+
+If you are running MacOS, try installing Apple Rosetta.
+
+If this error persists, run "npx hardhat clean --global".`,
+    },
   },
   BUILTIN_TASKS: {
     COMPILE_FAILURE: {

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -501,7 +501,7 @@ If you are running MacOS, try installing Apple Rosetta.
 If this error persists, run "npx hardhat clean --global".`,
     },
     CANT_RUN_SOLCJS_COMPILER: {
-      number: 504,
+      number: 505,
       messageTemplate: `A wasm version of solc failed to run.
 
 If this error persists, run "npx hardhat clean --global".`,


### PR DESCRIPTION
I discovered that the hardhat-build-systems weren't working anymore locally (maybe after recreating my devcontainer?), because they don't work on ARM+linux. The reason is that on ARM you need to use solcjs, and that wasn't ported to ESM.

Note: This just copied the logic from v2 and ESM-ified it.