### PR TITLE
chore: do not send hardhat_setLedgerOutputEnabled over http

### DIFF
--- a/.changeset/shaggy-bags-work.md
+++ b/.changeset/shaggy-bags-work.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Do not send `http_setLedgerOutputEnabled` messages if they reacht the HTTP Provider to prevent unwanted warnings in the local hardhat node logs

--- a/.changeset/shaggy-bags-work.md
+++ b/.changeset/shaggy-bags-work.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Do not send `http_setLedgerOutputEnabled` messages if they reacht the HTTP Provider to prevent unwanted warnings in the local hardhat node logs
+Do not send `http_setLedgerOutputEnabled` messages beyond the HTTP Provider to prevent unwanted warnings in the logs of the local hardhat node

--- a/packages/hardhat-core/src/internal/core/providers/http.ts
+++ b/packages/hardhat-core/src/internal/core/providers/http.ts
@@ -86,6 +86,15 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
   }
 
   public async request(args: RequestArguments): Promise<unknown> {
+    if (args.method === "hardhat_setLedgerOutputEnabled") {
+      const error = new ProviderError(
+        "hardhat_setLedgerOutputEnabled - Method not supported",
+        -32004
+      );
+      // eslint-disable-next-line @nomicfoundation/hardhat-internal-rules/only-hardhat-error
+      throw error;
+    }
+
     const jsonRpcRequest = this._getJsonRpcRequest(
       args.method,
       args.params as any[]

--- a/packages/hardhat-core/src/internal/core/providers/http.ts
+++ b/packages/hardhat-core/src/internal/core/providers/http.ts
@@ -86,6 +86,8 @@ export class HttpProvider extends EventEmitter implements EIP1193Provider {
   }
 
   public async request(args: RequestArguments): Promise<unknown> {
+    // This is a temporary fix to an issue with noisy warnings in the logs
+    // of a local node (#5406). This will be fixed in the next major release.
     if (args.method === "hardhat_setLedgerOutputEnabled") {
       const error = new ProviderError(
         "hardhat_setLedgerOutputEnabled - Method not supported",

--- a/packages/hardhat-core/test/internal/core/providers/http.ts
+++ b/packages/hardhat-core/test/internal/core/providers/http.ts
@@ -1,10 +1,11 @@
-import { assert } from "chai";
+import { assert, expect } from "chai";
 import { MockAgent, MockPool } from "undici";
 
 import { HttpProvider } from "../../../../src/internal/core/providers/http";
 import { ERRORS } from "../../../../src/internal/core/errors-list";
 import { SuccessfulJsonRpcResponse } from "../../../../src/internal/util/jsonrpc";
 import { expectHardhatError } from "../../../helpers/errors";
+import { ProviderError } from "../../../../src/internal/core/providers/errors";
 
 const TOO_MANY_REQUEST_STATUS = 429;
 
@@ -92,6 +93,20 @@ describe("HttpProvider", function () {
       const result = await provider.request({ method: "net_version" });
       assert.equal(result, successResponse.result);
       assert(tooManyRequestsReturned);
+    });
+
+    it("should throw an error if it receives hardhat_setLedgerOutputEnabled as a method", async function () {
+      const mockPool = makeMockPool(url);
+      mockPool
+        .intercept({ method: "POST", path: "/" })
+        .reply(200, successResponse);
+      const provider = new HttpProvider(url, networkName, {}, 20000, mockPool);
+      await expect(
+        provider.request({ method: "hardhat_setLedgerOutputEnabled" })
+      ).to.be.eventually.rejectedWith(
+        ProviderError,
+        "hardhat_setLedgerOutputEnabled - Method not supported"
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

Resolves #5406

The goal of this PR is to suppress `hardhat_setLedgerOutputEnabled - Method not supported` warnings from the local hardhat node logs. They appear there when one performs a deployment against a node and does not use `hardhat-ledger` plugin.

The approach presented in this PR is a "quick fix". It assumes that if a message with `hardhat_setLedgerOutputEnabled` method reaches an HTTP provider, it should be treated as an error and not processed further (otherwise, it would have been consumed by the ledger provider before it could reach the http provider). This ensures that if `hardhat-ledger` plugin is not used, the `hardhat_setLedgerOutputEnabled` message will never reach a running node. Hence, a warning will not be printed out by the node.

This is not an ideal solution as it exposes plugin context in the core package further. Some alternatives that I was thinking about in no particular order:
- modify the ignition not to send out `hardhat_setLedgerOutputEnabled` at all if a ledger provider is not present in the chain (the challenge being identifying a ledger provider)
- make `outputEnabled` a configuration option of the ledger plugin (I'm not sure whether completely enabling/disabling output is valid for the plugin; during deployment, we only disable it temporarily)
- suppress the message at a different layer (but the alternatives don't seem much better than the http provider as far as I can tell)