### PR TITLE
Upgrade to EDR v0.5 and add `enableRip7212` option

### DIFF
--- a/.changeset/great-crabs-hug.md
+++ b/.changeset/great-crabs-hug.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added an `enableRip7212` optional flag to the Hardhat Network config that enables [RIP-7212 (Precompile for secp256r1 Curve Support)](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md).

--- a/.changeset/modern-points-cover.md
+++ b/.changeset/modern-points-cover.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Bumped EDR to [v0.5.0](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.5.0).

--- a/docs/src/content/hardhat-network/docs/reference/index.md
+++ b/docs/src/content/hardhat-network/docs/reference/index.md
@@ -122,6 +122,10 @@ The `baseFeePerGas` of the first block. Note that when forking a remote network,
 
 The address used as coinbase in new blocks. Default value: `"0xc014ba5ec014ba5ec014ba5ec014ba5ec014ba5e"`.
 
+#### `enableRip7212`
+
+A flag indicating whether to enable [RIP-7212 (Precompile for secp256r1 Curve Support)](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md). Default value: `false`.
+
 ### Mining modes
 
 You can configure the mining behavior under your Hardhat Network settings:

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.1.2",
     "@metamask/eth-sig-util": "^4.0.0",
-    "@nomicfoundation/edr": "^0.4.2",
+    "@nomicfoundation/edr": "^0.5.0",
     "@nomicfoundation/ethereumjs-common": "4.0.4",
     "@nomicfoundation/ethereumjs-tx": "5.0.4",
     "@nomicfoundation/ethereumjs-util": "9.0.4",

--- a/packages/hardhat-core/src/internal/core/providers/construction.ts
+++ b/packages/hardhat-core/src/internal/core/providers/construction.ts
@@ -114,6 +114,7 @@ export async function createProvider(
           paths !== undefined ? getForkCacheDirPath(paths) : undefined,
         enableTransientStorage:
           hardhatNetConfig.enableTransientStorage ?? false,
+        enableRip7212: hardhatNetConfig.enableRip7212 ?? false,
       },
       {
         enabled: hardhatNetConfig.loggingEnabled,

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -120,6 +120,7 @@ interface HardhatNetworkProviderConfig {
   forkConfig?: ForkConfig;
   forkCachePath?: string;
   enableTransientStorage: boolean;
+  enableRip7212: boolean;
 }
 
 export function getNodeConfig(
@@ -255,7 +256,7 @@ export class EdrProviderWrapper
         }),
         cacheDir: config.forkCachePath,
         coinbase: Buffer.from(coinbase.slice(2), "hex"),
-        enableRip7212: false,
+        enableRip7212: config.enableRip7212,
         fork,
         hardfork: ethereumsjsHardforkToEdrSpecId(hardforkName),
         genesisAccounts: config.genesisAccounts.map((account) => {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -255,6 +255,7 @@ export class EdrProviderWrapper
         }),
         cacheDir: config.forkCachePath,
         coinbase: Buffer.from(coinbase.slice(2), "hex"),
