### PR TITLE
hardhat-core: upgrade chokidar to v4

### DIFF
--- a/.changeset/warm-tables-dress.md
+++ b/.changeset/warm-tables-dress.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Upgrade chokidar

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -115,7 +115,7 @@
     "ansi-escapes": "^4.3.0",
     "boxen": "^5.1.2",
     "chalk": "^2.4.2",
-    "chokidar": "^3.4.0",
+    "chokidar": "^4.0.0",
     "ci-info": "^2.0.0",
     "debug": "^4.1.1",
     "enquirer": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,8 +240,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       chokidar:
-        specifier: ^3.4.0
-        version: 3.6.0
+        specifier: ^4.0.0
+        version: 4.0.0
       ci-info:
         specifier: ^2.0.0
         version: 2.0.0
@@ -3432,9 +3432,9 @@ packages:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
 
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
+  chokidar@4.0.0:
+    resolution: {integrity: sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==}
+    engines: {node: '>= 14.16.0'}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -5954,6 +5954,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  readdirp@4.0.1:
+    resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
+    engines: {node: '>= 14.16.0'}
 
   rechoir@0.6.2:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
@@ -9459,17 +9463,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chokidar@3.6.0:
+  chokidar@4.0.0:
     dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
+      readdirp: 4.0.1
 
   chownr@1.1.4: {}
 
@@ -12317,6 +12313,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@4.0.1: {}
 
   rechoir@0.6.2:
     dependencies:


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

I bumped Chokidar to v4 from v3, which removed 11 dependencies and glob support, which Hardhat is not using. It still depends on mocha which depends on v3.5, so I will create a subsequent PR to bump it there
