### PR TITLE
[WIP] Project root resolution

### DIFF
--- a/v-next/core/src/index.ts
+++ b/v-next/core/src/index.ts
@@ -15,6 +15,9 @@ import { HardhatRuntimeEnvironmentImplementation } from "./internal/hre.js";
  * @param config - The user's Hardhat configuration.
  * @param userProvidedGlobalOptions - The global options provided by the
  *  user.
+ * @param projectRoot - The root of the Hardhat project. Hardhat expects this
+ * to be the root of the npm project containing your config file. If none is
+ * provided, it will use the root of the npm project that contains the CWD.
  * @param unsafeOptions - Options used to bypass some initialization, to avoid
  *  redoing it in the CLI. Should only be used in the official CLI.
  * @returns The Hardhat Runtime Environment.
@@ -22,11 +25,13 @@ import { HardhatRuntimeEnvironmentImplementation } from "./internal/hre.js";
 export async function createBaseHardhatRuntimeEnvironment(
   config: HardhatUserConfig,
   userProvidedGlobalOptions: Partial<GlobalOptions> = {},
+  projectRoot?: string,
   unsafeOptions?: UnsafeHardhatRuntimeEnvironmentOptions,
 ): Promise<HardhatRuntimeEnvironment> {
   return HardhatRuntimeEnvironmentImplementation.create(
     config,
     userProvidedGlobalOptions,
+    projectRoot,
     unsafeOptions,
   );
 }

--- a/v-next/core/src/index.ts
+++ b/v-next/core/src/index.ts
@@ -36,6 +36,7 @@ export async function createBaseHardhatRuntimeEnvironment(
   );
 }
 
+export { resolveProjectRoot } from "./internal/hre.js";
 export { parseArgumentValue } from "./internal/arguments.js";
 export { resolvePluginList } from "./internal/plugins/resolve-plugin-list.js";
 export { buildGlobalOptionDefinitions } from "./internal/global-options.js";

--- a/v-next/core/src/internal/hook-manager.ts
+++ b/v-next/core/src/internal/hook-manager.ts
@@ -17,7 +17,11 @@ import {
   assertHardhatInvariant,
 } from "@ignored/hardhat-vnext-errors";
 
