### PR TITLE
feat: added etherlink and etherlink testnet

### DIFF
--- a/packages/hardhat-verify/src/internal/chain-config.ts
+++ b/packages/hardhat-verify/src/internal/chain-config.ts
@@ -187,6 +187,22 @@ export const builtinChains: ChainConfig[] = [
     },
   },
   {
+    network: "etherlink",
+    chainId: 42793,
+    urls: {
+      apiURL: "https://explorer.etherlink.com/api/v2",
+      browserURL: "https://explorer.etherlink.com",
+    },
+  },
+  {
+    network: "etherlinkTestnet",
+    chainId: 128123,
+    urls: {
+      apiURL: "https://testnet-explorer.etherlink.com/api/v2",
+      browserURL: "https://testnet-explorer.etherlink.com",
+    },
+  },
+  {
     network: "avalancheFujiTestnet",
     chainId: 43113,
     urls: {


### PR DESCRIPTION
I wanted to add a network that I use to hardhat verify.

### PR adds following changes
- [x] Added Etherlink and etherlink testnet to verify smart contracts