### PR TITLE
Add await in provider creation

### DIFF
--- a/.changeset/loud-cooks-obey.md
+++ b/.changeset/loud-cooks-obey.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed `debug` logs in Hardhat Network initialization process.

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -628,7 +628,7 @@ export async function createHardhatNetworkProvider(
   log("Making tracing config");
   const tracingConfig = await makeTracingConfig(artifacts);
   log("Creating EDR provider");
-  const provider = EdrProviderWrapper.create(
+  const provider = await EdrProviderWrapper.create(
     hardhatNetworkProviderConfig,
     loggerConfig,
     tracingConfig


### PR DESCRIPTION
In https://github.com/NomicFoundation/hardhat/pull/5478 I added some debug logs to investigate a false negative we have now and then on EDR's CI. But I forgot to await the provider creation, so these logs are pretty useless as they are.

This PR just adds the proper await.