### PR TITLE
Basic debug logging

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1537,6 +1537,9 @@ importers:
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
+      debug:
+        specifier: ^4.1.1
+        version: 4.3.4(supports-color@8.1.1)
       enquirer:
         specifier: ^2.3.0
         version: 2.4.1
@@ -1556,6 +1559,9 @@ importers:
       '@nomicfoundation/hardhat-test-utils':
         specifier: workspace:^
         version: link:../hardhat-test-utils
+      '@types/debug':
+        specifier: ^4.1.4
+        version: 4.1.12
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9
@@ -1908,6 +1914,9 @@ importers:
 
   v-next/hardhat-utils:
     dependencies:
+      debug:
+        specifier: ^4.1.1
+        version: 4.3.4(supports-color@8.1.1)
       fast-equals:
         specifier: ^5.0.1
         version: 5.0.1
@@ -1930,6 +1939,9 @@ importers:
       '@types/bn.js':
         specifier: ^5.1.5
         version: 5.1.5
+      '@types/debug':
+        specifier: ^4.1.4
+        version: 4.1.12
       '@types/keccak':
         specifier: ^3.0.4
         version: 3.0.4

--- a/v-next/core/package.json
+++ b/v-next/core/package.json
@@ -55,8 +55,8 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
-    "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@microsoft/api-extractor": "^7.43.4",
+    "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/node": "^20.14.9",
     "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^7.7.1",

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -18,6 +18,7 @@
     "./common-errors": "./dist/src/common-errors.js",
     "./crypto": "./dist/src/crypto.js",
     "./date": "./dist/src/date.js",
+    "./debug": "./dist/src/debug.js",
     "./error": "./dist/src/error.js",
     "./eth": "./dist/src/eth.js",
     "./fs": "./dist/src/fs.js",
@@ -57,6 +58,7 @@
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
     "@types/bn.js": "^5.1.5",
+    "@types/debug": "^4.1.4",
     "@types/keccak": "^3.0.4",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
@@ -74,6 +76,7 @@
     "typescript-eslint": "7.7.1"
   },
   "dependencies": {
+    "debug": "^4.1.1",
     "fast-equals": "^5.0.1",
     "keccak": "^3.0.4",
     "rfdc": "^1.3.1",

--- a/v-next/hardhat-utils/src/debug.ts
+++ b/v-next/hardhat-utils/src/debug.ts
@@ -1,0 +1,38 @@
+import debugLib from "debug";
+
+/**
+ * A simple decorator that adds debug logging for when a method is entered and exited.
+ *
+ * This decorator is meant to be used for debugging purposes only. It should not be committed in runtime code.
+ *
+ * Example usage:
+ *
+ * ```
+ * class MyClass {
+ *   @withDebugLogs("MyClass:exampleClassMethod")
+ *   public function exampleClassMethod(...)
+ * }
+ * ```
+ */
+export function withDebugLogs<This, Args extends any[], Return>(
+  tag: string = "",
+) {
+  return function actualDecorator(
+    originalMethod: (this: This, ...args: Args) => Return,
+    _context: ClassMethodDecoratorContext<
+      This,
+      (this: This, ...args: Args) => Return
+    >,
+  ): (this: This, ...args: Args) => Return {
+    const log = debugLib(`hardhat:dev:core${tag === "" ? "" : `:${tag}`}`);
+
+    function replacementMethod(this: This, ...args: Args): Return {
+      log(`Entering method with args:`, args);
+      const result = originalMethod.call(this, ...args);
+      log(`Exiting method.`);
+      return result;
+    }
+
+    return replacementMethod;
+  };
+}

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -58,6 +58,7 @@
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
+    "@types/debug": "^4.1.4",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
@@ -78,6 +79,7 @@
     "@ignored/hardhat-vnext-utils": "workspace:^3.0.0-next.2",
     "@ignored/hardhat-vnext-zod-utils": "workspace:^3.0.0-next.2",
     "chalk": "^5.3.0",
+    "debug": "^4.1.1",
     "enquirer": "^2.3.0",
     "tsx": "^4.11.0",
     "zod": "^3.23.8"


### PR DESCRIPTION
- added basic debug logging throughout the main CLI function
- added a `withDebugLogs` decorator to core to easily enable debug logging to any class method
  - added this decorator to some class methods that I thought would be helpful, but it can always be added to others in the future as well

fixes #5363 

I would add a screenshot of the output, but there's A Lot. Recommend pulling the branch and testing inside `v-next/example-project`