### PR TITLE
feat: add a built-in console task

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -7,6 +7,11 @@ const hardhatPlugin: HardhatPlugin = {
   tasks: [
     task("console", "Opens a hardhat console")
       .setAction(import.meta.resolve("./task-action.js"))
+      .addOption({
+        name: "history",
+        description: "Path to a history file",
+        defaultValue: "console-history.txt",
+      })
       .addVariadicArgument({
         name: "commands",
         description: "Commands to run in the console",

--- a/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -1,0 +1,19 @@
+import type { HardhatPlugin } from "@ignored/hardhat-vnext-core/types/plugins";
+
+import { task } from "@ignored/hardhat-vnext-core/config";
+
+const hardhatPlugin: HardhatPlugin = {
+  id: "console",
+  tasks: [
+    task("console", "Opens a hardhat console")
+      .setAction(import.meta.resolve("./task-action.js"))
+      .addVariadicArgument({
+        name: "commands",
+        description: "Commands to run in the console",
+        defaultValue: [".help"],
+      })
+      .build(),
+  ],
+};
+
+export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -12,6 +12,10 @@ const hardhatPlugin: HardhatPlugin = {
         description: "Path to a history file",
         defaultValue: "console-history.txt",
       })
+      .addFlag({
+        name: "noCompile",
+        description: "Don't compile before running this task",
+      })
       .addVariadicArgument({
         name: "commands",
         description: "Commands to run in the console",

--- a/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
@@ -1,0 +1,46 @@
+import type { NewTaskActionFunction } from "@ignored/hardhat-vnext-core/types/tasks";
+import type { REPLServer } from "node:repl";
+
+import path from "node:path";
+import repl from "node:repl";
+
+import { getCacheDir } from "@ignored/hardhat-vnext-core/global-dir";
+import debug from "debug";
+
+const log = debug("hardhat:core:tasks:console");
+
+interface ConsoleActionArguments {
+  commands: string[];
+}
+
+const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
+  { commands },
+  _hre,
+) => {
+  const globalCacheDir = await getCacheDir();
+
+  return new Promise<REPLServer>((resolve) => {
+    // Start a new REPL server with the default options
+    const replServer = repl.start();
+
+    // Set up the REPL history file in the global cache directory
+    const historyPath = path.join(globalCacheDir, "console-history.txt");
+    replServer.setupHistory(historyPath, (err: Error | null) => {
+      if (err !== null) {
+        log(`Failed to setup REPL history: ${err.message}`);
+      }
+    });
+
+    // Execute each command in the REPL server
+    for (const command of commands) {
+      replServer.write(`${command}\n`);
+    }
+
+    // Resolve the task action promise when the REPL server exits
+    replServer.on("exit", () => {
+      resolve(replServer);
+    });
+  });
+};
+
+export default consoleAction;

--- a/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
@@ -46,6 +46,11 @@ const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
 
     // Add the Hardhat Runtime Environment to the REPL context
     replServer.context.hre = hre;
+    replServer.context.config = hre.config;
+    replServer.context.tasks = hre.tasks;
+    replServer.context.globalOptions = hre.globalOptions;
+    replServer.context.hooks = hre.hooks;
+    replServer.context.interruptions = hre.interruptions;
 
     // Set up the REPL history file if the historyPath has been set
     if (historyPath !== undefined) {

--- a/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
@@ -24,10 +24,11 @@ const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
   // Resolve the history path if it is not empty
   let historyPath: string | undefined;
   if (history !== "") {
-    const globalCacheDir = await getCacheDir();
+    // TODO(#5599): Replace with hre.config.paths.cache once it is available
+    const cacheDir = await getCacheDir();
     historyPath = path.isAbsolute(history)
       ? history
-      : path.resolve(globalCacheDir, history);
+      : path.resolve(cacheDir, history);
   }
 
   // If noCompile is false, run the compile task first

--- a/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
@@ -53,7 +53,7 @@ const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
         replServer.setupHistory(historyPath, (err: Error | null) => {
           // Fail silently if the history file cannot be set up
           if (err !== null) {
-            log(`Failed to setup REPL history: ${err.message}`);
+            log("Failed to setup REPL history", err);
           }
           resolveSetupHistory();
         });

--- a/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
@@ -18,7 +18,7 @@ interface ConsoleActionArguments {
 
 const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
   { commands, history, options },
-  _hre,
+  hre,
 ) => {
   // Resolve the history path if it is not empty
   let historyPath: string | undefined;
@@ -37,6 +37,9 @@ const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
     replServer.on("exit", () => {
       resolve(replServer);
     });
+
+    // Add the Hardhat Runtime Environment to the REPL context
+    replServer.context.hre = hre;
 
     // Set up the REPL history file if the historyPath has been set
     if (historyPath !== undefined) {

--- a/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
@@ -33,7 +33,7 @@ const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
 
   // If noCompile is false, run the compile task first
   if (!noCompile) {
-    // todo: run compile task
+    // TODO(#5600): run compile task
   }
 
   return new Promise<REPLServer>(async (resolve) => {

--- a/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
@@ -12,24 +12,30 @@ const log = debug("hardhat:core:tasks:console");
 interface ConsoleActionArguments {
   commands: string[];
   history: string;
+  noCompile: boolean;
   // We accept ReplOptions as an argument to allow tests overriding the IO streams
   options?: repl.ReplOptions;
 }
 
 const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
-  { commands, history, options },
+  { commands, history, noCompile, options },
   hre,
 ) => {
-  return new Promise<REPLServer>(async (resolve) => {
-    // Resolve the history path if it is not empty
-    let historyPath: string | undefined;
-    if (history !== "") {
-      const globalCacheDir = await getCacheDir();
-      historyPath = path.isAbsolute(history)
-        ? history
-        : path.resolve(globalCacheDir, history);
-    }
+  // Resolve the history path if it is not empty
+  let historyPath: string | undefined;
+  if (history !== "") {
+    const globalCacheDir = await getCacheDir();
+    historyPath = path.isAbsolute(history)
+      ? history
+      : path.resolve(globalCacheDir, history);
+  }
 
+  // If noCompile is false, run the compile task first
+  if (!noCompile) {
+    // todo: run compile task
+  }
+
+  return new Promise<REPLServer>(async (resolve) => {
     // Start a new REPL server with the default options
     const replServer = repl.start(options);
 

--- a/v-next/hardhat/src/internal/builtin-plugins/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/index.ts
@@ -1,13 +1,20 @@
 import type { HardhatPlugin } from "@ignored/hardhat-vnext-core/types/plugins";
 
 import clean from "./clean/index.js";
+import console from "./console/index.js";
 import hardhatFoo from "./hardhat-foo/index.js";
 import run from "./run/index.js";
 
 // Note: When importing a plugin, you have to export its types, so that its
 // type extensions, if any, also get loaded.
 export type * from "./clean/index.js";
+export type * from "./console/index.js";
 export type * from "./hardhat-foo/index.js";
 export type * from "./run/index.js";
 
-export const builtinPlugins: HardhatPlugin[] = [clean, hardhatFoo, run];
+export const builtinPlugins: HardhatPlugin[] = [
+  clean,
+  console,
+  hardhatFoo,
+  run,
+];

--- a/v-next/hardhat/src/internal/builtin-plugins/run/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/run/task-action.ts
@@ -27,7 +27,7 @@ const runScriptWithHardhat: NewTaskActionFunction<RunActionArguments> = async (
   }
 
   if (!noCompile) {
-    // todo: run compile task
+    // TODO(#5600): run compile task
   }
 
   try {

--- a/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
@@ -138,7 +138,7 @@ describe("console/task-action", function () {
     });
 
     afterEach(function () {
-      fs.rmSync(cacheDir, { recursive: true });
+      fs.rmSync(cacheDir, { recursive: true, force: true });
     });
 
     it("should create a history file", async function () {

--- a/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
@@ -27,6 +27,10 @@ describe("console/task-action", function () {
   });
 
   beforeEach(function () {
+    // Using process.stdin for the input during tests is not reliable as it
+    // causes the test runner to hang indefinitely. We use a PassThrough stream
+    // instead. This, in turn, prevents us from using process.stdout for output.
+    // Hence, we use a PassThrough stream for output as well.
     const input = new PassThrough();
     const output = new PassThrough();
     output.pipe(process.stdout);
@@ -142,6 +146,8 @@ describe("console/task-action", function () {
     let history: string;
 
     beforeEach(async function () {
+      // We use a temporary cache dir to avoid conflicts with other tests
+      // and global user settings.
       cacheDir = await fsPromises.mkdtemp(
         path.resolve(os.tmpdir(), "console-action-test-"),
       );
@@ -149,6 +155,9 @@ describe("console/task-action", function () {
     });
 
     afterEach(async function () {
+      // We try to remove the temporary cache dir after each test, but we don't
+      // fail the test if it fails. For example, we have observed that in GHA
+      // on Windows, the temp dir cannot be removed due to permission issues.
       try {
         await remove(cacheDir);
       } catch (error) {

--- a/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
@@ -40,6 +40,7 @@ describe("console/task-action", function () {
         {
           commands: ['await import("./scripts/non-existent.js");', ".exit"],
           history: "",
+          noCompile: false,
           options,
         },
         hre,
@@ -52,6 +53,7 @@ describe("console/task-action", function () {
         {
           commands: [".help", 'await import("./scripts/success.js");', ".exit"],
           history: "",
+          noCompile: false,
           options,
         },
         hre,
@@ -64,6 +66,7 @@ describe("console/task-action", function () {
         {
           commands: ['await import("./scripts/throws.js");', ".exit"],
           history: "",
+          noCompile: false,
           options,
         },
         hre,
@@ -80,6 +83,7 @@ describe("console/task-action", function () {
         {
           commands: ['await import("./scripts/non-existent.ts");', ".exit"],
           history: "",
+          noCompile: false,
           options,
         },
         hre,
@@ -92,6 +96,7 @@ describe("console/task-action", function () {
         {
           commands: ['await import("./scripts/success.ts");', ".exit"],
           history: "",
+          noCompile: false,
           options,
         },
         hre,
@@ -104,6 +109,7 @@ describe("console/task-action", function () {
         {
           commands: ['await import("./scripts/throws.ts");', ".exit"],
           history: "",
+          noCompile: false,
           options,
         },
         hre,
@@ -118,6 +124,7 @@ describe("console/task-action", function () {
         {
           commands: ["console.log(hre);", ".exit"],
           history: "",
+          noCompile: false,
           options,
         },
         hre,
@@ -150,6 +157,7 @@ describe("console/task-action", function () {
         {
           commands: [".help", ".exit"],
           history,
+          noCompile: false,
           options,
         },
         hre,

--- a/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
@@ -146,6 +146,7 @@ describe("console/task-action", function () {
     let history: string;
 
     beforeEach(async function () {
+      // TODO(#5601): Use the mkdtemp from hardhat-utils once it's available
       // We use a temporary cache dir to avoid conflicts with other tests
       // and global user settings.
       cacheDir = await fsPromises.mkdtemp(

--- a/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
@@ -1,0 +1,74 @@
+import type { HardhatRuntimeEnvironment } from "@ignored/hardhat-vnext-core/types/hre";
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+import { ensureError } from "@ignored/hardhat-vnext-utils/error";
+
+import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
+import consoleAction from "../../../../src/internal/builtin-plugins/console/task-action.js";
+import { useFixtureProject } from "../../../helpers/project.js";
+
+describe("console/task-action", function () {
+  let hre: HardhatRuntimeEnvironment;
+
+  before(async function () {
+    hre = await createHardhatRuntimeEnvironment({});
+  });
+
+  describe("javascript", function () {
+    useFixtureProject("run-js-script");
+
+    it("should throw inside the console if script does not exist", async function () {
+      const replServer = await consoleAction(
+        { commands: ['await import("./scripts/non-existent.js");', ".exit"] },
+        hre,
+      );
+      ensureError(replServer.lastError);
+    });
+
+    it("should run a script inside the console successfully", async function () {
+      const replServer = await consoleAction(
+        { commands: ['await import("./scripts/success.js");', ".exit"] },
+        hre,
+      );
+      assert.equal(replServer.lastError, undefined);
+    });
+
+    it("should throw inside the console if the script throws", async function () {
+      const replServer = await consoleAction(
+        { commands: ['await import("./scripts/throws.js");', ".exit"] },
+        hre,
+      );
+      ensureError(replServer.lastError);
+    });
+  });
+
+  describe("typescript", function () {
+    useFixtureProject("run-ts-script");
+
+    it("should throw inside the console if script does not exist", async function () {
+      const replServer = await consoleAction(
+        { commands: ['await import("./scripts/non-existent.ts");', ".exit"] },
+        hre,
+      );
+      ensureError(replServer.lastError);
+    });
+
+    it("should run a script inside the console successfully", async function () {
+      const replServer = await consoleAction(
+        { commands: ['await import("./scripts/success.ts");', ".exit"] },
+        hre,
+      );
+      assert.equal(replServer.lastError, undefined);
+    });
+
+    it("should throw inside the console if the script throws", async function () {
+      const replServer = await consoleAction(
+        { commands: ['await import("./scripts/throws.ts");', ".exit"] },
+        hre,
+      );
+      ensureError(replServer.lastError);
+    });
+  });
+});

--- a/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
@@ -112,6 +112,20 @@ describe("console/task-action", function () {
     });
   });
 
+  describe("context", function () {
+    it("should expose the Hardhat Runtime Environment", async function () {
+      const replServer = await consoleAction(
+        {
+          commands: ["console.log(hre);", ".exit"],
+          history: "",
+          options,
+        },
+        hre,
+      );
+      assert.equal(replServer.lastError, undefined);
+    });
+  });
+
   describe("history", function () {
     let cacheDir: string;
     let history: string;

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -223,6 +223,7 @@ Usage: hardhat [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUM
 AVAILABLE TASKS:
 
   clean                    Clears the cache and deletes all artifacts
+  console                  Opens a hardhat console
   example                  Example task
   run                      Runs a user-defined script after compiling the project
   task                     A task that uses arg1


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Resolves #5575

This PR adds a `console` task to the next version of `hardhat`. Here's how it looks like:

```
$ # Show console task's help
$ 
$ pnpm hardhat console --help
Opens a hardhat console

Usage: hardhat [GLOBAL OPTIONS] console [--history <STRING>] [--no-compile] [--] [commands]

OPTIONS:

  --history         Path to a history file
  --no-compile      Don't compile before running this task

POSITIONAL ARGUMENTS:

  commands          Commands to run in the console

For global options help run: hardhat --help
$ 
$ # Run the console task and preview the `hre` context variable
$ 
$ pnpm hardhat console
> .help
.break    Sometimes you get stuck, this gets you out
.clear    Break, and also clear the local context
.editor   Enter editor mode
.exit     Exit the REPL
.help     Print this help message
.load     Load JS from a file into the REPL session
.save     Save all evaluated commands in this REPL session to a file

Press Ctrl+C to abort current expression, Ctrl+D to exit the REPL
> hre
HardhatRuntimeEnvironmentImplementation { userConfig: { tasks: [Array], plugins: [Array], privateKey: [Object] }, config: { plugins: [Array], tasks: [Array], path...
```

The task includes the following options:
- `history` - allows specifying the path where REPL history file should be stored. If it's relative, it will be resolved in the context of global hardhat cache dir. If it is explicitly set to an empty string, the history will not be preserved. It defaults to `console-history.txt` in the global hardhat cache dir. This is very helpful during testing, but I thought it might be useful to the users, too.
- `noCompile` - disables compilation task. This is not implemented yet.
- `options` - This is a hidden argument. It is not exposed to the users. It is only used during testing to set custom REPL options. In particular, we override the IO streams during testing because otherwise the test runner hangs indefinitely.
- `commands` - This is a variadic argument. One can provide a list of commands that should be executed in the REPL after the startup. It defaults to running the `.help` command after startup. This is very helpful during testing because we want to run the commands after the entire REPL setup fully complete there, but I thought it might be useful to the users, too. 

#### Testing
- [x] Added tests for the newly created task action; they are passing in CI
- [x] Manually run the newly added task in the `example-project`; `pnpm hardhat console`