### PR TITLE
Don't check dependencies of private packages

### DIFF
--- a/scripts/check-v-next-dependencies.js
+++ b/scripts/check-v-next-dependencies.js
@@ -136,11 +136,8 @@ function main() {
 
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
 
-    // temporarily ignore hardhat toolboxs
-    if (
-      packageJson.name === "@nomicfoundation/hardhat-toolbox" ||
-      packageJson.name === "@nomicfoundation/hardhat-toolbox-viem"
-    ) {
+    // We ignore any private package
+    if (packageJson.private === true) {
       continue;
     }
 


### PR DESCRIPTION
This PR fixes the v-next workflow to enforce consistent dependency versions across packages. It now doesn't take private packages into account.