### PR TITLE
Isolate the build-system package errors

### DIFF
--- a/v-next/core/test/internal/configuration-variables/configuration-variables.ts
+++ b/v-next/core/test/internal/configuration-variables/configuration-variables.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
+
 import { ResolvedConfigurationVariableImplementation } from "../../../src/internal/configuration-variables.js";
 import { HookManagerImplementation } from "../../../src/internal/hook-manager.js";
 import { UserInterruptionManagerImplementation } from "../../../src/internal/user-interruptions.js";
@@ -55,7 +57,7 @@ describe("ResolvedConfigurationVariable", () => {
 
     await assert.rejects(
       variable.get(),
-      "Configuration variable not found as an env variable",
+      new HardhatError(HardhatError.ERRORS.GENERAL.ENV_VAR_NOT_FOUND),
     );
   });
 
@@ -97,7 +99,12 @@ describe("ResolvedConfigurationVariable", () => {
 
     process.env.foo = "not a url";
 
-    await assert.rejects(variable.getUrl(), "Invalid URL: not a url");
+    await assert.rejects(
+      variable.getUrl(),
+      new HardhatError(HardhatError.ERRORS.GENERAL.INVALID_URL, {
+        url: "not a url",
+      }),
+    );
 
     delete process.env.foo;
   });
@@ -123,7 +130,12 @@ describe("ResolvedConfigurationVariable", () => {
 
     process.env.foo = "not a bigint";
 
-    await assert.rejects(variable.getBigInt(), "Invalid BigInt: not a bigint");
+    await assert.rejects(
+      variable.getBigInt(),
+      new HardhatError(HardhatError.ERRORS.GENERAL.INVALID_BIGINT, {
+        value: "not a bigint",
+      }),
+    );
 
     delete process.env.foo;
   });

--- a/v-next/core/test/internal/hook-manager.ts
+++ b/v-next/core/test/internal/hook-manager.ts
@@ -21,6 +21,8 @@ import type { UserInterruptionManager } from "../../src/types/user-interruptions
 import assert from "node:assert/strict";
 import { describe, it, beforeEach } from "node:test";
 
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
+
 import { HookManagerImplementation } from "../../src/internal/hook-manager.js";
 import { UserInterruptionManagerImplementation } from "../../src/internal/user-interruptions.js";
 
@@ -269,11 +271,14 @@ describe("HookManager", () => {
                 return {};
               },
             ),
-          {
-            name: "HardhatError",
-            message:
-              'HHE1300: Plugin "example" hook factory for "config" is not a valid file:// URL: ./fixture-plugins/config-plugin.js.',
-          },
+          new HardhatError(
+            HardhatError.ERRORS.HOOKS.INVALID_HOOK_FACTORY_PATH,
+            {
+              hookCategoryName: "config",
+              pluginId: "example",
+              path: "./fixture-plugins/config-plugin.js",
+            },
+          ),
         );
       });
     });

--- a/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { detectPluginNpmDependencyProblems } from "../../../src/internal/plugins/detect-plugin-npm-dependency-problems.js";
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
 describe("Plugins - detect npm dependency problems", () => {
   const plugin: HardhatPlugin = {
@@ -52,10 +53,9 @@ describe("Plugins - detect npm dependency problems", () => {
             plugin,
             nonInstalledPackageProjectFixture,
           ),
-        {
-          name: "HardhatError",
-          message: 'HHE1200: Plugin "example-plugin" is not installed.',
-        },
+        new HardhatError(HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED, {
+          pluginId: "example-plugin",
+        }),
       );
     });
   });
@@ -79,11 +79,10 @@ describe("Plugins - detect npm dependency problems", () => {
 
         await assert.rejects(
           detectPluginNpmDependencyProblems(plugin, notInstalledPeerDepFixture),
-          {
-            name: "HardhatError",
-            message:
-              'HHE1201: Plugin "example-plugin" is missing a peer dependency "peer2".',
-          },
+          new HardhatError(
+            HardhatError.ERRORS.PLUGINS.PLUGIN_MISSING_DEPENDENCY,
+            { pluginId: "example-plugin", peerDependencyName: "peer2" },
+          ),
         );
       });
     });
@@ -113,11 +112,15 @@ describe("Plugins - detect npm dependency problems", () => {
             plugin,
             peerDepWithWrongVersionFixture,
           ),
-        {
-          name: "HardhatError",
-          message:
-            'HHE1202: Plugin "example-plugin" has a peer dependency "peer2" with expected version "^1.0.0" but the installed version is "2.0.0".',
-        },
+        new HardhatError(
+          HardhatError.ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH,
+          {
+            pluginId: "example-plugin",
+            peerDependencyName: "peer2",
+            expectedVersion: "^1.0.0",
+            installedVersion: "2.0.0",
+          },
+        ),
       );
     });
   });

--- a/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -3,8 +3,9 @@ import type { HardhatPlugin } from "../../../src/types/plugins.js";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { detectPluginNpmDependencyProblems } from "../../../src/internal/plugins/detect-plugin-npm-dependency-problems.js";
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+
+import { detectPluginNpmDependencyProblems } from "../../../src/internal/plugins/detect-plugin-npm-dependency-problems.js";
 
 describe("Plugins - detect npm dependency problems", () => {
   const plugin: HardhatPlugin = {

--- a/v-next/core/test/internal/plugins/resolve-plugin-list.ts
+++ b/v-next/core/test/internal/plugins/resolve-plugin-list.ts
@@ -3,6 +3,8 @@ import type { HardhatPlugin } from "../../../src/types/plugins.js";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
+
 import { resolvePluginList } from "../../../src/internal/plugins/resolve-plugin-list.js";
 
 describe("Plugins - resolve plugin list", () => {
@@ -149,11 +151,9 @@ describe("Plugins - resolve plugin list", () => {
 
     await assert.rejects(
       async () => resolvePluginList([a, copy], installedPackageFixture),
-      {
-        name: "HardhatError",
-        message:
-          'HHE4: Duplicated plugin id "dup" found. Did you install multiple versions of the same plugin?',
-      },
+      new HardhatError(HardhatError.ERRORS.GENERAL.DUPLICATED_PLUGIN_ID, {
+        id: "dup",
+      }),
     );
   });
 
@@ -171,10 +171,10 @@ describe("Plugins - resolve plugin list", () => {
 
       await assert.rejects(
         async () => resolvePluginList([plugin], installedPackageFixture),
-        {
-          name: "HardhatError",
-          message: 'HHE1203: Plugin "plugin" dependency could not be loaded.',
-        },
+        new HardhatError(
+          HardhatError.ERRORS.PLUGINS.PLUGIN_DEPENDENCY_FAILED_LOAD,
+          { pluginId: plugin.id },
+        ),
       );
     });
 
@@ -195,10 +195,9 @@ describe("Plugins - resolve plugin list", () => {
 
       await assert.rejects(
         async () => resolvePluginList([plugin], notInstalledPackageFixture),
-        {
-          name: "HardhatError",
-          message: 'HHE1200: Plugin "example" is not installed.',
-        },
+        new HardhatError(HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED, {
+          pluginId: "example",
+        }),
       );
     });
   });

--- a/v-next/core/test/internal/tasks/builders.ts
+++ b/v-next/core/test/internal/tasks/builders.ts
@@ -39,21 +39,19 @@ describe("Task builders", () => {
 
     describe("Task id validation", () => {
       it("should throw if the id is an empty string", () => {
-        assert.throws(() => new EmptyTaskDefinitionBuilderImplementation(""), {
-          name: "HardhatError",
-          message:
-            "HHE208: Task id cannot be an empty string or an empty array",
-        });
+        assert.throws(
+          () => new EmptyTaskDefinitionBuilderImplementation(""),
+          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+        );
       });
 
       it("should throw if the array of ids is empty", () => {
         const ids: string[] = [];
 
-        assert.throws(() => new EmptyTaskDefinitionBuilderImplementation(ids), {
-          name: "HardhatError",
-          message:
-            "HHE208: Task id cannot be an empty string or an empty array",
-        });
+        assert.throws(
+          () => new EmptyTaskDefinitionBuilderImplementation(ids),
+          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+        );
       });
     });
 
@@ -137,21 +135,19 @@ describe("Task builders", () => {
 
     describe("Task id validation", () => {
       it("should throw if the id is an empty string", () => {
-        assert.throws(() => new NewTaskDefinitionBuilderImplementation(""), {
-          name: "HardhatError",
-          message:
-            "HHE208: Task id cannot be an empty string or an empty array",
-        });
+        assert.throws(
+          () => new NewTaskDefinitionBuilderImplementation(""),
+          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+        );
       });
 
       it("should throw if the array of ids is empty", () => {
         const ids: string[] = [];
 
-        assert.throws(() => new NewTaskDefinitionBuilderImplementation(ids), {
-          name: "HardhatError",
-          message:
-            "HHE208: Task id cannot be an empty string or an empty array",
-        });
+        assert.throws(
+          () => new NewTaskDefinitionBuilderImplementation(ids),
+          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+        );
       });
     });
 
@@ -188,25 +184,33 @@ describe("Task builders", () => {
 
       it("should throw when trying to build a task definition without an action", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
-        assert.throws(() => builder.build(), {
-          name: "HardhatError",
-          message: `HHE202: The task task-id doesn't have an action`,
-        });
+        assert.throws(
+          () => builder.build(),
+          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.NO_ACTION, {
+            task: "task-id",
+          }),
+        );
       });
 
       it("should throw if the task action is not a valid file URL", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
 
-        assert.throws(() => builder.setAction("not-a-valid-file-url"), {
-          name: "HardhatError",
-          message:
-            "HHE201: Invalid file action: not-a-valid-file-url is not a valid file URL",
-        });
-        assert.throws(() => builder.setAction("file://"), {
-          name: "HardhatError",
-          message:
-            "HHE201: Invalid file action: file:// is not a valid file URL",
-        });
+        assert.throws(
+          () => builder.setAction("not-a-valid-file-url"),
+          new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
+            { action: "not-a-valid-file-url" },
+          ),
+        );
+        assert.throws(
+          () => builder.setAction("file://"),
+          new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
+            {
+              action: "file://",
+            },
+          ),
+        );
       });
     });
 
@@ -676,10 +680,12 @@ describe("Task builders", () => {
 
         invalidNames.forEach((name) => {
           fnNames.forEach((fnName) => {
-            assert.throws(() => builder[fnName]({ name }), {
-              name: "HardhatError",
-              message: `HHE303: Argument name ${name} is invalid`,
-            });
+            assert.throws(
+              () => builder[fnName]({ name }),
+              new HardhatError(HardhatError.ERRORS.ARGUMENTS.INVALID_NAME, {
+                name,
+              }),
+            );
           });
         });
       });
@@ -697,10 +703,12 @@ describe("Task builders", () => {
 
         names.forEach((name) => {
           fnNames.forEach((fnName) => {
-            assert.throws(() => builder[fnName]({ name }), {
-              name: "HardhatError",
-              message: `HHE302: Argument name ${name} is already in use`,
-            });
+            assert.throws(
+              () => builder[fnName]({ name }),
+              new HardhatError(HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME, {
+                name,
+              }),
+            );
           });
         });
       });
@@ -709,10 +717,12 @@ describe("Task builders", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
 
         RESERVED_PARAMETER_NAMES.forEach((name) => {
-          assert.throws(() => builder.addOption({ name }), {
-            name: "HardhatError",
-            message: `HHE301: Argument name ${name} is reserved`,
-          });
+          assert.throws(
+            () => builder.addOption({ name }),
+            new HardhatError(HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME, {
+              name,
+            }),
+          );
         });
       });
     });
@@ -778,17 +788,18 @@ describe("Task builders", () => {
 
         assert.throws(
           () => builder.addPositionalParameter({ name: "param2" }),
-          {
-            name: "HardhatError",
-            message:
-              "HHE204: Cannot add required positional param param2 after an optional one",
-          },
+          new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.REQUIRED_PARAM_AFTER_OPTIONAL,
+            { name: "param2" },
+          ),
         );
-        assert.throws(() => builder.addVariadicParameter({ name: "param3" }), {
-          name: "HardhatError",
-          message:
-            "HHE204: Cannot add required positional param param3 after an optional one",
-        });
+        assert.throws(
+          () => builder.addVariadicParameter({ name: "param3" }),
+          new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.REQUIRED_PARAM_AFTER_OPTIONAL,
+            { name: "param3" },
+          ),
+        );
       });
 
       it("should throw if trying to add a positional parameter after a variadic one", () => {
@@ -798,18 +809,19 @@ describe("Task builders", () => {
 
         assert.throws(
           () => builder.addPositionalParameter({ name: "param2" }),
-          {
-            name: "HardhatError",
-            message:
-              "HHE203: Cannot add the positional param param2 after a variadic one",
-          },
+          new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.POSITIONAL_PARAM_AFTER_VARIADIC,
+            { name: "param2" },
+          ),
         );
 
-        assert.throws(() => builder.addVariadicParameter({ name: "param3" }), {
-          name: "HardhatError",
-          message:
-            "HHE203: Cannot add the positional param param3 after a variadic one",
-        });
+        assert.throws(
+          () => builder.addVariadicParameter({ name: "param3" }),
+          new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.POSITIONAL_PARAM_AFTER_VARIADIC,
+            { name: "param3" },
+          ),
+        );
       });
     });
   });
@@ -850,11 +862,7 @@ describe("Task builders", () => {
       it("should throw if the id is an empty string", () => {
         assert.throws(
           () => new TaskOverrideDefinitionBuilderImplementation(""),
-          {
-            name: "HardhatError",
-            message:
-              "HHE208: Task id cannot be an empty string or an empty array",
-          },
+          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
         );
       });
 
@@ -863,11 +871,7 @@ describe("Task builders", () => {
 
         assert.throws(
           () => new TaskOverrideDefinitionBuilderImplementation(ids),
-          {
-            name: "HardhatError",
-            message:
-              "HHE208: Task id cannot be an empty string or an empty array",
-          },
+          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
         );
       });
     });
@@ -909,10 +913,12 @@ describe("Task builders", () => {
         const builder = new TaskOverrideDefinitionBuilderImplementation(
           "task-id",
         );
-        assert.throws(() => builder.build(), {
-          name: "HardhatError",
-          message: `HHE202: The task task-id doesn't have an action`,
-        });
+        assert.throws(
+          () => builder.build(),
+          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.NO_ACTION, {
+            task: "task-id",
+          }),
+        );
       });
 
       it("should throw if the task action is not a valid file URL", () => {
@@ -920,16 +926,20 @@ describe("Task builders", () => {
           "task-id",
         );
 
-        assert.throws(() => builder.setAction("not-a-valid-file-url"), {
-          name: "HardhatError",
-          message:
-            "HHE201: Invalid file action: not-a-valid-file-url is not a valid file URL",
-        });
-        assert.throws(() => builder.setAction("file://"), {
-          name: "HardhatError",
-          message:
-            "HHE201: Invalid file action: file:// is not a valid file URL",
-        });
+        assert.throws(
+          () => builder.setAction("not-a-valid-file-url"),
+          new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
+            { action: "not-a-valid-file-url" },
+          ),
+        );
+        assert.throws(
+          () => builder.setAction("file://"),
+          new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
+            { action: "file://" },
+          ),
+        );
       });
     });
 
@@ -1137,10 +1147,12 @@ describe("Task builders", () => {
 
         invalidNames.forEach((name) => {
           fnNames.forEach((fnName) => {
-            assert.throws(() => builder[fnName]({ name }), {
-              name: "HardhatError",
-              message: `HHE303: Argument name ${name} is invalid`,
-            });
+            assert.throws(
+              () => builder[fnName]({ name }),
+              new HardhatError(HardhatError.ERRORS.ARGUMENTS.INVALID_NAME, {
+                name,
+              }),
+            );
           });
         });
       });
@@ -1156,10 +1168,12 @@ describe("Task builders", () => {
 
         names.forEach((name) => {
           fnNames.forEach((fnName) => {
-            assert.throws(() => builder[fnName]({ name }), {
-              name: "HardhatError",
-              message: `HHE302: Argument name ${name} is already in use`,
-            });
+            assert.throws(
+              () => builder[fnName]({ name }),
+              new HardhatError(HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME, {
+                name,
+              }),
+            );
           });
         });
       });
@@ -1170,10 +1184,12 @@ describe("Task builders", () => {
         );
 
         RESERVED_PARAMETER_NAMES.forEach((name) => {
-          assert.throws(() => builder.addOption({ name }), {
-            name: "HardhatError",
-            message: `HHE301: Argument name ${name} is reserved`,
-          });
+          assert.throws(
+            () => builder.addOption({ name }),
+            new HardhatError(HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME, {
+              name,
+            }),
+          );
         });
       });
     });

