### PR TITLE
No `.help` on console start

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -19,7 +19,7 @@ const hardhatPlugin: HardhatPlugin = {
       .addVariadicArgument({
         name: "commands",
         description: "Commands to run in the console",
-        defaultValue: [".help"],
+        defaultValue: [],
       })
       .build(),
   ],

--- a/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -18,7 +18,7 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .addVariadicArgument({
         name: "commands",
-        description: "Commands to run then the console starts",
+        description: "Commands to run when the console starts",
         defaultValue: [],
       })
       .build(),

--- a/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -18,7 +18,7 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .addVariadicArgument({
         name: "commands",
-        description: "Commands to run in the console",
+        description: "Commands to run then the console starts",
         defaultValue: [],
       })
       .build(),


### PR DESCRIPTION
This PR removes the `.help` command as the default one to be run when we start the console.

The reason here is that the help message is generic about Node.js, and that can confuse, given that users expect a "hardhat console" and most probably hardhat-related help.

We can consider adding a hardhat-specific help command later.

I also reworded the description of the `commands` params, to make it clear that it's run at the beginning, vs them being the only commands run.