### PR TITLE
Introduce the Zod `conditionalUnionType` helper

### DIFF
--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -261,7 +261,7 @@ function createConfig(
           selector:
             "CallExpression[callee.object.name='z'][callee.property.name=union]",
           message:
-            "Use the unionType helper from the zod utils package instead, as it provides better error messages.",
+            "Use the conditionalUnionType or unionType helpers from the zod utils package instead, as it provides better error messages.",
         },
       ],
       "@typescript-eslint/restrict-plus-operands": "error",
@@ -398,7 +398,7 @@ function createConfig(
               name: "zod",
               importNames: ["union"],
               message:
-                "Use the unionType helper from the zod utils package instead, as it provides better error messages.",
+                "Use the conditionalUnionType or unionType helpers from the zod utils package instead, as it provides better error messages.",
             },
           ],
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2162,6 +2162,10 @@ importers:
         version: 7.7.1(eslint@8.57.0)(typescript@5.5.4)
 
   v-next/hardhat-zod-utils:
+    dependencies:
+      '@ignored/hardhat-vnext-utils':
+        specifier: workspace:^3.0.0-next.2
+        version: link:../hardhat-utils
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: ^4.3.0

--- a/v-next/hardhat-mocha-test-runner/src/hookHandlers/config.ts
+++ b/v-next/hardhat-mocha-test-runner/src/hookHandlers/config.ts
@@ -1,7 +1,9 @@
 import type { ConfigHooks } from "@ignored/hardhat-vnext/types/hooks";
 
+import { isObject } from "@ignored/hardhat-vnext-utils/lang";
 import { resolveFromRoot } from "@ignored/hardhat-vnext-utils/path";
 import {
+  conditionalUnionType,
   unionType,
   validateUserConfigZodType,
 } from "@ignored/hardhat-vnext-zod-utils";
