### PR TITLE
Clean task

### DIFF
--- a/v-next/core/src/global-dir.ts
+++ b/v-next/core/src/global-dir.ts
@@ -1,7 +1,7 @@
 import { ensureDir } from "@ignored/hardhat-vnext-utils/fs";
 
 /**
- *  Returns the path to the hardhat configuration directory.
+ * Returns the path to the hardhat configuration directory.
  *
  * @returns The path to the hardhat configuration directory.
  */
@@ -9,6 +9,17 @@ export async function getConfigDir(): Promise<string> {
   const { config } = await generatePaths();
   await ensureDir(config);
   return config;
+}
+
+/**
+ * Returns the path to the hardhat cache directory.
+ *
+ * @returns The path to the hardhat cache directory.
+ */
+export async function getCacheDir(): Promise<string> {
+  const { cache } = await generatePaths();
+  await ensureDir(cache);
+  return cache;
 }
 
 async function generatePaths(packageName = "hardhat") {

--- a/v-next/core/src/internal/hre.ts
+++ b/v-next/core/src/internal/hre.ts
@@ -196,6 +196,8 @@ async function resolveUserConfig(
     tasks: config.tasks ?? [],
     paths: {
       root: projectRoot,
+      cache: config.paths?.cache ?? "", // TODO: resolve cache path
+      artifacts: config.paths?.artifacts ?? "", // TODO: resolve artifacts path
     },
   };
 

--- a/v-next/core/src/types/config.ts
+++ b/v-next/core/src/types/config.ts
@@ -52,8 +52,11 @@ export interface HardhatUserConfig {
 /**
  * The different paths that conform a Hardhat project.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface -- TODO: add the paths
-export interface ProjectPathsUserConfig {}
+export interface ProjectPathsUserConfig {
+  root?: string;
+  cache?: string;
+  artifacts?: string;
+}
 
 /**
  * The resolved Hardhat configuration.

--- a/v-next/core/src/types/config.ts
+++ b/v-next/core/src/types/config.ts
@@ -64,4 +64,6 @@ export interface HardhatConfig {
 
 export interface ProjectPathsConfig {
   root: string;
+  cache: string;
+  artifacts: string;
 }

--- a/v-next/core/test/internal/configuration-variables/configuration-variables.ts
+++ b/v-next/core/test/internal/configuration-variables/configuration-variables.ts
@@ -26,6 +26,8 @@ describe("ResolvedConfigurationVariable", () => {
         plugins: [],
         paths: {
           root: projectRoot,
+          cache: "",
+          artifacts: "",
         },
       },
       hooks: hookManager,

--- a/v-next/core/test/internal/hook-manager.ts
+++ b/v-next/core/test/internal/hook-manager.ts
@@ -103,6 +103,8 @@ describe("HookManager", () => {
             plugins: [],
             paths: {
               root: projectRoot,
+              cache: "",
+              artifacts: "",
             },
           },
           hooks: hookManager,
@@ -171,6 +173,8 @@ describe("HookManager", () => {
           tasks: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         };
 
@@ -224,6 +228,8 @@ describe("HookManager", () => {
           tasks: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         };
 
@@ -327,6 +333,8 @@ describe("HookManager", () => {
             plugins: [],
             paths: {
               root: projectRoot,
+              cache: "",
+              artifacts: "",
             },
           },
           hooks: hookManager,
@@ -345,6 +353,8 @@ describe("HookManager", () => {
           tasks: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         };
 
@@ -429,6 +439,8 @@ describe("HookManager", () => {
           tasks: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         };
 
@@ -550,6 +562,8 @@ describe("HookManager", () => {
             plugins: [],
             paths: {
               root: projectRoot,
+              cache: "",
+              artifacts: "",
             },
           },
           hooks: hookManager,
@@ -642,6 +656,8 @@ describe("HookManager", () => {
           tasks: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         };
 
@@ -684,6 +700,8 @@ describe("HookManager", () => {
             plugins: [],
             paths: {
               root: projectRoot,
+              cache: "",
+              artifacts: "",
             },
           },
           hooks: hookManager,
@@ -700,6 +718,8 @@ describe("HookManager", () => {
           tasks: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         };
 
@@ -718,6 +738,8 @@ describe("HookManager", () => {
           tasks: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         };
 
@@ -801,6 +823,8 @@ describe("HookManager", () => {
           tasks: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         };
 
@@ -843,6 +867,8 @@ describe("HookManager", () => {
             plugins: [],
             paths: {
               root: projectRoot,
+              cache: "",
+              artifacts: "",
             },
           },
           hooks: hookManager,
@@ -1002,6 +1028,8 @@ function buildMockHardhatRuntimeEnvironment(
       plugins: [],
       paths: {
         root: projectRoot,
+        cache: "",
+        artifacts: "",
       },
     },
     tasks: mockTaskManager,

--- a/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
+++ b/v-next/core/test/internal/user-interruptions/user-interruptions-manager.ts
@@ -30,6 +30,8 @@ describe("UserInterruptionManager", () => {
           plugins: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         },
         globalOptions: {},
@@ -74,6 +76,8 @@ describe("UserInterruptionManager", () => {
           plugins: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         },
         globalOptions: {},
@@ -120,6 +124,8 @@ describe("UserInterruptionManager", () => {
           plugins: [],
           paths: {
             root: projectRoot,
+            cache: "",
+            artifacts: "",
           },
         },
         globalOptions: {},

--- a/v-next/hardhat/src/internal/builtin-plugins/clean/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/clean/index.ts
@@ -1,0 +1,18 @@
+import type { HardhatPlugin } from "@ignored/hardhat-vnext-core/types/plugins";
+
+import { task } from "@ignored/hardhat-vnext-core/config";
+
+const hardhatPlugin: HardhatPlugin = {
+  id: "clean",
+  tasks: [
+    task("clean", "Clears the cache and deletes all artifacts")
+      .addFlag({
+        name: "global",
+        description: "Clear the global cache",
+      })
+      .setAction(import.meta.resolve("./task-action.js"))
+      .build(),
+  ],
+};
+
+export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/builtin-plugins/clean/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/clean/task-action.ts
@@ -1,0 +1,26 @@
+import type { NewTaskActionFunction } from "@ignored/hardhat-vnext-core/types/tasks";
+
+import { getCacheDir } from "@ignored/hardhat-vnext-core/global-dir";
+import { emptyDir, remove } from "@ignored/hardhat-vnext-utils/fs";
+
+interface CleanActionArguments {
+  global: boolean;
+}
+
+const cleanAction: NewTaskActionFunction<CleanActionArguments> = async (
+  { global },
+  { config },
+) => {
+  if (global) {
+    const globalCacheDir = await getCacheDir();
+    await emptyDir(globalCacheDir);
+  }
+
+  await emptyDir(config.paths.cache);
+  await remove(config.paths.artifacts);
+
+  // TODO: Uncomment this when we have a clearCache method in the artifacts module
+  // artifacts.clearCache?.();
+};
+
+export default cleanAction;

--- a/v-next/hardhat/src/internal/builtin-plugins/clean/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/clean/task-action.ts
@@ -18,9 +18,6 @@ const cleanAction: NewTaskActionFunction<CleanActionArguments> = async (
 
   await emptyDir(config.paths.cache);
   await remove(config.paths.artifacts);
-
-  // TODO: Uncomment this when we have a clearCache method in the artifacts module
-  // artifacts.clearCache?.();
 };
 
 export default cleanAction;

--- a/v-next/hardhat/src/internal/builtin-plugins/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/index.ts
@@ -1,11 +1,13 @@
 import type { HardhatPlugin } from "@ignored/hardhat-vnext-core/types/plugins";
 
+import clean from "./clean/index.js";
 import hardhatFoo from "./hardhat-foo/index.js";
 import run from "./run/index.js";
 
 // Note: When importing a plugin, you have to export its types, so that its
 // type extensions, if any, also get loaded.
+export type * from "./clean/index.js";
 export type * from "./hardhat-foo/index.js";
 export type * from "./run/index.js";
 
-export const builtinPlugins: HardhatPlugin[] = [hardhatFoo, run];
+export const builtinPlugins: HardhatPlugin[] = [clean, hardhatFoo, run];

--- a/v-next/hardhat/test/internal/builtin-plugins/clean/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/clean/task-action.ts
@@ -1,0 +1,112 @@
+import type { HardhatRuntimeEnvironment } from "@ignored/hardhat-vnext-core/types/hre";
+
+import assert from "node:assert/strict";
+import path from "node:path";
+import { before, beforeEach, describe, it } from "node:test";
+
+import { getCacheDir } from "@ignored/hardhat-vnext-core/global-dir";
+import {
+  exists,
+  mkdir,
+  readdir,
+  remove,
+  writeUtf8File,
+} from "@ignored/hardhat-vnext-utils/fs";
+
+import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
+import cleanAction from "../../../../src/internal/builtin-plugins/clean/task-action.js";
+import { useFixtureProject } from "../../../helpers/project.js";
+
+function assertCleanBehavior(global: boolean, globalCacheDir: string) {
+  it("should empty the cache dir", async () => {
+    const cacheContents = await readdir(path.join(process.cwd(), "cache"));
+    assert.ok(cacheContents.length === 0, "Cache dir is not empty");
+  });
+
+  it("should remove the artifacts dir", async () => {
+    assert.ok(
+      exists(path.join(process.cwd(), "artifacts")),
+      "Artifacts dir does not exist",
+    );
+  });
+
+  if (global) {
+    it("should empty the global cache dir when the global flag is true", async () => {
+      const globalCacheContents = await readdir(globalCacheDir);
+      assert.ok(
+        globalCacheContents.length === 0,
+        "Global cache dir is not empty",
+      );
+    });
+  } else {
+    it("should not empty the global cache dir when the global flag is false", async () => {
+      const globalCacheContents = await readdir(globalCacheDir);
+      assert.ok(globalCacheContents.length > 0, "Global cache dir is empty");
+    });
+  }
+}
+
+describe("clean/task-action", () => {
+  let hre: HardhatRuntimeEnvironment;
+  let globalCacheDir: string;
+
+  before(async function () {
+    hre = await createHardhatRuntimeEnvironment({});
+    globalCacheDir = await getCacheDir();
+  });
+
+  describe("cleanAction", () => {
+    useFixtureProject("loaded-config");
+
+    describe("when cache and artifact dirs don't exist", async () => {
+      beforeEach(async () => {
+        await remove(globalCacheDir);
+        await remove(path.join(process.cwd(), "cache"));
+        await remove(path.join(process.cwd(), "artifacts"));
+      });
+
+      await cleanAction({ global: true }, hre);
+      assertCleanBehavior(true, globalCacheDir);
+    });
+
+    describe("when cache and artifact are empty dirs", async () => {
+      beforeEach(async () => {
+        await remove(globalCacheDir);
+        await remove(path.join(process.cwd(), "cache"));
+        await remove(path.join(process.cwd(), "artifacts"));
+        await getCacheDir(); // Recreate the cache dir
+        await mkdir(path.join(process.cwd(), "cache"));
+        await mkdir(path.join(process.cwd(), "artifacts"));
+      });
+
+      await cleanAction({ global: true }, hre);
+      assertCleanBehavior(true, globalCacheDir);
+    });
+
+    describe("when cache and artifact dirs aren't empty", async () => {
+      beforeEach(async () => {
+        await remove(globalCacheDir);
+        await remove(path.join(process.cwd(), "cache"));
+        await remove(path.join(process.cwd(), "artifacts"));
+        await getCacheDir(); // Recreate the cache dir
+        await writeUtf8File(path.join(globalCacheDir, "a"), "");
+        await writeUtf8File(path.join(process.cwd(), "cache", "a"), "");
+        await writeUtf8File(path.join(process.cwd(), "artifacts", "a"), "");
+      });
+
+      await cleanAction({ global: true }, hre);
+      assertCleanBehavior(true, globalCacheDir);
+    });
+
+    describe("when global flag is false", async () => {
+      beforeEach(async () => {
+        await remove(globalCacheDir);
+        await getCacheDir(); // Recreate the cache dir
+        await writeUtf8File(path.join(globalCacheDir, "a"), "");
+      });
+
+      await cleanAction({ global: false }, hre);
+      assertCleanBehavior(false, globalCacheDir);
+    });
+  });
+});

--- a/v-next/hardhat/test/internal/builtin-plugins/run/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/run/task-action.ts
@@ -9,7 +9,7 @@ import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
 import runScriptWithHardhat from "../../../../src/internal/builtin-plugins/run/task-action.js";
 import { useFixtureProject } from "../../../helpers/project.js";
 
-describe("runScriptWithHardhat", function () {
+describe("run/task-action", function () {
   let hre: HardhatRuntimeEnvironment;
 
   before(async function () {

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -222,6 +222,7 @@ Usage: hardhat [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUM
 
 AVAILABLE TASKS:
 
+  clean                    Clears the cache and deletes all artifacts
   example                  Example task
   run                      Runs a user-defined script after compiling the project
   task                     A task that uses arg1


### PR DESCRIPTION
This PR requires https://github.com/NomicFoundation/hardhat/pull/5527 ~and https://github.com/NomicFoundation/hardhat/pull/5517.~

The logic to create the `cache` and `artifacts` paths is missing, as it's outside the scope of this issue. Because of this, the tests are somewhat "manual" – we handle the folders manually to simulate different scenarios. However, this should be acceptable.

~The build is currently failing because it needs [PR #5517](https://github.com/NomicFoundation/hardhat/pull/5517) and some additional code (e.g., adding the `cache` and `artifacts` properties in `v-next/core/test/internal/hook-manager.ts`).~

The task might require additional steps, such as calling `artifacts.clearCache?.()`, which depends on how the new build system works.