### PR TITLE
Add hardhat-switch-network plugin

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -995,6 +995,14 @@ const communityPlugins: IPlugin[] = [
     description: "Hardhat plugin for the Trezor hardware wallet",
     tags: ["Trezor", "Wallet"],
   },
+  {
+    name: "hardhat-switch-network",
+    author: "0xNeshi",
+    authorUrl: "https://github.com/0xNeshi",
+    description:
+      "Hardhat plugin for enabling on-the-fly network switching within your Hardhat scripts and tasks",
+    tags: ["Tasks", "Scripts", "Testing"],
+  },
 ];
 
 const officialPlugins: IPlugin[] = [


### PR DESCRIPTION
This PR adds a new plugin named hardhat-switch-network which is used to enable on-the-fly network switching within Hardhat scripts, tests and tasks.

It can be found on this: https://github.com/0xNeshi/hardhat-switch-network
It's npm repo: https://www.npmjs.com/package/hardhat-switch-network

It is supposed so replace the now-unmaintained package [hardhat-change-network](https://www.npmjs.com/package/hardhat-change-network), which is also listen in the the _plugins.ts_ file [here](https://github.com/fwx5618177/hardhat/blob/main/docs/src/content/hardhat-runner/plugins/plugins.ts#L282)
