### PR TITLE
Add hardfork histories for opt and arb mainnet/sepolia

### DIFF
--- a/.changeset/unlucky-tips-jam.md
+++ b/.changeset/unlucky-tips-jam.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added hardfork histories for Optimim and Arbitrum chains

--- a/packages/hardhat-core/src/internal/core/config/default-config.ts
+++ b/packages/hardhat-core/src/internal/core/config/default-config.ts
@@ -141,6 +141,8 @@ export const defaultHardhatNetworkParams: Omit<
         ]),
       },
     ],
+    // TODO: the rest of this config is a temporary workaround,
+    // see https://github.com/NomicFoundation/edr/issues/522
     [
       10, // optimism mainnet
       {

--- a/packages/hardhat-core/src/internal/core/config/default-config.ts
+++ b/packages/hardhat-core/src/internal/core/config/default-config.ts
@@ -141,6 +141,30 @@ export const defaultHardhatNetworkParams: Omit<
         ]),
       },
     ],
+    [
+      10, // optimism mainnet
+      {
+        hardforkHistory: new Map([[HardforkName.SHANGHAI, 0]]),
+      },
+    ],
+    [
+      11155420, // optimism sepolia
+      {
+        hardforkHistory: new Map([[HardforkName.SHANGHAI, 0]]),
+      },
+    ],
+    [
+      42161, // arbitrum one
+      {
+        hardforkHistory: new Map([[HardforkName.SHANGHAI, 0]]),
+      },
+    ],
+    [
+      421614, // arbitrum sepolia
+      {
+        hardforkHistory: new Map([[HardforkName.SHANGHAI, 0]]),
+      },
+    ],
   ]),
 };
 


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/edr/issues/447.

We don't have hardfork activation histories for optimism and arbitrum. This means that if you fork one of those networks and immediately make a call, you'll get a "No known hardfork for execution on historical block..." error, because those calls are executed in the forked block, which uses the remote hardfork.

A scenario that doesn't work and is easier to understand is a call executed in a block before the forked block, for the same reason, but this is rarely done.

You might be wondering "why aren't more people complaining about this? Surely there are many users forking optimism and arbitrum", and I think the answer is that normally you send a transaction before making a call, which mines a new block and then the subsequent calls use the local, known hardfork.

The "histories" are used are obviously wrong. This basically says "use Shanghai for these chains". Finding the proper hardfork block numbers for L2s is hard, and even if you can do it there are extra problems: 1) those hardforks might not map 1-1 with ethereum mainnet hardforks, and 2) the hardforks might be specified using timestamps instead of block numbers, which makes this even harder.

So I did the lazy, conservative thing and set Shanghai to block 0 for the four chains.