### PR TITLE
chore: set exit code to 1 on test failures

### DIFF
--- a/v-next/hardhat-mocha-test-runner/src/task-action.ts
+++ b/v-next/hardhat-mocha-test-runner/src/task-action.ts
@@ -85,7 +85,7 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   });
 
   if (testFailures > 0) {
-    process.exitCode = testFailures;
+    process.exitCode = 1;
   }
 
   return testFailures;

--- a/v-next/hardhat-node-test-runner/src/task-action.ts
+++ b/v-next/hardhat-node-test-runner/src/task-action.ts
@@ -91,7 +91,7 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   const testFailures = await runTests();
 
   if (testFailures > 0) {
-    process.exitCode = testFailures;
+    process.exitCode = 1;
   }
 
   return testFailures;


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This is a follow-up to the discussions in https://github.com/NomicFoundation/hardhat/pull/5584#discussion_r1731096110 and https://nomicfoundation.slack.com/archives/C05MKFQJBCH/p1724801183793089?thread_ts=1724682710.005219&cid=C05MKFQJBCH

This PR ensures that both node:test and mocha test runner plugins set the process exit code to 1 instead of a number of failures when they encounter test failures. This ensures our exit code usage is along what's commonly expected, e.g. https://tldp.org/LDP/abs/html/exitcodes.html
