### PR TITLE
fix: pnpm build before pnpm test:only

### DIFF
--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -17,7 +17,6 @@
     "lint:fix": "pnpm prettier --write",
     "prettier": "prettier \"**/*.{ts,js,md,json}\"",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "devDependencies": {

--- a/v-next/hardhat-build-system/package.json
+++ b/v-next/hardhat-build-system/package.json
@@ -26,8 +26,8 @@
     "test": "node --import tsx/esm --test --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "pretest": "pnpm build",
+    "pretest:only": "pnpm build",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "files": [

--- a/v-next/hardhat-errors/package.json
+++ b/v-next/hardhat-errors/package.json
@@ -28,8 +28,8 @@
     "test": "node --import tsx/esm --test --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "pretest": "pnpm build",
+    "pretest:only": "pnpm build",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "files": [

--- a/v-next/hardhat-mocha-test-runner/package.json
+++ b/v-next/hardhat-mocha-test-runner/package.json
@@ -27,8 +27,8 @@
     "test": "node --import tsx/esm --test --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "pretest": "pnpm build",
+    "pretest:only": "pnpm build",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "files": [

--- a/v-next/hardhat-node-test-reporter/package.json
+++ b/v-next/hardhat-node-test-reporter/package.json
@@ -29,8 +29,9 @@
     "test:integration": "node --import tsx/esm integration-tests/index.ts --color",
     "posttest": "pnpm test:integration",
     "pretest": "pnpm build",
+    "pretest:only": "pnpm build",
+    "pretest:integration": "pnpm build",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "files": [

--- a/v-next/hardhat-node-test-runner/package.json
+++ b/v-next/hardhat-node-test-runner/package.json
@@ -27,8 +27,8 @@
     "test": "node --import tsx/esm --test --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "pretest": "pnpm build",
+    "pretest:only": "pnpm build",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "files": [

--- a/v-next/hardhat-test-utils/package.json
+++ b/v-next/hardhat-test-utils/package.json
@@ -23,8 +23,8 @@
     "test": "node --import tsx/esm --test --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "pretest": "pnpm build",
+    "pretest:only": "pnpm build",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "files": [

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -43,8 +43,8 @@
     "test": "node --import tsx/esm --test --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "pretest": "pnpm build",
+    "pretest:only": "pnpm build",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "files": [

--- a/v-next/hardhat-zod-utils/package.json
+++ b/v-next/hardhat-zod-utils/package.json
@@ -28,8 +28,8 @@
     "test": "node --import tsx/esm --test --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "pretest": "pnpm build",
+    "pretest:only": "pnpm build",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "files": [

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -45,8 +45,8 @@
     "test": "node --import tsx/esm --test --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "pretest": "pnpm build",
+    "pretest:only": "pnpm build",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "files": [

--- a/v-next/template-package/package.json
+++ b/v-next/template-package/package.json
@@ -30,8 +30,8 @@
     "test": "node --import tsx/esm --test --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@ignored/hardhat-vnext-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "pretest": "pnpm build",
+    "pretest:only": "pnpm build",
     "build": "tsc --build .",
-    "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"
   },
   "files": [


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

While trying to replicate https://nomicfoundation.slack.com/archives/C03P6B72ZHU/p1725284046675349, I discovered that the described issue was most likely caused by not running `pnpm install` after a switch to a branch which added new dependencies.

For `pnpm test`, we were already ensuring that `pnpm build` is run before the test command. This makes it quite obvious when dependencies are missing because the build process fails.

We weren't doing the same for `pnpm test:only`, which resulted in more cryptic errors coming from tests. In this PR, I'm proposing to add the pre step for that task, too.

I'm also removing `prepublishOnly` since we do not define `publishOnly` task.

To replicate the issue that this PR is trying to address:
1. Check out `galargh/promise-await` branch (https://github.com/NomicFoundation/hardhat/commit/7bf535285d9f74978d5f8ca5ca2f1584cf734385)
2. Go to the `v-next/hardhat` package
3. Run `pnpm test:only`

You should see a bunch of `Did you forget to await a promise?` errors. Unfortunately, the error that we get on the reporter side is not too specific:
```
{
     "code": "ERR_TEST_FAILURE",
     "failureType": "testCodeFailure",
     "cause": "test failed",
     "exitCode": 1,
     "signal": null
 }
 ```
 
The information displayed inline during the test case run is much more helpful, but unfortunately, it gets lost in a sea of error summaries at the end. The error you can see during the test run is as follows, but as I said we don't get access to it in the reporter:
```
node:internal/modules/run_main:115
    triggerUncaughtException(
    ^
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'def' imported from /GitHub/NomicFoundation/hardhat/v-next/hardhat/src/internal/core/hre.ts
    at packageResolve (node:internal/modules/esm/resolve:842:9)
    at moduleResolve (node:internal/modules/esm/resolve:915:18)
    at defaultResolve (node:internal/modules/esm/resolve:1132:11)
    at nextResolve (node:internal/modules/esm/hooks:746:28)
    at resolveBase (file:///GitHub/NomicFoundation/hardhat/node_modules/.pnpm/tsx@4.16.5/node_modules/tsx/dist/esm/index.mjs?1725523844135:2:3126)
    at resolveDirectory (file:///GitHub/NomicFoundation/hardhat/node_modules/.pnpm/tsx@4.16.5/node_modules/tsx/dist/esm/index.mjs?1725523844135:2:3498)
    at resolveTsPaths (file:///GitHub/NomicFoundation/hardhat/node_modules/.pnpm/tsx@4.16.5/node_modules/tsx/dist/esm/index.mjs?1725523844135:2:3987)
    at resolve (file:///GitHub/NomicFoundation/hardhat/node_modules/.pnpm/tsx@4.16.5/node_modules/tsx/dist/esm/index.mjs?1725523844135:2:4361)
    at nextResolve (node:internal/modules/esm/hooks:746:28)
    at Hooks.resolve (node:internal/modules/esm/hooks:238:30) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```