### PR TITLE
Simplify `tsconfig.json` files with ${configDir}

### DIFF
--- a/config-v-next/tsconfig.json
+++ b/config-v-next/tsconfig.json
@@ -12,7 +12,8 @@
     "skipDefaultLibCheck": true,
     "sourceMap": true,
     "composite": true,
-    "incremental": true
+    "incremental": true,
+    "typeRoots": ["${configDir}/node_modules/@types"]
   },
   "exclude": ["${configDir}/dist", "${configDir}/node_modules"]
 }

--- a/config-v-next/tsconfig.json
+++ b/config-v-next/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.node20.json",
   "compilerOptions": {
+    "outDir": "${configDir}/dist",
     "declaration": true,
     "declarationMap": true,
     "forceConsistentCasingInFileNames": true,
@@ -9,6 +10,9 @@
     "noEmitOnError": true,
     "noImplicitOverride": true,
     "skipDefaultLibCheck": true,
-    "sourceMap": true
-  }
+    "sourceMap": true,
+    "composite": true,
+    "incremental": true
+  },
+  "exclude": ["${configDir}/dist", "${configDir}/node_modules"]
 }

--- a/v-next/core/tsconfig.json
+++ b/v-next/core/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../config-v-next/tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "composite": true,
-    "incremental": true
-  },
-  "exclude": ["./dist", "./node_modules"],
   "references": [
     {
       "path": "../hardhat-errors"

--- a/v-next/example-project/tsconfig.json
+++ b/v-next/example-project/tsconfig.json
@@ -1,15 +1,5 @@
 {
   "extends": "../../config-v-next/tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "composite": true,
-    "incremental": true
-  },
-  "exclude": [
-    "./dist",
-    "./node_modules",
-    "./test/fixture-projects/hardhat.config.ts"
-  ],
   "references": [
     {
       "path": "../hardhat"

--- a/v-next/hardhat-build-system/tsconfig.json
+++ b/v-next/hardhat-build-system/tsconfig.json
@@ -1,15 +1,5 @@
 {
   "extends": "../../config-v-next/tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "composite": true,
-    "incremental": true
-  },
-  "exclude": [
-    "./dist",
-    "./node_modules",
-    "./test/fixture-projects/hardhat.config.ts"
-  ],
   "references": [
     {
       "path": "../hardhat-errors"

--- a/v-next/hardhat-errors/tsconfig.json
+++ b/v-next/hardhat-errors/tsconfig.json
@@ -1,15 +1,5 @@
 {
   "extends": "../../config-v-next/tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "composite": true,
-    "incremental": true
-  },
-  "exclude": [
-    "./dist",
-    "./node_modules",
-    "./test/fixture-projects/hardhat.config.ts"
-  ],
   "references": [
     {
       "path": "../hardhat-node-test-reporter"

--- a/v-next/hardhat-node-test-reporter/tsconfig.json
+++ b/v-next/hardhat-node-test-reporter/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "extends": "../../config-v-next/tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "composite": true,
-    "incremental": true
-  },
-  "exclude": ["./dist", "./node_modules"],
   "references": []
 }

--- a/v-next/hardhat-utils/tsconfig.json
+++ b/v-next/hardhat-utils/tsconfig.json
@@ -1,15 +1,5 @@
 {
   "extends": "../../config-v-next/tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "composite": true,
-    "incremental": true
-  },
-  "exclude": [
-    "./dist",
-    "./node_modules",
-    "./test/fixture-projects/hardhat.config.ts"
-  ],
   "references": [
     {
       "path": "../hardhat-node-test-reporter"

--- a/v-next/hardhat-zod-utils/tsconfig.json
+++ b/v-next/hardhat-zod-utils/tsconfig.json
@@ -1,15 +1,5 @@
 {
   "extends": "../../config-v-next/tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "composite": true,
-    "incremental": true
-  },
-  "exclude": [
-    "./dist",
-    "./node_modules",
-    "./test/fixture-projects/hardhat.config.ts"
-  ],
   "references": [
     {
       "path": "../core"

--- a/v-next/hardhat/tsconfig.json
+++ b/v-next/hardhat/tsconfig.json
@@ -1,16 +1,5 @@
 {
   "extends": "../../config-v-next/tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "composite": true,
-    "incremental": true,
-    "resolveJsonModule": true
-  },
-  "exclude": [
-    "./dist",
-    "./node_modules",
-    "./test/fixture-projects/hardhat.config.ts"
-  ],
   "references": [
     {
       "path": "../core"

--- a/v-next/template-package/tsconfig.json
+++ b/v-next/template-package/tsconfig.json
@@ -1,15 +1,5 @@
 {
   "extends": "../../config-v-next/tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "composite": true,
-    "incremental": true
-  },
-  "exclude": [
-    "./dist",
-    "./node_modules",
-    "./test/fixture-projects/hardhat.config.ts"
-  ],
   "references": [
     {
       "path": "../hardhat-node-test-reporter"


### PR DESCRIPTION
TS 5.5 added a `${configDir}` variable that you can use in shared configs to define values relative to the actual config dir. This allows you to simplify the shared configurations. This PR takes advantage of that.