### PR TITLE
Add debug logs for provider creation

### DIFF
--- a/.changeset/fuzzy-mangos-behave.md
+++ b/.changeset/fuzzy-mangos-behave.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add `debug` logs to Hardhat Network initialization process.

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -619,11 +619,17 @@ export async function createHardhatNetworkProvider(
   loggerConfig: LoggerConfig,
   artifacts?: Artifacts
 ): Promise<EIP1193Provider> {
-  return EdrProviderWrapper.create(
+  log("Making tracing config");
+  const tracingConfig = await makeTracingConfig(artifacts);
+  log("Creating EDR provider");
+  const provider = EdrProviderWrapper.create(
     hardhatNetworkProviderConfig,
     loggerConfig,
-    await makeTracingConfig(artifacts)
+    tracingConfig
   );
+  log("EDR provider created");
+
+  return provider;
 }
 
 async function makeTracingConfig(


### PR DESCRIPTION
Now and then, there are some timeouts in EDR Hardhat tests ([example](https://github.com/NomicFoundation/edr/actions/runs/9759246239/job/26935518228?pr=537)) related to the provider initialization in a `beforeEach` hook.

This seems super weird to me. That before each only has two async operations: [a call to `createHardhatNetworkProvider`](https://github.com/NomicFoundation/edr/blob/dfdd38047d7a41b061abfad5fe8676c391dfd2b3/hardhat-tests/test/internal/hardhat-network/helpers/useProvider.ts#L81) and a `server.listen()` call a bit below that. I'm completely sure that the alchemy provider (which is the one with the timeout) doesn't use the server, so the only async operation is the provider creation.

But `createHardhatNetworkProvider` is async just because it calls the `makeTracingConfig` function, which loads some build info files. I doubt that this is the function that is causing a 50s timeout, so the alternative is that there's something weird going on now and then with `EdrProviderWrapper.create`.

The easiest way to evaluate this theory is to add some debug logs, and to add `DEBUG="hardhat:core:hardhat-network:*"` in EDR's CI. This won't produce any results until a new version of Hardhat is released _and_ a new timeout is hit (it doesn't happen often), but this is not urgent so this is fine.