### PR TITLE
Change how we load tsx

### DIFF
--- a/v-next/hardhat/src/cli.ts
+++ b/v-next/hardhat/src/cli.ts
@@ -1,6 +1,11 @@
+import { register } from "tsx/esm/api";
+
 // We enable the sourcemaps before loading main, so that everything except this
 // small file is loaded with sourcemaps enabled.
 process.setSourceMapsEnabled(true);
+
+// Register tsx
+const _unregister = register();
 
 // eslint-disable-next-line no-restricted-syntax -- Allow top-level await here
 const { main } = await import("./internal/cli/main.js");

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -12,8 +12,6 @@ import type {
   TaskArguments,
 } from "@ignored/hardhat-vnext-core/types/tasks";
 
-import "tsx"; // NOTE: This is important, it allows us to load .ts files form the CLI
-
 import {
   buildGlobalOptionDefinitions,
   parseArgumentValue,


### PR DESCRIPTION
This is a small PR that changes how we load `tsx` in the CLI, to follow [its documentation](https://tsx.is/dev-api/register-esm).