### PR TITLE
Remove unused plugin property

### DIFF
--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -110,7 +110,6 @@ const config: HardhatUserConfig = {
     // if testing node plugin, use the following line instead
     // HardhatNodeTestRunner,
   ],
-  privateKey: configVariable("privateKey"),
   paths: {
     tests: "test/mocha",
     // if testing node plugin, use the following line instead


### PR DESCRIPTION
Fix building error caused by [this PR](https://github.com/NomicFoundation/hardhat/pull/5702).
The property `privateKey` should have been deleted in the example-project because it was added by the temporary `hardhatFoo plugin`. 
The plugin has been removed so the property is no longer available