### PR TITLE
Improve task not found logic

### DIFF
--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -294,9 +294,10 @@ function getTaskFromCliArguments(
     }
 
     if (task === undefined) {
-      task = hre.tasks.getTask(arg);
-      if (task === undefined) {
-        return [arg];
+      try {
+        task = hre.tasks.getTask(arg);
+      } catch (error) {
+        return [arg]; // No task found
       }
     } else {
       const subtask = task.subtasks.get(arg);

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -415,6 +415,17 @@ describe("main", function () {
         });
       });
 
+      it("should throw because the task parameter is not defined", function () {
+        const command = "npx hardhat undefined-task";
+
+        const cliArguments = command.split(" ").slice(2);
+        const usedCliArguments = [false];
+
+        const res = parseTaskAndArguments(cliArguments, usedCliArguments, hre);
+
+        assert.deepEqual(res, ["undefined-task"]);
+      });
+
       it("should throw because the parameter is not defined", function () {
         const command = "npx hardhat task0 --undefinedParam <value>";
 


### PR DESCRIPTION
Currently, when a task is not found, an error is thrown. 
However, we need a more graceful approach so that we can print a help message in the CLI.