### PR TITLE
ci: fix hardhat dependencies reporting

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -108,7 +108,21 @@ jobs:
         run: pnpm build
       # https://github.com/pnpm/pnpm/issues/6166
       - name: Deploy
-        run: pnpm deploy --config.shamefully-hoist=true --config.hoist=true --config.node-linker=true --config.shared-workspace-lockfile=false --filter="$(jq -r .name package.json)" --prod --no-optional bundle
+        run: |
+          pnpm deploy --config.shamefully-hoist=true --config.hoist=true --config.node-linker=true --config.shared-workspace-lockfile=false --filter="$(jq -r .name package.json)" --prod --no-optional bundle
+          # We need to move the node_modules links from v-next/hardhat/bundle to bundle because
+          # https://github.com/pnpm/pnpm/pull/8465 broke modules generation with the set of options we provide
+          for old_link in $(find v-next/hardhat/bundle -type l); do
+            echo "Processing link $old_link"
+            new_link="${old_link#v-next/hardhat/}"
+            new_link_dir="$(dirname "$new_link")"
+            old_link_target="$(readlink -f "$old_link")"
+            mkdir -p "$new_link_dir"
+            ln -rs "$old_link_target" "$new_link"
+            new_link_target="$(readlink "$new_link")"
+            echo "Created link $new_link -> $new_link_target"
+          done
+          rm -rf v-next
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.package }}

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -135,7 +135,11 @@ jobs:
           fi
         shell: bash
       - uses: actions/download-artifact@v4
+      - id: download
+        run: ls -1 | wc -l | xargs -I {} -0 echo "count={}" | tee -a $GITHUB_OUTPUT
+        shell: bash
       - id: comment
+        if: steps.download.outputs.count != '0'
         run: |
           echo 'body<<EOF' >> $GITHUB_OUTPUT
           for bundle in *; do
@@ -156,7 +160,7 @@ jobs:
             echo '' | tee -a $GITHUB_OUTPUT
           done
           echo 'EOF' >> $GITHUB_OUTPUT
-      - if: github.event_name == 'pull_request'
+      - if: github.event_name == 'pull_request' && steps.download.outputs.count != '0'
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: bundle


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This PR fixes the following two issues:
- If `pnpm-lock.yaml` was NOT modified, we should not post a comment. Currently, we're posting a comment that looks like this - https://github.com/NomicFoundation/hardhat/pull/5681#issuecomment-2312898202. To fix this, I added a check to see whether the bundle aggregate downloaded any bundles or not.
- An uploaded bundle artifact should include `node_modules`. After https://github.com/pnpm/pnpm/pull/8465, in our setup, `pnpm deploy` started producing two `node_modules` dirs at two different locations (only one of them being inside the bundle path). To quickly fix this, I added a loop which moves the links from the "wrong" `node_modules` directory to the correct one.

TODO:
- [ ] Raise an issue with `pnpm` about `pnpm deploy` getting broken for us in https://github.com/pnpm/pnpm/releases/tag/v9.9.0