### PR TITLE
fix: return no accounts if `eth_accounts` is deprecated

### DIFF
--- a/.changeset/popular-ways-whisper.md
+++ b/.changeset/popular-ways-whisper.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Fix for `getSigners` against networks where `eth_accounts` is deprecated.

--- a/packages/hardhat-ethers/src/internal/helpers.ts
+++ b/packages/hardhat-ethers/src/internal/helpers.ts
@@ -40,7 +40,20 @@ function isArtifact(artifact: any): artifact is Artifact {
 export async function getSigners(
   hre: HardhatRuntimeEnvironment
 ): Promise<HardhatEthersSigner[]> {
-  const accounts: string[] = await hre.ethers.provider.send("eth_accounts", []);
+  let accounts: string[];
+
+  try {
+    accounts = await hre.ethers.provider.send("eth_accounts", []);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      /the method has been deprecated: eth_accounts/.test(error.message)
+    ) {
+      return [];
+    }
+
+    throw error;
+  }
 
   const signersWithAddress = await Promise.all(
     accounts.map((account) => getSigner(hre, account))

--- a/packages/hardhat-ethers/test/index.ts
+++ b/packages/hardhat-ethers/test/index.ts
@@ -73,6 +73,25 @@ describe("Ethers plugin", function () {
             "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
           );
         });
+
+        it("should return an empty array of signers if `eth_accounts` is deprecated", async function () {
+          const originalSend = this.env.ethers.provider.send;
+
+          this.env.ethers.provider.send = async function (
+            method: string,
+            params: any
+          ) {
+            if (method === "eth_accounts") {
+              throw new Error("the method has been deprecated: eth_accounts");
+            }
+
+            return originalSend.call(this, method, params);
+          };
+
+          const sigs = await this.env.ethers.getSigners();
+
+          assert.deepStrictEqual(sigs, []);
+        });
       });
 
       describe("getImpersonatedSigner", function () {


### PR DESCRIPTION
Erigon now responds that `eth_accounts` is deprecated when we make an RPC call. Instead of erroring we now return an empty set of accounts from `hre.ethers.getSigners` if `eth_accounts` is deprecated. Effectively we fall back with no unlocked accounts available from the node.
    
Fixes #5572.

## Manual Testing

This was tested by running a local [Erigon node in dev mode](https://github.com/erigontech/erigon/blob/release/2.60/DEV_CHAIN.md), connecting to it via a Hardhat script and invoking `hre.ethers.getSigners()`.