### PR TITLE
Fix provider events when init is called

### DIFF
--- a/.changeset/chilled-sheep-buy.md
+++ b/.changeset/chilled-sheep-buy.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed a problem with provider events when `provider.init` was explicitly called before the first request.

--- a/packages/hardhat-core/src/internal/core/providers/lazy-initialization.ts
+++ b/packages/hardhat-core/src/internal/core/providers/lazy-initialization.ts
@@ -40,6 +40,19 @@ export class LazyInitializationProviderAdapter implements EthereumProvider {
         this._initializingPromise = this._providerFactory();
       }
       this.provider = await this._initializingPromise;
+
+      // Copy any event emitter events before initialization over to the provider
+      const recordedEvents = this._emitter.eventNames();
+
+      for (const event of recordedEvents) {
+        const listeners = this._emitter.rawListeners(event) as Listener[];
+        for (const listener of listeners) {
+          this.provider.on(event, listener);
+          this._emitter.removeListener(event, listener);
+        }
+      }
+
+      this.provider.setMaxListeners(this._emitter.getMaxListeners());
     }
     return this.provider;
   }
@@ -158,19 +171,6 @@ export class LazyInitializationProviderAdapter implements EthereumProvider {
 
     if (this.provider === undefined) {
       this.provider = await this.init();
-
-      // Copy any event emitter events before initialization over to the provider
-      const recordedEvents = this._emitter.eventNames();
-
-      for (const event of recordedEvents) {
-        const listeners = this._emitter.rawListeners(event) as Listener[];
-        for (const listener of listeners) {
-          this.provider.on(event, listener);
-          this._emitter.removeListener(event, listener);
-        }
-      }
-
-      this.provider.setMaxListeners(this._emitter.getMaxListeners());
     }
 
     return this.provider;

--- a/packages/hardhat-core/src/internal/core/providers/lazy-initialization.ts
+++ b/packages/hardhat-core/src/internal/core/providers/lazy-initialization.ts
@@ -44,6 +44,8 @@ export class LazyInitializationProviderAdapter implements EthereumProvider {
       // Copy any event emitter events before initialization over to the provider
       const recordedEvents = this._emitter.eventNames();
 
+      this.provider.setMaxListeners(this._emitter.getMaxListeners());
+
       for (const event of recordedEvents) {
         const listeners = this._emitter.rawListeners(event) as Listener[];
         for (const listener of listeners) {
@@ -51,8 +53,6 @@ export class LazyInitializationProviderAdapter implements EthereumProvider {
           this._emitter.removeListener(event, listener);
         }
       }
-
-      this.provider.setMaxListeners(this._emitter.getMaxListeners());
     }
     return this.provider;
   }

--- a/packages/hardhat-core/test/internal/core/providers/lazy-initialization.ts
+++ b/packages/hardhat-core/test/internal/core/providers/lazy-initialization.ts
@@ -97,12 +97,26 @@ describe("LazyInitializationProviderAdapter", () => {
       assert.equal(callTimes, 3);
     });
 
-    it("should move the registered events to the provider after initialization", async () => {
+    it("should move the registered events to the provider after implicit initialization", async () => {
       provider.on("event", eventHandler);
       provider.on("otherevent", eventHandler);
       provider.once("onceevent", eventHandler);
 
       await provider.request({ method: "a-method" }); // init the inner provider calling the constructor function
+      provider.emit("event"); // 1
+      provider.emit("otherevent"); // 2
+      provider.emit("onceevent"); // 3
+      provider.emit("onceevent"); // 3
+
+      assert.deepEqual(callTimes, 3);
+    });
+
+    it("should move the registered events to the provider after explicit initialization", async () => {
+      provider.on("event", eventHandler);
+      provider.on("otherevent", eventHandler);
+      provider.once("onceevent", eventHandler);
+
+      await provider.init();
       provider.emit("event"); // 1
       provider.emit("otherevent"); // 2
       provider.emit("onceevent"); // 3


### PR DESCRIPTION
Provider events are not working when `provider.init` is called explicitly, instead of the provider being implicitly initialized with the first request. The problem was that the events were only forwarded in the `_getOrInitProvider` function instead of that being done in `init`. This PR fixes this and adds a test for that scenario.