### PR TITLE
update node versions supported to include node 22

### DIFF
--- a/.changeset/shiny-wasps-invite.md
+++ b/.changeset/shiny-wasps-invite.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add support for Node v22

--- a/.github/workflows/hardhat-chai-matchers-ci.yml
+++ b/.github/workflows/hardhat-chai-matchers-ci.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-core-ci.yml
+++ b/.github/workflows/hardhat-core-ci.yml
@@ -118,6 +118,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # TODO: Currently there is no @types/node for Node 22,
+        # include it when it is available.
         node: [18, 20]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/hardhat-ethers-ci.yml
+++ b/.github/workflows/hardhat-ethers-ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-foundry-ci.yml
+++ b/.github/workflows/hardhat-foundry-ci.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-ledger-ci.yml
+++ b/.github/workflows/hardhat-ledger-ci.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-network-helpers-ci.yml
+++ b/.github/workflows/hardhat-network-helpers-ci.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-network-tracing-all-solc-versions.yml
+++ b/.github/workflows/hardhat-network-tracing-all-solc-versions.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-shorthand-ci.yml
+++ b/.github/workflows/hardhat-shorthand-ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-solhint-ci.yml
+++ b/.github/workflows/hardhat-solhint-ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-solpp-ci.yml
+++ b/.github/workflows/hardhat-solpp-ci.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-toolbox-ci.yml
+++ b/.github/workflows/hardhat-toolbox-ci.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-truffle4-ci.yml
+++ b/.github/workflows/hardhat-truffle4-ci.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-truffle5-ci.yml
+++ b/.github/workflows/hardhat-truffle5-ci.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-verify-ci.yml
+++ b/.github/workflows/hardhat-verify-ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-viem-ci.yml
+++ b/.github/workflows/hardhat-viem-ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-vyper-ci.yml
+++ b/.github/workflows/hardhat-vyper-ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-web3-ci.yml
+++ b/.github/workflows/hardhat-web3-ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-web3-legacy-ci.yml
+++ b/.github/workflows/hardhat-web3-legacy-ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/hardhat-web3-v4-ci.yml
+++ b/.github/workflows/hardhat-web3-v4-ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/docs/src/content/hardhat-runner/docs/reference/stability-guarantees.md
+++ b/docs/src/content/hardhat-runner/docs/reference/stability-guarantees.md
@@ -15,9 +15,9 @@ We will only introduce these changes when a hardfork activates on Mainnet. This 
 
 ## Node.js versions support
 
-Hardhat supports every currently maintained LTS Node.js version, up to two months after its end-of-life. After that period of time, we will stop testing against it, and print a warning when trying to use it. At that point, we will release a new minor version.
+Hardhat works with every released and supported **even** Node.js version. This includes all **even** Node.js versions with a release status of: `Current`, `Active LTS` or `Maintenance`. Hardhat will cease support two months after the Node.js version's end-of-life. After that period of time, we will stop testing against it, and print a warning when trying to use it. At that point, we will release a new minor version.
 
