### PR TITLE
ci: trigger v-next ci on changes to scripts

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -10,12 +10,14 @@ on:
       - "v-next/**"
       - "config-v-next/**"
       - "pnpm-lock.yaml"
+      - "scripts/**"
   pull_request:
     paths:
       - ".github/workflows/v-next-ci.yml"
       - "v-next/**"
       - "config-v-next/**"
       - "pnpm-lock.yaml"
+      - "scripts/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This PR ensures we run CI on PRs to v-next when we modify `scripts`. This was discovered in https://github.com/NomicFoundation/hardhat/pull/5671

There is a more general question whether we want to run the v-next CI on any PR to the v-next branch since we require `ci` and `lint` checks in merge queue. This PR doesn't address this fully.
