### PR TITLE
Forbid top-level-await

### DIFF
--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -236,6 +236,11 @@ function createConfig(configFilePath) {
           message:
             "assert.ok should provide an error message as the second argument",
         },
+        {
+          selector: "AwaitExpression:not(:function AwaitExpression)",
+          message:
+            "Top-level await is only allowed in a few cases. Please discuss this change with the team.",
+        },
       ],
       "@typescript-eslint/restrict-plus-operands": "error",
       "@typescript-eslint/restrict-template-expressions": [

--- a/v-next/hardhat/src/cli.ts
+++ b/v-next/hardhat/src/cli.ts
@@ -2,6 +2,7 @@
 // small file is loaded with sourcemaps enabled.
 process.setSourceMapsEnabled(true);
 
+// eslint-disable-next-line no-restricted-syntax -- Allow top-level await here
 const { main } = await import("./internal/cli/main.js");
 
 main(process.argv.slice(2)).catch((error: unknown) => {

--- a/v-next/hardhat/src/index.ts
+++ b/v-next/hardhat/src/index.ts
@@ -2,10 +2,12 @@ import { resolveHardhatConfigPath } from "./config.js";
 import { importUserConfig } from "./internal/helpers/config-loading.js";
 import { getHardhatRuntimeEnvironmentSingleton } from "./internal/hre-singleton.js";
 
+/* eslint-disable no-restricted-syntax -- Allow top-level await here */
 const configPath = await resolveHardhatConfigPath();
 const userConfig = await importUserConfig(configPath);
 
 const hre = await getHardhatRuntimeEnvironmentSingleton(userConfig);
+/* eslint-enable no-restricted-syntax */
 
 export const { config, tasks, globalOptions, hooks, interruptions } = hre;
 


### PR DESCRIPTION
This PR adds a rule to eslint to forbid top-level-await.

We use it in two files, but we shouldn't use it anywhere else. They are the client's entry point and the index of `hardhat`, both initialize instances of the HRE.