### PR TITLE
Fix `hre` initialization

### DIFF
--- a/v-next/hardhat/.eslintrc.cjs
+++ b/v-next/hardhat/.eslintrc.cjs
@@ -1,3 +1,11 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
 module.exports = createConfig(__filename);
+
+module.exports.rules["no-restricted-imports"][1].paths.push({
+  // TODO: Rename this once we migrate to the official package names
+  name: "@ignored/hardhat-vnext-core",
+  importNames: ["createHardhatRuntimeEnvironment"],
+  message:
+    "Use the version of `createHardhatRuntimeEnvironment` found in `hre.js` instead of this one.",
+});

--- a/v-next/hardhat/src/hre.ts
+++ b/v-next/hardhat/src/hre.ts
@@ -4,6 +4,7 @@ import type { HardhatRuntimeEnvironment } from "./types/hre.js";
 import type { UnsafeHardhatRuntimeEnvironmentOptions } from "@ignored/hardhat-vnext-core/types/cli";
 
 import {
+  // eslint-disable-next-line no-restricted-imports -- This is the one place where we allow it
   createHardhatRuntimeEnvironment as originalCreateHardhatRuntimeEnvironment,
   resolvePluginList,
 } from "@ignored/hardhat-vnext-core";

--- a/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/index.ts
@@ -19,7 +19,7 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .build(),
   ],
-  globalOptions: [globalFlag({ name: "flag", description: "A flag" })],
+  globalOptions: [globalFlag({ name: "fooPluginFlag", description: "A flag" })],
 };
 
 export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -27,9 +27,10 @@ import { isCi } from "@ignored/hardhat-vnext-utils/ci";
 import { kebabToCamelCase } from "@ignored/hardhat-vnext-utils/string";
 
 import { resolveHardhatConfigPath } from "../../config.js";
+import { createHardhatRuntimeEnvironment } from "../../hre.js";
 import { builtinPlugins } from "../builtin-plugins/index.js";
 import { importUserConfig } from "../helpers/config-loading.js";
-import { getHardhatRuntimeEnvironmentSingleton } from "../hre-singleton.js";
+import { setHardhatRuntimeEnvironmentSingleton } from "../hre-singleton.js";
 
 import { printErrorMessages } from "./error-handler.js";
 import { getGlobalHelpString } from "./helpers/getGlobalHelpString.js";
@@ -84,14 +85,14 @@ export async function main(
       usedCliArguments,
     );
 
