### PR TITLE
Use `hardhat-test-utils`' functions

### DIFF
--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -242,6 +242,18 @@ function createConfig(configFilePath, options = { onlyHardhatError: true }) {
           message:
             "Top-level await is only allowed in a few cases. Please discuss this change with the team.",
         },
+        {
+          selector:
+            "CallExpression[callee.object.name='assert'][callee.property.name=doesNotThrow]",
+          message:
+            "Don't use assert.doesNotThrow. Just call the function directly, letting the error bubble up if thrown",
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='assert'][callee.property.name=doesNotReject]",
+          message:
+            "Don't use assert.doesNotReject. Just await the async-function-call/promise directly, letting the error bubble up if rejected",
+        },
       ],
       "@typescript-eslint/restrict-plus-operands": "error",
       "@typescript-eslint/restrict-template-expressions": [

--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -10,10 +10,13 @@ const path = require("path");
  * The only packages that should not use this config are our own eslint plugins/rules.
  *
  * @param {string} configFilePath The path to the config file that is using this function.
- * @param {{ onlyHardhatError?: boolean }} options An object with options to enable/disable certain rules.
+ * @param {{ onlyHardhatError?: boolean, enforceHardhatTestUtils?: boolean }} options An object with options to enable/disable certain rules.
  * @returns {import("eslint").Linter.Config}
  */
-function createConfig(configFilePath, options = { onlyHardhatError: true }) {
+function createConfig(
+  configFilePath,
+  options = { onlyHardhatError: true, enforceHardhatTestUtils: true }
+) {
   /**
    * @type {import("eslint").Linter.Config}
    */
@@ -423,6 +426,21 @@ function createConfig(configFilePath, options = { onlyHardhatError: true }) {
         ],
       },
     });
+  }
+
+  if (options.enforceHardhatTestUtils) {
+    config.rules["no-restricted-syntax"].push(
+      {
+        selector:
+          "CallExpression[callee.object.name='assert'][callee.property.name=throws]",
+        message: "Don't use assert.throws. Use our test helpers instead.",
+      },
+      {
+        selector:
+          "CallExpression[callee.object.name='assert'][callee.property.name=rejects]",
+        message: "Don't use assert.rejects. Use our test helpers instead.",
+      }
+    );
   }
 
   return config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1450,6 +1450,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: ^7.43.4
         version: 7.43.4(@types/node@20.14.9)
+      '@nomicfoundation/hardhat-test-utils':
+        specifier: workspace:^
+        version: link:../hardhat-test-utils
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9

--- a/v-next/core/package.json
+++ b/v-next/core/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
+    "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@microsoft/api-extractor": "^7.43.4",
     "@types/node": "^20.14.9",
     "@types/semver": "^7.5.8",

--- a/v-next/core/test/internal/configuration-variables/configuration-variables.ts
+++ b/v-next/core/test/internal/configuration-variables/configuration-variables.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
-import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { ResolvedConfigurationVariableImplementation } from "../../../src/internal/configuration-variables.js";
 import { HookManagerImplementation } from "../../../src/internal/hook-manager.js";