+        enableRip7212: false,
         fork,
         hardfork: ethereumsjsHardforkToEdrSpecId(hardforkName),
         genesisAccounts: config.genesisAccounts.map((account) => {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/exit.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/exit.ts
@@ -24,6 +24,7 @@ export class Exit {
       case SuccessReason.Stop:
       case SuccessReason.Return:
       case SuccessReason.SelfDestruct:
+      case SuccessReason.EofReturnContract:
         return new Exit(ExitCode.SUCCESS);
     }
 

--- a/packages/hardhat-core/src/types/config.ts
+++ b/packages/hardhat-core/src/types/config.ts
@@ -58,6 +58,7 @@ export interface HardhatNetworkUserConfig {
   coinbase?: string;
   chains?: HardhatNetworkChainsUserConfig;
   enableTransientStorage?: boolean;
+  enableRip7212?: boolean;
 }
 
 export type HardhatNetworkAccountsUserConfig =
@@ -155,6 +156,7 @@ export interface HardhatNetworkConfig {
   chains: HardhatNetworkChainsConfig;
   allowBlocksWithSameTimestamp?: boolean;
   enableTransientStorage?: boolean;
+  enableRip7212?: boolean;
 }
 
 export type HardhatNetworkAccountsConfig =

--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/useProvider.ts
@@ -101,6 +101,7 @@ export function useProvider({
         coinbase,
         allowBlocksWithSameTimestamp,
         enableTransientStorage: false,
+        enableRip7212: false,
       },
       {
         enabled: loggerEnabled,

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/execution.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/execution.ts
@@ -53,6 +53,7 @@ export async function instantiateProvider(
     coinbase: "0x0000000000000000000000000000000000000000",
     initialBaseFeePerGas: 0,
     enableTransientStorage: false,
+    enableRip7212: false,
   };
 
   const provider = await EdrProviderWrapper.create(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,8 +201,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
       '@nomicfoundation/edr':
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: ^0.5.0
+        version: 0.5.0
       '@nomicfoundation/ethereumjs-common':
         specifier: 4.0.4
         version: 4.0.4
@@ -2332,36 +2332,36 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.4.2':
-    resolution: {integrity: sha512-S+hhepupfqpBvMa9M1PVS08sVjGXsLnjyAsjhrrsjsNuTHVLhKzhkguvBD5g4If5skrwgOaVqpag4wnQbd15kQ==}
+  '@nomicfoundation/edr-darwin-arm64@0.5.0':
+    resolution: {integrity: sha512-G6OX/PESdfU4ZOyJ4MDh4eevW0wt2mduuxA+thXtTcStOiQTtPuV205h4kLOR5wRB1Zz6Zy0LedTMax7TzOtGw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-darwin-x64@0.4.2':
-    resolution: {integrity: sha512-/zM94AUrXz6CmcsecRNHJ50jABDUFafmGc4iBmkfX/mTp4tVZj7XTyIogrQIt0FnTaeb4CgZoLap2+8tW/Uldg==}
+  '@nomicfoundation/edr-darwin-x64@0.5.0':
+    resolution: {integrity: sha512-fI7uHfHqPtdPZjkFUTpotc/F5gGv41ws+jSZy9+2AR9RDMOAIXMEArOx9rGLBcevWu8SFnyH/l/77kG/5FXbDw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.4.2':
-    resolution: {integrity: sha512-TV3Pr2tFvvmCfPCi9PaCGLtqn+oLaPKfL2NWpnoCeFFdzDQXi2L930yP1oUPY5RXd78NLdVHMkEkbhb2b6Wuvg==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.5.0':
+    resolution: {integrity: sha512-eMC3sWPkBZILg2/YB4Xv6IR0nggCLt5hS8K8jjHeGEeUs9pf8poBF2Oy+G4lSu0YLLjexGzHypz9/P+pIuxZHw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.4.2':
-    resolution: {integrity: sha512-PALwrLBk1M9rolXyhSX8xdhe5jL0qf/PgiCIF7W7lUyVKrI/I0oiU0EHDk/Xw7yi2UJg4WRyhhZoHYa0g4g8Qg==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.5.0':
+    resolution: {integrity: sha512-yPK0tKjYRxe5ktggFr8aBHH0DCI9uafuaD8QuzyrQAfSf/m/ebTdgthROdbYp6eRk5mJyfAQT/45fM3tnlYsWw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.4.2':
-    resolution: {integrity: sha512-5svkftypDjAZ1LxV1onojlaqPRxrTEjJLkrUwLL+Fao5ZMe7aTnk5QQ1Jv76gW6WYZnMXNgjPhRcnw3oSNrqFA==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.5.0':
+    resolution: {integrity: sha512-Hds8CRYi4DEyuErjcwUNSvNpMzmOYUihW4qYCoKgSBUVS5saX1PyPYvFYuYpeU5J8/T2iMk6yAPVLCxtKbgnKg==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.4.2':
-    resolution: {integrity: sha512-qiMlXQTggdH9zfOB4Eil4rQ95z8s7QdLJcOfz5Aym12qJNkCyF9hi4cc4dDCWA0CdI3x3oLbuf8qb81SF8R45w==}
+  '@nomicfoundation/edr-linux-x64-musl@0.5.0':
+    resolution: {integrity: sha512-1hXMDSzdyh5ojwO3ZSRbt7t5KKYycGUlFdC3lgJRZ7gStB8xjb7RA3hZn2csn9OydS950Ne4nh+puNq91iXApw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.4.2':
-    resolution: {integrity: sha512-hDkAb0iaMmGYwBY/rA1oCX8VpsezfQcHPEPIEGXEcWC3WbnOgIZo0Qkpu/g0OMtFOJSQlWLXvKZuV7blhnrQag==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.5.0':
+    resolution: {integrity: sha512-CFagD423400xXkRmACIR13FoocN48qi4ogRnuFQIvBDtEE3aMEajfFj4bycmQQDqnqChsZy/jwD4OxbX6oaNJw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr@0.4.2':
-    resolution: {integrity: sha512-U7v0HuZHfrsl/5FpUzuB2FYA0+FUglHHwiO6NhvLtNYKMZcPzdS6iUriMp/7GWs0SVxW3bAht9GinZPxdhVwWg==}
+  '@nomicfoundation/edr@0.5.0':
+    resolution: {integrity: sha512-nAUyjGhxntXje/1AkDX9POfH+pqUxdi4XHzIhaf/dJYs7fgAFxL3STBK1OYcA3LR7vtiylLHMz7wxjqLzlLGKg==}
     engines: {node: '>= 18'}
 
   '@nomicfoundation/ethereumjs-block@5.0.4':
@@ -8150,29 +8150,29 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.4.2': {}
+  '@nomicfoundation/edr-darwin-arm64@0.5.0': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.4.2': {}
+  '@nomicfoundation/edr-darwin-x64@0.5.0': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.4.2': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.5.0': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.4.2': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.5.0': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.4.2': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.5.0': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.4.2': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.5.0': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.4.2': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.5.0': {}
 
-  '@nomicfoundation/edr@0.4.2':
+  '@nomicfoundation/edr@0.5.0':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.4.2
-      '@nomicfoundation/edr-darwin-x64': 0.4.2
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.4.2
-      '@nomicfoundation/edr-linux-arm64-musl': 0.4.2
-      '@nomicfoundation/edr-linux-x64-gnu': 0.4.2
-      '@nomicfoundation/edr-linux-x64-musl': 0.4.2
-      '@nomicfoundation/edr-win32-x64-msvc': 0.4.2
+      '@nomicfoundation/edr-darwin-arm64': 0.5.0
+      '@nomicfoundation/edr-darwin-x64': 0.5.0
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.5.0
+      '@nomicfoundation/edr-linux-arm64-musl': 0.5.0
+      '@nomicfoundation/edr-linux-x64-gnu': 0.5.0
+      '@nomicfoundation/edr-linux-x64-musl': 0.5.0
+      '@nomicfoundation/edr-win32-x64-msvc': 0.5.0
 
   '@nomicfoundation/ethereumjs-block@5.0.4':
     dependencies:


### PR DESCRIPTION
This PR upgrades EDR to v0.5 which includes support for EIP-7212.

Closes https://github.com/NomicFoundation/edr/issues/523.