### PR TITLE
chore: upgrade typescript to ~5.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "hardhat": "workspace:*",
     "prettier": "2.4.1",
     "shelljs": "^0.8.5",
-    "typescript": "~5.0.0"
+    "typescript": "~5.5.0"
   },
   "scripts": {
     "build": "tsc --build packages/hardhat-core packages/hardhat-ethers packages/hardhat-verify packages/hardhat-vyper packages/hardhat-web3-v4 packages/hardhat-chai-matchers packages/hardhat-network-helpers packages/hardhat-toolbox packages/hardhat-foundry packages/hardhat-ledger packages/hardhat-viem packages/hardhat-toolbox-viem",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.8.5
         version: 0.8.5
       typescript:
-        specifier: ~5.0.0
-        version: 5.0.4
+        specifier: ~5.5.0
+        version: 5.5.4
 
   packages/common:
     devDependencies:
@@ -9048,7 +9048,7 @@ snapshots:
       commander: 10.0.1
       filing-cabinet: 4.2.0
       precinct: 11.0.5
-      typescript: 5.5.4
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
 
@@ -9775,7 +9775,7 @@ snapshots:
       sass-lookup: 5.0.1
       stylus-lookup: 5.0.1
       tsconfig-paths: 4.2.0
-      typescript: 5.5.4
+      typescript: 5.0.4
 
   fill-range@7.1.1:
     dependencies:


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

We use `${configDir}` template variable in our `tsconfig.json` on `v-next` (e.g. https://github.com/NomicFoundation/hardhat/blob/bae09d38603cc31b7257c43b9d3abc768384abd4/config-v-next/tsconfig.json#L4) which has only been released in TypeScript 5.5 (https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#the-configdir-template-variable-for-configuration-files).

I've noticed it only, because I had my VSCode configured to use the workspace version of TypeScript, and when browsing files in `v-next`, it'd fail to resolve types.