### PR TITLE
Change network helpers' tests to Sepolia

### DIFF
--- a/packages/hardhat-network-helpers/test/helpers/reset.ts
+++ b/packages/hardhat-network-helpers/test/helpers/reset.ts
@@ -24,12 +24,12 @@ describe("resetWithoutFork", function () {
 
     const mainnetBlockNumber = await hh.time.latestBlock();
 
-    // fork goerli
-    await hh.reset(INFURA_URL.replace("mainnet", "goerli"));
+    // fork sepolia
+    await hh.reset(INFURA_URL.replace("mainnet", "sepolia"));
 
-    const goerliBlockNumber = await hh.time.latestBlock();
+    const sepoliaBlockNumber = await hh.time.latestBlock();
 
-    const blockNumberDelta = Math.abs(mainnetBlockNumber - goerliBlockNumber);
+    const blockNumberDelta = Math.abs(mainnetBlockNumber - sepoliaBlockNumber);
 
     // check that there is a significative difference between the latest
     // block numbers of each chain


### PR DESCRIPTION
This PR changes `hardhat-network-helper`'s tests from Goerli to Sepolia