### PR TITLE
ci: trigger v-next ci on pull requests to v-next branch

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -5,17 +5,10 @@ on:
   push:
     branches:
       - v-next
-    paths:
-      - ".github/workflows/v-next-ci.yml"
-      - "v-next/**"
-      - "config-v-next/**"
-      - "pnpm-lock.yaml"
   pull_request:
-    paths:
-      - ".github/workflows/v-next-ci.yml"
-      - "v-next/**"
-      - "config-v-next/**"
-      - "pnpm-lock.yaml"
+    # TODO: Remove the filter when v-next is merged into main
+    branches:
+      - v-next
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This is an alternative to https://github.com/NomicFoundation/hardhat/pull/5675 which ensures we run `ci` and `lint` on every PR to `v-next`. 

We could consider extracting `check_*` jobs out of the workflow since neither `ci` nor `lint` depend on it but I don't think that's strictly necessary.