### PR TITLE
Task parameters are treated as unrecognized global parameters

### DIFF
--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -224,6 +224,7 @@ export async function parseGlobalArguments(
     usedCliArguments,
     parameters,
     globalArguments,
+    true,
   );
 
   return globalArguments;
@@ -357,6 +358,7 @@ function parseDoubleDashArgs(
   usedCliArguments: boolean[],
   parametersMap: Map<string, NamedTaskParameter | GlobalParameter>,
   argumentsMap: TaskArguments,
+  isGlobalParameter = false,
 ) {
   for (let i = 0; i < cliArguments.length; i++) {
     if (usedCliArguments[i]) {
@@ -379,6 +381,11 @@ function parseDoubleDashArgs(
     const paramInfo = parametersMap.get(paramName);
 
     if (paramInfo === undefined) {
+      if (isGlobalParameter === true) {
+        continue;
+      }
+
+      // Only throw an error when the parameter is not a global parameter, because it might be a parameter related to a task
       throw new HardhatError(
         HardhatError.ERRORS.ARGUMENTS.UNRECOGNIZED_NAMED_PARAM,
         {

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -358,7 +358,7 @@ function parseDoubleDashArgs(
   usedCliArguments: boolean[],
   parametersMap: Map<string, NamedTaskParameter | GlobalParameter>,
   argumentsMap: TaskArguments,
-  isGlobalParameter = false,
+  ignoreUnknownParameter = false,
 ) {
   for (let i = 0; i < cliArguments.length; i++) {
     if (usedCliArguments[i]) {
@@ -381,7 +381,7 @@ function parseDoubleDashArgs(
     const paramInfo = parametersMap.get(paramName);
 
     if (paramInfo === undefined) {
-      if (isGlobalParameter === true) {
+      if (ignoreUnknownParameter === true) {
         continue;
       }
 

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -216,7 +216,7 @@ describe("main", function () {
     });
 
     it("should not fail when a global parameter is not recognized (it might be a task parameter)", async function () {
-      const command = "npx hardhat task --nonExistingFlag <value>";
+      const command = "npx hardhat task --taskFlag <value>";
 
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -214,6 +214,22 @@ describe("main", function () {
         flag: true,
       });
     });
+
+    it("should not fail when a global parameter is not recognized (it might be a task parameter)", async function () {
+      const command = "npx hardhat task --nonExistingFlag <value>";
+
+      const cliArguments = command.split(" ").slice(2);
+      const usedCliArguments = new Array(cliArguments.length).fill(false);
+
+      const globalArguments = await parseGlobalArguments(
+        globalParamsIndex,
+        cliArguments,
+        usedCliArguments,
+      );
+
+      assert.deepEqual(usedCliArguments, [false, false, false]);
+      assert.deepEqual(globalArguments, {});
+    });
   });
 
   describe("parseTaskAndArguments", function () {


### PR DESCRIPTION
This PR fixes [this bug](https://github.com/NomicFoundation/hardhat/issues/5353).

PROBLEM
To parse global and task parameters, the same function was used. However, the logic should have been slightly different. If a parameter is not found in the global parameters map when parsing the CLI arguments, no error should be thrown because it might be a task parameter. But when a parameter is not found in the task parameters map when parsing the CLI arguments, an error must be thrown because, at this point, everything should be parsed. The old logic was throwing an error when not finding a match for a global parameter.

SOLUTION
Add a flag in the function definition (default to false) to specify global parameter behavior (do not throw if missing) or task parameter behavior (throw if missing).