### PR TITLE
Re-throw hardhat errors from scripts

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/run/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/run/task-action.ts
@@ -36,6 +36,10 @@ const runScriptWithHardhat: NewTaskActionFunction<RunActionArguments> = async (
   } catch (error) {
     ensureError(error);
 
+    if (HardhatError.isHardhatError(error)) {
+      throw error;
+    }
+
     throw new HardhatError(
       HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
       {

--- a/v-next/hardhat/src/internal/builtin-plugins/run/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/run/task-action.ts
@@ -4,6 +4,7 @@ import { isAbsolute, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { ensureError } from "@ignored/hardhat-vnext-utils/error";
 import { exists } from "@ignored/hardhat-vnext-utils/fs";
 
 interface RunActionArguments {
@@ -33,18 +34,16 @@ const runScriptWithHardhat: NewTaskActionFunction<RunActionArguments> = async (
   try {
     await import(pathToFileURL(normalizedPath).href);
   } catch (error) {
-    if (error instanceof Error) {
-      throw new HardhatError(
-        HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
-        {
-          script,
-          error: error.message,
-        },
-        error,
-      );
-    }
+    ensureError(error);
 
-    throw error;
+    throw new HardhatError(
+      HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
+      {
+        script,
+        error: error.message,
+      },
+      error,
+    );
   }
 };
 

--- a/v-next/hardhat/test/fixture-projects/run-ts-script/scripts/throws-hardhat-error.ts
+++ b/v-next/hardhat/test/fixture-projects/run-ts-script/scripts/throws-hardhat-error.ts
@@ -1,0 +1,3 @@
+import { assertHardhatInvariant } from "@ignored/hardhat-vnext-errors";
+
+assertHardhatInvariant(false, "Intentional invariant violation");

--- a/v-next/hardhat/test/internal/builtin-plugins/run/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/run/task-action.ts
@@ -79,18 +79,33 @@ describe("run/task-action", function () {
       );
     });
 
-    it("should throw if the script throws", async function () {
-      await assertRejectsWithHardhatError(
-        runScriptWithHardhat(
-          { script: "./scripts/throws.ts", noCompile: false },
-          hre,
-        ),
-        HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
-        {
-          script: "./scripts/throws.ts",
-          error: "broken script",
-        },
-      );
+    describe("when the script throws", () => {
+      it("should throw RUN_SCRIPT_ERROR if the script throws a non-HardhatError", async function () {
+        await assertRejectsWithHardhatError(
+          runScriptWithHardhat(
+            { script: "./scripts/throws.ts", noCompile: false },
+            hre,
+          ),
+          HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
+          {
+            script: "./scripts/throws.ts",
+            error: "broken script",
+          },
+        );
+      });
+
+      it("should throw the HardhatError if the script throws a HardhatError", async function () {
+        await assertRejectsWithHardhatError(
+          runScriptWithHardhat(
+            { script: "./scripts/throws-hardhat-error.ts", noCompile: false },
+            hre,
+          ),
+          HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR,
+          {
+            message: "Intentional invariant violation",
+          },
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
When using `hardhat run` I noticed that we were "encapsulating" any `HardhatError` thrown by the script in another `HardhatError`. This PR changes that to rethrow it instead. 

The reasoning here is that if we throw the error, we want it to reach the user as is.