### PR TITLE
`ethereum-cryptography` cleanup

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1999,12 +1999,12 @@ importers:
       debug:
         specifier: ^4.1.1
         version: 4.3.6(supports-color@8.1.1)
+      ethereum-cryptography:
+        specifier: ^2.2.1
+        version: 2.2.1
       fast-equals:
         specifier: ^5.0.1
         version: 5.0.1
-      keccak:
-        specifier: ^3.0.4
-        version: 3.0.4
       rfdc:
         specifier: ^1.3.1
         version: 1.4.1
@@ -2024,9 +2024,6 @@ importers:
       '@types/debug':
         specifier: ^4.1.4
         version: 4.1.12
-      '@types/keccak':
-        specifier: ^3.0.4
-        version: 3.0.4
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1477,8 +1477,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.1
       ethereum-cryptography:
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: ^2.2.1
+        version: 2.2.1
       semver:
         specifier: ^7.6.3
         version: 7.6.3
@@ -2712,9 +2712,6 @@ packages:
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
 
-  '@noble/hashes@1.1.2':
-    resolution: {integrity: sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==}
-
   '@noble/hashes@1.2.0':
     resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
 
@@ -2725,9 +2722,6 @@ packages:
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
-
-  '@noble/secp256k1@1.6.2':
-    resolution: {integrity: sha512-4AmNQqf+ysJx67kw3SMiPQl/JMjGB97dRGvAmwEu7txbY8B8FAHanQ0V9+i2b1ti+uQt5Cs9OByeDrFOaN1kjw==}
 
   '@noble/secp256k1@1.7.1':
     resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
@@ -2879,17 +2873,11 @@ packages:
   '@scure/base@1.1.7':
     resolution: {integrity: sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==}
 
-  '@scure/bip32@1.1.0':
-    resolution: {integrity: sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==}
-
   '@scure/bip32@1.1.5':
     resolution: {integrity: sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==}
 
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
-
-  '@scure/bip39@1.1.0':
-    resolution: {integrity: sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==}
 
   '@scure/bip39@1.1.1':
     resolution: {integrity: sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==}
@@ -4257,9 +4245,6 @@ packages:
 
   ethereum-cryptography@0.1.3:
     resolution: {integrity: sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==}
-
-  ethereum-cryptography@1.1.1:
-    resolution: {integrity: sha512-zp6caNCfG3S2LtSjCeZtOjfRCXNoPv16XTBzM/jOVVlWmO1m59QZdp+VpI8Org4UwPTJ/LzI/XbRHKqi4cMRVg==}
 
   ethereum-cryptography@1.2.0:
     resolution: {integrity: sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==}
@@ -7345,15 +7330,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.4.0
 
-  '@noble/hashes@1.1.2': {}
-
   '@noble/hashes@1.2.0': {}
 
   '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
-
-  '@noble/secp256k1@1.6.2': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -7520,12 +7501,6 @@ snapshots:
 
   '@scure/base@1.1.7': {}
 
-  '@scure/bip32@1.1.0':
-    dependencies:
-      '@noble/hashes': 1.1.2
-      '@noble/secp256k1': 1.6.2
-      '@scure/base': 1.1.7
-
   '@scure/bip32@1.1.5':
     dependencies:
       '@noble/hashes': 1.2.0
@@ -7534,13 +7509,8 @@ snapshots:
 
   '@scure/bip32@1.4.0':
     dependencies:
-      '@noble/curves': 1.4.0
+      '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.7
-
-  '@scure/bip39@1.1.0':
-    dependencies:
-      '@noble/hashes': 1.1.2
       '@scure/base': 1.1.7
 
   '@scure/bip39@1.1.1':
@@ -9175,7 +9145,7 @@ snapshots:
       axios: 1.7.3(debug@4.3.6)
       cli-table3: 0.5.1
       colors: 1.4.0
-      ethereum-cryptography: 1.1.1
+      ethereum-cryptography: 1.2.0
       ethers: 5.7.2
       fs-readdir-recursive: 1.1.0
       lodash: 4.17.21
@@ -9210,13 +9180,6 @@ snapshots:
       scrypt-js: 3.0.1
       secp256k1: 4.0.3
       setimmediate: 1.0.5
-
-  ethereum-cryptography@1.1.1:
-    dependencies:
-      '@noble/hashes': 1.1.2
-      '@noble/secp256k1': 1.6.2
-      '@scure/bip32': 1.1.0
-      '@scure/bip39': 1.1.0
 
   ethereum-cryptography@1.2.0:
     dependencies:
@@ -11656,7 +11619,7 @@ snapshots:
 
   webauthn-p256@0.0.5:
     dependencies:
-      '@noble/curves': 1.4.0
+      '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
 
   webidl-conversions@3.0.1: {}

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -59,7 +59,6 @@
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
     "@types/bn.js": "^5.1.5",
     "@types/debug": "^4.1.4",
-    "@types/keccak": "^3.0.4",
     "@types/node": "^20.14.9",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
@@ -77,8 +76,8 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
+    "ethereum-cryptography": "^2.2.1",
     "fast-equals": "^5.0.1",
-    "keccak": "^3.0.4",
     "rfdc": "^1.3.1",
     "undici": "^6.16.1"
   }

--- a/v-next/hardhat-utils/src/crypto.ts
+++ b/v-next/hardhat-utils/src/crypto.ts
@@ -1,6 +1,6 @@
-import type * as KeccakT from "keccak";
-
 import { createHash } from "node:crypto";
+
+import { keccak256 as keccak256Impl } from "ethereum-cryptography/keccak";
 
 /**
  * Computes the Keccak-256 hash of the input bytes.
@@ -9,14 +9,7 @@ import { createHash } from "node:crypto";
  * @returns The Keccak-256 hash of the input bytes.
  */
 export async function keccak256(bytes: Uint8Array): Promise<Uint8Array> {
-  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We have to
-  typecast the import because the type definitions for the `keccak` package are
-  incorrect. */
-  const { default: createKeccakHash } = (await import("keccak")) as unknown as {
-    default: (algorithm: KeccakT.KeccakAlgorithm) => KeccakT.Keccak;
-  };
-
-  return createKeccakHash("keccak256").update(Buffer.from(bytes)).digest();
+  return keccak256Impl(bytes);
 }
 
 /**

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -83,7 +83,7 @@
     "debug": "^4.1.1",
     "enquirer": "^2.3.0",
     "env-paths": "^2.2.0",
-    "ethereum-cryptography": "1.1.1",
+    "ethereum-cryptography": "^2.2.1",
     "semver": "^7.6.3",
     "tsx": "^4.11.0",
     "zod": "^3.23.8"


### PR DESCRIPTION
This PR introduces two changes:

- It unpins the version of `ethereum-cryptography` in `hardhat`, which had no reason to be pinned.
- It uses `ethereum-cryptography` in `hardhat-utils` to be consistent with the dependencies that we use, hence decreasing the total number of dependencies.