### PR TITLE
Add `hardhat-test-utils` package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1547,6 +1547,9 @@ importers:
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-node-test-reporter
+      '@nomicfoundation/hardhat-test-utils':
+        specifier: workspace:^
+        version: link:../hardhat-test-utils
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9
@@ -1653,6 +1656,9 @@ importers:
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.0
         version: link:../hardhat-node-test-reporter
+      '@nomicfoundation/hardhat-test-utils':
+        specifier: workspace:^
+        version: link:../hardhat-test-utils
       '@types/ci-info':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1975,6 +1981,9 @@ importers:
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-node-test-reporter
+      '@nomicfoundation/hardhat-test-utils':
+        specifier: workspace:^
+        version: link:../hardhat-test-utils
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9
@@ -2029,6 +2038,9 @@ importers:
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-node-test-reporter
+      '@nomicfoundation/hardhat-test-utils':
+        specifier: workspace:^
+        version: link:../hardhat-test-utils
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1836,6 +1836,64 @@ importers:
         specifier: 7.7.1
         version: 7.7.1(eslint@8.57.0)(typescript@5.5.2)
 
+  v-next/hardhat-test-utils:
+    dependencies:
+      '@ignored/hardhat-vnext-errors':
+        specifier: workspace:^3.0.0-next.2
+        version: link:../hardhat-errors
+      '@ignored/hardhat-vnext-utils':
+        specifier: workspace:^3.0.0-next.2
+        version: link:../hardhat-utils
+    devDependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.3.0
+        version: 4.3.0(eslint@8.57.0)
+      '@ignored/hardhat-vnext-node-test-reporter':
+        specifier: workspace:^3.0.0-next.2
+        version: link:../hardhat-node-test-reporter
+      '@types/node':
+        specifier: ^20.14.9
+        version: 20.14.9
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.7.1
+        version: 7.9.0(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)(typescript@5.5.2)
+      '@typescript-eslint/parser':
+        specifier: ^7.7.1
+        version: 7.9.0(eslint@8.57.0)(typescript@5.5.2)
+      eslint:
+        specifier: 8.57.0
+        version: 8.57.0
+      eslint-config-prettier:
+        specifier: 9.1.0
+        version: 9.1.0(eslint@8.57.0)
+      eslint-import-resolver-typescript:
+        specifier: ^3.6.1
+        version: 3.6.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-import:
+        specifier: 2.29.1
+        version: 2.29.1(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-no-only-tests:
+        specifier: 3.1.0
+        version: 3.1.0
+      expect-type:
+        specifier: ^0.19.0
+        version: 0.19.0
+      prettier:
+        specifier: 3.2.5
+        version: 3.2.5
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.5
+      tsx:
+        specifier: ^4.11.0
+        version: 4.11.0
+      typescript:
+        specifier: ~5.5.0
+        version: 5.5.2
+      typescript-eslint:
+        specifier: 7.7.1
+        version: 7.7.1(eslint@8.57.0)(typescript@5.5.2)
+
   v-next/hardhat-utils:
     dependencies:
       fast-equals:
@@ -5851,6 +5909,7 @@ packages:
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:

--- a/v-next/hardhat-build-system/package.json
+++ b/v-next/hardhat-build-system/package.json
@@ -38,9 +38,9 @@
     "README.md"
   ],
   "dependencies": {
-    "@nomicfoundation/ethereumjs-util": "9.0.4",
     "@ignored/hardhat-vnext-errors": "workspace:^3.0.0-next.0",
     "@ignored/hardhat-vnext-utils": "workspace:^3.0.0-next.0",
+    "@nomicfoundation/ethereumjs-util": "9.0.4",
     "@nomicfoundation/solidity-analyzer": "^0.1.0",
     "adm-zip": "^0.4.16",
     "aggregate-error": "^3.0.0",
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.0",
+    "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/ci-info": "^2.0.0",
     "@types/debug": "^4.1.4",
     "@types/find-up": "^2.1.1",

--- a/v-next/hardhat-build-system/tsconfig.json
+++ b/v-next/hardhat-build-system/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "../hardhat-node-test-reporter"
     },
     {
+      "path": "../hardhat-test-utils"
+    },
+    {
       "path": "../hardhat-utils"
     }
   ]

--- a/v-next/hardhat-test-utils/.eslintrc.cjs
+++ b/v-next/hardhat-test-utils/.eslintrc.cjs
@@ -1,0 +1,3 @@
+const { createConfig } = require("../../config-v-next/eslint.cjs");
+
+module.exports = createConfig(__filename);

