### PR TITLE
Fix two bugs in the telemetry consent workflow

### DIFF
--- a/v-next/hardhat-test-utils/src/fs.ts
+++ b/v-next/hardhat-test-utils/src/fs.ts
@@ -1,0 +1,36 @@
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { beforeEach, afterEach } from "node:test";
+
+import {
+  ensureDir,
+  getRealPath,
+  emptyDir,
+  remove,
+} from "@ignored/hardhat-vnext-utils/fs";
+
+/**
+ * Creates a tmp directory before each test, and removes it after each test.
+ * @param nameHint - A hint to use as part of  name of the tmp directory.
+ */
+export function useTmpDir(nameHint: string = "tmp-dir"): void {
+  let previousWorkingDir: string;
+  let tmpDir: string;
+
+  beforeEach(async function () {
+    previousWorkingDir = process.cwd();
+
+    const tmpDirContainer = await getRealPath(tmpdir());
+
+    tmpDir = path.join(tmpDirContainer, `hardhat-tests-${nameHint}`);
+    await ensureDir(tmpDir);
+    await emptyDir(tmpDir);
+
+    process.chdir(tmpDir);
+  });
+
+  afterEach(async function () {
+    process.chdir(previousWorkingDir);
+    await remove(tmpDir);
+  });
+}

--- a/v-next/hardhat-test-utils/src/index.ts
+++ b/v-next/hardhat-test-utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./fixture-projects.js";
 export * from "./hardhat-error.js";
+export * from "./fs.js";

