### PR TITLE
Remove leftover `_eventAdapter` from `EdrProviderWrapper`

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -182,7 +182,6 @@ export class EdrProviderWrapper
     private readonly _node: {
       _vm: MinimalEthereumJsVm;
     },
-    private readonly _eventAdapter: EdrProviderEventAdapter,
     private readonly _vmTraceDecoder: VmTraceDecoder,
     private readonly _rawTraceCallbacks: RawTraceCallbacks,
     // The common configuration for EthereumJS VM is not used by EDR, but tests expect it as part of the provider.
@@ -323,7 +322,6 @@ export class EdrProviderWrapper
     const wrapper = new EdrProviderWrapper(
       provider,
       minimalEthereumJsNode,
-      eventAdapter,
       vmTraceDecoder,
       rawTraceCallbacks,
       common,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Seems to be a leftover from #4747 and it looks to be unused now as we create a new instance of `EdrProviderEventAdapter` explicitly in `create()` and move it into lambda.

Feel free to disregard if that's not true and/or we want to keep it.

