### PR TITLE
ci: add test-all-solc-versions input to the core ci

### DIFF
--- a/.github/workflows/hardhat-core-ci.yml
+++ b/.github/workflows/hardhat-core-ci.yml
@@ -22,7 +22,7 @@ on:
       test-all-solc-versions:
         description: Test all solc versions
         required: false
-        default: 'false'
+        default: "false"
 
 defaults:
   run:

--- a/.github/workflows/hardhat-core-ci.yml
+++ b/.github/workflows/hardhat-core-ci.yml
@@ -18,6 +18,11 @@ on:
       - "packages/hardhat-core/**"
       - "packages/hardhat-common/**"
   workflow_dispatch:
+    inputs:
+      test-all-solc-versions:
+        description: Test all solc versions
+        required: false
+        default: 'false'
 
 defaults:
   run:
@@ -63,6 +68,7 @@ jobs:
           DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true
           FORCE_COLOR: 3
           NODE_OPTIONS: --max-old-space-size=4096
+          HARDHAT_TESTS_ALL_SOLC_VERSIONS: ${{ github.event.inputs.test-all-solc-versions}}
         run: pnpm test:except-provider
 
   test-provider:

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/README.md
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/README.md
@@ -56,7 +56,7 @@ There are two other directories under `test-files`. One is `version-independent`
 
 ## How tests are executed
 
-The `compilers-list.ts` module has a list of solc versions that can be used by these tests. By default, only the ones that have `latestSolcVersion: true` are run, but we have a [CI workflow](https://github.com/NomicFoundation/hardhat/actions/workflows/hardhat-network-tracing-all-solc-versions.yml) that runs once per day and executes these tests using all the available compilers.
+The `compilers-list.ts` module has a list of solc versions that can be used by these tests. By default, only the ones that have `latestSolcVersion: true` are run, but we have a [CI workflow](https://github.com/NomicFoundation/hardhat/actions/workflows/hardhat-core-ci.yml) that you can trigger manually with the `test-all-solc-versions` input set to `true` to executes the tests using all the available compilers.
 
 These compilers are grouped by minor version (that is, a group with all the 0.5.x compilers, a group all the 0.6.x compilers and so on) and each group is used to run the tests in the corresponding directory (`test-files/0_5`, `test-files/0_6`, and so on).
 

--- a/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts
@@ -722,7 +722,7 @@ async function runCallTransactionTest(
 }
 
 const onlyLatestSolcVersions =
-  process.env.HARDHAT_TESTS_ALL_SOLC_VERSIONS === undefined;
+  process.env.HARDHAT_TESTS_ALL_SOLC_VERSIONS !== "true";
 
 const filterSolcVersionBy =
   (versionRange: string) =>


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This PR restores the ability to run the tests for all solc versions in CI on demand. It doesn't change the default of running the tests only for the compiler versions marked as latest. 

Here's an example run - https://github.com/NomicFoundation/hardhat/actions/runs/10846884277 

Note that it currently fails with OOM errors :( These are the standard machines sizes - https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories Do you think we should act on it?
