### PR TITLE
Add stale issues Github Actions Workflow

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,21 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale issues
+        uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been automatically closed due to inactivity. If you still need help, please reopen the issue and provide the requested information.'
+          days-before-stale: 7
+          days-before-close: 7
+          only-labels: 'status:needs-more-info'
+          exempt-issue-labels: 'status:do-not-close'
+

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -2,7 +2,7 @@ name: Close Stale Issues
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Runs daily at midnight UTC
+    - cron: "0 0 * * *" # Runs daily at midnight UTC
   workflow_dispatch:
 
 jobs:
@@ -13,9 +13,8 @@ jobs:
         uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue has been automatically closed due to inactivity. If you still need help, please reopen the issue and provide the requested information.'
+          stale-issue-message: "This issue has been automatically closed due to inactivity. If you still need help, please reopen the issue and provide the requested information."
           days-before-stale: 7
           days-before-close: 7
-          only-labels: 'status:needs-more-info'
-          exempt-issue-labels: 'status:do-not-close'
-
+          only-labels: "status:needs-more-info"
+          exempt-issue-labels: "status:do-not-close"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
Solves https://github.com/NomicFoundation/hardhat/issues/5306.

This pull request introduces a GitHub Actions workflow that automatically closes issues labeled with `status:needs-more-info` if there has been no follow-up for a specified period of time. This helps maintain a clean and manageable issue tracker by closing inactive support cases that require additional information from the reporter.

Following considerations are had for the current implementation:
1. The workflow runs daily at midnight UTC to check for stale issues
2. The workflow can also be triggered manually from the GitHub Actions tab using the `workflow_dispatch` event
3. Issues labeled with `status:needs-more-info` will be marked as stale after 7 days of inactivity
4. Once marked as stale, the issue will be automatically closed after an additional 7 days if there is still no activity
5. Exemption: Issues labeled with `status:do-not-close` will be exempt from being marked as stale and closed automatically

No testing has been performed over the current implementation.
The https://github.com/actions/stale repository examples were used for designing the current Github Action Workflow.