--- a/v-next/hardhat-test-utils/.gitignore
+++ b/v-next/hardhat-test-utils/.gitignore
@@ -1,0 +1,5 @@
+# Node modules
+/node_modules
+
+# Compilation output
+/dist

--- a/v-next/hardhat-test-utils/.prettierignore
+++ b/v-next/hardhat-test-utils/.prettierignore
@@ -1,0 +1,3 @@
+/node_modules
+/dist
+CHANGELOG.md

--- a/v-next/hardhat-test-utils/LICENSE
+++ b/v-next/hardhat-test-utils/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2024 Nomic Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/v-next/hardhat-test-utils/README.md
+++ b/v-next/hardhat-test-utils/README.md
@@ -1,0 +1,3 @@
+# Hardhat test utils
+
+This is an internal package that includes test utilities used during the development of Hardhat.

--- a/v-next/hardhat-test-utils/package.json
+++ b/v-next/hardhat-test-utils/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@nomicfoundation/hardhat-test-utils",
+  "private": true,
+  "version": "3.0.0",
+  "description": "Test utilities used to develop and test Hardhat",
+  "homepage": "https://github.com/nomicfoundation/hardhat/tree/v-next/v-next/hardhat-test-utils",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NomicFoundation/hardhat",
+    "directory": "v-next/hardhat-test-utils"
+  },
+  "author": "Nomic Foundation",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./dist/src/index.js"
+  },
+  "scripts": {
+    "lint": "pnpm prettier --check && pnpm eslint",
+    "lint:fix": "pnpm prettier --write && pnpm eslint --fix",
+    "eslint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "prettier": "prettier \"**/*.{ts,js,md,json}\"",
+    "test": "node --import tsx/esm --test --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
+    "test:only": "node --import tsx/esm --test --test-only --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
+    "pretest": "pnpm build",
+    "build": "tsc --build .",
+    "prepublishOnly": "pnpm build",
+    "clean": "rimraf dist"
+  },
+  "files": [
+    "dist/src/",
+    "src/",
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md"
+  ],
+  "devDependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
+    "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
+    "@types/node": "^20.14.9",
+    "@typescript-eslint/eslint-plugin": "^7.7.1",
+    "@typescript-eslint/parser": "^7.7.1",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "2.29.1",
+    "eslint-plugin-no-only-tests": "3.1.0",
+    "expect-type": "^0.19.0",
+    "prettier": "3.2.5",
+    "rimraf": "^5.0.5",
+    "tsx": "^4.11.0",
+    "typescript": "~5.5.0",
+    "typescript-eslint": "7.7.1"
+  },
+  "dependencies": {
+    "@ignored/hardhat-vnext-utils": "workspace:^3.0.0-next.2",
+    "@ignored/hardhat-vnext-errors": "workspace:^3.0.0-next.2"
+  }
+}

--- a/v-next/hardhat-test-utils/src/hardhat-error.ts
+++ b/v-next/hardhat-test-utils/src/hardhat-error.ts
@@ -44,7 +44,7 @@ export function assertThrowsHardhatError<
   assert.fail("Function did not throw any error");
 }
 
