### PR TITLE
fix: exit check task with exit code 1 when solhint raises errors

### DIFF
--- a/.changeset/breezy-chairs-relax.md
+++ b/.changeset/breezy-chairs-relax.md
@@ -2,8 +2,4 @@
 "@nomiclabs/hardhat-solhint": major
 ---
 
-Ensured the check task exists with exit code 1 when solhint raises any errors and updated solhint dependency to [v5.0.2](https://github.com/protofire/solhint/releases/tag/v5.0.2)
-
-## ⚠️ Breaking Change ⚠️
-
-This release introduces a breaking change. Previously, the check task would exit with exit code 0 even if solhint raised some errors. Starting with this version, the check task will exit with exit code 1 if any errors are raised and 0 otherwise.
+Ensured the check task exits with exit code 1 when solhint raises any errors; this is a breaking change since the check task would previously always exit with exit code 0

--- a/.changeset/breezy-chairs-relax.md
+++ b/.changeset/breezy-chairs-relax.md
@@ -1,0 +1,9 @@
+---
+"@nomiclabs/hardhat-solhint": major
+---
+
+Ensured the check task exists with exit code 1 when solhint raises any errors and updated solhint dependency to [v5.0.2](https://github.com/protofire/solhint/releases/tag/v5.0.2)
+
+## ⚠️ Breaking Change ⚠️
+
+This release introduces a breaking change. Previously, the check task would exit with exit code 0 even if solhint raised some errors. Starting with this version, the check task will exit with exit code 1 if any errors are raised and 0 otherwise.

--- a/.changeset/early-laws-trade.md
+++ b/.changeset/early-laws-trade.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-solhint": major
+---
+
+Updated solhint dependency to [v5.0.2](https://github.com/protofire/solhint/releases/tag/v5.0.2)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,8 @@ Unlike linking, if you make a change in the code, you'll need to repeat the proc
 
 An even more realistic way of using your local changes in a project is to use [`pnpm pack`](https://pnpm.io/cli/pack):
 
-1. Go to `packages/hardhat-core` and run `pnpm pack`. This will create a `nomiclabs-hardhat-x.y.z.tgz` file in that directory.
-2. Go to some hardhat project and run `npm install /path/to/hardhat/packages/hardhat/nomiclabs-hardhat-x.y.z.tgz`.
+1. Go to `packages/hardhat-core` and run `pnpm pack`. This will create a `hardhat-x.y.z.tgz` file in that directory.
+2. Go to some hardhat project and run `npm install /path/to/hardhat/packages/hardhat-core/hardhat-x.y.z.tgz`.
 
 Unlike linking, if you make a change in the code, you'll need to repeat the process.
 

--- a/packages/hardhat-solhint/package.json
+++ b/packages/hardhat-solhint/package.json
@@ -35,7 +35,7 @@
     "README.md"
   ],
   "dependencies": {
-    "solhint": "^3.6.2"
+    "solhint": "^5.0.2"
   },
   "devDependencies": {
     "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",

--- a/packages/hardhat-solhint/package.json
+++ b/packages/hardhat-solhint/package.json
@@ -35,7 +35,7 @@
     "README.md"
   ],
   "dependencies": {
-    "solhint": "^3.4.0"
+    "solhint": "^3.6.2"
   },
   "devDependencies": {
     "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",

--- a/packages/hardhat-solhint/src/index.ts
+++ b/packages/hardhat-solhint/src/index.ts
@@ -127,4 +127,15 @@ task("check", async (_, { run }, runSuper) => {
   const reports = await run("hardhat-solhint:run-solhint");
 
   printReport(reports);
+
+  const errorsCount = reports.reduce(
+    (acc: number, i: { errorCount: number }) => {
+      return acc + i.errorCount;
+    },
+    0
+  );
+
+  if (errorsCount > 0) {
+    process.exit(1);
+  }
 });

--- a/packages/hardhat-solhint/src/index.ts
+++ b/packages/hardhat-solhint/src/index.ts
@@ -136,6 +136,7 @@ task("check", async (_, { run }, runSuper) => {
   );
 
   if (errorsCount > 0) {
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 });

--- a/packages/hardhat-solhint/test/fixture-projects/no-errors-project/.solhint.json
+++ b/packages/hardhat-solhint/test/fixture-projects/no-errors-project/.solhint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "solhint:all"
+}

--- a/packages/hardhat-solhint/test/fixture-projects/no-errors-project/contracts/Greeter.sol
+++ b/packages/hardhat-solhint/test/fixture-projects/no-errors-project/contracts/Greeter.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.8.0;
+
+
+contract Greeter {
+
+    string greeting;
+    constructor(string memory _greeting) public {
+        greeting = _greeting;
+    }
+
+    function greet() public view returns (string memory) {
+        return greeting;
+    }
+
+}

--- a/packages/hardhat-solhint/test/fixture-projects/no-errors-project/hardhat.config.js
+++ b/packages/hardhat-solhint/test/fixture-projects/no-errors-project/hardhat.config.js
@@ -1,0 +1,5 @@
+require("../../../src/index");
+
+module.exports = {
+  solidity: "0.5.15",
+};

--- a/packages/hardhat-solhint/test/tests.ts
+++ b/packages/hardhat-solhint/test/tests.ts
@@ -36,28 +36,24 @@ describe("Solhint plugin", function () {
       );
     });
 
-    it("should run the check task and exit", async function () {
+    it("should run the check task and set the exit code to 1", async function () {
       const consoleLogStub = sinon.stub(console, "log");
-      const processExitStub = sinon.stub(process, "exit");
       await this.env.run("check");
       assert.isTrue(consoleLogStub.calledOnce);
-      assert.isTrue(processExitStub.calledOnceWith(1));
+      assert.strictEqual(process.exitCode, 1);
       consoleLogStub.restore();
-      processExitStub.restore();
+      process.exitCode = undefined;
     });
   });
 
   describe("Project with no errors", function () {
     useEnvironment("no-errors-project");
 
-    it("should run the check task and not exit", async function () {
+    it("should run the check task and not set the exit code", async function () {
       const consoleLogStub = sinon.stub(console, "log");
-      const processExitStub = sinon.stub(process, "exit");
       await this.env.run("check");
       assert.isTrue(consoleLogStub.calledOnce);
-      assert.isTrue(processExitStub.notCalled);
-      consoleLogStub.restore();
-      processExitStub.restore();
+      assert.strictEqual(process.exitCode, undefined);
     });
   });
 

--- a/packages/hardhat-solhint/test/tests.ts
+++ b/packages/hardhat-solhint/test/tests.ts
@@ -36,11 +36,28 @@ describe("Solhint plugin", function () {
       );
     });
 
-    it("should run the check task without throwing an error", async function () {
+    it("should run the check task and exit", async function () {
       const consoleLogStub = sinon.stub(console, "log");
+      const processExitStub = sinon.stub(process, "exit");
       await this.env.run("check");
       assert.isTrue(consoleLogStub.calledOnce);
+      assert.isTrue(processExitStub.calledOnceWith(1));
       consoleLogStub.restore();
+      processExitStub.restore();
+    });
+  });
+
+  describe("Project with no errors", function () {
+    useEnvironment("no-errors-project");
+
+    it("should run the check task and not exit", async function () {
+      const consoleLogStub = sinon.stub(console, "log");
+      const processExitStub = sinon.stub(process, "exit");
+      await this.env.run("check");
+      assert.isTrue(consoleLogStub.calledOnce);
+      assert.isTrue(processExitStub.notCalled);
+      consoleLogStub.restore();
+      processExitStub.restore();
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -861,8 +861,8 @@ importers:
   packages/hardhat-solhint:
     dependencies:
       solhint:
-        specifier: ^3.6.2
-        version: 3.6.2(typescript@5.0.4)
+        specifier: ^5.0.2
+        version: 5.0.2(typescript@5.0.4)
     devDependencies:
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
@@ -2511,6 +2511,18 @@ packages:
     resolution: {integrity: sha512-WadzXP6rXSQT51BgsmVT5OVxWS9+DWSsn8ebhtFBKb60Z3S8KA0wo5wiM7AQIrhNb4qfcQqk6HpYo6Fmpum4ew==}
     hasBin: true
 
+  '@pnpm/config.env-replace@1.1.0':
+    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/network.ca-file@1.0.2':
+    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/npm-conf@2.2.2':
+    resolution: {integrity: sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==}
+    engines: {node: '>=12'}
+
   '@scure/base@1.1.6':
     resolution: {integrity: sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==}
 
@@ -2581,9 +2593,6 @@ packages:
 
   '@solidity-parser/parser@0.14.5':
     resolution: {integrity: sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==}
-
-  '@solidity-parser/parser@0.16.2':
-    resolution: {integrity: sha512-PI9NfoA3P8XK2VBkK5oIfRgKDsicwDZfkVq9ZTBCQYGOP1N2owgY2dyLGyU5/J/hQs8KRk55kdmvTLjy3Mu3vg==}
 
   '@solidity-parser/parser@0.18.0':
     resolution: {integrity: sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==}
@@ -3549,6 +3558,9 @@ packages:
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   constant-case@2.0.0:
     resolution: {integrity: sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==}
@@ -4540,6 +4552,9 @@ packages:
     resolution: {integrity: sha512-hBv2ty9QN2RdbJJMK3hesmSkFTjVIHyIDDbssCKnSmq62edGgImJWD10Eb1k77TiV1bxloxqcFAVK8+9pkhOig==}
     engines: {node: '>=14.16'}
 
+  graceful-fs@4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -5076,6 +5091,10 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  latest-version@7.0.0:
+    resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
+    engines: {node: '>=14.16'}
 
   lcid@1.0.0:
     resolution: {integrity: sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==}
@@ -5623,6 +5642,10 @@ packages:
     resolution: {integrity: sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==}
     engines: {node: '>=8'}
 
+  package-json@8.1.1:
+    resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
+    engines: {node: '>=14.16'}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -5807,6 +5830,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -5944,6 +5970,14 @@ packages:
   regexp.prototype.flags@1.5.2:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
+
+  registry-auth-token@5.0.2:
+    resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
+    engines: {node: '>=14'}
+
+  registry-url@6.0.1:
+    resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
+    engines: {node: '>=12'}
 
   release-zalgo@1.0.0:
     resolution: {integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==}
@@ -6220,8 +6254,8 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  solhint@3.6.2:
-    resolution: {integrity: sha512-85EeLbmkcPwD+3JR7aEMKsVC9YrRSxd4qkXuMzrlf7+z2Eqdfm1wHWq1ffTuo5aDhoZxp2I9yF3QkxZOxOL7aQ==}
+  solhint@5.0.2:
+    resolution: {integrity: sha512-fDoflGz1jztGRqEDiLI25wSvpjGu0fIqeRXXYKYt4qBOA0EJi8RZwlM11+K2ZAcGFW2K8bevJ2A/wtZ0lDi/bw==}
     hasBin: true
 
   solidity-coverage@0.8.12:
@@ -8358,6 +8392,18 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@pnpm/config.env-replace@1.1.0': {}
+
+  '@pnpm/network.ca-file@1.0.2':
+    dependencies:
+      graceful-fs: 4.2.10
+
+  '@pnpm/npm-conf@2.2.2':
+    dependencies:
+      '@pnpm/config.env-replace': 1.1.0
+      '@pnpm/network.ca-file': 1.0.2
+      config-chain: 1.1.13
+
   '@scure/base@1.1.6': {}
 
   '@scure/bip32@1.1.5':
@@ -8463,10 +8509,6 @@ snapshots:
   '@sinonjs/text-encoding@0.7.2': {}
 
   '@solidity-parser/parser@0.14.5':
-    dependencies:
-      antlr4ts: 0.5.0-alpha.4
-
-  '@solidity-parser/parser@0.16.2':
     dependencies:
       antlr4ts: 0.5.0-alpha.4
 
@@ -9546,6 +9588,11 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
       typedarray: 0.0.6
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   constant-case@2.0.0:
     dependencies:
@@ -10871,6 +10918,8 @@ snapshots:
       p-cancelable: 3.0.0
       responselike: 2.0.1
 
+  graceful-fs@4.2.10: {}
+
   graceful-fs@4.2.11: {}
 
   grapheme-splitter@1.0.4: {}
@@ -11382,6 +11431,10 @@ snapshots:
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  latest-version@7.0.0:
+    dependencies:
+      package-json: 8.1.1
 
   lcid@1.0.0:
     dependencies:
@@ -11948,6 +12001,13 @@ snapshots:
       lodash.flattendeep: 4.4.0
       release-zalgo: 1.0.0
 
+  package-json@8.1.1:
+    dependencies:
+      got: 12.1.0
+      registry-auth-token: 5.0.2
+      registry-url: 6.0.1
+      semver: 7.6.2
+
   pako@1.0.11: {}
 
   param-case@2.1.1:
@@ -12118,6 +12178,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  proto-list@1.2.4: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -12270,6 +12332,14 @@ snapshots:
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
+
+  registry-auth-token@5.0.2:
+    dependencies:
+      '@pnpm/npm-conf': 2.2.2
+
+  registry-url@6.0.1:
+    dependencies:
+      rc: 1.2.8
 
   release-zalgo@1.0.0:
     dependencies:
@@ -12616,9 +12686,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  solhint@3.6.2(typescript@5.0.4):
+  solhint@5.0.2(typescript@5.0.4):
     dependencies:
-      '@solidity-parser/parser': 0.16.2
+      '@solidity-parser/parser': 0.18.0
       ajv: 6.12.6
       antlr4: 4.13.1
       ast-parents: 0.0.1
@@ -12629,6 +12699,7 @@ snapshots:
       glob: 8.1.0
       ignore: 5.3.1
       js-yaml: 4.1.0
+      latest-version: 7.0.0
       lodash: 4.17.21
       pluralize: 8.0.0
       semver: 7.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -861,7 +861,7 @@ importers:
   packages/hardhat-solhint:
     dependencies:
       solhint:
-        specifier: ^3.4.0
+        specifier: ^3.6.2
         version: 3.6.2(typescript@5.0.4)
     devDependencies:
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Resolves https://github.com/NomicFoundation/hardhat/issues/5057

This PR modifies the `hardhat-solhint` plugin.

It changes the `check` task behaviour. After the changes, when `solhint` reports **any** errors (note, this does not apply to warnings), the task exists with error code 1.

The updated behaviour is in line with how `solhint` behaves as a standalone CLI tool.

Please note that this is, currently, a breaking change since it's modifying solhint plugin/check task behaviour. I will update the changesets and mark the PR as "ready for review", once we align on the open questions I outline below.

#### Open Questions
1. ~~Should we update `solhint` to the most recent version `v5.0.2`?~~ Yes
2. ~~Should we control the newly added behaviour via configuration? If so, we could also support failing the check task when a threshold of warnings is crossed. In solhint, this is controlled via command line options.~~ No (not yet, at least)


