### PR TITLE
update vnext to typescript 5.5

### DIFF
--- a/config-v-next/tsconfig.json
+++ b/config-v-next/tsconfig.json
@@ -5,6 +5,7 @@
     "declarationMap": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
+    "isolatedDeclarations": true,
     "noEmitOnError": true,
     "noImplicitOverride": true,
     "skipDefaultLibCheck": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^5.61.0
-        version: 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+        version: 5.62.0(eslint@8.57.0)(typescript@5.5.2)
       requireindex:
         specifier: ^1.2.0
         version: 1.2.0
@@ -50,7 +50,7 @@ importers:
         version: 8.3.0(eslint@8.57.0)
       eslint-doc-generator:
         specifier: ^1.0.0
-        version: 1.6.2(eslint@8.57.0)(typescript@5.4.5)
+        version: 1.6.2(eslint@8.57.0)(typescript@5.5.2)
       eslint-plugin-eslint-plugin:
         specifier: ^5.0.0
         version: 5.4.0(eslint@8.57.0)
@@ -71,7 +71,7 @@ importers:
     dependencies:
       eslint-module-utils:
         specifier: ^2.8.0
-        version: 2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       requireindex:
         specifier: ^1.2.0
         version: 1.2.0
@@ -84,7 +84,7 @@ importers:
         version: 8.3.0(eslint@8.57.0)
       eslint-doc-generator:
         specifier: ^1.0.0
-        version: 1.6.2(eslint@8.57.0)(typescript@5.4.5)
+        version: 1.6.2(eslint@8.57.0)(typescript@5.5.2)
       eslint-plugin-eslint-plugin:
         specifier: ^5.0.0
         version: 5.4.0(eslint@8.57.0)
