### PR TITLE
Adds logic for forcing through verification when is verified check fails

### DIFF
--- a/.changeset/fuzzy-eyes-collect.md
+++ b/.changeset/fuzzy-eyes-collect.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-verify": patch
 ---
 
-Makes force flag comprehensive enough to cover failing optional calls
+Make the `--force` flag override the check of any existing verification, even in the presence of errors.

--- a/.changeset/fuzzy-eyes-collect.md
+++ b/.changeset/fuzzy-eyes-collect.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Makes force flag comprehensive enough to cover failing optional calls

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -27,6 +27,7 @@ import {
   UnexpectedNumberOfFilesError,
   VerificationAPIUnexpectedMessageError,
   ContractAlreadyVerifiedError,
+  NetworkRequestError,
 } from "../errors";
 import { Etherscan } from "../etherscan";
 import { Bytecode } from "../solc/bytecode";
@@ -102,7 +103,15 @@ subtask(TASK_VERIFY_ETHERSCAN)
       chainConfig
     );
 
-    const isVerified = await etherscan.isVerified(address);
+    let isVerified = false
+    try {
+      isVerified = await etherscan.isVerified(address);
+    } catch (err) {
+      if (!force || err instanceof NetworkRequestError) {
+        throw err
+      }
+      // https://github.com/blockscout/blockscout/issues/9001
+    }
     if (!force && isVerified) {
       const contractURL = etherscan.getContractUrl(address);
       console.log(`The contract ${address} has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.

--- a/packages/hardhat-verify/src/internal/tasks/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/tasks/etherscan.ts
@@ -103,12 +103,12 @@ subtask(TASK_VERIFY_ETHERSCAN)
       chainConfig
     );
 
-    let isVerified = false
+    let isVerified = false;
     try {
       isVerified = await etherscan.isVerified(address);
     } catch (err) {
       if (!force || err instanceof NetworkRequestError) {
-        throw err
+        throw err;
       }
       // https://github.com/blockscout/blockscout/issues/9001
     }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
There is a bug in blockscout's latest releases. It has been around for quite a while. Unfortunately it only happens in certain situations. The [issue](https://github.com/blockscout/blockscout/issues/9001) is that an `isVerified` check will fail if the backend is put into a certain state. The easy way around this would simply be to include that set of errors / states to be ignored when provided a force flag. 

I do not think that hardhat verify should cover all of the quirks of the many backends that are bound to emerge into eternity, however, I think that the force flag being more comprehensive (less narrowly applied) than it currently is could be a reasonable middle ground, provided that it does not run afoul of any eip's.