### PR TITLE
Check for missing dependencies when failing to import a file action

### DIFF
--- a/v-next/core/src/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/src/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -13,13 +13,13 @@ import semver from "semver";
  * @param plugin - the plugin to be validated
  * @param basePathForNpmResolution - the directory path to use for node module resolution, defaulting to `process.cwd()`
  * @throws {HardhatError} with descriptor:
- * - {@link ERRORS.ARTIFACTS.PLUGIN_NOT_INSTALLED} if the plugin is not installed as an npm package
- * - {@link ERRORS.ARTIFACTS.PLUGIN_MISSING_DEPENDENCY} if the plugin's package peer dependency is not installed
- * - {@link ERRORS.ARTIFACTS.DEPENDENCY_VERSION_MISMATCH} if the plugin's package peer dependency is installed but has the wrong version
+ * - {@link HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED} if the plugin is not installed as an npm package
+ * - {@link HardhatError.ERRORS.PLUGINS.PLUGIN_MISSING_DEPENDENCY} if the plugin's package peer dependency is not installed
+ * - {@link HardhatError.ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH} if the plugin's package peer dependency is installed but has the wrong version
  */
 export async function detectPluginNpmDependencyProblems(
   plugin: HardhatPlugin,
-  basePathForNpmResolution: string,
+  basePathForNpmResolution: string = process.cwd(),
 ): Promise<void> {
   if (plugin.npmPackage === undefined) {
     return;


### PR DESCRIPTION
Part of https://github.com/NomicFoundation/hardhat/issues/5229

Also added the default specified in the JSDoc for `basePathForNpmResolution` in `detectPluginNpmDependencyProblems` (double checked with Pato).