### PR TITLE
chore: remove eslint rules from packages in v-next

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,7 +22,9 @@
     "@nomiclabs/hardhat-vyper",
     "@nomicfoundation/hardhat-web3-v4",
     "@nomicfoundation/example-project",
-    "@nomicfoundation/template-package"
+    "@nomicfoundation/template-package",
+    "@nomicfoundation/eslint-plugin-hardhat-internal-rules",
+    "@nomicfoundation/eslint-plugin-slow-imports"
   ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true

--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -10,10 +10,9 @@ const path = require("path");
  * The only packages that should not use this config are our own eslint plugins/rules.
  *
  * @param {string} configFilePath The path to the config file that is using this function.
- * @param {string[]} [packageEntryPoints=[]] The entry points of the package, expressed as relative paths from the config file.
  * @returns {import("eslint").Linter.Config}
  */
-function createConfig(configFilePath, packageEntryPoints = []) {
+function createConfig(configFilePath) {
   /**
    * @type {import("eslint").Linter.Config}
    */
@@ -23,7 +22,6 @@ function createConfig(configFilePath, packageEntryPoints = []) {
       es2022: true,
       node: true,
     },
-    extends: ["plugin:@nomicfoundation/slow-imports/recommended"],
     settings: {
       "import/resolver": {
         typescript: true,
@@ -36,11 +34,9 @@ function createConfig(configFilePath, packageEntryPoints = []) {
       tsconfigRootDir: path.dirname(configFilePath),
     },
     plugins: [
-      "@nomicfoundation/hardhat-internal-rules",
       "import",
       "no-only-tests",
       "@typescript-eslint",
-      "@nomicfoundation/slow-imports",
       "@eslint-community/eslint-comments",
     ],
     rules: {
@@ -391,22 +387,6 @@ function createConfig(configFilePath, packageEntryPoints = []) {
       },
     ],
   };
-
-  // TODO: Maybe re-enable it once we have a more stable project structure
-  // if (packageEntryPoints.length > 0) {
-  //   const acceptableTopLevelImports = [];
-  //   config.overrides?.push({
-  //     files: packageEntryPoints,
-  //     rules: {
-  //       "@nomicfoundation/slow-imports/no-top-level-external-import": [
-  //         "error",
-  //         {
-  //           ignoreModules: [...acceptableTopLevelImports],
-  //         },
-  //       ],
-  //     },
-  //   });
-  // }
 
   return config;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1447,12 +1447,6 @@ importers:
       '@microsoft/api-extractor':
         specifier: ^7.43.4
         version: 7.43.4(@types/node@20.14.9)
-      '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-hardhat-internal-rules
-      '@nomicfoundation/eslint-plugin-slow-imports':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-slow-imports
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9
@@ -1550,12 +1544,6 @@ importers:
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-node-test-reporter
-      '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-hardhat-internal-rules
-      '@nomicfoundation/eslint-plugin-slow-imports':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-slow-imports
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9
@@ -1662,12 +1650,6 @@ importers:
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.0
         version: link:../hardhat-node-test-reporter
-      '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-hardhat-internal-rules
-      '@nomicfoundation/eslint-plugin-slow-imports':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-slow-imports
       '@types/ci-info':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1753,12 +1735,6 @@ importers:
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-node-test-reporter
-      '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-hardhat-internal-rules
-      '@nomicfoundation/eslint-plugin-slow-imports':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-slow-imports
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9
@@ -1814,12 +1790,6 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0
     devDependencies:
-      '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-hardhat-internal-rules
-      '@nomicfoundation/eslint-plugin-slow-imports':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-slow-imports
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9
@@ -1884,12 +1854,6 @@ importers:
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-node-test-reporter
-      '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-hardhat-internal-rules
-      '@nomicfoundation/eslint-plugin-slow-imports':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-slow-imports
       '@types/bn.js':
         specifier: ^5.1.5
         version: 5.1.5
@@ -1950,12 +1914,6 @@ importers:
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-node-test-reporter
-      '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-hardhat-internal-rules
-      '@nomicfoundation/eslint-plugin-slow-imports':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-slow-imports
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9
@@ -2010,12 +1968,6 @@ importers:
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-node-test-reporter
-      '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-hardhat-internal-rules
-      '@nomicfoundation/eslint-plugin-slow-imports':
-        specifier: workspace:^
-        version: link:../../packages/eslint-plugin-slow-imports
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9

--- a/v-next/core/.eslintrc.cjs
+++ b/v-next/core/.eslintrc.cjs
@@ -1,3 +1,3 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename, ["src/index.ts"]);
+module.exports = createConfig(__filename);

--- a/v-next/core/package.json
+++ b/v-next/core/package.json
@@ -54,8 +54,6 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@microsoft/api-extractor": "^7.43.4",
-    "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
-    "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
     "@types/node": "^20.14.9",
     "@types/semver": "^7.5.8",

--- a/v-next/hardhat-build-system/.eslintrc.cjs
+++ b/v-next/hardhat-build-system/.eslintrc.cjs
@@ -1,3 +1,3 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename, ["src/index.ts"]);
+module.exports = createConfig(__filename);

--- a/v-next/hardhat-build-system/package.json
+++ b/v-next/hardhat-build-system/package.json
@@ -60,8 +60,6 @@
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
-    "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
-    "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.0",
     "@types/ci-info": "^2.0.0",
     "@types/debug": "^4.1.4",

--- a/v-next/hardhat-build-system/src/internal/solidity/parse.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/parse.ts
@@ -46,7 +46,6 @@ export class Parser {
         throw new HardhatError(HardhatError.ERRORS.GENERAL.CORRUPTED_LOCKFILE);
       }
 
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw e;
     }
   }

