### PR TITLE
Make the test reporter's integration tests more robust across node versions

### DIFF
--- a/v-next/hardhat-node-test-reporter/integration-tests/index.ts
+++ b/v-next/hardhat-node-test-reporter/integration-tests/index.ts
@@ -71,5 +71,9 @@ function normalizeOutputs(output: string): string {
       .replaceAll(/\(.*?:\d+:\d+\)/g, (match) => {
         return match.replaceAll(path.sep, "/");
       })
+      // Remove lines like `at TestHook.run (node:internal/test_runner/test:1107:18)`
+      .replaceAll(/at .*? \(node\:.*?:\d+:\d+\)/g, "")
+      // Remove lines like `at node:internal/test_runner/test:776:20`
+      .replaceAll(/at node\:.*?:\d+:\d+/g, "")
   );
 }

--- a/v-next/hardhat-node-test-reporter/integration-tests/index.ts
+++ b/v-next/hardhat-node-test-reporter/integration-tests/index.ts
@@ -60,10 +60,16 @@ for (const entry of readdirSync(import.meta.dirname + "/fixture-tests")) {
 }
 
 function normalizeOutputs(output: string): string {
-  return output
-    .replace(/\(\d+ms\)/, "(Xms)")
-    .replaceAll("\r\n", "\n")
-    .replaceAll(/\(.*?:\d+:\d+\)/g, (match) => {
-      return match.replaceAll(path.sep, "/");
-    });
+  return (
+    output
+      // Normalize the time it took to run the test
+      .replace(/\(\d+ms\)/, "(Xms)")
+      // Normalize windows new lines
+      .replaceAll("\r\n", "\n")
+      // Normalize path separators to `/` within the (file:line:column)
+      // part of the stack traces
+      .replaceAll(/\(.*?:\d+:\d+\)/g, (match) => {
+        return match.replaceAll(path.sep, "/");
+      })
+  );
 }


### PR DESCRIPTION
This PR fixes the test runner's integration tests, which had stopped passing with the release of Node v22.3.0.

The reason they were failing was that the stack traces have some references to Node's internals and those change across versions.

This PR removes those references before comparing the expected results.