### PR TITLE
Task fixes

### DIFF
--- a/v-next/core/src/internal/tasks/utils.ts
+++ b/v-next/core/src/internal/tasks/utils.ts
@@ -9,9 +9,3 @@ export function formatTaskId(taskId: string | string[]): string {
 export function getActorFragment(pluginId: string | undefined): string {
   return pluginId !== undefined ? `Plugin ${pluginId} is` : "You are";
 }
-
-const FILE_PROTOCOL_PATTERN = /^file:\/\/.+/;
-
-export function isValidActionUrl(action: string): boolean {
-  return FILE_PROTOCOL_PATTERN.test(action);
-}

--- a/v-next/core/src/internal/tasks/validations.ts
+++ b/v-next/core/src/internal/tasks/validations.ts
@@ -1,0 +1,151 @@
+import type {
+  ArgumentType,
+  ArgumentValue,
+  OptionDefinition,
+  PositionalArgumentDefinition,
+} from "../../types/arguments.js";
+
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
+
+import {
+  isArgumentNameValid,
+  isArgumentValueValid,
+  RESERVED_ARGUMENT_NAMES,
+} from "../arguments.js";
+
+import { formatTaskId } from "./utils.js";
+
+export function validateId(id: string | string[]): void {
+  if (id.length === 0) {
+    throw new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK_ID);
+  }
+}
+
+export function validateAction(action: unknown): void {
+  if (typeof action === "string" && !isValidActionUrl(action)) {
+    throw new HardhatError(
+      HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_FILE_ACTION,
+      {
+        action,
+      },
+    );
+  }
+}
+
+export function validateOption(
+  optionDefinition: OptionDefinition,
+  usedNames: Set<string>,
+  taskId: string | string[],
+): void {
+  validateArgumentName(optionDefinition.name);
+
+  if (usedNames.has(optionDefinition.name)) {
+    throw new HardhatError(HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME, {
+      name: optionDefinition.name,
+    });
+  }
+
+  validateArgumentValue({
+    name: "defaultValue",
+    value: optionDefinition.defaultValue,
+    expectedType: optionDefinition.type,
+    taskId: formatTaskId(taskId),
+  });
+
+  usedNames.add(optionDefinition.name);
+}
+
+export function validatePositionalArgument(
+  positionalArgDef: PositionalArgumentDefinition,
+  usedNames: Set<string>,
+  taskId: string | string[],
+  lastArg?: PositionalArgumentDefinition,
+): void {
+  validateArgumentName(positionalArgDef.name);
+
+  if (usedNames.has(positionalArgDef.name)) {
+    throw new HardhatError(HardhatError.ERRORS.ARGUMENTS.DUPLICATED_NAME, {
+      name: positionalArgDef.name,
+    });
+  }
+
+  if (positionalArgDef.defaultValue !== undefined) {
+    validateArgumentValue({
+      name: "defaultValue",
+      value: positionalArgDef.defaultValue,
+      isVariadic: positionalArgDef.isVariadic,
+      expectedType: positionalArgDef.type,
+      taskId: formatTaskId(taskId),
+    });
+  }
+
+  if (lastArg !== undefined && lastArg.isVariadic) {
+    throw new HardhatError(
+      HardhatError.ERRORS.TASK_DEFINITIONS.POSITIONAL_ARG_AFTER_VARIADIC,
+      {
+        name: positionalArgDef.name,
+      },
+    );
+  }
+
+  if (
+    lastArg !== undefined &&
+    lastArg.defaultValue !== undefined &&
+    positionalArgDef.defaultValue === undefined
+  ) {
+    throw new HardhatError(
+      HardhatError.ERRORS.TASK_DEFINITIONS.REQUIRED_ARG_AFTER_OPTIONAL,
+      {
+        name: positionalArgDef.name,
+      },
+    );
+  }
+
+  usedNames.add(positionalArgDef.name);
+}
+
+const FILE_PROTOCOL_PATTERN = /^file:\/\/.+/;
+
+function isValidActionUrl(action: string): boolean {
+  return FILE_PROTOCOL_PATTERN.test(action);
+}
+
+function validateArgumentName(name: string): void {
+  if (!isArgumentNameValid(name)) {
+    throw new HardhatError(HardhatError.ERRORS.ARGUMENTS.INVALID_NAME, {
+      name,
+    });
+  }
+
+  if (RESERVED_ARGUMENT_NAMES.has(name)) {
+    throw new HardhatError(HardhatError.ERRORS.ARGUMENTS.RESERVED_NAME, {
+      name,
+    });
+  }
+}
+
+function validateArgumentValue({
+  name,
+  expectedType,
+  isVariadic = false,
+  value,
+  taskId,
+}: {
+  name: string;
+  expectedType: ArgumentType;
+  isVariadic?: boolean;
+  value: ArgumentValue | ArgumentValue[];
+  taskId: string | string[];
+}): void {
+  if (!isArgumentValueValid(expectedType, value, isVariadic)) {
+    throw new HardhatError(
+      HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_VALUE_FOR_TYPE,
+      {
+        value,
+        name,
+        type: expectedType,
+        task: formatTaskId(taskId),
+      },
+    );
+  }
+}

