### PR TITLE
fix: rework `runSequentialHandlers` plugin ordering

### DIFF
--- a/v-next/hardhat/src/internal/core/hook-manager.ts
+++ b/v-next/hardhat/src/internal/core/hook-manager.ts
@@ -220,16 +220,12 @@ export class HookManagerImplementation implements HookManager {
     hookCategoryName: HookCategoryNameT,
     hookName: HookNameT,
   ): Promise<Array<HardhatHooks[HookCategoryNameT][HookNameT]>> {
-    const reversedPluginHooks = (
-      await this.#getPluginHooks(hookCategoryName, hookName)
-    ).reverse();
-
-    const dynamicHooks = await this.#getDynamicHooks(
+    const handlersInChainedOrder = await this.#getHandlersInChainedRunningOrder(
       hookCategoryName,
       hookName,
     );
 
-    return [...dynamicHooks, ...reversedPluginHooks];
+    return handlersInChainedOrder.reverse();
   }
 
   async #getDynamicHooks<

--- a/v-next/hardhat/src/types/hooks.ts
+++ b/v-next/hardhat/src/types/hooks.ts
@@ -309,10 +309,10 @@ export interface HookManager {
 
   /**
    * Runs all the handlers for a hook in the following priority order:
-   *  - Dynamically registered handlers come first, in the reverse order they
-   *   were registered.
-   *  - Plugin handlers come last, in the resolved order of the plugins
+   *  - Plugin handlers come first, in the resolved order of the plugins
    *  list, hence if B has a dependency on A, the order will be A then B.
+   *  - Dynamically registered handlers come last, in the order they
+   *  were registered.
    *
    * @param hookCategoryName The name of the category of the hook whose
    *  handlers should be run.

--- a/v-next/hardhat/src/types/hooks.ts
+++ b/v-next/hardhat/src/types/hooks.ts
@@ -253,23 +253,6 @@ export interface HardhatRuntimeEnvironmentHooks {
  */
 export interface HookManager {
   /**
-   * Returns an array with the existing handlers for a hook, in priority order.
-   *
-   * The priority is defined like this:
-   *  - Dynamically registered handlers come first, in the reverse order they
-   *   were registered.
-   *  - Plugin handlers come last, in the same reverse of the resolved plugins
-   *  list, as seen in `HardhatConfig#plugins`.
-   */
-  getHandlers<
-    HookCategoryNameT extends keyof HardhatHooks,
-    HookNameT extends keyof HardhatHooks[HookCategoryNameT],
-  >(
-    hookCategoryName: HookCategoryNameT,
-    hookName: HookNameT,
-  ): Promise<Array<HardhatHooks[HookCategoryNameT][HookNameT]>>;
-
-  /**
    * Registers handlers for a category of hooks.
    */
   registerHandlers<HookCategoryNameT extends keyof HardhatHooks>(
@@ -288,8 +271,12 @@ export interface HookManager {
   /**
    * Runs the existing handlers of a hook in a chained fashion.
    *
-   * This chain has the same order than the one returned by `getHooks`, plus the
-   * default handler which is added at the end.
+   * This chain has the following priority order:
+   *  - Dynamically registered handlers come first, in the reverse order they
+   *   were registered.
+   *  - Plugin handlers come last, in the same reverse of the resolved plugins
+   *  list, as seen in `HardhatConfig#plugins`.
+   *  - The default handler is called last.
    *
    * The first handler is called with `initialParams`, and then it can call
    * `next` to call the next handler in the chain.
@@ -321,8 +308,11 @@ export interface HookManager {
   ): Promise<Awaited<Return<HookT>>>;
 
   /**
-   * Runs all the handlers for a hook in the same order that `getHandlers`
-   * returns them.
+   * Runs all the handlers for a hook in the following priority order:
+   *  - Dynamically registered handlers come first, in the reverse order they
+   *   were registered.
+   *  - Plugin handlers come last, in the resolved order of the plugins
+   *  list, hence if B has a dependency on A, the order will be A then B.
    *
    * @param hookCategoryName The name of the category of the hook whose
    *  handlers should be run.

--- a/v-next/hardhat/test/internal/core/hook-manager.ts
+++ b/v-next/hardhat/test/internal/core/hook-manager.ts
@@ -228,10 +228,10 @@ describe("HookManager", () => {
             );
 
             assert.deepEqual(result, [
-              "FromHandler2",
-              "FromHandler1",
               "FromExamplePlugin1",
               "FromExamplePlugin2",
+              "FromHandler1",
+              "FromHandler2",
             ]);
           });
         });
@@ -723,7 +723,7 @@ describe("HookManager", () => {
           ["input"] as any,
         );
 
-        assert.deepEqual(result, ["third", "second", "first"]);
+        assert.deepEqual(result, ["first", "second", "third"]);
       });
 
       it("Should let handlers access the passed context (for non-config hooks)", async () => {


### PR DESCRIPTION
The plugin reverse ordering of handlers makes sense for the chained
running of hooks but is wrong for the sequential running, where
dependent plugins should run before the dependee.

We make several moves:

- remove the `getHandlers` method from the API as it is only used
  internally to the hook manager
- create equivalents to `getHandlers` with explicit logic for reversing
  the plugin order for chained running, and keeping the dependency order
  for sequential.

## Reviewers Suggestion

This PR should be reviewed a commit at a time to avoid the jitter from the test restructuring.
