### PR TITLE
ci: test:integration if the task is available

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -153,8 +153,10 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build
         run: pnpm build
-      - name: Run tests
+      - name: Run unit tests
         run: pnpm run test
+      - name: Run integration tests
+        run: pnpm --if-present test:integration
 
   ci-aggregate:
     needs: ci


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This PR enables running `test:integration` task in CI (if the task is present for the package). This currently affects only the test reporter. It was discovered as part of #5437

This PR will be ready for review once the CI is 🟢 