--- a/v-next/core/src/types/arguments.ts
+++ b/v-next/core/src/types/arguments.ts
@@ -57,7 +57,7 @@ export type ArgumentTypeToValueType<T extends ArgumentType> =
 export interface OptionDefinition<T extends ArgumentType = ArgumentType> {
   name: string;
   description: string;
-  type: ArgumentType;
+  type: T;
   defaultValue: ArgumentTypeToValueType<T>;
 }
 

--- a/v-next/core/test/internal/tasks/task-manager.ts
+++ b/v-next/core/test/internal/tasks/task-manager.ts
@@ -1102,6 +1102,7 @@ describe("TaskManagerImplementation", () => {
             tasks: [
               new NewTaskDefinitionBuilderImplementation("task1")
                 .addOption({ name: "arg1", defaultValue: "default" })
+                .addOption({ name: "withDefault", defaultValue: "default" })
                 .addFlag({ name: "flag1" })
                 .addPositionalArgument({ name: "posArg" })
                 .addVariadicArgument({ name: "varArg" })
@@ -1111,6 +1112,7 @@ describe("TaskManagerImplementation", () => {
                     flag1: true,
                     posArg: "posValue",
                     varArg: ["varValue1", "varValue2"],
+                    withDefault: "default",
                   });
                 })
                 .build(),
@@ -1132,16 +1134,31 @@ describe("TaskManagerImplementation", () => {
           },
         ],
       });
-
-      const task1 = hre.tasks.getTask("task1");
-      await task1.run({
+      // withDefault option is intentionally omitted
+      const providedArgs = {
         arg1: "arg1Value",
         flag1: true,
         posArg: "posValue",
         varArg: ["varValue1", "varValue2"],
         arg2: "arg2Value",
         flag2: true,
-      });
+      };
+
+      const task1 = hre.tasks.getTask("task1");
+      await task1.run(providedArgs);
+      // Ensure withDefault is not added to the args
+      assert.deepEqual(
+        providedArgs,
+        {
+          arg1: "arg1Value",
+          flag1: true,
+          posArg: "posValue",
+          varArg: ["varValue1", "varValue2"],
+          arg2: "arg2Value",
+          flag2: true,
+        },
+        "Expected the providedArgs to not change",
+      );
     });
 
     it("should run a task with arguments and resolve their default values", async () => {

--- a/v-next/core/test/internal/tasks/utils.ts
+++ b/v-next/core/test/internal/tasks/utils.ts
@@ -1,10 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import {
-  formatTaskId,
-  isValidActionUrl,
-} from "../../../src/internal/tasks/utils.js";
+import { formatTaskId } from "../../../src/internal/tasks/utils.js";
 
 describe("Task utils", () => {
   describe("formatTaskId", () => {
@@ -14,18 +11,6 @@ describe("Task utils", () => {
 
     it("should return the input joined by a space if it is an array", () => {
       assert.equal(formatTaskId(["foo", "bar"]), "foo bar");
-    });
-  });
-
-  describe("isValidActionUrl", () => {
-    it("should return true if the action is a file URL", () => {
-      assert.equal(isValidActionUrl("file://foo"), true);
-    });
-
-    it("should return false if the action is not a file URL", () => {
-      assert.equal(isValidActionUrl("http://foo"), false);
-      assert.equal(isValidActionUrl("file://"), false);
-      assert.equal(isValidActionUrl("missing-protocol"), false);
     });
   });
 });


### PR DESCRIPTION
This PR includes 3 unrelated fixes for tasks that were discussed with Pato in a previous PR. These can be reviewed commit by commit:

1. Ensure the `taskArguments` provided to the `run` method are not modified. Previously, this could happen when a default value was assigned to a missing argument.
2. Fix a type error in the `OptionDefinition`.
3. Validate the task object in the `TaskManager`. This is needed because the user can provide a plain task object instead of using the builders, skipping the validations.