### PR TITLE
Added eslint rules

### DIFF
--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -99,6 +99,13 @@ function createConfig(configFilePath, packageEntryPoints = []) {
         { assertionStyle: "never" },
       ],
       "@typescript-eslint/consistent-type-definitions": "error",
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        {
+          prefer: "type-imports",
+          disallowTypeAnnotations: true,
+        },
+      ],
       "@typescript-eslint/dot-notation": "error",
       "@typescript-eslint/explicit-member-accessibility": [
         "error",

--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -214,6 +214,12 @@ function createConfig(configFilePath, packageEntryPoints = []) {
           message:
             "Use ensureError() or HardhatError.isHardhatError instead of casting the error",
         },
+        {
+          selector:
+            "CallExpression[callee.object.name='assert'][callee.property.name=/strict/i]",
+          message:
+            "Use non-strict methods when importing from 'node:assert/strict'",
+        },
       ],
       "@typescript-eslint/restrict-plus-operands": "error",
       "@typescript-eslint/restrict-template-expressions": [

--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -227,6 +227,8 @@ function createConfig(configFilePath, packageEntryPoints = []) {
           message:
             "Use non-strict methods when importing from 'node:assert/strict'",
         },
+        // We forbid using assert.ok and assert directly without a message
+        // as this may cause a bug. See: https://github.com/nodejs/node/issues/52962
         {
           selector: "CallExpression[callee.name='assert'][arguments.length<2]",
           message:

--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -220,6 +220,17 @@ function createConfig(configFilePath, packageEntryPoints = []) {
           message:
             "Use non-strict methods when importing from 'node:assert/strict'",
         },
+        {
+          selector: "CallExpression[callee.name='assert'][arguments.length<2]",
+          message:
+            "assert should provide an error message as the second argument",
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='assert'][callee.property.name='ok'][arguments.length<2]",
+          message:
+            "assert.ok should provide an error message as the second argument",
+        },
       ],
       "@typescript-eslint/restrict-plus-operands": "error",
       "@typescript-eslint/restrict-template-expressions": [

--- a/v-next/core/src/config.ts
+++ b/v-next/core/src/config.ts
@@ -1,3 +1,11 @@
+import type { ConfigurationVariable } from "./types/config.js";
+import type { GlobalParameter } from "./types/global-parameters.js";
+import type {
+  EmptyTaskDefinitionBuilder,
+  NewTaskDefinitionBuilder,
+  TaskOverrideDefinitionBuilder,
+} from "./types/tasks.js";
+
 import { buildGlobalParameterDefinition } from "./internal/global-parameters.js";
 import {
   EmptyTaskDefinitionBuilderImplementation,
@@ -5,13 +13,6 @@ import {
   TaskOverrideDefinitionBuilderImplementation,
 } from "./internal/tasks/builders.js";
 import { ParameterType } from "./types/common.js";
-import { ConfigurationVariable } from "./types/config.js";
-import { GlobalParameter } from "./types/global-parameters.js";
-import {
-  EmptyTaskDefinitionBuilder,
-  NewTaskDefinitionBuilder,
-  TaskOverrideDefinitionBuilder,
-} from "./types/tasks.js";
 
 export type { HardhatUserConfig } from "./types/config.js";
 

--- a/v-next/core/src/index.ts
+++ b/v-next/core/src/index.ts
@@ -1,8 +1,9 @@
+import type { UnsafeHardhatRuntimeEnvironmentOptions } from "./types/cli.js";
+import type { HardhatUserConfig } from "./types/config.js";
+import type { GlobalArguments } from "./types/global-parameters.js";
+import type { HardhatRuntimeEnvironment } from "./types/hre.js";
+
 import { HardhatRuntimeEnvironmentImplementation } from "./internal/hre.js";
-import { UnsafeHardhatRuntimeEnvironmentOptions } from "./types/cli.js";
-import { HardhatUserConfig } from "./types/config.js";
-import { GlobalArguments } from "./types/global-parameters.js";
-import { HardhatRuntimeEnvironment } from "./types/hre.js";
 
 /**
  * Creates an instances of the Hardhat Runtime Environment.

--- a/v-next/core/src/internal/configuration-variables.ts
+++ b/v-next/core/src/internal/configuration-variables.ts
@@ -1,10 +1,10 @@
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
-
-import {
+import type {
   ConfigurationVariable,
   ResolvedConfigurationVariable,
 } from "../types/config.js";
-import { HookManager } from "../types/hooks.js";
+import type { HookManager } from "../types/hooks.js";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 
 export class ResolvedConfigurationVariableImplementation
   implements ResolvedConfigurationVariable

--- a/v-next/core/src/internal/global-parameters.ts
+++ b/v-next/core/src/internal/global-parameters.ts
@@ -1,10 +1,10 @@
-import { ParameterType } from "../types/common.js";
-import {
+import type { ParameterType } from "../types/common.js";
+import type {
   GlobalArguments,
   GlobalParameter,
   GlobalParameterMap,
 } from "../types/global-parameters.js";
-import { HardhatPlugin } from "../types/plugins.js";
+import type { HardhatPlugin } from "../types/plugins.js";
 
 /**
  * Builds a map of the global parameters, validating them.

--- a/v-next/core/src/internal/hook-manager.ts
+++ b/v-next/core/src/internal/hook-manager.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- Typescript
 can handle the generic types in this file correctly. It can do it for function
 signatures, but not for function bodies. */
-import {
+import type {
   ChainedHook,
   HookContext,
   HookManager,
@@ -9,8 +9,8 @@ import {
   InitialChainedHookParams,
   HardhatHooks,
 } from "../types/hooks.js";
-import { HardhatPlugin } from "../types/plugins.js";
-import { LastParameter, Return } from "../types/utils.js";
+import type { HardhatPlugin } from "../types/plugins.js";
+import type { LastParameter, Return } from "../types/utils.js";
 
 export class HookManagerImplementation implements HookManager {
   readonly #pluginsInReverseOrder: HardhatPlugin[];

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -1,19 +1,18 @@
-import type { HardhatRuntimeEnvironment } from "../types/hre.js";
-
-import { UnsafeHardhatRuntimeEnvironmentOptions } from "../types/cli.js";
-import { HardhatUserConfig, HardhatConfig } from "../types/config.js";
-import {
+import type { UnsafeHardhatRuntimeEnvironmentOptions } from "../types/cli.js";
+import type { HardhatUserConfig, HardhatConfig } from "../types/config.js";
+import type {
   GlobalArguments,
   GlobalParameterMap,
 } from "../types/global-parameters.js";
-import {
+import type {
   HardhatUserConfigValidationError,
   HookContext,
   HookManager,
 } from "../types/hooks.js";
-import { HardhatPlugin } from "../types/plugins.js";
-import { TaskManager } from "../types/tasks.js";
-import { UserInterruptionManager } from "../types/user-interruptions.js";
+import type { HardhatRuntimeEnvironment } from "../types/hre.js";
+import type { HardhatPlugin } from "../types/plugins.js";
+import type { TaskManager } from "../types/tasks.js";
+import type { UserInterruptionManager } from "../types/user-interruptions.js";
 
 import { ResolvedConfigurationVariableImplementation } from "./configuration-variables.js";
 import {

--- a/v-next/core/src/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/src/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -1,11 +1,11 @@
+import type { HardhatPlugin } from "../../types/plugins.js";
+import type { PackageJson } from "@nomicfoundation/hardhat-utils/package";
+
 import { createRequire } from "node:module";
 import path from "node:path";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import { PackageJson } from "@nomicfoundation/hardhat-utils/package";
 import semver from "semver";
-
-import { HardhatPlugin } from "../../types/plugins.js";
 
 /**
  * Validate that a plugin is installed and that its peer dependencies are installed and satisfy the version constraints.

--- a/v-next/core/src/internal/tasks/task-manager.ts
+++ b/v-next/core/src/internal/tasks/task-manager.ts
@@ -1,18 +1,19 @@
+import type { GlobalParameterMap } from "../../types/global-parameters.js";
+import type { HardhatRuntimeEnvironment } from "../../types/hre.js";
+import type {
+  Task,
+  TaskDefinition,
+  TaskManager,
+  NewTaskDefinition,
+  TaskOverrideDefinition,
+} from "../../types/tasks.js";
+
 import {
   HardhatError,
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
 
-import { GlobalParameterMap } from "../../types/global-parameters.js";
-import { HardhatRuntimeEnvironment } from "../../types/hre.js";
-import {
-  Task,
-  TaskDefinition,
-  TaskDefinitionType,
-  TaskManager,
-  NewTaskDefinition,
-  TaskOverrideDefinition,
-} from "../../types/tasks.js";
+import { TaskDefinitionType } from "../../types/tasks.js";
 
 import { ResolvedTask } from "./resolved-task.js";
 import { formatTaskId, getActorFragment } from "./utils.js";

--- a/v-next/core/src/internal/user-interruptions.ts
+++ b/v-next/core/src/internal/user-interruptions.ts
@@ -1,7 +1,7 @@
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import type { HookContext, HookManager } from "../types/hooks.js";
+import type { UserInterruptionManager } from "../types/user-interruptions.js";
 
-import { HookContext, HookManager } from "../types/hooks.js";
-import { UserInterruptionManager } from "../types/user-interruptions.js";
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 
 import { AsyncMutex } from "./async-mutex.js";
 

--- a/v-next/core/src/types/cli.ts
+++ b/v-next/core/src/types/cli.ts
@@ -1,5 +1,5 @@
-import { GlobalParameterMap } from "./global-parameters.js";
-import { HardhatPlugin } from "./plugins.js";
+import type { GlobalParameterMap } from "./global-parameters.js";
+import type { HardhatPlugin } from "./plugins.js";
 
 /**
  * An object that contains options to bypass some initialization, to avoid

--- a/v-next/core/src/types/global-parameters.ts
+++ b/v-next/core/src/types/global-parameters.ts
@@ -1,4 +1,4 @@
-import { ParameterType } from "./common.js";
+import type { ParameterType } from "./common.js";
 
 /**
  * A global parameter with an associated value and a default if not provided by

--- a/v-next/core/src/types/hooks.ts
+++ b/v-next/core/src/types/hooks.ts
@@ -1,13 +1,13 @@
-import {
+import type {
   ConfigurationVariable,
   HardhatConfig,
   HardhatUserConfig,
   ResolvedConfigurationVariable,
 } from "./config.js";
-import { GlobalArguments } from "./global-parameters.js";
-import { HardhatRuntimeEnvironment } from "./hre.js";
-import { UserInterruptionManager } from "./user-interruptions.js";
-import {
+import type { GlobalArguments } from "./global-parameters.js";
+import type { HardhatRuntimeEnvironment } from "./hre.js";
+import type { UserInterruptionManager } from "./user-interruptions.js";
+import type {
   LastParameter,
   ParametersExceptFirst,
   ParametersExceptFirstAndLast,

--- a/v-next/core/src/types/hre.ts
+++ b/v-next/core/src/types/hre.ts
@@ -1,7 +1,6 @@
-import { HardhatConfig } from "../types/config.js";
-
-import { GlobalArguments } from "./global-parameters.js";
-import { UserInterruptionManager } from "./user-interruptions.js";
+import type { GlobalArguments } from "./global-parameters.js";
+import type { UserInterruptionManager } from "./user-interruptions.js";
+import type { HardhatConfig } from "../types/config.js";
 
 /**
  * The Hardhat Runtime Environment (HRE) is an object that exposes

--- a/v-next/core/src/types/plugins.ts
+++ b/v-next/core/src/types/plugins.ts
@@ -1,6 +1,6 @@
-import { GlobalParameter } from "./global-parameters.js";
-import { HardhatHooks } from "./hooks.js";
-import { TaskDefinition } from "./tasks.js";
+import type { GlobalParameter } from "./global-parameters.js";
+import type { HardhatHooks } from "./hooks.js";
+import type { TaskDefinition } from "./tasks.js";
 
 // We add the plugins to the config types with a module augmentation to avoid
 // introducing a circular dependency that would look like this:

--- a/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -1,8 +1,9 @@
+import type { HardhatPlugin } from "../../../src/types/plugins.js";
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { detectPluginNpmDependencyProblems } from "../../../src/internal/plugins/detect-plugin-npm-dependency-problems.js";
-import { HardhatPlugin } from "../../../src/types/plugins.js";
 
 describe("Plugins - detect npm dependency problems", () => {
   const plugin: HardhatPlugin = {

--- a/v-next/core/test/internal/plugins/resolve-plugin-list.ts
+++ b/v-next/core/test/internal/plugins/resolve-plugin-list.ts
@@ -10,14 +10,11 @@ describe("Plugins - resolve plugin list", () => {
   );
 
   it("should return empty on an empty plugin list", async () => {
-    assert.deepStrictEqual(
-      await resolvePluginList([], installedPackageFixture),
-      [],
-    );
+    assert.deepEqual(await resolvePluginList([], installedPackageFixture), []);
   });
 
   it("should return empty on an undefined plugin list", async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await resolvePluginList(undefined, installedPackageFixture),
       [],
     );
@@ -28,7 +25,7 @@ describe("Plugins - resolve plugin list", () => {
       id: "example-plugin",
     };
 
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await resolvePluginList([plugin], installedPackageFixture),
       [plugin],
     );
@@ -40,9 +37,10 @@ describe("Plugins - resolve plugin list", () => {
     const b: HardhatPlugin = { id: "b", dependencies: [async () => c] };
     const a: HardhatPlugin = { id: "a", dependencies: [async () => b] };
 
-    assert.deepStrictEqual(
+    const expected = [c, b, a];
+    assert.deepEqual(
       await resolvePluginList([a], installedPackageFixture),
-      [c, b, a],
+      expected,
     );
   });
 
@@ -52,9 +50,10 @@ describe("Plugins - resolve plugin list", () => {
     const b: HardhatPlugin = { id: "b" };
     const a: HardhatPlugin = { id: "a" };
 
-    assert.deepStrictEqual(
+    const expected = [a, b, c];
+    assert.deepEqual(
       await resolvePluginList([a, b, c], installedPackageFixture),
-      [a, b, c],
+      expected,
     );
   });
 
@@ -69,9 +68,10 @@ describe("Plugins - resolve plugin list", () => {
       dependencies: [async () => b, async () => c],
     };
 
-    assert.deepStrictEqual(
+    const expected = [b, c, a];
+    assert.deepEqual(
       await resolvePluginList([a], installedPackageFixture),
-      [b, c, a],
+      expected,
     );
   });
 
@@ -83,9 +83,10 @@ describe("Plugins - resolve plugin list", () => {
     const b: HardhatPlugin = { id: "b", dependencies: [async () => c] };
     const a: HardhatPlugin = { id: "a", dependencies: [async () => c] };
 
-    assert.deepStrictEqual(
+    const expected = [c, a, b];
+    assert.deepEqual(
       await resolvePluginList([a, b], installedPackageFixture),
-      [c, a, b],
+      expected,
     );
   });
 
@@ -103,9 +104,10 @@ describe("Plugins - resolve plugin list", () => {
       dependencies: [async () => b, async () => c],
     };
 
-    assert.deepStrictEqual(
+    const expected = [d, b, c, a];
+    assert.deepEqual(
       await resolvePluginList([a], installedPackageFixture),
-      [d, b, c, a],
+      expected,
     );
   });
 
@@ -133,9 +135,10 @@ describe("Plugins - resolve plugin list", () => {
       dependencies: [async () => c, async () => d],
     };
 
-    assert.deepStrictEqual(
+    const expected = [i, g, c, d, a, h, e, f, b];
+    assert.deepEqual(
       await resolvePluginList([a, b], installedPackageFixture),
-      [i, g, c, d, a, h, e, f, b],
+      expected,
     );
   });
 

--- a/v-next/core/test/internal/plugins/resolve-plugin-list.ts
+++ b/v-next/core/test/internal/plugins/resolve-plugin-list.ts
@@ -1,8 +1,9 @@
+import type { HardhatPlugin } from "../../../src/types/plugins.js";
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { resolvePluginList } from "../../../src/internal/plugins/resolve-plugin-list.js";
-import { HardhatPlugin } from "../../../src/types/plugins.js";
 
 describe("Plugins - resolve plugin list", () => {
   const installedPackageFixture = import.meta.resolve(

--- a/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
+++ b/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
@@ -1,9 +1,10 @@
+import type { UserInterruptionHooks } from "../../../src/types/hooks.js";
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HookManagerImplementation } from "../../../src/internal/hook-manager.js";
 import { UserInterruptionManagerImplementation } from "../../../src/internal/user-interruptions.js";
-import { UserInterruptionHooks } from "../../../src/types/hooks.js";
 
 describe("UserInterruptionManager", () => {
   describe("displayMessage", () => {

--- a/v-next/hardhat-build-system/src/internal/build-system.ts
+++ b/v-next/hardhat-build-system/src/internal/build-system.ts
@@ -1,5 +1,11 @@
+import type { TasksOverrides } from "./tasks.js";
+import type {
+  Artifacts,
+  CompilationJobCreationError,
+  BuildConfig,
+} from "./types/index.js";
+
 import {
-  TasksOverrides,
   taskCompileRemoveObsoleteArtifacts,
   taskCompileSolidity,
   taskCompileSolidityGetCompilationJobsFailureReasons,
@@ -8,11 +14,6 @@ import {
   taskCompileSolidityGetSourcePaths,
   taskCompileSolidityReadFile,
 } from "./tasks.js";
-import {
-  Artifacts,
-  CompilationJobCreationError,
-  BuildConfig,
-} from "./types/index.js";
 import { Artifacts as ArtifactsImpl } from "./utils/artifacts.js";
 
 export interface BuildRequest {

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/compiler-input.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/compiler-input.ts
@@ -1,4 +1,4 @@
-import { CompilationJob, CompilerInput } from "../../types/index.js";
+import type { CompilationJob, CompilerInput } from "../../types/index.js";
 
 export function getInputFromCompilationJob(
   compilationJob: CompilationJob,

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
@@ -1,3 +1,5 @@
+import type { CompilerInput, CompilerOutput } from "../../types/index.js";
+
 import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import os from "node:os";
@@ -10,8 +12,6 @@ import {
 } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import * as semver from "semver";
-
-import { CompilerInput, CompilerOutput } from "../../types/index.js";
 
 export interface ICompiler {
   compile(input: CompilerInput): Promise<CompilerOutput>;

--- a/v-next/hardhat-build-system/src/internal/solidity/dependencyGraph.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/dependencyGraph.ts
@@ -1,11 +1,10 @@
+import type { ResolvedFile, Resolver } from "./resolver.js";
+import type * as taskTypes from "../types/builtin-tasks/index.js";
+
 import {
   HardhatError,
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
-
-import * as taskTypes from "../types/builtin-tasks/index.js";
-
-import { ResolvedFile, Resolver } from "./resolver.js";
 
 export class DependencyGraph implements taskTypes.DependencyGraph {
   public static async createFromResolvedFiles(

--- a/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
@@ -1,3 +1,10 @@
+import type { Parser } from "./parse.js";
+import type {
+  FileContent,
+  LibraryInfo,
+  ResolvedFile as IResolvedFile,
+} from "../types/builtin-tasks/index.js";
+
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -8,11 +15,6 @@ import {
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import resolve from "resolve";
 
-import {
-  FileContent,
-  LibraryInfo,
-  ResolvedFile as IResolvedFile,
-} from "../types/builtin-tasks/index.js";
 import { getRealPath } from "../utils/fs-utils.js";
 import { createNonCryptographicHashBasedIdentifier } from "../utils/hash.js";
 import { applyRemappings } from "../utils/remappings.js";
@@ -25,8 +27,6 @@ import {
   validateSourceNameExistenceAndCasing,
   validateSourceNameFormat,
 } from "../utils/source-names.js";
-
-import { Parser } from "./parse.js";
 
 const NODE_MODULES = "node_modules";
 

--- a/v-next/hardhat-build-system/src/internal/tasks.ts
+++ b/v-next/hardhat-build-system/src/internal/tasks.ts
@@ -1,3 +1,16 @@
+import type * as taskTypes from "./types/builtin-tasks/index.js";
+import type {
+  Artifacts,
+  CompilationJob,
+  CompilationJobCreationError,
+  CompilerInput,
+  CompilerOutput,
+  BuildConfig,
+  ResolvedFile,
+  SolcBuild,
+} from "./types/index.js";
+import type { Artifacts as ArtifactsImpl } from "./utils/artifacts.js";
+
 import {
   HardhatError,
   assertHardhatInvariant,
@@ -24,23 +37,8 @@ import { getEvmVersionFromSolcVersion } from "./solidity/compiler/solc-info.js";
 import { DependencyGraph } from "./solidity/dependencyGraph.js";
 import { Parser } from "./solidity/parse.js";
 import { Resolver } from "./solidity/resolver.js";
-import { CompilationJobsCreationResult } from "./types/builtin-tasks/index.js";
-import * as taskTypes from "./types/builtin-tasks/index.js";
-import {
-  Artifacts,
-  CompilationJob,
-  CompilationJobCreationError,
-  CompilationJobCreationErrorReason,
-  CompilerInput,
-  CompilerOutput,
-  BuildConfig,
-  ResolvedFile,
-  SolcBuild,
-} from "./types/index.js";
-import {
-  Artifacts as ArtifactsImpl,
-  getArtifactFromContractOutput,
-} from "./utils/artifacts.js";
+import { CompilationJobCreationErrorReason } from "./types/index.js";
+import { getArtifactFromContractOutput } from "./utils/artifacts.js";
 import { getFullyQualifiedName } from "./utils/contract-names.js";
 import { getAllFilesMatching } from "./utils/fs-utils.js";
 import { getCompilersDir } from "./utils/global-dir.js";
@@ -1176,8 +1174,8 @@ export async function taskCompileSolidityLogCompilationResult(
 // TASK_COMPILE_REMOVE_OBSOLETE_ARTIFACTS
 // TESTED
 export async function taskCompileRemoveObsoleteArtifacts(artifacts: Artifacts) {
-  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- 
-  We know this is the actual implementation, so we use some non-public methods 
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+  We know this is the actual implementation, so we use some non-public methods
   here by downcasting */
   const artifactsImpl = artifacts as ArtifactsImpl;
   await artifactsImpl.removeObsoleteArtifacts();
@@ -1283,7 +1281,7 @@ export async function taskCompileSolidity(
     dependencyGraph.getResolvedFiles(),
   );
 
-  const compilationJobsCreationResult: CompilationJobsCreationResult =
+  const compilationJobsCreationResult: taskTypes.CompilationJobsCreationResult =
     await taskCompileSolidityGetCompilationJobs(
       config,
       dependencyGraph,
@@ -1336,8 +1334,8 @@ export async function taskCompileSolidity(
 
   const allArtifactsEmittedPerFile = solidityFilesCache.getEntries();
 
-  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- 
-  We know this is the actual implementation, so we use some non-public methods 
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+  We know this is the actual implementation, so we use some non-public methods
   here by downcasting */
   const artifactsImpl = artifacts as ArtifactsImpl;
   artifactsImpl.addValidArtifacts(allArtifactsEmittedPerFile);

--- a/v-next/hardhat-build-system/src/internal/types/config.ts
+++ b/v-next/hardhat-build-system/src/internal/types/config.ts
@@ -1,4 +1,4 @@
-import { SolcConfig } from "./builtin-tasks/compile.js";
+import type { SolcConfig } from "./builtin-tasks/compile.js";
 
 export interface BuildConfig {
   paths: ProjectPathsConfig;

--- a/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
@@ -1,3 +1,12 @@
+import type {
+  Artifact,
+  Artifacts as IArtifacts,
+  BuildInfo,
+  CompilerInput,
+  CompilerOutput,
+  DebugFile,
+} from "../types/index.js";
+
 import fsPromises from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -14,15 +23,6 @@ import {
   writeJsonFile,
 } from "@nomicfoundation/hardhat-utils/fs";
 import debug from "debug";
-
-import {
-  Artifact,
-  Artifacts as IArtifacts,
-  BuildInfo,
-  CompilerInput,
-  CompilerOutput,
-  DebugFile,
-} from "../types/index.js";
 
 import {
   ARTIFACT_FORMAT_VERSION,

--- a/v-next/hardhat-build-system/src/internal/utils/download.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/download.ts
@@ -1,9 +1,10 @@
+import type { DispatcherOptions } from "@nomicfoundation/hardhat-utils/request";
+
 import path from "node:path";
 
 import { ensureDir, move } from "@nomicfoundation/hardhat-utils/fs";
 import {
   download as downloadCompiler,
-  DispatcherOptions,
   shouldUseProxy,
 } from "@nomicfoundation/hardhat-utils/request";
 

--- a/v-next/hardhat-build-system/src/internal/utils/solidity-files-cache.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/solidity-files-cache.ts
@@ -1,6 +1,6 @@
-import * as path from "node:path";
+import type { ProjectPathsConfig } from "../types/config.js";
 
-import { ProjectPathsConfig } from "../types/config.js";
+import * as path from "node:path";
 
 export const SOLIDITY_FILES_CACHE_FILENAME = "solidity-files-cache.json";
 

--- a/v-next/hardhat-build-system/test/helpers.ts
+++ b/v-next/hardhat-build-system/test/helpers.ts
@@ -1,3 +1,10 @@
+import type {
+  BuildConfig,
+  SolidityConfig,
+} from "../src/internal/types/config.js";
+import type { SolcConfig } from "../src/internal/types/index.js";
+import type { ErrorDescriptor } from "@nomicfoundation/hardhat-errors";
+
 import { AssertionError } from "node:assert";
 import assert from "node:assert/strict";
 import { rmSync } from "node:fs";
@@ -6,14 +13,12 @@ import path from "node:path";
 import { beforeEach } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { ErrorDescriptor, HardhatError } from "@nomicfoundation/hardhat-errors";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { getRealPath, mkdir, remove } from "@nomicfoundation/hardhat-utils/fs";
 import semver from "semver";
 
 import { ResolvedFile } from "../src/internal/solidity/resolver.js";
-import { BuildConfig, SolidityConfig } from "../src/internal/types/config.js";
-import { SolcConfig } from "../src/internal/types/index.js";
 
 const _filename = fileURLToPath(import.meta.url);
 const _dirname = path.dirname(_filename);

--- a/v-next/hardhat-build-system/test/index.ts
+++ b/v-next/hardhat-build-system/test/index.ts
@@ -213,10 +213,11 @@ describe("build-system", () => {
       const buildSystem = new BuildSystem(config);
       await buildSystem.build();
 
+      const calledWithExpectedMessage =
+        "Compiled 4 Solidity files successfully (evm targets: paris, petersburg, shanghai, unknown evm version for solc version 0.4.11).";
       assert(
-        spyFunctionConsoleLog.calledWith(
-          "Compiled 4 Solidity files successfully (evm targets: paris, petersburg, shanghai, unknown evm version for solc version 0.4.11).",
-        ),
+        spyFunctionConsoleLog.calledWith(calledWithExpectedMessage),
+        `expected console.log to be called with "${calledWithExpectedMessage}" but got "${spyFunctionConsoleLog.args[0][0]}"`,
       );
 
       spyFunctionConsoleLog.restore();

--- a/v-next/hardhat-build-system/test/internal/utils/artifacts.ts
+++ b/v-next/hardhat-build-system/test/internal/utils/artifacts.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- TODO: Stop
 using invalid objects in tests */
+import type {
+  Artifact,
+  BuildInfo,
+  CompilerInput,
+  CompilerOutput,
+} from "../../../src/internal/types/artifacts.js";
+
 import assert from "node:assert/strict";
 import * as os from "node:os";
 import path from "node:path";
@@ -12,12 +19,6 @@ import {
   writeJsonFile,
 } from "@nomicfoundation/hardhat-utils/fs";
 
-import {
-  Artifact,
-  BuildInfo,
-  CompilerInput,
-  CompilerOutput,
-} from "../../../src/internal/types/artifacts.js";
 import {
   Artifacts,
   getArtifactFromContractOutput,

--- a/v-next/hardhat-errors/src/errors.ts
+++ b/v-next/hardhat-errors/src/errors.ts
@@ -1,7 +1,9 @@
+import type { ErrorDescriptor } from "./descriptors.js";
+
 import { CustomError } from "@nomicfoundation/hardhat-utils/error";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { ERRORS, ErrorDescriptor } from "./descriptors.js";
+import { ERRORS } from "./descriptors.js";
 
 export type ErrorMessageTemplateValue =
   | string

--- a/v-next/hardhat-errors/test/errors.ts
+++ b/v-next/hardhat-errors/test/errors.ts
@@ -25,35 +25,56 @@ const mockErrorDescriptor = {
 describe("HardhatError", () => {
   describe("Type guard", () => {
     it("Should return true for HardhatErrors", () => {
+      const error = new HardhatError(mockErrorDescriptor);
       assert.ok(
-        HardhatError.isHardhatError(new HardhatError(mockErrorDescriptor)),
+        HardhatError.isHardhatError(error),
+        `error ${error.number} is a HardhatError, but isHardhatError returned false`,
       );
     });
 
     it("Should return true for HardhatErrors with the same ErrorDescriptor", () => {
+      const error = new HardhatError(mockErrorDescriptor);
       assert.ok(
-        HardhatError.isHardhatError(
-          new HardhatError(mockErrorDescriptor),
-          mockErrorDescriptor,
-        ),
+        HardhatError.isHardhatError(error, mockErrorDescriptor),
+        `error ${error.number} matches the descriptor ${JSON.stringify(mockErrorDescriptor, null, 2)}, but isHardhatError returned false`,
       );
     });
 
     it("Should return false for everything else", () => {
-      assert.ok(!HardhatError.isHardhatError(new Error()));
-      assert.ok(!HardhatError.isHardhatError(undefined));
-      assert.ok(!HardhatError.isHardhatError(null));
-      assert.ok(!HardhatError.isHardhatError(123));
-      assert.ok(!HardhatError.isHardhatError("123"));
-      assert.ok(!HardhatError.isHardhatError({ asd: 123 }));
+      assert.ok(
+        !HardhatError.isHardhatError(new Error()),
+        "new Error() is not a HardhatError, but isHardhatError returned true",
+      );
+      assert.ok(
+        !HardhatError.isHardhatError(undefined),
+        "undefined is not a HardhatError, but isHardhatError returned true",
+      );
+      assert.ok(
+        !HardhatError.isHardhatError(null),
+        "null is not a HardhatError, but isHardhatError returned true",
+      );
+      assert.ok(
+        !HardhatError.isHardhatError(123),
+        "123 is not a HardhatError, but isHardhatError returned true",
+      );
+      assert.ok(
+        !HardhatError.isHardhatError("123"),
+        '"123" is not a HardhatError, but isHardhatError returned true',
+      );
+      assert.ok(
+        !HardhatError.isHardhatError({ asd: 123 }),
+        "{ asd: 123 } is not a HardhatError, but isHardhatError returned true",
+      );
     });
 
     it("Should return false for HardhatErrors with a different ErrorDescriptor", () => {
+      const error = new HardhatError(mockErrorDescriptor);
       assert.ok(
-        !HardhatError.isHardhatError(new HardhatError(mockErrorDescriptor), {
+        !HardhatError.isHardhatError(error, {
           ...mockErrorDescriptor,
           number: 1,
         }),
+        `error ${error.number} doesn't match the descriptor ${JSON.stringify(mockErrorDescriptor, null, 2)}, but isHardhatError returned true`,
       );
     });
   });
@@ -400,7 +421,7 @@ describe("Type tests", () => {
     describe("Edge cases", () => {
       it("Should support {}", () => {
         expectTypeOf<MessagetTemplateArguments<"foo {} {}">>().toEqualTypeOf<{
-          /* eslint-disable-next-line @typescript-eslint/naming-convention -- 
+          /* eslint-disable-next-line @typescript-eslint/naming-convention --
           This test case is intentionally testing a weird variable name */
           "": ErrorMessageTemplateValue;
         }>();

--- a/v-next/hardhat-errors/test/errors.ts
+++ b/v-next/hardhat-errors/test/errors.ts
@@ -1,19 +1,16 @@
+import type { ErrorDescriptor } from "../src/descriptors.js";
+import type {
+  ErrorMessageTemplateValue,
+  MessagetTemplateArguments,
+} from "../src/errors.js";
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { expectTypeOf } from "expect-type";
 
-import {
-  ERRORS,
-  ERROR_CATEGORIES,
-  ErrorDescriptor,
-} from "../src/descriptors.js";
-import {
-  ErrorMessageTemplateValue,
-  HardhatError,
-  MessagetTemplateArguments,
-  applyErrorMessageTemplate,
-} from "../src/errors.js";
+import { ERRORS, ERROR_CATEGORIES } from "../src/descriptors.js";
+import { HardhatError, applyErrorMessageTemplate } from "../src/errors.js";
 
 const mockErrorDescriptor = {
   number: 123,

--- a/v-next/hardhat-node-test-reporter/src/diagnostics.ts
+++ b/v-next/hardhat-node-test-reporter/src/diagnostics.ts
@@ -1,4 +1,4 @@
-import { TestEventData } from "./node-types.js";
+import type { TestEventData } from "./node-types.js";
 
 export interface GlobalDiagnostics {
   tests: number;

--- a/v-next/hardhat-node-test-reporter/src/formatting.ts
+++ b/v-next/hardhat-node-test-reporter/src/formatting.ts
@@ -1,8 +1,9 @@
+import type { GlobalDiagnostics } from "./diagnostics.js";
+import type { TestEventData } from "./node-types.js";
+
 import chalk from "chalk";
 
-import { GlobalDiagnostics } from "./diagnostics.js";
 import { formatError } from "./error-formatting.js";
-import { TestEventData } from "./node-types.js";
 
 export const INFO_SYMBOL = chalk.blue("\u2139");
 export const SUCCESS_SYMBOL = chalk.green("✔");

--- a/v-next/hardhat-node-test-reporter/src/github-actions.ts
+++ b/v-next/hardhat-node-test-reporter/src/github-actions.ts
@@ -1,9 +1,10 @@
+import type { TestEventData } from "./node-types.js";
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { formatError } from "./error-formatting.js";
 import { cleanupTestFailError } from "./node-test-error-utils.js";
-import { TestEventData } from "./node-types.js";
 
 export async function annotatePR(
   event: TestEventData["test:fail"],

--- a/v-next/hardhat-node-test-reporter/src/reporter.ts
+++ b/v-next/hardhat-node-test-reporter/src/reporter.ts
@@ -1,3 +1,10 @@
+import type { Failure } from "./formatting.js";
+import type {
+  TestEventData,
+  TestEventSource,
+  TestReporterResult,
+} from "./node-types.js";
+
 import chalk from "chalk";
 
 import { processGlobalDiagnostics } from "./diagnostics.js";
@@ -9,15 +16,9 @@ import {
   formatTestFailure,
   formatTestPass,
   formatSlowTestInfo,
-  Failure,
 } from "./formatting.js";
 import { annotatePR } from "./github-actions.js";
 import { isSubtestFailedError } from "./node-test-error-utils.js";
-import {
-  TestEventData,
-  TestEventSource,
-  TestReporterResult,
-} from "./node-types.js";
 
 export const SLOW_TEST_THRESHOLD = 75;
 
@@ -220,7 +221,7 @@ export default async function* customReporter(
         break;
       }
       /* eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check --
-      We have this extra check here becase we know the @types/node type is 
+      We have this extra check here becase we know the @types/node type is
       unreliable */
       default: {
         const _isNever: never = event;

--- a/v-next/hardhat-utils/src/request.ts
+++ b/v-next/hardhat-utils/src/request.ts
@@ -1,7 +1,7 @@
+import type EventEmitter from "node:events";
 import type { ParsedUrlQueryInput } from "node:querystring";
 import type UndiciT from "undici";
 
-import EventEmitter from "node:events";
 import fs from "node:fs";
 import querystring from "node:querystring";
 import stream from "node:stream/promises";

--- a/v-next/hardhat-utils/test/fs.ts
+++ b/v-next/hardhat-utils/test/fs.ts
@@ -576,7 +576,7 @@ describe("File system utils", () => {
       const encoder = new TextEncoder();
       const binaryContent = encoder.encode(content);
 
-      assert.deepStrictEqual(await readBinaryFile(filePath), binaryContent);
+      assert.deepEqual(await readBinaryFile(filePath), binaryContent);
       expectTypeOf(await readBinaryFile(filePath)).toMatchTypeOf<Uint8Array>();
     });
 

--- a/v-next/hardhat-utils/test/helpers/request.ts
+++ b/v-next/hardhat-utils/test/helpers/request.ts
@@ -1,8 +1,8 @@
+import type { DispatcherOptions } from "../../src/request.js";
+
 import { after, before } from "node:test";
 
 import { MockAgent } from "undici";
-
-import { DispatcherOptions } from "../../src/request.js";
 
 export function getTestDispatcherOptions(options: DispatcherOptions = {}) {
   return {

--- a/v-next/hardhat-utils/test/lang.ts
+++ b/v-next/hardhat-utils/test/lang.ts
@@ -342,20 +342,50 @@ describe("lang", () => {
 
   describe("isObject", () => {
     it("Should return true for objects", () => {
-      assert.ok(isObject({}));
-      assert.ok(isObject({ a: 1 }));
-      assert.ok(isObject(new Date()));
-      assert.ok(isObject(new Map()));
-      assert.ok(isObject(new Set()));
+      assert.ok(isObject({}), "{} is an object, but isObject returned false");
+      assert.ok(
+        isObject({ a: 1 }),
+        "{ a: 1 } is an object, but isObject returned false",
+      );
+      assert.ok(
+        isObject(new Date()),
+        "new Date() is an object, but isObject returned false",
+      );
+      assert.ok(
+        isObject(new Map()),
+        "new Map() is an object, but isObject returned false",
+      );
+      assert.ok(
+        isObject(new Set()),
+        "new Set() is an object, but isObject returned false",
+      );
     });
 
     it("Should return false for non-objects", () => {
-      assert.ok(!isObject(null));
-      assert.ok(!isObject(undefined));
-      assert.ok(!isObject([]));
-      assert.ok(!isObject(""));
-      assert.ok(!isObject(42));
-      assert.ok(!isObject(true));
+      assert.ok(
+        !isObject(null),
+        "null is not an object, but isObject returned true",
+      );
+      assert.ok(
+        !isObject(undefined),
+        "undefined is not an object, but isObject returned true",
+      );
+      assert.ok(
+        !isObject([]),
+        "[] is not an object, but isObject returned true",
+      );
+      assert.ok(
+        !isObject(""),
+        "'' is not an object, but isObject returned true",
+      );
+      assert.ok(
+        !isObject(42),
+        "42 is not an object, but isObject returned true",
+      );
+      assert.ok(
+        !isObject(true),
+        "true is not an object, but isObject returned true",
+      );
     });
   });
 });

--- a/v-next/hardhat-utils/test/package.ts
+++ b/v-next/hardhat-utils/test/package.ts
@@ -1,3 +1,5 @@
+import type { PackageJson } from "../src/package.js";
+
 import assert from "node:assert/strict";
 import path from "node:path";
 import { describe, it } from "node:test";
@@ -6,7 +8,6 @@ import { expectTypeOf } from "expect-type";
 
 import { createFile, mkdir, writeJsonFile, writeUtf8File } from "../src/fs.js";
 import {
-  PackageJson,
   findClosestPackageJson,
   readClosestPackageJson,
   findClosestPackageRoot,

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -1,6 +1,8 @@
-import { HardhatUserConfig } from "@nomicfoundation/hardhat-core/config";
-import { HardhatUserConfigValidationError } from "@nomicfoundation/hardhat-core/types/hooks";
-import { ZodType, ZodTypeDef, ZodIssue, z } from "zod";
+import type { HardhatUserConfig } from "@nomicfoundation/hardhat-core/config";
+import type { HardhatUserConfigValidationError } from "@nomicfoundation/hardhat-core/types/hooks";
+import type { ZodType, ZodTypeDef, ZodIssue } from "zod";
+
+import { z } from "zod";
 
 /**
  * A Zod type to validate Hardhat's ConfigurationVariable objects.

--- a/v-next/hardhat-zod-utils/test/index.ts
+++ b/v-next/hardhat-zod-utils/test/index.ts
@@ -3,6 +3,6 @@ import { describe, it } from "node:test";
 
 describe("Example tests", () => {
   it("foo", function () {
-    assert.ok(true);
+    assert.ok(true, "this shouldn't fail");
   });
 });

--- a/v-next/hardhat/src/hre.ts
+++ b/v-next/hardhat/src/hre.ts
@@ -1,12 +1,13 @@
+import type { HardhatUserConfig } from "./types/config.js";
+import type { GlobalArguments } from "./types/global-parameters.js";
+import type { HardhatRuntimeEnvironment } from "./types/hre.js";
+
 import {
   createHardhatRuntimeEnvironment as originalCreateHardhatRuntimeEnvironment,
   resolvePluginList,
 } from "@nomicfoundation/hardhat-core";
 
 import { builtinPlugins } from "./internal/builtin-plugins/index.js";
-import { HardhatUserConfig } from "./types/config.js";
-import { GlobalArguments } from "./types/global-parameters.js";
-import { HardhatRuntimeEnvironment } from "./types/hre.js";
 
 /**
  * Creates an instances of the Hardhat Runtime Environment.

--- a/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/hookHandlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/hookHandlers/config.ts
@@ -1,4 +1,5 @@
-import { ConfigHooks } from "@nomicfoundation/hardhat-core/types/hooks";
+import type { ConfigHooks } from "@nomicfoundation/hardhat-core/types/hooks";
+
 import {
   sensitiveStringType,
   validateUserConfigZodType,

--- a/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/hookHandlers/configurationVariables.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/hookHandlers/configurationVariables.ts
@@ -1,4 +1,4 @@
-import { ConfigurationVariableHooks } from "@nomicfoundation/hardhat-core/types/hooks";
+import type { ConfigurationVariableHooks } from "@nomicfoundation/hardhat-core/types/hooks";
 
 export default async () => {
   const handlers: Partial<ConfigurationVariableHooks> = {

--- a/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/index.ts
@@ -1,5 +1,6 @@
+import type { HardhatPlugin } from "@nomicfoundation/hardhat-core/types/plugins";
+
 import { globalFlag, task } from "@nomicfoundation/hardhat-core/config";
-import { HardhatPlugin } from "@nomicfoundation/hardhat-core/types/plugins";
 import "./type-extensions.js";
 
 export default {

--- a/v-next/hardhat/src/internal/builtin-plugins/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/index.ts
@@ -1,4 +1,4 @@
-import { HardhatPlugin } from "@nomicfoundation/hardhat-core/types/plugins";
+import type { HardhatPlugin } from "@nomicfoundation/hardhat-core/types/plugins";
 
 import hardhatFoo from "./hardhat-foo/index.js";
 

--- a/v-next/hardhat/test/hre/index.ts
+++ b/v-next/hardhat/test/hre/index.ts
@@ -65,7 +65,10 @@ describe("HRE", () => {
           it("should load a config file in the current directory", async () => {
             const configPath = await resolveConfigPath();
 
-            assert(configPath.endsWith("hardhat.config.js"));
+            assert(
+              configPath.endsWith("hardhat.config.js"),
+              `expected configPath to end with hardhat.config.js, but got ${configPath}`,
+            );
           });
         });
 
@@ -75,7 +78,10 @@ describe("HRE", () => {
           it("should load a config file in the parent directory", async () => {
             const configPath = await resolveConfigPath();
 
-            assert(configPath.endsWith("hardhat.config.js"));
+            assert(
+              configPath.endsWith("hardhat.config.js"),
+              `expected configPath to end with hardhat.config.js, but got ${configPath}`,
+            );
           });
         });
       });
@@ -87,7 +93,10 @@ describe("HRE", () => {
           it("should load a config file in the current directory", async () => {
             const configPath = await resolveConfigPath();
 
-            assert(configPath.endsWith("hardhat.config.ts"));
+            assert(
+              configPath.endsWith("hardhat.config.ts"),
+              `expected configPath to end with hardhat.config.js, but got ${configPath}`,
+            );
           });
         });
 
@@ -97,7 +106,10 @@ describe("HRE", () => {
           it("should load a config file in the parent directory", async () => {
             const configPath = await resolveConfigPath();
 
-            assert(configPath.endsWith("hardhat.config.ts"));
+            assert(
+              configPath.endsWith("hardhat.config.ts"),
+              `expected configPath to end with hardhat.config.js, but got ${configPath}`,
+            );
           });
         });
       });

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -1,3 +1,13 @@
+import type {
+  GlobalParameterMap,
+  GlobalParameterMapEntry,
+} from "@nomicfoundation/hardhat-core/types/global-parameters";
+import type { HardhatRuntimeEnvironment } from "@nomicfoundation/hardhat-core/types/hre";
+import type {
+  NewTaskDefinition,
+  NewTaskDefinitionBuilder,
+} from "@nomicfoundation/hardhat-core/types/tasks";
+
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
@@ -8,15 +18,6 @@ import {
   globalParameter,
   task,
 } from "@nomicfoundation/hardhat-core/config";
-import {
-  GlobalParameterMap,
-  GlobalParameterMapEntry,
-} from "@nomicfoundation/hardhat-core/types/global-parameters";
-import { HardhatRuntimeEnvironment } from "@nomicfoundation/hardhat-core/types/hre";
-import {
-  NewTaskDefinition,
-  NewTaskDefinitionBuilder,
-} from "@nomicfoundation/hardhat-core/types/tasks";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
 


### PR DESCRIPTION
**Added 3 ESLint rules:**

1. **`@typescript-eslint/consistent-type-imports`**
   - Enforces using `import type ...` for type imports.
   - See: [consistent-type-imports documentation](https://typescript-eslint.io/rules/consistent-type-imports/)

2. **`no-restricted-syntax`**
   - Selector that matches `assert.strictEqual`, `assert.deepStrictEqual`, `assert.notStrictEqual`, etc., and requires using the non-strict versions. This works because all exports from `node:assert/strict` are already in strict mode.
   - Selector that matches `assert` and `assert.ok` and requires an assertion message. This is to avoid running into the bug that slows down the test suite.
