### PR TITLE
New only-hardhat-error rule

### DIFF
--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -14,6 +14,8 @@ import type { HardhatPlugin } from "../types/plugins.js";
 import type { TaskManager } from "../types/tasks.js";
 import type { UserInterruptionManager } from "../types/user-interruptions.js";
 
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
+
 import { ResolvedConfigurationVariableImplementation } from "./configuration-variables.js";
 import {
   buildGlobalOptionsMap,
@@ -61,14 +63,14 @@ export class HardhatRuntimeEnvironmentImplementation
     );
 
     if (userConfigValidationErrors.length > 0) {
-      throw new Error(
-        `Invalid config:\n\t${userConfigValidationErrors
+      throw new HardhatError(HardhatError.ERRORS.GENERAL.INVALID_CONFIG, {
+        errors: `\t${userConfigValidationErrors
           .map(
             (error) =>
               `* Config error in .${error.path.join(".")}: ${error.message}`,
           )
           .join("\n\t")}`,
-      );
+      });
     }
 
     // Resolve config

--- a/v-next/hardhat-build-system/.eslintrc.cjs
+++ b/v-next/hardhat-build-system/.eslintrc.cjs
@@ -1,3 +1,3 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename);
+module.exports = createConfig(__filename, { onlyHardhatError: false });

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -189,6 +189,13 @@ Please add the property "type" with the value "module" in your package.json to e
       websiteDescription:
         "The global option is already defined by another plugin. Please ensure that global options are uniquely named to avoid conflicts.",
     },
+    INVALID_CONFIG: {
+      number: 16,
+      messageTemplate: `Invalid config:
+{errors}`,
+      websiteTitle: "Invalid config",
+      websiteDescription: `The configuration you provided is invalid. Please check the documentation to learn how to configure Hardhat correctly.`,
+    },
   },
   INTERNAL: {
     ASSERTION_ERROR: {

--- a/v-next/hardhat-utils/.eslintrc.cjs
+++ b/v-next/hardhat-utils/.eslintrc.cjs
@@ -1,3 +1,3 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename);
+module.exports = createConfig(__filename, { onlyHardhatError: false });


### PR DESCRIPTION
This PR introduces a `no-restricted-syntax` rule that forbids throwing any error except for:

- `throw new HardhatError(...)`
- `throw variableName` within `catch` clauses. — The rationale here is to allow re-throwing of the error that was caught.

We could later improve this with a custom rule to:

- Allow subclasses of `HardhatError`
- Only allow `throw variable` when the variable is the one in the `catch (variable)`.

I believe that `no-restricted-syntax` isn't expressive enough for these things, as they are semantic conditions and not entirely syntactic. Still, I think this is a good trade-off.

PS: This depends on #5460 just for convenience and to avoid merge conflicts.