-export async function assertThrowsHardhatErrorAsync<
+export async function assertRejectsWithHardhatError<
   ErrorDescriptorT extends ErrorDescriptor,
 >(
   f: (() => Promise<any>) | Promise<any>,

--- a/v-next/hardhat-test-utils/src/hardhat-error.ts
+++ b/v-next/hardhat-test-utils/src/hardhat-error.ts
@@ -1,0 +1,68 @@
+import type { ErrorDescriptor } from "@ignored/hardhat-vnext-errors";
+
+import assert from "node:assert/strict";
+
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { ensureError } from "@ignored/hardhat-vnext-utils/error";
+
+export function assertIsHardhatError<ErrorDescriptorT extends ErrorDescriptor>(
+  error: unknown,
+  descritor: ErrorDescriptorT,
+  messageArguments: HardhatError<ErrorDescriptorT>["messageArguments"],
+): asserts error is HardhatError<ErrorDescriptorT> {
+  assert.ok(HardhatError.isHardhatError(error), "Error is not a HardhatError");
+
+  // We first compare the number individually to throw a better error message
+  // in case the descriptors are different.
+  assert.equal(
+    error.descriptor.number,
+    descritor.number,
+    `Expected error number ${descritor.number}, but got ${error.descriptor.number}`,
+  );
+
+  assert.deepEqual(error.descriptor, descritor);
+
+  assert.deepEqual(error.messageArguments, messageArguments);
+}
+
+export function assertThrowsHardhatError<
+  ErrorDescriptorT extends ErrorDescriptor,
+>(
+  f: () => any,
+  descritor: ErrorDescriptorT,
+  messageArguments: HardhatError<ErrorDescriptorT>["messageArguments"],
+): void {
+  try {
+    f();
+  } catch (error) {
+    ensureError(error);
+    assertIsHardhatError(error, descritor, messageArguments);
+
+    return;
+  }
+
+  assert.fail("Function did not throw any error");
+}
+
+export async function assertThrowsHardhatErrorAsync<
+  ErrorDescriptorT extends ErrorDescriptor,
+>(
+  f: (() => Promise<any>) | Promise<any>,
+  descritor: ErrorDescriptorT,
+  messageArguments: HardhatError<ErrorDescriptorT>["messageArguments"],
+): Promise<void> {
+  try {
+    if (f instanceof Promise) {
+      await f;
+    } else {
+      await f();
+    }
+  } catch (error) {
+    ensureError(error);
+    assertIsHardhatError(error, descritor, messageArguments);
+
+    return;
+  }
+
+  assert.fail("Function did not throw any error");
+}

--- a/v-next/hardhat-test-utils/src/index.ts
+++ b/v-next/hardhat-test-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./hardhat-error.js";

--- a/v-next/hardhat-test-utils/test/hardhat-error.ts
+++ b/v-next/hardhat-test-utils/test/hardhat-error.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
+
+import {
+  assertIsHardhatError,
+  assertThrowsHardhatError,
+  assertThrowsHardhatErrorAsync,
+} from "../src/hardhat-error.js";
+
+describe("HardhatError helpers", () => {
+  describe("assertIsHardhatError", () => {
+    it("should throw if the error is not a HardhatError", () => {
+      assert.throws(() => {
+        assertIsHardhatError(
+          new Error("Not a HardhatError"),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
+          { action: "foo", task: "bar" },
+        );
+      });
+
+      assert.throws(() => {
+        assertIsHardhatError(
+          123,
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
+          { action: "foo", task: "bar" },
+        );
+      });
+    });
+
+    it("should throw if the error has a different descriptor", () => {
+      assert.throws(() => {
+        assertIsHardhatError(
+          new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+            { option: "foo", task: "bar" },
+          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
+          { action: "foo", task: "bar" },
+        );
+      });
+    });
+
+    it("should throw if the error has different message arguments", () => {
+      assert.throws(() => {
+        assertIsHardhatError(
+          new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+            { option: "foo", task: "bar" },
+          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+          { option: "foo2", task: "bar" },
+        );
+      });
+    });
+
+    it("Should not throw if the error is a HardhatError with the same descriptor and message arguments", () => {
+      assertIsHardhatError(
+        new HardhatError(
+          HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+          { option: "foo", task: "bar" },
+        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+        { option: "foo", task: "bar" },
+      );
+    });
+  });
+
+  describe("assertThrowsHardhatError", () => {
+    it("should throw if the function does not throw", () => {
+      assert.throws(() => {
+        assertThrowsHardhatError(
+          () => {},
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
+          { action: "foo", task: "bar" },
+        );
+      });
+    });
+
+    it("asserts the error that was thrown", () => {
+      assert.throws(() =>
+        assertThrowsHardhatError(
+          () => {
+            throw new HardhatError(
+              HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+              { option: "foo", task: "bar" },
+            );
+          },
+          HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+          { option: "foo2", task: "bar" },
+        ),
+      );
+
+      assertThrowsHardhatError(
+        () => {
+          throw new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+            { option: "foo", task: "bar" },
+          );
+        },
+        HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+        { option: "foo", task: "bar" },
+      );
+    });
+  });
+
+  describe("assertThrowsHardhatErrorAsync", () => {
+    it("should throw if the function doesn't return a promise that rejects", async () => {
+      await assert.rejects(async () =>
+        assertThrowsHardhatErrorAsync(
+          async () => {},
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
+          { action: "foo", task: "bar" },
+        ),
+      );
+    });
+
+    it("should throw the promise that rejects", async () => {
+      await assert.rejects(async () =>
+        assertThrowsHardhatErrorAsync(
+          Promise.resolve(1),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
+          { action: "foo", task: "bar" },
+        ),
+      );
+    });
+
+    it("asserts the error of the rejection", async () => {
+      await assert.rejects(() =>
+        assertThrowsHardhatErrorAsync(
+          async () => {
+            throw new HardhatError(
+              HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+              { option: "foo", task: "bar" },
+            );
+          },
+          HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+          { option: "foo2", task: "bar" },
+        ),
+      );
+
+      await assert.rejects(() =>
+        assertThrowsHardhatErrorAsync(
+          Promise.reject(
+            new HardhatError(
+              HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+              { option: "foo", task: "bar" },
+            ),
+          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+          { option: "foo2", task: "bar" },
+        ),
+      );
+
+      await assertThrowsHardhatErrorAsync(
+        async () => {
+          throw new HardhatError(
+            HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+            { option: "foo", task: "bar" },
+          );
+        },
+        HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+        { option: "foo", task: "bar" },
+      );
+    });
+  });
+});

--- a/v-next/hardhat-test-utils/test/hardhat-error.ts
+++ b/v-next/hardhat-test-utils/test/hardhat-error.ts
@@ -6,7 +6,7 @@ import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import {
   assertIsHardhatError,
   assertThrowsHardhatError,
-  assertThrowsHardhatErrorAsync,
+  assertRejectsWithHardhatError,
 } from "../src/hardhat-error.js";
 
 describe("HardhatError helpers", () => {
@@ -105,10 +105,10 @@ describe("HardhatError helpers", () => {
     });
   });
 
-  describe("assertThrowsHardhatErrorAsync", () => {
+  describe("assertRejectsWithHardhatError", () => {
     it("should throw if the function doesn't return a promise that rejects", async () => {
       await assert.rejects(async () =>
-        assertThrowsHardhatErrorAsync(
+        assertRejectsWithHardhatError(
           async () => {},
           HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
           { action: "foo", task: "bar" },
@@ -118,7 +118,7 @@ describe("HardhatError helpers", () => {
 
     it("should throw the promise that rejects", async () => {
       await assert.rejects(async () =>
-        assertThrowsHardhatErrorAsync(
+        assertRejectsWithHardhatError(
           Promise.resolve(1),
           HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
           { action: "foo", task: "bar" },
@@ -128,7 +128,7 @@ describe("HardhatError helpers", () => {
 
     it("asserts the error of the rejection", async () => {
       await assert.rejects(() =>
-        assertThrowsHardhatErrorAsync(
+        assertRejectsWithHardhatError(
           async () => {
             throw new HardhatError(
               HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
@@ -141,7 +141,7 @@ describe("HardhatError helpers", () => {
       );
 
       await assert.rejects(() =>
-        assertThrowsHardhatErrorAsync(
+        assertRejectsWithHardhatError(
           Promise.reject(
             new HardhatError(
               HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
@@ -153,7 +153,7 @@ describe("HardhatError helpers", () => {
         ),
       );
 
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         async () => {
           throw new HardhatError(
             HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,

--- a/v-next/hardhat-test-utils/tsconfig.json
+++ b/v-next/hardhat-test-utils/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../config-v-next/tsconfig.json",
+  "references": [
+    {
+      "path": "../hardhat-errors"
+    },
+    {
+      "path": "../hardhat-utils"
+    },
+    {
+      "path": "../hardhat-node-test-reporter"
+    }
+  ]
+}

--- a/v-next/hardhat-zod-utils/package.json
+++ b/v-next/hardhat-zod-utils/package.json
@@ -43,6 +43,7 @@
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@ignored/hardhat-vnext-core": "workspace:^3.0.0-next.2",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
+    "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",

--- a/v-next/hardhat-zod-utils/tsconfig.json
+++ b/v-next/hardhat-zod-utils/tsconfig.json
@@ -6,6 +6,9 @@
     },
     {
       "path": "../hardhat-node-test-reporter"
+    },
+    {
+      "path": "../hardhat-test-utils"
     }
   ]
 }

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
+    "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",

--- a/v-next/hardhat/tsconfig.json
+++ b/v-next/hardhat/tsconfig.json
@@ -11,6 +11,9 @@
       "path": "../hardhat-node-test-reporter"
     },
     {
+      "path": "../hardhat-test-utils"
+    },
+    {
       "path": "../hardhat-utils"
     },
     {

--- a/v-next/template-package/package.json
+++ b/v-next/template-package/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
+    "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",

--- a/v-next/template-package/tsconfig.json
+++ b/v-next/template-package/tsconfig.json
@@ -3,6 +3,9 @@
   "references": [
     {
       "path": "../hardhat-node-test-reporter"
+    },
+    {
+      "path": "../hardhat-test-utils"
     }
   ]
 }


### PR DESCRIPTION
This PR introduces a new private package, `@nomicfoundation/hardhat-test-utils`, and installs it in all the `v-next` packages that are compatible with it (i.e. not dendencies of it).

This PR only introduces helpers for `HardhatError` related assertions, but it doesn't change any existing test.

A follow-up PR will change the existing tests to use the new utilities.