### PR TITLE
fix(hardhat-viem): type consistency + retryCount 0 on devnet

### DIFF
--- a/.changeset/kind-radios-begin.md
+++ b/.changeset/kind-radios-begin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Moved types to `HardhatViemHelpers` and initialized `ContractTypesMap` as empty for better extensibility. Improved performance by disabling retries in dev nets (thanks @TateB!)

--- a/packages/hardhat-viem/src/internal/type-extensions.ts
+++ b/packages/hardhat-viem/src/internal/type-extensions.ts
@@ -1,46 +1,19 @@
-import type {
-  Address,
-  PublicClientConfig,
-  WalletClientConfig,
-  TestClientConfig,
-} from "viem";
-import type {
-  PublicClient,
-  TestClient,
-  WalletClient,
-  deployContract,
-  sendDeploymentTransaction,
-  getContractAt,
-} from "../types";
+import type { HardhatViemHelpers } from "../types";
 import "hardhat/types/runtime";
 import "hardhat/types/artifacts";
 
 declare module "hardhat/types/runtime" {
   interface HardhatRuntimeEnvironment {
-    viem: {
-      getPublicClient(
-        publicClientConfig?: Partial<PublicClientConfig>
-      ): Promise<PublicClient>;
-      getWalletClients(
-        walletClientConfig?: Partial<WalletClientConfig>
-      ): Promise<WalletClient[]>;
-      getWalletClient(
-        address: Address,
-        walletClientConfig?: Partial<WalletClientConfig>
-      ): Promise<WalletClient>;
-      getTestClient(
-        testClientConfig?: Partial<TestClientConfig>
-      ): Promise<TestClient>;
-      deployContract: typeof deployContract;
-      sendDeploymentTransaction: typeof sendDeploymentTransaction;
-      getContractAt: typeof getContractAt;
-    };
+    viem: HardhatViemHelpers;
   }
 }
 
 declare module "hardhat/types/artifacts" {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface ArtifactsMap {}
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface ContractTypesMap {}
 
   interface Artifacts {
     readArtifact<ArgT extends keyof ArtifactsMap>(

--- a/packages/hardhat-viem/src/types.ts
+++ b/packages/hardhat-viem/src/types.ts
@@ -83,4 +83,23 @@ export declare function getContractAt<CN extends string>(
   config?: GetContractAtConfig
 ): Promise<GetContractReturnType>;
 
+export interface HardhatViemHelpers {
+  getPublicClient(
+    publicClientConfig?: Partial<viemT.PublicClientConfig>
+  ): Promise<PublicClient>;
+  getWalletClients(
+    walletClientConfig?: Partial<viemT.WalletClientConfig>
+  ): Promise<WalletClient[]>;
+  getWalletClient(
+    address: viemT.Address,
+    walletClientConfig?: Partial<viemT.WalletClientConfig>
+  ): Promise<WalletClient>;
+  getTestClient(
+    testClientConfig?: Partial<viemT.TestClientConfig>
+  ): Promise<TestClient>;
+  deployContract: typeof deployContract;
+  sendDeploymentTransaction: typeof sendDeploymentTransaction;
+  getContractAt: typeof getContractAt;
+}
+
 export type { AbiParameterToPrimitiveType } from "abitype";

--- a/packages/hardhat-viem/test/mocks/provider.ts
+++ b/packages/hardhat-viem/test/mocks/provider.ts
@@ -11,7 +11,12 @@ export class EthereumMockedProvider
   extends EventEmitter
   implements EthereumProvider
 {
-  public async request(_args: RequestArguments): Promise<any> {}
+  public calledCount = 0;
+
+  public async request(_args: RequestArguments): Promise<any> {
+    this.calledCount++;
+    throw new Error();
+  }
 
   public async send(_method: string, _params: any[] = []) {}
 


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

added some small type changes to allow for more extensibility, as well ensuring there are 0 retries when on developer networks to avoid wasting time when testing for errors

### Type changes

- added initialisation of `ContractTypesMap` as empty so it can be referenced without an initial contract compiled (e.g. for an external lib)
- moved the types under `HardhatRuntimeEnvironment.viem` to their own interface `HardhatViemHelpers` which allows the `viem` object to be extended with other types

### Retry count change

the default `retryCount` on the custom transport is 3, meaning in most cases RPC requests are retried 3 times.
when writing tests with expected reverts from write calls this is ok, since the `sendTransaction` function specifies a retry count of 0. however, when testing read calls with expected reverts this isn't the case, and there is time wasted in retrying calls that will always revert. 

to fix read call tests (and anything else i'm not aware of), i changed the retry count to be 0 when on dev nets. this should be fine since:
- dev nets are local and produce consistent results
- ethers doesn't have retries by default anyway