### PR TITLE
Clean up the VMTracer and trace events interface in TS

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -469,11 +469,11 @@ export class EdrProviderWrapper
   }
 
   /**
-   * Injects a `VMTracer` that observes EVM throughout requests.
+   * Sets a `VMTracer` that observes EVM throughout requests.
    *
    * Used for internal stack traces integration tests.
    */
-  public injectVmTracer(vmTracer?: VMTracer) {
+  public setVmTracer(vmTracer?: VMTracer) {
     this._vmTracer = vmTracer;
   }
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -576,7 +576,7 @@ export class EdrProviderWrapper
   private async _rawTraceToSolidityStackTrace(
     rawTrace: RawTrace
   ): Promise<SolidityStackTrace | undefined> {
-    const vmTracer = new VMTracer(false);
+    const vmTracer = new VMTracer();
 
     const trace = rawTrace.trace();
     for (const traceItem of trace) {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -167,6 +167,9 @@ export class EdrProviderWrapper
   // temporarily added to make smock work with HH+EDR
   private _callOverrideCallback?: CallOverrideCallback;
 
+  /** Used for internal stack trace tests. */
+  private _vmTracer?: VMTracer;
+
   private constructor(
     private readonly _provider: EdrProviderT,
     // we add this for backwards-compatibility with plugins like solidity-coverage
@@ -175,7 +178,6 @@ export class EdrProviderWrapper
     },
     private readonly _eventAdapter: EdrProviderEventAdapter,
     private readonly _vmTraceDecoder: VmTraceDecoder,
-    private readonly _vmTracer: VMTracer | undefined,
     // The common configuration for EthereumJS VM is not used by EDR, but tests expect it as part of the provider.
     private readonly _common: Common,
     tracingConfig?: TracingConfig
@@ -190,8 +192,7 @@ export class EdrProviderWrapper
   public static async create(
     config: HardhatNetworkProviderConfig,
     loggerConfig: LoggerConfig,
-    tracingConfig?: TracingConfig,
-    vmTracer?: VMTracer
+    tracingConfig?: TracingConfig
   ): Promise<EdrProviderWrapper> {
     const { Provider } = requireNapiRsModule(
       "@nomicfoundation/edr"
@@ -316,7 +317,6 @@ export class EdrProviderWrapper
       minimalEthereumJsNode,
       eventAdapter,
       vmTraceDecoder,
-      vmTracer,
       common,
       tracingConfig
     );
@@ -468,9 +468,13 @@ export class EdrProviderWrapper
     }
   }
 
-  /** Used for internal stack traces integration tests. Only defined there. */
-  public vmTracer(): VMTracer | undefined {
-    return this._vmTracer;
+  /**
+   * Injects a `VMTracer` that observes EVM throughout requests.
+   *
+   * Used for internal stack traces integration tests.
+   */
+  public injectVmTracer(vmTracer?: VMTracer) {
+    this._vmTracer = vmTracer;
   }
 
   // temporarily added to make smock work with HH+EDR

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/exit.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/exit.ts
@@ -91,25 +91,4 @@ export class Exit {
 
     const _exhaustiveCheck: never = this.kind;
   }
-
-  public getEdrExceptionalHalt(): ExceptionalHalt {
-    const { ExceptionalHalt } = requireNapiRsModule(
-      "@nomicfoundation/edr"
-    ) as typeof import("@nomicfoundation/edr");
-
-    switch (this.kind) {
-      case ExitCode.OUT_OF_GAS:
-        return ExceptionalHalt.OutOfGas;
-      case ExitCode.INVALID_OPCODE:
-        return ExceptionalHalt.OpcodeNotFound;
-      case ExitCode.CODESIZE_EXCEEDS_MAXIMUM:
-        return ExceptionalHalt.CreateContractSizeLimit;
-      case ExitCode.CREATE_COLLISION:
-        return ExceptionalHalt.CreateCollision;
-
-      default:
-        // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
-        throw new Error(`Unmatched exit code: ${this.kind}`);
-    }
-  }
 }

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/message-trace.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/message-trace.ts
@@ -34,8 +34,6 @@ export interface PrecompileMessageTrace extends BaseMessageTrace {
 
 export interface BaseEvmMessageTrace extends BaseMessageTrace {
   code: Uint8Array;
-  value: bigint;
-  returnData: Uint8Array;
   steps: MessageTraceStep[];
   bytecode?: Bytecode;
   // The following is just an optimization: When processing this traces it's useful to know ahead of

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-tracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-tracer.ts
@@ -46,10 +46,6 @@ export class VMTracer {
     return this._lastError;
   }
 
-  public clearLastError() {
-    this._lastError = undefined;
-  }
-
   private _shouldKeepTracing() {
     return this._throwErrors || this._lastError === undefined;
   }

--- a/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-tracer.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/stack-traces/vm-tracer.ts
@@ -54,7 +54,7 @@ export class VMTracer {
     return this._throwErrors || this._lastError === undefined;
   }
 
-  public async addBeforeMessage(message: TracingMessage) {
+  public addBeforeMessage(message: TracingMessage) {
     if (!this._shouldKeepTracing()) {
       return;
     }
@@ -151,7 +151,7 @@ export class VMTracer {
     }
   }
 
-  public async addStep(step: TracingStep) {
+  public addStep(step: TracingStep) {
     if (!this._shouldKeepTracing()) {
       return;
     }
@@ -177,7 +177,7 @@ export class VMTracer {
     }
   }
 
-  public async addAfterMessage(result: ExecutionResult, haltOverride?: Exit) {
+  public addAfterMessage(result: ExecutionResult, haltOverride?: Exit) {
     if (!this._shouldKeepTracing()) {
       return;
     }

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/execution.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/execution.ts
@@ -1,5 +1,3 @@
-import { assert } from "chai";
-
 import {
   bigIntToHex,
   bytesToHex,
@@ -60,8 +58,7 @@ export async function instantiateProvider(
   const provider = await EdrProviderWrapper.create(
     config,
     loggerConfig,
-    tracingConfig,
-    new VMTracer(false)
+    tracingConfig
   );
 
   return provider;
@@ -108,10 +105,8 @@ export async function traceTransaction(
   provider: EdrProviderWrapper,
   txData: TxData
 ): Promise<MessageTrace> {
-  const vmTracer = provider.vmTracer();
-  if (vmTracer === undefined) {
-    assert.fail("VMTracer should always be initialized in stack-traces");
-  }
+  const vmTracer = new VMTracer(false);
+  provider.injectVmTracer(vmTracer);
 
   try {
     await provider.request({
@@ -136,6 +131,6 @@ export async function traceTransaction(
     }
     return trace;
   } finally {
-    vmTracer.clearLastError();
+    provider.injectVmTracer(undefined);
   }
 }

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/execution.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/execution.ts
@@ -105,7 +105,7 @@ export async function traceTransaction(
   provider: EdrProviderWrapper,
   txData: TxData
 ): Promise<MessageTrace> {
-  const vmTracer = new VMTracer(false);
+  const vmTracer = new VMTracer();
   provider.injectVmTracer(vmTracer);
 
   try {

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/execution.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/execution.ts
@@ -106,7 +106,7 @@ export async function traceTransaction(
   txData: TxData
 ): Promise<MessageTrace> {
   const vmTracer = new VMTracer();
-  provider.injectVmTracer(vmTracer);
+  provider.setVmTracer(vmTracer);
 
   try {
     await provider.request({
@@ -131,6 +131,6 @@ export async function traceTransaction(
     }
     return trace;
   } finally {
-    provider.injectVmTracer(undefined);
+    provider.setVmTracer(undefined);
   }
 }

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -27,7 +27,6 @@ import {
 } from "../../../../src/internal/hardhat-network/stack-traces/solidity-stack-trace";
 import { SolidityTracer } from "../../../../src/internal/hardhat-network/stack-traces/solidityTracer";
 import { VmTraceDecoder } from "../../../../src/internal/hardhat-network/stack-traces/vm-trace-decoder";
-import { VMTracer } from "../../../../src/internal/hardhat-network/stack-traces/vm-tracer";
 import {
   BuildInfo,
   CompilerInput,
@@ -498,7 +497,7 @@ async function runTest(
 
   const logger = new FakeModulesLogger();
   const solidityTracer = new SolidityTracer();
-  const [provider, vmTracer] = await instantiateProvider(
+  const provider = await instantiateProvider(
     {
       enabled: false,
       printLineFn: logger.printLineFn(),
@@ -517,7 +516,6 @@ async function runTest(
         txIndex,
         tx,
         provider,
-        vmTracer,
         compilerOutput,
         txIndexToContract
       );
@@ -541,7 +539,6 @@ async function runTest(
         txIndex,
         tx,
         provider,
-        vmTracer,
         compilerOutput,
         contract!
       );
@@ -650,7 +647,6 @@ async function runDeploymentTransactionTest(
   txIndex: number,
   tx: DeploymentTransaction,
   provider: EdrProviderWrapper,
-  vmTracer: VMTracer,
   compilerOutput: CompilerOutput,
   txIndexToContract: Map<number, DeployedContract>
 ): Promise<CreateMessageTrace> {
@@ -682,7 +678,7 @@ async function runDeploymentTransactionTest(
 
   const data = Buffer.concat([deploymentBytecode, params]);
 
-  const trace = await traceTransaction(provider, vmTracer, {
+  const trace = await traceTransaction(provider, {
     value: tx.value !== undefined ? BigInt(tx.value) : undefined,
     data,
     gas: tx.gas !== undefined ? BigInt(tx.gas) : undefined,
@@ -695,7 +691,6 @@ async function runCallTransactionTest(
   txIndex: number,
   tx: CallTransaction,
   provider: EdrProviderWrapper,
-  vmTracer: VMTracer,
   compilerOutput: CompilerOutput,
   contract: DeployedContract
 ): Promise<CallMessageTrace> {
@@ -716,7 +711,7 @@ async function runCallTransactionTest(
     data = Buffer.from([]);
   }
 
-  const trace = await traceTransaction(provider, vmTracer, {
+  const trace = await traceTransaction(provider, {
     to: contract.address,
     value: tx.value !== undefined ? BigInt(tx.value) : undefined,
     data,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Rather than defining the callbacks at the provider instantiation time for the entire lifetime of the provider, this allows for a more granular control of injecting the trace event listener (VMTracer), thus simplifying how the information flows. In the test logic, we no longer tightly couple two classes but have to keep them side by side and we can stop observing the EVM if needed, without paying the runtime cost.

While technically it's a standalone improvement, the https://github.com/NomicFoundation/edr/pull/531 can nicely build on top if it as it will also allow us to conveniently observe the trace whenever needed all at once in Rust (with the Rust port of `VmTracer` in that PR); it also removes some dead code.

<!-- Add a description of your PR here -->
