### PR TITLE
move parseTaskAndArguments into the tests as a temporary fix for tests

### DIFF
--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -249,39 +249,6 @@ export function parseTask(
   return taskOrId;
 }
 
-/**
- * Parses the task id and its arguments.
- *
- * @returns The task and its arguments, or an array with the unrecognized task
- *  id. If no task id is provided, an empty array is returned.
- */
-// todo: this function isn't used anymore and needs to be removed
-export function parseTaskAndArguments(
-  cliArguments: string[],
-  usedCliArguments: boolean[],
-  hre: HardhatRuntimeEnvironment,
-):
-  | {
-      task: Task;
-      taskArguments: TaskArguments;
-    }
-  | string[] {
-  const taskOrId = parseTask(cliArguments, usedCliArguments, hre);
-  if (Array.isArray(taskOrId)) {
-    return taskOrId;
-  }
-
-  const task = taskOrId;
-
-  const taskArguments = parseTaskArguments(
-    cliArguments,
-    usedCliArguments,
-    task,
-  );
-
-  return { task, taskArguments };
-}
-
 function getTaskFromCliArguments(
   cliArguments: string[],
   usedCliArguments: boolean[],
@@ -341,7 +308,7 @@ function getTaskFromCliArguments(
   return task;
 }
 
-function parseTaskArguments(
+export function parseTaskArguments(
   cliArguments: string[],
   usedCliArguments: boolean[],
   task: Task,

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -6,6 +6,8 @@ import type { HardhatRuntimeEnvironment } from "@nomicfoundation/hardhat-core/ty
 import type {
   NewTaskDefinition,
   NewTaskDefinitionBuilder,
+  Task,
+  TaskArguments,
 } from "@nomicfoundation/hardhat-core/types/tasks";
 
 import assert from "node:assert/strict";
@@ -27,7 +29,8 @@ import {
   main,
   parseGlobalOptions,
   parseHardhatSpecialArguments,
-  parseTaskAndArguments,
+  parseTask,
+  parseTaskArguments,
 } from "../../../src/internal/cli/main.js";
 import { resetHardhatRuntimeEnvironmentSingleton } from "../../../src/internal/hre-singleton.js";
 import { getHardhatVersion } from "../../../src/internal/utils/package.js";
@@ -465,6 +468,33 @@ For global options help run: hardhat --help`;
   });
 
   describe("parseTaskAndArguments", function () {
+    // This is not an ideal way to test these two functions now that they're split apart,
+    // but I don't think it's worth the time to refactor all of these tests right now since the logic is the same.
+    function parseTaskAndArguments(
+      cliArguments: string[],
+      usedCliArguments: boolean[],
+      hreLocal: HardhatRuntimeEnvironment,
+    ):
+      | {
+          task: Task;
+          taskArguments: TaskArguments;
+        }
+      | string[] {
+      const parsedTask = parseTask(cliArguments, usedCliArguments, hreLocal);
+      if (Array.isArray(parsedTask)) {
+        return parsedTask;
+      }
+
+      return {
+        task: parsedTask,
+        taskArguments: parseTaskArguments(
+          cliArguments,
+          usedCliArguments,
+          parsedTask,
+        ),
+      };
+    }
+
     let hre: HardhatRuntimeEnvironment;
     let tasks: NewTaskDefinition[];
     let subtasks: NewTaskDefinition[];


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/hardhat/issues/5410

Ideally, this PR would split the tests into appropriate tests of `parseTask` and `parseTaskArguments`, however, there are many tests and the logic for testing both is deeply intertwined in both. Since the underlying logic is the same, I decided to simply make `parseTaskAndArguments` a test-only function abstraction since I don't think it's worth the dev time right now to fully break out all the tests.