@@ -72,10 +74,17 @@ const mochaConfigType = z.object({
 
 const userConfigType = z.object({
   mocha: z.optional(mochaConfigType),
-  test: unionType(
-    [z.object({ mocha: z.string().optional() }), z.string()],
-    "Expected a string or an object with an optional 'mocha' property",
-  ).optional(),
+  paths: z
+    .object({
+      test: conditionalUnionType(
+        [
+          [(data) => typeof data === "string", z.string()],
+          [isObject, z.object({ mocha: z.string().optional() })],
+        ],
+        "Expected a string or an object with an optional 'mocha' property",
+      ).optional(),
+    })
+    .optional(),
 });
 
 export default async (): Promise<Partial<ConfigHooks>> => {

--- a/v-next/hardhat-node-test-runner/src/hookHandlers/config.ts
+++ b/v-next/hardhat-node-test-runner/src/hookHandlers/config.ts
@@ -1,17 +1,25 @@
 import type { ConfigHooks } from "@ignored/hardhat-vnext/types/hooks";
 
+import { isObject } from "@ignored/hardhat-vnext-utils/lang";
 import { resolveFromRoot } from "@ignored/hardhat-vnext-utils/path";
 import {
-  unionType,
+  conditionalUnionType,
   validateUserConfigZodType,
 } from "@ignored/hardhat-vnext-zod-utils";
 import { z } from "zod";
 
 const userConfigType = z.object({
-  test: unionType(
-    [z.object({ nodeTest: z.string().optional() }), z.string()],
-    "Expected a string or an object with an optional 'nodeTest' property",
-  ).optional(),
+  paths: z
+    .object({
+      test: conditionalUnionType(
+        [
+          [isObject, z.object({ nodeTest: z.string().optional() })],
+          [(data) => typeof data === "string", z.string()],
+        ],
+        "Expected a string or an object with an optional 'nodeTest' property",
+      ).optional(),
+    })
+    .optional(),
 });
 
 export default async (): Promise<Partial<ConfigHooks>> => {

--- a/v-next/hardhat-zod-utils/package.json
+++ b/v-next/hardhat-zod-utils/package.json
@@ -59,6 +59,9 @@
     "typescript-eslint": "7.7.1",
     "zod": "^3.23.8"
   },
+  "dependencies": {
+    "@ignored/hardhat-vnext-utils": "workspace:^3.0.0-next.2"
+  },
   "peerDependencies": {
     "zod": "^3.23.8"
   }

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -1,5 +1,6 @@
 import type { ZodTypeDef, ZodType } from "zod";
 
+import { isObject } from "@ignored/hardhat-vnext-utils/lang";
 import { z } from "zod";
 
 /**
@@ -148,7 +149,7 @@ export const configurationVariableType = z.object({
 export const sensitiveStringType = conditionalUnionType(
   [
     [(data) => typeof data === "string", z.string()],
-    [(data) => typeof data === "object", configurationVariableType],
+    [isObject, configurationVariableType],
   ],
   "Expected a string or a Configuration Variable",
 );
@@ -159,7 +160,7 @@ export const sensitiveStringType = conditionalUnionType(
 export const sensitiveUrlType = conditionalUnionType(
   [
     [(data) => typeof data === "string", z.string().url()],
-    [(data) => typeof data === "object", configurationVariableType],
+    [isObject, configurationVariableType],
   ],
   "Expected a URL or a Configuration Variable",
 );

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -103,10 +103,23 @@ export const conditionalUnionType = (
  *
  * @example
  * ```ts
- * const type = z.object({
+ * const typeWithFoo = z.object({
  *   foo: z.string(),
  *   bar: unexpectedFieldType("This field is incompatible with `foo`"),
  * });
+ *
+ * const typeWithBar = z.object({
+ *   bar: z.string(),
+ *   foo: unexpectedFieldType("This field is incompatible with `bar`"),
+ * });
+ *
+ * const union = conditionalUnionType(
+ *   [
+ *     [(data) => isObject(data) && "foo" in data, typeWithFoo],
+ *     [(data) => isObject(data) && "bar" in data, typeWithBar],
+ *   ],
+ *   "Expected an object with either a `foo` or a `bar` field",
+ * );
  * ```
  *
  * @param errorMessage The error message to display if the field is present.

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -20,8 +20,13 @@ export interface HardhatUserConfigValidationError {
  * A Zod untagged union type that returns a custom error message if the value
  * is missing or invalid.
  *
- * In most cases you should prefer using {@link conditionalUnionType} instead.
- * Especially if one or more of the types in the union are objects.
+ * WARNING: In most cases you should use {@link conditionalUnionType} instead.
+ *
+ * This union type is valid for simple cases, where the union is made of
+ * primitive or simple types.
+ *
+ * If you have a type that's complex, like an object or array, you must use
+ * {@link conditionalUnionType}.
  */
 export const unionType = (
   types: Parameters<typeof z.union>[0],

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -19,6 +19,9 @@ export interface HardhatUserConfigValidationError {
 /**
  * A Zod untagged union type that returns a custom error message if the value
  * is missing or invalid.
+ *
+ * In most cases you should prefer using {@link conditionalUnionType} instead.
+ * Especially if one or more of the types in the union are objects.
  */
 export const unionType = (
   types: Parameters<typeof z.union>[0],

--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -32,6 +32,88 @@ export const unionType = (
   });
 
 /**
+ * A Zod union type that allows you to provide hints to Zod about which of the
+ * type variant it should use.
+ *
+ * It receives an array of tuples, where each tuple contains a predicate
+ * function and a ZodType. The predicate function takes the data to be parsed
+ * and returns a boolean. If the predicate function returns true, the ZodType
+ * is used to parse the data.
+ *
+ * If none of the predicates returns true, an error is added to the context
+ * with the noMatchMessage message.
+ *
+ * For example, you can use this to conditionally validate a union type based
+ * on the values `typeof` and its fields:
+ *
+ * @example
+ * ```ts
+ * const fooType = conditionalUnionType(
+ *   [
+ *     [(data) => typeof data === "string", z.string()],
+ *     [(data) => Array.isArray(data), z.array(z.string()).nonempty()],
+ *     [(data) => isObject(data), z.object({foo: z.string().optional()})]
+ *   ],
+ *   "Expected a string, an array of strings, or an object with an optional 'foo' property",
+ * );
+ * ```
+ *
+ * @param cases An array of tuples of a predicate function and a ZodType.
+ * @param noMatchMessage THe error message to return if none of the predicates
+ * returns true.
+ * @returns The conditional union ZodType.
+ */
+export const conditionalUnionType = (
+  cases: Array<[predicate: (data: unknown) => boolean, zodType: ZodType<any>]>,
+  noMatchMessage: string,
+) =>
+  z.any().superRefine((data, ctx) => {
+    const matchingCase = cases.find(([predicate]) => predicate(data));
+    if (matchingCase === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: noMatchMessage,
+      });
+      return;
+    }
+
+    const zodeType = matchingCase[1];
+
+    const parsedData = zodeType.safeParse(data);
+    if (parsedData.error !== undefined) {
+      for (const issue of parsedData.error.issues) {
+        ctx.addIssue(issue);
+      }
+    }
+  });
+
+/**
+ * Creates a Zod type to validate that a field of an object doesn't exist.
+ *
+ * This is useful when you have a {@link conditionalUnionType} that represents
+ * a union of object types with incompatible fields between each other.
+ *
+ * @example
+ * ```ts
+ * const type = z.object({
+ *   foo: z.string(),
+ *   bar: unexpectedFieldType("This field is incompatible with `foo`"),
+ * });
+ * ```
+ *
+ * @param errorMessage The error message to display if the field is present.
+ * @returns A Zod type that validates that a field of an object doesn't exist.
+ */
+export const incompatibleFieldType = (errorMessage = "Unexpected field") =>
+  z
+    .never({
+      errorMap: () => ({
+        message: errorMessage,
+      }),
+    })
+    .optional();
+
+/**
  * A Zod type to validate Hardhat's ConfigurationVariable objects.
  */
 export const configurationVariableType = z.object({
@@ -42,16 +124,22 @@ export const configurationVariableType = z.object({
 /**
  * A Zod type to validate Hardhat's SensitiveString values.
  */
-export const sensitiveStringType = unionType(
-  [z.string(), configurationVariableType],
+export const sensitiveStringType = conditionalUnionType(
+  [
+    [(data) => typeof data === "string", z.string()],
+    [(data) => typeof data === "object", configurationVariableType],
+  ],
   "Expected a string or a Configuration Variable",
 );
 
 /**
  * A Zod type to validate Hardhat's SensitiveString values that expect a URL.
  */
-export const sensitiveUrlType = unionType(
-  [z.string().url(), configurationVariableType],
+export const sensitiveUrlType = conditionalUnionType(
+  [
+    [(data) => typeof data === "string", z.string().url()],
+    [(data) => typeof data === "object", configurationVariableType],
+  ],
   "Expected a URL or a Configuration Variable",
 );
 
@@ -64,15 +152,15 @@ export const sensitiveUrlType = unionType(
  * from the root of the config object, so that they are correctly reported to
  * the user.
  */
-export async function validateUserConfigZodType<
+export function validateUserConfigZodType<
   Output,
   Def extends ZodTypeDef = ZodTypeDef,
   Input = Output,
 >(
   hardhatUserConfig: HardhatUserConfigToValidate,
   configType: ZodType<Output, Def, Input>,
-): Promise<HardhatUserConfigValidationError[]> {
-  const result = await configType.safeParseAsync(hardhatUserConfig);
+): HardhatUserConfigValidationError[] {
+  const result = configType.safeParse(hardhatUserConfig);
 
   if (result.success) {
     return [];

--- a/v-next/hardhat-zod-utils/test/index.ts
+++ b/v-next/hardhat-zod-utils/test/index.ts
@@ -3,14 +3,19 @@ import { describe, it } from "node:test";
 
 import { z } from "zod";
 
-import { unionType } from "../src/index.js";
+import { unionType, conditionalUnionType } from "../src/index.js";
 
 function assertParseResult(
   result: z.SafeParseReturnType<any, any>,
   expectedMessage: string,
+  path?: Array<string | number>,
 ) {
   assert.equal(result.error?.errors.length, 1);
   assert.equal(result.error?.errors[0].message, expectedMessage);
+
+  if (path !== undefined) {
+    assert.deepEqual(result.error?.errors[0].path, path);
+  }
 }
 
 describe("unionType", () => {
@@ -30,5 +35,124 @@ describe("unionType", () => {
     assertParseResult(union.safeParse({}), "Expected error message");
 
     assertParseResult(union.safeParse(undefined), "Expected error message");
+  });
+});
+
+describe("conditionalUnionType", () => {
+  describe("Conditions evaluation", () => {
+    it("should return the first type that matches", async () => {
+      const shouldUseString = conditionalUnionType(
+        [
+          [(data) => typeof data === "string", z.string()],
+          [(data) => typeof data === "string", z.string().url()],
+        ],
+        "No match",
+      );
+
+      // Both conditions match, but we only use the first one
+      assert.equal(shouldUseString.safeParse("asd").success, true);
+
+      const shouldUseUrl = conditionalUnionType(
+        [
+          [(data) => typeof data === "string", z.string().url()],
+          [(data) => typeof data === "string", z.string()],
+        ],
+        "No match",
+      );
+
+      assertParseResult(shouldUseUrl.safeParse("asd"), "Invalid url");
+    });
+
+    it("should return the provided error message if no condition matches", async () => {
+      const shouldUseString = conditionalUnionType(
+        [
+          [(data) => typeof data === "string", z.string()],
+          [(data) => typeof data === "string", z.string().url()],
+        ],
+        "No match",
+      );
+
+      // Both conditions match, but we only use the first one
+      assertParseResult(shouldUseString.safeParse(123), "No match");
+    });
+  });
+
+  describe("Zod issues paths", () => {
+    it("should have an empty path when nothing matches in as a top-level type", async () => {
+      const shouldUseString = conditionalUnionType(
+        [
+          [(data) => typeof data === "string", z.string()],
+          [(data) => typeof data === "string", z.string().url()],
+        ],
+        "No match",
+      );
+
+      assertParseResult(shouldUseString.safeParse(123), "No match", []);
+    });
+
+    it("Should have the path to the nested error if a condition matches", () => {
+      const shouldUseString = conditionalUnionType(
+        [
+          [(data) => typeof data === "object", z.object({ foo: z.string() })],
+          [(data) => typeof data === "string", z.string().url()],
+        ],
+        "No match",
+      );
+
+      assertParseResult(
+        shouldUseString.safeParse({ foo: 123 }),
+        "Expected string, received number",
+        ["foo"],
+      );
+    });
+
+    it("Should have the path to the nested error, even if it's also a conditional union type", () => {
+      const shouldUseString = conditionalUnionType(
+        [
+          [(data) => typeof data === "string", z.string()],
+          [
+            (data) => typeof data === "object",
+            conditionalUnionType(
+              [
+                [
+                  (data) =>
+                    typeof data === "object" && data !== null && "foo" in data,
+                  z.object({ foo: z.string().url() }),
+                ],
+                [
+                  (data) =>
+                    typeof data === "object" && data !== null && "bar" in data,
+                  z.object({ bar: z.array(z.number()) }),
+                ],
+              ],
+              "No internal match",
+            ),
+          ],
+        ],
+        "No outer match",
+      );
+
+      assertParseResult(shouldUseString.safeParse(123), "No outer match", []);
+
+      assertParseResult(shouldUseString.safeParse({}), "No internal match", []);
+
+      assertParseResult(
+        shouldUseString.safeParse({ foo: "asd" }),
+        "Invalid url",
+        ["foo"],
+      );
+
+      assertParseResult(
+        shouldUseString.safeParse({ bar: "asd" }),
+        "Expected array, received string",
+        ["bar"],
+      );
+
+      assertParseResult(
+        shouldUseString.safeParse({ bar: ["asd"] }),
+        "Expected number, received string",
+        ["bar", 0],
+      );
+    });
   });
 });

--- a/v-next/hardhat-zod-utils/test/index.ts
+++ b/v-next/hardhat-zod-utils/test/index.ts
@@ -77,7 +77,7 @@ describe("conditionalUnionType", () => {
         "No match",
       );
 
-      // Both conditions match, but we only use the first one
+      // No condition matches, so we return the provided error message
       assertParseResult(shouldUseString.safeParse(123), "No match");
     });
   });

--- a/v-next/hardhat-zod-utils/test/index.ts
+++ b/v-next/hardhat-zod-utils/test/index.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { isObject } from "@ignored/hardhat-vnext-utils/lang";
 import { z } from "zod";
 
 import {
@@ -97,7 +98,7 @@ describe("conditionalUnionType", () => {
     it("Should have the path to the nested error if a condition matches", () => {
       const shouldUseString = conditionalUnionType(
         [
-          [(data) => typeof data === "object", z.object({ foo: z.string() })],
+          [isObject, z.object({ foo: z.string() })],
           [(data) => typeof data === "string", z.string().url()],
         ],
         "No match",
@@ -115,17 +116,15 @@ describe("conditionalUnionType", () => {
         [
           [(data) => typeof data === "string", z.string()],
           [
-            (data) => typeof data === "object",
+            isObject,
             conditionalUnionType(
               [
                 [
-                  (data) =>
-                    typeof data === "object" && data !== null && "foo" in data,
+                  (data) => isObject(data) && "foo" in data,
                   z.object({ foo: z.string().url() }),
                 ],
                 [
-                  (data) =>
-                    typeof data === "object" && data !== null && "bar" in data,
+                  (data) => isObject(data) && "bar" in data,
                   z.object({ bar: z.array(z.number()) }),
                 ],
               ],

--- a/v-next/hardhat-zod-utils/test/index.ts
+++ b/v-next/hardhat-zod-utils/test/index.ts
@@ -3,7 +3,11 @@ import { describe, it } from "node:test";
 
 import { z } from "zod";
 
-import { unionType, conditionalUnionType } from "../src/index.js";
+import {
+  unionType,
+  conditionalUnionType,
+  incompatibleFieldType,
+} from "../src/index.js";
 
 function assertParseResult(
   result: z.SafeParseReturnType<any, any>,
@@ -154,5 +158,29 @@ describe("conditionalUnionType", () => {
         ["bar", 0],
       );
     });
+  });
+});
+
+describe("incompatibleFieldType", () => {
+  it("should return an error if the field is present", async () => {
+    const type = z.object({
+      bar: incompatibleFieldType("Expected error"),
+    });
+
+    assertParseResult(type.safeParse({ bar: "asd" }), "Expected error", [
+      "bar",
+    ]);
+
+    assertParseResult(type.safeParse({ bar: null }), "Expected error", ["bar"]);
+  });
+
+  it("should not return an error if the field is not present", async () => {
+    const type = z.object({
+      bar: incompatibleFieldType("Expected error"),
+    });
+
+    assert.equal(type.safeParse({}).success, true);
+    assert.equal(type.safeParse({ foo: 123 }).success, true);
+    assert.equal(type.safeParse({ bar: undefined }).success, true);
   });
 });

--- a/v-next/hardhat-zod-utils/tsconfig.json
+++ b/v-next/hardhat-zod-utils/tsconfig.json
@@ -9,6 +9,9 @@
     },
     {
       "path": "../hardhat-test-utils"
+    },
+    {
+      "path": "../hardhat-utils"
     }
   ]
 }


### PR DESCRIPTION
This PR adds a new helper to our zod utils.

I originally planned to remove the old `unionType`, but it's still valid.

I also introduced another helper that's meant to be used with `conditionalUnionType`: `incompatibleFieldType`. See its docs.