--- a/v-next/hardhat-build-system/src/internal/error-descriptors.ts
+++ b/v-next/hardhat-build-system/src/internal/error-descriptors.ts
@@ -48,7 +48,6 @@ export const ERROR_CATEGORIES: {
   };
 } = {
   GENERAL: { min: 1, max: 99, websiteTitle: "General errors" },
-  INTERNAL: { min: 100, max: 199, websiteTitle: "Internal Hardhat errors" },
   TASK_DEFINITIONS: {
     min: 200,
     max: 299,
@@ -69,28 +68,10 @@ export const ERROR_CATEGORIES: {
     max: 1199,
     websiteTitle: "Contract name errors",
   },
-  PLUGINS: {
-    min: 1200,
-    max: 1299,
-    websiteTitle: "Plugin errors",
-  },
-  HOOKS: {
-    min: 1300,
-    max: 1399,
-    websiteTitle: "Hooks errors",
-  },
 };
 
 export const ERRORS = {
   GENERAL: {
-    NOT_INSIDE_PROJECT: {
-      number: 1,
-      messageTemplate: "You are not inside a Hardhat project.",
-      websiteTitle: "You are not inside a Hardhat project",
-      websiteDescription: `You are trying to run Hardhat outside of a Hardhat project.
-
-You can learn how to use Hardhat by reading the [Getting Started guide](/hardhat-runner/docs/getting-started).`,
-    },
     CORRUPTED_LOCKFILE: {
       number: 2,
       messageTemplate: `You installed Hardhat with a corrupted lockfile due to the NPM bug #4828.
@@ -114,128 +95,6 @@ Note that you don't need to do this every time you install a new dependency, but
 
 Please double check the file path.`,
     },
-    DUPLICATED_PLUGIN_ID: {
-      number: 4,
-      messageTemplate:
-        'Duplicated plugin id "{id}" found. Did you install multiple versions of the same plugin?',
-      websiteTitle: "Duplicated plugin id",
-      websiteDescription: `While loading the plugins, two different plugins where found with the same id.
-
-Please double check whether you have multiple versions of the same plugin installed.`,
-    },
-    NO_CONFIG_FILE_FOUND: {
-      number: 5,
-      messageTemplate: "No Hardhat config file found",
-      websiteTitle: "No Hardhat config file found",
-      websiteDescription:
-        "Hardhat couldn't find a config file in the current directory or any of its parents.",
-    },
-    INVALID_CONFIG_PATH: {
-      number: 6,
-      messageTemplate: "Config file {configPath} not found",
-      websiteTitle: "Invalid config path",
-      websiteDescription: "The config file doesn't exist at the provided path.",
-    },
-    NO_CONFIG_EXPORTED: {
-      number: 7,
-      messageTemplate: "No config exported in {configPath}",
-      websiteTitle: "No config exported",
-      websiteDescription: "There is nothing exported from the config file.",
-    },
-    INVALID_CONFIG_OBJECT: {
-      number: 8,
-      messageTemplate: "Invalid config exported in {configPath}",
-      websiteTitle: "Invalid config object",
-      websiteDescription:
-        "The config file doesn't export a valid configuration object.",
-    },
-    ENV_VAR_NOT_FOUND: {
-      number: 9,
-      messageTemplate: "Configuration variable not found as an env variable",
-      websiteTitle: "Configuration variable not found",
-      websiteDescription: `A configuration variable was expected to be set as an environment variable, but it wasn't.`,
-    },
-    INVALID_URL: {
-      number: 10,
-      messageTemplate: "Invalid URL: {url}",
-      websiteTitle: "Invalid URL",
-      websiteDescription: `Given value was not a valid URL.`,
-    },
-    INVALID_BIGINT: {
-      number: 11,
-      messageTemplate: "Invalid BigInt: {value}",
-      websiteTitle: "Invalid BigInt",
-      websiteDescription: `Given value was not a valid BigInt.`,
-    },
-    HARDHAT_PROJECT_ALREADY_CREATED: {
-      number: 12,
-      messageTemplate:
-        "You are trying to initialize a project inside an existing Hardhat project. The path to the project's configuration file is: {hardhatProjectRootPath}.",
-      websiteTitle: "Hardhat project already created",
-      websiteDescription: `Cannot create a new Hardhat project, the current folder is already associated with a project.`,
-    },
-    NOT_INSIDE_PROJECT_ON_WINDOWS: {
-      number: 13,
-      messageTemplate: `You are not inside a project and Hardhat failed to initialize a new one.
-
-If you were trying to create a new project, please try again using Windows Subsystem for Linux (WSL) or PowerShell.
-`,
-      websiteTitle:
-        "You are not inside a Hardhat project and Hardhat failed to initialize a new one",
-      websiteDescription: `You are trying to run Hardhat outside of a Hardhat project, and we couldn't initialize one.
-
-If you were trying to create a new project, please try again using Windows Subsystem for Linux (WSL) or PowerShell.
-
-You can learn how to use Hardhat by reading the [Getting Started guide](/hardhat-runner/docs/getting-started).`,
-    },
-    NOT_IN_INTERACTIVE_SHELL: {
-      number: 14,
-      messageTemplate:
-        "You are trying to initialize a project but you are not in an interactive shell.",
-      websiteTitle: "Not inside an interactive shell",
-      websiteDescription: `You are trying to initialize a project but you are not in an interactive shell.
-
-Please re-run the command inside an interactive shell.`,
-    },
-    UNSUPPORTED_OPERATION: {
-      number: 15,
-      messageTemplate: "{operation} is not supported in Hardhat.",
-      websiteTitle: "Unsupported operation",
-      websiteDescription: `You are trying to perform an unsupported operation.
-
-Unless you are creating a task or plugin, this is probably a bug.
-
-Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
-    },
-    ONLY_ESM_SUPPORTED: {
-      number: 16,
-      messageTemplate: `Hardhat only supports ESM projects. Please be sure to specify "'type': 'module'" in your package.json`,
-      websiteTitle: "Only ESM projects are supported",
-      websiteDescription: `You are trying to initialize a new Hardhat project, but your package.json does not have the property "type" set to "module".
-
-Currently, Hardhat only supports ESM projects.
-
-Please add the property "type" with the value "module" in your package.json to ensure that your project is recognized as an ESM project.`,
-    },
-    GLOBAL_OPTION_ALREADY_DEFINED: {
-      number: 17,
-      messageTemplate:
-        "Plugin {plugin} is trying to define the global option {globalOption} but it is already defined by plugin {definedByPlugin}",
-      websiteTitle: "Global option already defined",
-      websiteDescription:
-        "The global option is already defined by another plugin. Please ensure that global options are uniquely named to avoid conflicts.",
-    },
-  },
-  INTERNAL: {
-    ASSERTION_ERROR: {
-      number: 100,
-      messageTemplate: "An internal invariant was violated: {message}",
-      websiteTitle: "Invariant violation",
-      websiteDescription: `An internal invariant was violated. This is probably caused by a programming error in Hardhat or in one of the used plugins.
-
-Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
-      shouldBeReported: true,
-    },
   },
   TASK_DEFINITIONS: {
     DEPRECATED_TRANSFORM_IMPORT_TASK: {
@@ -246,132 +105,6 @@ Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us i
       websiteDescription: `This task has been deprecated in favor of a new approach.`,
       shouldBeReported: true,
     },
-    INVALID_FILE_ACTION: {
-      number: 201,
-      messageTemplate: "Invalid file action: {action} is not a valid file URL",
-      websiteTitle: "Invalid file action",
-      websiteDescription: `The setAction function was called with a string parameter that is not a valid file URL. A valid file URL must start with 'file://'.
-
-Please ensure that you are providing a correct file URL.`,
-    },
-    NO_ACTION: {
-      number: 202,
-      messageTemplate: "The task {task} doesn't have an action",
-      websiteTitle: "Task missing action",
-      websiteDescription: `A task was defined without an action.
-
-Please ensure that an action is defined for each task.`,
-    },
-    POSITIONAL_PARAM_AFTER_VARIADIC: {
-      number: 203,
-      messageTemplate:
-        "Cannot add the positional param {name} after a variadic one",
-      websiteTitle: "Invalid task definition",
-      websiteDescription:
-        "A variadic parameter must always be the last positional parameter in a task definition.",
-    },
-    REQUIRED_PARAM_AFTER_OPTIONAL: {
-      number: 204,
-      messageTemplate:
-        "Cannot add required positional param {name} after an optional one",
-      websiteTitle: "Invalid task definition",
-      websiteDescription:
-        "Required positional parameters must be defined before optional ones in a task definition.",
-    },
-    TASK_NOT_FOUND: {
-      number: 205,
-      messageTemplate: "Task {task} not found",
-      websiteTitle: "Task not found",
-      websiteDescription: "The provided task name does not match any task.",
-    },
-    SUBTASK_WITHOUT_PARENT: {
-      number: 206,
-      messageTemplate:
-        "Task {task} not found when attempting to define subtask {subtask}. If you intend to only define subtasks, please first define {task} as an empty task",
-      websiteTitle: "Subtask without parent",
-      websiteDescription:
-        "The parent task of the subtask being defined was not found. If you intend to only define subtasks, please first define the parent task as an empty task.",
-    },
-    TASK_ALREADY_DEFINED: {
-      number: 207,
-      messageTemplate:
-        "{actorFragment} trying to define the task {task} but it is already defined{definedByFragment}",
-      websiteTitle: "Task already defined",
-      websiteDescription:
-        "The task is already defined. Please ensure that tasks are uniquely named to avoid conflicts.",
-    },
-    EMPTY_TASK_ID: {
-      number: 208,
-      messageTemplate: "Task id cannot be an empty string or an empty array",
-      websiteTitle: "Empty task id",
-      websiteDescription:
-        "The task id cannot be an empty string or an empty array. Please ensure that the array of task names is not empty.",
-    },
-    TASK_OPTION_ALREADY_DEFINED: {
-      number: 209,
-      messageTemplate:
-        "{actorFragment} trying to define task {task} with the option {option} but it is already defined as a global option by plugin {globalOptionPluginId}",
-      websiteTitle: "Task option already defined",
-      websiteDescription:
-        "The task option is already defined as a global option by another plugin. Please ensure that task options are uniquely named to avoid conflicts.",
-    },
-    TASK_OVERRIDE_OPTION_ALREADY_DEFINED: {
-      number: 210,
-      messageTemplate:
-        "{actorFragment} trying to override the parameter {optionName} of the task {task} but it is already defined",
-      websiteTitle: "Task override option already defined",
-      websiteDescription:
-        "An attempt is being made to override an option that has already been defined. Please ensure that the option is not defined before trying to override it.",
-    },
-    EMPTY_TASK: {
-      number: 211,
-      messageTemplate: "Can't run the empty task {task}",
-      websiteTitle: "Empty task",
-      websiteDescription:
-        "The task is empty. Please ensure that tasks have at least one action.",
-    },
-    INVALID_ACTION_URL: {
-      number: 212,
-      messageTemplate:
-        "Unable to import the module specified by the action {action} of task {task}",
-      websiteTitle: "Invalid action URL",
-      websiteDescription:
-        "The action URL is invalid. Please ensure that the URL is correct.",
-    },
-    INVALID_ACTION: {
-      number: 213,
-      messageTemplate:
-        "The action resolved from {action} in task {task} is not a function",
-      websiteTitle: "Invalid action",
-      websiteDescription:
-        "The action of the task is not a function. Make sure that the file pointed to by the action URL exports a function as the default export.",
-    },
-    MISSING_VALUE_FOR_PARAMETER: {
-      number: 214,
-      messageTemplate:
-        "Missing value for the parameter named {parameter} in the task {task}",
-      websiteTitle: "Missing value for the task parameter",
-      websiteDescription: `You tried to run a task, but one of the values of its parameters was missing.
-
-Please double check how you invoked Hardhat or ran your task.`,
-    },
-    INVALID_VALUE_FOR_TYPE: {
-      number: 215,
-      messageTemplate:
-        "Invalid value {value} for argument {name} of type {type} in the task {task}",
-      websiteTitle: "Invalid argument type",
-      websiteDescription: `One of your task arguments has an invalid type.
-
-Please double check your task arguments.`,
-    },
-    UNRECOGNIZED_NAMED_PARAM: {
-      number: 216,
-      messageTemplate: "Invalid parameter {parameter} for the task {task}",
-      websiteTitle: "Invalid parameter value",
-      websiteDescription: `One of the parameters for your task is invalid.
-
-Please double check your arguments.`,
-    },
   },
   ARGUMENTS: {
     INVALID_VALUE_FOR_TYPE: {
@@ -380,86 +113,6 @@ Please double check your arguments.`,
         "Invalid value {value} for argument {name} of type {type}",
       websiteTitle: "Invalid argument type",
       websiteDescription: `One of your Hardhat or task arguments has an invalid type.
-
-Please double check your arguments.`,
-    },
-    RESERVED_NAME: {
-      number: 301,
-      messageTemplate: "Argument name {name} is reserved",
-      websiteTitle: "Reserved argument name",
-      websiteDescription: `One of your Hardhat or task arguments has a reserved name.
-
-Please double check your arguments.`,
-    },
-    DUPLICATED_NAME: {
-      number: 302,
-      messageTemplate: "Argument name {name} is already in use",
-      websiteTitle: "Argument name already in use",
-      websiteDescription: `One of your Hardhat or task argument names is already in use.
-
-Please double check your arguments.`,
-    },
-    INVALID_NAME: {
-      number: 303,
-      messageTemplate: "Argument name {name} is invalid",
-      websiteTitle: "Invalid argument name",
-      websiteDescription: `One of your Hardhat or task argument names is invalid.
-
-Please double check your arguments.`,
-    },
-    UNRECOGNIZED_OPTION: {
-      number: 304,
-      messageTemplate:
-        "Invalid option {option}. It is neither a valid global option nor associated with any task. Did you forget to add the task first, or did you misspell it?",
-      websiteTitle: "Invalid option value",
-      websiteDescription: `One of your Hardhat options is invalid.
-
-Please double check your arguments.`,
-    },
-    MISSING_VALUE_FOR_PARAMETER: {
-      number: 305,
-      messageTemplate: "Missing value for the task parameter named {paramName}",
-      websiteTitle: "Missing value for the task parameter",
-      websiteDescription: `You tried to run a task, but one of the values of its parameters was missing.
-
-Please double check how you invoked Hardhat or ran your task.`,
-    },
-    UNUSED_ARGUMENT: {
-      number: 306,
-      messageTemplate:
-        "The argument with value {value} was not consumed because it is not associated with any task.",
-      websiteTitle: "Argument was not consumed",
-      websiteDescription: `You tried to run a task, but one of your arguments was not consumed.
-
-Please double check how you invoked Hardhat or ran your task.`,
-    },
-    INVALID_INPUT_FILE: {
-      number: 307,
-      messageTemplate:
-        "Invalid argument {name}: File {value} doesn't exist or is not a readable file.",
-      websiteTitle: "Invalid file argument",
-      websiteDescription: `One of your tasks expected a file as an argument, but you provided a
-nonexistent or non-readable file.
-
-Please double check your arguments.`,
-    },
-    MISSING_CONFIG_FILE: {
-      number: 308,
-      messageTemplate:
-        'The configuration parameter "--config" was passed, but no file path was provided.',
-      websiteTitle: "Missing configuration file path",
-      websiteDescription: `A path to the configuration file is expected after the parameter
-"--config", but none was provided.
-
-Please double check your arguments.`,
-    },
-    CANNOT_COMBINE_INIT_AND_CONFIG_PATH: {
-      number: 309,
-      messageTemplate:
-        'The configuration parameter "--config" cannot be used with the "init" command',
-      websiteTitle:
-        'The configuration parameter "--config" cannot be used with the "init" command',
-      websiteDescription: `The configuration parameter "--config" cannot be used with the "init" command.
 
 Please double check your arguments.`,
     },
@@ -700,22 +353,6 @@ The first supported version is {firstSupportedVersion}`,
 Please use a newer, supported version.`,
       shouldBeReported: true,
     },
-    RUN_FILE_NOT_FOUND: {
-      number: 603,
-      messageTemplate: `Script {script} doesn't exist`,
-      websiteTitle: "Script doesn't exist",
-      websiteDescription: `Tried to use \`hardhat run\` to execute a nonexistent script.
-
-Please double check your script's path.`,
-    },
-    RUN_SCRIPT_ERROR: {
-      number: 604,
-      messageTemplate: `Error running script {script}: {error}`,
-      websiteTitle: "Error running script",
-      websiteDescription: `Running a script resulted in an error.
-
-Please check Hardhat's output for more details.`,
-    },
   },
   ARTIFACTS: {
     NOT_FOUND: {
@@ -840,45 +477,6 @@ If you aren't overriding compilation-related tasks, please report this as a bug.
       websiteDescription: `A contract name was expected to be in fully qualified form, but it's not.
 
 A fully qualified name should look like file.sol:Contract`,
-    },
-  },
-  PLUGINS: {
-    PLUGIN_NOT_INSTALLED: {
-      number: 1200,
-      messageTemplate: 'Plugin "{pluginId}" is not installed.',
-      websiteTitle: "Plugin not installed",
-      websiteDescription: `A plugin was included in the Hardhat config but has not been installed into "node_modules".`,
-    },
-    PLUGIN_MISSING_DEPENDENCY: {
-      number: 1201,
-      messageTemplate:
-        'Plugin "{pluginId}" is missing a peer dependency "{peerDependencyName}".',
-      websiteTitle: "Plugin missing peer dependency",
-      websiteDescription: `A plugin's peer dependency has not been installed.`,
-    },
-    DEPENDENCY_VERSION_MISMATCH: {
-      number: 1202,
-      messageTemplate:
-        'Plugin "{pluginId}" has a peer dependency "{peerDependencyName}" with expected version "{expectedVersion}" but the installed version is "{installedVersion}".',
-      websiteTitle: "Dependency version mismatch",
-      websiteDescription: `A plugin's peer dependency expected version does not match the version of the installed package.
-
-Please install a version of the peer dependency that meets the plugin's requirements.`,
-    },
-    PLUGIN_DEPENDENCY_FAILED_LOAD: {
-      number: 1203,
-      messageTemplate: 'Plugin "{pluginId}" dependency could not be loaded.',
-      websiteTitle: "Plugin dependency could not be loaded",
-      websiteDescription: `The loading of a plugin's dependent plugin failed.`,
-    },
-  },
-  HOOKS: {
-    INVALID_HOOK_FACTORY_PATH: {
-      number: 1300,
-      messageTemplate:
-        'Plugin "{pluginId}" hook factory for "{hookCategoryName}" is not a valid file:// URL: {path}.',
-      websiteTitle: "Plugin hook factory is not a valid file URL",
-      websiteDescription: `The loading of a plugin's hook factory failed as the import path is not a valid file:// URL.`,
     },
   },
 } as const;

--- a/v-next/hardhat-build-system/src/internal/error-descriptors.ts
+++ b/v-next/hardhat-build-system/src/internal/error-descriptors.ts
@@ -1,0 +1,884 @@
+/**
+ * A description of a kind of error that Hardhat can throw.
+ */
+export interface ErrorDescriptor {
+  /**
+   * The error number, which should be unique.
+   */
+  number: number;
+
+  /**
+   * The id of the plugin that throws this error.
+   */
+  pluginId?: string;
+
+  /**
+   * A tempalte of the message of the error.
+   *
+   * This should be a short description. If possible, it should tell the user
+   * how to solve their problem.
+   *
+   * @see The `applyErrorMessageTemplate` function.
+   */
+  messageTemplate: string;
+
+  /**
+   * `true` if this error should be reported
+   */
+  shouldBeReported?: true;
+
+  /**
+   * The title to use on the website section explaining this error, which can
+   * use markdown.
+   */
+  websiteTitle: string;
+
+  /**
+   * The description to use on the website section explaining this error, which
+   * can use markdown.
+   */
+  websiteDescription: string;
+}
+
+export const ERROR_CATEGORIES: {
+  [categoryName: string]: {
+    min: number;
+    max: number;
+    websiteTitle: string;
+  };
+} = {
+  GENERAL: { min: 1, max: 99, websiteTitle: "General errors" },
+  INTERNAL: { min: 100, max: 199, websiteTitle: "Internal Hardhat errors" },
+  TASK_DEFINITIONS: {
+    min: 200,
+    max: 299,
+    websiteTitle: "Task definition errors",
+  },
+  ARGUMENTS: { min: 300, max: 399, websiteTitle: "Arguments related errors" },
+  RESOLVER: {
+    min: 400,
+    max: 499,
+    websiteTitle: "Dependencies resolution errors",
+  },
+  SOLC: { min: 500, max: 599, websiteTitle: "Solidity related errors" },
+  BUILTIN_TASKS: { min: 600, max: 699, websiteTitle: "Built-in tasks errors" },
+  ARTIFACTS: { min: 700, max: 799, websiteTitle: "Artifacts related errors" },
+  SOURCE_NAMES: { min: 1000, max: 1099, websiteTitle: "Source name errors" },
+  CONTRACT_NAMES: {
+    min: 1100,
+    max: 1199,
+    websiteTitle: "Contract name errors",
+  },
+  PLUGINS: {
+    min: 1200,
+    max: 1299,
+    websiteTitle: "Plugin errors",
+  },
+  HOOKS: {
+    min: 1300,
+    max: 1399,
+    websiteTitle: "Hooks errors",
+  },
+};
+
+export const ERRORS = {
+  GENERAL: {
+    NOT_INSIDE_PROJECT: {
+      number: 1,
+      messageTemplate: "You are not inside a Hardhat project.",
+      websiteTitle: "You are not inside a Hardhat project",
+      websiteDescription: `You are trying to run Hardhat outside of a Hardhat project.
+
+You can learn how to use Hardhat by reading the [Getting Started guide](/hardhat-runner/docs/getting-started).`,
+    },
+    CORRUPTED_LOCKFILE: {
+      number: 2,
+      messageTemplate: `You installed Hardhat with a corrupted lockfile due to the NPM bug #4828.
+
+Please delete your node_modules, package-lock.json, reinstall your project, and try again.`,
+      websiteTitle: "Corrupted lockfile",
+      websiteDescription: `Some versions of NPM are affected [by a bug](https://github.com/npm/cli/issues/4828) that leads to corrupt lockfiles being generated.
+
+This bug can only affect you if you, or someone at your team, installed the project without a lockfile, but with an existing node_modules.
+
+To avoid it, please delete both your node_modules and package-lock.json, and reinstall your project.
+
+Note that you don't need to do this every time you install a new dependency, but please make sure to delete your node_modules every time you delete your package-lock.json.`,
+    },
+    INVALID_READ_OF_DIRECTORY: {
+      number: 3,
+      messageTemplate:
+        "Invalid file path {absolutePath}. Attempting to read a directory instead of a file.",
+      websiteTitle: "Invalid read: a directory cannot be read",
+      websiteDescription: `An attempt was made to read a file, but a path to a directory was provided.
+
+Please double check the file path.`,
+    },
+    DUPLICATED_PLUGIN_ID: {
+      number: 4,
+      messageTemplate:
+        'Duplicated plugin id "{id}" found. Did you install multiple versions of the same plugin?',
+      websiteTitle: "Duplicated plugin id",
+      websiteDescription: `While loading the plugins, two different plugins where found with the same id.
+
+Please double check whether you have multiple versions of the same plugin installed.`,
+    },
+    NO_CONFIG_FILE_FOUND: {
+      number: 5,
+      messageTemplate: "No Hardhat config file found",
+      websiteTitle: "No Hardhat config file found",
+      websiteDescription:
+        "Hardhat couldn't find a config file in the current directory or any of its parents.",
+    },
+    INVALID_CONFIG_PATH: {
+      number: 6,
+      messageTemplate: "Config file {configPath} not found",
+      websiteTitle: "Invalid config path",
+      websiteDescription: "The config file doesn't exist at the provided path.",
+    },
+    NO_CONFIG_EXPORTED: {
+      number: 7,
+      messageTemplate: "No config exported in {configPath}",
+      websiteTitle: "No config exported",
+      websiteDescription: "There is nothing exported from the config file.",
+    },
+    INVALID_CONFIG_OBJECT: {
+      number: 8,
+      messageTemplate: "Invalid config exported in {configPath}",
+      websiteTitle: "Invalid config object",
+      websiteDescription:
+        "The config file doesn't export a valid configuration object.",
+    },
+    ENV_VAR_NOT_FOUND: {
+      number: 9,
+      messageTemplate: "Configuration variable not found as an env variable",
+      websiteTitle: "Configuration variable not found",
+      websiteDescription: `A configuration variable was expected to be set as an environment variable, but it wasn't.`,
+    },
+    INVALID_URL: {
+      number: 10,
+      messageTemplate: "Invalid URL: {url}",
+      websiteTitle: "Invalid URL",
+      websiteDescription: `Given value was not a valid URL.`,
+    },
+    INVALID_BIGINT: {
+      number: 11,
+      messageTemplate: "Invalid BigInt: {value}",
+      websiteTitle: "Invalid BigInt",
+      websiteDescription: `Given value was not a valid BigInt.`,
+    },
+    HARDHAT_PROJECT_ALREADY_CREATED: {
+      number: 12,
+      messageTemplate:
+        "You are trying to initialize a project inside an existing Hardhat project. The path to the project's configuration file is: {hardhatProjectRootPath}.",
+      websiteTitle: "Hardhat project already created",
+      websiteDescription: `Cannot create a new Hardhat project, the current folder is already associated with a project.`,
+    },
+    NOT_INSIDE_PROJECT_ON_WINDOWS: {
+      number: 13,
+      messageTemplate: `You are not inside a project and Hardhat failed to initialize a new one.
+
+If you were trying to create a new project, please try again using Windows Subsystem for Linux (WSL) or PowerShell.
+`,
+      websiteTitle:
+        "You are not inside a Hardhat project and Hardhat failed to initialize a new one",
+      websiteDescription: `You are trying to run Hardhat outside of a Hardhat project, and we couldn't initialize one.
+
+If you were trying to create a new project, please try again using Windows Subsystem for Linux (WSL) or PowerShell.
+
+You can learn how to use Hardhat by reading the [Getting Started guide](/hardhat-runner/docs/getting-started).`,
+    },
+    NOT_IN_INTERACTIVE_SHELL: {
+      number: 14,
+      messageTemplate:
+        "You are trying to initialize a project but you are not in an interactive shell.",
+      websiteTitle: "Not inside an interactive shell",
+      websiteDescription: `You are trying to initialize a project but you are not in an interactive shell.
+
+Please re-run the command inside an interactive shell.`,
+    },
+    UNSUPPORTED_OPERATION: {
+      number: 15,
+      messageTemplate: "{operation} is not supported in Hardhat.",
+      websiteTitle: "Unsupported operation",
+      websiteDescription: `You are trying to perform an unsupported operation.
+
+Unless you are creating a task or plugin, this is probably a bug.
+
+Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
+    },
+    ONLY_ESM_SUPPORTED: {
+      number: 16,
+      messageTemplate: `Hardhat only supports ESM projects. Please be sure to specify "'type': 'module'" in your package.json`,
+      websiteTitle: "Only ESM projects are supported",
+      websiteDescription: `You are trying to initialize a new Hardhat project, but your package.json does not have the property "type" set to "module".
+
+Currently, Hardhat only supports ESM projects.
+
+Please add the property "type" with the value "module" in your package.json to ensure that your project is recognized as an ESM project.`,
+    },
+    GLOBAL_OPTION_ALREADY_DEFINED: {
+      number: 17,
+      messageTemplate:
+        "Plugin {plugin} is trying to define the global option {globalOption} but it is already defined by plugin {definedByPlugin}",
+      websiteTitle: "Global option already defined",
+      websiteDescription:
+        "The global option is already defined by another plugin. Please ensure that global options are uniquely named to avoid conflicts.",
+    },
+  },
+  INTERNAL: {
+    ASSERTION_ERROR: {
+      number: 100,
+      messageTemplate: "An internal invariant was violated: {message}",
+      websiteTitle: "Invariant violation",
+      websiteDescription: `An internal invariant was violated. This is probably caused by a programming error in Hardhat or in one of the used plugins.
+
+Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
+      shouldBeReported: true,
+    },
+  },
+  TASK_DEFINITIONS: {
+    DEPRECATED_TRANSFORM_IMPORT_TASK: {
+      number: 200,
+      websiteTitle: "Use of deprecated remapping task",
+      messageTemplate:
+        "Task TASK_COMPILE_TRANSFORM_IMPORT_NAME is deprecated. Please update your @nomicfoundation/hardhat-foundry plugin version.",
+      websiteDescription: `This task has been deprecated in favor of a new approach.`,
+      shouldBeReported: true,
+    },
+    INVALID_FILE_ACTION: {
+      number: 201,
+      messageTemplate: "Invalid file action: {action} is not a valid file URL",
+      websiteTitle: "Invalid file action",
+      websiteDescription: `The setAction function was called with a string parameter that is not a valid file URL. A valid file URL must start with 'file://'.
+
+Please ensure that you are providing a correct file URL.`,
+    },
+    NO_ACTION: {
+      number: 202,
+      messageTemplate: "The task {task} doesn't have an action",
+      websiteTitle: "Task missing action",
+      websiteDescription: `A task was defined without an action.
+
+Please ensure that an action is defined for each task.`,
+    },
+    POSITIONAL_PARAM_AFTER_VARIADIC: {
+      number: 203,
+      messageTemplate:
+        "Cannot add the positional param {name} after a variadic one",
+      websiteTitle: "Invalid task definition",
+      websiteDescription:
+        "A variadic parameter must always be the last positional parameter in a task definition.",
+    },
+    REQUIRED_PARAM_AFTER_OPTIONAL: {
+      number: 204,
+      messageTemplate:
+        "Cannot add required positional param {name} after an optional one",
+      websiteTitle: "Invalid task definition",
+      websiteDescription:
+        "Required positional parameters must be defined before optional ones in a task definition.",
+    },
+    TASK_NOT_FOUND: {
+      number: 205,
+      messageTemplate: "Task {task} not found",
+      websiteTitle: "Task not found",
+      websiteDescription: "The provided task name does not match any task.",
+    },
+    SUBTASK_WITHOUT_PARENT: {
+      number: 206,
+      messageTemplate:
+        "Task {task} not found when attempting to define subtask {subtask}. If you intend to only define subtasks, please first define {task} as an empty task",
+      websiteTitle: "Subtask without parent",
+      websiteDescription:
+        "The parent task of the subtask being defined was not found. If you intend to only define subtasks, please first define the parent task as an empty task.",
+    },
+    TASK_ALREADY_DEFINED: {
+      number: 207,
+      messageTemplate:
+        "{actorFragment} trying to define the task {task} but it is already defined{definedByFragment}",
+      websiteTitle: "Task already defined",
+      websiteDescription:
+        "The task is already defined. Please ensure that tasks are uniquely named to avoid conflicts.",
+    },
+    EMPTY_TASK_ID: {
+      number: 208,
+      messageTemplate: "Task id cannot be an empty string or an empty array",
+      websiteTitle: "Empty task id",
+      websiteDescription:
+        "The task id cannot be an empty string or an empty array. Please ensure that the array of task names is not empty.",
+    },
+    TASK_OPTION_ALREADY_DEFINED: {
+      number: 209,
+      messageTemplate:
+        "{actorFragment} trying to define task {task} with the option {option} but it is already defined as a global option by plugin {globalOptionPluginId}",
+      websiteTitle: "Task option already defined",
+      websiteDescription:
+        "The task option is already defined as a global option by another plugin. Please ensure that task options are uniquely named to avoid conflicts.",
+    },
+    TASK_OVERRIDE_OPTION_ALREADY_DEFINED: {
+      number: 210,
+      messageTemplate:
+        "{actorFragment} trying to override the parameter {optionName} of the task {task} but it is already defined",
+      websiteTitle: "Task override option already defined",
+      websiteDescription:
+        "An attempt is being made to override an option that has already been defined. Please ensure that the option is not defined before trying to override it.",
+    },
+    EMPTY_TASK: {
+      number: 211,
+      messageTemplate: "Can't run the empty task {task}",
+      websiteTitle: "Empty task",
+      websiteDescription:
+        "The task is empty. Please ensure that tasks have at least one action.",
+    },
+    INVALID_ACTION_URL: {
+      number: 212,
+      messageTemplate:
+        "Unable to import the module specified by the action {action} of task {task}",
+      websiteTitle: "Invalid action URL",
+      websiteDescription:
+        "The action URL is invalid. Please ensure that the URL is correct.",
+    },
+    INVALID_ACTION: {
+      number: 213,
+      messageTemplate:
+        "The action resolved from {action} in task {task} is not a function",
+      websiteTitle: "Invalid action",
+      websiteDescription:
+        "The action of the task is not a function. Make sure that the file pointed to by the action URL exports a function as the default export.",
+    },
+    MISSING_VALUE_FOR_PARAMETER: {
+      number: 214,
+      messageTemplate:
+        "Missing value for the parameter named {parameter} in the task {task}",
+      websiteTitle: "Missing value for the task parameter",
+      websiteDescription: `You tried to run a task, but one of the values of its parameters was missing.
+
+Please double check how you invoked Hardhat or ran your task.`,
+    },
+    INVALID_VALUE_FOR_TYPE: {
+      number: 215,
+      messageTemplate:
+        "Invalid value {value} for argument {name} of type {type} in the task {task}",
+      websiteTitle: "Invalid argument type",
+      websiteDescription: `One of your task arguments has an invalid type.
+
+Please double check your task arguments.`,
+    },
+    UNRECOGNIZED_NAMED_PARAM: {
+      number: 216,
+      messageTemplate: "Invalid parameter {parameter} for the task {task}",
+      websiteTitle: "Invalid parameter value",
+      websiteDescription: `One of the parameters for your task is invalid.
+
+Please double check your arguments.`,
+    },
+  },
+  ARGUMENTS: {
+    INVALID_VALUE_FOR_TYPE: {
+      number: 300,
+      messageTemplate:
+        "Invalid value {value} for argument {name} of type {type}",
+      websiteTitle: "Invalid argument type",
+      websiteDescription: `One of your Hardhat or task arguments has an invalid type.
+
+Please double check your arguments.`,
+    },
+    RESERVED_NAME: {
+      number: 301,
+      messageTemplate: "Argument name {name} is reserved",
+      websiteTitle: "Reserved argument name",
+      websiteDescription: `One of your Hardhat or task arguments has a reserved name.
+
+Please double check your arguments.`,
+    },
+    DUPLICATED_NAME: {
+      number: 302,
+      messageTemplate: "Argument name {name} is already in use",
+      websiteTitle: "Argument name already in use",
+      websiteDescription: `One of your Hardhat or task argument names is already in use.
+
+Please double check your arguments.`,
+    },
+    INVALID_NAME: {
+      number: 303,
+      messageTemplate: "Argument name {name} is invalid",
+      websiteTitle: "Invalid argument name",
+      websiteDescription: `One of your Hardhat or task argument names is invalid.
+
+Please double check your arguments.`,
+    },
+    UNRECOGNIZED_OPTION: {
+      number: 304,
+      messageTemplate:
+        "Invalid option {option}. It is neither a valid global option nor associated with any task. Did you forget to add the task first, or did you misspell it?",
+      websiteTitle: "Invalid option value",
+      websiteDescription: `One of your Hardhat options is invalid.
+
+Please double check your arguments.`,
+    },
+    MISSING_VALUE_FOR_PARAMETER: {
+      number: 305,
+      messageTemplate: "Missing value for the task parameter named {paramName}",
+      websiteTitle: "Missing value for the task parameter",
+      websiteDescription: `You tried to run a task, but one of the values of its parameters was missing.
+
+Please double check how you invoked Hardhat or ran your task.`,
+    },
+    UNUSED_ARGUMENT: {
+      number: 306,
+      messageTemplate:
+        "The argument with value {value} was not consumed because it is not associated with any task.",
+      websiteTitle: "Argument was not consumed",
+      websiteDescription: `You tried to run a task, but one of your arguments was not consumed.
+
+Please double check how you invoked Hardhat or ran your task.`,
+    },
+    INVALID_INPUT_FILE: {
+      number: 307,
+      messageTemplate:
+        "Invalid argument {name}: File {value} doesn't exist or is not a readable file.",
+      websiteTitle: "Invalid file argument",
+      websiteDescription: `One of your tasks expected a file as an argument, but you provided a
+nonexistent or non-readable file.
+
+Please double check your arguments.`,
+    },
+    MISSING_CONFIG_FILE: {
+      number: 308,
+      messageTemplate:
+        'The configuration parameter "--config" was passed, but no file path was provided.',
+      websiteTitle: "Missing configuration file path",
+      websiteDescription: `A path to the configuration file is expected after the parameter
+"--config", but none was provided.
+
+Please double check your arguments.`,
+    },
+    CANNOT_COMBINE_INIT_AND_CONFIG_PATH: {
+      number: 309,
+      messageTemplate:
+        'The configuration parameter "--config" cannot be used with the "init" command',
+      websiteTitle:
+        'The configuration parameter "--config" cannot be used with the "init" command',
+      websiteDescription: `The configuration parameter "--config" cannot be used with the "init" command.
+
+Please double check your arguments.`,
+    },
+  },
+  RESOLVER: {
+    FILE_NOT_FOUND: {
+      number: 400,
+      messageTemplate: "File {file} doesn't exist.",
+      websiteTitle: "Solidity file not found",
+      websiteDescription: `Tried to resolve a nonexistent Solidity file as an entry-point.`,
+    },
+    LIBRARY_NOT_INSTALLED: {
+      number: 401,
+      messageTemplate: "Library {library} is not installed.",
+      websiteTitle: "Solidity library not installed",
+      websiteDescription: `One of your Solidity sources imports a library that is not installed.
+
+Please double check your imports or install the missing dependency.`,
+    },
+    LIBRARY_FILE_NOT_FOUND: {
+      number: 402,
+      messageTemplate: "File {file} doesn't exist.",
+      websiteTitle: "Missing library file",
+      websiteDescription: `One of your libraries' files was imported but doesn't exist.
+
+Please double check your imports or update your libraries.`,
+    },
+    ILLEGAL_IMPORT: {
+      number: 403,
+      messageTemplate: "Illegal import {imported} from {from}",
+      websiteTitle: "Illegal Solidity import",
+      websiteDescription: `One of your libraries tried to use a relative import to import a file outside of its scope.
+
+This is disabled for security reasons.`,
+    },
+    IMPORTED_FILE_NOT_FOUND: {
+      number: 404,
+      messageTemplate: "File {imported}, imported from {from}, not found.",
+      websiteTitle: "Imported file not found",
+      websiteDescription: `One of your source files imported a nonexistent file.
+
+Please double check your imports.`,
+    },
+    INVALID_IMPORT_BACKSLASH: {
+      number: 405,
+      messageTemplate:
+        "Invalid import {imported} from {from}. Imports must use / instead of \\, even in Windows",
+      websiteTitle: "Invalid import: use / instead of \\",
+      websiteDescription: `A Solidity file is trying to import another file via relative path and is using backslashes (\\\\) instead of slashes (/).
+
+You must always use slashes (/) in Solidity imports.`,
+    },
+    INVALID_IMPORT_PROTOCOL: {
+      number: 406,
+      messageTemplate:
+        "Invalid import {imported} from {from}. Hardhat doesn't support imports via {protocol}.",
+      websiteTitle: "Invalid import: trying to use an unsupported protocol",
+      websiteDescription: `A Solidity file is trying to import a file using an unsupported protocol, like http.
+
+You can only import files that are available locally or installed through npm.`,
+    },
+    INVALID_IMPORT_ABSOLUTE_PATH: {
+      number: 407,
+      messageTemplate:
+        "Invalid import {imported} from {from}. Hardhat doesn't support imports with absolute paths.",
+      websiteTitle: "Invalid import: absolute paths unsupported",
+      websiteDescription: `A Solidity file is trying to import a file using its absolute path.
+
+This is not supported, as it would lead to hard-to-reproduce compilations.`,
+    },
+    INVALID_IMPORT_OUTSIDE_OF_PROJECT: {
+      number: 408,
+      messageTemplate:
+        "Invalid import {imported} from {from}. The file being imported is outside of the project",
+      websiteTitle: "Invalid import: file outside of the project",
+      websiteDescription: `A Solidity file is trying to import a file that is outside of the project.
+
+This is not supported by Hardhat.`,
+    },
+    INVALID_IMPORT_WRONG_CASING: {
+      number: 409,
+      messageTemplate:
+        "Trying to import {imported} from {from}, but it has an incorrect casing.",
+      websiteTitle: "Invalid import: wrong file casing",
+      websiteDescription: `A Solidity file is trying to import a file but its source name casing was wrong.
+
+Hardhat's compiler is case sensitive to ensure projects are portable across different operating systems.`,
+    },
+    WRONG_SOURCE_NAME_CASING: {
+      number: 410,
+      messageTemplate:
+        "Trying to resolve the file {incorrect} but its correct case-sensitive name is {correct}",
+      websiteTitle: "Incorrect source name casing",
+      websiteDescription: `You tried to resolve a Solidity file with an incorrect casing.
+
+Hardhat's compiler is case sensitive to ensure projects are portable across different operating systems.`,
+    },
+    IMPORTED_LIBRARY_NOT_INSTALLED: {
+      number: 411,
+      messageTemplate:
+        "The library {library}, imported from {from}, is not installed. Try installing it using npm.",
+      websiteTitle: "Invalid import: library not installed",
+      websiteDescription: `A Solidity file is trying to import another which belongs to a library that is not installed.
+
+Try installing the library using npm.`,
+    },
+    INCLUDES_OWN_PACKAGE_NAME: {
+      number: 412,
+      messageTemplate:
+        "Invalid import {imported} from {from}. Trying to import file using the own package's name.",
+      websiteTitle: "Invalid import: includes own package's name",
+      websiteDescription: `A Solidity file is trying to import another using its own package name. This is most likely caused by an existing symlink for the package in your node_modules.
+
+Use a relative import instead of referencing the package's name.`,
+    },
+    IMPORTED_MAPPED_FILE_NOT_FOUND: {
+      number: 413,
+      messageTemplate:
+        "File {importName} => {imported}, imported from {from}, not found.",
+      websiteTitle: "Imported mapped file not found",
+      websiteDescription: `One of your source files imported a nonexistent or not installed file.
+
+Please double check your imports and installed libraries.`,
+    },
+    INVALID_IMPORT_OF_DIRECTORY: {
+      number: 414,
+      messageTemplate:
+        "Invalid import {imported} from {from}. Attempting to import a directory. Directories cannot be imported.",
+      websiteTitle: "Invalid import: a directory cannot be imported",
+      websiteDescription: `A Solidity file is attempting to import a directory, which is not possible.
+
+Please double check your imports.`,
+    },
+    AMBIGUOUS_SOURCE_NAMES: {
+      number: 415,
+      messageTemplate:
+        "Two different source names ({sourcenames}) resolve to the same file ({file}).",
+      websiteTitle: "Ambiguous source names",
+      websiteDescription: `Two different source names map to the same file.
+
+This is probably caused by multiple remappings pointing to the same source file.`,
+    },
+  },
+  SOLC: {
+    INVALID_VERSION: {
+      number: 500,
+      messageTemplate: `Solidity version {version} is invalid or hasn't been released yet.
+
+If you are certain it has been released, run "npx hardhat clean --global" and try again`,
+      websiteTitle: "Invalid or unreleased `solc` version",
+      websiteDescription: `The Solidity version in your config is invalid or hasn't been released yet.
+
+If you are certain it has been released, run \`npx hardhat clean --global\` and try again.`,
+    },
+    DOWNLOAD_FAILED: {
+      number: 501,
+      messageTemplate:
+        "Couldn't download compiler version {remoteVersion}. Please check your internet connection and try again.",
+      websiteTitle: "`solc` download failed",
+      websiteDescription: `Couldn't download \`solc\`.
+
+Please check your internet connection and try again.`,
+    },
+    VERSION_LIST_DOWNLOAD_FAILED: {
+      number: 502,
+      messageTemplate:
+        "Couldn't download compiler version list. Please check your internet connection and try again.",
+      websiteTitle: "Couldn't obtain `solc` version list",
+      websiteDescription: `Couldn't download \`solc\`'s version list.
+
+Please check your internet connection and try again.`,
+    },
+    INVALID_DOWNLOAD: {
+      number: 503,
+      messageTemplate: `Couldn't download compiler version {remoteVersion}: Checksum verification failed.
+
+Please check your internet connection and try again.
+
+If this error persists, run "npx hardhat clean --global".`,
+      websiteTitle: "Downloaded `solc` checksum verification failed",
+      websiteDescription: `Hardhat downloaded a version of the Solidity compiler, and its checksum verification failed.
+
+Please check your internet connection and try again.
+
+If this error persists, run \`npx hardhat clean --global\`.`,
+    },
+    CANT_RUN_NATIVE_COMPILER: {
+      number: 504,
+      messageTemplate: `A native version of solc failed to run.
+
+If you are running MacOS, try installing Apple Rosetta.
+
+If this error persists, run "npx hardhat clean --global".`,
+      websiteTitle: "Failed to run native solc",
+      websiteDescription: `Hardhat successfully downloaded a native version of solc but it doesn't run.
+
+If you are running MacOS, try installing Apple Rosetta.
+
+If this error persists, run "npx hardhat clean --global".`,
+    },
+    CANT_RUN_SOLCJS_COMPILER: {
+      number: 505,
+      messageTemplate: `A wasm version of solc failed to run.
+
+If this error persists, run "npx hardhat clean --global".`,
+      websiteTitle: "Failed to run solcjs",
+      websiteDescription: `Hardhat successfully downloaded a WASM version of solc but it doesn't run.
+
+If you are running MacOS, try installing Apple Rosetta.
+
+If this error persists, run "npx hardhat clean --global".`,
+    },
+  },
+  BUILTIN_TASKS: {
+    COMPILE_FAILURE: {
+      number: 600,
+      messageTemplate: "Compilation failed",
+      websiteTitle: "Compilation failed",
+      websiteDescription: `Your smart contracts failed to compile.
+
+Please check Hardhat's output for more details.`,
+    },
+    COMPILATION_JOBS_CREATION_FAILURE: {
+      number: 601,
+      messageTemplate: `The project cannot be compiled, see reasons below.
+
+{reasons}`,
+      websiteTitle: "The project cannot be compiled",
+      websiteDescription: `The project cannot be compiled with the current settings.`,
+    },
+    COMPILE_TASK_UNSUPPORTED_SOLC_VERSION: {
+      number: 602,
+      messageTemplate: `Version {version} is not supported by Hardhat.
+
+The first supported version is {firstSupportedVersion}`,
+      websiteTitle: "Unsupported solc version",
+      websiteDescription: `This version of solidity is not supported by Hardhat.
+Please use a newer, supported version.`,
+      shouldBeReported: true,
+    },
+    RUN_FILE_NOT_FOUND: {
+      number: 603,
+      messageTemplate: `Script {script} doesn't exist`,
+      websiteTitle: "Script doesn't exist",
+      websiteDescription: `Tried to use \`hardhat run\` to execute a nonexistent script.
+
+Please double check your script's path.`,
+    },
+    RUN_SCRIPT_ERROR: {
+      number: 604,
+      messageTemplate: `Error running script {script}: {error}`,
+      websiteTitle: "Error running script",
+      websiteDescription: `Running a script resulted in an error.
+
+Please check Hardhat's output for more details.`,
+    },
+  },
+  ARTIFACTS: {
+    NOT_FOUND: {
+      number: 700,
+      messageTemplate:
+        'Artifact for contract "{contractName}" not found. {suggestion}',
+      websiteTitle: "Artifact not found",
+      websiteDescription: `Tried to import a nonexistent artifact.
+
+Please double check that your contracts have been compiled and double check your artifact's name.`,
+    },
+    MULTIPLE_FOUND: {
+      number: 701,
+      messageTemplate: `There are multiple artifacts for contract "{contractName}", please use a fully qualified name.
+
+Please replace {contractName} for one of these options wherever you are trying to read its artifact:
+
+{candidates}
+`,
+      websiteTitle: "Multiple artifacts found",
+      websiteDescription: `There are multiple artifacts that match the given contract name, and Hardhat doesn't know which one to use.
+
+Please use the fully qualified name of the contract to disambiguate it.`,
+    },
+    WRONG_CASING: {
+      number: 702,
+      messageTemplate:
+        "Invalid artifact path {incorrect}, its correct case-sensitive path is {correct}",
+      websiteTitle: "Incorrect artifact path casing",
+      websiteDescription: `You tried to get an artifact file with an incorrect casing.
+
+Hardhat's artifact resolution is case sensitive to ensure projects are portable across different operating systems.`,
+      shouldBeReported: true,
+    },
+  },
+  SOURCE_NAMES: {
+    INVALID_SOURCE_NAME_ABSOLUTE_PATH: {
+      number: 1000,
+      messageTemplate:
+        "Invalid source name {name}. Expected source name but found an absolute path.",
+      websiteTitle: "Invalid source name: absolute path",
+      websiteDescription: `A Solidity source name was expected, but an absolute path was given.
+
+If you aren't overriding compilation-related tasks, please report this as a bug.`,
+      shouldBeReported: true,
+    },
+    INVALID_SOURCE_NAME_RELATIVE_PATH: {
+      number: 1001,
+      messageTemplate:
+        "Invalid source name {name}. Expected source name but found a relative path.",
+      websiteTitle: "Invalid source name: relative path",
+      websiteDescription: `A Solidity source name was expected, but a relative path was given.
+
+If you aren't overriding compilation-related tasks, please report this as a bug.`,
+      shouldBeReported: true,
+    },
+    INVALID_SOURCE_NAME_BACKSLASHES: {
+      number: 1002,
+      messageTemplate:
+        "Invalid source {name}. The source name uses backslashes (\\) instead of slashes (/).",
+      websiteTitle: "Invalid source name: backslashes",
+      websiteDescription: `A Solidity source name was invalid because it uses backslashes (\\\\) instead of slashes (/).
+
+If you aren't overriding compilation-related tasks, please report this as a bug.`,
+      shouldBeReported: true,
+    },
+    INVALID_SOURCE_NOT_NORMALIZED: {
+      number: 1003,
+      messageTemplate:
+        "Invalid source name {name}. Source names must be normalized",
+      websiteTitle: "Invalid source name: not normalized",
+      websiteDescription: `A Solidity source name was invalid because it wasn't normalized. It probably contains some "." or "..".
+
+If you aren't overriding compilation-related tasks, please report this as a bug.`,
+      shouldBeReported: true,
+    },
+    WRONG_CASING: {
+      number: 1004,
+      messageTemplate:
+        "Invalid source map {incorrect}, its correct case-sensitive source name is {correct}",
+      websiteTitle: "Incorrect source name casing",
+      websiteDescription: `You tried to resolve a Solidity file with an incorrect casing.
+
+Hardhat's compiler is case sensitive to ensure projects are portable across different operating systems.`,
+      shouldBeReported: true,
+    },
+    FILE_NOT_FOUND: {
+      number: 1005,
+      messageTemplate: "Solidity source file {name} not found",
+      websiteTitle: "Solidity source file not found",
+      websiteDescription: `A source name should correspond to an existing Solidity file but it doesn't.
+
+Hardhat's compiler is case sensitive to ensure projects are portable across different operating systems.`,
+      shouldBeReported: true,
+    },
+    NODE_MODULES_AS_LOCAL: {
+      number: 1006,
+      messageTemplate:
+        "The file {path} is treated as local but is inside a node_modules directory",
+      websiteTitle: "File from node_modules treated as local",
+      websiteDescription: `A file was treated as local but is inside a node_modules directory.
+
+If you aren't overriding compilation-related tasks, please report this as a bug.`,
+      shouldBeReported: true,
+    },
+    EXTERNAL_AS_LOCAL: {
+      number: 1007,
+      messageTemplate:
+        "The file {path} is treated as local but is outside the project",
+      websiteTitle: "File from outside the project treated as local",
+      websiteDescription: `A file was treated as local but is outside the project.
+
+If you aren't overriding compilation-related tasks, please report this as a bug.`,
+      shouldBeReported: true,
+    },
+  },
+  CONTRACT_NAMES: {
+    INVALID_FULLY_QUALIFIED_NAME: {
+      number: 1100,
+      messageTemplate: "Invalid fully qualified contract name {name}.",
+      websiteTitle: "Invalid fully qualified contract name",
+      websiteDescription: `A contract name was expected to be in fully qualified form, but it's not.
+
+A fully qualified name should look like file.sol:Contract`,
+    },
+  },
+  PLUGINS: {
+    PLUGIN_NOT_INSTALLED: {
+      number: 1200,
+      messageTemplate: 'Plugin "{pluginId}" is not installed.',
+      websiteTitle: "Plugin not installed",
+      websiteDescription: `A plugin was included in the Hardhat config but has not been installed into "node_modules".`,
+    },
+    PLUGIN_MISSING_DEPENDENCY: {
+      number: 1201,
+      messageTemplate:
+        'Plugin "{pluginId}" is missing a peer dependency "{peerDependencyName}".',
+      websiteTitle: "Plugin missing peer dependency",
+      websiteDescription: `A plugin's peer dependency has not been installed.`,
+    },
+    DEPENDENCY_VERSION_MISMATCH: {
+      number: 1202,
+      messageTemplate:
+        'Plugin "{pluginId}" has a peer dependency "{peerDependencyName}" with expected version "{expectedVersion}" but the installed version is "{installedVersion}".',
+      websiteTitle: "Dependency version mismatch",
+      websiteDescription: `A plugin's peer dependency expected version does not match the version of the installed package.
+
+Please install a version of the peer dependency that meets the plugin's requirements.`,
+    },
+    PLUGIN_DEPENDENCY_FAILED_LOAD: {
+      number: 1203,
+      messageTemplate: 'Plugin "{pluginId}" dependency could not be loaded.',
+      websiteTitle: "Plugin dependency could not be loaded",
+      websiteDescription: `The loading of a plugin's dependent plugin failed.`,
+    },
+  },
+  HOOKS: {
+    INVALID_HOOK_FACTORY_PATH: {
+      number: 1300,
+      messageTemplate:
+        'Plugin "{pluginId}" hook factory for "{hookCategoryName}" is not a valid file:// URL: {path}.',
+      websiteTitle: "Plugin hook factory is not a valid file URL",
+      websiteDescription: `The loading of a plugin's hook factory failed as the import path is not a valid file:// URL.`,
+    },
+  },
+} as const;

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/downloader.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/downloader.ts
@@ -22,6 +22,7 @@ import {
 } from "@ignored/hardhat-vnext-utils/fs";
 import debug from "debug";
 
+import { ERRORS } from "../../error-descriptors.js";
 import { download } from "../../utils/download.js";
 import { MultiProcessMutex } from "../../utils/multi-process-mutex.js";
 
@@ -199,17 +200,14 @@ export class CompilerDownloader implements ICompilerDownloader {
         } catch (e) {
           ensureError(e);
 
-          throw new HardhatError(
-            HardhatError.ERRORS.SOLC.VERSION_LIST_DOWNLOAD_FAILED,
-            e,
-          );
+          throw new HardhatError(ERRORS.SOLC.VERSION_LIST_DOWNLOAD_FAILED, e);
         }
 
         build = await this.#getCompilerBuild(version);
       }
 
       if (build === undefined) {
-        throw new HardhatError(HardhatError.ERRORS.SOLC.INVALID_VERSION, {
+        throw new HardhatError(ERRORS.SOLC.INVALID_VERSION, {
           version,
         });
       }
@@ -221,7 +219,7 @@ export class CompilerDownloader implements ICompilerDownloader {
         ensureError(e);
 
         throw new HardhatError(
-          HardhatError.ERRORS.SOLC.DOWNLOAD_FAILED,
+          ERRORS.SOLC.DOWNLOAD_FAILED,
           {
             remoteVersion: build.longVersion,
           },
@@ -231,7 +229,7 @@ export class CompilerDownloader implements ICompilerDownloader {
 
       const verified = await this.#verifyCompilerDownload(build, downloadPath);
       if (!verified) {
-        throw new HardhatError(HardhatError.ERRORS.SOLC.INVALID_DOWNLOAD, {
+        throw new HardhatError(ERRORS.SOLC.INVALID_DOWNLOAD, {
           remoteVersion: build.longVersion,
         });
       }

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/index.ts
@@ -13,6 +13,8 @@ import {
 import { ensureError } from "@ignored/hardhat-vnext-utils/error";
 import * as semver from "semver";
 
+import { ERRORS } from "../../error-descriptors.js";
+
 export interface ICompiler {
   compile(input: CompilerInput): Promise<CompilerOutput>;
 }
@@ -59,10 +61,7 @@ export class Compiler implements ICompiler {
       } catch (e) {
         ensureError(e);
 
-        throw new HardhatError(
-          HardhatError.ERRORS.SOLC.CANT_RUN_SOLCJS_COMPILER,
-          e,
-        );
+        throw new HardhatError(ERRORS.SOLC.CANT_RUN_SOLCJS_COMPILER, e);
       }
     });
 
@@ -120,10 +119,7 @@ export class NativeCompiler implements ICompiler {
       } catch (e) {
         ensureError(e);
 
-        throw new HardhatError(
-          HardhatError.ERRORS.SOLC.CANT_RUN_NATIVE_COMPILER,
-          e,
-        );
+        throw new HardhatError(ERRORS.SOLC.CANT_RUN_NATIVE_COMPILER, e);
       }
     });
 

--- a/v-next/hardhat-build-system/src/internal/solidity/dependencyGraph.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/dependencyGraph.ts
@@ -6,6 +6,8 @@ import {
   assertHardhatInvariant,
 } from "@ignored/hardhat-vnext-errors";
 
+import { ERRORS } from "../error-descriptors.js";
+
 export class DependencyGraph implements taskTypes.DependencyGraph {
   public static async createFromResolvedFiles(
     resolver: Resolver,
@@ -193,13 +195,10 @@ export class DependencyGraph implements taskTypes.DependencyGraph {
 
     if (sourceName !== undefined) {
       if (sourceName !== file.sourceName) {
-        throw new HardhatError(
-          HardhatError.ERRORS.RESOLVER.AMBIGUOUS_SOURCE_NAMES,
-          {
-            sourcenames: `'${sourceName}' and '${file.sourceName}'`,
-            file: file.absolutePath,
-          },
-        );
+        throw new HardhatError(ERRORS.RESOLVER.AMBIGUOUS_SOURCE_NAMES, {
+          sourcenames: `'${sourceName}' and '${file.sourceName}'`,
+          file: file.absolutePath,
+        });
       }
 
       return;

--- a/v-next/hardhat-build-system/src/internal/solidity/parse.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/parse.ts
@@ -2,6 +2,7 @@ import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import { ensureError } from "@ignored/hardhat-vnext-utils/error";
 
 import { SolidityFilesCache } from "../builtin-tasks/utils/solidity-files-cache.js";
+import { ERRORS } from "../error-descriptors.js";
 
 interface ParsedData {
   imports: string[];
@@ -43,7 +44,7 @@ export class Parser {
         typeof e.code === "string" &&
         e.code === "MODULE_NOT_FOUND"
       ) {
-        throw new HardhatError(HardhatError.ERRORS.GENERAL.CORRUPTED_LOCKFILE);
+        throw new HardhatError(ERRORS.GENERAL.CORRUPTED_LOCKFILE);
       }
 
       throw e;

--- a/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/resolver.ts
@@ -15,6 +15,7 @@ import {
 import { ensureError } from "@ignored/hardhat-vnext-utils/error";
 import resolve from "resolve";
 
+import { ERRORS } from "../error-descriptors.js";
 import { getRealPath } from "../utils/fs-utils.js";
 import { createNonCryptographicHashBasedIdentifier } from "../utils/hash.js";
 import { applyRemappings } from "../utils/remappings.js";
@@ -131,7 +132,7 @@ export class Resolver {
     // sanity check for deprecated task
     if (importName !== (await this.#transformImportName(importName))) {
       throw new HardhatError(
-        HardhatError.ERRORS.TASK_DEFINITIONS.DEPRECATED_TRANSFORM_IMPORT_TASK,
+        ERRORS.TASK_DEFINITIONS.DEPRECATED_TRANSFORM_IMPORT_TASK,
       );
     }
 
@@ -139,46 +140,34 @@ export class Resolver {
 
     const scheme = this.#getUriScheme(imported);
     if (scheme !== undefined) {
-      throw new HardhatError(
-        HardhatError.ERRORS.RESOLVER.INVALID_IMPORT_PROTOCOL,
-        {
-          from: from.sourceName,
-          imported,
-          protocol: scheme,
-        },
-      );
+      throw new HardhatError(ERRORS.RESOLVER.INVALID_IMPORT_PROTOCOL, {
+        from: from.sourceName,
+        imported,
+        protocol: scheme,
+      });
     }
 
     if (replaceBackslashes(imported) !== imported) {
-      throw new HardhatError(
-        HardhatError.ERRORS.RESOLVER.INVALID_IMPORT_BACKSLASH,
-        {
-          from: from.sourceName,
-          imported,
-        },
-      );
+      throw new HardhatError(ERRORS.RESOLVER.INVALID_IMPORT_BACKSLASH, {
+        from: from.sourceName,
+        imported,
+      });
     }
 
     if (isAbsolutePathSourceName(imported)) {
-      throw new HardhatError(
-        HardhatError.ERRORS.RESOLVER.INVALID_IMPORT_ABSOLUTE_PATH,
-        {
-          from: from.sourceName,
-          imported,
-        },
-      );
+      throw new HardhatError(ERRORS.RESOLVER.INVALID_IMPORT_ABSOLUTE_PATH, {
+        from: from.sourceName,
+        imported,
+      });
     }
 
     // Edge-case where an import can contain the current package's name in monorepos.
     // The path can be resolved because there's a symlink in the node modules.
     if (await includesOwnPackageName(imported)) {
-      throw new HardhatError(
-        HardhatError.ERRORS.RESOLVER.INCLUDES_OWN_PACKAGE_NAME,
-        {
-          from: from.sourceName,
-          imported,
-        },
-      );
+      throw new HardhatError(ERRORS.RESOLVER.INCLUDES_OWN_PACKAGE_NAME, {
+        from: from.sourceName,
+        imported,
+      });
     }
 
     try {
@@ -219,18 +208,15 @@ export class Resolver {
       return resolvedFile;
     } catch (error) {
       if (
+        HardhatError.isHardhatError(error, ERRORS.RESOLVER.FILE_NOT_FOUND) ||
         HardhatError.isHardhatError(
           error,
-          HardhatError.ERRORS.RESOLVER.FILE_NOT_FOUND,
-        ) ||
-        HardhatError.isHardhatError(
-          error,
-          HardhatError.ERRORS.RESOLVER.LIBRARY_FILE_NOT_FOUND,
+          ERRORS.RESOLVER.LIBRARY_FILE_NOT_FOUND,
         )
       ) {
         if (imported !== importName) {
           throw new HardhatError(
-            HardhatError.ERRORS.RESOLVER.IMPORTED_MAPPED_FILE_NOT_FOUND,
+            ERRORS.RESOLVER.IMPORTED_MAPPED_FILE_NOT_FOUND,
             {
               imported,
               importName,
@@ -240,7 +226,7 @@ export class Resolver {
           );
         } else {
           throw new HardhatError(
-            HardhatError.ERRORS.RESOLVER.IMPORTED_FILE_NOT_FOUND,
+            ERRORS.RESOLVER.IMPORTED_FILE_NOT_FOUND,
             {
               imported,
               from: from.sourceName,
@@ -253,11 +239,11 @@ export class Resolver {
       if (
         HardhatError.isHardhatError(
           error,
-          HardhatError.ERRORS.RESOLVER.WRONG_SOURCE_NAME_CASING,
+          ERRORS.RESOLVER.WRONG_SOURCE_NAME_CASING,
         )
       ) {
         throw new HardhatError(
-          HardhatError.ERRORS.RESOLVER.INVALID_IMPORT_WRONG_CASING,
+          ERRORS.RESOLVER.INVALID_IMPORT_WRONG_CASING,
           {
             imported,
             from: from.sourceName,
@@ -269,11 +255,11 @@ export class Resolver {
       if (
         HardhatError.isHardhatError(
           error,
-          HardhatError.ERRORS.RESOLVER.LIBRARY_NOT_INSTALLED,
+          ERRORS.RESOLVER.LIBRARY_NOT_INSTALLED,
         )
       ) {
         throw new HardhatError(
-          HardhatError.ERRORS.RESOLVER.IMPORTED_LIBRARY_NOT_INSTALLED,
+          ERRORS.RESOLVER.IMPORTED_LIBRARY_NOT_INSTALLED,
           {
             library: error.messageArguments.library,
             from: from.sourceName,
@@ -285,11 +271,11 @@ export class Resolver {
       if (
         HardhatError.isHardhatError(
           error,
-          HardhatError.ERRORS.GENERAL.INVALID_READ_OF_DIRECTORY,
+          ERRORS.GENERAL.INVALID_READ_OF_DIRECTORY,
         )
       ) {
         throw new HardhatError(
-          HardhatError.ERRORS.RESOLVER.INVALID_IMPORT_OF_DIRECTORY,
+          ERRORS.RESOLVER.INVALID_IMPORT_OF_DIRECTORY,
           {
             imported,
             from: from.sourceName,
@@ -342,7 +328,7 @@ export class Resolver {
         ensureError(error);
 
         throw new HardhatError(
-          HardhatError.ERRORS.RESOLVER.LIBRARY_NOT_INSTALLED,
+          ERRORS.RESOLVER.LIBRARY_NOT_INSTALLED,
           {
             library: libraryName,
           },
@@ -415,7 +401,7 @@ export class Resolver {
     // starts with ../ means that it's trying to get outside of the project.
     if (from.library === undefined && sourceName.startsWith("../")) {
       throw new HardhatError(
-        HardhatError.ERRORS.RESOLVER.INVALID_IMPORT_OUTSIDE_OF_PROJECT,
+        ERRORS.RESOLVER.INVALID_IMPORT_OUTSIDE_OF_PROJECT,
         { from: from.sourceName, imported },
       );
     }
@@ -426,7 +412,7 @@ export class Resolver {
     ) {
       // If the file is being imported from a library, this means that it's
       // trying to reach another one.
-      throw new HardhatError(HardhatError.ERRORS.RESOLVER.ILLEGAL_IMPORT, {
+      throw new HardhatError(ERRORS.RESOLVER.ILLEGAL_IMPORT, {
         from: from.sourceName,
         imported,
       });
@@ -548,28 +534,22 @@ export class Resolver {
       await validateSourceNameExistenceAndCasing(fromDir, sourceName);
     } catch (error) {
       if (
-        HardhatError.isHardhatError(
-          error,
-          HardhatError.ERRORS.SOURCE_NAMES.FILE_NOT_FOUND,
-        )
+        HardhatError.isHardhatError(error, ERRORS.SOURCE_NAMES.FILE_NOT_FOUND)
       ) {
         throw new HardhatError(
           isLibrary
-            ? HardhatError.ERRORS.RESOLVER.LIBRARY_FILE_NOT_FOUND
-            : HardhatError.ERRORS.RESOLVER.FILE_NOT_FOUND,
+            ? ERRORS.RESOLVER.LIBRARY_FILE_NOT_FOUND
+            : ERRORS.RESOLVER.FILE_NOT_FOUND,
           { file: sourceName },
           error,
         );
       }
 
       if (
-        HardhatError.isHardhatError(
-          error,
-          HardhatError.ERRORS.SOURCE_NAMES.WRONG_CASING,
-        )
+        HardhatError.isHardhatError(error, ERRORS.SOURCE_NAMES.WRONG_CASING)
       ) {
         throw new HardhatError(
-          HardhatError.ERRORS.RESOLVER.WRONG_SOURCE_NAME_CASING,
+          ERRORS.RESOLVER.WRONG_SOURCE_NAME_CASING,
           {
             incorrect: sourceName,
             correct: error.messageArguments.correct,

--- a/v-next/hardhat-build-system/src/internal/tasks.ts
+++ b/v-next/hardhat-build-system/src/internal/tasks.ts
@@ -22,6 +22,7 @@ import debug from "debug";
 import semver from "semver";
 
 import { SolidityFilesCache } from "./builtin-tasks/utils/solidity-files-cache.js";
+import { ERRORS } from "./error-descriptors.js";
 import {
   createCompilationJobFromFile,
   createCompilationJobsFromConnectedComponent,
@@ -117,12 +118,9 @@ export async function taskCompileSolidityReadFile(
     return await readUtf8File(absolutePath);
   } catch (e) {
     if (await isDirectory(absolutePath)) {
-      throw new HardhatError(
-        HardhatError.ERRORS.GENERAL.INVALID_READ_OF_DIRECTORY,
-        {
-          absolutePath,
-        },
-      );
+      throw new HardhatError(ERRORS.GENERAL.INVALID_READ_OF_DIRECTORY, {
+        absolutePath,
+      });
     }
 
     throw e;
@@ -232,7 +230,7 @@ export async function taskCompileSolidityHandleCompilationJobsFailures(
       );
 
     throw new HardhatError(
-      HardhatError.ERRORS.BUILTIN_TASKS.COMPILATION_JOBS_CREATION_FAILURE,
+      ERRORS.BUILTIN_TASKS.COMPILATION_JOBS_CREATION_FAILURE,
       {
         reasons,
       },
@@ -694,14 +692,11 @@ export async function taskCompileSolidityRunSolc(
   solcVersion?: string,
 ): Promise<any> {
   if (solcVersion !== undefined && semver.valid(solcVersion) === null) {
-    throw new HardhatError(
-      HardhatError.ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
-      {
-        value: solcVersion,
-        name: "solcVersion",
-        type: "string",
-      },
-    );
+    throw new HardhatError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+      value: solcVersion,
+      name: "solcVersion",
+      type: "string",
+    });
   }
 
   const compiler = new NativeCompiler(solcPath, solcVersion);
@@ -894,7 +889,7 @@ export async function taskCompileSolidityCheckErrors(
   await taskCompileSolidityLogCompilationErrors(output, quiet);
 
   if (hasCompilationErrors(output)) {
-    throw new HardhatError(HardhatError.ERRORS.BUILTIN_TASKS.COMPILE_FAILURE);
+    throw new HardhatError(ERRORS.BUILTIN_TASKS.COMPILE_FAILURE);
   }
 }
 
@@ -1080,7 +1075,7 @@ export async function taskCompileSolidityCompileJobs(
     // see issue https://github.com/nomiclabs/hardhat/issues/2004
     if (semver.lt(solcVersion, COMPILE_TASK_FIRST_SOLC_VERSION_SUPPORTED)) {
       throw new HardhatError(
-        HardhatError.ERRORS.BUILTIN_TASKS.COMPILE_TASK_UNSUPPORTED_SOLC_VERSION,
+        ERRORS.BUILTIN_TASKS.COMPILE_TASK_UNSUPPORTED_SOLC_VERSION,
         {
           version: solcVersion,
           firstSupportedVersion: COMPILE_TASK_FIRST_SOLC_VERSION_SUPPORTED,
@@ -1122,7 +1117,7 @@ export async function taskCompileSolidityCompileJobs(
       if (
         !HardhatError.isHardhatError(
           error,
-          HardhatError.ERRORS.BUILTIN_TASKS.COMPILE_FAILURE,
+          ERRORS.BUILTIN_TASKS.COMPILE_FAILURE,
         )
       ) {
         throw error;
@@ -1130,7 +1125,7 @@ export async function taskCompileSolidityCompileJobs(
     }
 
     // error is an aggregate error, and all errors are compilation failures
-    throw new HardhatError(HardhatError.ERRORS.BUILTIN_TASKS.COMPILE_FAILURE);
+    throw new HardhatError(ERRORS.BUILTIN_TASKS.COMPILE_FAILURE);
   }
 }
 

--- a/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/artifacts.ts
@@ -24,6 +24,8 @@ import {
 } from "@ignored/hardhat-vnext-utils/fs";
 import debug from "debug";
 
+import { ERRORS } from "../error-descriptors.js";
+
 import {
   ARTIFACT_FORMAT_VERSION,
   BUILD_INFO_DIR_NAME,
@@ -575,7 +577,7 @@ export class Artifacts implements IArtifacts {
       );
 
       if (artifactPath !== trueCasePath) {
-        throw new HardhatError(HardhatError.ERRORS.ARTIFACTS.WRONG_CASING, {
+        throw new HardhatError(ERRORS.ARTIFACTS.WRONG_CASING, {
           correct: this.#getFullyQualifiedNameFromPath(trueCasePath),
           incorrect: fullyQualifiedName,
         });
@@ -632,7 +634,7 @@ Please replace "${contractName}" for the correct contract name wherever you are 
       names,
     );
 
-    throw new HardhatError(HardhatError.ERRORS.ARTIFACTS.NOT_FOUND, {
+    throw new HardhatError(ERRORS.ARTIFACTS.NOT_FOUND, {
       contractName: fullyQualifiedName,
       suggestion: this.#formatSuggestions(similarNames, fullyQualifiedName),
     });
@@ -656,7 +658,7 @@ Please replace "${contractName}" for the correct contract name wherever you are 
       );
     }
 
-    throw new HardhatError(HardhatError.ERRORS.ARTIFACTS.NOT_FOUND, {
+    throw new HardhatError(ERRORS.ARTIFACTS.NOT_FOUND, {
       contractName,
       suggestion: this.#formatSuggestions(similarNames, contractName),
     });
@@ -753,7 +755,7 @@ Please replace "${contractName}" for the correct contract name wherever you are 
         this.#getFullyQualifiedNameFromPath(file),
       );
 
-      throw new HardhatError(HardhatError.ERRORS.ARTIFACTS.MULTIPLE_FOUND, {
+      throw new HardhatError(ERRORS.ARTIFACTS.MULTIPLE_FOUND, {
         contractName,
         candidates: candidates.join(os.EOL),
       });

--- a/v-next/hardhat-build-system/src/internal/utils/contract-names.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/contract-names.ts
@@ -3,6 +3,8 @@ import {
   assertHardhatInvariant,
 } from "@ignored/hardhat-vnext-errors";
 
+import { ERRORS } from "../error-descriptors.js";
+
 /**
  * Returns a fully qualified name from a sourceName and contractName.
  */
@@ -33,12 +35,9 @@ export function parseFullyQualifiedName(fullyQualifiedName: string): {
   const { sourceName, contractName } = parseName(fullyQualifiedName);
 
   if (sourceName === undefined) {
-    throw new HardhatError(
-      HardhatError.ERRORS.CONTRACT_NAMES.INVALID_FULLY_QUALIFIED_NAME,
-      {
-        name: fullyQualifiedName,
-      },
-    );
+    throw new HardhatError(ERRORS.CONTRACT_NAMES.INVALID_FULLY_QUALIFIED_NAME, {
+      name: fullyQualifiedName,
+    });
   }
 
   return { sourceName, contractName };

--- a/v-next/hardhat-build-system/src/internal/utils/source-names.ts
+++ b/v-next/hardhat-build-system/src/internal/utils/source-names.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
+import { ERRORS } from "../error-descriptors.js";
+
 import { FileNotFoundError, getFileTrueCase } from "./fs-utils.js";
 import { getPackageName } from "./package-info.js";
 
@@ -21,18 +23,15 @@ export async function localPathToSourceName(
   const normalized = normalizeSourceName(relativePath);
 
   if (normalized.startsWith("..")) {
-    throw new HardhatError(HardhatError.ERRORS.SOURCE_NAMES.EXTERNAL_AS_LOCAL, {
+    throw new HardhatError(ERRORS.SOURCE_NAMES.EXTERNAL_AS_LOCAL, {
       path: localFileAbsolutePath,
     });
   }
 
   if (normalized.includes(NODE_MODULES)) {
-    throw new HardhatError(
-      HardhatError.ERRORS.SOURCE_NAMES.NODE_MODULES_AS_LOCAL,
-      {
-        path: localFileAbsolutePath,
-      },
-    );
+    throw new HardhatError(ERRORS.SOURCE_NAMES.NODE_MODULES_AS_LOCAL, {
+      path: localFileAbsolutePath,
+    });
   }
 
   return getSourceNameTrueCase(projectRoot, relativePath);
@@ -62,7 +61,7 @@ async function getSourceNameTrueCase(
   } catch (error) {
     if (error instanceof FileNotFoundError) {
       throw new HardhatError(
-        HardhatError.ERRORS.SOURCE_NAMES.FILE_NOT_FOUND,
+        ERRORS.SOURCE_NAMES.FILE_NOT_FOUND,
         {
           name: p,
         },
@@ -175,7 +174,7 @@ export async function validateSourceNameExistenceAndCasing(
   const trueCaseSourceName = await getSourceNameTrueCase(fromDir, sourceName);
 
   if (trueCaseSourceName !== sourceName) {
-    throw new HardhatError(HardhatError.ERRORS.SOURCE_NAMES.WRONG_CASING, {
+    throw new HardhatError(ERRORS.SOURCE_NAMES.WRONG_CASING, {
       incorrect: sourceName,
       correct: trueCaseSourceName,
     });
@@ -191,7 +190,7 @@ export async function validateSourceNameExistenceAndCasing(
 export function validateSourceNameFormat(sourceName: string): void {
   if (isAbsolutePathSourceName(sourceName)) {
     throw new HardhatError(
-      HardhatError.ERRORS.SOURCE_NAMES.INVALID_SOURCE_NAME_ABSOLUTE_PATH,
+      ERRORS.SOURCE_NAMES.INVALID_SOURCE_NAME_ABSOLUTE_PATH,
       {
         name: sourceName,
       },
@@ -200,7 +199,7 @@ export function validateSourceNameFormat(sourceName: string): void {
 
   if (isExplicitRelativePath(sourceName)) {
     throw new HardhatError(
-      HardhatError.ERRORS.SOURCE_NAMES.INVALID_SOURCE_NAME_RELATIVE_PATH,
+      ERRORS.SOURCE_NAMES.INVALID_SOURCE_NAME_RELATIVE_PATH,
       {
         name: sourceName,
       },
@@ -211,7 +210,7 @@ export function validateSourceNameFormat(sourceName: string): void {
   // comes from slash vs backslash
   if (replaceBackslashes(sourceName) !== sourceName) {
     throw new HardhatError(
-      HardhatError.ERRORS.SOURCE_NAMES.INVALID_SOURCE_NAME_BACKSLASHES,
+      ERRORS.SOURCE_NAMES.INVALID_SOURCE_NAME_BACKSLASHES,
       {
         name: sourceName,
       },
@@ -219,12 +218,9 @@ export function validateSourceNameFormat(sourceName: string): void {
   }
 
   if (normalizeSourceName(sourceName) !== sourceName) {
-    throw new HardhatError(
-      HardhatError.ERRORS.SOURCE_NAMES.INVALID_SOURCE_NOT_NORMALIZED,
-      {
-        name: sourceName,
-      },
-    );
+    throw new HardhatError(ERRORS.SOURCE_NAMES.INVALID_SOURCE_NOT_NORMALIZED, {
+      name: sourceName,
+    });
   }
 }
 

--- a/v-next/hardhat-build-system/test/index.ts
+++ b/v-next/hardhat-build-system/test/index.ts
@@ -6,11 +6,11 @@ import path from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import ci from "ci-info";
 import sinon from "sinon";
 
 import { BuildSystem } from "../src/index.js";
+import { ERRORS } from "../src/internal/error-descriptors.js";
 import { CompilationJobCreationErrorReason } from "../src/internal/types/builtin-tasks/index.js";
 import {
   getAllFilesMatchingSync,
@@ -237,7 +237,7 @@ describe("build-system", () => {
 
         await expectHardhatErrorAsync(async () => {
           await buildSystem.solidityReadFile(absolutePath);
-        }, HardhatError.ERRORS.GENERAL.INVALID_READ_OF_DIRECTORY);
+        }, ERRORS.GENERAL.INVALID_READ_OF_DIRECTORY);
       });
     });
 
@@ -268,7 +268,7 @@ describe("build-system", () => {
 
         await expectHardhatErrorAsync(async () => {
           await buildSystem.build();
-        }, HardhatError.ERRORS.BUILTIN_TASKS.COMPILE_TASK_UNSUPPORTED_SOLC_VERSION);
+        }, ERRORS.BUILTIN_TASKS.COMPILE_TASK_UNSUPPORTED_SOLC_VERSION);
       });
     });
 
@@ -281,7 +281,7 @@ describe("build-system", () => {
 
         await expectHardhatErrorAsync(async () => {
           await buildSystem.build();
-        }, HardhatError.ERRORS.BUILTIN_TASKS.COMPILE_TASK_UNSUPPORTED_SOLC_VERSION);
+        }, ERRORS.BUILTIN_TASKS.COMPILE_TASK_UNSUPPORTED_SOLC_VERSION);
       });
     });
 
@@ -294,7 +294,7 @@ describe("build-system", () => {
 
         await expectHardhatErrorAsync(async () => {
           await buildSystem.build();
-        }, HardhatError.ERRORS.BUILTIN_TASKS.COMPILE_TASK_UNSUPPORTED_SOLC_VERSION);
+        }, ERRORS.BUILTIN_TASKS.COMPILE_TASK_UNSUPPORTED_SOLC_VERSION);
       });
     });
   });
@@ -1170,7 +1170,7 @@ Read about compiler configuration at https://hardhat.org/config
               },
             },
           }),
-        HardhatError.ERRORS.RESOLVER.AMBIGUOUS_SOURCE_NAMES,
+        ERRORS.RESOLVER.AMBIGUOUS_SOURCE_NAMES,
         /Two different source names \('\w+\/Foo.sol' and '\w+\/Foo.sol'\) resolve to the same file/,
       );
     });

--- a/v-next/hardhat-build-system/test/internal/utils/artifacts.ts
+++ b/v-next/hardhat-build-system/test/internal/utils/artifacts.ts
@@ -12,13 +12,13 @@ import * as os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, it } from "node:test";
 
-import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import {
   readJsonFile,
   remove,
   writeJsonFile,
 } from "@ignored/hardhat-vnext-utils/fs";
 
+import { ERRORS } from "../../../src/internal/error-descriptors.js";
 import {
   Artifacts,
   getArtifactFromContractOutput,
@@ -389,7 +389,7 @@ describe("Artifacts class", function () {
       const artifacts = new Artifacts(getTmpDir());
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact("NonExistent"),
-        HardhatError.ERRORS.ARTIFACTS.NOT_FOUND,
+        ERRORS.ARTIFACTS.NOT_FOUND,
       );
     });
 
@@ -406,7 +406,7 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(name),
-        HardhatError.ERRORS.ARTIFACTS.MULTIPLE_FOUND,
+        ERRORS.ARTIFACTS.MULTIPLE_FOUND,
         `Lib.sol:Lib${os.EOL}Lib2.sol:Lib`,
       );
     });
@@ -423,7 +423,7 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        HardhatError.ERRORS.ARTIFACTS.NOT_FOUND,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         /Did you mean "Lib"\?$/,
       );
     });
@@ -449,7 +449,7 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        HardhatError.ERRORS.ARTIFACTS.NOT_FOUND,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         expected,
       );
     });
@@ -466,7 +466,7 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        HardhatError.ERRORS.ARTIFACTS.NOT_FOUND,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         /Did you mean "Lib\.sol:Lib"\?/,
       );
     });
@@ -490,7 +490,7 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        HardhatError.ERRORS.ARTIFACTS.NOT_FOUND,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         expected,
       );
     });
@@ -507,7 +507,7 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        HardhatError.ERRORS.ARTIFACTS.NOT_FOUND,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         /not found\.\s*$/,
       );
     });
@@ -524,7 +524,7 @@ describe("Artifacts class", function () {
 
       await expectHardhatErrorAsync(
         () => artifacts.readArtifact(typo),
-        HardhatError.ERRORS.ARTIFACTS.NOT_FOUND,
+        ERRORS.ARTIFACTS.NOT_FOUND,
         /not found\.\s*$/,
       );
     });

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -55,20 +55,7 @@ export const ERROR_CATEGORIES: {
     websiteTitle: "Task definition errors",
   },
   ARGUMENTS: { min: 300, max: 399, websiteTitle: "Arguments related errors" },
-  RESOLVER: {
-    min: 400,
-    max: 499,
-    websiteTitle: "Dependencies resolution errors",
-  },
-  SOLC: { min: 500, max: 599, websiteTitle: "Solidity related errors" },
   BUILTIN_TASKS: { min: 600, max: 699, websiteTitle: "Built-in tasks errors" },
-  ARTIFACTS: { min: 700, max: 799, websiteTitle: "Artifacts related errors" },
-  SOURCE_NAMES: { min: 1000, max: 1099, websiteTitle: "Source name errors" },
-  CONTRACT_NAMES: {
-    min: 1100,
-    max: 1199,
-    websiteTitle: "Contract name errors",
-  },
   PLUGINS: {
     min: 1200,
     max: 1299,
@@ -90,29 +77,6 @@ export const ERRORS = {
       websiteDescription: `You are trying to run Hardhat outside of a Hardhat project.
 
 You can learn how to use Hardhat by reading the [Getting Started guide](/hardhat-runner/docs/getting-started).`,
-    },
-    CORRUPTED_LOCKFILE: {
-      number: 2,
-      messageTemplate: `You installed Hardhat with a corrupted lockfile due to the NPM bug #4828.
-
-Please delete your node_modules, package-lock.json, reinstall your project, and try again.`,
-      websiteTitle: "Corrupted lockfile",
-      websiteDescription: `Some versions of NPM are affected [by a bug](https://github.com/npm/cli/issues/4828) that leads to corrupt lockfiles being generated.
-
-This bug can only affect you if you, or someone at your team, installed the project without a lockfile, but with an existing node_modules.
-
-To avoid it, please delete both your node_modules and package-lock.json, and reinstall your project.
-
-Note that you don't need to do this every time you install a new dependency, but please make sure to delete your node_modules every time you delete your package-lock.json.`,
-    },
-    INVALID_READ_OF_DIRECTORY: {
-      number: 3,
-      messageTemplate:
-        "Invalid file path {absolutePath}. Attempting to read a directory instead of a file.",
-      websiteTitle: "Invalid read: a directory cannot be read",
-      websiteDescription: `An attempt was made to read a file, but a path to a directory was provided.
-
-Please double check the file path.`,
     },
     DUPLICATED_PLUGIN_ID: {
       number: 4,
@@ -231,21 +195,13 @@ Please add the property "type" with the value "module" in your package.json to e
       number: 100,
       messageTemplate: "An internal invariant was violated: {message}",
       websiteTitle: "Invariant violation",
-      websiteDescription: `An internal invariant was violated. This is probably caused by a programming error in Hardhat or in one of the used plugins.
-
+      websiteDescription: `An internal invariant was violated. This is probably caused by a programming in Hardhat or in one of the used plugins.
+    
 Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
       shouldBeReported: true,
     },
   },
   TASK_DEFINITIONS: {
-    DEPRECATED_TRANSFORM_IMPORT_TASK: {
-      number: 200,
-      websiteTitle: "Use of deprecated remapping task",
-      messageTemplate:
-        "Task TASK_COMPILE_TRANSFORM_IMPORT_NAME is deprecated. Please update your @nomicfoundation/hardhat-foundry plugin version.",
-      websiteDescription: `This task has been deprecated in favor of a new approach.`,
-      shouldBeReported: true,
-    },
     INVALID_FILE_ACTION: {
       number: 201,
       messageTemplate: "Invalid file action: {action} is not a valid file URL",
@@ -433,16 +389,6 @@ Please double check how you invoked Hardhat or ran your task.`,
 
 Please double check how you invoked Hardhat or ran your task.`,
     },
-    INVALID_INPUT_FILE: {
-      number: 307,
-      messageTemplate:
-        "Invalid argument {name}: File {value} doesn't exist or is not a readable file.",
-      websiteTitle: "Invalid file argument",
-      websiteDescription: `One of your tasks expected a file as an argument, but you provided a
-nonexistent or non-readable file.
-
-Please double check your arguments.`,
-    },
     MISSING_CONFIG_FILE: {
       number: 308,
       messageTemplate:
@@ -464,242 +410,7 @@ Please double check your arguments.`,
 Please double check your arguments.`,
     },
   },
-  RESOLVER: {
-    FILE_NOT_FOUND: {
-      number: 400,
-      messageTemplate: "File {file} doesn't exist.",
-      websiteTitle: "Solidity file not found",
-      websiteDescription: `Tried to resolve a nonexistent Solidity file as an entry-point.`,
-    },
-    LIBRARY_NOT_INSTALLED: {
-      number: 401,
-      messageTemplate: "Library {library} is not installed.",
-      websiteTitle: "Solidity library not installed",
-      websiteDescription: `One of your Solidity sources imports a library that is not installed.
-
-Please double check your imports or install the missing dependency.`,
-    },
-    LIBRARY_FILE_NOT_FOUND: {
-      number: 402,
-      messageTemplate: "File {file} doesn't exist.",
-      websiteTitle: "Missing library file",
-      websiteDescription: `One of your libraries' files was imported but doesn't exist.
-
-Please double check your imports or update your libraries.`,
-    },
-    ILLEGAL_IMPORT: {
-      number: 403,
-      messageTemplate: "Illegal import {imported} from {from}",
-      websiteTitle: "Illegal Solidity import",
-      websiteDescription: `One of your libraries tried to use a relative import to import a file outside of its scope.
-
-This is disabled for security reasons.`,
-    },
-    IMPORTED_FILE_NOT_FOUND: {
-      number: 404,
-      messageTemplate: "File {imported}, imported from {from}, not found.",
-      websiteTitle: "Imported file not found",
-      websiteDescription: `One of your source files imported a nonexistent file.
-
-Please double check your imports.`,
-    },
-    INVALID_IMPORT_BACKSLASH: {
-      number: 405,
-      messageTemplate:
-        "Invalid import {imported} from {from}. Imports must use / instead of \\, even in Windows",
-      websiteTitle: "Invalid import: use / instead of \\",
-      websiteDescription: `A Solidity file is trying to import another file via relative path and is using backslashes (\\\\) instead of slashes (/).
-
-You must always use slashes (/) in Solidity imports.`,
-    },
-    INVALID_IMPORT_PROTOCOL: {
-      number: 406,
-      messageTemplate:
-        "Invalid import {imported} from {from}. Hardhat doesn't support imports via {protocol}.",
-      websiteTitle: "Invalid import: trying to use an unsupported protocol",
-      websiteDescription: `A Solidity file is trying to import a file using an unsupported protocol, like http.
-
-You can only import files that are available locally or installed through npm.`,
-    },
-    INVALID_IMPORT_ABSOLUTE_PATH: {
-      number: 407,
-      messageTemplate:
-        "Invalid import {imported} from {from}. Hardhat doesn't support imports with absolute paths.",
-      websiteTitle: "Invalid import: absolute paths unsupported",
-      websiteDescription: `A Solidity file is trying to import a file using its absolute path.
-
-This is not supported, as it would lead to hard-to-reproduce compilations.`,
-    },
-    INVALID_IMPORT_OUTSIDE_OF_PROJECT: {
-      number: 408,
-      messageTemplate:
-        "Invalid import {imported} from {from}. The file being imported is outside of the project",
-      websiteTitle: "Invalid import: file outside of the project",
-      websiteDescription: `A Solidity file is trying to import a file that is outside of the project.
-
-This is not supported by Hardhat.`,
-    },
-    INVALID_IMPORT_WRONG_CASING: {
-      number: 409,
-      messageTemplate:
-        "Trying to import {imported} from {from}, but it has an incorrect casing.",
-      websiteTitle: "Invalid import: wrong file casing",
-      websiteDescription: `A Solidity file is trying to import a file but its source name casing was wrong.
-
-Hardhat's compiler is case sensitive to ensure projects are portable across different operating systems.`,
-    },
-    WRONG_SOURCE_NAME_CASING: {
-      number: 410,
-      messageTemplate:
-        "Trying to resolve the file {incorrect} but its correct case-sensitive name is {correct}",
-      websiteTitle: "Incorrect source name casing",
-      websiteDescription: `You tried to resolve a Solidity file with an incorrect casing.
-
-Hardhat's compiler is case sensitive to ensure projects are portable across different operating systems.`,
-    },
-    IMPORTED_LIBRARY_NOT_INSTALLED: {
-      number: 411,
-      messageTemplate:
-        "The library {library}, imported from {from}, is not installed. Try installing it using npm.",
-      websiteTitle: "Invalid import: library not installed",
-      websiteDescription: `A Solidity file is trying to import another which belongs to a library that is not installed.
-
-Try installing the library using npm.`,
-    },
-    INCLUDES_OWN_PACKAGE_NAME: {
-      number: 412,
-      messageTemplate:
-        "Invalid import {imported} from {from}. Trying to import file using the own package's name.",
-      websiteTitle: "Invalid import: includes own package's name",
-      websiteDescription: `A Solidity file is trying to import another using its own package name. This is most likely caused by an existing symlink for the package in your node_modules.
-
-Use a relative import instead of referencing the package's name.`,
-    },
-    IMPORTED_MAPPED_FILE_NOT_FOUND: {
-      number: 413,
-      messageTemplate:
-        "File {importName} => {imported}, imported from {from}, not found.",
-      websiteTitle: "Imported mapped file not found",
-      websiteDescription: `One of your source files imported a nonexistent or not installed file.
-
-Please double check your imports and installed libraries.`,
-    },
-    INVALID_IMPORT_OF_DIRECTORY: {
-      number: 414,
-      messageTemplate:
-        "Invalid import {imported} from {from}. Attempting to import a directory. Directories cannot be imported.",
-      websiteTitle: "Invalid import: a directory cannot be imported",
-      websiteDescription: `A Solidity file is attempting to import a directory, which is not possible.
-
-Please double check your imports.`,
-    },
-    AMBIGUOUS_SOURCE_NAMES: {
-      number: 415,
-      messageTemplate:
-        "Two different source names ({sourcenames}) resolve to the same file ({file}).",
-      websiteTitle: "Ambiguous source names",
-      websiteDescription: `Two different source names map to the same file.
-
-This is probably caused by multiple remappings pointing to the same source file.`,
-    },
-  },
-  SOLC: {
-    INVALID_VERSION: {
-      number: 500,
-      messageTemplate: `Solidity version {version} is invalid or hasn't been released yet.
-
-If you are certain it has been released, run "npx hardhat clean --global" and try again`,
-      websiteTitle: "Invalid or unreleased `solc` version",
-      websiteDescription: `The Solidity version in your config is invalid or hasn't been released yet.
-
-If you are certain it has been released, run \`npx hardhat clean --global\` and try again.`,
-    },
-    DOWNLOAD_FAILED: {
-      number: 501,
-      messageTemplate:
-        "Couldn't download compiler version {remoteVersion}. Please check your internet connection and try again.",
-      websiteTitle: "`solc` download failed",
-      websiteDescription: `Couldn't download \`solc\`.
-
-Please check your internet connection and try again.`,
-    },
-    VERSION_LIST_DOWNLOAD_FAILED: {
-      number: 502,
-      messageTemplate:
-        "Couldn't download compiler version list. Please check your internet connection and try again.",
-      websiteTitle: "Couldn't obtain `solc` version list",
-      websiteDescription: `Couldn't download \`solc\`'s version list.
-
-Please check your internet connection and try again.`,
-    },
-    INVALID_DOWNLOAD: {
-      number: 503,
-      messageTemplate: `Couldn't download compiler version {remoteVersion}: Checksum verification failed.
-
-Please check your internet connection and try again.
-
-If this error persists, run "npx hardhat clean --global".`,
-      websiteTitle: "Downloaded `solc` checksum verification failed",
-      websiteDescription: `Hardhat downloaded a version of the Solidity compiler, and its checksum verification failed.
-
-Please check your internet connection and try again.
-
-If this error persists, run \`npx hardhat clean --global\`.`,
-    },
-    CANT_RUN_NATIVE_COMPILER: {
-      number: 504,
-      messageTemplate: `A native version of solc failed to run.
-
-If you are running MacOS, try installing Apple Rosetta.
-
-If this error persists, run "npx hardhat clean --global".`,
-      websiteTitle: "Failed to run native solc",
-      websiteDescription: `Hardhat successfully downloaded a native version of solc but it doesn't run.
-
-If you are running MacOS, try installing Apple Rosetta.
-
-If this error persists, run "npx hardhat clean --global".`,
-    },
-    CANT_RUN_SOLCJS_COMPILER: {
-      number: 505,
-      messageTemplate: `A wasm version of solc failed to run.
-
-If this error persists, run "npx hardhat clean --global".`,
-      websiteTitle: "Failed to run solcjs",
-      websiteDescription: `Hardhat successfully downloaded a WASM version of solc but it doesn't run.
-
-If you are running MacOS, try installing Apple Rosetta.
-
-If this error persists, run "npx hardhat clean --global".`,
-    },
-  },
   BUILTIN_TASKS: {
-    COMPILE_FAILURE: {
-      number: 600,
-      messageTemplate: "Compilation failed",
-      websiteTitle: "Compilation failed",
-      websiteDescription: `Your smart contracts failed to compile.
-
-Please check Hardhat's output for more details.`,
-    },
-    COMPILATION_JOBS_CREATION_FAILURE: {
-      number: 601,
-      messageTemplate: `The project cannot be compiled, see reasons below.
-
-{reasons}`,
-      websiteTitle: "The project cannot be compiled",
-      websiteDescription: `The project cannot be compiled with the current settings.`,
-    },
-    COMPILE_TASK_UNSUPPORTED_SOLC_VERSION: {
-      number: 602,
-      messageTemplate: `Version {version} is not supported by Hardhat.
-
-The first supported version is {firstSupportedVersion}`,
-      websiteTitle: "Unsupported solc version",
-      websiteDescription: `This version of solidity is not supported by Hardhat.
-Please use a newer, supported version.`,
-      shouldBeReported: true,
-    },
     RUN_FILE_NOT_FOUND: {
       number: 603,
       messageTemplate: `Script {script} doesn't exist`,
@@ -715,131 +426,6 @@ Please double check your script's path.`,
       websiteDescription: `Running a script resulted in an error.
 
 Please check Hardhat's output for more details.`,
-    },
-  },
-  ARTIFACTS: {
-    NOT_FOUND: {
-      number: 700,
-      messageTemplate:
-        'Artifact for contract "{contractName}" not found. {suggestion}',
-      websiteTitle: "Artifact not found",
-      websiteDescription: `Tried to import a nonexistent artifact.
-
-Please double check that your contracts have been compiled and double check your artifact's name.`,
-    },
-    MULTIPLE_FOUND: {
-      number: 701,
-      messageTemplate: `There are multiple artifacts for contract "{contractName}", please use a fully qualified name.
-
-Please replace {contractName} for one of these options wherever you are trying to read its artifact:
-
-{candidates}
-`,
-      websiteTitle: "Multiple artifacts found",
-      websiteDescription: `There are multiple artifacts that match the given contract name, and Hardhat doesn't know which one to use.
-
-Please use the fully qualified name of the contract to disambiguate it.`,
-    },
-    WRONG_CASING: {
-      number: 702,
-      messageTemplate:
-        "Invalid artifact path {incorrect}, its correct case-sensitive path is {correct}",
-      websiteTitle: "Incorrect artifact path casing",
-      websiteDescription: `You tried to get an artifact file with an incorrect casing.
-
-Hardhat's artifact resolution is case sensitive to ensure projects are portable across different operating systems.`,
-      shouldBeReported: true,
-    },
-  },
-  SOURCE_NAMES: {
-    INVALID_SOURCE_NAME_ABSOLUTE_PATH: {
-      number: 1000,
-      messageTemplate:
-        "Invalid source name {name}. Expected source name but found an absolute path.",
-      websiteTitle: "Invalid source name: absolute path",
-      websiteDescription: `A Solidity source name was expected, but an absolute path was given.
-
-If you aren't overriding compilation-related tasks, please report this as a bug.`,
-      shouldBeReported: true,
-    },
-    INVALID_SOURCE_NAME_RELATIVE_PATH: {
-      number: 1001,
-      messageTemplate:
-        "Invalid source name {name}. Expected source name but found a relative path.",
-      websiteTitle: "Invalid source name: relative path",
-      websiteDescription: `A Solidity source name was expected, but a relative path was given.
-
-If you aren't overriding compilation-related tasks, please report this as a bug.`,
-      shouldBeReported: true,
-    },
-    INVALID_SOURCE_NAME_BACKSLASHES: {
-      number: 1002,
-      messageTemplate:
-        "Invalid source {name}. The source name uses backslashes (\\) instead of slashes (/).",
-      websiteTitle: "Invalid source name: backslashes",
-      websiteDescription: `A Solidity source name was invalid because it uses backslashes (\\\\) instead of slashes (/).
-
-If you aren't overriding compilation-related tasks, please report this as a bug.`,
-      shouldBeReported: true,
-    },
-    INVALID_SOURCE_NOT_NORMALIZED: {
-      number: 1003,
-      messageTemplate:
-        "Invalid source name {name}. Source names must be normalized",
-      websiteTitle: "Invalid source name: not normalized",
-      websiteDescription: `A Solidity source name was invalid because it wasn't normalized. It probably contains some "." or "..".
-
-If you aren't overriding compilation-related tasks, please report this as a bug.`,
-      shouldBeReported: true,
-    },
-    WRONG_CASING: {
-      number: 1004,
-      messageTemplate:
-        "Invalid source map {incorrect}, its correct case-sensitive source name is {correct}",
-      websiteTitle: "Incorrect source name casing",
-      websiteDescription: `You tried to resolve a Solidity file with an incorrect casing.
-
-Hardhat's compiler is case sensitive to ensure projects are portable across different operating systems.`,
-      shouldBeReported: true,
-    },
-    FILE_NOT_FOUND: {
-      number: 1005,
-      messageTemplate: "Solidity source file {name} not found",
-      websiteTitle: "Solidity source file not found",
-      websiteDescription: `A source name should correspond to an existing Solidity file but it doesn't.
-
-Hardhat's compiler is case sensitive to ensure projects are portable across different operating systems.`,
-      shouldBeReported: true,
-    },
-    NODE_MODULES_AS_LOCAL: {
-      number: 1006,
-      messageTemplate:
-        "The file {path} is treated as local but is inside a node_modules directory",
-      websiteTitle: "File from node_modules treated as local",
-      websiteDescription: `A file was treated as local but is inside a node_modules directory.
-
-If you aren't overriding compilation-related tasks, please report this as a bug.`,
-      shouldBeReported: true,
-    },
-    EXTERNAL_AS_LOCAL: {
-      number: 1007,
-      messageTemplate:
-        "The file {path} is treated as local but is outside the project",
-      websiteTitle: "File from outside the project treated as local",
-      websiteDescription: `A file was treated as local but is outside the project.
-
-If you aren't overriding compilation-related tasks, please report this as a bug.`,
-      shouldBeReported: true,
-    },
-  },
-  CONTRACT_NAMES: {
-    INVALID_FULLY_QUALIFIED_NAME: {
-      number: 1100,
-      messageTemplate: "Invalid fully qualified contract name {name}.",
-      websiteTitle: "Invalid fully qualified contract name",
-      websiteDescription: `A contract name was expected to be in fully qualified form, but it's not.
-
-A fully qualified name should look like file.sol:Contract`,
     },
   },
   PLUGINS: {

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -195,7 +195,7 @@ Please add the property "type" with the value "module" in your package.json to e
       number: 100,
       messageTemplate: "An internal invariant was violated: {message}",
       websiteTitle: "Invariant violation",
-      websiteDescription: `An internal invariant was violated. This is probably caused by a programming in Hardhat or in one of the used plugins.
+      websiteDescription: `An internal invariant was violated. This is probably caused by a programming error in Hardhat or in one of the used plugins.
     
 Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
       shouldBeReported: true,

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -49,23 +49,23 @@ export const ERROR_CATEGORIES: {
 } = {
   GENERAL: { min: 1, max: 99, websiteTitle: "General errors" },
   INTERNAL: { min: 100, max: 199, websiteTitle: "Internal Hardhat errors" },
-  TASK_DEFINITIONS: {
+  PLUGINS: {
     min: 200,
     max: 299,
-    websiteTitle: "Task definition errors",
-  },
-  ARGUMENTS: { min: 300, max: 399, websiteTitle: "Arguments related errors" },
-  BUILTIN_TASKS: { min: 600, max: 699, websiteTitle: "Built-in tasks errors" },
-  PLUGINS: {
-    min: 1200,
-    max: 1299,
     websiteTitle: "Plugin errors",
   },
   HOOKS: {
-    min: 1300,
-    max: 1399,
+    min: 300,
+    max: 399,
     websiteTitle: "Hooks errors",
   },
+  TASK_DEFINITIONS: {
+    min: 400,
+    max: 499,
+    websiteTitle: "Task definition errors",
+  },
+  ARGUMENTS: { min: 500, max: 599, websiteTitle: "Arguments related errors" },
+  BUILTIN_TASKS: { min: 600, max: 699, websiteTitle: "Built-in tasks errors" },
 };
 
 export const ERRORS = {
@@ -79,7 +79,7 @@ export const ERRORS = {
 You can learn how to use Hardhat by reading the [Getting Started guide](/hardhat-runner/docs/getting-started).`,
     },
     DUPLICATED_PLUGIN_ID: {
-      number: 4,
+      number: 2,
       messageTemplate:
         'Duplicated plugin id "{id}" found. Did you install multiple versions of the same plugin?',
       websiteTitle: "Duplicated plugin id",
@@ -88,58 +88,58 @@ You can learn how to use Hardhat by reading the [Getting Started guide](/hardhat
 Please double check whether you have multiple versions of the same plugin installed.`,
     },
     NO_CONFIG_FILE_FOUND: {
-      number: 5,
+      number: 3,
       messageTemplate: "No Hardhat config file found",
       websiteTitle: "No Hardhat config file found",
       websiteDescription:
         "Hardhat couldn't find a config file in the current directory or any of its parents.",
     },
     INVALID_CONFIG_PATH: {
-      number: 6,
+      number: 4,
       messageTemplate: "Config file {configPath} not found",
       websiteTitle: "Invalid config path",
       websiteDescription: "The config file doesn't exist at the provided path.",
     },
     NO_CONFIG_EXPORTED: {
-      number: 7,
+      number: 5,
       messageTemplate: "No config exported in {configPath}",
       websiteTitle: "No config exported",
       websiteDescription: "There is nothing exported from the config file.",
     },
     INVALID_CONFIG_OBJECT: {
-      number: 8,
+      number: 6,
       messageTemplate: "Invalid config exported in {configPath}",
       websiteTitle: "Invalid config object",
       websiteDescription:
         "The config file doesn't export a valid configuration object.",
     },
     ENV_VAR_NOT_FOUND: {
-      number: 9,
+      number: 7,
       messageTemplate: "Configuration variable not found as an env variable",
       websiteTitle: "Configuration variable not found",
       websiteDescription: `A configuration variable was expected to be set as an environment variable, but it wasn't.`,
     },
     INVALID_URL: {
-      number: 10,
+      number: 8,
       messageTemplate: "Invalid URL: {url}",
       websiteTitle: "Invalid URL",
       websiteDescription: `Given value was not a valid URL.`,
     },
     INVALID_BIGINT: {
-      number: 11,
+      number: 9,
       messageTemplate: "Invalid BigInt: {value}",
       websiteTitle: "Invalid BigInt",
       websiteDescription: `Given value was not a valid BigInt.`,
     },
     HARDHAT_PROJECT_ALREADY_CREATED: {
-      number: 12,
+      number: 10,
       messageTemplate:
         "You are trying to initialize a project inside an existing Hardhat project. The path to the project's configuration file is: {hardhatProjectRootPath}.",
       websiteTitle: "Hardhat project already created",
       websiteDescription: `Cannot create a new Hardhat project, the current folder is already associated with a project.`,
     },
     NOT_INSIDE_PROJECT_ON_WINDOWS: {
-      number: 13,
+      number: 11,
       messageTemplate: `You are not inside a project and Hardhat failed to initialize a new one.
 
 If you were trying to create a new project, please try again using Windows Subsystem for Linux (WSL) or PowerShell.
@@ -153,7 +153,7 @@ If you were trying to create a new project, please try again using Windows Subsy
 You can learn how to use Hardhat by reading the [Getting Started guide](/hardhat-runner/docs/getting-started).`,
     },
     NOT_IN_INTERACTIVE_SHELL: {
-      number: 14,
+      number: 12,
       messageTemplate:
         "You are trying to initialize a project but you are not in an interactive shell.",
       websiteTitle: "Not inside an interactive shell",
@@ -162,7 +162,7 @@ You can learn how to use Hardhat by reading the [Getting Started guide](/hardhat
 Please re-run the command inside an interactive shell.`,
     },
     UNSUPPORTED_OPERATION: {
-      number: 15,
+      number: 13,
       messageTemplate: "{operation} is not supported in Hardhat.",
       websiteTitle: "Unsupported operation",
       websiteDescription: `You are trying to perform an unsupported operation.
@@ -172,7 +172,7 @@ Unless you are creating a task or plugin, this is probably a bug.
 Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us improve Hardhat.`,
     },
     ONLY_ESM_SUPPORTED: {
-      number: 16,
+      number: 14,
       messageTemplate: `Hardhat only supports ESM projects. Please be sure to specify "'type': 'module'" in your package.json`,
       websiteTitle: "Only ESM projects are supported",
       websiteDescription: `You are trying to initialize a new Hardhat project, but your package.json does not have the property "type" set to "module".
@@ -182,7 +182,7 @@ Currently, Hardhat only supports ESM projects.
 Please add the property "type" with the value "module" in your package.json to ensure that your project is recognized as an ESM project.`,
     },
     GLOBAL_OPTION_ALREADY_DEFINED: {
-      number: 17,
+      number: 15,
       messageTemplate:
         "Plugin {plugin} is trying to define the global option {globalOption} but it is already defined by plugin {definedByPlugin}",
       websiteTitle: "Global option already defined",
@@ -201,9 +201,48 @@ Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us i
       shouldBeReported: true,
     },
   },
+  PLUGINS: {
+    PLUGIN_NOT_INSTALLED: {
+      number: 200,
+      messageTemplate: 'Plugin "{pluginId}" is not installed.',
+      websiteTitle: "Plugin not installed",
+      websiteDescription: `A plugin was included in the Hardhat config but has not been installed into "node_modules".`,
+    },
+    PLUGIN_MISSING_DEPENDENCY: {
+      number: 201,
+      messageTemplate:
+        'Plugin "{pluginId}" is missing a peer dependency "{peerDependencyName}".',
+      websiteTitle: "Plugin missing peer dependency",
+      websiteDescription: `A plugin's peer dependency has not been installed.`,
+    },
+    DEPENDENCY_VERSION_MISMATCH: {
+      number: 202,
+      messageTemplate:
+        'Plugin "{pluginId}" has a peer dependency "{peerDependencyName}" with expected version "{expectedVersion}" but the installed version is "{installedVersion}".',
+      websiteTitle: "Dependency version mismatch",
+      websiteDescription: `A plugin's peer dependency expected version does not match the version of the installed package.
+
+Please install a version of the peer dependency that meets the plugin's requirements.`,
+    },
+    PLUGIN_DEPENDENCY_FAILED_LOAD: {
+      number: 203,
+      messageTemplate: 'Plugin "{pluginId}" dependency could not be loaded.',
+      websiteTitle: "Plugin dependency could not be loaded",
+      websiteDescription: `The loading of a plugin's dependent plugin failed.`,
+    },
+  },
+  HOOKS: {
+    INVALID_HOOK_FACTORY_PATH: {
+      number: 300,
+      messageTemplate:
+        'Plugin "{pluginId}" hook factory for "{hookCategoryName}" is not a valid file:// URL: {path}.',
+      websiteTitle: "Plugin hook factory is not a valid file URL",
+      websiteDescription: `The loading of a plugin's hook factory failed as the import path is not a valid file:// URL.`,
+    },
+  },
   TASK_DEFINITIONS: {
     INVALID_FILE_ACTION: {
-      number: 201,
+      number: 400,
       messageTemplate: "Invalid file action: {action} is not a valid file URL",
       websiteTitle: "Invalid file action",
       websiteDescription: `The setAction function was called with a string parameter that is not a valid file URL. A valid file URL must start with 'file://'.
@@ -211,7 +250,7 @@ Please [report it](https://github.com/nomiclabs/hardhat/issues/new) to help us i
 Please ensure that you are providing a correct file URL.`,
     },
     NO_ACTION: {
-      number: 202,
+      number: 401,
       messageTemplate: "The task {task} doesn't have an action",
       websiteTitle: "Task missing action",
       websiteDescription: `A task was defined without an action.
@@ -219,7 +258,7 @@ Please ensure that you are providing a correct file URL.`,
 Please ensure that an action is defined for each task.`,
     },
     POSITIONAL_PARAM_AFTER_VARIADIC: {
-      number: 203,
+      number: 402,
       messageTemplate:
         "Cannot add the positional param {name} after a variadic one",
       websiteTitle: "Invalid task definition",
@@ -227,7 +266,7 @@ Please ensure that an action is defined for each task.`,
         "A variadic parameter must always be the last positional parameter in a task definition.",
     },
     REQUIRED_PARAM_AFTER_OPTIONAL: {
-      number: 204,
+      number: 403,
       messageTemplate:
         "Cannot add required positional param {name} after an optional one",
       websiteTitle: "Invalid task definition",
@@ -235,13 +274,13 @@ Please ensure that an action is defined for each task.`,
         "Required positional parameters must be defined before optional ones in a task definition.",
     },
     TASK_NOT_FOUND: {
-      number: 205,
+      number: 404,
       messageTemplate: "Task {task} not found",
       websiteTitle: "Task not found",
       websiteDescription: "The provided task name does not match any task.",
     },
     SUBTASK_WITHOUT_PARENT: {
-      number: 206,
+      number: 405,
       messageTemplate:
         "Task {task} not found when attempting to define subtask {subtask}. If you intend to only define subtasks, please first define {task} as an empty task",
       websiteTitle: "Subtask without parent",
@@ -249,7 +288,7 @@ Please ensure that an action is defined for each task.`,
         "The parent task of the subtask being defined was not found. If you intend to only define subtasks, please first define the parent task as an empty task.",
     },
     TASK_ALREADY_DEFINED: {
-      number: 207,
+      number: 406,
       messageTemplate:
         "{actorFragment} trying to define the task {task} but it is already defined{definedByFragment}",
       websiteTitle: "Task already defined",
@@ -257,14 +296,14 @@ Please ensure that an action is defined for each task.`,
         "The task is already defined. Please ensure that tasks are uniquely named to avoid conflicts.",
     },
     EMPTY_TASK_ID: {
-      number: 208,
+      number: 407,
       messageTemplate: "Task id cannot be an empty string or an empty array",
       websiteTitle: "Empty task id",
       websiteDescription:
         "The task id cannot be an empty string or an empty array. Please ensure that the array of task names is not empty.",
     },
     TASK_OPTION_ALREADY_DEFINED: {
-      number: 209,
+      number: 408,
       messageTemplate:
         "{actorFragment} trying to define task {task} with the option {option} but it is already defined as a global option by plugin {globalOptionPluginId}",
       websiteTitle: "Task option already defined",
@@ -272,7 +311,7 @@ Please ensure that an action is defined for each task.`,
         "The task option is already defined as a global option by another plugin. Please ensure that task options are uniquely named to avoid conflicts.",
     },
     TASK_OVERRIDE_OPTION_ALREADY_DEFINED: {
-      number: 210,
+      number: 409,
       messageTemplate:
         "{actorFragment} trying to override the parameter {optionName} of the task {task} but it is already defined",
       websiteTitle: "Task override option already defined",
@@ -280,14 +319,14 @@ Please ensure that an action is defined for each task.`,
         "An attempt is being made to override an option that has already been defined. Please ensure that the option is not defined before trying to override it.",
     },
     EMPTY_TASK: {
-      number: 211,
+      number: 410,
       messageTemplate: "Can't run the empty task {task}",
       websiteTitle: "Empty task",
       websiteDescription:
         "The task is empty. Please ensure that tasks have at least one action.",
     },
     INVALID_ACTION_URL: {
-      number: 212,
+      number: 411,
       messageTemplate:
         "Unable to import the module specified by the action {action} of task {task}",
       websiteTitle: "Invalid action URL",
@@ -295,7 +334,7 @@ Please ensure that an action is defined for each task.`,
         "The action URL is invalid. Please ensure that the URL is correct.",
     },
     INVALID_ACTION: {
-      number: 213,
+      number: 412,
       messageTemplate:
         "The action resolved from {action} in task {task} is not a function",
       websiteTitle: "Invalid action",
@@ -303,7 +342,7 @@ Please ensure that an action is defined for each task.`,
         "The action of the task is not a function. Make sure that the file pointed to by the action URL exports a function as the default export.",
     },
     MISSING_VALUE_FOR_PARAMETER: {
-      number: 214,
+      number: 413,
       messageTemplate:
         "Missing value for the parameter named {parameter} in the task {task}",
       websiteTitle: "Missing value for the task parameter",
@@ -312,7 +351,7 @@ Please ensure that an action is defined for each task.`,
 Please double check how you invoked Hardhat or ran your task.`,
     },
     INVALID_VALUE_FOR_TYPE: {
-      number: 215,
+      number: 414,
       messageTemplate:
         "Invalid value {value} for argument {name} of type {type} in the task {task}",
       websiteTitle: "Invalid argument type",
@@ -321,7 +360,7 @@ Please double check how you invoked Hardhat or ran your task.`,
 Please double check your task arguments.`,
     },
     UNRECOGNIZED_NAMED_PARAM: {
-      number: 216,
+      number: 415,
       messageTemplate: "Invalid parameter {parameter} for the task {task}",
       websiteTitle: "Invalid parameter value",
       websiteDescription: `One of the parameters for your task is invalid.
@@ -331,7 +370,7 @@ Please double check your arguments.`,
   },
   ARGUMENTS: {
     INVALID_VALUE_FOR_TYPE: {
-      number: 300,
+      number: 500,
       messageTemplate:
         "Invalid value {value} for argument {name} of type {type}",
       websiteTitle: "Invalid argument type",
@@ -340,7 +379,7 @@ Please double check your arguments.`,
 Please double check your arguments.`,
     },
     RESERVED_NAME: {
-      number: 301,
+      number: 501,
       messageTemplate: "Argument name {name} is reserved",
       websiteTitle: "Reserved argument name",
       websiteDescription: `One of your Hardhat or task arguments has a reserved name.
@@ -348,7 +387,7 @@ Please double check your arguments.`,
 Please double check your arguments.`,
     },
     DUPLICATED_NAME: {
-      number: 302,
+      number: 502,
       messageTemplate: "Argument name {name} is already in use",
       websiteTitle: "Argument name already in use",
       websiteDescription: `One of your Hardhat or task argument names is already in use.
@@ -356,7 +395,7 @@ Please double check your arguments.`,
 Please double check your arguments.`,
     },
     INVALID_NAME: {
-      number: 303,
+      number: 503,
       messageTemplate: "Argument name {name} is invalid",
       websiteTitle: "Invalid argument name",
       websiteDescription: `One of your Hardhat or task argument names is invalid.
@@ -364,7 +403,7 @@ Please double check your arguments.`,
 Please double check your arguments.`,
     },
     UNRECOGNIZED_OPTION: {
-      number: 304,
+      number: 504,
       messageTemplate:
         "Invalid option {option}. It is neither a valid global option nor associated with any task. Did you forget to add the task first, or did you misspell it?",
       websiteTitle: "Invalid option value",
@@ -373,7 +412,7 @@ Please double check your arguments.`,
 Please double check your arguments.`,
     },
     MISSING_VALUE_FOR_PARAMETER: {
-      number: 305,
+      number: 505,
       messageTemplate: "Missing value for the task parameter named {paramName}",
       websiteTitle: "Missing value for the task parameter",
       websiteDescription: `You tried to run a task, but one of the values of its parameters was missing.
@@ -381,7 +420,7 @@ Please double check your arguments.`,
 Please double check how you invoked Hardhat or ran your task.`,
     },
     UNUSED_ARGUMENT: {
-      number: 306,
+      number: 506,
       messageTemplate:
         "The argument with value {value} was not consumed because it is not associated with any task.",
       websiteTitle: "Argument was not consumed",
@@ -390,7 +429,7 @@ Please double check how you invoked Hardhat or ran your task.`,
 Please double check how you invoked Hardhat or ran your task.`,
     },
     MISSING_CONFIG_FILE: {
-      number: 308,
+      number: 507,
       messageTemplate:
         'The configuration parameter "--config" was passed, but no file path was provided.',
       websiteTitle: "Missing configuration file path",
@@ -400,7 +439,7 @@ Please double check how you invoked Hardhat or ran your task.`,
 Please double check your arguments.`,
     },
     CANNOT_COMBINE_INIT_AND_CONFIG_PATH: {
-      number: 309,
+      number: 508,
       messageTemplate:
         'The configuration parameter "--config" cannot be used with the "init" command',
       websiteTitle:
@@ -412,7 +451,7 @@ Please double check your arguments.`,
   },
   BUILTIN_TASKS: {
     RUN_FILE_NOT_FOUND: {
-      number: 603,
+      number: 600,
       messageTemplate: `Script {script} doesn't exist`,
       websiteTitle: "Script doesn't exist",
       websiteDescription: `Tried to use \`hardhat run\` to execute a nonexistent script.
@@ -420,51 +459,12 @@ Please double check your arguments.`,
 Please double check your script's path.`,
     },
     RUN_SCRIPT_ERROR: {
-      number: 604,
+      number: 601,
       messageTemplate: `Error running script {script}: {error}`,
       websiteTitle: "Error running script",
       websiteDescription: `Running a script resulted in an error.
 
 Please check Hardhat's output for more details.`,
-    },
-  },
-  PLUGINS: {
-    PLUGIN_NOT_INSTALLED: {
-      number: 1200,
-      messageTemplate: 'Plugin "{pluginId}" is not installed.',
-      websiteTitle: "Plugin not installed",
-      websiteDescription: `A plugin was included in the Hardhat config but has not been installed into "node_modules".`,
-    },
-    PLUGIN_MISSING_DEPENDENCY: {
-      number: 1201,
-      messageTemplate:
-        'Plugin "{pluginId}" is missing a peer dependency "{peerDependencyName}".',
-      websiteTitle: "Plugin missing peer dependency",
-      websiteDescription: `A plugin's peer dependency has not been installed.`,
-    },
-    DEPENDENCY_VERSION_MISMATCH: {
-      number: 1202,
-      messageTemplate:
-        'Plugin "{pluginId}" has a peer dependency "{peerDependencyName}" with expected version "{expectedVersion}" but the installed version is "{installedVersion}".',
-      websiteTitle: "Dependency version mismatch",
-      websiteDescription: `A plugin's peer dependency expected version does not match the version of the installed package.
-
-Please install a version of the peer dependency that meets the plugin's requirements.`,
-    },
-    PLUGIN_DEPENDENCY_FAILED_LOAD: {
-      number: 1203,
-      messageTemplate: 'Plugin "{pluginId}" dependency could not be loaded.',
-      websiteTitle: "Plugin dependency could not be loaded",
-      websiteDescription: `The loading of a plugin's dependent plugin failed.`,
-    },
-  },
-  HOOKS: {
-    INVALID_HOOK_FACTORY_PATH: {
-      number: 1300,
-      messageTemplate:
-        'Plugin "{pluginId}" hook factory for "{hookCategoryName}" is not a valid file:// URL: {path}.',
-      websiteTitle: "Plugin hook factory is not a valid file URL",
-      websiteDescription: `The loading of a plugin's hook factory failed as the import path is not a valid file:// URL.`,
     },
   },
 } as const;

--- a/v-next/hardhat/test/hre/index.ts
+++ b/v-next/hardhat/test/hre/index.ts
@@ -9,6 +9,7 @@ import {
   resetHardhatRuntimeEnvironmentSingleton,
 } from "../../src/internal/hre-singleton.js";
 import { useFixtureProject } from "../helpers/project.js";
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
 describe("HRE", () => {
   describe("createHardhatRuntimeEnvironment", () => {
@@ -53,9 +54,10 @@ describe("HRE", () => {
       });
 
       it("should throw if the config file is not found", async () => {
-        await assert.rejects(resolveHardhatConfigPath(), {
-          message: "HHE5: No Hardhat config file found",
-        });
+        await assert.rejects(
+          resolveHardhatConfigPath(),
+          new HardhatError(HardhatError.ERRORS.GENERAL.NO_CONFIG_FILE_FOUND),
+        );
       });
 
       describe("javascript config", () => {

--- a/v-next/hardhat/test/hre/index.ts
+++ b/v-next/hardhat/test/hre/index.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
+
 import { resolveHardhatConfigPath } from "../../src/config.js";
 import { createHardhatRuntimeEnvironment } from "../../src/hre.js";
 import { builtinPlugins } from "../../src/internal/builtin-plugins/index.js";
@@ -9,7 +11,6 @@ import {
   resetHardhatRuntimeEnvironmentSingleton,
 } from "../../src/internal/hre-singleton.js";
 import { useFixtureProject } from "../helpers/project.js";
-import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
 describe("HRE", () => {
   describe("createHardhatRuntimeEnvironment", () => {

--- a/v-next/hardhat/test/internal/builtin-plugins/run/runScriptWIthHardhat.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/run/runScriptWIthHardhat.ts
@@ -19,14 +19,18 @@ describe("runScriptWithHardhat", function () {
   it("should throw if script is not a string", async function () {
     await assert.rejects(
       runScriptWithHardhat({ script: 123, noCompile: false }, hre),
-      /An internal invariant was violated: Expected script to be a string/,
+      new HardhatError(HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR, {
+        message: "Expected script to be a string",
+      }),
     );
   });
 
   it("should throw if noCompile is not a boolean", async function () {
     await assert.rejects(
       runScriptWithHardhat({ script: "script.js", noCompile: 123 }, hre),
-      /An internal invariant was violated: Expected noCompile to be a boolean/,
+      new HardhatError(HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR, {
+        message: "Expected noCompile to be a boolean",
+      }),
     );
   });
 


### PR DESCRIPTION
This PR removes the build system's descriptors to avoid copying over multiple unnecessary ones.

I did this by copying the required descriptors into the package itself and then deleting everything that was not needed. After removing many descriptors, I also had to reorder them. Reviewing commit by commit may be simpler. 

Also, while fixing some errors, I ensured that we weren't using `assert.throws` or `assert.rejects` with error messages. Because of that, too many tests were failing after this refactor. 