### PR TITLE
changed solc version to 0.8.26 - resolves #5427

### DIFF
--- a/.changeset/lovely-kiwis-hang.md
+++ b/.changeset/lovely-kiwis-hang.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Upgrade bundled solcjs

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -136,7 +136,7 @@
     "raw-body": "^2.4.1",
     "resolve": "1.17.0",
     "semver": "^6.3.0",
-    "solc": "0.7.3",
+    "solc": "0.8.26",
     "source-map-support": "^0.5.13",
     "stacktrace-parser": "^0.1.10",
     "tsort": "0.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,8 +303,8 @@ importers:
         specifier: ^6.3.0
         version: 6.3.1
       solc:
-        specifier: 0.7.3
-        version: 0.7.3(debug@4.3.4)
+        specifier: 0.8.26
+        version: 0.8.26(debug@4.3.4)
       source-map-support:
         specifier: ^0.5.13
         version: 0.5.21
@@ -3532,12 +3532,13 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
-  commander@3.0.2:
-    resolution: {integrity: sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==}
-
   commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -6214,9 +6215,9 @@ packages:
     resolution: {integrity: sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==}
     hasBin: true
 
-  solc@0.7.3:
-    resolution: {integrity: sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==}
-    engines: {node: '>=8.0.0'}
+  solc@0.8.26:
+    resolution: {integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==}
+    engines: {node: '>=10.0.0'}
     hasBin: true
 
   solhint@3.6.2:
@@ -9531,9 +9532,9 @@ snapshots:
 
   commander@2.20.3: {}
 
-  commander@3.0.2: {}
-
   commander@6.2.1: {}
+
+  commander@8.3.0: {}
 
   commondir@1.0.1: {}
 
@@ -12603,15 +12604,13 @@ snapshots:
       semver: 5.7.2
       yargs: 4.8.1
 
-  solc@0.7.3(debug@4.3.4):
+  solc@0.8.26(debug@4.3.4):
     dependencies:
       command-exists: 1.2.9
-      commander: 3.0.2
+      commander: 8.3.0
       follow-redirects: 1.15.6(debug@4.3.4)
-      fs-extra: 0.30.0
       js-sha3: 0.8.0
       memorystream: 0.3.1
-      require-from-string: 2.0.2
       semver: 5.7.2
       tmp: 0.0.33
     transitivePeerDependencies:


### PR DESCRIPTION
- [ x  ] Because this PR includes a **bug fix**, relevant tests have been included.

in [hardhat/packages/hardhat-core/src/internal/solidity/compiler/solcrunner.js](https://github.com/NomicFoundation/hardhat/blob/91f6e21c0c1a2ed3b42f9b8c6d1069d169efe7d7/packages/hardhat-core/src/internal/solidity/compiler/solcjs-runner.js#L26), the previously offending package `solc` is used.  this is `solc`'s only appearance in this ENTIRE project.  By bumping the solc version from 0.7.3 to 0.8.26, `rimraf` is no longer a dependency, and one instance of an outdated `glob` being used has also been removed.  

resolves #5427 