@@ -1455,10 +1455,10 @@ importers:
         version: 7.5.8
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
-        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: ^7.7.1
-        version: 7.9.0(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1470,10 +1470,10 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import:
         specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
@@ -1482,7 +1482,7 @@ importers:
         version: 0.19.0
       madge:
         specifier: ^7.0.0
-        version: 7.0.0(typescript@5.4.3)
+        version: 7.0.0(typescript@5.5.2)
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1493,11 +1493,11 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0
       typescript:
-        specifier: ~5.4.0
-        version: 5.4.3
+        specifier: ~5.5.0
+        version: 5.5.2
       typescript-eslint:
         specifier: 7.7.1
-        version: 7.7.1(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.7.1(eslint@8.57.0)(typescript@5.5.2)
 
   v-next/example-project:
     devDependencies:
@@ -1511,8 +1511,8 @@ importers:
         specifier: 3.2.5
         version: 3.2.5
       typescript:
-        specifier: ~5.4.0
-        version: 5.4.5
+        specifier: ~5.5.0
+        version: 5.5.2
 
   v-next/hardhat:
     dependencies:
@@ -1552,10 +1552,10 @@ importers:
         version: 20.14.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
-        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: ^7.7.1
-        version: 7.9.0(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -1564,10 +1564,10 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import:
         specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
@@ -1581,11 +1581,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5
       typescript:
-        specifier: ~5.4.0
-        version: 5.4.5
+        specifier: ~5.5.0
+        version: 5.5.2
       typescript-eslint:
         specifier: 7.7.1
-        version: 7.7.1(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.7.1(eslint@8.57.0)(typescript@5.5.2)
 
   v-next/hardhat-build-system:
     dependencies:
@@ -1682,10 +1682,10 @@ importers:
         version: 9.0.11
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
-        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: ^7.7.1
-        version: 7.9.0(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       ci-info:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1697,10 +1697,10 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import:
         specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
@@ -1720,11 +1720,11 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0
       typescript:
-        specifier: ~5.4.0
-        version: 5.4.3
+        specifier: ~5.5.0
+        version: 5.5.2
       typescript-eslint:
         specifier: 7.7.1
-        version: 7.7.1(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.7.1(eslint@8.57.0)(typescript@5.5.2)
 
   v-next/hardhat-errors:
     dependencies:
@@ -1743,10 +1743,10 @@ importers:
         version: 20.14.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
-        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: ^7.7.1
-        version: 7.9.0(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -1755,10 +1755,10 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import:
         specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
@@ -1775,11 +1775,11 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0
       typescript:
-        specifier: ~5.4.0
-        version: 5.4.3
+        specifier: ~5.5.0
+        version: 5.5.2
       typescript-eslint:
         specifier: 7.7.1
-        version: 7.7.1(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.7.1(eslint@8.57.0)(typescript@5.5.2)
 
   v-next/hardhat-node-test-reporter:
     dependencies:
@@ -1798,10 +1798,10 @@ importers:
         version: 20.14.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
-        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: ^7.7.1
-        version: 7.9.0(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -1810,10 +1810,10 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import:
         specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
@@ -1830,11 +1830,11 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0
       typescript:
-        specifier: ~5.4.0
-        version: 5.4.5
+        specifier: ~5.5.0
+        version: 5.5.2
       typescript-eslint:
         specifier: 7.7.1
-        version: 7.7.1(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.7.1(eslint@8.57.0)(typescript@5.5.2)
 
   v-next/hardhat-utils:
     dependencies:
@@ -1868,10 +1868,10 @@ importers:
         version: 20.14.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
-        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: ^7.7.1
-        version: 7.9.0(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -1880,10 +1880,10 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import:
         specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
@@ -1900,11 +1900,11 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0
       typescript:
-        specifier: ~5.4.0
-        version: 5.4.3
+        specifier: ~5.5.0
+        version: 5.5.2
       typescript-eslint:
         specifier: 7.7.1
-        version: 7.7.1(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.7.1(eslint@8.57.0)(typescript@5.5.2)
 
   v-next/hardhat-zod-utils:
     devDependencies:
@@ -1922,10 +1922,10 @@ importers:
         version: 20.14.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
-        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: ^7.7.1
-        version: 7.9.0(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -1934,10 +1934,10 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import:
         specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
@@ -1954,11 +1954,11 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0
       typescript:
-        specifier: ~5.4.0
-        version: 5.4.5
+        specifier: ~5.5.0
+        version: 5.5.2
       typescript-eslint:
         specifier: 7.7.1
-        version: 7.7.1(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.7.1(eslint@8.57.0)(typescript@5.5.2)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1976,10 +1976,10 @@ importers:
         version: 20.14.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
-        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: ^7.7.1
-        version: 7.9.0(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -1988,10 +1988,10 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import:
         specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
@@ -2008,11 +2008,11 @@ importers:
         specifier: ^4.11.0
         version: 4.11.0
       typescript:
-        specifier: ~5.4.0
-        version: 5.4.3
+        specifier: ~5.5.0
+        version: 5.5.2
       typescript-eslint:
         specifier: 7.7.1
-        version: 7.7.1(eslint@8.57.0)(typescript@5.4.3)
+        version: 7.7.1(eslint@8.57.0)(typescript@5.5.2)
 
 packages:
 
@@ -6453,13 +6453,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.4.3:
-    resolution: {integrity: sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+  typescript@5.5.2:
+    resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -8238,13 +8233,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.7.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)':
+  '@typescript-eslint/eslint-plugin@7.7.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.7.1(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/parser': 7.7.1(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/scope-manager': 7.7.1
-      '@typescript-eslint/type-utils': 7.7.1(eslint@8.57.0)(typescript@5.4.3)
-      '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/type-utils': 7.7.1(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 7.7.1
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
@@ -8252,65 +8247,27 @@ snapshots:
       ignore: 5.3.1
       natural-compare: 1.4.0
       semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.4.3)
+      ts-api-utils: 1.3.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.4.3
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.7.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.7.1(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/scope-manager': 7.7.1
-      '@typescript-eslint/type-utils': 7.7.1(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 7.7.1
-      debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.57.0
-      graphemer: 1.4.0
-      ignore: 5.3.1
-      natural-compare: 1.4.0
-      semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.4.5)
-    optionalDependencies:
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.9.0(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/parser': 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/scope-manager': 7.9.0
-      '@typescript-eslint/type-utils': 7.9.0(eslint@8.57.0)(typescript@5.4.3)
-      '@typescript-eslint/utils': 7.9.0(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/type-utils': 7.9.0(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 7.9.0
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.4.3)
+      ts-api-utils: 1.3.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/eslint-plugin@7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
-    dependencies:
-      '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.9.0(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/scope-manager': 7.9.0
-      '@typescript-eslint/type-utils': 7.9.0(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.9.0(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 7.9.0
-      eslint: 8.57.0
-      graphemer: 1.4.0
-      ignore: 5.3.1
-      natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.4.5)
-    optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8326,55 +8283,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.3)':
+  '@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.7.1
       '@typescript-eslint/types': 7.7.1
-      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.3)
+      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 7.7.1
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.4.3
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 7.7.1
-      '@typescript-eslint/types': 7.7.1
-      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 7.7.1
-      debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.57.0
-    optionalDependencies:
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3)':
+  '@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.9.0
       '@typescript-eslint/types': 7.9.0
-      '@typescript-eslint/typescript-estree': 7.9.0(typescript@5.4.3)
+      '@typescript-eslint/typescript-estree': 7.9.0(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 7.9.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 7.9.0
-      '@typescript-eslint/types': 7.9.0
-      '@typescript-eslint/typescript-estree': 7.9.0(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 7.9.0
-      debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.57.0
-    optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8410,51 +8341,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@7.7.1(eslint@8.57.0)(typescript@5.4.3)':
+  '@typescript-eslint/type-utils@7.7.1(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.3)
-      '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.5.2)
+      '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.5.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.4.3)
+      ts-api-utils: 1.3.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.4.3
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@7.7.1(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@7.9.0(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 7.9.0(typescript@5.5.2)
+      '@typescript-eslint/utils': 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/type-utils@7.9.0(eslint@8.57.0)(typescript@5.4.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 7.9.0(typescript@5.4.3)
-      '@typescript-eslint/utils': 7.9.0(eslint@8.57.0)(typescript@5.4.3)
-      debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.4.3)
-    optionalDependencies:
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/type-utils@7.9.0(eslint@8.57.0)(typescript@5.4.5)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 7.9.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.9.0(eslint@8.57.0)(typescript@5.4.5)
-      debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.4.5)
-    optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8480,7 +8387,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.4.5)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -8488,13 +8395,13 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
-      tsutils: 3.21.0(typescript@5.4.5)
+      tsutils: 3.21.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.7.1(typescript@5.4.3)':
+  '@typescript-eslint/typescript-estree@7.7.1(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/types': 7.7.1
       '@typescript-eslint/visitor-keys': 7.7.1
@@ -8503,28 +8410,13 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.4
       semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.4.3)
+      ts-api-utils: 1.3.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.4.3
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.7.1(typescript@5.4.5)':
-    dependencies:
-      '@typescript-eslint/types': 7.7.1
-      '@typescript-eslint/visitor-keys': 7.7.1
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.4
-      semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.4.5)
-    optionalDependencies:
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@7.9.0(typescript@5.4.3)':
+  '@typescript-eslint/typescript-estree@7.9.0(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/types': 7.9.0
       '@typescript-eslint/visitor-keys': 7.9.0
@@ -8533,24 +8425,9 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.4
       semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.4.3)
+      ts-api-utils: 1.3.0(typescript@5.5.2)
     optionalDependencies:
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@7.9.0(typescript@5.4.5)':
-    dependencies:
-      '@typescript-eslint/types': 7.9.0
-      '@typescript-eslint/visitor-keys': 7.9.0
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.4
-      semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.4.5)
-    optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8569,14 +8446,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.2)
       eslint: 8.57.0
       eslint-scope: 5.1.1
       semver: 7.6.2
@@ -8584,51 +8461,26 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.7.1(eslint@8.57.0)(typescript@5.4.3)':
+  '@typescript-eslint/utils@7.7.1(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 7.7.1
       '@typescript-eslint/types': 7.7.1
-      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.3)
+      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.5.2)
       eslint: 8.57.0
       semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.7.1(eslint@8.57.0)(typescript@5.4.5)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 7.7.1
-      '@typescript-eslint/types': 7.7.1
-      '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.4.5)
-      eslint: 8.57.0
-      semver: 7.6.2
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/utils@7.9.0(eslint@8.57.0)(typescript@5.4.3)':
+  '@typescript-eslint/utils@7.9.0(eslint@8.57.0)(typescript@5.5.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@typescript-eslint/scope-manager': 7.9.0
       '@typescript-eslint/types': 7.9.0
-      '@typescript-eslint/typescript-estree': 7.9.0(typescript@5.4.3)
-      eslint: 8.57.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/utils@7.9.0(eslint@8.57.0)(typescript@5.4.5)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@typescript-eslint/scope-manager': 7.9.0
-      '@typescript-eslint/types': 7.9.0
-      '@typescript-eslint/typescript-estree': 7.9.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 7.9.0(typescript@5.5.2)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -9200,14 +9052,14 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig@8.3.6(typescript@5.4.5):
+  cosmiconfig@8.3.6(typescript@5.5.2):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   crc-32@1.2.2: {}
 
@@ -9400,10 +9252,10 @@ snapshots:
 
   detective-typescript@11.2.0:
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.2)
       ast-module-types: 5.0.0
       node-source-walk: 6.0.2
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9658,13 +9510,13 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-doc-generator@1.6.2(eslint@8.57.0)(typescript@5.4.5):
+  eslint-doc-generator@1.6.2(eslint@8.57.0)(typescript@5.5.2):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.5.2)
       ajv: 8.12.0
       boolean: 3.2.0
       commander: 10.0.1
-      cosmiconfig: 8.3.6(typescript@5.4.5)
+      cosmiconfig: 8.3.6(typescript@5.5.2)
       deepmerge: 4.3.1
       dot-prop: 7.2.0
       eslint: 8.57.0
@@ -9685,30 +9537,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      fast-glob: 3.3.2
-      get-tsconfig: 4.7.3
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
-    dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
-      enhanced-resolve: 5.16.1
-      eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -9729,25 +9564,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.9.0(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/parser': 7.9.0(eslint@8.57.0)(typescript@5.5.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.9.0(eslint@8.57.0)(typescript@5.4.5)
-      eslint: 8.57.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9789,7 +9613,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.5
@@ -9799,7 +9623,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -9810,34 +9634,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.9.0(eslint@8.57.0)(typescript@5.4.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
-    dependencies:
-      array-includes: 3.1.7
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.57.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      hasown: 2.0.2
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.1.7
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.9.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.9.0(eslint@8.57.0)(typescript@5.5.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -10970,7 +10767,7 @@ snapshots:
 
   lru_map@0.3.3: {}
 
-  madge@7.0.0(typescript@5.4.3):
+  madge@7.0.0(typescript@5.5.2):
     dependencies:
       chalk: 4.1.2
       commander: 7.2.0
@@ -10986,7 +10783,7 @@ snapshots:
       ts-graphviz: 1.8.2
       walkdir: 0.4.1
     optionalDependencies:
-      typescript: 5.4.3
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12237,13 +12034,9 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@1.3.0(typescript@5.4.3):
+  ts-api-utils@1.3.0(typescript@5.5.2):
     dependencies:
-      typescript: 5.4.3
-
-  ts-api-utils@1.3.0(typescript@5.4.5):
-    dependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   ts-command-line-args@2.5.1:
     dependencies:
@@ -12302,10 +12095,10 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.0.4
 
-  tsutils@3.21.0(typescript@5.4.5):
+  tsutils@3.21.0(typescript@5.5.2):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   tsx@4.11.0:
     dependencies:
@@ -12423,25 +12216,14 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@7.7.1(eslint@8.57.0)(typescript@5.4.3):
+  typescript-eslint@7.7.1(eslint@8.57.0)(typescript@5.5.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.7.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.3))(eslint@8.57.0)(typescript@5.4.3)
-      '@typescript-eslint/parser': 7.7.1(eslint@8.57.0)(typescript@5.4.3)
-      '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.4.3)
+      '@typescript-eslint/eslint-plugin': 7.7.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/parser': 7.7.1(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.5.2)
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  typescript-eslint@7.7.1(eslint@8.57.0)(typescript@5.4.5):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 7.7.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/parser': 7.7.1(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.4.5)
-      eslint: 8.57.0
-    optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12449,9 +12231,7 @@ snapshots:
 
   typescript@5.4.2: {}
 
-  typescript@5.4.3: {}
-
-  typescript@5.4.5: {}
+  typescript@5.5.2: {}
 
   typical@4.0.0: {}
 

--- a/v-next/core/package.json
+++ b/v-next/core/package.json
@@ -70,7 +70,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.11.0",
-    "typescript": "~5.4.0",
+    "typescript": "~5.5.0",
     "typescript-eslint": "7.7.1"
   },
   "dependencies": {

--- a/v-next/core/src/internal/parameters.ts
+++ b/v-next/core/src/internal/parameters.ts
@@ -7,7 +7,7 @@ import { ParameterType } from "../types/common.js";
 /**
  * Names that can't be used as global- nor task-parameter names.
  */
-export const RESERVED_PARAMETER_NAMES = new Set([
+export const RESERVED_PARAMETER_NAMES: Set<string> = new Set([
   "config",
   "help",
   "showStackTraces",

--- a/v-next/core/test/internal/fixture-plugins/config-plugin.ts
+++ b/v-next/core/test/internal/fixture-plugins/config-plugin.ts
@@ -4,7 +4,7 @@ import type {
   HardhatUserConfigValidationError,
 } from "../../../src/types/hooks.js";
 
-export default async () => {
+export default async (): Promise<Partial<ConfigHooks>> => {
   const handlers: Partial<ConfigHooks> = {
     validateUserConfig: async (
       _config: HardhatUserConfig,

--- a/v-next/core/test/utils.ts
+++ b/v-next/core/test/utils.ts
@@ -18,7 +18,7 @@ export function createTestEnvManager() {
   });
 
   return {
-    setEnvVar(name: string, value: string) {
+    setEnvVar(name: string, value: string): void {
       // Before setting a new value, save the original value if it hasn't been saved yet
       if (!changes.has(name)) {
         originalValues.set(name, process.env[name]);

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -95,7 +95,7 @@ const greeting = task("hello", "Prints a greeting")
   })
   .build();
 
-export default {
+const config: HardhatUserConfig = {
   tasks: [
     exampleTaskOverride,
     testTask,
@@ -130,4 +130,6 @@ export default {
     },
   ],
   privateKey: configVariable("privateKey"),
-} satisfies HardhatUserConfig;
+};
+
+export default config;

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -24,6 +24,6 @@
     "@ignored/hardhat-vnext": "workspace:^3.0.0-next.3",
     "@types/node": "^20.14.9",
     "prettier": "3.2.5",
-    "typescript": "~5.4.0"
+    "typescript": "~5.5.0"
   }
 }

--- a/v-next/hardhat-build-system/package.json
+++ b/v-next/hardhat-build-system/package.json
@@ -83,7 +83,7 @@
     "rimraf": "^5.0.5",
     "sinon": "^9.0.0",
     "tsx": "^4.11.0",
-    "typescript": "~5.4.0",
+    "typescript": "~5.5.0",
     "typescript-eslint": "7.7.1"
   }
 }

--- a/v-next/hardhat-build-system/src/internal/build-system.ts
+++ b/v-next/hardhat-build-system/src/internal/build-system.ts
@@ -3,6 +3,7 @@ import type {
   Artifacts,
   CompilationJobCreationError,
   BuildConfig,
+  DependencyGraph,
 } from "./types/index.js";
 
 import {
@@ -71,7 +72,7 @@ export class BuildSystem {
   // TODO: TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS_FAILURE_REASONS - naming? Do we want to keep it?
   public async solidityGetCompilationJobsFailureReasons(
     errors: CompilationJobCreationError[],
-  ) {
+  ): Promise<string> {
     return taskCompileSolidityGetCompilationJobsFailureReasons(errors);
   }
 
@@ -80,7 +81,7 @@ export class BuildSystem {
   public async solidityGetDependencyGraph(
     sourceNames: string[],
     config: BuildConfig,
-  ) {
+  ): Promise<DependencyGraph> {
     return taskCompileSolidityGetDependencyGraph(sourceNames, config);
   }
 

--- a/v-next/hardhat-build-system/src/internal/builtin-tasks/utils/solidity-files-cache.ts
+++ b/v-next/hardhat-build-system/src/internal/builtin-tasks/utils/solidity-files-cache.ts
@@ -84,7 +84,7 @@ export class SolidityFilesCache {
     this.#cache = _cache;
   }
 
-  public async removeNonExistingFiles() {
+  public async removeNonExistingFiles(): Promise<void> {
     await Promise.all(
       Object.keys(this.#cache.files).map(async (absolutePath) => {
         if (!(await exists(absolutePath))) {
@@ -94,11 +94,11 @@ export class SolidityFilesCache {
     );
   }
 
-  public async writeToFile(solidityFilesCachePath: string) {
+  public async writeToFile(solidityFilesCachePath: string): Promise<void> {
     await writeJsonFile(solidityFilesCachePath, this.#cache);
   }
 
-  public addFile(absolutePath: string, entry: CacheEntry) {
+  public addFile(absolutePath: string, entry: CacheEntry): void {
     this.#cache.files[absolutePath] = entry;
   }
 
@@ -110,7 +110,7 @@ export class SolidityFilesCache {
     return this.#cache.files[file];
   }
 
-  public removeEntry(file: string) {
+  public removeEntry(file: string): void {
     delete this.#cache.files[file];
   }
 

--- a/v-next/hardhat-build-system/src/internal/solidity/compilation-job.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compilation-job.ts
@@ -114,7 +114,7 @@ export class CompilationJob implements taskTypes.CompilationJob {
 
   constructor(public solidityConfig: SolcConfig) {}
 
-  public addFileToCompile(file: ResolvedFile, emitsArtifacts: boolean) {
+  public addFileToCompile(file: ResolvedFile, emitsArtifacts: boolean): void {
     const fileToCompile = this.#filesToCompile.get(file.sourceName);
 
     // if the file doesn't exist, we add it
@@ -151,7 +151,7 @@ export class CompilationJob implements taskTypes.CompilationJob {
     return this.solidityConfig;
   }
 
-  public isEmpty() {
+  public isEmpty(): boolean {
     return this.#filesToCompile.size === 0;
   }
 

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/downloader.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/downloader.ts
@@ -152,7 +152,7 @@ export class CompilerDownloader implements ICompilerDownloader {
   constructor(
     _platform: CompilerPlatform,
     _compilersDir: string,
-    _compilerListCachePeriodMs = CompilerDownloader.defaultCompilerListCachePeriod,
+    _compilerListCachePeriodMs: number = CompilerDownloader.defaultCompilerListCachePeriod,
     _downloadFunction: typeof download = download,
   ) {
     this.#platform = _platform;

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
@@ -24,7 +24,7 @@ export class Compiler implements ICompiler {
     this.#pathToSolcJs = pathToSolcJs;
   }
 
-  public async compile(input: CompilerInput) {
+  public async compile(input: CompilerInput): Promise<any> {
     const scriptPath = fileURLToPath(import.meta.resolve("./solcjs-runner.js"));
 
     // If the script is a TypeScript file, we need to pass the --import tsx/esm
@@ -79,7 +79,7 @@ export class NativeCompiler implements ICompiler {
     this.#solcVersion = _solcVersion;
   }
 
-  public async compile(input: CompilerInput) {
+  public async compile(input: CompilerInput): Promise<any> {
     const args = ["--standard-json"];
 
     // Logic to make sure that solc default import callback is not being used.

--- a/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
@@ -56,7 +56,7 @@ export class ResolvedFile implements IResolvedFile {
     }
   }
 
-  public getVersionedName() {
+  public getVersionedName(): string {
     return (
       this.sourceName +
       (this.library !== undefined ? `@v${this.library.version}` : "")

--- a/v-next/hardhat-build-system/src/internal/tasks.ts
+++ b/v-next/hardhat-build-system/src/internal/tasks.ts
@@ -173,7 +173,10 @@ export async function taskCompileSolidityGetCompilationJobs(
   config: BuildConfig,
   dependencyGraph: taskTypes.DependencyGraph,
   solidityFilesCache?: SolidityFilesCache,
-) {
+): Promise<{
+  jobs: taskTypes.CompilationJob[];
+  errors: taskTypes.CompilationJobCreationError[];
+}> {
   const connectedComponents = dependencyGraph.getConnectedComponents();
 
   log(
@@ -217,7 +220,7 @@ export async function taskCompileSolidityGetCompilationJobs(
  */
 export async function taskCompileSolidityHandleCompilationJobsFailures(
   compilationJobsCreationErrors: CompilationJobCreationError[],
-) {
+): Promise<void> {
   const hasErrors = compilationJobsCreationErrors.length > 0;
 
   if (hasErrors) {
@@ -535,7 +538,9 @@ export async function taskCompileSolidityMergeCompilationJobs(
 /**
  * Prints a message when there's nothing to compile.
  */
-export async function taskCompileSolidityLogNothingToCompile(quiet: boolean) {
+export async function taskCompileSolidityLogNothingToCompile(
+  quiet: boolean,
+): Promise<void> {
   if (!quiet) {
     console.log("Nothing to compile");
   }
@@ -547,7 +552,7 @@ export async function taskCompileSolidityLogDownloadCompilerStart(
   solcVersion: string,
   isCompilerDownloaded: boolean,
   _quiet: boolean, // TODO: keep unused?
-) {
+): Promise<void> {
   if (isCompilerDownloaded) {
     return;
   }
@@ -560,7 +565,7 @@ export async function taskCompileSolidityLogDownloadCompilerEnd(
   _solcVersion: string, // TODO: keep unused?
   _isCompilerDownloaded: boolean, // TODO: keep unused?
   _quiet: boolean, // TODO: keep unused?
-) {
+): Promise<void> {
   return;
 }
 
@@ -658,7 +663,7 @@ export async function taskCompileSolidityLogRunCompilerStart(
   _compilationJobs: CompilationJob[], // TODO: keep unused?
   _compilationJobIndex: number, // TODO: keep unused?
   _quiet: boolean, // TODO: keep unused?
-) {
+): Promise<void> {
   return;
 }
 
@@ -715,7 +720,7 @@ export async function taskCompileSolidityLogRunCompilerEnd(
   _compilationJobIndex: number, // TODO: keep unused?
   _output: any, // TODO: keep unused?
   _quiet: boolean, // TODO: keep unused?
-) {
+): Promise<void> {
   return;
 }
 
@@ -784,7 +789,10 @@ export async function taskCompileSolidityCompile(
   compilationJob: CompilationJob,
   compilationJobs: CompilationJob[],
   compilationJobIndex: number,
-) {
+): Promise<{
+  output: CompilerOutput;
+  solcBuild: taskTypes.SolcBuild;
+}> {
   return taskCompileSolidityCompileSolc(
     input,
     quiet,
@@ -804,7 +812,7 @@ export async function taskCompileSolidityCompile(
 export async function taskCompileSolidityLogCompilationErrors(
   output: any,
   _quiet: boolean, // TODO: keep unused?
-) {
+): Promise<void> {
   if (output?.errors === undefined) {
     return;
   }
@@ -882,7 +890,7 @@ function isConsoleLogError(error: any): boolean {
 export async function taskCompileSolidityCheckErrors(
   output: any,
   quiet: boolean,
-) {
+): Promise<void> {
   await taskCompileSolidityLogCompilationErrors(output, quiet);
 
   if (hasCompilationErrors(output)) {
@@ -1000,7 +1008,13 @@ export async function taskCompileSolidityCompileJob(
   quiet: boolean,
   emitsArtifacts: boolean,
   artifacts: Artifacts,
-) {
+): Promise<{
+  artifactsEmittedPerFile: taskTypes.ArtifactsEmittedPerFile;
+  compilationJob: taskTypes.CompilationJob;
+  input: CompilerInput;
+  output: CompilerOutput;
+  solcBuild: taskTypes.SolcBuild;
+}> {
   log(`Compiling job with version '${compilationJob.getSolcConfig().version}'`);
   const input: CompilerInput =
     await taskCompileSolidityGetCompilerInput(compilationJob);
@@ -1125,7 +1139,7 @@ export async function taskCompileSolidityCompileJobs(
 export async function taskCompileSolidityLogCompilationResult(
   compilationJobs: CompilationJob[],
   _quiet?: boolean, // TODO: keep unused?
-) {
+): Promise<void> {
   let count = 0;
   const evmVersions = new Set<string>();
   const unknownEvmVersions = new Set<string>();
@@ -1170,7 +1184,9 @@ export async function taskCompileSolidityLogCompilationResult(
 
 // TASK_COMPILE_REMOVE_OBSOLETE_ARTIFACTS
 // TESTED
-export async function taskCompileRemoveObsoleteArtifacts(artifacts: Artifacts) {
+export async function taskCompileRemoveObsoleteArtifacts(
+  artifacts: Artifacts,
+): Promise<void> {
   /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
   We know this is the actual implementation, so we use some non-public methods
   here by downcasting */
@@ -1244,7 +1260,7 @@ export async function taskCompileSolidity(
   quiet: boolean,
   concurrency: number,
   tasksOverrides: TasksOverrides | undefined,
-) {
+): Promise<void> {
   const rootPath = config.paths.root;
 
   const sourcePaths: string[] = await taskCompileSolidityGetSourcePaths(

--- a/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
@@ -76,7 +76,7 @@ export class Artifacts implements IArtifacts {
 
   public addValidArtifacts(
     validArtifacts: Array<{ sourceName: string; artifacts: string[] }>,
-  ) {
+  ): void {
     this.#validArtifacts.push(...validArtifacts);
   }
 
@@ -193,7 +193,7 @@ export class Artifacts implements IArtifacts {
   public async saveArtifactAndDebugFile(
     artifact: Artifact,
     pathToBuildInfo?: string,
-  ) {
+  ): Promise<void> {
     try {
       // artifact
       const fullyQualifiedName = getFullyQualifiedName(
@@ -347,7 +347,7 @@ export class Artifacts implements IArtifacts {
   /**
    * Remove all artifacts that don't correspond to the current solidity files
    */
-  public async removeObsoleteArtifacts() {
+  public async removeObsoleteArtifacts(): Promise<void> {
     // We clear the cache here, as we want to be sure this runs correctly
     this.clearCache();
 
@@ -402,7 +402,7 @@ export class Artifacts implements IArtifacts {
     return path.join(this.#artifactsPath, sourceName, `${contractName}.json`);
   }
 
-  public clearCache() {
+  public clearCache(): void {
     // Avoid accidentally re-enabling the cache
     if (this.#cache === undefined) {
       return;
@@ -414,7 +414,7 @@ export class Artifacts implements IArtifacts {
     };
   }
 
-  public disableCache() {
+  public disableCache(): void {
     this.#cache = undefined;
   }
 

--- a/v-next/hardhat-build-system/src/internal/utils/download.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/download.ts
@@ -22,7 +22,7 @@ function resolveTempFileName(filePath: string): string {
   });
 }
 
-export async function download(url: string, filePath: string) {
+export async function download(url: string, filePath: string): Promise<void> {
   const dispatcherOptions: DispatcherOptions = {};
   if (process.env.proxy !== undefined && shouldUseProxy(url)) {
     dispatcherOptions.proxy = process.env.proxy;

--- a/v-next/hardhat-build-system/src/internal/utils/global-dir.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/global-dir.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { ensureDir } from "@ignored/hardhat-vnext-utils/fs";
 
-export async function getCompilersDir() {
+export async function getCompilersDir(): Promise<string> {
   const cache = await getCacheDir();
   // Note: we introduce `-v2` to invalidate all the previous compilers at once
   const compilersCache = path.join(cache, "compilers-v2");

--- a/v-next/hardhat-build-system/src/internal/utils/source-names.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/source-names.ts
@@ -171,7 +171,7 @@ export async function isLocalSourceName(
 export async function validateSourceNameExistenceAndCasing(
   fromDir: string,
   sourceName: string,
-) {
+): Promise<void> {
   const trueCaseSourceName = await getSourceNameTrueCase(fromDir, sourceName);
 
   if (trueCaseSourceName !== sourceName) {
@@ -188,7 +188,7 @@ export async function validateSourceNameExistenceAndCasing(
  * It throws if the format is invalid.
  * If it doesn't throw all you know is that the format is valid.
  */
-export function validateSourceNameFormat(sourceName: string) {
+export function validateSourceNameFormat(sourceName: string): void {
   if (isAbsolutePathSourceName(sourceName)) {
     throw new HardhatError(
       HardhatError.ERRORS.SOURCE_NAMES.INVALID_SOURCE_NAME_ABSOLUTE_PATH,

--- a/v-next/hardhat-build-system/src/internal/utils/string.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/string.ts
@@ -5,7 +5,7 @@ export function replaceAll(
   str: string,
   toReplace: string,
   replacement: string,
-) {
+): string {
   return str.split(toReplace).join(replacement);
 }
 
@@ -18,7 +18,11 @@ export function replaceAll(
  * @param plural An optional plural form of the word. If non is given, the
  * plural form is constructed by appending an "s" to the singular form.
  */
-export function pluralize(n: number, singular: string, plural?: string) {
+export function pluralize(
+  n: number,
+  singular: string,
+  plural?: string,
+): string {
   if (n === 1) {
     return singular;
   }

--- a/v-next/hardhat-build-system/test/helpers.ts
+++ b/v-next/hardhat-build-system/test/helpers.ts
@@ -50,7 +50,7 @@ const defaultSolcOutputSelection = {
     "": ["ast"],
   },
 };
-export function cleanFixtureProjectDir(fixtureProjectName: string) {
+export function cleanFixtureProjectDir(fixtureProjectName: string): void {
   const folderPath = path.join(
     _dirname,
     "fixture-projects",
@@ -61,7 +61,7 @@ export function cleanFixtureProjectDir(fixtureProjectName: string) {
   rmSync(path.join(folderPath, "cache"), { recursive: true, force: true });
 }
 
-export function useFixtureProject(fixtureProjectName: string) {
+export function useFixtureProject(fixtureProjectName: string): void {
   beforeEach(async () => {
     process.chdir(path.join(_dirname, "fixture-projects", fixtureProjectName));
 
@@ -214,7 +214,7 @@ export async function expectHardhatErrorAsync(
   f: () => Promise<any>,
   errorDescriptor: ErrorDescriptor,
   errorMessage?: string | RegExp,
-) {
+): Promise<void> {
   // We create the error here to capture the stack trace before the await.
   // This makes things easier, at least as long as we don't have async stack
   // traces. This may change in the near-ish future.
@@ -314,5 +314,5 @@ export function useTmpDir(nameHint: string) {
     tmpDir = await getEmptyTmpDir(nameHint);
   });
 
-  return () => tmpDir;
+  return (): string => tmpDir;
 }

--- a/v-next/hardhat-errors/package.json
+++ b/v-next/hardhat-errors/package.json
@@ -54,7 +54,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.11.0",
-    "typescript": "~5.4.0",
+    "typescript": "~5.5.0",
     "typescript-eslint": "7.7.1"
   },
   "dependencies": {

--- a/v-next/hardhat-errors/src/errors.ts
+++ b/v-next/hardhat-errors/src/errors.ts
@@ -49,7 +49,7 @@ const IS_HARDHAT_PLUGIN_ERROR_PROPERTY_NAME = "_isHardhatPluginError";
 export class HardhatError<
   ErrorDescriptorT extends ErrorDescriptor,
 > extends CustomError {
-  public static readonly ERRORS = ERRORS;
+  public static readonly ERRORS: typeof ERRORS = ERRORS;
 
   readonly #descriptor: ErrorDescriptorT;
 

--- a/v-next/hardhat-node-test-reporter/package.json
+++ b/v-next/hardhat-node-test-reporter/package.json
@@ -53,7 +53,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.11.0",
-    "typescript": "~5.4.0",
+    "typescript": "~5.5.0",
     "typescript-eslint": "7.7.1"
   },
   "dependencies": {

--- a/v-next/hardhat-node-test-reporter/src/formatting.ts
+++ b/v-next/hardhat-node-test-reporter/src/formatting.ts
@@ -5,8 +5,8 @@ import chalk from "chalk";
 
 import { formatError } from "./error-formatting.js";
 
-export const INFO_SYMBOL = chalk.blue("\u2139");
-export const SUCCESS_SYMBOL = chalk.green("✔");
+export const INFO_SYMBOL: string = chalk.blue("\u2139");
+export const SUCCESS_SYMBOL: string = chalk.green("✔");
 
 export interface Failure {
   index: number;

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -69,7 +69,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.11.0",
-    "typescript": "~5.4.0",
+    "typescript": "~5.5.0",
     "typescript-eslint": "7.7.1"
   },
   "dependencies": {

--- a/v-next/hardhat-utils/src/fs.ts
+++ b/v-next/hardhat-utils/src/fs.ts
@@ -343,7 +343,7 @@ export async function mkdir(absolutePath: string): Promise<void> {
  * Alias for `mkdir`.
  * @see mkdir
  */
-export const ensureDir = mkdir;
+export const ensureDir: (absolutePath: string) => Promise<void> = mkdir;
 
 /**
  * Retrieves the last change time of a file or directory's properties.

--- a/v-next/hardhat-utils/src/fs.ts
+++ b/v-next/hardhat-utils/src/fs.ts
@@ -343,7 +343,7 @@ export async function mkdir(absolutePath: string): Promise<void> {
  * Alias for `mkdir`.
  * @see mkdir
  */
-export const ensureDir: (absolutePath: string) => Promise<void> = mkdir;
+export const ensureDir: typeof mkdir = mkdir;
 
 /**
  * Retrieves the last change time of a file or directory's properties.

--- a/v-next/hardhat-utils/src/internal/eth.ts
+++ b/v-next/hardhat-utils/src/internal/eth.ts
@@ -25,14 +25,14 @@ class RandomBytesGenerator {
 let hashGenerator: RandomBytesGenerator | null = null;
 let addressGenerator: RandomBytesGenerator | null = null;
 
-export async function getHashGenerator() {
+export async function getHashGenerator(): Promise<RandomBytesGenerator> {
   if (hashGenerator === null) {
     hashGenerator = await RandomBytesGenerator.create("hashSeed");
   }
   return hashGenerator;
 }
 
-export async function getAddressGenerator() {
+export async function getAddressGenerator(): Promise<RandomBytesGenerator> {
   if (addressGenerator === null) {
     addressGenerator = await RandomBytesGenerator.create("addressSeed");
   }

--- a/v-next/hardhat-utils/src/internal/hex.ts
+++ b/v-next/hardhat-utils/src/internal/hex.ts
@@ -4,7 +4,7 @@ import {
   isHexStringPrefixed,
 } from "../hex.js";
 
-export function padToEven(value: string) {
+export function padToEven(value: string): string {
   const isPrefixed = isHexStringPrefixed(value);
   const unprefixed = getUnprefixedHexString(value);
 

--- a/v-next/hardhat-utils/src/internal/lang.ts
+++ b/v-next/hardhat-utils/src/internal/lang.ts
@@ -1,7 +1,7 @@
 import type rfdcT from "rfdc";
 
 let clone: ReturnType<typeof rfdcT> | null = null;
-export async function getDeepCloneFunction() {
+export async function getDeepCloneFunction(): Promise<<T>(input: T) => T> {
   const { default: rfdc } = await import("rfdc");
 
   if (clone === null) {

--- a/v-next/hardhat-utils/src/internal/request.ts
+++ b/v-next/hardhat-utils/src/internal/request.ts
@@ -1,4 +1,5 @@
 import type { DispatcherOptions, RequestOptions } from "../request.js";
+import type EventEmitter from "node:events";
 import type UndiciT from "undici";
 
 import path from "node:path";
@@ -28,7 +29,13 @@ export async function getBaseRequestOptions(
   requestUrl: string,
   { extraHeaders, abortSignal, queryParams }: RequestOptions = {},
   dispatcherOrDispatcherOptions?: UndiciT.Dispatcher | DispatcherOptions,
-) {
+): Promise<{
+  query?: Record<string, any> | undefined;
+  signal?: EventEmitter | AbortSignal | undefined;
+  dispatcher: UndiciT.Dispatcher;
+  headers: Record<string, string>;
+  throwOnError: boolean;
+}> {
   const { Dispatcher } = await import("undici");
   const dispatcher =
     dispatcherOrDispatcherOptions instanceof Dispatcher
@@ -50,7 +57,7 @@ export async function getBaseRequestOptions(
 export function getHeaders(
   requestUrl: string,
   extraHeaders: Record<string, string> = {},
-) {
+): Record<string, string> {
   const headers: Record<string, string> = {
     ...extraHeaders,
     "User-Agent": extraHeaders["User-Agent"] ?? DEFAULT_USER_AGENT,
@@ -64,7 +71,7 @@ export function getHeaders(
   return headers;
 }
 
-export function getAuthHeader(requestUrl: string) {
+export function getAuthHeader(requestUrl: string): string | undefined {
   const parsedUrl = new URL(requestUrl);
   if (parsedUrl.username === "") {
     return undefined;

--- a/v-next/hardhat-utils/test/helpers/fs.ts
+++ b/v-next/hardhat-utils/test/helpers/fs.ts
@@ -22,5 +22,5 @@ export function useTmpDir(nameHint: string) {
     tmpDir = await getEmptyTmpDir(nameHint);
   });
 
-  return () => tmpDir;
+  return (): string => tmpDir;
 }

--- a/v-next/hardhat-utils/test/helpers/request.ts
+++ b/v-next/hardhat-utils/test/helpers/request.ts
@@ -1,10 +1,13 @@
 import type { DispatcherOptions } from "../../src/request.js";
+import type { Interceptable } from "undici";
 
 import { after, before } from "node:test";
 
 import { MockAgent } from "undici";
 
-export function getTestDispatcherOptions(options: DispatcherOptions = {}) {
+export function getTestDispatcherOptions(
+  options: DispatcherOptions = {},
+): DispatcherOptions & { isTestDispatcher: true } {
   return {
     ...options,
     isTestDispatcher: true,
@@ -16,9 +19,9 @@ const mockAgent = new MockAgent({
   keepAliveMaxTimeout: 10,
 });
 
-export const mockPool = mockAgent.get("http://localhost:3000");
+export const mockPool: Interceptable = mockAgent.get("http://localhost:3000");
 
-export const setupRequestMocking = () => {
+export const setupRequestMocking: () => void = () => {
   before(() => {
     mockAgent.disableNetConnect();
   });

--- a/v-next/hardhat-zod-utils/package.json
+++ b/v-next/hardhat-zod-utils/package.json
@@ -55,7 +55,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.11.0",
-    "typescript": "~5.4.0",
+    "typescript": "~5.5.0",
     "typescript-eslint": "7.7.1",
     "zod": "^3.23.8"
   },

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -7,7 +7,22 @@ import { z } from "zod";
 /**
  * A Zod type to validate Hardhat's ConfigurationVariable objects.
  */
-export const configurationVariableType = z.object({
+export const configurationVariableType: z.ZodObject<
+  {
+    _type: z.ZodLiteral<"ConfigurationVariable">;
+    name: z.ZodString;
+  },
+  "strip",
+  z.ZodTypeAny,
+  {
+    _type: "ConfigurationVariable";
+    name: string;
+  },
+  {
+    _type: "ConfigurationVariable";
+    name: string;
+  }
+> = z.object({
   _type: z.literal("ConfigurationVariable"),
   name: z.string(),
 });
@@ -15,10 +30,27 @@ export const configurationVariableType = z.object({
 /**
  * A Zod type to validate Hardhat's SensitiveString values.
  */
-export const sensitiveStringType = z.union([
-  z.string(),
-  configurationVariableType,
-]);
+export const sensitiveStringType: z.ZodUnion<
+  [
+    z.ZodString,
+    z.ZodObject<
+      {
+        _type: z.ZodLiteral<"ConfigurationVariable">;
+        name: z.ZodString;
+      },
+      "strip",
+      z.ZodTypeAny,
+      {
+        _type: "ConfigurationVariable";
+        name: string;
+      },
+      {
+        _type: "ConfigurationVariable";
+        name: string;
+      }
+    >,
+  ]
+> = z.union([z.string(), configurationVariableType]);
 
 /**
  * A function to validate the user's configuration object against a Zod type.

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -68,7 +68,7 @@
     "expect-type": "^0.19.0",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
-    "typescript": "~5.4.0",
+    "typescript": "~5.5.0",
     "typescript-eslint": "7.7.1"
   },
   "dependencies": {

--- a/v-next/hardhat/src/index.ts
+++ b/v-next/hardhat/src/index.ts
@@ -1,3 +1,10 @@
+import type { HardhatConfig } from "./types/config.js";
+import type { GlobalOptions } from "./types/global-options.js";
+import type { HookManager } from "./types/hooks.js";
+import type { HardhatRuntimeEnvironment } from "./types/hre.js";
+import type { TaskManager } from "./types/tasks.js";
+import type { UserInterruptionManager } from "./types/user-interruptions.js";
+
 import { resolveHardhatConfigPath } from "./config.js";
 import { importUserConfig } from "./internal/helpers/config-loading.js";
 import { getHardhatRuntimeEnvironmentSingleton } from "./internal/hre-singleton.js";
@@ -6,9 +13,14 @@ import { getHardhatRuntimeEnvironmentSingleton } from "./internal/hre-singleton.
 const configPath = await resolveHardhatConfigPath();
 const userConfig = await importUserConfig(configPath);
 
-const hre = await getHardhatRuntimeEnvironmentSingleton(userConfig);
+const hre: HardhatRuntimeEnvironment =
+  await getHardhatRuntimeEnvironmentSingleton(userConfig);
 /* eslint-enable no-restricted-syntax */
 
-export const { config, tasks, globalOptions, hooks, interruptions } = hre;
+export const config: HardhatConfig = hre.config;
+export const tasks: TaskManager = hre.tasks;
+export const globalOptions: GlobalOptions = hre.globalOptions;
+export const hooks: HookManager = hre.hooks;
+export const interruptions: UserInterruptionManager = hre.interruptions;
 
 export default hre;

--- a/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/hookHandlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/hookHandlers/config.ts
@@ -15,7 +15,7 @@ const hardhatUserConfig = z.object({
   privateKey: z.optional(sensitiveStringType),
 });
 
-export default async () => {
+export default async (): Promise<Partial<ConfigHooks>> => {
   const handlers: Partial<ConfigHooks> = {
     validateUserConfig: async (userConfig) => {
       return validateUserConfigZodType(userConfig, hardhatUserConfig);

--- a/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/hookHandlers/configurationVariables.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/hookHandlers/configurationVariables.ts
@@ -1,6 +1,6 @@
 import type { ConfigurationVariableHooks } from "@ignored/hardhat-vnext-core/types/hooks";
 
-export default async () => {
+export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
   const handlers: Partial<ConfigurationVariableHooks> = {
     fetchValue: async (context, variable, _next) => {
       return context.interruptions.requestSecretInput(

--- a/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/index.ts
@@ -4,7 +4,7 @@ import { globalFlag, task } from "@ignored/hardhat-vnext-core/config";
 
 import "./type-extensions.js";
 
-export default {
+const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-foo",
   hookHandlers: {
     config: import.meta.resolve("./hookHandlers/config.js"),
@@ -20,4 +20,6 @@ export default {
       .build(),
   ],
   globalOptions: [globalFlag({ name: "flag", description: "A flag" })],
-} satisfies HardhatPlugin;
+};
+
+export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/builtin-plugins/run/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/run/index.ts
@@ -2,7 +2,7 @@ import type { HardhatPlugin } from "@ignored/hardhat-vnext-core/types/plugins";
 
 import { ParameterType, task } from "@ignored/hardhat-vnext-core/config";
 
-export default {
+const hardhatPlugin: HardhatPlugin = {
   id: "run",
   tasks: [
     task("run", "Runs a user-defined script after compiling the project")
@@ -18,4 +18,6 @@ export default {
       .setAction(import.meta.resolve("./runScriptWithHardhat.js"))
       .build(),
   ],
-} satisfies HardhatPlugin;
+};
+
+export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/cli/helpers/utils.ts
+++ b/v-next/hardhat/src/internal/cli/helpers/utils.ts
@@ -1,7 +1,10 @@
 import type { ParameterType } from "@ignored/hardhat-vnext-core/config";
 import type { Task } from "@ignored/hardhat-vnext-core/types/tasks";
 
-export const GLOBAL_OPTIONS = [
+export const GLOBAL_OPTIONS: Array<{
+  name: string;
+  description: string;
+}> = [
   {
     name: "--config",
     description: "A Hardhat config file.",

--- a/v-next/hardhat/src/internal/cli/init/init.ts
+++ b/v-next/hardhat/src/internal/cli/init/init.ts
@@ -4,7 +4,7 @@ import { findClosestHardhatConfig } from "../../helpers/config-loading.js";
 
 import { createProject } from "./project-creation.js";
 
-export async function initHardhat() {
+export async function initHardhat(): Promise<void> {
   await throwIfCwdAlreadyInsideProject();
 
   if (

--- a/v-next/hardhat/src/internal/cli/init/project-creation.ts
+++ b/v-next/hardhat/src/internal/cli/init/project-creation.ts
@@ -21,7 +21,7 @@ enum Action {
   QUIT = "Quit",
 }
 
-export async function createProject() {
+export async function createProject(): Promise<void> {
   printAsciiLogo();
 
   await printWelcomeMessage();

--- a/v-next/hardhat/src/internal/cli/init/sample-config-file.ts
+++ b/v-next/hardhat/src/internal/cli/init/sample-config-file.ts
@@ -1,7 +1,7 @@
 // TODO: test that is testing the last version of solidity
 const solidityVersion = "0.8.24";
 
-export const EMPTY_HARDHAT_CONFIG = `import type { HardhatUserConfig } from "@nomicfoundation/hardhat/config";
+export const EMPTY_HARDHAT_CONFIG: string = `import type { HardhatUserConfig } from "@nomicfoundation/hardhat/config";
 
 export default {
   solidity: "${solidityVersion}",

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -144,6 +144,7 @@ export async function parseHardhatSpecialArguments(
   cliArguments: string[],
   usedCliArguments: boolean[],
 ): Promise<{
+  init: boolean;
   configPath: string | undefined;
   showStackTraces: boolean;
   help: boolean;

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -36,7 +36,10 @@ import { getHelpString } from "./helpers/getHelpString.js";
 import { initHardhat } from "./init/init.js";
 import { printVersionMessage } from "./version.js";
 
-export async function main(cliArguments: string[], print = console.log) {
+export async function main(
+  cliArguments: string[],
+  print: (message?: any, ...optionalParams: any[]) => void = console.log,
+): Promise<void> {
   const hreInitStart = performance.now();
 
   const usedCliArguments: boolean[] = new Array(cliArguments.length).fill(
@@ -157,7 +160,12 @@ export async function main(cliArguments: string[], print = console.log) {
 export async function parseHardhatSpecialArguments(
   cliArguments: string[],
   usedCliArguments: boolean[],
-) {
+): Promise<{
+  configPath: string | undefined;
+  showStackTraces: boolean;
+  help: boolean;
+  version: boolean;
+}> {
   let configPath: string | undefined;
   let showStackTraces: boolean = isCi();
   let help: boolean = false;

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -38,10 +38,8 @@ import { printVersionMessage } from "./version.js";
 
 export async function main(
   cliArguments: string[],
-  print: (message?: any, ...optionalParams: any[]) => void = console.log,
+  print: (message: string) => void = console.log,
 ): Promise<void> {
-  const hreInitStart = performance.now();
-
   const usedCliArguments: boolean[] = new Array(cliArguments.length).fill(
     false,
   );
@@ -91,11 +89,6 @@ export async function main(
       },
     );
 
-    const hreInitEnd = performance.now();
-    print("Time to initialize the HRE (ms):", hreInitEnd - hreInitStart);
-
-    const taskParsingStart = performance.now();
-
     const taskOrId = parseTask(cliArguments, usedCliArguments, hre);
 
     if (Array.isArray(taskOrId)) {
@@ -127,17 +120,7 @@ export async function main(
       task,
     );
 
-    const taskParsingEnd = performance.now();
-
-    print("Time to parse the task (ms):", taskParsingEnd - taskParsingStart);
-
-    const taskRunningStart = performance.now();
-
     await task.run(taskArguments);
-
-    const taskRunningEnd = performance.now();
-
-    print("Time to run the task (ms):", taskRunningEnd - taskRunningStart);
   } catch (error) {
     process.exitCode = 1;
 
@@ -148,7 +131,7 @@ export async function main(
 
     // TODO: Print the errors nicely, especially `HardhatError`s.
 
-    print("Error running the task:", error.message);
+    print(`Error running the task: ${error.message}`);
 
     if (hardhatSpecialArgs.showStackTraces) {
       print("");

--- a/v-next/hardhat/src/internal/cli/version.ts
+++ b/v-next/hardhat/src/internal/cli/version.ts
@@ -1,5 +1,7 @@
 import { getHardhatVersion } from "../utils/package.js";
 
-export async function printVersionMessage(print = console.log) {
+export async function printVersionMessage(
+  print: (message?: any, ...optionalParams: any[]) => void = console.log,
+): Promise<void> {
   print(await getHardhatVersion());
 }

--- a/v-next/hardhat/src/internal/cli/version.ts
+++ b/v-next/hardhat/src/internal/cli/version.ts
@@ -1,7 +1,7 @@
 import { getHardhatVersion } from "../utils/package.js";
 
 export async function printVersionMessage(
-  print: (message?: any, ...optionalParams: any[]) => void = console.log,
+  print: (message: string) => void = console.log,
 ): Promise<void> {
   print(await getHardhatVersion());
 }

--- a/v-next/hardhat/src/internal/helpers/config-loading.ts
+++ b/v-next/hardhat/src/internal/helpers/config-loading.ts
@@ -21,7 +21,9 @@ export async function findClosestHardhatConfig(): Promise<string> {
   throw new HardhatError(HardhatError.ERRORS.GENERAL.NO_CONFIG_FILE_FOUND);
 }
 
-export async function importUserConfig(configPath: string) {
+export async function importUserConfig(
+  configPath: string,
+): Promise<Record<string | symbol, unknown>> {
   const normalizedPath = isAbsolute(configPath)
     ? configPath
     : resolve(process.cwd(), configPath);

--- a/v-next/hardhat/src/internal/helpers/config-loading.ts
+++ b/v-next/hardhat/src/internal/helpers/config-loading.ts
@@ -1,3 +1,5 @@
+import type { HardhatUserConfig } from "@ignored/hardhat-vnext-core/config";
+
 import { isAbsolute, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -23,7 +25,7 @@ export async function findClosestHardhatConfig(): Promise<string> {
 
 export async function importUserConfig(
   configPath: string,
-): Promise<Record<string | symbol, unknown>> {
+): Promise<HardhatUserConfig> {
   const normalizedPath = isAbsolute(configPath)
     ? configPath
     : resolve(process.cwd(), configPath);

--- a/v-next/hardhat/src/internal/hre-singleton.ts
+++ b/v-next/hardhat/src/internal/hre-singleton.ts
@@ -26,6 +26,6 @@ export async function getHardhatRuntimeEnvironmentSingleton(
  *
  * It should be used only in tests.
  */
-export function resetHardhatRuntimeEnvironmentSingleton() {
+export function resetHardhatRuntimeEnvironmentSingleton(): void {
   hre = undefined;
 }

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/base-project/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/base-project/hardhat.config.ts
@@ -13,6 +13,8 @@ const customTask = task("task")
   })
   .build();
 
-export default {
+const config: HardhatUserConfig = {
   tasks: [customTask],
-} satisfies HardhatUserConfig;
+};
+
+export default config;

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/subtask-help/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/subtask-help/hardhat.config.ts
@@ -4,6 +4,8 @@ import { emptyTask } from "@ignored/hardhat-vnext-core/config";
 
 const customTask = emptyTask("empty-task", "empty task description").build();
 
-export default {
+const config: HardhatUserConfig = {
   tasks: [customTask],
-} satisfies HardhatUserConfig;
+};
+
+export default config;

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/tasks-and-subtasks/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/tasks-and-subtasks/hardhat.config.ts
@@ -68,6 +68,8 @@ const customSubtask2 = task(["task-default", "subtask-default"])
   })
   .build();
 
-export default {
+const config: HardhatUserConfig = {
   tasks: [customTask, customTask2, customSubtask, customSubtask2],
-} satisfies HardhatUserConfig;
+};
+
+export default config;

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/user-config/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/user-config/hardhat.config.ts
@@ -1,5 +1,7 @@
 import type { HardhatUserConfig } from "@ignored/hardhat-vnext-core/config";
 
-export default {
+const config: HardhatUserConfig = {
   tasks: [],
-} satisfies HardhatUserConfig;
+};
+
+export default config;

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/user-config/user-hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/user-config/user-hardhat.config.ts
@@ -12,6 +12,8 @@ const customTask = task("user-task")
   })
   .build();
 
-export default {
+const config: HardhatUserConfig = {
   tasks: [customTask],
-} satisfies HardhatUserConfig;
+};
+
+export default config;

--- a/v-next/hardhat/test/fixture-projects/run-ts-script/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/run-ts-script/hardhat.config.ts
@@ -1,6 +1,8 @@
+import type { HardhatUserConfig } from "@ignored/hardhat-vnext/config";
+
 import { task } from "@ignored/hardhat-vnext/config";
 
-export default {
+const config: HardhatUserConfig = {
   tasks: [
     task("test", "Prints a test")
       .setAction(async () => {
@@ -9,3 +11,5 @@ export default {
       .build(),
   ],
 };
+
+export default config;

--- a/v-next/hardhat/test/helpers/project.ts
+++ b/v-next/hardhat/test/helpers/project.ts
@@ -10,7 +10,10 @@ import { exists, getRealPath } from "@ignored/hardhat-vnext-utils/fs";
  * @param projectName The base name of the folder with the project to use.
  * @param changeDirTo If provided, the working directory will be changed to this. Must be a child of the project folder.
  */
-export function useFixtureProject(projectName: string, changeDirTo?: string) {
+export function useFixtureProject(
+  projectName: string,
+  changeDirTo?: string,
+): void {
   let projectPath: string;
   let prevWorkingDir: string;
 

--- a/v-next/template-package/package.json
+++ b/v-next/template-package/package.json
@@ -56,7 +56,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.11.0",
-    "typescript": "~5.4.0",
+    "typescript": "~5.5.0",
     "typescript-eslint": "7.7.1"
   }
 }

--- a/v-next/template-package/src/index.ts
+++ b/v-next/template-package/src/index.ts
@@ -1,13 +1,13 @@
 import { concat } from "./utils/string.js";
 
-export function foo() {
+export function foo(): string {
   return "foo";
 }
 
-export function bar() {
+export function bar(): string {
   return "bar";
 }
 
-export function foobar() {
+export function foobar(): string {
   return concat(foo(), bar());
 }

--- a/v-next/template-package/src/utils/string.ts
+++ b/v-next/template-package/src/utils/string.ts
@@ -1,3 +1,3 @@
-export function concat(a: string, b: string) {
+export function concat(a: string, b: string): string {
   return a + b;
 }


### PR DESCRIPTION
Update the `v-next` packages to use typescript v5.5 and [enable isolated declarations](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#isolated-declarations).

The type determination has been mechanical based on vscode - I have not created any new types.