-We recommend running Hardhat using the current LTS Node.js version. You can learn about it [here](https://nodejs.org/en/about/previous-releases).
+We recommend running Hardhat using the latest _Active LTS_ Node.js version. You can learn about more Node.js releases [here](https://github.com/nodejs/Release).
 
 ## How to avoid the breaking changes introduced by Hardhat
 

--- a/docs/src/content/tutorial/setting-up-the-environment.md
+++ b/docs/src/content/tutorial/setting-up-the-environment.md
@@ -21,7 +21,7 @@ Copy and paste these commands in a terminal:
 ```
 sudo apt update
 sudo apt install curl git
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
@@ -33,9 +33,9 @@ There are multiple ways of installing Node.js on MacOS. We will be using [Node V
 
 ```
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-nvm install 20
-nvm use 20
-nvm alias default 20
+nvm install 22
+nvm use 22
+nvm alias default 22
 npm install npm --global # Upgrade npm to the latest version
 ```
 
@@ -61,12 +61,12 @@ If your version of Node.js is older and [not supported by Hardhat](../hardhat-ru
 
 ### MacOS
 
-You can change your Node.js version using [nvm](http://github.com/creationix/nvm). To upgrade to Node.js `20.x` run these in a terminal:
+You can change your Node.js version using [nvm](http://github.com/creationix/nvm). To upgrade to Node.js `22.x` run these in a terminal:
 
 ```
-nvm install 20
-nvm use 20
-nvm alias default 20
+nvm install 22
+nvm use 22
+nvm alias default 22
 npm install npm --global # Upgrade npm to the latest version
 ```
 

--- a/packages/hardhat-core/src/internal/cli/bootstrap.ts
+++ b/packages/hardhat-core/src/internal/cli/bootstrap.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-import semver from "semver";
+
 import chalk from "chalk";
 
-import { SUPPORTED_NODE_VERSIONS } from "./constants";
+import { isNodeVersionToWarnOn } from "./is-node-version-to-warn-on";
 
-if (!semver.satisfies(process.version, SUPPORTED_NODE_VERSIONS.join(" || "))) {
+if (isNodeVersionToWarnOn(process.version)) {
   console.warn(
     chalk.yellow.bold(`WARNING:`),
     `You are currently using Node.js ${process.version}, which is not supported by Hardhat. This can lead to unexpected behavior. See https://hardhat.org/nodejs-versions`

--- a/packages/hardhat-core/src/internal/cli/constants.ts
+++ b/packages/hardhat-core/src/internal/cli/constants.ts
@@ -1,1 +1,1 @@
-export const SUPPORTED_NODE_VERSIONS = ["^18.0.0", "^20.0.0"];
+export const SUPPORTED_NODE_VERSIONS = ["^18.0.0", "^20.0.0", "^22.0.0"];

--- a/packages/hardhat-core/src/internal/cli/is-node-version-to-warn-on.ts
+++ b/packages/hardhat-core/src/internal/cli/is-node-version-to-warn-on.ts
@@ -1,0 +1,16 @@
+import semver from "semver";
+
+import { SUPPORTED_NODE_VERSIONS } from "./constants";
+
+/**
+ * Determine if the node version is unsupported by Hardhat
+ * and so a warning message should be shown.
+ *
+ * The current rule is that Hardhat supports all `Current`,
+ * `Active LTS`, and `Maintenance LTS` versions of Node.js
+ * as defined in the Node.js release schedule and encoded
+ * in the `SUPPORTED_NODE_VERSIONS` constant.
+ */
+export function isNodeVersionToWarnOn(nodeVersion: string): boolean {
+  return !semver.satisfies(nodeVersion, SUPPORTED_NODE_VERSIONS.join(" || "));
+}

--- a/packages/hardhat-core/test/internal/cli/is-node-version-to-warn-on.ts
+++ b/packages/hardhat-core/test/internal/cli/is-node-version-to-warn-on.ts
@@ -1,0 +1,43 @@
+import { assert } from "chai";
+import { isNodeVersionToWarnOn } from "../../../src/internal/cli/is-node-version-to-warn-on";
+
+describe("isNodeVersionToWarnOn", function () {
+  it("Should not warn on supported versions", function () {
+    assert.isFalse(isNodeVersionToWarnOn("v18.0.0"));
+    assert.isFalse(isNodeVersionToWarnOn("v18.20.3"));
+
+    assert.isFalse(isNodeVersionToWarnOn("v20.0.0"));
+    assert.isFalse(isNodeVersionToWarnOn("v20.14.0"));
+
+    assert.isFalse(isNodeVersionToWarnOn("v22.0.0"));
+    assert.isFalse(isNodeVersionToWarnOn("v22.3.0"));
+  });
+
+  it("Should warn on unsupported older node versions", function () {
+    assert(isNodeVersionToWarnOn("v10.0.0"));
+    assert(isNodeVersionToWarnOn("v10.24.1"));
+
+    assert(isNodeVersionToWarnOn("v12.0.0"));
+    assert(isNodeVersionToWarnOn("v12.22.12"));
+
+    assert(isNodeVersionToWarnOn("v14.0.0"));
+    assert(isNodeVersionToWarnOn("v14.21.3"));
+
+    assert(isNodeVersionToWarnOn("v16.0.0"));
+    assert(isNodeVersionToWarnOn("v16.20.20"));
+  });
+
+  it("Should warn on unsupported newer versions", function () {
+    assert(isNodeVersionToWarnOn("v24.0.0"));
+    assert(isNodeVersionToWarnOn("v24.3.0"));
+  });
+
+  it("Should warn on unsupported odd number releases", function () {
+    assert(isNodeVersionToWarnOn("v15.14.0"));
+    assert(isNodeVersionToWarnOn("v17.9.1"));
+    assert(isNodeVersionToWarnOn("v19.9.0"));
+    assert(isNodeVersionToWarnOn("v21.7.3"));
+    assert(isNodeVersionToWarnOn("v23.0.0"));
+    assert(isNodeVersionToWarnOn("v25.0.0"));
+  });
+});

--- a/packages/hardhat-core/test/internal/cli/is-node-version-to-warn-on.ts
+++ b/packages/hardhat-core/test/internal/cli/is-node-version-to-warn-on.ts
@@ -13,26 +13,32 @@ describe("isNodeVersionToWarnOn", function () {
     assert.isFalse(isNodeVersionToWarnOn("v22.3.0"));
   });
 
+  it("Should not warn on even newer versions even if they are unsupported", function () {
+    assert.isFalse(isNodeVersionToWarnOn("v24.0.0"));
+    assert.isFalse(isNodeVersionToWarnOn("v24.3.0"));
+  });
+
   it("Should warn on unsupported older node versions", function () {
     assert(isNodeVersionToWarnOn("v10.0.0"));
     assert(isNodeVersionToWarnOn("v10.24.1"));
 
+    assert(isNodeVersionToWarnOn("v11.0.0"));
+
     assert(isNodeVersionToWarnOn("v12.0.0"));
     assert(isNodeVersionToWarnOn("v12.22.12"));
 
+    assert(isNodeVersionToWarnOn("v13.0.0"));
+
     assert(isNodeVersionToWarnOn("v14.0.0"));
     assert(isNodeVersionToWarnOn("v14.21.3"));
+
+    assert(isNodeVersionToWarnOn("v15.0.0"));
 
     assert(isNodeVersionToWarnOn("v16.0.0"));
     assert(isNodeVersionToWarnOn("v16.20.20"));
   });
 
-  it("Should warn on unsupported newer versions", function () {
-    assert(isNodeVersionToWarnOn("v24.0.0"));
-    assert(isNodeVersionToWarnOn("v24.3.0"));
-  });
-
-  it("Should warn on unsupported odd number releases", function () {
+  it("Should warn on odd number releases", function () {
     assert(isNodeVersionToWarnOn("v15.14.0"));
     assert(isNodeVersionToWarnOn("v17.9.1"));
     assert(isNodeVersionToWarnOn("v19.9.0"));


### PR DESCRIPTION
This PR does three things:

1. Adds Node.js v22 support
2. Updates the stability guarantees text in our docs to clarify our version support policy
3. Updates the logic for displaying the unsupported version warning

## Node.js v22 support

The [node releases repo](https://github.com/nodejs/Release) indicate that node 22 is in the _Current_ release status. So we should support it.

## Improved stability guarantee text

We are updating our stability guarantees text to indicate that we will support **even numbered major versions** with a status of either:

* Current
* Active LTS
* Maintentance LTS

This is based on the node releases: https://nodejs.org/en/about/previous-releases and https://github.com/nodejs/Release

## Updated Warning Rule

Previously, Hardhat showed a version warning for any unsupported version:

1. All odd numbered major version numbers
4. All versions before the min version
5. All version after the max version

That rule has now been updated so that warnings are only shown for 1 and 2. Newer even versions don't display the unsupported versions warning message.

## PR Review Approach

Commit at a time.