-    const hre = await getHardhatRuntimeEnvironmentSingleton(
+    const hre = await createHardhatRuntimeEnvironment(
       userConfig,
       userProvidedGlobalOptions,
-      {
-        resolvedPlugins,
-        globalOptionDefinitions,
-      },
+      { resolvedPlugins, globalOptionDefinitions },
     );
+
+    // This must be the first time we set it, otherwise we let it crash
+    setHardhatRuntimeEnvironmentSingleton(hre);
 
     const taskOrId = parseTask(cliArguments, usedCliArguments, hre);
 

--- a/v-next/hardhat/src/internal/hre-singleton.ts
+++ b/v-next/hardhat/src/internal/hre-singleton.ts
@@ -1,24 +1,29 @@
 import type { HardhatRuntimeEnvironment } from "../types/hre.js";
 
-import { createHardhatRuntimeEnvironment } from "@ignored/hardhat-vnext-core";
+import { assertHardhatInvariant } from "@ignored/hardhat-vnext-errors";
 
 let hre: HardhatRuntimeEnvironment | undefined;
 
 /**
- * This function returns a singleton instance of the Hardhat Runtime Environment.
+ * This function returns a singleton instance of the Hardhat Runtime Environment
+ * if it was already initialized.
  *
  * It exists so that the CLI and the programmatic API are always using the same HRE instance.
- *
- * Note: Only the params of the first call are used.
  */
-export async function getHardhatRuntimeEnvironmentSingleton(
-  ...params: Parameters<typeof createHardhatRuntimeEnvironment>
-): Promise<HardhatRuntimeEnvironment> {
-  if (hre === undefined) {
-    hre = await createHardhatRuntimeEnvironment(...params);
-  }
-
+export function getHardhatRuntimeEnvironmentSingleton():
+  | HardhatRuntimeEnvironment
+  | undefined {
   return hre;
+}
+
+/**
+ * Sets the singleton instance of the Hardhat Runtime Environment.
+ */
+export function setHardhatRuntimeEnvironmentSingleton(
+  newHre: HardhatRuntimeEnvironment,
+): void {
+  assertHardhatInvariant(hre === undefined, "HRE singleton already set");
+  hre = newHre;
 }
 
 /**

--- a/v-next/hardhat/test/fixture-projects/run-ts-script/scripts/success.ts
+++ b/v-next/hardhat/test/fixture-projects/run-ts-script/scripts/success.ts
@@ -1,5 +1,5 @@
-import hre from "@ignored/hardhat-vnext";
+import maybeHre from "@ignored/hardhat-vnext";
 
-if (!hre.tasks.rootTasks.has("test")) {
+if (!maybeHre.tasks.rootTasks.has("test")) {
   throw new Error("test task not found");
 }

--- a/v-next/hardhat/test/hre/index.ts
+++ b/v-next/hardhat/test/hre/index.ts
@@ -42,6 +42,12 @@ describe("HRE", () => {
       );
       assert.deepEqual(hre1, hre2);
     });
+
+    it("should include the builtin plugins", async () => {
+      const hre = await getHardhatRuntimeEnvironmentSingleton({});
+
+      assert.deepEqual(hre.config.plugins, builtinPlugins);
+    });
   });
 
   describe("config loading", () => {

--- a/v-next/hardhat/test/hre/index.ts
+++ b/v-next/hardhat/test/hre/index.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
@@ -13,13 +13,15 @@ import {
 import { useFixtureProject } from "../helpers/project.js";
 
 describe("HRE", () => {
+  afterEach(() => {
+    resetHardhatRuntimeEnvironmentSingleton();
+  });
+
   describe("createHardhatRuntimeEnvironment", () => {
     it("should include the built-in plugins", async () => {
       const hre = await createHardhatRuntimeEnvironment({});
 
       assert.deepEqual(hre.config.plugins, builtinPlugins);
-
-      resetHardhatRuntimeEnvironmentSingleton();
     });
   });
 
@@ -39,8 +41,6 @@ describe("HRE", () => {
         { id: "custom task" },
       );
       assert.deepEqual(hre1, hre2);
-
-      resetHardhatRuntimeEnvironmentSingleton();
     });
   });
 
@@ -125,8 +125,6 @@ describe("HRE", () => {
         const hre = await import("../../src/index.js");
 
         assert.deepEqual(hre.config.plugins, [{ id: "test-plugin" }]);
-
-        resetHardhatRuntimeEnvironmentSingleton();
       });
     });
   });

--- a/v-next/hardhat/test/hre/index.ts
+++ b/v-next/hardhat/test/hre/index.ts
@@ -9,6 +9,7 @@ import { builtinPlugins } from "../../src/internal/builtin-plugins/index.js";
 import {
   getHardhatRuntimeEnvironmentSingleton,
   resetHardhatRuntimeEnvironmentSingleton,
+  setHardhatRuntimeEnvironmentSingleton,
 } from "../../src/internal/hre-singleton.js";
 import { useFixtureProject } from "../helpers/project.js";
 
@@ -26,27 +27,29 @@ describe("HRE", () => {
   });
 
   describe("getHardhatRuntimeEnvironmentSingleton", () => {
-    it("should return the same instance", async () => {
-      const hre1 = await getHardhatRuntimeEnvironmentSingleton({
-        plugins: [{ id: "custom task" }],
-      });
-      const hre2 = await getHardhatRuntimeEnvironmentSingleton({});
+    it("Should return undefined if it wasn't set", () => {
+      assert.equal(getHardhatRuntimeEnvironmentSingleton(), undefined);
+      assert.equal(getHardhatRuntimeEnvironmentSingleton(), undefined);
+    });
 
-      assert.deepEqual(
-        hre1.config.plugins.find((p) => p.id === "custom task"),
-        { id: "custom task" },
-      );
-      assert.deepEqual(
-        hre2.config.plugins.find((p) => p.id === "custom task"),
-        { id: "custom task" },
-      );
-      assert.deepEqual(hre1, hre2);
+    it("should return the same instance after it's set", async () => {
+      const hre = await createHardhatRuntimeEnvironment({});
+      setHardhatRuntimeEnvironmentSingleton(hre);
+
+      const hre1 = getHardhatRuntimeEnvironmentSingleton();
+      const hre2 = getHardhatRuntimeEnvironmentSingleton();
+
+      assert.ok(hre1 === hre, "The instances are not the same");
+      assert.ok(hre2 === hre, "The instances are not the same");
     });
 
     it("should include the builtin plugins", async () => {
-      const hre = await getHardhatRuntimeEnvironmentSingleton({});
+      const hre = await createHardhatRuntimeEnvironment({});
+      setHardhatRuntimeEnvironmentSingleton(hre);
+      const singletonHre = getHardhatRuntimeEnvironmentSingleton();
 
-      assert.deepEqual(hre.config.plugins, builtinPlugins);
+      assert.ok(singletonHre === hre, "The instances are not the same");
+      assert.deepEqual(singletonHre.config.plugins, builtinPlugins);
     });
   });
 
@@ -130,7 +133,10 @@ describe("HRE", () => {
       it("should load the config file", async () => {
         const hre = await import("../../src/index.js");
 
-        assert.deepEqual(hre.config.plugins, [{ id: "test-plugin" }]);
+        assert.deepEqual(hre.config.plugins, [
+          ...builtinPlugins,
+          { id: "test-plugin" },
+        ]);
       });
     });
   });

--- a/v-next/hardhat/test/internal/builtin-plugins/run/runScriptWIthHardhat.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/run/runScriptWIthHardhat.ts
@@ -3,9 +3,9 @@ import type { HardhatRuntimeEnvironment } from "@ignored/hardhat-vnext-core/type
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
-import { createHardhatRuntimeEnvironment } from "@ignored/hardhat-vnext-core";
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
+import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
 import runScriptWithHardhat from "../../../../src/internal/builtin-plugins/run/runScriptWithHardhat.js";
 import { useFixtureProject } from "../../../helpers/project.js";
 

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -14,7 +14,6 @@ import assert from "node:assert/strict";
 import { afterEach, before, describe, it } from "node:test";
 import { pathToFileURL } from "node:url";
 
-import { createHardhatRuntimeEnvironment } from "@ignored/hardhat-vnext-core";
 import {
   ArgumentType,
   globalFlag,
@@ -25,6 +24,7 @@ import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import { isCi } from "@ignored/hardhat-vnext-utils/ci";
 import chalk from "chalk";
 
+import { createHardhatRuntimeEnvironment } from "../../../src/hre.js";
 import {
   main,
   parseGlobalOptions,

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -228,7 +228,7 @@ GLOBAL OPTIONS:
   --help                   Shows this message, or a task's help if its name is provided.
   --show-stack-traces      Show stack traces (always enabled on CI servers).
   --version                Shows hardhat's version.
-  --flag                   A flag
+  --foo-plugin-flag        A flag
 
 To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
 


### PR DESCRIPTION
This PR fixes a bug I found, that prevented the builtin plugins from being loaded when a user was initializing the HRE with `import "hardhat"`. This PR fixes that by ensuring that the HRE is always initialized using `hardhat/hre`.


The changes introduced here are, in order:

- Introduced a failing test, showing the bug.
- Refactor the initialization process to always use the `hardhat/hre` module.
- Fix some unrelated failing test after the refactor.
- Added an eslint rule to `hardhat` to avoid repeating that mistake.

