### PR TITLE
ci: start tracking hardhat dependencies

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.filter.outputs.changes }}
+      files: ${{ toJSON(steps.filter.outputs) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -79,17 +80,24 @@ jobs:
       - id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
+          list-files: json
           filters: ${{ steps.generate.outputs.filters }}
 
   bundle:
+    # Depending on list-packages only to check whether pnpm-lock.yaml has changed
+    # This could be handled by a simpler job, but an extra runner would have to be allocated for it
     needs: list-packages
 
-    if: needs.list-packages.outputs.packages != '[]'
+    if: |
+      contains(fromJSON(needs.list-packages.outputs.files).hardhat_files, '.github/workflows/v-next-ci.yml') ||
+        contains(fromJSON(needs.list-packages.outputs.files).hardhat_files, 'pnpm-lock.yaml')
 
+    # Using a matrix strategy even though there's only one package
+    # because we will want to add, at least, hardhat-toolbox in the future
     strategy:
       fail-fast: false
       matrix:
-        package: ${{ fromJson(needs.list-packages.outputs.packages) }}
+        package: ['hardhat']
 
     name: "[${{ matrix.package }}] bundle"
     runs-on: ubuntu-latest
@@ -134,49 +142,32 @@ jobs:
           fi
         shell: bash
       - uses: actions/download-artifact@v4
-      - id: stats
+      - id: comment
         run: |
-          echo "Bundles"
-          echo 'bundles<<EOF' >> $GITHUB_OUTPUT
-          du -sh * | sort -rh | tee -a $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
-          echo "Dependencies"
-          echo 'dependencies<<EOF' >> $GITHUB_OUTPUT
-          du -sh */node_modules/@*/* */node_modules/* | grep -Ev 'node_modules/@[^/]+$' | sort -rh | tee -a $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
-          echo "Packages"
-          echo 'packages<<EOF' >> $GITHUB_OUTPUT
-          du -sh * --exclude=*/node_modules | sort -rh | tee -a $GITHUB_OUTPUT
+          echo 'body<<EOF' >> $GITHUB_OUTPUT
+          for bundle in *; do
+            echo "# $bundle" | tee -a $GITHUB_OUTPUT
+            echo '' | tee -a $GITHUB_OUTPUT
+            echo "Size: "'`'"$(du -sh $bundle | cut -f1)"'`' | tee -a $GITHUB_OUTPUT
+            echo '' | tee -a $GITHUB_OUTPUT
+            echo '<details>' | tee -a $GITHUB_OUTPUT
+            echo '<summary>Dependencies</summary>' | tee -a $GITHUB_OUTPUT
+            echo '' | tee -a $GITHUB_OUTPUT
+            echo '```' | tee -a $GITHUB_OUTPUT
+            du -shc $bundle/node_modules/@*/* $bundle/node_modules/* |
+              grep -Ev '/node_modules/@[^/]+$' | sort -rh |
+              sed "s|$bundle/node_modules/||" | tee -a $GITHUB_OUTPUT
+            echo '```' | tee -a $GITHUB_OUTPUT
+            echo '</details>' | tee -a $GITHUB_OUTPUT
+            echo '' | tee -a $GITHUB_OUTPUT
+          done
           echo 'EOF' >> $GITHUB_OUTPUT
       - if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: bundle
           recreate: true
-          message: |
-            ## Bundle size(s)
-
-            ```
-            ${{ steps.stats.outputs.bundles }}
-            ```
-
-            <details>
-            <summary>Dependencies Only</summary>
-
-            ```
-            ${{ steps.stats.outputs.dependencies }}
-            ```
-            </details>
-
-            <details>
-            <summary>Without Dependencies</summary>
-
-            ```
-            ${{ steps.stats.outputs.packages }}
-            ```
-            </details>
+          message: ${{ steps.comment.outputs.body }}
 
   lint:
     needs: list-packages

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -167,7 +167,6 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: bundle
-          recreate: true
           message: ${{ steps.comment.outputs.body }}
 
   lint:

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -148,11 +148,11 @@ jobs:
           for bundle in *; do
             echo "# $bundle" | tee -a $GITHUB_OUTPUT
             echo '' | tee -a $GITHUB_OUTPUT
-            echo "Size: "'`'"$(du -sh $bundle --exclude=$bundle/node_modules/.pnpm | cut -f1)"'`' | tee -a $GITHUB_OUTPUT
-            echo "Dependencies Count (including transitive): "'`'"$(find node_modules/@* node_modules -depth 1 -type d ! -name '.*' ! -name '@*' | wc -l)"'`' | tee -a $GITHUB_OUTPUT
+            echo "Total size of the bundle: "'`'"$(du -sh $bundle --exclude=$bundle/node_modules/.pnpm | cut -f1)"'`' | tee -a $GITHUB_OUTPUT
+            echo "Total number of dependencies (including transitive): "'`'"$(find $bundle/node_modules/@* $bundle/node_modules -mindepth 1 -maxdepth 1 -type d ! -name '.*' ! -name '@*' | wc -l)"'`' | tee -a $GITHUB_OUTPUT
             echo '' | tee -a $GITHUB_OUTPUT
             echo '<details>' | tee -a $GITHUB_OUTPUT
-            echo '<summary>Dependencies (by size)</summary>' | tee -a $GITHUB_OUTPUT
+            echo '<summary>List of dependencies (sorted by size)</summary>' | tee -a $GITHUB_OUTPUT
             echo '' | tee -a $GITHUB_OUTPUT
             echo '```' | tee -a $GITHUB_OUTPUT
             du -shc $bundle/node_modules/@*/* $bundle/node_modules/* |

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -134,10 +134,21 @@ jobs:
           fi
         shell: bash
       - uses: actions/download-artifact@v4
-      - id: du
+      - id: stats
         run: |
-          echo 'stdout<<EOF' >> $GITHUB_OUTPUT
-          du -sh * | tee -a $GITHUB_OUTPUT
+          echo "Bundles"
+          echo 'bundles<<EOF' >> $GITHUB_OUTPUT
+          du -sh * | sort -rh | tee -a $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+          echo "Dependencies"
+          echo 'dependencies<<EOF' >> $GITHUB_OUTPUT
+          du -sh */node_modules/@*/* */node_modules/* | grep -Ev 'node_modules/@[^/]+$' | sort -rh | tee -a $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+          echo "Packages"
+          echo 'packages<<EOF' >> $GITHUB_OUTPUT
+          du -sh * --exclude=*/node_modules | sort -rh | tee -a $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
       - if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
@@ -148,8 +159,24 @@ jobs:
             ## Bundle size(s)
 
             ```
-            ${{ steps.du.outputs.stdout }}
+            ${{ steps.stats.outputs.bundles }}
             ```
+
+            <details>
+            <summary>Dependencies Only</summary>
+
+            ```
+            ${{ steps.stats.outputs.dependencies }}
+            ```
+            </details>
+
+            <details>
+            <summary>Without Dependencies</summary>
+
+            ```
+            ${{ steps.stats.outputs.packages }}
+            ```
+            </details>
 
   lint:
     needs: list-packages

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -148,7 +148,7 @@ jobs:
           for bundle in *; do
             echo "# $bundle" | tee -a $GITHUB_OUTPUT
             echo '' | tee -a $GITHUB_OUTPUT
-            echo "Size: "'`'"$(du -sh $bundle | cut -f1)"'`' | tee -a $GITHUB_OUTPUT
+            echo "Size: "'`'"$(du -sh $bundle --exclude=$bundle/node_modules/.pnpm | cut -f1)"'`' | tee -a $GITHUB_OUTPUT
             echo '' | tee -a $GITHUB_OUTPUT
             echo '<details>' | tee -a $GITHUB_OUTPUT
             echo '<summary>Dependencies</summary>' | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -149,9 +149,10 @@ jobs:
             echo "# $bundle" | tee -a $GITHUB_OUTPUT
             echo '' | tee -a $GITHUB_OUTPUT
             echo "Size: "'`'"$(du -sh $bundle --exclude=$bundle/node_modules/.pnpm | cut -f1)"'`' | tee -a $GITHUB_OUTPUT
+            echo "Dependencies Count (including transitive): "'`'"$(find node_modules/@* node_modules -depth 1 -type d ! -name '.*' ! -name '@*' | wc -l)"'`' | tee -a $GITHUB_OUTPUT
             echo '' | tee -a $GITHUB_OUTPUT
             echo '<details>' | tee -a $GITHUB_OUTPUT
-            echo '<summary>Dependencies</summary>' | tee -a $GITHUB_OUTPUT
+            echo '<summary>Dependencies (by size)</summary>' | tee -a $GITHUB_OUTPUT
             echo '' | tee -a $GITHUB_OUTPUT
             echo '```' | tee -a $GITHUB_OUTPUT
             du -shc $bundle/node_modules/@*/* $bundle/node_modules/* |

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -81,6 +81,76 @@ jobs:
         with:
           filters: ${{ steps.generate.outputs.filters }}
 
+  bundle:
+    needs: list-packages
+
+    if: needs.list-packages.outputs.packages != '[]'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.list-packages.outputs.packages) }}
+
+    name: "[${{ matrix.package }}] bundle"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: v-next/${{ matrix.package }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-env
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Build
+        run: pnpm build
+      # https://github.com/pnpm/pnpm/issues/6166
+      - name: Deploy
+        run: pnpm deploy --config.shamefully-hoist=true --config.hoist=true --config.node-linker=true --config.shared-workspace-lockfile=false --filter="$(jq -r .name package.json)" --prod --no-optional bundle
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.package }}
+          path: |
+            v-next/${{ matrix.package }}/bundle
+
+  bundle-aggregate:
+    needs: bundle
+
+    if: ${{ !cancelled() }}
+
+    name: bundle
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - env:
+          result: ${{ needs.bundle.result }}
+        run: |
+          if [[ "$result" == "failure" ]]; then
+            exit 1
+          fi
+        shell: bash
+      - uses: actions/download-artifact@v4
+      - id: du
+        run: |
+          echo 'stdout<<EOF' >> $GITHUB_OUTPUT
+          du -sh * | tee -a $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+      - if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: bundle
+          recreate: true
+          message: |
+            ## Bundle size(s)
+
+            ```
+            ${{ steps.du.outputs.stdout }}
+            ```
+
   lint:
     needs: list-packages
 

--- a/v-next/core/.gitignore
+++ b/v-next/core/.gitignore
@@ -12,3 +12,6 @@
 
 # c8 output
 /coverage
+
+# pnpm deploy output
+/bundle

--- a/v-next/example-project/.gitignore
+++ b/v-next/example-project/.gitignore
@@ -3,3 +3,6 @@
 
 # Compilation output
 /dist
+
+# pnpm deploy output
+/bundle

--- a/v-next/hardhat-build-system/.gitignore
+++ b/v-next/hardhat-build-system/.gitignore
@@ -3,3 +3,6 @@
 
 # Compilation output
 /dist
+
+# pnpm deploy output
+/bundle

--- a/v-next/hardhat-errors/.gitignore
+++ b/v-next/hardhat-errors/.gitignore
@@ -3,3 +3,6 @@
 
 # Compilation output
 /dist
+
+# pnpm deploy output
+/bundle

--- a/v-next/hardhat-node-test-reporter/.gitignore
+++ b/v-next/hardhat-node-test-reporter/.gitignore
@@ -3,3 +3,6 @@
 
 # Compilation output
 /dist
+
+# pnpm deploy output
+/bundle

--- a/v-next/hardhat-test-utils/.gitignore
+++ b/v-next/hardhat-test-utils/.gitignore
@@ -3,3 +3,6 @@
 
 # Compilation output
 /dist
+
+# pnpm deploy output
+/bundle

--- a/v-next/hardhat-utils/.gitignore
+++ b/v-next/hardhat-utils/.gitignore
@@ -3,3 +3,6 @@
 
 # Compilation output
 /dist
+
+# pnpm deploy output
+/bundle

--- a/v-next/hardhat-zod-utils/.gitignore
+++ b/v-next/hardhat-zod-utils/.gitignore
@@ -3,3 +3,6 @@
 
 # Compilation output
 /dist
+
+# pnpm deploy output
+/bundle

--- a/v-next/hardhat/.gitignore
+++ b/v-next/hardhat/.gitignore
@@ -3,3 +3,6 @@
 
 # Compilation output
 /dist
+
+# pnpm deploy output
+/bundle

--- a/v-next/template-package/.gitignore
+++ b/v-next/template-package/.gitignore
@@ -3,3 +3,6 @@
 
 # Compilation output
 /dist
+
+# pnpm deploy output
+/bundle


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Resolves #5366 

This PR implements the solution to dependency tracking initiative proposed in https://www.notion.so/nomicfoundation/Hardhat-Dependency-Tracking-4da1bbd17a7443b7a2ab9f9da1931903?pvs=4

The newly added job posts "sticky" comments on PRs, ensuring that there is no more than 1 comment generated by the job per PR.

An example of a comment - https://github.com/NomicFoundation/hardhat/pull/5653#issuecomment-2298481372