### PR TITLE
ci: do not pipe output to stdout during console test

### DIFF
--- a/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
@@ -33,7 +33,6 @@ describe("console/task-action", function () {
     // Hence, we use a PassThrough stream for output as well.
     const input = new PassThrough();
     const output = new PassThrough();
-    output.pipe(process.stdout);
     options = {
       input,
       output,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

I have noticed that the console task test that I recently added is flaky, e.g. https://github.com/NomicFoundation/hardhat/actions/runs/10484622700/job/29039290910

```
1) console/task-action
     test/internal/builtin-plugins/console/task-action.ts:

   Error: Unable to deserialize cloned data due to invalid or unsupported version.
       at #proccessRawBuffer (node:internal/test_runner/runner:319:20)
       at FileTest.parseMessage (node:internal/test_runner/runner:255:28)
       at Socket.<anonymous> (node:internal/test_runner/runner:353:15)
       at Socket.emit (node:events:520:28)
       at addChunk (node:internal/streams/readable:559:12)
       at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
       at Readable.push (node:internal/streams/readable:390:5)
       at Pipe.onStreamRead (node:internal/stream_base_commons:191:23)
```

Please note that I didn't do a full investigation on the root cause yet, because I suspect that this patch might be a quick fix for the issue we're noticing. If that's not the case, I'd propose spending a little more time on a more in-depth investigation.

#### Testing

- [x] Re-run CI on this PR 10 times (https://github.com/NomicFoundation/hardhat/actions/runs/10504142162?pr=5666)