--- a/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
@@ -298,7 +298,6 @@ export class Resolver {
         );
       }
 
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw error;
     }
   }
@@ -579,7 +578,6 @@ export class Resolver {
         );
       }
 
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw error;
     }
   }

--- a/v-next/hardhat-build-system/src/internal/tasks.ts
+++ b/v-next/hardhat-build-system/src/internal/tasks.ts
@@ -125,7 +125,6 @@ export async function taskCompileSolidityReadFile(
       );
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw e;
   }
 }
@@ -1102,7 +1101,6 @@ export async function taskCompileSolidityCompileJobs(
     return { artifactsEmittedPerJob };
   } catch (e) {
     if (!(e instanceof AggregateError)) {
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw e;
     }
 
@@ -1113,7 +1111,6 @@ export async function taskCompileSolidityCompileJobs(
           HardhatError.ERRORS.BUILTIN_TASKS.COMPILE_FAILURE,
         )
       ) {
-        // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
         throw error;
       }
     }

--- a/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
@@ -94,7 +94,6 @@ export class Artifacts implements IArtifacts {
         return false;
       }
 
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw e;
     }
 
@@ -590,7 +589,6 @@ export class Artifacts implements IArtifacts {
         );
       }
 
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw e;
     }
   }

--- a/v-next/hardhat-build-system/src/internal/utils/fs-utils.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/fs-utils.ts
@@ -52,11 +52,9 @@ async function readdir(absolutePathToDir: string) {
     }
 
     if (e.code === "ENOTDIR") {
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw new InvalidDirectoryError(absolutePathToDir, e);
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw new FileSystemAccessError(e.message, e);
   }
 }
@@ -106,7 +104,6 @@ export async function getFileTrueCase(
     }
   }
 
-  // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
   throw new FileNotFoundError(path.join(from, relativePath));
 }
 
@@ -156,11 +153,9 @@ function readdirSync(absolutePathToDir: string) {
     }
 
     if (e.code === "ENOTDIR") {
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw new InvalidDirectoryError(absolutePathToDir, e);
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw new FileSystemAccessError(e.message, e);
   }
 }
@@ -201,7 +196,6 @@ export function getFileTrueCaseSync(
     }
   }
 
-  // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
   throw new FileNotFoundError(path.join(from, relativePath));
 }
 
