### PR TITLE
fix: hardhat-chai-matchers - add check byte32 string to reverted matcher

### DIFF
--- a/.changeset/ninety-trainers-rush.md
+++ b/.changeset/ninety-trainers-rush.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-chai-matchers": patch
 ---
 
-Enhanced byte32 string in `reverted` matcher check
+Enhanced the `reverted` matcher to correctly handle `bytes32` strings (thanks @iosh!)

--- a/.changeset/ninety-trainers-rush.md
+++ b/.changeset/ninety-trainers-rush.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-chai-matchers": patch
+---
+
+Enhanced byte32 string in `reverted` matcher check

--- a/packages/hardhat-chai-matchers/src/internal/reverted/reverted.ts
+++ b/packages/hardhat-chai-matchers/src/internal/reverted/reverted.ts
@@ -3,7 +3,11 @@ import type EthersT from "ethers";
 import { buildAssert } from "../../utils";
 import { REVERTED_MATCHER } from "../constants";
 import { assertIsNotNull, preventAsyncMatcherChaining } from "../utils";
-import { decodeReturnData, getReturnDataFromError } from "./utils";
+import {
+  decodeReturnData,
+  getReturnDataFromError,
+  parseBytes32String,
+} from "./utils";
 
 export function supportReverted(
   Assertion: Chai.AssertionStatic,
@@ -35,6 +39,14 @@ export function supportReverted(
         }
 
         const receipt = await getTransactionReceipt(hash);
+
+        if (receipt === null) {
+          // If the receipt is null, maybe the string is a bytes32 string
+          if (isByte32String(hash)) {
+            assert(false, "Expected transaction to be reverted");
+            return;
+          }
+        }
 
         assertIsNotNull(receipt, "receipt");
         assert(
@@ -133,4 +145,13 @@ function isTransactionReceipt(x: unknown): x is { status: number } {
 
 function isValidTransactionHash(x: string): boolean {
   return /0x[0-9a-fA-F]{64}/.test(x);
+}
+
+function isByte32String(v: string): boolean {
+  try {
+    parseBytes32String(v);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/hardhat-chai-matchers/src/internal/reverted/reverted.ts
+++ b/packages/hardhat-chai-matchers/src/internal/reverted/reverted.ts
@@ -42,7 +42,7 @@ export function supportReverted(
 
         if (receipt === null) {
           // If the receipt is null, maybe the string is a bytes32 string
-          if (isByte32String(hash)) {
+          if (isBytes32String(hash)) {
             assert(false, "Expected transaction to be reverted");
             return;
           }
@@ -147,7 +147,7 @@ function isValidTransactionHash(x: string): boolean {
   return /0x[0-9a-fA-F]{64}/.test(x);
 }
 
-function isByte32String(v: string): boolean {
+function isBytes32String(v: string): boolean {
   try {
     parseBytes32String(v);
     return true;

--- a/packages/hardhat-chai-matchers/src/internal/reverted/utils.ts
+++ b/packages/hardhat-chai-matchers/src/internal/reverted/utils.ts
@@ -125,3 +125,8 @@ export function resultToArray(result: EthersT.Result): any[] {
         : x
     );
 }
+
+export function parseBytes32String(v: string): string {
+  const ethers = require("ethers") as typeof EthersT;
+  return ethers.decodeBytes32String(v);
+}

--- a/packages/hardhat-chai-matchers/test/reverted/reverted.ts
+++ b/packages/hardhat-chai-matchers/test/reverted/reverted.ts
@@ -112,6 +112,14 @@ describe("INTEGRATION: Reverted", function () {
           "Expected a valid transaction hash, but got '0x123'"
         );
       });
+
+      it("promise of an byte32 string", async function () {
+        await expect(
+          Promise.resolve(
+            "0x3230323400000000000000000000000000000000000000000000000000000000"
+          )
+        ).not.to.be.reverted;
+      });
     });
 
     describe("with a TxResponse as its subject", function () {


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

 Add when receipt is null, check if value is a byte32 string. minimal changes were in PRto resolve #4725 


I see the following comment in the code

```js

        // If the subject of the assertion is not connected to a transaction
        // (hash, receipt, etc.), then the assertion fails.
        // Since we use `false` here, this means that `.not.to.be.reverted`
        // assertions will pass instead of always throwing a validation error.
        // This allows users to do things like:
        //   `expect(c.callStatic.f()).to.not.be.reverted`
        assert(false, "Expected transaction to be reverted");
```

So i think maybe we can change the check to :

```js
      if (
        isTransactionResponse(value) ||
        (typeof value === "string" && isValidTransactionHash(value))
      ) {
        const hash = typeof value === "string" ? value : value.hash;

        // if (!isValidTransactionHash(hash)) {
        //   throw new TypeError(
        //     `Expected a valid transaction hash, but got '${hash}'`
        //   );
        // }

```
This way, we can enable other data types to pass the test, but they will be broken change. 