@@ -56,7 +56,7 @@ describe("ResolvedConfigurationVariable", () => {
       { name: "foo", _type: "ConfigurationVariable" },
     );
 
-    await assertThrowsHardhatErrorAsync(
+    await assertRejectsWithHardhatError(
       variable.get(),
       HardhatError.ERRORS.GENERAL.ENV_VAR_NOT_FOUND,
       {},
@@ -101,7 +101,7 @@ describe("ResolvedConfigurationVariable", () => {
 
     process.env.foo = "not a url";
 
-    await assertThrowsHardhatErrorAsync(
+    await assertRejectsWithHardhatError(
       variable.getUrl(),
       HardhatError.ERRORS.GENERAL.INVALID_URL,
       {
@@ -133,7 +133,7 @@ describe("ResolvedConfigurationVariable", () => {
 
     process.env.foo = "not a bigint";
 
-    await assertThrowsHardhatErrorAsync(
+    await assertRejectsWithHardhatError(
       variable.getBigInt(),
       HardhatError.ERRORS.GENERAL.INVALID_BIGINT,
       {

--- a/v-next/core/test/internal/configuration-variables/configuration-variables.ts
+++ b/v-next/core/test/internal/configuration-variables/configuration-variables.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
 
 import { ResolvedConfigurationVariableImplementation } from "../../../src/internal/configuration-variables.js";
 import { HookManagerImplementation } from "../../../src/internal/hook-manager.js";
@@ -55,9 +56,10 @@ describe("ResolvedConfigurationVariable", () => {
       { name: "foo", _type: "ConfigurationVariable" },
     );
 
-    await assert.rejects(
+    await assertThrowsHardhatErrorAsync(
       variable.get(),
-      new HardhatError(HardhatError.ERRORS.GENERAL.ENV_VAR_NOT_FOUND),
+      HardhatError.ERRORS.GENERAL.ENV_VAR_NOT_FOUND,
+      {},
     );
   });
 
@@ -99,11 +101,12 @@ describe("ResolvedConfigurationVariable", () => {
 
     process.env.foo = "not a url";
 
-    await assert.rejects(
+    await assertThrowsHardhatErrorAsync(
       variable.getUrl(),
-      new HardhatError(HardhatError.ERRORS.GENERAL.INVALID_URL, {
+      HardhatError.ERRORS.GENERAL.INVALID_URL,
+      {
         url: "not a url",
-      }),
+      },
     );
 
     delete process.env.foo;
@@ -130,11 +133,12 @@ describe("ResolvedConfigurationVariable", () => {
 
     process.env.foo = "not a bigint";
 
-    await assert.rejects(
+    await assertThrowsHardhatErrorAsync(
       variable.getBigInt(),
-      new HardhatError(HardhatError.ERRORS.GENERAL.INVALID_BIGINT, {
+      HardhatError.ERRORS.GENERAL.INVALID_BIGINT,
+      {
         value: "not a bigint",
-      }),
+      },
     );
 
     delete process.env.foo;

--- a/v-next/core/test/internal/global-options.ts
+++ b/v-next/core/test/internal/global-options.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { globalOption, ArgumentType } from "../../src/config.js";
 import { RESERVED_ARGUMENT_NAMES } from "../../src/internal/arguments.js";
@@ -86,7 +87,7 @@ describe("Global Options", () => {
         defaultValue: false,
       });
 
-      assert.throws(
+      assertThrowsHardhatError(
         () =>
           buildGlobalOptionDefinitions([
             {
@@ -98,19 +99,18 @@ describe("Global Options", () => {
               globalOptions: [globalOptionDefinition2],
             },
           ]),
-        new HardhatError(
-          HardhatError.ERRORS.GENERAL.GLOBAL_OPTION_ALREADY_DEFINED,
-          {
-            plugin: "plugin2",
-            globalOption: "globalOption1",
-            definedByPlugin: "plugin1",
-          },
-        ),
+
+        HardhatError.ERRORS.GENERAL.GLOBAL_OPTION_ALREADY_DEFINED,
+        {
+          plugin: "plugin2",
+          globalOption: "globalOption1",
+          definedByPlugin: "plugin1",
+        },
       );
     });
 
     it("should throw if an option name is not valid", () => {
-      assert.throws(
+      assertThrowsHardhatError(
         () =>
           buildGlobalOptionDefinitions([
             {
@@ -125,15 +125,16 @@ describe("Global Options", () => {
               ],
             },
           ]),
-        new HardhatError(HardhatError.ERRORS.ARGUMENTS.INVALID_NAME, {
+        HardhatError.ERRORS.ARGUMENTS.INVALID_NAME,
+        {
           name: "foo bar",
-        }),
+        },
       );
     });
 
     it("should throw if an option name is reserved", () => {
       RESERVED_ARGUMENT_NAMES.forEach((name) => {
-        assert.throws(
+        assertThrowsHardhatError(
           () =>
             buildGlobalOptionDefinitions([
               {
@@ -148,15 +149,16 @@ describe("Global Options", () => {
                 ],
               },
             ]),
-          new HardhatError(HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME, {
+          HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME,
+          {
             name,
-          }),
+          },
         );
       });
     });
 
     it("should throw if an options default value does not match the type", () => {
-      assert.throws(
+      assertThrowsHardhatError(
         () =>
           buildGlobalOptionDefinitions([
             {
@@ -173,11 +175,12 @@ describe("Global Options", () => {
               ],
             },
           ]),
-        new HardhatError(HardhatError.ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+        HardhatError.ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+        {
           value: "bar",
           name: "defaultValue",
           type: ArgumentType.BOOLEAN,
-        }),
+        },
       );
     });
   });
@@ -210,37 +213,39 @@ describe("Global Options", () => {
     });
 
     it("should throw if the option name is not valid", () => {
-      assert.throws(
+      assertThrowsHardhatError(
         () =>
           buildGlobalOptionDefinition({
             name: "foo bar",
             description: "Foo description",
             defaultValue: "bar",
           }),
-        new HardhatError(HardhatError.ERRORS.ARGUMENTS.INVALID_NAME, {
+        HardhatError.ERRORS.ARGUMENTS.INVALID_NAME,
+        {
           name: "foo bar",
-        }),
+        },
       );
     });
 
     it("should throw if the option name is reserved", () => {
       RESERVED_ARGUMENT_NAMES.forEach((name) => {
-        assert.throws(
+        assertThrowsHardhatError(
           () =>
             buildGlobalOptionDefinition({
               name,
               description: "Foo description",
               defaultValue: "bar",
             }),
-          new HardhatError(HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME, {
+          HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME,
+          {
             name,
-          }),
+          },
         );
       });
     });
 
     it("should throw if the default value does not match the type", () => {
-      assert.throws(
+      assertThrowsHardhatError(
         () =>
           buildGlobalOptionDefinition({
             name: "foo",
@@ -250,11 +255,12 @@ describe("Global Options", () => {
             Intentionally testing an invalid type */
             defaultValue: "bar" as any,
           }),
-        new HardhatError(HardhatError.ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+        HardhatError.ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+        {
           value: "bar",
           name: "defaultValue",
           type: ArgumentType.BOOLEAN,
-        }),
+        },
       );
     });
   });
@@ -416,13 +422,14 @@ describe("Global Options", () => {
 
       setEnvVar("HARDHAT_GLOBAL_OPTION1", "not a boolean");
 
-      assert.throws(
+      assertThrowsHardhatError(
         () => resolveGlobalOptions({}, globalOptionDefinitions),
-        new HardhatError(HardhatError.ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+        HardhatError.ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+        {
           value: "not a boolean",
           name: "globalOption1",
           type: ArgumentType.BOOLEAN,
-        }),
+        },
       );
     });
   });

--- a/v-next/core/test/internal/hook-manager.ts
+++ b/v-next/core/test/internal/hook-manager.ts
@@ -23,7 +23,7 @@ import { describe, it, beforeEach } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import { ensureError } from "@ignored/hardhat-vnext-utils/error";
-import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { HookManagerImplementation } from "../../src/internal/hook-manager.js";
 import { UserInterruptionManagerImplementation } from "../../src/internal/user-interruptions.js";
@@ -266,7 +266,7 @@ describe("HookManager", () => {
 
         const manager = new HookManagerImplementation([examplePlugin]);
 
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           async () =>
             manager.runHandlerChain(
               "config",

--- a/v-next/core/test/internal/hook-manager.ts
+++ b/v-next/core/test/internal/hook-manager.ts
@@ -22,6 +22,8 @@ import assert from "node:assert/strict";
 import { describe, it, beforeEach } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { ensureError } from "@ignored/hardhat-vnext-utils/error";
+import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
 
 import { HookManagerImplementation } from "../../src/internal/hook-manager.js";
 import { UserInterruptionManagerImplementation } from "../../src/internal/user-interruptions.js";
@@ -235,20 +237,23 @@ describe("HookManager", () => {
 
         const manager = new HookManagerImplementation([examplePlugin]);
 
-        await assert.rejects(
-          async () =>
-            manager.runHandlerChain(
-              "config",
-              "extendUserConfig",
-              [{}],
-              async () => {
-                return {};
-              },
-            ),
-          {
-            code: "ERR_MODULE_NOT_FOUND",
-          },
-        );
+        try {
+          await manager.runHandlerChain(
+            "config",
+            "extendUserConfig",
+            [{}],
+            async () => {
+              return {};
+            },
+          );
+        } catch (error) {
+          ensureError(error);
+          assert.ok("code" in error, "Error has no code property");
+          assert.equal(error.code, "ERR_MODULE_NOT_FOUND");
+          return;
+        }
+
+        assert.fail("Expected an error, but none was thrown");
       });
 
       it("should throw if a non-filepath is given to the plugin being loaded", async () => {
@@ -261,7 +266,7 @@ describe("HookManager", () => {
 
         const manager = new HookManagerImplementation([examplePlugin]);
 
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           async () =>
             manager.runHandlerChain(
               "config",
@@ -271,14 +276,12 @@ describe("HookManager", () => {
                 return {};
               },
             ),
-          new HardhatError(
-            HardhatError.ERRORS.HOOKS.INVALID_HOOK_FACTORY_PATH,
-            {
-              hookCategoryName: "config",
-              pluginId: "example",
-              path: "./fixture-plugins/config-plugin.js",
-            },
-          ),
+          HardhatError.ERRORS.HOOKS.INVALID_HOOK_FACTORY_PATH,
+          {
+            hookCategoryName: "config",
+            pluginId: "example",
+            path: "./fixture-plugins/config-plugin.js",
+          },
         );
       });
     });

--- a/v-next/core/test/internal/hook-manager.ts
+++ b/v-next/core/test/internal/hook-manager.ts
@@ -903,9 +903,7 @@ describe("HookManager", () => {
           },
         };
 
-        assert.doesNotThrow(() =>
-          hookManager.unregisterHandlers("config", exampleHook),
-        );
+        hookManager.unregisterHandlers("config", exampleHook);
       });
     });
   });

--- a/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -1,9 +1,9 @@
 import type { HardhatPlugin } from "../../../src/types/plugins.js";
 
-import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
 
 import { detectPluginNpmDependencyProblems } from "../../../src/internal/plugins/detect-plugin-npm-dependency-problems.js";
 
@@ -44,15 +44,16 @@ describe("Plugins - detect npm dependency problems", () => {
         "./fixture-projects/not-installed-package",
       );
 
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         async () =>
           detectPluginNpmDependencyProblems(
             plugin,
             nonInstalledPackageProjectFixture,
           ),
-        new HardhatError(HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED, {
+        HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
+        {
           pluginId: "example-plugin",
-        }),
+        },
       );
     });
   });
@@ -75,12 +76,10 @@ describe("Plugins - detect npm dependency problems", () => {
           "./fixture-projects/not-installed-peer-dep",
         );
 
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           detectPluginNpmDependencyProblems(plugin, notInstalledPeerDepFixture),
-          new HardhatError(
-            HardhatError.ERRORS.PLUGINS.PLUGIN_MISSING_DEPENDENCY,
-            { pluginId: "example-plugin", peerDependencyName: "peer2" },
-          ),
+          HardhatError.ERRORS.PLUGINS.PLUGIN_MISSING_DEPENDENCY,
+          { pluginId: "example-plugin", peerDependencyName: "peer2" },
         );
       });
     });
@@ -105,21 +104,19 @@ describe("Plugins - detect npm dependency problems", () => {
         "./fixture-projects/peer-dep-with-wrong-version",
       );
 
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         async () =>
           detectPluginNpmDependencyProblems(
             plugin,
             peerDepWithWrongVersionFixture,
           ),
-        new HardhatError(
-          HardhatError.ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH,
-          {
-            pluginId: "example-plugin",
-            peerDependencyName: "peer2",
-            expectedVersion: "^1.0.0",
-            installedVersion: "2.0.0",
-          },
-        ),
+        HardhatError.ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH,
+        {
+          pluginId: "example-plugin",
+          peerDependencyName: "peer2",
+          expectedVersion: "^1.0.0",
+          installedVersion: "2.0.0",
+        },
       );
     });
   });

--- a/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -18,14 +18,12 @@ describe("Plugins - detect npm dependency problems", () => {
       "./fixture-projects/peer-dep-with-wrong-version",
     );
 
-    await assert.doesNotReject(async () =>
-      detectPluginNpmDependencyProblems(
-        {
-          ...plugin,
-          npmPackage: undefined,
-        },
-        peerDepWithWrongVersionFixture,
-      ),
+    await detectPluginNpmDependencyProblems(
+      {
+        ...plugin,
+        npmPackage: undefined,
+      },
+      peerDepWithWrongVersionFixture,
     );
   });
 
@@ -35,11 +33,9 @@ describe("Plugins - detect npm dependency problems", () => {
         "./fixture-projects/installed-package",
       );
 
-      await assert.doesNotReject(async () =>
-        detectPluginNpmDependencyProblems(
-          plugin,
-          installedPackageProjectFixture,
-        ),
+      await detectPluginNpmDependencyProblems(
+        plugin,
+        installedPackageProjectFixture,
       );
     });
 
@@ -68,8 +64,9 @@ describe("Plugins - detect npm dependency problems", () => {
           "./fixture-projects/installed-peer-deps",
         );
 
-        await assert.doesNotReject(async () =>
-          detectPluginNpmDependencyProblems(plugin, installedPeerDepsFixture),
+        await detectPluginNpmDependencyProblems(
+          plugin,
+          installedPeerDepsFixture,
         );
       });
 
@@ -94,8 +91,9 @@ describe("Plugins - detect npm dependency problems", () => {
           "./fixture-projects/installed-peer-deps-as-sub-node-modules",
         );
 
-        await assert.doesNotReject(async () =>
-          detectPluginNpmDependencyProblems(plugin, installedPeerDepsFixture),
+        await detectPluginNpmDependencyProblems(
+          plugin,
+          installedPeerDepsFixture,
         );
       });
     });

--- a/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -3,7 +3,7 @@ import type { HardhatPlugin } from "../../../src/types/plugins.js";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
-import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { detectPluginNpmDependencyProblems } from "../../../src/internal/plugins/detect-plugin-npm-dependency-problems.js";
 
@@ -44,7 +44,7 @@ describe("Plugins - detect npm dependency problems", () => {
         "./fixture-projects/not-installed-package",
       );
 
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         async () =>
           detectPluginNpmDependencyProblems(
             plugin,
@@ -76,7 +76,7 @@ describe("Plugins - detect npm dependency problems", () => {
           "./fixture-projects/not-installed-peer-dep",
         );
 
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           detectPluginNpmDependencyProblems(plugin, notInstalledPeerDepFixture),
           HardhatError.ERRORS.PLUGINS.PLUGIN_MISSING_DEPENDENCY,
           { pluginId: "example-plugin", peerDependencyName: "peer2" },
@@ -104,7 +104,7 @@ describe("Plugins - detect npm dependency problems", () => {
         "./fixture-projects/peer-dep-with-wrong-version",
       );
 
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         async () =>
           detectPluginNpmDependencyProblems(
             plugin,

--- a/v-next/core/test/internal/plugins/resolve-plugin-list.ts
+++ b/v-next/core/test/internal/plugins/resolve-plugin-list.ts
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
-import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { resolvePluginList } from "../../../src/internal/plugins/resolve-plugin-list.js";
 
@@ -150,7 +150,7 @@ describe("Plugins - resolve plugin list", () => {
     const a = { id: "dup" };
     const copy = { id: "dup" };
 
-    await assertThrowsHardhatErrorAsync(
+    await assertRejectsWithHardhatError(
       async () => resolvePluginList([a, copy], installedPackageFixture),
       HardhatError.ERRORS.GENERAL.DUPLICATED_PLUGIN_ID,
       {
@@ -171,7 +171,7 @@ describe("Plugins - resolve plugin list", () => {
         ],
       };
 
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         async () => resolvePluginList([plugin], installedPackageFixture),
         HardhatError.ERRORS.PLUGINS.PLUGIN_DEPENDENCY_FAILED_LOAD,
         { pluginId: plugin.id },
@@ -193,7 +193,7 @@ describe("Plugins - resolve plugin list", () => {
         ],
       };
 
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         async () => resolvePluginList([plugin], notInstalledPackageFixture),
         HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
         {

--- a/v-next/core/test/internal/plugins/resolve-plugin-list.ts
+++ b/v-next/core/test/internal/plugins/resolve-plugin-list.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
 
 import { resolvePluginList } from "../../../src/internal/plugins/resolve-plugin-list.js";
 
@@ -149,11 +150,12 @@ describe("Plugins - resolve plugin list", () => {
     const a = { id: "dup" };
     const copy = { id: "dup" };
 
-    await assert.rejects(
+    await assertThrowsHardhatErrorAsync(
       async () => resolvePluginList([a, copy], installedPackageFixture),
-      new HardhatError(HardhatError.ERRORS.GENERAL.DUPLICATED_PLUGIN_ID, {
+      HardhatError.ERRORS.GENERAL.DUPLICATED_PLUGIN_ID,
+      {
         id: "dup",
-      }),
+      },
     );
   });
 
@@ -169,12 +171,10 @@ describe("Plugins - resolve plugin list", () => {
         ],
       };
 
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         async () => resolvePluginList([plugin], installedPackageFixture),
-        new HardhatError(
-          HardhatError.ERRORS.PLUGINS.PLUGIN_DEPENDENCY_FAILED_LOAD,
-          { pluginId: plugin.id },
-        ),
+        HardhatError.ERRORS.PLUGINS.PLUGIN_DEPENDENCY_FAILED_LOAD,
+        { pluginId: plugin.id },
       );
     });
 
@@ -193,11 +193,12 @@ describe("Plugins - resolve plugin list", () => {
         ],
       };
 
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         async () => resolvePluginList([plugin], notInstalledPackageFixture),
-        new HardhatError(HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED, {
+        HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
+        {
           pluginId: "example",
-        }),
+        },
       );
     });
   });

--- a/v-next/core/test/internal/tasks/builders.ts
+++ b/v-next/core/test/internal/tasks/builders.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { RESERVED_ARGUMENT_NAMES } from "../../../src/internal/arguments.js";
 import {
@@ -53,18 +54,20 @@ describe("Task builders", () => {
 
     describe("Task id validation", () => {
       it("should throw if the id is an empty string", () => {
-        assert.throws(
+        assertThrowsHardhatError(
           () => new EmptyTaskDefinitionBuilderImplementation(""),
-          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+          HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID,
+          {},
         );
       });
 
       it("should throw if the array of ids is empty", () => {
         const ids: string[] = [];
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => new EmptyTaskDefinitionBuilderImplementation(ids),
-          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+          HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID,
+          {},
         );
       });
     });
@@ -149,18 +152,20 @@ describe("Task builders", () => {
 
     describe("Task id validation", () => {
       it("should throw if the id is an empty string", () => {
-        assert.throws(
+        assertThrowsHardhatError(
           () => new NewTaskDefinitionBuilderImplementation(""),
-          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+          HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID,
+          {},
         );
       });
 
       it("should throw if the array of ids is empty", () => {
         const ids: string[] = [];
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => new NewTaskDefinitionBuilderImplementation(ids),
-          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+          HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID,
+          {},
         );
       });
     });
@@ -198,32 +203,29 @@ describe("Task builders", () => {
 
       it("should throw when trying to build a task definition without an action", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
-        assert.throws(
+        assertThrowsHardhatError(
           () => builder.build(),
-          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.NO_ACTION, {
+          HardhatError.ERRORS.TASK_DEFINITIONS.NO_ACTION,
+          {
             task: "task-id",
-          }),
+          },
         );
       });
 
       it("should throw if the task action is not a valid file URL", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => builder.setAction("not-a-valid-file-url"),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
-            { action: "not-a-valid-file-url" },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
+          { action: "not-a-valid-file-url" },
         );
-        assert.throws(
+        assertThrowsHardhatError(
           () => builder.setAction("file://"),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
-            {
-              action: "file://",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
+          {
+            action: "file://",
+          },
         );
       });
     });
@@ -694,11 +696,12 @@ describe("Task builders", () => {
 
         invalidNames.forEach((name) => {
           fnNames.forEach((fnName) => {
-            assert.throws(
+            assertThrowsHardhatError(
               () => builder[fnName]({ name }),
-              new HardhatError(HardhatError.ERRORS.ARGUMENTS.INVALID_NAME, {
+              HardhatError.ERRORS.ARGUMENTS.INVALID_NAME,
+              {
                 name,
-              }),
+              },
             );
           });
         });
@@ -717,11 +720,12 @@ describe("Task builders", () => {
 
         names.forEach((name) => {
           fnNames.forEach((fnName) => {
-            assert.throws(
+            assertThrowsHardhatError(
               () => builder[fnName]({ name }),
-              new HardhatError(HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME, {
+              HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME,
+              {
                 name,
-              }),
+              },
             );
           });
         });
@@ -731,11 +735,12 @@ describe("Task builders", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
 
         RESERVED_ARGUMENT_NAMES.forEach((name) => {
-          assert.throws(
+          assertThrowsHardhatError(
             () => builder.addOption({ name }),
-            new HardhatError(HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME, {
+            HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME,
+            {
               name,
-            }),
+            },
           );
         });
       });
@@ -748,7 +753,7 @@ describe("Task builders", () => {
         const fnNames = ["addOption", "addPositionalArgument"] as const;
 
         fnNames.forEach((fnName) => {
-          assert.throws(
+          assertThrowsHardhatError(
             () =>
               builder[fnName]({
                 name: "arg",
@@ -757,19 +762,17 @@ describe("Task builders", () => {
                 defaultValue: 123 as any,
                 type: ArgumentType.STRING,
               }),
-            new HardhatError(
-              HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
-              {
-                value: 123,
-                name: "defaultValue",
-                type: ArgumentType.STRING,
-                task: "task-id",
-              },
-            ),
+            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
+            {
+              value: 123,
+              name: "defaultValue",
+              type: ArgumentType.STRING,
+              task: "task-id",
+            },
           );
         });
 
-        assert.throws(
+        assertThrowsHardhatError(
           () =>
             builder.addVariadicArgument({
               name: "arg",
@@ -778,15 +781,13 @@ describe("Task builders", () => {
               defaultValue: [123, 456, 789] as any,
               type: ArgumentType.STRING,
             }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
-            {
-              value: [123, 456, 789],
-              name: "defaultValue",
-              type: ArgumentType.STRING,
-              task: "task-id",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
+          {
+            value: [123, 456, 789],
+            name: "defaultValue",
+            type: ArgumentType.STRING,
+            task: "task-id",
+          },
         );
       });
     });
@@ -800,19 +801,15 @@ describe("Task builders", () => {
           defaultValue: "default",
         });
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => builder.addPositionalArgument({ name: "arg2" }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.REQUIRED_ARG_AFTER_OPTIONAL,
-            { name: "arg2" },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.REQUIRED_ARG_AFTER_OPTIONAL,
+          { name: "arg2" },
         );
-        assert.throws(
+        assertThrowsHardhatError(
           () => builder.addVariadicArgument({ name: "arg3" }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.REQUIRED_ARG_AFTER_OPTIONAL,
-            { name: "arg3" },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.REQUIRED_ARG_AFTER_OPTIONAL,
+          { name: "arg3" },
         );
       });
 
@@ -821,20 +818,16 @@ describe("Task builders", () => {
 
         builder.addVariadicArgument({ name: "arg" });
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => builder.addPositionalArgument({ name: "arg2" }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.POSITIONAL_ARG_AFTER_VARIADIC,
-            { name: "arg2" },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.POSITIONAL_ARG_AFTER_VARIADIC,
+          { name: "arg2" },
         );
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => builder.addVariadicArgument({ name: "arg3" }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.POSITIONAL_ARG_AFTER_VARIADIC,
-            { name: "arg3" },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.POSITIONAL_ARG_AFTER_VARIADIC,
+          { name: "arg3" },
         );
       });
     });
@@ -874,18 +867,20 @@ describe("Task builders", () => {
 
     describe("Task id validation", () => {
       it("should throw if the id is an empty string", () => {
-        assert.throws(
+        assertThrowsHardhatError(
           () => new TaskOverrideDefinitionBuilderImplementation(""),
-          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+          HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID,
+          {},
         );
       });
 
       it("should throw if the array of ids is empty", () => {
         const ids: string[] = [];
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => new TaskOverrideDefinitionBuilderImplementation(ids),
-          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+          HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID,
+          {},
         );
       });
     });
@@ -927,11 +922,12 @@ describe("Task builders", () => {
         const builder = new TaskOverrideDefinitionBuilderImplementation(
           "task-id",
         );
-        assert.throws(
+        assertThrowsHardhatError(
           () => builder.build(),
-          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.NO_ACTION, {
+          HardhatError.ERRORS.TASK_DEFINITIONS.NO_ACTION,
+          {
             task: "task-id",
-          }),
+          },
         );
       });
 
@@ -940,19 +936,15 @@ describe("Task builders", () => {
           "task-id",
         );
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => builder.setAction("not-a-valid-file-url"),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
-            { action: "not-a-valid-file-url" },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
+          { action: "not-a-valid-file-url" },
         );
-        assert.throws(
+        assertThrowsHardhatError(
           () => builder.setAction("file://"),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
-            { action: "file://" },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
+          { action: "file://" },
         );
       });
     });
@@ -1161,11 +1153,12 @@ describe("Task builders", () => {
 
         invalidNames.forEach((name) => {
           fnNames.forEach((fnName) => {
-            assert.throws(
+            assertThrowsHardhatError(
               () => builder[fnName]({ name }),
-              new HardhatError(HardhatError.ERRORS.ARGUMENTS.INVALID_NAME, {
+              HardhatError.ERRORS.ARGUMENTS.INVALID_NAME,
+              {
                 name,
-              }),
+              },
             );
           });
         });
@@ -1182,11 +1175,12 @@ describe("Task builders", () => {
 
         names.forEach((name) => {
           fnNames.forEach((fnName) => {
-            assert.throws(
+            assertThrowsHardhatError(
               () => builder[fnName]({ name }),
-              new HardhatError(HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME, {
+              HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME,
+              {
                 name,
-              }),
+              },
             );
           });
         });
@@ -1198,11 +1192,12 @@ describe("Task builders", () => {
         );
 
         RESERVED_ARGUMENT_NAMES.forEach((name) => {
-          assert.throws(
+          assertThrowsHardhatError(
             () => builder.addOption({ name }),
-            new HardhatError(HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME, {
+            HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME,
+            {
               name,
-            }),
+            },
           );
         });
       });
@@ -1214,7 +1209,7 @@ describe("Task builders", () => {
           "task-id",
         );
 
-        assert.throws(
+        assertThrowsHardhatError(
           () =>
             builder.addOption({
               name: "arg",
@@ -1223,15 +1218,13 @@ describe("Task builders", () => {
               defaultValue: 123 as any,
               type: ArgumentType.STRING,
             }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
-            {
-              value: 123,
-              name: "defaultValue",
-              type: ArgumentType.STRING,
-              task: "task-id",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
+          {
+            value: 123,
+            name: "defaultValue",
+            type: ArgumentType.STRING,
+            task: "task-id",
+          },
         );
       });
     });

--- a/v-next/core/test/internal/tasks/task-manager.ts
+++ b/v-next/core/test/internal/tasks/task-manager.ts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import {
   assertThrowsHardhatError,
-  assertThrowsHardhatErrorAsync,
+  assertRejectsWithHardhatError,
 } from "@nomicfoundation/hardhat-test-utils";
 
 import { ArgumentType, globalOption } from "../../../src/config.js";
@@ -380,7 +380,7 @@ describe("TaskManagerImplementation", () => {
    */
   describe("errors", () => {
     it("should throw if there's a global option with the same name as a task option", async () => {
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -417,7 +417,7 @@ describe("TaskManagerImplementation", () => {
     });
 
     it("should throw if there's a global option with the same name as a task positional argument", async () => {
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -454,7 +454,7 @@ describe("TaskManagerImplementation", () => {
     });
 
     it("should throw if trying to add a task with an empty id", async () => {
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -479,7 +479,7 @@ describe("TaskManagerImplementation", () => {
     });
 
     it("should throw if trying to add a subtask for a task that doesn't exist", async () => {
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -505,7 +505,7 @@ describe("TaskManagerImplementation", () => {
     });
 
     it("should throw if trying to add a task that already exists", async () => {
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -539,7 +539,7 @@ describe("TaskManagerImplementation", () => {
 
     it("should throw if trying to override a task that doesn't exist", async () => {
       // Empty id task will not be found as empty ids are not allowed
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -564,7 +564,7 @@ describe("TaskManagerImplementation", () => {
       );
 
       // task1 will not be found as it's not defined
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -586,7 +586,7 @@ describe("TaskManagerImplementation", () => {
 
     it("should throw if trying to override a task and there is a name clash with an existing option", async () => {
       // added argument clash with an existing option
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -619,7 +619,7 @@ describe("TaskManagerImplementation", () => {
       );
 
       // added flag clash with an existing option
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -654,7 +654,7 @@ describe("TaskManagerImplementation", () => {
 
     it("should throw if trying to override a task and there is a name clash with an exising flag argument", async () => {
       // added argument clash with an existing flag
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -687,7 +687,7 @@ describe("TaskManagerImplementation", () => {
       );
 
       // added flag clash with an existing flag
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -722,7 +722,7 @@ describe("TaskManagerImplementation", () => {
 
     it("should throw if trying to override a task and there is a name clash with an exising positional argument", async () => {
       // added argument clash with an existing positional argument
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -755,7 +755,7 @@ describe("TaskManagerImplementation", () => {
       );
 
       // added flag clash with an existing positional argument
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -790,7 +790,7 @@ describe("TaskManagerImplementation", () => {
 
     it("should throw if trying to override a task and there is a name clash with an exising variadic argument", async () => {
       // added argument clash with an existing variadic argument
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -823,7 +823,7 @@ describe("TaskManagerImplementation", () => {
       );
 
       // added flag clash with an existing variadic argument
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -859,7 +859,7 @@ describe("TaskManagerImplementation", () => {
     it("should throw if a plugins tries to override a task defined in the config", async () => {
       // this will fail as the config tasks are processed after
       // the plugin tasks so the override logic will not find task1
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         createBaseHardhatRuntimeEnvironment({
           tasks: [
             new NewTaskDefinitionBuilderImplementation("task1")
@@ -1284,7 +1284,7 @@ describe("TaskManagerImplementation", () => {
         });
 
         const task1 = hre.tasks.getTask("task1");
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({}),
           HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK,
           {
@@ -1308,7 +1308,7 @@ describe("TaskManagerImplementation", () => {
         });
 
         const task1 = hre.tasks.getTask("task1");
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({ otherArg: "otherArgValue" }),
           HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
           {
@@ -1338,7 +1338,7 @@ describe("TaskManagerImplementation", () => {
         const task1 = hre.tasks.getTask("task1");
 
         // option is missing
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({
             posArg: "posValue",
             varArg: ["varValue1", "varValue2"],
@@ -1351,7 +1351,7 @@ describe("TaskManagerImplementation", () => {
         );
 
         // posArg is missing
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({
             option: "arg1Value",
             varArg: ["varValue1", "varValue2"],
@@ -1364,7 +1364,7 @@ describe("TaskManagerImplementation", () => {
         );
 
         // varArg is missing
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({
             option: "arg1Value",
             posArg: "posValue",
@@ -1406,7 +1406,7 @@ describe("TaskManagerImplementation", () => {
         const task1 = hre.tasks.getTask("task1");
 
         // option has the wrong type
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({
             option: "not a bigint",
             posArg: 10,
@@ -1422,7 +1422,7 @@ describe("TaskManagerImplementation", () => {
         );
 
         // posArg has the wrong type
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({
             option: 5n,
             posArg: true,
@@ -1438,7 +1438,7 @@ describe("TaskManagerImplementation", () => {
         );
 
         // varArg has the wrong type (not an array)
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({
             option: 5n,
             posArg: 10,
@@ -1454,7 +1454,7 @@ describe("TaskManagerImplementation", () => {
         );
 
         // varArg has the wrong type (array element has the wrong type)
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({
             option: 5n,
             posArg: 10,
@@ -1485,7 +1485,7 @@ describe("TaskManagerImplementation", () => {
         });
 
         const task1 = hre.tasks.getTask("task1");
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({}),
           HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION_URL,
           {
@@ -1520,7 +1520,7 @@ describe("TaskManagerImplementation", () => {
           ],
         });
 
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           hre.tasks.getTask("task1").run({}),
           HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
           {
@@ -1551,7 +1551,7 @@ describe("TaskManagerImplementation", () => {
           ],
         });
 
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           hre.tasks.getTask("task1").run({}),
           HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
           {
@@ -1579,7 +1579,7 @@ describe("TaskManagerImplementation", () => {
         });
 
         const task1 = hre.tasks.getTask("task1");
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({}),
           HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
           {
@@ -1608,7 +1608,7 @@ describe("TaskManagerImplementation", () => {
         });
 
         const task1 = hre.tasks.getTask("task1");
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           task1.run({}),
           HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
           {

--- a/v-next/core/test/internal/tasks/task-manager.ts
+++ b/v-next/core/test/internal/tasks/task-manager.ts
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import {
+  assertThrowsHardhatError,
+  assertThrowsHardhatErrorAsync,
+} from "@nomicfoundation/hardhat-test-utils";
 
 import { ArgumentType, globalOption } from "../../../src/config.js";
 import { createBaseHardhatRuntimeEnvironment } from "../../../src/index.js";
@@ -376,7 +380,7 @@ describe("TaskManagerImplementation", () => {
    */
   describe("errors", () => {
     it("should throw if there's a global option with the same name as a task option", async () => {
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -401,20 +405,19 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OPTION_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin1 is",
-            task: "task1",
-            option: "arg1",
-            globalOptionPluginId: "plugin2",
-          },
-        ),
+
+        HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OPTION_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin1 is",
+          task: "task1",
+          option: "arg1",
+          globalOptionPluginId: "plugin2",
+        },
       );
     });
 
     it("should throw if there's a global option with the same name as a task positional argument", async () => {
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -439,20 +442,19 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OPTION_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin1 is",
-            task: "task1",
-            option: "arg1",
-            globalOptionPluginId: "plugin2",
-          },
-        ),
+
+        HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OPTION_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin1 is",
+          task: "task1",
+          option: "arg1",
+          globalOptionPluginId: "plugin2",
+        },
       );
     });
 
     it("should throw if trying to add a task with an empty id", async () => {
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -471,12 +473,13 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID),
+        HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID,
+        {},
       );
     });
 
     it("should throw if trying to add a subtask for a task that doesn't exist", async () => {
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -493,18 +496,16 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.SUBTASK_WITHOUT_PARENT,
-          {
-            task: "task1",
-            subtask: "task1 subtask1",
-          },
-        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS.SUBTASK_WITHOUT_PARENT,
+        {
+          task: "task1",
+          subtask: "task1 subtask1",
+        },
       );
     });
 
     it("should throw if trying to add a task that already exists", async () => {
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -527,20 +528,18 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin2 is",
-            task: "task1",
-            definedByFragment: " by plugin plugin1",
-          },
-        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS.TASK_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin2 is",
+          task: "task1",
+          definedByFragment: " by plugin plugin1",
+        },
       );
     });
 
     it("should throw if trying to override a task that doesn't exist", async () => {
       // Empty id task will not be found as empty ids are not allowed
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -558,13 +557,14 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND, {
+        HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND,
+        {
           task: "",
-        }),
+        },
       );
 
       // task1 will not be found as it's not defined
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -577,15 +577,16 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND, {
+        HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND,
+        {
           task: "task1",
-        }),
+        },
       );
     });
 
     it("should throw if trying to override a task and there is a name clash with an existing option", async () => {
       // added argument clash with an existing option
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -608,18 +609,17 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin2 is",
-            option: "arg1",
-            task: "task1",
-          },
-        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS
+          .TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin2 is",
+          option: "arg1",
+          task: "task1",
+        },
       );
 
       // added flag clash with an existing option
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -642,20 +642,19 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin2 is",
-            option: "arg1",
-            task: "task1",
-          },
-        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS
+          .TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin2 is",
+          option: "arg1",
+          task: "task1",
+        },
       );
     });
 
     it("should throw if trying to override a task and there is a name clash with an exising flag argument", async () => {
       // added argument clash with an existing flag
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -678,18 +677,17 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin2 is",
-            option: "flag1",
-            task: "task1",
-          },
-        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS
+          .TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin2 is",
+          option: "flag1",
+          task: "task1",
+        },
       );
 
       // added flag clash with an existing flag
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -712,20 +710,19 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin2 is",
-            option: "flag1",
-            task: "task1",
-          },
-        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS
+          .TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin2 is",
+          option: "flag1",
+          task: "task1",
+        },
       );
     });
 
     it("should throw if trying to override a task and there is a name clash with an exising positional argument", async () => {
       // added argument clash with an existing positional argument
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -748,18 +745,17 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin2 is",
-            option: "arg1",
-            task: "task1",
-          },
-        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS
+          .TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin2 is",
+          option: "arg1",
+          task: "task1",
+        },
       );
 
       // added flag clash with an existing positional argument
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -782,20 +778,19 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin2 is",
-            option: "flag1",
-            task: "task1",
-          },
-        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS
+          .TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin2 is",
+          option: "flag1",
+          task: "task1",
+        },
       );
     });
 
     it("should throw if trying to override a task and there is a name clash with an exising variadic argument", async () => {
       // added argument clash with an existing variadic argument
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -818,18 +813,17 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin2 is",
-            option: "arg1",
-            task: "task1",
-          },
-        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS
+          .TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin2 is",
+          option: "arg1",
+          task: "task1",
+        },
       );
 
       // added flag clash with an existing variadic argument
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           plugins: [
             {
@@ -852,21 +846,20 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(
-          HardhatError.ERRORS.TASK_DEFINITIONS.TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
-          {
-            actorFragment: "Plugin plugin2 is",
-            option: "flag1",
-            task: "task1",
-          },
-        ),
+        HardhatError.ERRORS.TASK_DEFINITIONS
+          .TASK_OVERRIDE_OPTION_ALREADY_DEFINED,
+        {
+          actorFragment: "Plugin plugin2 is",
+          option: "flag1",
+          task: "task1",
+        },
       );
     });
 
     it("should throw if a plugins tries to override a task defined in the config", async () => {
       // this will fail as the config tasks are processed after
       // the plugin tasks so the override logic will not find task1
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         createBaseHardhatRuntimeEnvironment({
           tasks: [
             new NewTaskDefinitionBuilderImplementation("task1")
@@ -884,9 +877,10 @@ describe("TaskManagerImplementation", () => {
             },
           ],
         }),
-        new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND, {
+        HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND,
+        {
           task: "task1",
-        }),
+        },
       );
     });
   });
@@ -923,11 +917,12 @@ describe("TaskManagerImplementation", () => {
     it("should throw if the task doesn't exist", async () => {
       const hre = await createBaseHardhatRuntimeEnvironment({});
       // task1 will not be found as it's not defined
-      assert.throws(
+      assertThrowsHardhatError(
         () => hre.tasks.getTask("task1"),
-        new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND, {
+        HardhatError.ERRORS.TASK_DEFINITIONS.TASK_NOT_FOUND,
+        {
           task: "task1",
-        }),
+        },
       );
     });
   });
@@ -1289,11 +1284,12 @@ describe("TaskManagerImplementation", () => {
         });
 
         const task1 = hre.tasks.getTask("task1");
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({}),
-          new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK, {
+          HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK,
+          {
             task: "task1",
-          }),
+          },
         );
       });
 
@@ -1312,15 +1308,13 @@ describe("TaskManagerImplementation", () => {
         });
 
         const task1 = hre.tasks.getTask("task1");
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({ otherArg: "otherArgValue" }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
-            {
-              option: "otherArg",
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+          {
+            option: "otherArg",
+            task: "task1",
+          },
         );
       });
 
@@ -1344,48 +1338,42 @@ describe("TaskManagerImplementation", () => {
         const task1 = hre.tasks.getTask("task1");
 
         // option is missing
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({
             posArg: "posValue",
             varArg: ["varValue1", "varValue2"],
           }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
-            {
-              argument: "option",
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
+          {
+            argument: "option",
+            task: "task1",
+          },
         );
 
         // posArg is missing
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({
             option: "arg1Value",
             varArg: ["varValue1", "varValue2"],
           }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
-            {
-              argument: "posArg",
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
+          {
+            argument: "posArg",
+            task: "task1",
+          },
         );
 
         // varArg is missing
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({
             option: "arg1Value",
             posArg: "posValue",
           }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
-            {
-              argument: "varArg",
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
+          {
+            argument: "varArg",
+            task: "task1",
+          },
         );
       });
 
@@ -1418,75 +1406,67 @@ describe("TaskManagerImplementation", () => {
         const task1 = hre.tasks.getTask("task1");
 
         // option has the wrong type
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({
             option: "not a bigint",
             posArg: 10,
             varArg: ["file1", "file2", "file3"],
           }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
-            {
-              value: "not a bigint",
-              name: "option",
-              type: ArgumentType.BIGINT,
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
+          {
+            value: "not a bigint",
+            name: "option",
+            type: ArgumentType.BIGINT,
+            task: "task1",
+          },
         );
 
         // posArg has the wrong type
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({
             option: 5n,
             posArg: true,
             varArg: ["file1", "file2", "file3"],
           }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
-            {
-              value: true,
-              name: "posArg",
-              type: ArgumentType.INT,
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
+          {
+            value: true,
+            name: "posArg",
+            type: ArgumentType.INT,
+            task: "task1",
+          },
         );
 
         // varArg has the wrong type (not an array)
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({
             option: 5n,
             posArg: 10,
             varArg: "not an array",
           }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
-            {
-              value: "not an array",
-              name: "varArg",
-              type: ArgumentType.FILE,
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
+          {
+            value: "not an array",
+            name: "varArg",
+            type: ArgumentType.FILE,
+            task: "task1",
+          },
         );
 
         // varArg has the wrong type (array element has the wrong type)
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({
             option: 5n,
             posArg: 10,
             varArg: ["file1", 5, "file3"],
           }),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
-            {
-              value: ["file1", 5, "file3"],
-              name: "varArg",
-              type: ArgumentType.FILE,
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
+          {
+            value: ["file1", 5, "file3"],
+            name: "varArg",
+            type: ArgumentType.FILE,
+            task: "task1",
+          },
         );
       });
 
@@ -1505,15 +1485,13 @@ describe("TaskManagerImplementation", () => {
         });
 
         const task1 = hre.tasks.getTask("task1");
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({}),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION_URL,
-            {
-              action: "file://not-a-module",
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION_URL,
+          {
+            action: "file://not-a-module",
+            task: "task1",
+          },
         );
       });
 
@@ -1542,11 +1520,12 @@ describe("TaskManagerImplementation", () => {
           ],
         });
 
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           hre.tasks.getTask("task1").run({}),
-          new HardhatError(HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED, {
+          HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
+          {
             pluginId: "plugin1",
-          }),
+          },
         );
 
         // the missing dependency is used in the TASK_OVERRIDE action
@@ -1572,11 +1551,12 @@ describe("TaskManagerImplementation", () => {
           ],
         });
 
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           hre.tasks.getTask("task1").run({}),
-          new HardhatError(HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED, {
+          HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
+          {
             pluginId: "plugin2",
-          }),
+          },
         );
       });
 
@@ -1599,15 +1579,13 @@ describe("TaskManagerImplementation", () => {
         });
 
         const task1 = hre.tasks.getTask("task1");
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({}),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
-            {
-              action: actionUrl,
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
+          {
+            action: actionUrl,
+            task: "task1",
+          },
         );
       });
 
@@ -1630,15 +1608,13 @@ describe("TaskManagerImplementation", () => {
         });
 
         const task1 = hre.tasks.getTask("task1");
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           task1.run({}),
-          new HardhatError(
-            HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
-            {
-              action: actionUrl,
-              task: "task1",
-            },
-          ),
+          HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
+          {
+            action: actionUrl,
+            task: "task1",
+          },
         );
       });
     });

--- a/v-next/core/tsconfig.json
+++ b/v-next/core/tsconfig.json
@@ -9,6 +9,9 @@
     },
     {
       "path": "../hardhat-utils"
+    },
+    {
+      "path": "../hardhat-test-utils"
     }
   ]
 }

--- a/v-next/hardhat-test-utils/.eslintrc.cjs
+++ b/v-next/hardhat-test-utils/.eslintrc.cjs
@@ -1,3 +1,3 @@
 const { createConfig } = require("../../config-v-next/eslint.cjs");
 
-module.exports = createConfig(__filename);
+module.exports = createConfig(__filename, { enforceHardhatTestUtils: false });

--- a/v-next/hardhat-test-utils/src/hardhat-error.ts
+++ b/v-next/hardhat-test-utils/src/hardhat-error.ts
@@ -5,6 +5,14 @@ import assert from "node:assert/strict";
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import { ensureError } from "@ignored/hardhat-vnext-utils/error";
 
+/**
+ * Asserts that an error is a HardhatError with a certain descriptor and message
+ * arguments.
+ *
+ * @param error The error.
+ * @param descritor The error descriptor.
+ * @param messageArguments The message arguments.
+ */
 export function assertIsHardhatError<ErrorDescriptorT extends ErrorDescriptor>(
   error: unknown,
   descritor: ErrorDescriptorT,
@@ -25,6 +33,14 @@ export function assertIsHardhatError<ErrorDescriptorT extends ErrorDescriptor>(
   assert.deepEqual(error.messageArguments, messageArguments);
 }
 
+/**
+ * Asserts that calling a function throws a HardhatError with a certain
+ * descriptor and message arguments.
+ *
+ * @param f The function that should throw.
+ * @param descritor The error descriptor.
+ * @param messageArguments The message arguments.
+ */
 export function assertThrowsHardhatError<
   ErrorDescriptorT extends ErrorDescriptor,
 >(
@@ -44,18 +60,27 @@ export function assertThrowsHardhatError<
   assert.fail("Function did not throw any error");
 }
 
+/**
+ * Asserts that an async operation (i.e. calling an async function or a promise)
+ * gets rejected with a HardhatError with a certain descriptor and message
+ * arguments.
+ *
+ * @param op The async operation. If it's a function, it's called and awaited.
+ * @param descritor The error descriptor.
+ * @param messageArguments The message arguments.
+ */
 export async function assertRejectsWithHardhatError<
   ErrorDescriptorT extends ErrorDescriptor,
 >(
-  f: (() => Promise<any>) | Promise<any>,
+  op: (() => Promise<any>) | Promise<any>,
   descritor: ErrorDescriptorT,
   messageArguments: HardhatError<ErrorDescriptorT>["messageArguments"],
 ): Promise<void> {
   try {
-    if (f instanceof Promise) {
-      await f;
+    if (op instanceof Promise) {
+      await op;
     } else {
-      await f();
+      await op();
     }
   } catch (error) {
     ensureError(error);

--- a/v-next/hardhat-test-utils/src/hardhat-error.ts
+++ b/v-next/hardhat-test-utils/src/hardhat-error.ts
@@ -10,12 +10,12 @@ import { ensureError } from "@ignored/hardhat-vnext-utils/error";
  * arguments.
  *
  * @param error The error.
- * @param descritor The error descriptor.
+ * @param descriptor The error descriptor.
  * @param messageArguments The message arguments.
  */
 export function assertIsHardhatError<ErrorDescriptorT extends ErrorDescriptor>(
   error: unknown,
-  descritor: ErrorDescriptorT,
+  descriptor: ErrorDescriptorT,
   messageArguments: HardhatError<ErrorDescriptorT>["messageArguments"],
 ): asserts error is HardhatError<ErrorDescriptorT> {
   assert.ok(HardhatError.isHardhatError(error), "Error is not a HardhatError");
@@ -24,11 +24,11 @@ export function assertIsHardhatError<ErrorDescriptorT extends ErrorDescriptor>(
   // in case the descriptors are different.
   assert.equal(
     error.descriptor.number,
-    descritor.number,
-    `Expected error number ${descritor.number}, but got ${error.descriptor.number}`,
+    descriptor.number,
+    `Expected error number ${descriptor.number}, but got ${error.descriptor.number}`,
   );
 
-  assert.deepEqual(error.descriptor, descritor);
+  assert.deepEqual(error.descriptor, descriptor);
 
   assert.deepEqual(error.messageArguments, messageArguments);
 }
@@ -38,21 +38,21 @@ export function assertIsHardhatError<ErrorDescriptorT extends ErrorDescriptor>(
  * descriptor and message arguments.
  *
  * @param f The function that should throw.
- * @param descritor The error descriptor.
+ * @param descriptor The error descriptor.
  * @param messageArguments The message arguments.
  */
 export function assertThrowsHardhatError<
   ErrorDescriptorT extends ErrorDescriptor,
 >(
   f: () => any,
-  descritor: ErrorDescriptorT,
+  descriptor: ErrorDescriptorT,
   messageArguments: HardhatError<ErrorDescriptorT>["messageArguments"],
 ): void {
   try {
     f();
   } catch (error) {
     ensureError(error);
-    assertIsHardhatError(error, descritor, messageArguments);
+    assertIsHardhatError(error, descriptor, messageArguments);
 
     return;
   }
@@ -66,14 +66,14 @@ export function assertThrowsHardhatError<
  * arguments.
  *
  * @param op The async operation. If it's a function, it's called and awaited.
- * @param descritor The error descriptor.
+ * @param descriptor The error descriptor.
  * @param messageArguments The message arguments.
  */
 export async function assertRejectsWithHardhatError<
   ErrorDescriptorT extends ErrorDescriptor,
 >(
   op: (() => Promise<any>) | Promise<any>,
-  descritor: ErrorDescriptorT,
+  descriptor: ErrorDescriptorT,
   messageArguments: HardhatError<ErrorDescriptorT>["messageArguments"],
 ): Promise<void> {
   try {
@@ -84,7 +84,7 @@ export async function assertRejectsWithHardhatError<
     }
   } catch (error) {
     ensureError(error);
-    assertIsHardhatError(error, descritor, messageArguments);
+    assertIsHardhatError(error, descriptor, messageArguments);
 
     return;
   }

--- a/v-next/hardhat/test/hre/index.ts
+++ b/v-next/hardhat/test/hre/index.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
 
 import { resolveHardhatConfigPath } from "../../src/config.js";
 import { createHardhatRuntimeEnvironment } from "../../src/hre.js";
@@ -64,9 +65,10 @@ describe("HRE", () => {
       });
 
       it("should throw if the config file is not found", async () => {
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           resolveHardhatConfigPath(),
-          new HardhatError(HardhatError.ERRORS.GENERAL.NO_CONFIG_FILE_FOUND),
+          HardhatError.ERRORS.GENERAL.NO_CONFIG_FILE_FOUND,
+          {},
         );
       });
 

--- a/v-next/hardhat/test/hre/index.ts
+++ b/v-next/hardhat/test/hre/index.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
-import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { resolveHardhatConfigPath } from "../../src/config.js";
 import { createHardhatRuntimeEnvironment } from "../../src/hre.js";
@@ -65,7 +65,7 @@ describe("HRE", () => {
       });
 
       it("should throw if the config file is not found", async () => {
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           resolveHardhatConfigPath(),
           HardhatError.ERRORS.GENERAL.NO_CONFIG_FILE_FOUND,
           {},

--- a/v-next/hardhat/test/internal/builtin-plugins/run/runScriptWIthHardhat.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/run/runScriptWIthHardhat.ts
@@ -3,7 +3,7 @@ import type { HardhatRuntimeEnvironment } from "@ignored/hardhat-vnext-core/type
 import { before, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
-import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
 import runScriptWithHardhat from "../../../../src/internal/builtin-plugins/run/runScriptWithHardhat.js";
@@ -17,7 +17,7 @@ describe("runScriptWithHardhat", function () {
   });
 
   it("should throw if script is not a string", async function () {
-    await assertThrowsHardhatErrorAsync(
+    await assertRejectsWithHardhatError(
       runScriptWithHardhat({ script: 123, noCompile: false }, hre),
       HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR,
       {
@@ -27,7 +27,7 @@ describe("runScriptWithHardhat", function () {
   });
 
   it("should throw if noCompile is not a boolean", async function () {
-    await assertThrowsHardhatErrorAsync(
+    await assertRejectsWithHardhatError(
       runScriptWithHardhat({ script: "script.js", noCompile: 123 }, hre),
       HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR,
       {
@@ -40,7 +40,7 @@ describe("runScriptWithHardhat", function () {
     useFixtureProject("run-js-script");
 
     it("should throw if script does not exist", async function () {
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         runScriptWithHardhat(
           { script: "./scripts/non-existent.js", noCompile: false },
           hre,
@@ -60,7 +60,7 @@ describe("runScriptWithHardhat", function () {
     });
 
     it("should throw if the script throws", async function () {
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         runScriptWithHardhat(
           { script: "./scripts/throws.js", noCompile: false },
           hre,
@@ -78,7 +78,7 @@ describe("runScriptWithHardhat", function () {
     useFixtureProject("run-ts-script");
 
     it("should throw if script does not exist", async function () {
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         runScriptWithHardhat(
           { script: "./scripts/non-existent.ts", noCompile: false },
           hre,
@@ -98,7 +98,7 @@ describe("runScriptWithHardhat", function () {
     });
 
     it("should throw if the script throws", async function () {
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         runScriptWithHardhat(
           { script: "./scripts/throws.ts", noCompile: false },
           hre,

--- a/v-next/hardhat/test/internal/builtin-plugins/run/runScriptWIthHardhat.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/run/runScriptWIthHardhat.ts
@@ -1,9 +1,9 @@
 import type { HardhatRuntimeEnvironment } from "@ignored/hardhat-vnext-core/types/hre";
 
-import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
 
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
 import runScriptWithHardhat from "../../../../src/internal/builtin-plugins/run/runScriptWithHardhat.js";
@@ -17,20 +17,22 @@ describe("runScriptWithHardhat", function () {
   });
 
   it("should throw if script is not a string", async function () {
-    await assert.rejects(
+    await assertThrowsHardhatErrorAsync(
       runScriptWithHardhat({ script: 123, noCompile: false }, hre),
-      new HardhatError(HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR, {
+      HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR,
+      {
         message: "Expected script to be a string",
-      }),
+      },
     );
   });
 
   it("should throw if noCompile is not a boolean", async function () {
-    await assert.rejects(
+    await assertThrowsHardhatErrorAsync(
       runScriptWithHardhat({ script: "script.js", noCompile: 123 }, hre),
-      new HardhatError(HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR, {
+      HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR,
+      {
         message: "Expected noCompile to be a boolean",
-      }),
+      },
     );
   });
 
@@ -38,14 +40,15 @@ describe("runScriptWithHardhat", function () {
     useFixtureProject("run-js-script");
 
     it("should throw if script does not exist", async function () {
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         runScriptWithHardhat(
           { script: "./scripts/non-existent.js", noCompile: false },
           hre,
         ),
-        new HardhatError(HardhatError.ERRORS.BUILTIN_TASKS.RUN_FILE_NOT_FOUND, {
+        HardhatError.ERRORS.BUILTIN_TASKS.RUN_FILE_NOT_FOUND,
+        {
           script: "./scripts/non-existent.js",
-        }),
+        },
       );
     });
 
@@ -57,15 +60,16 @@ describe("runScriptWithHardhat", function () {
     });
 
     it("should throw if the script throws", async function () {
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         runScriptWithHardhat(
           { script: "./scripts/throws.js", noCompile: false },
           hre,
         ),
-        new HardhatError(HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR, {
+        HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
+        {
           script: "./scripts/throws.js",
           error: "broken script",
-        }),
+        },
       );
     });
   });
@@ -74,14 +78,15 @@ describe("runScriptWithHardhat", function () {
     useFixtureProject("run-ts-script");
 
     it("should throw if script does not exist", async function () {
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         runScriptWithHardhat(
           { script: "./scripts/non-existent.ts", noCompile: false },
           hre,
         ),
-        new HardhatError(HardhatError.ERRORS.BUILTIN_TASKS.RUN_FILE_NOT_FOUND, {
+        HardhatError.ERRORS.BUILTIN_TASKS.RUN_FILE_NOT_FOUND,
+        {
           script: "./scripts/non-existent.ts",
-        }),
+        },
       );
     });
 
@@ -93,15 +98,16 @@ describe("runScriptWithHardhat", function () {
     });
 
     it("should throw if the script throws", async function () {
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         runScriptWithHardhat(
           { script: "./scripts/throws.ts", noCompile: false },
           hre,
         ),
-        new HardhatError(HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR, {
+        HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
+        {
           script: "./scripts/throws.ts",
           error: "broken script",
-        }),
+        },
       );
     });
   });

--- a/v-next/hardhat/test/internal/cli/init/init.ts
+++ b/v-next/hardhat/test/internal/cli/init/init.ts
@@ -8,6 +8,7 @@ import {
   readUtf8File,
   remove,
 } from "@ignored/hardhat-vnext-utils/fs";
+import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
 
 import { initHardhat } from "../../../../src/internal/cli/init/init.js";
 import { EMPTY_HARDHAT_CONFIG } from "../../../../src/internal/cli/init/sample-config-file.js";
@@ -88,9 +89,10 @@ describe("init", function () {
       it("should throw an error because the project is not of type esm", async function () {
         process.env.HARDHAT_CREATE_EMPTY_TYPESCRIPT_HARDHAT_CONFIG = "true";
 
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           async () => initHardhat(),
-          new HardhatError(HardhatError.ERRORS.GENERAL.ONLY_ESM_SUPPORTED),
+          HardhatError.ERRORS.GENERAL.ONLY_ESM_SUPPORTED,
+          {},
         );
       });
     });
@@ -101,9 +103,10 @@ describe("init", function () {
       it("should throw an error because the project is not of type esm", async function () {
         process.env.HARDHAT_CREATE_EMPTY_TYPESCRIPT_HARDHAT_CONFIG = "true";
 
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           async () => initHardhat(),
-          new HardhatError(HardhatError.ERRORS.GENERAL.ONLY_ESM_SUPPORTED),
+          HardhatError.ERRORS.GENERAL.ONLY_ESM_SUPPORTED,
+          {},
         );
       });
     });
@@ -113,14 +116,12 @@ describe("init", function () {
     useFixtureProject("cli/init/already-in-hh-project");
 
     it("should fail because there is already a hardhat.config.ts file", async function () {
-      await assert.rejects(
+      await assertThrowsHardhatErrorAsync(
         async () => initHardhat(),
-        new HardhatError(
-          HardhatError.ERRORS.GENERAL.HARDHAT_PROJECT_ALREADY_CREATED,
-          {
-            hardhatProjectRootPath: await findClosestHardhatConfig(),
-          },
-        ),
+        HardhatError.ERRORS.GENERAL.HARDHAT_PROJECT_ALREADY_CREATED,
+        {
+          hardhatProjectRootPath: await findClosestHardhatConfig(),
+        },
       );
     });
   });
@@ -129,19 +130,17 @@ describe("init", function () {
     it("should fail because the command is not executed inside an interactive shell", async function () {
       if (process.platform === "win32") {
         // Test for windows CI
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           async () => initHardhat(),
-          new HardhatError(
-            HardhatError.ERRORS.GENERAL.NOT_INSIDE_PROJECT_ON_WINDOWS,
-          ),
+          HardhatError.ERRORS.GENERAL.NOT_INSIDE_PROJECT_ON_WINDOWS,
+          {},
         );
       } else {
         // Test for all others CI
-        await assert.rejects(
+        await assertThrowsHardhatErrorAsync(
           async () => initHardhat(),
-          new HardhatError(
-            HardhatError.ERRORS.GENERAL.NOT_IN_INTERACTIVE_SHELL,
-          ),
+          HardhatError.ERRORS.GENERAL.NOT_IN_INTERACTIVE_SHELL,
+          {},
         );
       }
     });

--- a/v-next/hardhat/test/internal/cli/init/init.ts
+++ b/v-next/hardhat/test/internal/cli/init/init.ts
@@ -8,7 +8,7 @@ import {
   readUtf8File,
   remove,
 } from "@ignored/hardhat-vnext-utils/fs";
-import { assertThrowsHardhatErrorAsync } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { initHardhat } from "../../../../src/internal/cli/init/init.js";
 import { EMPTY_HARDHAT_CONFIG } from "../../../../src/internal/cli/init/sample-config-file.js";
@@ -89,7 +89,7 @@ describe("init", function () {
       it("should throw an error because the project is not of type esm", async function () {
         process.env.HARDHAT_CREATE_EMPTY_TYPESCRIPT_HARDHAT_CONFIG = "true";
 
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           async () => initHardhat(),
           HardhatError.ERRORS.GENERAL.ONLY_ESM_SUPPORTED,
           {},
@@ -103,7 +103,7 @@ describe("init", function () {
       it("should throw an error because the project is not of type esm", async function () {
         process.env.HARDHAT_CREATE_EMPTY_TYPESCRIPT_HARDHAT_CONFIG = "true";
 
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           async () => initHardhat(),
           HardhatError.ERRORS.GENERAL.ONLY_ESM_SUPPORTED,
           {},
@@ -116,7 +116,7 @@ describe("init", function () {
     useFixtureProject("cli/init/already-in-hh-project");
 
     it("should fail because there is already a hardhat.config.ts file", async function () {
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         async () => initHardhat(),
         HardhatError.ERRORS.GENERAL.HARDHAT_PROJECT_ALREADY_CREATED,
         {
@@ -130,14 +130,14 @@ describe("init", function () {
     it("should fail because the command is not executed inside an interactive shell", async function () {
       if (process.platform === "win32") {
         // Test for windows CI
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           async () => initHardhat(),
           HardhatError.ERRORS.GENERAL.NOT_INSIDE_PROJECT_ON_WINDOWS,
           {},
         );
       } else {
         // Test for all others CI
-        await assertThrowsHardhatErrorAsync(
+        await assertRejectsWithHardhatError(
           async () => initHardhat(),
           HardhatError.ERRORS.GENERAL.NOT_IN_INTERACTIVE_SHELL,
           {},

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -22,6 +22,10 @@ import {
 } from "@ignored/hardhat-vnext-core/config";
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import { isCi } from "@ignored/hardhat-vnext-utils/ci";
+import {
+  assertThrowsHardhatError,
+  assertThrowsHardhatErrorAsync,
+} from "@nomicfoundation/hardhat-test-utils";
 import chalk from "chalk";
 
 import { createHardhatRuntimeEnvironment } from "../../../src/hre.js";
@@ -369,11 +373,10 @@ For global options help run: hardhat --help`;
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-      assert.rejects(
+      assertThrowsHardhatErrorAsync(
         async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
-        new HardhatError(
-          HardhatError.ERRORS.ARGUMENTS.CANNOT_COMBINE_INIT_AND_CONFIG_PATH,
-        ),
+        HardhatError.ERRORS.ARGUMENTS.CANNOT_COMBINE_INIT_AND_CONFIG_PATH,
+        {},
       );
     });
 
@@ -383,11 +386,12 @@ For global options help run: hardhat --help`;
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-      assert.rejects(
+      assertThrowsHardhatErrorAsync(
         async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
-        new HardhatError(HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME, {
+        HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME,
+        {
           name: "--config",
-        }),
+        },
       );
     });
 
@@ -397,9 +401,10 @@ For global options help run: hardhat --help`;
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-      assert.rejects(
+      assertThrowsHardhatErrorAsync(
         async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
-        new HardhatError(HardhatError.ERRORS.ARGUMENTS.MISSING_CONFIG_FILE),
+        HardhatError.ERRORS.ARGUMENTS.MISSING_CONFIG_FILE,
+        {},
       );
     });
   });
@@ -744,11 +749,12 @@ For global options help run: hardhat --help`;
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => parseTaskAndArguments(cliArguments, usedCliArguments, hre),
-          new HardhatError(HardhatError.ERRORS.ARGUMENTS.UNRECOGNIZED_OPTION, {
+          HardhatError.ERRORS.ARGUMENTS.UNRECOGNIZED_OPTION,
+          {
             option: "--undefinedArg",
-          }),
+          },
         );
       });
 
@@ -758,11 +764,12 @@ For global options help run: hardhat --help`;
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => parseTaskAndArguments(cliArguments, usedCliArguments, hre),
-          new HardhatError(HardhatError.ERRORS.ARGUMENTS.UNRECOGNIZED_OPTION, {
+          HardhatError.ERRORS.ARGUMENTS.UNRECOGNIZED_OPTION,
+          {
             option: "--arg",
-          }),
+          },
         );
       });
 
@@ -772,14 +779,12 @@ For global options help run: hardhat --help`;
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => parseTaskAndArguments(cliArguments, usedCliArguments, hre),
-          new HardhatError(
-            HardhatError.ERRORS.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
-            {
-              argument: "--arg",
-            },
-          ),
+          HardhatError.ERRORS.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+          {
+            argument: "--arg",
+          },
         );
       });
 
@@ -789,14 +794,12 @@ For global options help run: hardhat --help`;
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false, false, true, false];
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => parseTaskAndArguments(cliArguments, usedCliArguments, hre),
-          new HardhatError(
-            HardhatError.ERRORS.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
-            {
-              argument: "--arg",
-            },
-          ),
+          HardhatError.ERRORS.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+          {
+            argument: "--arg",
+          },
         );
       });
 
@@ -806,14 +809,12 @@ For global options help run: hardhat --help`;
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false];
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => parseTaskAndArguments(cliArguments, usedCliArguments, hre),
-          new HardhatError(
-            HardhatError.ERRORS.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
-            {
-              argument: "arg",
-            },
-          ),
+          HardhatError.ERRORS.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+          {
+            argument: "arg",
+          },
         );
       });
     });
@@ -975,14 +976,12 @@ For global options help run: hardhat --help`;
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false];
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => parseTaskAndArguments(cliArguments, usedCliArguments, hre),
-          new HardhatError(
-            HardhatError.ERRORS.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
-            {
-              argument: "arg",
-            },
-          ),
+          HardhatError.ERRORS.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+          {
+            argument: "arg",
+          },
         );
       });
     });
@@ -1050,14 +1049,12 @@ For global options help run: hardhat --help`;
         const cliArguments = command.split(" ").slice(2);
         const usedCliArguments = [false];
 
-        assert.throws(
+        assertThrowsHardhatError(
           () => parseTaskAndArguments(cliArguments, usedCliArguments, hre),
-          new HardhatError(
-            HardhatError.ERRORS.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
-            {
-              argument: "arg",
-            },
-          ),
+          HardhatError.ERRORS.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+          {
+            argument: "arg",
+          },
         );
       });
     });
@@ -1362,11 +1359,12 @@ For global options help run: hardhat --help`;
         const usedCliArguments = new Array(cliArguments.length).fill(false);
 
         // Throws because the flag argument does not expect values, so the "false" argument will not be consumed
-        assert.throws(
+        assertThrowsHardhatError(
           () => parseTaskAndArguments(cliArguments, usedCliArguments, hre),
-          new HardhatError(HardhatError.ERRORS.ARGUMENTS.UNUSED_ARGUMENT, {
+          HardhatError.ERRORS.ARGUMENTS.UNUSED_ARGUMENT,
+          {
             value: "<value>",
-          }),
+          },
         );
       });
     });

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -24,7 +24,7 @@ import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import { isCi } from "@ignored/hardhat-vnext-utils/ci";
 import {
   assertThrowsHardhatError,
-  assertThrowsHardhatErrorAsync,
+  assertRejectsWithHardhatError,
 } from "@nomicfoundation/hardhat-test-utils";
 import chalk from "chalk";
 
@@ -373,7 +373,7 @@ For global options help run: hardhat --help`;
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.ARGUMENTS.CANNOT_COMBINE_INIT_AND_CONFIG_PATH,
         {},
@@ -386,7 +386,7 @@ For global options help run: hardhat --help`;
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME,
         {
@@ -401,7 +401,7 @@ For global options help run: hardhat --help`;
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-      await assertThrowsHardhatErrorAsync(
+      await assertRejectsWithHardhatError(
         async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.ARGUMENTS.MISSING_CONFIG_FILE,
         {},

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -373,7 +373,7 @@ For global options help run: hardhat --help`;
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-      assertThrowsHardhatErrorAsync(
+      await assertThrowsHardhatErrorAsync(
         async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.ARGUMENTS.CANNOT_COMBINE_INIT_AND_CONFIG_PATH,
         {},
@@ -386,7 +386,7 @@ For global options help run: hardhat --help`;
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-      assertThrowsHardhatErrorAsync(
+      await assertThrowsHardhatErrorAsync(
         async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME,
         {
@@ -401,7 +401,7 @@ For global options help run: hardhat --help`;
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
-      assertThrowsHardhatErrorAsync(
+      await assertThrowsHardhatErrorAsync(
         async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.ARGUMENTS.MISSING_CONFIG_FILE,
         {},


### PR DESCRIPTION
This PR adds new `eslint` rules to forbid the error-related assertions that `node:assert/strict` has, and forces us to use our own instead.

It also fixies all the new linter errors, so it's a large and repetitive PR.