### PR TITLE
Zod utils improvements

### DIFF
--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -257,6 +257,12 @@ function createConfig(
           message:
             "Don't use assert.doesNotReject. Just await the async-function-call/promise directly, letting the error bubble up if rejected",
         },
+        {
+          selector:
+            "CallExpression[callee.object.name='z'][callee.property.name=union]",
+          message:
+            "Use the unionType helper from the zod utils package instead, as it provides better error messages.",
+        },
       ],
       "@typescript-eslint/restrict-plus-operands": "error",
       "@typescript-eslint/restrict-template-expressions": [
@@ -387,6 +393,12 @@ function createConfig(
                 ),
               ],
               message: "Use node:assert/strict instead.",
+            },
+            {
+              name: "zod",
+              importNames: ["union"],
+              message:
+                "Use the unionType helper from the zod utils package instead, as it provides better error messages.",
             },
           ],
         },

--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -426,7 +426,7 @@ function createConfig(
       files: ["src/**/*.ts"],
       rules: {
         "no-restricted-syntax": [
-          "error",
+          ...config.rules["no-restricted-syntax"],
           {
             // This is a best effor selector that forbids every throw unless it's a `new HardhatError`,
             // or throwing a variable within a catch clause.

--- a/v-next/hardhat-mocha-test-runner/src/hookHandlers/config.ts
+++ b/v-next/hardhat-mocha-test-runner/src/hookHandlers/config.ts
@@ -1,6 +1,9 @@
 import type { ConfigHooks } from "@ignored/hardhat-vnext/types/hooks";
 
-import { validateUserConfigZodType } from "@ignored/hardhat-vnext-zod-utils";
+import {
+  unionType,
+  validateUserConfigZodType,
+} from "@ignored/hardhat-vnext-zod-utils";
 import { z } from "zod";
 
 const mochaConfigType = z.object({
@@ -27,23 +30,39 @@ const mochaConfigType = z.object({
   reporterOptions: z.any().optional(),
   retries: z.number().optional(),
   slow: z.number().optional(),
-  timeout: z.union([z.number(), z.string()]).optional(),
-  ui: z
-    .union([
+  timeout: unionType(
+    [z.number(), z.string()],
+    "Expected a number or a string",
+  ).optional(),
+  ui: unionType(
+    [
       z.literal("bdd"),
       z.literal("tdd"),
       z.literal("qunit"),
       z.literal("exports"),
-    ])
-    .optional(),
+    ],
+    'Expected "bdd", "tdd", "qunit" or "exports"',
+  ).optional(),
   parallel: z.boolean().optional(),
   jobs: z.number().optional(),
   rootHooks: z
     .object({
-      afterAll: z.union([z.function(), z.array(z.function())]).optional(),
-      beforeAll: z.union([z.function(), z.array(z.function())]).optional(),
-      afterEach: z.union([z.function(), z.array(z.function())]).optional(),
-      beforeEach: z.union([z.function(), z.array(z.function())]).optional(),
+      afterAll: unionType(
+        [z.function(), z.array(z.function())],
+        "Expected a function or an array of functions",
+      ).optional(),
+      beforeAll: unionType(
+        [z.function(), z.array(z.function())],
+        "Expected a function or an array of functions",
+      ).optional(),
+      afterEach: unionType(
+        [z.function(), z.array(z.function())],
+        "Expected a function or an array of functions",
+      ).optional(),
+      beforeEach: unionType(
+        [z.function(), z.array(z.function())],
+        "Expected a function or an array of functions",
+      ).optional(),
     })
     .optional(),
   require: z.array(z.string()).optional(),

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -29,10 +29,10 @@ export const configurationVariableType = z.object({
 /**
  * A Zod type to validate Hardhat's SensitiveString values.
  */
-export const sensitiveStringType = z.union([
-  z.string(),
-  configurationVariableType,
-]);
+export const sensitiveStringType = unionType(
+  [z.string(), configurationVariableType],
+  "Expected a string or a Configuration Variable",
+);
 
 /**
  * A function to validate the user's configuration object against a Zod type.

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -12,6 +12,7 @@ export const unionType = (
   types: Parameters<typeof z.union>[0],
   errorMessage: string,
 ) =>
+  // eslint-disable-next-line no-restricted-syntax -- This is the only place we allos z.union
   z.union(types, {
     errorMap: () => ({
       message: errorMessage,

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -7,22 +7,7 @@ import { z } from "zod";
 /**
  * A Zod type to validate Hardhat's ConfigurationVariable objects.
  */
-export const configurationVariableType: z.ZodObject<
-  {
-    _type: z.ZodLiteral<"ConfigurationVariable">;
-    name: z.ZodString;
-  },
-  "strip",
-  z.ZodTypeAny,
-  {
-    _type: "ConfigurationVariable";
-    name: string;
-  },
-  {
-    _type: "ConfigurationVariable";
-    name: string;
-  }
-> = z.object({
+export const configurationVariableType = z.object({
   _type: z.literal("ConfigurationVariable"),
   name: z.string(),
 });
@@ -30,27 +15,10 @@ export const configurationVariableType: z.ZodObject<
 /**
  * A Zod type to validate Hardhat's SensitiveString values.
  */
-export const sensitiveStringType: z.ZodUnion<
-  [
-    z.ZodString,
-    z.ZodObject<
-      {
-        _type: z.ZodLiteral<"ConfigurationVariable">;
-        name: z.ZodString;
-      },
-      "strip",
-      z.ZodTypeAny,
-      {
-        _type: "ConfigurationVariable";
-        name: string;
-      },
-      {
-        _type: "ConfigurationVariable";
-        name: string;
-      }
-    >,
-  ]
-> = z.union([z.string(), configurationVariableType]);
+export const sensitiveStringType = z.union([
+  z.string(),
+  configurationVariableType,
+]);
 
 /**
  * A function to validate the user's configuration object against a Zod type.

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -35,6 +35,14 @@ export const sensitiveStringType = unionType(
 );
 
 /**
+ * A Zod type to validate Hardhat's SensitiveString values that expect a URL.
+ */
+export const sensitiveUrlType = unionType(
+  [z.string().url(), configurationVariableType],
+  "Expected a URL or a Configuration Variable",
+);
+
+/**
  * A function to validate the user's configuration object against a Zod type.
  */
 export async function validateUserConfigZodType<

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -12,7 +12,7 @@ export const unionType = (
   types: Parameters<typeof z.union>[0],
   errorMessage: string,
 ) =>
-  // eslint-disable-next-line no-restricted-syntax -- This is the only place we allos z.union
+  // eslint-disable-next-line no-restricted-syntax -- This is the only place we allow z.union
   z.union(types, {
     errorMap: () => ({
       message: errorMessage,

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatUserConfig } from "@ignored/hardhat-vnext-core/config";
 import type { HardhatUserConfigValidationError } from "@ignored/hardhat-vnext-core/types/hooks";
-import type { ZodType, ZodTypeDef, ZodIssue } from "zod";
+import type { ZodType, ZodTypeDef } from "zod";
 
 import { z } from "zod";
 
@@ -50,38 +50,9 @@ export async function validateUserConfigZodType<
   if (result.success) {
     return [];
   } else {
-    return result.error.errors.map((issue) =>
-      zodIssueToValidationError(config, configType, issue),
-    );
+    return result.error.errors.map((issue) => ({
+      path: issue.path,
+      message: issue.message,
+    }));
   }
-}
-
-function zodIssueToValidationError<
-  Output,
-  Def extends ZodTypeDef = ZodTypeDef,
-  Input = Output,
->(
-  _config: HardhatUserConfig,
-  _configType: ZodType<Output, Def, Input>,
-  zodIssue: ZodIssue,
-): HardhatUserConfigValidationError {
-  // TODO: `invalid_union` errors are too ambiguous. How can we improve them?
-  //  This is just a sketch: not perfect nor tested.
-  if (zodIssue.code === "invalid_union") {
-    return {
-      path: zodIssue.path,
-      message: `Expected ${zodIssue.unionErrors
-        .flatMap((ue) => ue.errors)
-        .map((zi) => {
-          if (zi.code === "invalid_type") {
-            return zi.expected;
-          }
-
-          return "(please see the docs)";
-        })
-        .join(" or ")}`,
-    };
-  }
-
-  return { path: zodIssue.path, message: zodIssue.message };
 }

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -5,6 +5,20 @@ import type { ZodType, ZodTypeDef, ZodIssue } from "zod";
 import { z } from "zod";
 
 /**
+ * A Zod untagged union type that returns a custom error message if the value
+ * is missing or invalid.
+ */
+export const unionType = (
+  types: Parameters<typeof z.union>[0],
+  errorMessage: string,
+) =>
+  z.union(types, {
+    errorMap: () => ({
+      message: errorMessage,
+    }),
+  });
+
+/**
  * A Zod type to validate Hardhat's ConfigurationVariable objects.
  */
 export const configurationVariableType = z.object({

--- a/v-next/hardhat-zod-utils/test/index.ts
+++ b/v-next/hardhat-zod-utils/test/index.ts
@@ -1,8 +1,34 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-describe("Example tests", () => {
-  it("foo", function () {
-    assert.ok(true, "this shouldn't fail");
+import { z } from "zod";
+
+import { unionType } from "../src/index.js";
+
+function assertParseResult(
+  result: z.SafeParseReturnType<any, any>,
+  expectedMessage: string,
+) {
+  assert.equal(result.error?.errors.length, 1);
+  assert.equal(result.error?.errors[0].message, expectedMessage);
+}
+
+describe("unionType", () => {
+  it("It should return the expected error message", function () {
+    const union = unionType(
+      [z.object({ a: z.string() }), z.object({ b: z.string() })],
+      "Expected error message",
+    );
+
+    assertParseResult(
+      union.safeParse({ a: 123, c: 123 }),
+      "Expected error message",
+    );
+
+    assertParseResult(union.safeParse(123), "Expected error message");
+
+    assertParseResult(union.safeParse({}), "Expected error message");
+
+    assertParseResult(union.safeParse(undefined), "Expected error message");
   });
 });

--- a/v-next/hardhat-zod-utils/tsconfig.json
+++ b/v-next/hardhat-zod-utils/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../config-v-next/tsconfig.json",
+  "compilerOptions": {
+    "isolatedDeclarations": false
+  },
   "references": [
     {
       "path": "../core"

--- a/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/hardhat-foo/hook-handlers/config.ts
@@ -2,12 +2,18 @@ import type { ConfigHooks } from "@ignored/hardhat-vnext-core/types/hooks";
 
 import {
   sensitiveStringType,
+  unionType,
   validateUserConfigZodType,
 } from "@ignored/hardhat-vnext-zod-utils";
 import { z } from "zod";
 
 const fooUserConfigType = z.object({
-  bar: z.optional(z.union([z.number(), z.array(z.number())])),
+  bar: z.optional(
+    unionType(
+      [z.number(), z.array(z.number())],
+      "Expected a number or an array of numbers",
+    ),
+  ),
 });
 
 const hardhatUserConfig = z.object({

--- a/v-next/hardhat/src/internal/cli/telemetry/analytics/subprocess.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/analytics/subprocess.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax -- This is the entry point of a
+subprocess, so we need to allow of top-level await here */
 import { writeJsonFile } from "@ignored/hardhat-vnext-utils/fs";
 import { postJsonRequest } from "@ignored/hardhat-vnext-utils/request";
 

--- a/v-next/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
@@ -89,7 +89,7 @@ class Reporter {
     error: Error,
     configPath: string = "",
   ): Promise<boolean> {
-    if (!(await this.shouldBeReported(error))) {
+    if (!(await this.#shouldBeReported(error))) {
       log("Error not send: this type of error should not be reported");
       return false;
     }
@@ -108,7 +108,7 @@ class Reporter {
     return true;
   }
 
-  private async shouldBeReported(error: Error): Promise<boolean> {
+  async #shouldBeReported(error: Error): Promise<boolean> {
     if (!this.#telemetryEnabled) {
       return false;
     }

--- a/v-next/hardhat/src/internal/cli/telemetry/sentry/subprocess.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/sentry/subprocess.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-restricted-syntax -- This is the entry point of a
+subprocess, so we need to allow of top-level await here */
 import type { Event } from "@sentry/node";
 
 import { writeJsonFile } from "@ignored/hardhat-vnext-utils/fs";


### PR DESCRIPTION
This PR introduces a few improvements to the zod utils package and how we use it:

- It disables `isolatedModules` in that package as it's super inconvenient and just an internal package.
- It introduces a `unionType` helper, equivalent to `z.union` but with a custom error message.
- It introduces a `sensitiveUrlType,` which is a variant of `sensitiveStringType.`
- It adds linter rules to prevent us from using `z.union` in the future.

While building this, I discovered a misconfiguration in `eslint`, so I fixed the config and every new linter error I found after that.