### PR TITLE
fix: correct peer dependency for Hardhat

### DIFF
--- a/.changeset/bright-falcons-impress.md
+++ b/.changeset/bright-falcons-impress.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Fix for corrupted Hardhat peer dependency version from pnpm.

--- a/.changeset/lovely-onions-notice.md
+++ b/.changeset/lovely-onions-notice.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-solhint": patch
+---
+
+Fix for corrupted Hardhat peer dependency version from pnpm.

--- a/.changeset/olive-comics-kick.md
+++ b/.changeset/olive-comics-kick.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Fix for corrupted Hardhat peer dependency version from pnpm.

--- a/.changeset/pink-bees-search.md
+++ b/.changeset/pink-bees-search.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Fix for corrupted Hardhat peer dependency version from pnpm.

--- a/.changeset/six-colts-cover.md
+++ b/.changeset/six-colts-cover.md
@@ -1,0 +1,5 @@
+---
+"@nomiclabs/hardhat-vyper": patch
+---
+
+Fix for corrupted Hardhat peer dependency version from pnpm.


### PR DESCRIPTION
We release packages via pnpm, version 9.4.0 incorrectly swapped out `workspace:^2.0.0` as `^2.22.92.0.0` in some of our packages for the hardhat peer dependency.

See `hardhat-ethers@3.0.7` code tab on npm as an example:

https://www.npmjs.com/package/@nomicfoundation/hardhat-ethers?activeTab=code

![image](https://github.com/user-attachments/assets/a8c4a9f2-76e8-460b-bc50-e25d28c5fcd1)

I have went pack through our releases since the start of the year identifying packages where the latest version has a corrupted `peerDependency`.

We are adding patch changesets to trigger new release using the latest version of pnpm, for:

- hardhat-ethers
- hardhat-solhint
- hardhat-verify
- hardhat-vyper
- hardhat-viem

See this discussion thread on the pnpm issue: https://github.com/pnpm/pnpm/pull/8261
And the follow on fix: https://github.com/pnpm/pnpm/pull/8383

Fixes #5694.
