### PR TITLE
feat: add zksync as supported network

### DIFF
--- a/packages/hardhat-network-helpers/src/utils.ts
+++ b/packages/hardhat-network-helpers/src/utils.ts
@@ -19,6 +19,7 @@ async function checkIfDevelopmentNetwork(
 
       cachedIsDevelopmentNetwork =
         version.toLowerCase().startsWith("hardhatnetwork") ||
+        version.toLowerCase().startsWith("zksync") ||
         version.toLowerCase().startsWith("anvil");
     } catch (e) {
       cachedIsDevelopmentNetwork = false;


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This PR adds ZKsync network to the supported networks in `hardhat-network-helpers`.

Testing

- [x] Manually tested this change on a ZKsync local node in a separate project and made sure that `zksync` is a development network and that JSON RPC endpoints are ran against ZKsync node.
- [x] Manually created tests in a separate project to make sure that functionality works in tests too.


