### PR TITLE
hh-utils flaky subprocess test: ensure the JSON file is fully written before attempting to read it

### DIFF
--- a/v-next/hardhat-utils/test/subprocess.ts
+++ b/v-next/hardhat-utils/test/subprocess.ts
@@ -35,8 +35,12 @@ async function checkIfSubprocessWasExecuted() {
       counter++;
 
       if (await exists(ABSOLUTE_PATH_TO_TMP_RESULT_SUBPROCESS_FILE)) {
-        clearInterval(intervalId);
-        resolve(true);
+        try {
+          // Wait for the file to be readable. The file could exist but the writing could be in progress.
+          await readJsonFile(ABSOLUTE_PATH_TO_TMP_RESULT_SUBPROCESS_FILE);
+          clearInterval(intervalId);
+          resolve(true);
+        } catch (_err) {}
       } else if (counter > MAX_COUNTER) {
         clearInterval(intervalId);
         reject("Subprocess was not executed in the expected time");


### PR DESCRIPTION
The test to verify that the subprocess functionality works correctly is structured as follows:

1 -  the main test process starts and call the subprocess util function 
2- a subprocess is spawned, which writes specific data to a JSON file (this data is used to test that the subprocess was executed correctly)
3 - the main test process sets an interval and waits for the file to be ready
4 - once the file is ready, the main test process verifies that the data within it is accurate

Problem: 
There are cases where the file is created, prompting the main test process to access it. However, the data might not be fully written yet, leading to an error because the JSON file is improperly formatted.

Solution: 
During the interval that checks whether the JSON file has been created, also validate the JSON format. If the JSON is invalid, this indicates the file is not yet fully written, and the test should continue waiting.