--- a/v-next/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
@@ -24,16 +24,20 @@ interface TelemetryConsent {
  * If not, prompts the user to provide it.
  * Consent is only asked in interactive environments.
  *
+ * @param telemetryConsentFilePath - The path to the telemetry consent file,
+ * which should only be provided in tests.
  * @returns True if the user consents to telemetry and if current environment supports telemetry, false otherwise.
  */
-export async function ensureTelemetryConsent(): Promise<boolean> {
+export async function ensureTelemetryConsent(
+  telemetryConsentFilePath?: string,
+): Promise<boolean> {
   log("Ensuring that user has provided telemetry consent");
 
   if (!isTelemetryAllowedInEnvironment()) {
     return false;
   }
 
-  const consent = await getTelemetryConsent();
+  const consent = await getTelemetryConsent(telemetryConsentFilePath);
   if (consent !== undefined) {
     return consent;
   }
@@ -45,9 +49,13 @@ export async function ensureTelemetryConsent(): Promise<boolean> {
 /**
  * Checks whether telemetry is supported in the current environment and whether the user has provided consent.
  *
+ * @param telemetryConsentFilePath - The path to the telemetry consent file,
+ * which should only be provided in tests.
  * @returns True if the user consents to telemetry and if current environment supports telemetry, false otherwise.
  */
-export async function isTelemetryAllowed(): Promise<boolean> {
+export async function isTelemetryAllowed(
+  telemetryConsentFilePath?: string,
+): Promise<boolean> {
   if (!isTelemetryAllowedInEnvironment()) {
     return false;
   }
@@ -59,7 +67,7 @@ export async function isTelemetryAllowed(): Promise<boolean> {
       : false;
   }
 
-  const consent = await getTelemetryConsent();
+  const consent = await getTelemetryConsent(telemetryConsentFilePath);
   log(`Telemetry consent value: ${consent}`);
 
   return consent !== undefined ? consent : false;
@@ -89,11 +97,13 @@ export function isTelemetryAllowedInEnvironment(): boolean {
 /**
  * Retrieves the user's telemetry consent status from the consent file.
  *
+ * @param telemetryConsentFilePath - The path to the telemetry consent file,
+ * which should only be provided in tests.
  * @returns True if the user consents to telemetry, false if they do not consent,
  * and undefined if no consent has been provided.
  */
-async function getTelemetryConsent(): Promise<boolean | undefined> {
-  const telemetryConsentFilePath = await getTelemetryConsentFilePath();
+async function getTelemetryConsent(telemetryConsentFilePath?: string) {
+  telemetryConsentFilePath ??= await getTelemetryConsentFilePath();
 
   log(`Looking for telemetry consent file at ${telemetryConsentFilePath}`);
 

--- a/v-next/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
@@ -95,6 +95,8 @@ export function isTelemetryAllowedInEnvironment(): boolean {
 async function getTelemetryConsent(): Promise<boolean | undefined> {
   const telemetryConsentFilePath = await getTelemetryConsentFilePath();
 
+  log(`Looking for telemetry consent file at ${telemetryConsentFilePath}`);
+
   if (await exists(telemetryConsentFilePath)) {
     // Telemetry consent was already provided, hence return the answer
     return (await readJsonFile<TelemetryConsent>(telemetryConsentFilePath))
@@ -116,8 +118,8 @@ async function requestTelemetryConsent(): Promise<boolean> {
     return false;
   }
 
-  // Store user's consent choice
   log(`Storing telemetry consent with value: ${consent}`);
+
   await writeJsonFile(await getTelemetryConsentFilePath(), { consent });
 
   await sendTelemetryConsentAnalytics(consent);
@@ -126,8 +128,6 @@ async function requestTelemetryConsent(): Promise<boolean> {
 }
 
 async function confirmTelemetryConsent(): Promise<boolean | undefined> {
-  log("Prompting user for telemetry consent");
-
   return confirmationPromptWithTimeout(
     "telemetryConsent",
     "Help us improve Hardhat with anonymous crash reports & basic usage data?",

--- a/v-next/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
@@ -8,7 +8,7 @@ import {
 } from "@ignored/hardhat-vnext-utils/fs";
 import debug from "debug";
 
-import { getConfigDir } from "../../global-dir.js";
+import { getTelemetryDir } from "../../global-dir.js";
 import { confirmationPromptWithTimeout } from "../prompt/prompt.js";
 
 import { sendTelemetryConsentAnalytics } from "./analytics/analytics.js";
@@ -117,7 +117,7 @@ async function getTelemetryConsent(telemetryConsentFilePath?: string) {
 }
 
 async function getTelemetryConsentFilePath() {
-  const configDir = await getConfigDir();
+  const configDir = await getTelemetryDir();
   return path.join(configDir, "telemetry-consent.json");
 }
 

--- a/v-next/hardhat/src/internal/constants.ts
+++ b/v-next/hardhat/src/internal/constants.ts
@@ -1,2 +1,3 @@
+export const HARDHAT_PACKAGE_NAME = "hardhat";
 export const HARDHAT_NAME = "Hardhat";
 export const HARDHAT_WEBSITE_URL = "https://hardhat.org/";

--- a/v-next/hardhat/src/internal/global-dir.ts
+++ b/v-next/hardhat/src/internal/global-dir.ts
@@ -1,5 +1,7 @@
 import { ensureDir } from "@ignored/hardhat-vnext-utils/fs";
 
+import { HARDHAT_PACKAGE_NAME } from "./constants.js";
+
 /**
  * Returns the path to the hardhat configuration directory.
  *
@@ -27,17 +29,15 @@ export async function getCacheDir(): Promise<string> {
  * If no package name is provided, the default package name "hardhat" is used.
  * Ensures that the directory exists before returning the path.
  *
- * @param packageName - The name of the package to get the telemetry directory for. Defaults to "hardhat".
- *
  * @returns A promise that resolves to the path of the telemetry directory.
  */
-export async function getTelemetryDir(packageName?: string): Promise<string> {
-  const { data } = await generatePaths(packageName);
+export async function getTelemetryDir(): Promise<string> {
+  const { data } = await generatePaths();
   await ensureDir(data);
   return data;
 }
 
-async function generatePaths(packageName = "hardhat") {
+async function generatePaths() {
   const { default: envPaths } = await import("env-paths");
-  return envPaths(packageName);
+  return envPaths(HARDHAT_PACKAGE_NAME);
 }

--- a/v-next/hardhat/test/internal/cli/telemetry/telemetry-permissions.ts
+++ b/v-next/hardhat/test/internal/cli/telemetry/telemetry-permissions.ts
@@ -1,65 +1,57 @@
 import assert from "node:assert/strict";
-import path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
-import { remove, writeJsonFile } from "@ignored/hardhat-vnext-utils/fs";
+import { writeJsonFile } from "@ignored/hardhat-vnext-utils/fs";
+import { useTmpDir } from "@nomicfoundation/hardhat-test-utils";
 
 import { isTelemetryAllowed } from "../../../../src/internal/cli/telemetry/telemetry-permissions.js";
-import { getConfigDir } from "../../../../src/internal/global-dir.js";
 
-async function setTelemetryConsentFile(consent: boolean) {
-  const configDir = await getConfigDir();
-  const filePath = path.join(configDir, "telemetry-consent.json");
+async function setTelemetryConsentFile(filePath: string, consent: boolean) {
   await writeJsonFile(filePath, { consent });
 }
 
-async function deleteTelemetryConsentFile() {
-  const configDir = await getConfigDir();
-  const filePath = path.join(configDir, "telemetry-consent.json");
-  await remove(filePath);
-}
-
 describe("telemetry-permissions", () => {
+  // We use a tmp dir and store the telemetry consent file there, using a
+  // relative path
+  useTmpDir("telemetry-permissions");
+  const CONSENT_FILE_PATH = "./telemetry-consent.json";
+
   beforeEach(async () => {
     delete process.env.HARDHAT_TEST_INTERACTIVE_ENV;
-
-    await deleteTelemetryConsentFile();
   });
 
   afterEach(async () => {
     delete process.env.HARDHAT_TEST_INTERACTIVE_ENV;
-
-    await deleteTelemetryConsentFile();
   });
 
   describe("isTelemetryAllowed", () => {
     it("should return false because not an interactive environment", async () => {
-      await setTelemetryConsentFile(true);
+      await setTelemetryConsentFile(CONSENT_FILE_PATH, true);
 
-      const res = await isTelemetryAllowed();
+      const res = await isTelemetryAllowed(CONSENT_FILE_PATH);
       assert.equal(res, false);
     });
 
     it("should return false because the user did not give telemetry consent", async () => {
       process.env.HARDHAT_TEST_INTERACTIVE_ENV = "true";
-      await setTelemetryConsentFile(false);
+      await setTelemetryConsentFile(CONSENT_FILE_PATH, false);
 
-      const res = await isTelemetryAllowed();
+      const res = await isTelemetryAllowed(CONSENT_FILE_PATH);
       assert.equal(res, false);
     });
 
     it("should return false because the telemetry consent is not set", async () => {
       process.env.HARDHAT_TEST_INTERACTIVE_ENV = "true";
 
-      const res = await isTelemetryAllowed();
+      const res = await isTelemetryAllowed(CONSENT_FILE_PATH);
       assert.equal(res, false);
     });
 
     it("should return true because the user gave telemetry consent", async () => {
       process.env.HARDHAT_TEST_INTERACTIVE_ENV = "true";
-      await setTelemetryConsentFile(true);
+      await setTelemetryConsentFile(CONSENT_FILE_PATH, true);
 
-      const res = await isTelemetryAllowed();
+      const res = await isTelemetryAllowed(CONSENT_FILE_PATH);
       assert.equal(res, true);
     });
   });


### PR DESCRIPTION
This PR adds many (temporary) logs to the telemetry consent workflow, as I suspect there's a bug somewhere.

While doing that, I discovered and fixed a bug: If the user canceled a prompt, we'd still wait 10 seconds.