### PR TITLE
Add function in hh-utils to check if process is running in the CI

### DIFF
--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -10,6 +10,7 @@
   "exports": {
     "./bigint": "./dist/src/bigint.js",
     "./bytes": "./dist/src/bytes.js",
+    "./ci": "./dist/src/ci.js",
     "./common-errors": "./dist/src/common-errors.js",
     "./crypto": "./dist/src/crypto.js",
     "./date": "./dist/src/date.js",

--- a/v-next/hardhat-utils/src/ci.ts
+++ b/v-next/hardhat-utils/src/ci.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns 'true' if the current process is running in the GitHub CI environment.
+ */
+export function isCI() {
+  return process.env.CI === "true";
+}

--- a/v-next/hardhat-utils/src/ci.ts
+++ b/v-next/hardhat-utils/src/ci.ts
@@ -1,6 +1,33 @@
 /**
- * Returns 'true' if the current process is running in the GitHub CI environment.
+ * Checks whether the current process is running in a CI environment.
+ *
+ * @returns True if the current process is running in a CI environment.
  */
-export function isCI() {
-  return process.env.CI === "true";
+export function isCi() {
+  const env = process.env;
+
+  return !!(
+    isGithubActions() ||
+    isNow() ||
+    isAwsCodeBuild() ||
+    env.CI !== undefined || // Travis CI, CircleCI, Cirrus CI, GitLab CI, Appveyor, CodeShip, dsari
+    env.CONTINUOUS_INTEGRATION !== undefined || // Travis CI, Cirrus CI
+    env.BUILD_NUMBER !== undefined || // Jenkins, TeamCity
+    env.RUN_ID !== undefined || // TaskCluster, dsari
+    false
+  );
+}
+
+function isGithubActions(): boolean {
+  return process.env.GITHUB_ACTIONS !== undefined;
+}
+
+function isNow() {
+  return (
+    process.env.NOW !== undefined || process.env.DEPLOYMENT_ID !== undefined
+  );
+}
+
+function isAwsCodeBuild() {
+  return process.env.CODEBUILD_BUILD_NUMBER !== undefined;
 }

--- a/v-next/hardhat-utils/src/ci.ts
+++ b/v-next/hardhat-utils/src/ci.ts
@@ -6,15 +6,14 @@
 export function isCi() {
   const env = process.env;
 
-  return !!(
+  return (
     isGithubActions() ||
     isNow() ||
     isAwsCodeBuild() ||
     env.CI !== undefined || // Travis CI, CircleCI, Cirrus CI, GitLab CI, Appveyor, CodeShip, dsari
     env.CONTINUOUS_INTEGRATION !== undefined || // Travis CI, Cirrus CI
     env.BUILD_NUMBER !== undefined || // Jenkins, TeamCity
-    env.RUN_ID !== undefined || // TaskCluster, dsari
-    false
+    env.RUN_ID !== undefined // TaskCluster, dsari
   );
 }
 

--- a/v-next/hardhat-utils/test/ci.ts
+++ b/v-next/hardhat-utils/test/ci.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { isCI } from "../src/ci.js";
+
+describe("ci", () => {
+  it("should be true because the ENV variable CI is true", async function () {
+    process.env.CI = "true";
+    assert.equal(isCI(), true);
+  });
+
+  it("should be false because the ENV variable CI is false", async function () {
+    process.env.CI = "false";
+    assert.equal(isCI(), false);
+  });
+
+  it("should be false because the ENV variable CI is undefined", async function () {
+    assert.equal(isCI(), false);
+  });
+});

--- a/v-next/hardhat-utils/test/ci.ts
+++ b/v-next/hardhat-utils/test/ci.ts
@@ -1,20 +1,64 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { after, beforeEach, describe, it } from "node:test";
 
-import { isCI } from "../src/ci.js";
+import { isCi } from "../src/ci.js";
+
+// Get the original ENV variables so they can be restored at the end of teh tests
+const ORIGINAL_ENV_VARS = process.env;
 
 describe("ci", () => {
-  it("should be true because the ENV variable CI is true", async function () {
-    process.env.CI = "true";
-    assert.equal(isCI(), true);
-  });
+  describe("isCi", () => {
+    beforeEach(function () {
+      process.env = {};
+    });
 
-  it("should be false because the ENV variable CI is false", async function () {
-    process.env.CI = "false";
-    assert.equal(isCI(), false);
-  });
+    after(function () {
+      // Restore original ENV variables
+      process.env = ORIGINAL_ENV_VARS;
+    });
 
-  it("should be false because the ENV variable CI is undefined", async function () {
-    assert.equal(isCI(), false);
+    it("should be false because all the ENV variables are undefined", async function () {
+      assert.equal(isCi(), false);
+    });
+
+    it("should be true because the ENV variable CI is true", async function () {
+      process.env.CI = "true";
+      assert.equal(isCi(), true);
+    });
+
+    it("should be true because the ENV variable CONTINUOUS_INTEGRATION is true", async function () {
+      process.env.CONTINUOUS_INTEGRATION = "true";
+      assert.equal(isCi(), true);
+    });
+
+    it("should be true because the ENV variable BUILD_NUMBER is true", async function () {
+      process.env.BUILD_NUMBER = "true";
+      assert.equal(isCi(), true);
+    });
+
+    it("should be true because the ENV variable RUN_ID is true", async function () {
+      process.env.RUN_ID = "true";
+      assert.equal(isCi(), true);
+    });
+
+    it("should be true because the ENV variable GITHUB_ACTIONS is true", async function () {
+      process.env.GITHUB_ACTIONS = "true";
+      assert.equal(isCi(), true);
+    });
+
+    it("should be true because the ENV variable NOW is true", async function () {
+      process.env.NOW = "true";
+      assert.equal(isCi(), true);
+    });
+
+    it("should be true because the ENV variable DEPLOYMENT_ID is true", async function () {
+      process.env.DEPLOYMENT_ID = "true";
+      assert.equal(isCi(), true);
+    });
+
+    it("should be true because the ENV variable CODEBUILD_BUILD_NUMBER is true", async function () {
+      process.env.CODEBUILD_BUILD_NUMBER = "true";
+      assert.equal(isCi(), true);
+    });
   });
 });


### PR DESCRIPTION
Implement a function to check if the process is running in GitHub CI. 
The logic combines the code from [pnpm](https://pnpm.io/cli/install#--frozen-lockfile) and the [hardhat code](https://github.com/NomicFoundation/hardhat/blob/bdd04d37f2ee41f68943f60bf0fd3ac5546a05ad/packages/hardhat-core/src/internal/util/ci-detection.ts#L20) in hh-core