+import { detectPluginNpmDependencyProblems } from "./plugins/detect-plugin-npm-dependency-problems.js";
+
 export class HookManagerImplementation implements HookManager {
+  readonly #projectRoot: string;
+
   readonly #pluginsInReverseOrder: HardhatPlugin[];
 
   /**
@@ -44,7 +48,8 @@ export class HookManagerImplementation implements HookManager {
     Array<Partial<HardhatHooks[keyof HardhatHooks]>>
   > = new Map();
 
-  constructor(plugins: HardhatPlugin[]) {
+  constructor(projectRoot: string, plugins: HardhatPlugin[]) {
+    this.#projectRoot = projectRoot;
     this.#pluginsInReverseOrder = plugins.toReversed();
   }
 
@@ -252,7 +257,7 @@ export class HookManagerImplementation implements HookManager {
 
         if (typeof hookHandlerCategoryFactory === "string") {
           hookCategory = await this.#loadHookCategoryFactory(
-            plugin.id,
+            plugin,
             hookCategoryName,
             hookHandlerCategoryFactory,
           );
@@ -288,7 +293,7 @@ export class HookManagerImplementation implements HookManager {
   }
 
   async #loadHookCategoryFactory<HookCategoryNameT extends keyof HardhatHooks>(
-    pluginId: string,
+    plugin: HardhatPlugin,
     hookCategoryName: HookCategoryNameT,
     path: string,
   ): Promise<Partial<HardhatHooks[HookCategoryNameT]>> {
@@ -296,27 +301,34 @@ export class HookManagerImplementation implements HookManager {
       throw new HardhatError(
         HardhatError.ERRORS.HOOKS.INVALID_HOOK_FACTORY_PATH,
         {
-          pluginId,
+          pluginId: plugin.id,
           hookCategoryName,
           path,
         },
       );
     }
 
-    const mod = await import(path);
+    let mod;
+
+    try {
+      mod = await import(path);
+    } catch (error) {
+      await detectPluginNpmDependencyProblems(plugin, this.#projectRoot);
+      throw error;
+    }
 
     const factory = mod.default;
 
     assertHardhatInvariant(
       typeof factory === "function",
-      `Plugin ${pluginId} doesn't export a hook factory for category ${hookCategoryName} in ${path}`,
+      `Plugin ${plugin.id} doesn't export a hook factory for category ${hookCategoryName} in ${path}`,
     );
 
     const category = await factory();
 
     assertHardhatInvariant(
       category !== null && typeof category === "object",
-      `Plugin ${pluginId} doesn't export a valid factory for category ${hookCategoryName} in ${path}, it didn't return an object`,
+      `Plugin ${plugin.id} doesn't export a valid factory for category ${hookCategoryName} in ${path}, it didn't return an object`,
     );
 
     return category;

--- a/v-next/core/src/internal/hook-manager.ts
+++ b/v-next/core/src/internal/hook-manager.ts
@@ -313,7 +313,7 @@ export class HookManagerImplementation implements HookManager {
     try {
       mod = await import(path);
     } catch (error) {
-      await detectPluginNpmDependencyProblems(plugin, this.#projectRoot);
+      await detectPluginNpmDependencyProblems(this.#projectRoot, plugin);
       throw error;
     }
 

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -75,14 +75,20 @@ export class HardhatRuntimeEnvironmentImplementation
     // Resolve config
 
     const resolvedConfig = await resolveUserConfig(
+      resolvedProjectRoot,
       hooks,
       resolvedPlugins,
       inputUserConfig,
     );
 
-    // We override the plugins, as we want to prevent plugins from changing this
-    const config = {
+    // We override the plugins and the proejct root, as we want to prevent
+    // the plugins from changing them
+    const config: HardhatConfig = {
       ...resolvedConfig,
+      paths: {
+        ...resolvedConfig.paths,
+        root: resolvedProjectRoot,
+      },
       plugins: resolvedPlugins,
     };
 
@@ -181,6 +187,7 @@ async function validateUserConfig(
 }
 
 async function resolveUserConfig(
+  projectRoot: string,
   hooks: HookManager,
   sortedPlugins: HardhatPlugin[],
   config: HardhatUserConfig,
@@ -188,6 +195,9 @@ async function resolveUserConfig(
   const initialResolvedConfig: HardhatConfig = {
     plugins: sortedPlugins,
     tasks: config.tasks ?? [],
+    paths: {
+      root: projectRoot,
+    },
   };
 
   return hooks.runHandlerChain(

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -42,9 +42,12 @@ export class HardhatRuntimeEnvironmentImplementation
 
     const resolvedPlugins =
       unsafeOptions?.resolvedPlugins ??
-      (await resolvePluginList(inputUserConfig.plugins, resolvedProjectRoot));
+      (await resolvePluginList(resolvedProjectRoot, inputUserConfig.plugins));
 
-    const hooks = new HookManagerImplementation(resolvedPlugins);
+    const hooks = new HookManagerImplementation(
+      resolvedProjectRoot,
+      resolvedPlugins,
+    );
 
     // extend user config:
     const extendedUserConfig = await runUserConfigExtensions(

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -14,10 +14,8 @@ import type { HardhatPlugin } from "../types/plugins.js";
 import type { TaskManager } from "../types/tasks.js";
 import type { UserInterruptionManager } from "../types/user-interruptions.js";
 
-import path from "node:path";
-
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
-import { findClosestPackageJson } from "@ignored/hardhat-vnext-utils/package";
+import { findClosestPackageRoot } from "@ignored/hardhat-vnext-utils/package";
 
 import { ResolvedConfigurationVariableImplementation } from "./configuration-variables.js";
 import {
@@ -143,17 +141,13 @@ export class HardhatRuntimeEnvironmentImplementation
   }
 }
 
-async function resolveProjectRoot(
+/**
+ * Resolves the project root of a Hardhat project.
+ */
+export async function resolveProjectRoot(
   projectRoot: string | undefined,
 ): Promise<string> {
-  if (projectRoot !== undefined) {
-    return projectRoot;
-  }
-
-  const packageJsonPath = await findClosestPackageJson(process.cwd());
-  const packageJsonDir = path.dirname(packageJsonPath);
-
-  return packageJsonDir;
+  return findClosestPackageRoot(projectRoot ?? process.cwd());
 }
 
 async function runUserConfigExtensions(

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -26,6 +26,7 @@ import { HookManagerImplementation } from "./hook-manager.js";
 import { resolvePluginList } from "./plugins/resolve-plugin-list.js";
 import { TaskManagerImplementation } from "./tasks/task-manager.js";
 import { UserInterruptionManagerImplementation } from "./user-interruptions.js";
+import { getRealPath } from "@ignored/hardhat-vnext-utils/fs";
 
 export class HardhatRuntimeEnvironmentImplementation
   implements HardhatRuntimeEnvironment
@@ -142,12 +143,17 @@ export class HardhatRuntimeEnvironmentImplementation
 }
 
 /**
- * Resolves the project root of a Hardhat project.
+ * Resolves the project root of a Hardhat project based on the config file or
+ * another path within the project. If not provided, it will be resolved from
+ * the current working directory.
+ *
+ * @param absolutePathWithinProject An absolute path within the project, usually
+ * the config file.
  */
 export async function resolveProjectRoot(
-  projectRoot: string | undefined,
+  absolutePathWithinProject: string | undefined,
 ): Promise<string> {
-  return findClosestPackageRoot(projectRoot ?? process.cwd());
+  return findClosestPackageRoot(absolutePathWithinProject ?? process.cwd());
 }
 
 async function runUserConfigExtensions(

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -26,7 +26,6 @@ import { HookManagerImplementation } from "./hook-manager.js";
 import { resolvePluginList } from "./plugins/resolve-plugin-list.js";
 import { TaskManagerImplementation } from "./tasks/task-manager.js";
 import { UserInterruptionManagerImplementation } from "./user-interruptions.js";
-import { getRealPath } from "@ignored/hardhat-vnext-utils/fs";
 
 export class HardhatRuntimeEnvironmentImplementation
   implements HardhatRuntimeEnvironment

--- a/v-next/core/src/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/src/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -8,26 +8,30 @@ import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import semver from "semver";
 
 /**
- * Validate that a plugin is installed and that its peer dependencies are installed and satisfy the version constraints.
+ * Validate that a plugin is installed and that its peer dependencies are
+ * installed and satisfy the version constraints.
  *
- * @param plugin - the plugin to be validated
- * @param basePathForNpmResolution - the directory path to use for node module resolution, defaulting to `process.cwd()`
+ * @param basePathForNpmResolution the dir path for node module resolution
+ * @param plugin the plugin to be validated
  * @throws {HardhatError} with descriptor:
- * - {@link HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED} if the plugin is not installed as an npm package
- * - {@link HardhatError.ERRORS.PLUGINS.PLUGIN_MISSING_DEPENDENCY} if the plugin's package peer dependency is not installed
- * - {@link HardhatError.ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH} if the plugin's package peer dependency is installed but has the wrong version
+ * - {@link HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED} if the plugin is
+ * not installed as an npm package
+ * - {@link HardhatError.ERRORS.PLUGINS.PLUGIN_MISSING_DEPENDENCY} if the
+ * plugin's package peer dependency is not installed
+ * - {@link HardhatError.ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH} if the
+ * plugin's package peer dependency is installed but has the wrong version
  */
 export async function detectPluginNpmDependencyProblems(
-  plugin: HardhatPlugin,
   basePathForNpmResolution: string,
+  plugin: HardhatPlugin,
 ): Promise<void> {
   if (plugin.npmPackage === undefined) {
     return;
   }
 
   const pluginPackageResult = readPackageJsonViaNodeRequire(
-    plugin.npmPackage,
     basePathForNpmResolution,
+    plugin.npmPackage,
   );
 
   if (pluginPackageResult === undefined) {
@@ -46,8 +50,8 @@ export async function detectPluginNpmDependencyProblems(
     pluginPackageJson.peerDependencies,
   )) {
     const dependencyPackageJsonResult = readPackageJsonViaNodeRequire(
-      dependencyName,
       packagePath,
+      dependencyName,
     );
 
     if (dependencyPackageJsonResult === undefined) {
@@ -77,16 +81,16 @@ export async function detectPluginNpmDependencyProblems(
 }
 
 /**
- * Read the package.json of a named package resolved through the node
- * require system.
+ * Read the package.json of a named package resolved through the node require
+ * system.
  *
- * @param packageName - the package name i.e. "@nomiclabs/hardhat-waffle"
- * @param baseRequirePath - the directory path to use for resolution, defaults to `process.cwd()`
+ * @param packageName the package name i.e. "@nomiclabs/hardhat-waffle"
+ * @param baseRequirePath  the dir path for node module resolution
  * @returns the package.json object or undefined if the package is not found
  */
 function readPackageJsonViaNodeRequire(
-  packageName: string,
   baseRequirePath: string,
+  packageName: string,
 ): { packageJson: PackageJson; packagePath: string } | undefined {
   try {
     const require = createRequire(baseRequirePath);

--- a/v-next/core/src/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/src/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -19,7 +19,7 @@ import semver from "semver";
  */
 export async function detectPluginNpmDependencyProblems(
   plugin: HardhatPlugin,
-  basePathForNpmResolution: string = process.cwd(),
+  basePathForNpmResolution: string,
 ): Promise<void> {
   if (plugin.npmPackage === undefined) {
     return;

--- a/v-next/core/src/internal/plugins/resolve-plugin-list.ts
+++ b/v-next/core/src/internal/plugins/resolve-plugin-list.ts
@@ -83,7 +83,7 @@ async function loadDependency(
   } catch (error) {
     ensureError(error);
 
-    await detectPluginNpmDependencyProblems(plugin, projectRoot);
+    await detectPluginNpmDependencyProblems(projectRoot, plugin);
 
     throw new HardhatError(
       HardhatError.ERRORS.PLUGINS.PLUGIN_DEPENDENCY_FAILED_LOAD,

--- a/v-next/core/src/internal/tasks/resolved-task.ts
+++ b/v-next/core/src/internal/tasks/resolved-task.ts
@@ -266,7 +266,10 @@ export class ResolvedTask implements Task {
           `Plugin with id ${actionPluginId} not found.`,
         );
 
-        await detectPluginNpmDependencyProblems(plugin);
+        await detectPluginNpmDependencyProblems(
+          plugin,
+          this.#hre.config.paths.root,
+        );
       }
 
       throw new HardhatError(

--- a/v-next/core/src/internal/tasks/resolved-task.ts
+++ b/v-next/core/src/internal/tasks/resolved-task.ts
@@ -267,8 +267,8 @@ export class ResolvedTask implements Task {
         );
 
         await detectPluginNpmDependencyProblems(
-          plugin,
           this.#hre.config.paths.root,
+          plugin,
         );
       }
 

--- a/v-next/core/src/types/config.ts
+++ b/v-next/core/src/types/config.ts
@@ -45,11 +45,23 @@ export type SensitiveString = string | ConfigurationVariable;
  * The user's Hardhat configuration, as exported in their
  * config file.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface -- Used through module aumentation
-export interface HardhatUserConfig {}
+export interface HardhatUserConfig {
+  paths?: ProjectPathsUserConfig;
+}
+
+/**
+ * The different paths that conform a Hardhat project.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface -- TODO: add the paths
+export interface ProjectPathsUserConfig {}
 
 /**
  * The resolved Hardhat configuration.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface -- Used through module aumentation
-export interface HardhatConfig {}
+export interface HardhatConfig {
+  paths: ProjectPathsConfig;
+}
+
+export interface ProjectPathsConfig {
+  root: string;
+}

--- a/v-next/core/test/internal/configuration-variables/configuration-variables.ts
+++ b/v-next/core/test/internal/configuration-variables/configuration-variables.ts
@@ -1,11 +1,10 @@
 import assert from "node:assert/strict";
-import path from "node:path";
 import { before, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
-import { findClosestPackageJson } from "@ignored/hardhat-vnext-utils/package";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
+import { resolveProjectRoot } from "../../../src/index.js";
 import { ResolvedConfigurationVariableImplementation } from "../../../src/internal/configuration-variables.js";
 import { HookManagerImplementation } from "../../../src/internal/hook-manager.js";
 import { UserInterruptionManagerImplementation } from "../../../src/internal/user-interruptions.js";
@@ -14,9 +13,7 @@ describe("ResolvedConfigurationVariable", () => {
   let hookManager: HookManagerImplementation;
 
   before(async () => {
-    const projectRoot = path.dirname(
-      await findClosestPackageJson(process.cwd()),
-    );
+    const projectRoot = await resolveProjectRoot(process.cwd());
 
     hookManager = new HookManagerImplementation(projectRoot, []);
     const userInterruptionsManager = new UserInterruptionManagerImplementation(

--- a/v-next/core/test/internal/configuration-variables/configuration-variables.ts
+++ b/v-next/core/test/internal/configuration-variables/configuration-variables.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import { before, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { findClosestPackageJson } from "@ignored/hardhat-vnext-utils/package";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { ResolvedConfigurationVariableImplementation } from "../../../src/internal/configuration-variables.js";
@@ -11,8 +13,12 @@ import { UserInterruptionManagerImplementation } from "../../../src/internal/use
 describe("ResolvedConfigurationVariable", () => {
   let hookManager: HookManagerImplementation;
 
-  before(() => {
-    hookManager = new HookManagerImplementation([]);
+  before(async () => {
+    const projectRoot = path.dirname(
+      await findClosestPackageJson(process.cwd()),
+    );
+
+    hookManager = new HookManagerImplementation(projectRoot, []);
     const userInterruptionsManager = new UserInterruptionManagerImplementation(
       hookManager,
     );

--- a/v-next/core/test/internal/configuration-variables/configuration-variables.ts
+++ b/v-next/core/test/internal/configuration-variables/configuration-variables.ts
@@ -27,6 +27,9 @@ describe("ResolvedConfigurationVariable", () => {
       config: {
         tasks: [],
         plugins: [],
+        paths: {
+          root: projectRoot,
+        },
       },
       hooks: hookManager,
       globalOptions: {},

--- a/v-next/core/test/internal/hook-manager.ts
+++ b/v-next/core/test/internal/hook-manager.ts
@@ -102,6 +102,9 @@ describe("HookManager", () => {
           config: {
             tasks: [],
             plugins: [],
+            paths: {
+              root: projectRoot,
+            },
           },
           hooks: hookManager,
           globalOptions: {},
@@ -167,6 +170,9 @@ describe("HookManager", () => {
         const originalConfig: HardhatConfig = {
           plugins: [],
           tasks: [],
+          paths: {
+            root: projectRoot,
+          },
         };
 
         hookManager.registerHandlers("config", {
@@ -217,6 +223,9 @@ describe("HookManager", () => {
         const expectedConfig: HardhatConfig = {
           plugins: [],
           tasks: [],
+          paths: {
+            root: projectRoot,
+          },
         };
 
         const manager = new HookManagerImplementation(projectRoot, [
@@ -317,6 +326,9 @@ describe("HookManager", () => {
           config: {
             tasks: [],
             plugins: [],
+            paths: {
+              root: projectRoot,
+            },
           },
           hooks: hookManager,
           globalOptions: {},
@@ -332,6 +344,9 @@ describe("HookManager", () => {
         const defaultImplementationVersionOfConfig: HardhatConfig = {
           plugins: [],
           tasks: [],
+          paths: {
+            root: projectRoot,
+          },
         };
 
         const resultConfig = await hookManager.runHandlerChain(
@@ -413,6 +428,9 @@ describe("HookManager", () => {
         const expectedConfig: HardhatConfig = {
           plugins: [],
           tasks: [],
+          paths: {
+            root: projectRoot,
+          },
         };
 
         hookManager.registerHandlers("config", {
@@ -531,6 +549,9 @@ describe("HookManager", () => {
           config: {
             tasks: [],
             plugins: [],
+            paths: {
+              root: projectRoot,
+            },
           },
           hooks: hookManager,
           globalOptions: {},
@@ -541,7 +562,10 @@ describe("HookManager", () => {
       });
 
       it("Should return the empty set if no handlers are registered", async () => {
-        const mockHre = buildMockHardhatRuntimeEnvironment(hookManager);
+        const mockHre = buildMockHardhatRuntimeEnvironment(
+          projectRoot,
+          hookManager,
+        );
 
         const resultHre = await hookManager.runSequentialHandlers(
           "hre",
@@ -617,6 +641,9 @@ describe("HookManager", () => {
         const expectedConfig: HardhatConfig = {
           plugins: [],
           tasks: [],
+          paths: {
+            root: projectRoot,
+          },
         };
 
         hookManager.registerHandlers("config", {
@@ -656,6 +683,9 @@ describe("HookManager", () => {
           config: {
             tasks: [],
             plugins: [],
+            paths: {
+              root: projectRoot,
+            },
           },
           hooks: hookManager,
           globalOptions: {},
@@ -669,6 +699,9 @@ describe("HookManager", () => {
         const originalConfig: HardhatConfig = {
           plugins: [],
           tasks: [],
+          paths: {
+            root: projectRoot,
+          },
         };
 
         const results = await hookManager.runParallelHandlers(
@@ -684,6 +717,9 @@ describe("HookManager", () => {
         const originalConfig: HardhatConfig = {
           plugins: [],
           tasks: [],
+          paths: {
+            root: projectRoot,
+          },
         };
 
         hookManager.registerHandlers("config", {
@@ -735,7 +771,10 @@ describe("HookManager", () => {
       });
 
       it("Should pass the context to the handler (for non-config)", async () => {
-        const mockHre = buildMockHardhatRuntimeEnvironment(hookManager);
+        const mockHre = buildMockHardhatRuntimeEnvironment(
+          projectRoot,
+          hookManager,
+        );
 
         hookManager.registerHandlers("hre", {
           created: async (
@@ -761,6 +800,9 @@ describe("HookManager", () => {
         const expectedConfig: HardhatConfig = {
           plugins: [],
           tasks: [],
+          paths: {
+            root: projectRoot,
+          },
         };
 
         const validationError = {
@@ -800,6 +842,9 @@ describe("HookManager", () => {
           config: {
             tasks: [],
             plugins: [],
+            paths: {
+              root: projectRoot,
+            },
           },
           hooks: hookManager,
           globalOptions: {},
@@ -929,6 +974,7 @@ describe("HookManager", () => {
 });
 
 function buildMockHardhatRuntimeEnvironment(
+  projectRoot: string,
   hookManager: HookManager,
 ): HardhatRuntimeEnvironment {
   const mockInteruptionManager: UserInterruptionManager = {
@@ -955,6 +1001,9 @@ function buildMockHardhatRuntimeEnvironment(
     config: {
       tasks: [],
       plugins: [],
+      paths: {
+        root: projectRoot,
+      },
     },
     tasks: mockTaskManager,
     globalOptions: {},

--- a/v-next/core/test/internal/hook-manager.ts
+++ b/v-next/core/test/internal/hook-manager.ts
@@ -19,14 +19,13 @@ import type { Task, TaskManager } from "../../src/types/tasks.js";
 import type { UserInterruptionManager } from "../../src/types/user-interruptions.js";
 
 import assert from "node:assert/strict";
-import path from "node:path";
 import { describe, it, beforeEach, before } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import { ensureError } from "@ignored/hardhat-vnext-utils/error";
-import { findClosestPackageJson } from "@ignored/hardhat-vnext-utils/package";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
+import { resolveProjectRoot } from "../../src/index.js";
 import { HookManagerImplementation } from "../../src/internal/hook-manager.js";
 import { UserInterruptionManagerImplementation } from "../../src/internal/user-interruptions.js";
 
@@ -34,7 +33,7 @@ describe("HookManager", () => {
   let projectRoot: string;
 
   before(async () => {
-    projectRoot = path.dirname(await findClosestPackageJson(process.cwd()));
+    projectRoot = await resolveProjectRoot(process.cwd());
   });
 
   describe("plugin hooks", () => {

--- a/v-next/core/test/internal/hook-manager.ts
+++ b/v-next/core/test/internal/hook-manager.ts
@@ -19,16 +19,24 @@ import type { Task, TaskManager } from "../../src/types/tasks.js";
 import type { UserInterruptionManager } from "../../src/types/user-interruptions.js";
 
 import assert from "node:assert/strict";
-import { describe, it, beforeEach } from "node:test";
+import path from "node:path";
+import { describe, it, beforeEach, before } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import { ensureError } from "@ignored/hardhat-vnext-utils/error";
+import { findClosestPackageJson } from "@ignored/hardhat-vnext-utils/package";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import { HookManagerImplementation } from "../../src/internal/hook-manager.js";
 import { UserInterruptionManagerImplementation } from "../../src/internal/user-interruptions.js";
 
 describe("HookManager", () => {
+  let projectRoot: string;
+
+  before(async () => {
+    projectRoot = path.dirname(await findClosestPackageJson(process.cwd()));
+  });
+
   describe("plugin hooks", () => {
     describe("running", () => {
       let hookManager: HookManager;
@@ -83,7 +91,9 @@ describe("HookManager", () => {
           },
         };
 
-        const manager = new HookManagerImplementation([examplePlugin]);
+        const manager = new HookManagerImplementation(projectRoot, [
+          examplePlugin,
+        ]);
 
         const userInterruptionsManager =
           new UserInterruptionManagerImplementation(hookManager);
@@ -209,7 +219,9 @@ describe("HookManager", () => {
           tasks: [],
         };
 
-        const manager = new HookManagerImplementation([examplePlugin]);
+        const manager = new HookManagerImplementation(projectRoot, [
+          examplePlugin,
+        ]);
 
         const validationResult = await manager.runSequentialHandlers(
           "config",
@@ -235,7 +247,9 @@ describe("HookManager", () => {
           },
         };
 
-        const manager = new HookManagerImplementation([examplePlugin]);
+        const manager = new HookManagerImplementation(projectRoot, [
+          examplePlugin,
+        ]);
 
         try {
           await manager.runHandlerChain(
@@ -264,7 +278,9 @@ describe("HookManager", () => {
           },
         };
 
-        const manager = new HookManagerImplementation([examplePlugin]);
+        const manager = new HookManagerImplementation(projectRoot, [
+          examplePlugin,
+        ]);
 
         await assertRejectsWithHardhatError(
           async () =>
@@ -292,7 +308,7 @@ describe("HookManager", () => {
       let hookManager: HookManager;
 
       beforeEach(() => {
-        const manager = new HookManagerImplementation([]);
+        const manager = new HookManagerImplementation(projectRoot, []);
 
         const userInterruptionsManager =
           new UserInterruptionManagerImplementation(hookManager);
@@ -506,7 +522,7 @@ describe("HookManager", () => {
       let hookManager: HookManager;
 
       beforeEach(() => {
-        const manager = new HookManagerImplementation([]);
+        const manager = new HookManagerImplementation(projectRoot, []);
 
         const userInterruptionsManager =
           new UserInterruptionManagerImplementation(hookManager);
@@ -631,7 +647,7 @@ describe("HookManager", () => {
       let hookManager: HookManager;
 
       beforeEach(() => {
-        const manager = new HookManagerImplementation([]);
+        const manager = new HookManagerImplementation(projectRoot, []);
 
         const userInterruptionsManager =
           new UserInterruptionManagerImplementation(hookManager);
@@ -775,7 +791,7 @@ describe("HookManager", () => {
       let hookManager: HookManager;
 
       beforeEach(() => {
-        const manager = new HookManagerImplementation([]);
+        const manager = new HookManagerImplementation(projectRoot, []);
 
         const userInterruptionsManager =
           new UserInterruptionManagerImplementation(hookManager);

--- a/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/core/test/internal/plugins/detect-plugin-npm-dependency-problems.ts
@@ -18,13 +18,10 @@ describe("Plugins - detect npm dependency problems", () => {
       "./fixture-projects/peer-dep-with-wrong-version",
     );
 
-    await detectPluginNpmDependencyProblems(
-      {
-        ...plugin,
-        npmPackage: undefined,
-      },
-      peerDepWithWrongVersionFixture,
-    );
+    await detectPluginNpmDependencyProblems(peerDepWithWrongVersionFixture, {
+      ...plugin,
+      npmPackage: undefined,
+    });
   });
 
   describe("when the plugin has no peer deps", () => {
@@ -34,8 +31,8 @@ describe("Plugins - detect npm dependency problems", () => {
       );
 
       await detectPluginNpmDependencyProblems(
-        plugin,
         installedPackageProjectFixture,
+        plugin,
       );
     });
 
@@ -47,8 +44,8 @@ describe("Plugins - detect npm dependency problems", () => {
       await assertRejectsWithHardhatError(
         async () =>
           detectPluginNpmDependencyProblems(
-            plugin,
             nonInstalledPackageProjectFixture,
+            plugin,
           ),
         HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
         {
@@ -66,8 +63,8 @@ describe("Plugins - detect npm dependency problems", () => {
         );
 
         await detectPluginNpmDependencyProblems(
-          plugin,
           installedPeerDepsFixture,
+          plugin,
         );
       });
 
@@ -77,7 +74,7 @@ describe("Plugins - detect npm dependency problems", () => {
         );
 
         await assertRejectsWithHardhatError(
-          detectPluginNpmDependencyProblems(plugin, notInstalledPeerDepFixture),
+          detectPluginNpmDependencyProblems(notInstalledPeerDepFixture, plugin),
           HardhatError.ERRORS.PLUGINS.PLUGIN_MISSING_DEPENDENCY,
           { pluginId: "example-plugin", peerDependencyName: "peer2" },
         );
@@ -91,8 +88,8 @@ describe("Plugins - detect npm dependency problems", () => {
         );
 
         await detectPluginNpmDependencyProblems(
-          plugin,
           installedPeerDepsFixture,
+          plugin,
         );
       });
     });
@@ -107,8 +104,8 @@ describe("Plugins - detect npm dependency problems", () => {
       await assertRejectsWithHardhatError(
         async () =>
           detectPluginNpmDependencyProblems(
-            plugin,
             peerDepWithWrongVersionFixture,
+            plugin,
           ),
         HardhatError.ERRORS.PLUGINS.DEPENDENCY_VERSION_MISMATCH,
         {

--- a/v-next/core/test/internal/plugins/resolve-plugin-list.ts
+++ b/v-next/core/test/internal/plugins/resolve-plugin-list.ts
@@ -14,12 +14,12 @@ describe("Plugins - resolve plugin list", () => {
   );
 
   it("should return empty on an empty plugin list", async () => {
-    assert.deepEqual(await resolvePluginList([], installedPackageFixture), []);
+    assert.deepEqual(await resolvePluginList(installedPackageFixture, []), []);
   });
 
   it("should return empty on an undefined plugin list", async () => {
     assert.deepEqual(
-      await resolvePluginList(undefined, installedPackageFixture),
+      await resolvePluginList(installedPackageFixture, undefined),
       [],
     );
   });
@@ -30,7 +30,7 @@ describe("Plugins - resolve plugin list", () => {
     };
 
     assert.deepEqual(
-      await resolvePluginList([plugin], installedPackageFixture),
+      await resolvePluginList(installedPackageFixture, [plugin]),
       [plugin],
     );
   });
@@ -43,7 +43,7 @@ describe("Plugins - resolve plugin list", () => {
 
     const expected = [c, b, a];
     assert.deepEqual(
-      await resolvePluginList([a], installedPackageFixture),
+      await resolvePluginList(installedPackageFixture, [a]),
       expected,
     );
   });
@@ -56,7 +56,7 @@ describe("Plugins - resolve plugin list", () => {
 
     const expected = [a, b, c];
     assert.deepEqual(
-      await resolvePluginList([a, b, c], installedPackageFixture),
+      await resolvePluginList(installedPackageFixture, [a, b, c]),
       expected,
     );
   });
@@ -74,7 +74,7 @@ describe("Plugins - resolve plugin list", () => {
 
     const expected = [b, c, a];
     assert.deepEqual(
-      await resolvePluginList([a], installedPackageFixture),
+      await resolvePluginList(installedPackageFixture, [a]),
       expected,
     );
   });
@@ -89,7 +89,7 @@ describe("Plugins - resolve plugin list", () => {
 
     const expected = [c, a, b];
     assert.deepEqual(
-      await resolvePluginList([a, b], installedPackageFixture),
+      await resolvePluginList(installedPackageFixture, [a, b]),
       expected,
     );
   });
@@ -110,7 +110,7 @@ describe("Plugins - resolve plugin list", () => {
 
     const expected = [d, b, c, a];
     assert.deepEqual(
-      await resolvePluginList([a], installedPackageFixture),
+      await resolvePluginList(installedPackageFixture, [a]),
       expected,
     );
   });
@@ -141,7 +141,7 @@ describe("Plugins - resolve plugin list", () => {
 
     const expected = [i, g, c, d, a, h, e, f, b];
     assert.deepEqual(
-      await resolvePluginList([a, b], installedPackageFixture),
+      await resolvePluginList(installedPackageFixture, [a, b]),
       expected,
     );
   });
@@ -151,7 +151,7 @@ describe("Plugins - resolve plugin list", () => {
     const copy = { id: "dup" };
 
     await assertRejectsWithHardhatError(
-      async () => resolvePluginList([a, copy], installedPackageFixture),
+      async () => resolvePluginList(installedPackageFixture, [a, copy]),
       HardhatError.ERRORS.GENERAL.DUPLICATED_PLUGIN_ID,
       {
         id: "dup",
@@ -172,7 +172,7 @@ describe("Plugins - resolve plugin list", () => {
       };
 
       await assertRejectsWithHardhatError(
-        async () => resolvePluginList([plugin], installedPackageFixture),
+        async () => resolvePluginList(installedPackageFixture, [plugin]),
         HardhatError.ERRORS.PLUGINS.PLUGIN_DEPENDENCY_FAILED_LOAD,
         { pluginId: plugin.id },
       );
@@ -194,7 +194,7 @@ describe("Plugins - resolve plugin list", () => {
       };
 
       await assertRejectsWithHardhatError(
-        async () => resolvePluginList([plugin], notInstalledPackageFixture),
+        async () => resolvePluginList(notInstalledPackageFixture, [plugin]),
         HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
         {
           pluginId: "example",

--- a/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
+++ b/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
@@ -30,6 +30,9 @@ describe("UserInterruptionManager", () => {
         config: {
           tasks: [],
           plugins: [],
+          paths: {
+            root: projectRoot,
+          },
         },
         globalOptions: {},
         hooks: hookManager,
@@ -71,6 +74,9 @@ describe("UserInterruptionManager", () => {
         config: {
           tasks: [],
           plugins: [],
+          paths: {
+            root: projectRoot,
+          },
         },
         globalOptions: {},
         hooks: hookManager,
@@ -114,6 +120,9 @@ describe("UserInterruptionManager", () => {
         config: {
           tasks: [],
           plugins: [],
+          paths: {
+            root: projectRoot,
+          },
         },
         globalOptions: {},
         hooks: hookManager,

--- a/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
+++ b/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
@@ -1,11 +1,9 @@
 import type { UserInterruptionHooks } from "../../../src/types/hooks.js";
 
 import assert from "node:assert/strict";
-import path from "node:path";
 import { before, describe, it } from "node:test";
 
-import { findClosestPackageJson } from "@ignored/hardhat-vnext-utils/package";
-
+import { resolveProjectRoot } from "../../../src/index.js";
 import { HookManagerImplementation } from "../../../src/internal/hook-manager.js";
 import { UserInterruptionManagerImplementation } from "../../../src/internal/user-interruptions.js";
 
@@ -13,7 +11,7 @@ describe("UserInterruptionManager", () => {
   let projectRoot: string;
 
   before(async () => {
-    projectRoot = path.dirname(await findClosestPackageJson(process.cwd()));
+    projectRoot = await resolveProjectRoot(process.cwd());
   });
 
   describe("displayMessage", () => {

--- a/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
+++ b/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
@@ -1,15 +1,24 @@
 import type { UserInterruptionHooks } from "../../../src/types/hooks.js";
 
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import path from "node:path";
+import { before, describe, it } from "node:test";
+
+import { findClosestPackageJson } from "@ignored/hardhat-vnext-utils/package";
 
 import { HookManagerImplementation } from "../../../src/internal/hook-manager.js";
 import { UserInterruptionManagerImplementation } from "../../../src/internal/user-interruptions.js";
 
 describe("UserInterruptionManager", () => {
+  let projectRoot: string;
+
+  before(async () => {
+    projectRoot = path.dirname(await findClosestPackageJson(process.cwd()));
+  });
+
   describe("displayMessage", () => {
     it("Should call a dynamic handler with a given message from an interruptor", async () => {
-      const hookManager = new HookManagerImplementation([]);
+      const hookManager = new HookManagerImplementation(projectRoot, []);
       const userInterruptionManager = new UserInterruptionManagerImplementation(
         hookManager,
       );
@@ -54,7 +63,7 @@ describe("UserInterruptionManager", () => {
 
   describe("requestInput", () => {
     it("Should call a dynamic handler with a given input description from an interruptor", async () => {
-      const hookManager = new HookManagerImplementation([]);
+      const hookManager = new HookManagerImplementation(projectRoot, []);
       const userInterruptionManager = new UserInterruptionManagerImplementation(
         hookManager,
       );
@@ -97,7 +106,7 @@ describe("UserInterruptionManager", () => {
 
   describe("requestSecretInput", () => {
     it("Should call a dynamic handler with a given input description from an interruptor", async () => {
-      const hookManager = new HookManagerImplementation([]);
+      const hookManager = new HookManagerImplementation(projectRoot, []);
       const userInterruptionManager = new UserInterruptionManagerImplementation(
         hookManager,
       );

--- a/v-next/hardhat-utils/src/package.ts
+++ b/v-next/hardhat-utils/src/package.ts
@@ -29,39 +29,39 @@ export interface PackageJson {
  * Searches for the nearest `package.json` file, starting from the directory of
  * the provided file path or url string and moving up the directory tree.
  *
- * @param filePathOrUrl The file path or url string from which to start the
- * search. The url must be a file url. This is useful when you want to find
- * the nearest `package.json` file relative to the current module, as you
- * can use `import.meta.url`.
+ * @param pathOrUrl A path or url string from which to start the search. The url
+ * must be a file url. This is useful when you want to find the nearest
+ * `package.json` file relative to the current module, as you can use
+ * `import.meta.url`.
  * @returns The absolute path to the nearest `package.json` file.
  * @throws PackageJsonNotFoundError If no `package.json` file is found.
  */
 export async function findClosestPackageJson(
-  filePathOrUrl: string,
+  pathOrUrl: string,
 ): Promise<string> {
-  const filePath = getFilePath(filePathOrUrl);
+  const filePath = getFilePath(pathOrUrl);
 
   if (filePath === undefined) {
-    throw new PackageJsonNotFoundError(filePathOrUrl);
+    throw new PackageJsonNotFoundError(pathOrUrl);
   }
 
-  const packageJsonPath = await findUp("package.json", path.dirname(filePath));
+  const packageJsonPath = await findUp("package.json", filePath);
 
   if (packageJsonPath === undefined) {
-    throw new PackageJsonNotFoundError(filePathOrUrl);
+    throw new PackageJsonNotFoundError(pathOrUrl);
   }
 
   return packageJsonPath;
 }
 
 /**
- * Reads the nearest `package.json` file, starting from the directory of the
- * provided file path or url string and moving up the directory tree.
+ * Reads the nearest `package.json` file, starting from provided path or url
+ * string and moving up the directory tree.
  *
- * @param filePathOrUrl The file path or url string from which to start the
- * search. The url must be a file url. This is useful when you want to find
- * the nearest `package.json` file relative to the current module, as you
- * can use `import.meta.url`.
+ * @param pathOrUrl A path or url string from which to start the search. The url
+ * must be a file url. This is useful when you want to find the nearest
+ * `package.json` file relative to the current module, as you can use
+ * `import.meta.url`.
  * @returns The contents of the nearest `package.json` file, parsed as a
  * {@link PackageJson} object.
  * @throws PackageJsonNotFoundError If no `package.json` file is found.
@@ -69,9 +69,9 @@ export async function findClosestPackageJson(
  * be read.
  */
 export async function readClosestPackageJson(
-  filePathOrUrl: string,
+  pathOrUrl: string,
 ): Promise<PackageJson> {
-  const packageJsonPath = await findClosestPackageJson(filePathOrUrl);
+  const packageJsonPath = await findClosestPackageJson(pathOrUrl);
   try {
     return await readJsonFile<PackageJson>(packageJsonPath);
   } catch (e) {
@@ -81,16 +81,16 @@ export async function readClosestPackageJson(
 }
 
 /**
- * Finds the root directory of the nearest package, starting from the directory
- * of the provided file path or url string and moving up the directory tree.
+ * Finds the root directory of the nearest package, starting from the provided
+ * path or url string and moving up the directory tree.
  *
  * This function uses `findClosestPackageJson` to find the nearest `package.json`
  * file and then returns the directory that contains that file.
  *
- * @param filePathOrUrl The file path or url string from which to start the
- * search. The url must be a file url. This is useful when you want to find
- * the nearest `package.json` file relative to the current module, as you
- * can use `import.meta.url`.
+ * @param pathOrUrl A path or url string from which to start the search. The url
+ * must be a file url. This is useful when you want to find the nearest
+ * `package.json` file relative to the current module, as you can use
+ * `import.meta.url`.
  * @returns The absolute path of the root directory of the nearest package.
  */
 export async function findClosestPackageRoot(

--- a/v-next/hardhat-utils/test/package.ts
+++ b/v-next/hardhat-utils/test/package.ts
@@ -48,6 +48,16 @@ describe("package", () => {
       assert.equal(actualPath, expectedPath);
     });
 
+    it("Should find the closest package.json relative to a directory when its within that directory", async () => {
+      const expectedPath = path.join(getTmpDir(), "package.json");
+      const fromPath = getTmpDir();
+      await createFile(expectedPath);
+
+      const actualPath = await findClosestPackageJson(fromPath);
+
+      assert.equal(actualPath, expectedPath);
+    });
+
     it("Should throw PackageJsonNotFoundError if no package.json is found", async () => {
       const fromPath = path.join(getTmpDir(), "subdir", "subsubdir");
 

--- a/v-next/hardhat/src/index.ts
+++ b/v-next/hardhat/src/index.ts
@@ -5,6 +5,8 @@ import type { HardhatRuntimeEnvironment } from "./types/hre.js";
 import type { TaskManager } from "./types/tasks.js";
 import type { UserInterruptionManager } from "./types/user-interruptions.js";
 
+import { resolveProjectRoot } from "@ignored/hardhat-vnext-core";
+
 import { resolveHardhatConfigPath } from "./config.js";
 import { createHardhatRuntimeEnvironment } from "./hre.js";
 import {
@@ -19,9 +21,10 @@ let maybeHre: HardhatRuntimeEnvironment | undefined =
 if (maybeHre === undefined) {
   /* eslint-disable no-restricted-syntax -- Allow top-level await here */
   const configPath = await resolveHardhatConfigPath();
+  const projectRoot = await resolveProjectRoot(configPath);
   const userConfig = await importUserConfig(configPath);
 
-  maybeHre = await createHardhatRuntimeEnvironment(userConfig);
+  maybeHre = await createHardhatRuntimeEnvironment(userConfig, {}, projectRoot);
   /* eslint-enable no-restricted-syntax */
 
   setGlobalHardhatRuntimeEnvironment(maybeHre);

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -18,6 +18,7 @@ import {
   buildGlobalOptionDefinitions,
   parseArgumentValue,
   resolvePluginList,
+  resolveProjectRoot,
 } from "@ignored/hardhat-vnext-core";
 import { ArgumentType } from "@ignored/hardhat-vnext-core/types/arguments";
 import {
@@ -68,16 +69,17 @@ export async function main(
       builtinGlobalOptions.configPath = await resolveHardhatConfigPath();
     }
 
+    const projectRoot = await resolveProjectRoot(
+      builtinGlobalOptions.configPath,
+    );
+
     const userConfig = await importUserConfig(builtinGlobalOptions.configPath);
 
     const configPlugins = Array.isArray(userConfig.plugins)
       ? userConfig.plugins
       : [];
     const plugins = [...builtinPlugins, ...configPlugins];
-    const resolvedPlugins = await resolvePluginList(
-      plugins,
-      builtinGlobalOptions.configPath,
-    );
+    const resolvedPlugins = await resolvePluginList(projectRoot, plugins);
 
     const pluginGlobalOptionDefinitions =
       buildGlobalOptionDefinitions(resolvedPlugins);
@@ -94,6 +96,7 @@ export async function main(
     const hre = await createHardhatRuntimeEnvironment(
       userConfig,
       { ...builtinGlobalOptions, ...userProvidedGlobalOptions },
+      projectRoot,
       { resolvedPlugins, globalOptionDefinitions },
     );
 

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -26,6 +26,7 @@ import {
   assertHardhatInvariant,
 } from "@ignored/hardhat-vnext-errors";
 import { isCi } from "@ignored/hardhat-vnext-utils/ci";
+import { getRealPath } from "@ignored/hardhat-vnext-utils/fs";
 import { kebabToCamelCase } from "@ignored/hardhat-vnext-utils/string";
 
 import { resolveHardhatConfigPath } from "../../config.js";
@@ -70,7 +71,7 @@ export async function main(
     }
 
     const projectRoot = await resolveProjectRoot(
-      builtinGlobalOptions.configPath,
+      await getRealPath(builtinGlobalOptions.configPath),
     );
 
     const userConfig = await importUserConfig(builtinGlobalOptions.configPath);


### PR DESCRIPTION
This PR revamps how we manage the project root resolution and how it impacts other parts of the system.

The project root in Hardhat v3 will be the root of the npm package containing the Hardhat config file, or the one containing the CWD if an instance of the HRE is initialized without using a config file.

This PR touches several files, so here's a summary of the changes:
- The base HRE constructor in the `core` package now accepts an optional projectRoot.
- There's now a `resolveProjectRoot`  helper exposed in `core`.
- Plugin installation error detection is now run based on the project root, as plugins and their dependencies should all be installed in the npm package containing the project.
- I added that same error detection logic to the hook manager, because loading actions can fail.
- The three ways to initialize the HRE (the cli, importing `hardhat`, and using `createHardhatRuntimeEnvironment`) were updated according to the new project root logic.
- I implemented a small change to the `/package` module in the utils package.

I'm marking this as WIP as I still haven't added tests for the new functionality yet.

Fixes #5436