### PR TITLE
fix: run pnpm install to fix the lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1539,7 +1539,7 @@ importers:
         version: 5.3.0
       debug:
         specifier: ^4.1.1
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.6(supports-color@8.1.1)
       enquirer:
         specifier: ^2.3.0
         version: 2.4.1
@@ -1916,7 +1916,7 @@ importers:
     dependencies:
       debug:
         specifier: ^4.1.1
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.6(supports-color@8.1.1)
       fast-equals:
         specifier: ^5.0.1
         version: 5.0.1


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

I noticed that the pnpm lockfile is broken on the `v-next` currently. This is likely because I merged https://github.com/NomicFoundation/hardhat/pull/5574 which brought in `main` into `v-next` so it naturally had a lot of changes (including having to rewrite pnpm lock) and then https://github.com/NomicFoundation/hardhat/pull/5541 got merged which likely got tested before and, later, the conflict was too obscure for GitHub to notice.

To fix the lockfile, I just ran `pnpm install` in the root.