@@ -222,11 +216,9 @@ export async function getRealPath(absolutePath: string): Promise<string> {
     }
 
     if (e.code === "ENOENT") {
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw new FileNotFoundError(absolutePath, e);
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw new FileSystemAccessError(e.message, e);
   }
 }
@@ -248,11 +240,9 @@ export function getRealPathSync(absolutePath: string): string {
     }
 
     if (e.code === "ENOENT") {
-      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
       throw new FileNotFoundError(absolutePath, e);
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw new FileSystemAccessError(e.message, e);
   }
 }

--- a/v-next/hardhat-build-system/src/internal/utils/source-names.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/source-names.ts
@@ -70,7 +70,6 @@ async function getSourceNameTrueCase(
       );
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw error;
   }
 }
@@ -157,7 +156,6 @@ export async function isLocalSourceName(
       return false;
     }
 
-    // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error -- Re-throwing the error
     throw error;
   }
 

--- a/v-next/hardhat-errors/.eslintrc.cjs
+++ b/v-next/hardhat-errors/.eslintrc.cjs
@@ -1,3 +1,3 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename, ["src/index.ts"]);
+module.exports = createConfig(__filename);

--- a/v-next/hardhat-errors/package.json
+++ b/v-next/hardhat-errors/package.json
@@ -41,8 +41,6 @@
   ],
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
-    "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
-    "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^7.7.1",

--- a/v-next/hardhat-node-test-reporter/.eslintrc.cjs
+++ b/v-next/hardhat-node-test-reporter/.eslintrc.cjs
@@ -1,6 +1,6 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename, ["src/reporter.ts"]);
+module.exports = createConfig(__filename);
 
 module.exports.overrides.push({
   files: ["integration-tests/**/*.ts"],

--- a/v-next/hardhat-node-test-reporter/package.json
+++ b/v-next/hardhat-node-test-reporter/package.json
@@ -41,8 +41,6 @@
     "README.md"
   ],
   "devDependencies": {
-    "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
-    "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",

--- a/v-next/hardhat-utils/.eslintrc.cjs
+++ b/v-next/hardhat-utils/.eslintrc.cjs
@@ -1,3 +1,3 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename, ["src/index.ts"]);
+module.exports = createConfig(__filename);

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -54,8 +54,6 @@
   ],
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
-    "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
-    "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
     "@types/bn.js": "^5.1.5",
     "@types/keccak": "^3.0.4",

--- a/v-next/hardhat-zod-utils/.eslintrc.cjs
+++ b/v-next/hardhat-zod-utils/.eslintrc.cjs
@@ -1,3 +1,3 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename, ["src/index.ts"]);
+module.exports = createConfig(__filename);

--- a/v-next/hardhat-zod-utils/package.json
+++ b/v-next/hardhat-zod-utils/package.json
@@ -41,8 +41,6 @@
   ],
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
-    "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
-    "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@ignored/hardhat-vnext-core": "workspace:^3.0.0-next.2",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
     "@types/node": "^20.14.9",

--- a/v-next/hardhat/.eslintrc.cjs
+++ b/v-next/hardhat/.eslintrc.cjs
@@ -1,3 +1,3 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename, ["src/index.ts"]);
+module.exports = createConfig(__filename);

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -55,8 +55,6 @@
   ],
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
-    "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
-    "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^7.7.1",

--- a/v-next/template-package/.eslintrc.cjs
+++ b/v-next/template-package/.eslintrc.cjs
@@ -1,6 +1,3 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename, [
-  "src/index.ts",
-  "src/other-entry-point.ts",
-]);
+module.exports = createConfig(__filename);

--- a/v-next/template-package/package.json
+++ b/v-next/template-package/package.json
@@ -43,8 +43,6 @@
   ],
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
-    "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",
-    "@nomicfoundation/eslint-plugin-slow-imports": "workspace:^",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^7.7.1",


### PR DESCRIPTION
The two eslint rule packages are the only packages that are referenced in v-next.

To simplify in infra and lives we are going to switch off those rules in v-next for the moment. They can be re-added later.

Specifically this allows us to add the eslint rules to the ignore list of changeset.

Resolves #5447.