### PR TITLE
hook manager tests

### DIFF
--- a/v-next/core/src/internal/hook-manager.ts
+++ b/v-next/core/src/internal/hook-manager.ts
@@ -12,6 +12,8 @@ import type {
 import type { HardhatPlugin } from "../types/plugins.js";
 import type { LastParameter, Return } from "../types/utils.js";
 
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+
 export class HookManagerImplementation implements HookManager {
   readonly #pluginsInReverseOrder: HardhatPlugin[];
 
@@ -108,10 +110,10 @@ export class HookManagerImplementation implements HookManager {
 
     let handlerParams: Parameters<typeof defaultImplementation>;
     if (hookCategoryName !== "config") {
-      // TODO: assert that this.#context is not undefinded
-      if (this.#context === undefined) {
-        throw new Error(`Context must be set before running non-config hooks`);
-      }
+      assertHardhatInvariant(
+        this.#context !== undefined,
+        "Context must be set before running non-config hooks",
+      );
 
       handlerParams = [this.#context, ...params] as any;
     } else {

--- a/v-next/core/src/internal/hook-manager.ts
+++ b/v-next/core/src/internal/hook-manager.ts
@@ -182,10 +182,10 @@ export class HookManagerImplementation implements HookManager {
 
     let handlerParams: any;
     if (hookCategoryName !== "config") {
-      // TODO: assert that this.#context is not undefinded
-      if (this.#context === undefined) {
-        throw new Error(`Context must be set before running non-config hooks`);
-      }
+      assertHardhatInvariant(
+        this.#context !== undefined,
+        "Context must be set before running non-config hooks",
+      );
 
       handlerParams = [this.#context, ...params];
     } else {

--- a/v-next/core/src/internal/hook-manager.ts
+++ b/v-next/core/src/internal/hook-manager.ts
@@ -299,21 +299,17 @@ export class HookManagerImplementation implements HookManager {
 
     const factory = mod.default;
 
-    // TODO: Assert that the factory is a function
-    if (typeof factory !== "function") {
-      throw new Error(
-        `Plugin ${pluginId} doesn't export a hook factory for category ${hookCategoryName} in ${path}`,
-      );
-    }
+    assertHardhatInvariant(
+      typeof factory === "function",
+      `Plugin ${pluginId} doesn't export a hook factory for category ${hookCategoryName} in ${path}`,
+    );
 
     const category = await factory();
 
-    // TODO: Assert that category is not undefined and it's an object -- should use !isObject(category)
-    if (typeof category !== "object" || category === null) {
-      throw new Error(
-        `Plugin ${pluginId} doesn't export a valid factory for category ${hookCategoryName} in ${path}, it didn't return an object`,
-      );
-    }
+    assertHardhatInvariant(
+      category !== null && typeof category === "object",
+      `Plugin ${pluginId} doesn't export a valid factory for category ${hookCategoryName} in ${path}, it didn't return an object`,
+    );
 
     return category;
   }

--- a/v-next/core/src/internal/hook-manager.ts
+++ b/v-next/core/src/internal/hook-manager.ts
@@ -12,7 +12,10 @@ import type {
 import type { HardhatPlugin } from "../types/plugins.js";
 import type { LastParameter, Return } from "../types/utils.js";
 
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import {
+  HardhatError,
+  assertHardhatInvariant,
+} from "@nomicfoundation/hardhat-errors";
 
 export class HookManagerImplementation implements HookManager {
   readonly #pluginsInReverseOrder: HardhatPlugin[];
@@ -290,8 +293,13 @@ export class HookManagerImplementation implements HookManager {
     path: string,
   ): Promise<Partial<HardhatHooks[HookCategoryNameT]>> {
     if (!path.startsWith("file://")) {
-      throw new Error(
-        `Plugin ${pluginId} hook factory for ${hookCategoryName} is not a valid file:// URL: ${path}`,
+      throw new HardhatError(
+        HardhatError.ERRORS.HOOKS.INVALID_HOOK_FACTORY_PATH,
+        {
+          pluginId,
+          hookCategoryName,
+          path,
+        },
       );
     }
 

--- a/v-next/core/src/internal/hook-manager.ts
+++ b/v-next/core/src/internal/hook-manager.ts
@@ -149,10 +149,10 @@ export class HookManagerImplementation implements HookManager {
 
     let handlerParams: any;
     if (hookCategoryName !== "config") {
-      // TODO: assert that this.#context is not undefinded
-      if (this.#context === undefined) {
-        throw new Error(`Context must be set before running non-config hooks`);
-      }
+      assertHardhatInvariant(
+        this.#context !== undefined,
+        "Context must be set before running non-config hooks",
+      );
 
       handlerParams = [this.#context, ...params];
     } else {

--- a/v-next/core/test/internal/fixture-plugins/config-plugin.ts
+++ b/v-next/core/test/internal/fixture-plugins/config-plugin.ts
@@ -1,0 +1,22 @@
+import type { HardhatUserConfig } from "../../../src/types/config.js";
+import type {
+  ConfigHooks,
+  HardhatUserConfigValidationError,
+} from "@nomicfoundation/hardhat-core/types/hooks";
+
+export default async () => {
+  const handlers: Partial<ConfigHooks> = {
+    validateUserConfig: async (
+      _config: HardhatUserConfig,
+    ): Promise<HardhatUserConfigValidationError[]> => {
+      return [
+        {
+          message: "FromLoadedPlugin",
+          path: [],
+        },
+      ];
+    },
+  };
+
+  return handlers;
+};

--- a/v-next/core/test/internal/fixture-plugins/config-plugin.ts
+++ b/v-next/core/test/internal/fixture-plugins/config-plugin.ts
@@ -2,7 +2,7 @@ import type { HardhatUserConfig } from "../../../src/types/config.js";
 import type {
   ConfigHooks,
   HardhatUserConfigValidationError,
-} from "@nomicfoundation/hardhat-core/types/hooks";
+} from "../../../src/types/hooks.js";
 
 export default async () => {
   const handlers: Partial<ConfigHooks> = {

--- a/v-next/core/test/internal/hook-manager.ts
+++ b/v-next/core/test/internal/hook-manager.ts
@@ -1,0 +1,216 @@
+import type {
+  ConfigurationVariable,
+  HardhatConfig,
+  HardhatUserConfig,
+} from "../../src/types/config.js";
+import type { HookContext, HookManager } from "../../src/types/hooks.js";
+
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
+
+import { HookManagerImplementation } from "../../src/internal/hook-manager.js";
+import { UserInterruptionManagerImplementation } from "../../src/internal/user-interruptions.js";
+
+describe("HookManager", () => {
+  describe("runHandlerChain", () => {
+    let hookManager: HookManager;
+
+    beforeEach(() => {
+      const manager = new HookManagerImplementation([]);
+
+      const userInterruptionsManager =
+        new UserInterruptionManagerImplementation(hookManager);
+
+      manager.setContext({
+        config: {
+          tasks: [],
+          plugins: [],
+        },
+        hooks: hookManager,
+        globalArguments: {},
+        interruptions: userInterruptionsManager,
+      });
+
+      hookManager = manager;
+    });
+
+    it("should return the default implementation if no other handlers are provided", async () => {
+      const notExpectedConfig = {};
+
+      const defaultImplementationVersionOfConfig: HardhatConfig = {
+        plugins: [],
+        tasks: [],
+      };
+
+      const resultConfig = await hookManager.runHandlerChain(
+        "config",
+        "extendUserConfig",
+        [notExpectedConfig],
+        async () => {
+          return defaultImplementationVersionOfConfig;
+        },
+      );
+
+      assert.equal(resultConfig, defaultImplementationVersionOfConfig);
+    });
+
+    it("should run the handlers as a chain finishing with the default implementation", async () => {
+      const sequence: string[] = [];
+
+      hookManager.registerHandlers("config", {
+        extendUserConfig: async (
+          config: HardhatUserConfig,
+          next: (nextConfig: HardhatUserConfig) => Promise<HardhatUserConfig>,
+        ) => {
+          sequence.push("first:before");
+          const newConfig = await next(config);
+          sequence.push("first:after");
+
+          return newConfig;
+        },
+      });
+
+      hookManager.registerHandlers("config", {
+        extendUserConfig: async (
+          config: HardhatUserConfig,
+          next: (nextConfig: HardhatUserConfig) => Promise<HardhatUserConfig>,
+        ) => {
+          sequence.push("second:before");
+          const newConfig = await next(config);
+          sequence.push("second:after");
+
+          return newConfig;
+        },
+      });
+
+      hookManager.registerHandlers("config", {
+        extendUserConfig: async (
+          config: HardhatUserConfig,
+          next: (nextConfig: HardhatUserConfig) => Promise<HardhatUserConfig>,
+        ) => {
+          sequence.push("third:before");
+          const newConfig = await next(config);
+          sequence.push("third:after");
+
+          return newConfig;
+        },
+      });
+
+      await hookManager.runHandlerChain(
+        "config",
+        "extendUserConfig",
+        [{}],
+        async () => {
+          sequence.push("default");
+          return {};
+        },
+      );
+
+      assert.deepEqual(sequence, [
+        "third:before",
+        "second:before",
+        "first:before",
+        "default",
+        "first:after",
+        "second:after",
+        "third:after",
+      ]);
+    });
+
+    it("should pass the parameters directly for config hooks", async () => {
+      const expectedConfig: HardhatConfig = {
+        plugins: [],
+        tasks: [],
+      };
+
+      hookManager.registerHandlers("config", {
+        extendUserConfig: async (
+          config: HardhatUserConfig,
+          next: (nextConfig: HardhatUserConfig) => Promise<HardhatUserConfig>,
+        ) => {
+          assert.equal(
+            config,
+            expectedConfig,
+            "the param passed to runHandlerChain should be object equal with the param passed to the handlers",
+          );
+
+          const newConfig = await next(config);
+
+          return newConfig;
+        },
+      });
+
+      const resultConfig = await hookManager.runHandlerChain(
+        "config",
+        "extendUserConfig",
+        [expectedConfig],
+        async (c) => {
+          assert.equal(
+            c,
+            expectedConfig,
+            "the param passed through the next hierarchy should be object equal with the param passed to the default implementation",
+          );
+
+          return c;
+        },
+      );
+
+      assert.equal(resultConfig, expectedConfig);
+    });
+
+    it("should pass the parameters with hook context for non-config hooks", async () => {
+      const exampleConfigVar: ConfigurationVariable = {
+        _type: "ConfigurationVariable",
+        name: "example",
+      };
+
+      hookManager.registerHandlers("configurationVariables", {
+        fetchValue: async (
+          context: HookContext,
+          variable: ConfigurationVariable,
+          next: (
+            nextContext: HookContext,
+            nextVariable: ConfigurationVariable,
+          ) => Promise<string>,
+        ) => {
+          assert(
+            context !== null && typeof context === "object",
+            "Hook Context should be an object",
+          );
+
+          assert.equal(
+            variable,
+            exampleConfigVar,
+            "the param passed to runHandlerChain should be object equal with the param passed to the handlers",
+          );
+
+          const newValue = await next(context, variable);
+
+          return newValue;
+        },
+      });
+
+      const resultValue = await hookManager.runHandlerChain(
+        "configurationVariables",
+        "fetchValue",
+        [exampleConfigVar],
+        async (context, configVar) => {
+          assert(
+            context !== null && typeof context === "object",
+            "Hook Context should be an object",
+          );
+
+          assert.equal(
+            configVar,
+            exampleConfigVar,
+            "the param passed through the next hierarchy should be object equal with the param passed to the default implementation",
+          );
+
+          return "default-value";
+        },
+      );
+
+      assert.equal(resultValue, "default-value");
+    });
+  });
+});

--- a/v-next/core/test/internal/hook-manager.ts
+++ b/v-next/core/test/internal/hook-manager.ts
@@ -277,9 +277,9 @@ describe("HookManager", () => {
               },
             ),
           {
-            name: "Error",
+            name: "HardhatError",
             message:
-              "Plugin example hook factory for config is not a valid file:// URL: ./fixture-plugins/config-plugin.js",
+              'HHE1300: Plugin "example" hook factory for "config" is not a valid file:// URL: ./fixture-plugins/config-plugin.js.',
           },
         );
       });

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -74,6 +74,11 @@ export const ERROR_CATEGORIES: {
     max: 1299,
     websiteTitle: "Plugin errors",
   },
+  HOOKS: {
+    min: 1300,
+    max: 1399,
+    websiteTitle: "Hooks errors",
+  },
 };
 
 export const ERRORS = {
@@ -781,6 +786,15 @@ Please install a version of the peer dependency that meets the plugin's requirem
       messageTemplate: 'Plugin "{pluginId}" dependency could not be loaded.',
       websiteTitle: "Plugin dependency could not be loaded",
       websiteDescription: `The loading of a plugin's dependent plugin failed.`,
+    },
+  },
+  HOOKS: {
+    INVALID_HOOK_FACTORY_PATH: {
+      number: 1300,
+      messageTemplate:
+        'Plugin "{pluginId}" hook factory for "{hookCategoryName}" is not a valid file:// URL: {path}.',
+      websiteTitle: "Plugin hook factory is not a valid file URL",
+      websiteDescription: `The loading of a plugin's hook factory failed as the import path is not a valid file:// URL.`,
     },
   },
 } as const;


### PR DESCRIPTION
Add unit tests around the `HookManager` in `./v-next/core/src/internal/Hook-Manager.ts`.

It applies some small refactoring to the `HookManager` swapping in assertion instead of conditionals throwing errors, and replacing a plain `Error` with a specific `HardhatError`.

Resolves #5231.

## TODO

- [x] runHandlerChain
- [x] runSequentialHandlers
- [x] runParallelHandlers
- [x] unregisterHandlers