### PR TITLE
fix: support for vyper version 0.4.0 with the new output identifiers

### DIFF
--- a/.changeset/wet-cars-sin.md
+++ b/.changeset/wet-cars-sin.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-vyper": patch
+---
+
+Support Vyper 0.4.0's new output identifiers (Thanks, @kiriyaga-txfusion!)

--- a/packages/hardhat-vyper/src/constants.ts
+++ b/packages/hardhat-vyper/src/constants.ts
@@ -3,3 +3,4 @@ export const ARTIFACT_FORMAT_VERSION = "hh-vyper-artifact-1";
 export const DEBUG_NAMESPACE = "hardhat:plugin:vyper";
 export const CACHE_FORMAT_VERSION = "hh-vy-cache-1";
 export const VYPER_FILES_CACHE_FILENAME = "vyper-files-cache.json";
+export const OUTPUT_BREAKABLE_VYPER_VERSION = "0.4.0";

--- a/packages/hardhat-vyper/src/index.ts
+++ b/packages/hardhat-vyper/src/index.ts
@@ -23,7 +23,10 @@ import {
   TASK_COMPILE_VYPER_LOG_DOWNLOAD_COMPILER_END,
   TASK_COMPILE_VYPER_LOG_COMPILATION_RESULT,
 } from "./task-names";
-import { DEFAULT_VYPER_VERSION } from "./constants";
+import {
+  DEFAULT_VYPER_VERSION,
+  OUTPUT_BREAKABLE_VYPER_VERSION,
+} from "./constants";
 import { Compiler } from "./compiler";
 import { CompilerDownloader } from "./downloader";
 import {
@@ -344,10 +347,24 @@ ${list}`
           }
         );
 
-        for (const [sourceName, output] of Object.entries(contracts)) {
+        const { localPathToSourceName } = await import(
+          "hardhat/utils/source-names"
+        );
+
+        for (const [contractSourceIdentifier, output] of Object.entries(
+          contracts
+        )) {
+          const sourceName = semver.gte(
+            vyperVersion,
+            OUTPUT_BREAKABLE_VYPER_VERSION
+          )
+            ? await localPathToSourceName(
+                config.paths.root,
+                contractSourceIdentifier
+              )
+            : contractSourceIdentifier;
           const artifact = getArtifactFromVyperOutput(sourceName, output);
           await artifacts.saveArtifactAndDebugFile(artifact);
-
           const file = files.find((f) => f.sourceName === sourceName);
           assertPluginInvariant(
             file !== undefined,

--- a/packages/hardhat-vyper/test/fixture-projects/compilation-with-vyper-output-breakable-version/contracts/A.vy
+++ b/packages/hardhat-vyper/test/fixture-projects/compilation-with-vyper-output-breakable-version/contracts/A.vy
@@ -1,0 +1,8 @@
+# pragma version ~=0.4.0
+
+IMMUTABLE_1: public(immutable(String[4]))
+
+@deploy
+@payable
+def __init__():
+    IMMUTABLE_1 = "A"

--- a/packages/hardhat-vyper/test/fixture-projects/compilation-with-vyper-output-breakable-version/contracts/B.vy
+++ b/packages/hardhat-vyper/test/fixture-projects/compilation-with-vyper-output-breakable-version/contracts/B.vy
@@ -1,0 +1,8 @@
+# pragma version ~=0.4.0
+
+IMMUTABLE_1: public(immutable(String[4]))
+
+@deploy
+@payable
+def __init__():
+    IMMUTABLE_1 = "B"

--- a/packages/hardhat-vyper/test/fixture-projects/compilation-with-vyper-output-breakable-version/hardhat.config.js
+++ b/packages/hardhat-vyper/test/fixture-projects/compilation-with-vyper-output-breakable-version/hardhat.config.js
@@ -1,0 +1,15 @@
+require("../../../src/index");
+
+module.exports = {
+  vyper: {
+    compilers: [
+      {
+        version: "0.4.0",
+        settings: {
+          evmVersion: "paris",
+          optimize: "gas",
+        },
+      },
+    ],
+  },
+};

--- a/packages/hardhat-vyper/test/tests.ts
+++ b/packages/hardhat-vyper/test/tests.ts
@@ -305,4 +305,16 @@ describe("Vyper plugin", function () {
       );
     });
   });
+
+  describe("compile project with different ouput identifiers returned from the vyper compiler", function () {
+    useFixtureProject("compilation-with-vyper-output-breakable-version");
+    useEnvironment();
+
+    it("Should successfully compile the contracts for versions >= 0.4.0", async function () {
+      await this.env.run(TASK_COMPILE);
+
+      assert.equal(this.env.artifacts.readArtifactSync("A").contractName, "A");
+      assert.equal(this.env.artifacts.readArtifactSync("B").contractName, "B");
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Here's the refactored sentence with the additional details:

The new vyper version 0.4.0 returns output with source path instead of source name, so we need to address this on the plugin side. This PR will resolve some already created issues:
- https://github.com/NomicFoundation/hardhat/issues/5463
- https://github.com/matter-labs/hardhat-zksync/issues/1203

