### PR TITLE
Implement logic for the --version cli global argument

### DIFF
--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -14,6 +14,8 @@ import type {
 
 import "tsx"; // NOTE: This is important, it allows us to load .ts files form the CLI
 
+import { fileURLToPath } from "node:url";
+
 import {
   buildGlobalParameterMap,
   resolvePluginList,
@@ -24,6 +26,11 @@ import {
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
+import { readJsonFile } from "@nomicfoundation/hardhat-utils/fs";
+import {
+  PackageJson,
+  findClosestPackageJson,
+} from "@nomicfoundation/hardhat-utils/package";
 import { kebabToCamelCase } from "@nomicfoundation/hardhat-utils/string";
 
 import { builtinPlugins } from "../builtin-plugins/index.js";
@@ -46,7 +53,7 @@ export async function main(cliArguments: string[]) {
   );
 
   if (hardhatSpecialArgs.version) {
-    console.log("3.0.0");
+    await printVersionMessage();
     return;
   }
 
@@ -501,6 +508,21 @@ function parsePositionalAndVariadicParameters(
 
   // Check if all the required parameters have been used
   validateRequiredParameters(task.positionalParameters, taskArguments);
+}
+
+async function printVersionMessage() {
+  const packageJsonPath = await findClosestPackageJson(
+    fileURLToPath(import.meta.url),
+  );
+
+  assertHardhatInvariant(
+    packageJsonPath !== null,
+    "There should be a package.json in hardhat's root directory",
+  );
+
+  const packageJson: PackageJson = await readJsonFile(packageJsonPath);
+
+  console.log(packageJson.version);
 }
 
 function validateRequiredParameters(

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -32,7 +32,8 @@ import {
   resolveConfigPath,
 } from "../helpers/config-loading.js";
 import { getHardhatRuntimeEnvironmentSingleton } from "../hre-singleton.js";
-import { getHardhatVersion } from "../utils/package.js";
+
+import { printVersionMessage } from "./version.js";
 
 export async function main(cliArguments: string[], print = console.log) {
   const hreInitStart = performance.now();
@@ -496,10 +497,6 @@ function parsePositionalAndVariadicParameters(
 
   // Check if all the required parameters have been used
   validateRequiredParameters(task.positionalParameters, taskArguments);
-}
-
-async function printVersionMessage(print = console.log) {
-  print(await getHardhatVersion());
 }
 
 function validateRequiredParameters(

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -47,7 +47,7 @@ export async function main(cliArguments: string[], print = console.log) {
   );
 
   if (hardhatSpecialArgs.version) {
-    await printVersionMessage();
+    await printVersionMessage(print);
     return;
   }
 
@@ -498,8 +498,8 @@ function parsePositionalAndVariadicParameters(
   validateRequiredParameters(task.positionalParameters, taskArguments);
 }
 
-async function printVersionMessage() {
-  console.log(await getHardhatVersion());
+async function printVersionMessage(print = console.log) {
+  print(await getHardhatVersion());
 }
 
 function validateRequiredParameters(

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -14,8 +14,6 @@ import type {
 
 import "tsx"; // NOTE: This is important, it allows us to load .ts files form the CLI
 
-import { fileURLToPath } from "node:url";
-
 import {
   buildGlobalParameterMap,
   resolvePluginList,
@@ -26,11 +24,6 @@ import {
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
-import { readJsonFile } from "@nomicfoundation/hardhat-utils/fs";
-import {
-  PackageJson,
-  findClosestPackageJson,
-} from "@nomicfoundation/hardhat-utils/package";
 import { kebabToCamelCase } from "@nomicfoundation/hardhat-utils/string";
 
 import { builtinPlugins } from "../builtin-plugins/index.js";
@@ -39,6 +32,7 @@ import {
   resolveConfigPath,
 } from "../helpers/config-loading.js";
 import { getHardhatRuntimeEnvironmentSingleton } from "../hre-singleton.js";
+import { getHardhatVersion } from "../utils/package.js";
 
 export async function main(cliArguments: string[]) {
   const hreInitStart = performance.now();
@@ -511,18 +505,7 @@ function parsePositionalAndVariadicParameters(
 }
 
 async function printVersionMessage() {
-  const packageJsonPath = await findClosestPackageJson(
-    fileURLToPath(import.meta.url),
-  );
-
-  assertHardhatInvariant(
-    packageJsonPath !== null,
-    "There should be a package.json in hardhat's root directory",
-  );
-
-  const packageJson: PackageJson = await readJsonFile(packageJsonPath);
-
-  console.log(packageJson.version);
+  console.log(await getHardhatVersion());
 }
 
 function validateRequiredParameters(

--- a/v-next/hardhat/src/internal/cli/version.ts
+++ b/v-next/hardhat/src/internal/cli/version.ts
@@ -1,0 +1,5 @@
+import { getHardhatVersion } from "../utils/package.js";
+
+export async function printVersionMessage(print = console.log) {
+  print(await getHardhatVersion());
+}

--- a/v-next/hardhat/src/internal/utils/package.ts
+++ b/v-next/hardhat/src/internal/utils/package.ts
@@ -1,0 +1,22 @@
+import type { PackageJson } from "@nomicfoundation/hardhat-utils/package";
+
+import { fileURLToPath } from "node:url";
+
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import { readJsonFile } from "@nomicfoundation/hardhat-utils/fs";
+import { findClosestPackageJson } from "@nomicfoundation/hardhat-utils/package";
+
+export async function getHardhatVersion(): Promise<string> {
+  const packageJsonPath = await findClosestPackageJson(
+    fileURLToPath(import.meta.url),
+  );
+
+  assertHardhatInvariant(
+    packageJsonPath !== null,
+    "There should be a package.json in hardhat's root directory",
+  );
+
+  const packageJson: PackageJson = await readJsonFile(packageJsonPath);
+
+  return packageJson.version;
+}

--- a/v-next/hardhat/src/internal/utils/package.ts
+++ b/v-next/hardhat/src/internal/utils/package.ts
@@ -1,22 +1,11 @@
 import type { PackageJson } from "@nomicfoundation/hardhat-utils/package";
 
-import { fileURLToPath } from "node:url";
-
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
-import { readJsonFile } from "@nomicfoundation/hardhat-utils/fs";
-import { findClosestPackageJson } from "@nomicfoundation/hardhat-utils/package";
+import { readClosestPackageJson } from "@nomicfoundation/hardhat-utils/package";
 
 export async function getHardhatVersion(): Promise<string> {
-  const packageJsonPath = await findClosestPackageJson(
-    fileURLToPath(import.meta.url),
+  const packageJson: PackageJson = await readClosestPackageJson(
+    import.meta.url,
   );
-
-  assertHardhatInvariant(
-    packageJsonPath !== null,
-    "There should be a package.json in hardhat's root directory",
-  );
-
-  const packageJson: PackageJson = await readJsonFile(packageJsonPath);
 
   return packageJson.version;
 }

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -29,6 +29,7 @@ import {
   parseTaskAndArguments,
 } from "../../../src/internal/cli/main.js";
 import { resetHardhatRuntimeEnvironmentSingleton } from "../../../src/internal/hre-singleton.js";
+import { getHardhatVersion } from "../../../src/internal/utils/package.js";
 import { useFixtureProject } from "../../helpers/project.js";
 
 async function getTasksAndHreEnvironment(
@@ -82,26 +83,25 @@ describe("main", function () {
     describe("version", function () {
       useFixtureProject("cli/parsing/base-project");
 
-      // TODO: as soon as the 'version task' is done, this test should be updated
-      it.todo(
-        "should print the version and instantly return",
-        async function () {
-          const lines: string[] = [];
+      it("should print the version and instantly return", async function () {
+        const lines: string[] = [];
 
-          const command = "npx hardhat --version";
-          const cliArguments = command.split(" ").slice(2);
+        const command = "npx hardhat --version";
+        const cliArguments = command.split(" ").slice(2);
 
-          await main(cliArguments, (msg) => {
-            lines.push(msg);
-          });
+        await main(cliArguments, (msg) => {
+          lines.push(msg);
+        });
 
-          assert.equal(lines.length, 1);
-          assert.equal(lines[0], "3.0.0");
-          // Check that the process exits right after printing the version, the remaining parsing logic should not be executed
-          const tasksResults = await getTasksAndSubtaskResults();
-          assert.equal(tasksResults.wasParam1Used, false);
-        },
-      );
+        // Get the expected package version
+        const expectedVersion = await getHardhatVersion();
+
+        assert.equal(lines.length, 1);
+        assert.equal(lines[0], expectedVersion);
+        // Check that the process exits right after printing the version, the remaining parsing logic should not be executed
+        const tasksResults = await getTasksAndSubtaskResults();
+        assert.equal(tasksResults.wasParam1Used, false);
+      });
     });
 
     describe("show-stack-traces", function () {


### PR DESCRIPTION
[Task description](https://github.com/NomicFoundation/hardhat/issues/5360)

[This PR](https://github.com/NomicFoundation/hardhat/pull/5380) should be merged first.

CHANGES:
- add a function to console.log the Hardhat version
- add a function to get the Hardhat version in the 'hardhat package'  at the path src/internal/utils/package.ts. For this function no test has been added because not very useful: a test would repeat the same logic in the test file as the original function because the hh package version cannot be hardcoded, since it constantly changes