### PR TITLE
Network Manager M1 remaining tasks

### DIFF
--- a/v-next/hardhat-zod-utils/src/index.ts
+++ b/v-next/hardhat-zod-utils/src/index.ts
@@ -1,6 +1,5 @@
 import type { ZodTypeDef, ZodType } from "zod";
 
-import { isObject } from "@ignored/hardhat-vnext-utils/lang";
 import { z } from "zod";
 
 /**
@@ -138,7 +137,7 @@ export const incompatibleFieldType = (errorMessage = "Unexpected field") =>
 /**
  * A Zod type to validate Hardhat's ConfigurationVariable objects.
  */
-export const configurationVariableType = z.object({
+export const configurationVariableSchema = z.object({
   _type: z.literal("ConfigurationVariable"),
   name: z.string(),
 });
@@ -146,21 +145,24 @@ export const configurationVariableType = z.object({
 /**
  * A Zod type to validate Hardhat's SensitiveString values.
  */
-export const sensitiveStringType = conditionalUnionType(
-  [
-    [(data) => typeof data === "string", z.string()],
-    [isObject, configurationVariableType],
-  ],
+export const sensitiveStringSchema = unionType(
+  [z.string(), configurationVariableSchema],
   "Expected a string or a Configuration Variable",
 );
 
 /**
  * A Zod type to validate Hardhat's SensitiveString values that expect a URL.
+ *
+ * TODO: The custom error message in the unionType function doesn't work
+ * correctly when using string().url() for validation, see:
+ * https://github.com/colinhacks/zod/issues/2940
+ * As a workaround, we provide the error message directly in the url() call.
+ * We should remove this when the issue is fixed.
  */
-export const sensitiveUrlType = conditionalUnionType(
+export const sensitiveUrlSchema = unionType(
   [
-    [(data) => typeof data === "string", z.string().url()],
-    [isObject, configurationVariableType],
+    z.string().url("Expected a URL or a Configuration Variable"),
+    configurationVariableSchema,
   ],
   "Expected a URL or a Configuration Variable",
 );

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -1,72 +1,93 @@
 import type {
+  ConfigurationVariable,
   GasConfig,
   GasUserConfig,
+  HardhatConfig,
+  HardhatUserConfig,
   HttpNetworkConfig,
   NetworkConfig,
   NetworkUserConfig,
+  ResolvedConfigurationVariable,
 } from "../../../../types/config.js";
 import type { ConfigHooks } from "../../../../types/hooks.js";
 
 import { validateUserConfig } from "../type-validation.js";
 
 export default async (): Promise<Partial<ConfigHooks>> => ({
-  extendUserConfig: async (config, next) => {
-    const extendedConfig = await next(config);
-
-    const networks: Record<string, NetworkUserConfig> =
-      extendedConfig.networks ?? {};
-
-    return {
-      ...extendedConfig,
-      networks: {
-        ...networks,
-        localhost: {
-          url: "http://localhost:8545",
-          ...networks.localhost,
-          type: "http",
-        },
-      },
-    };
-  },
+  extendUserConfig,
   validateUserConfig,
-  resolveUserConfig: async (userConfig, resolveConfigurationVariable, next) => {
-    const resolvedConfig = await next(userConfig, resolveConfigurationVariable);
+  resolveUserConfig,
+});
 
-    const networks: Record<string, NetworkUserConfig> =
-      userConfig.networks ?? {};
+export async function extendUserConfig(
+  config: HardhatUserConfig,
+  next: (nextConfig: HardhatUserConfig) => Promise<HardhatUserConfig>,
+): Promise<HardhatUserConfig> {
+  const extendedConfig = await next(config);
 
-    const resolvedNetworks: Record<string, NetworkConfig> = {};
+  const networks: Record<string, NetworkUserConfig> =
+    extendedConfig.networks ?? {};
 
-    for (const [networkName, networkConfig] of Object.entries(networks)) {
-      if (networkConfig.type !== "http") {
-        // eslint-disable-next-line no-restricted-syntax -- TODO
-        throw new Error("Only HTTP network is supported for now");
-      }
-
-      const resolvedNetworkConfig: HttpNetworkConfig = {
+  return {
+    ...extendedConfig,
+    networks: {
+      ...networks,
+      localhost: {
+        url: "http://localhost:8545",
+        ...networks.localhost,
         type: "http",
-        chainId: networkConfig.chainId,
-        chainType: networkConfig.chainType,
-        from: networkConfig.from,
-        gas: resolveGasConfig(networkConfig.gas),
-        gasMultiplier: networkConfig.gasMultiplier ?? 1,
-        gasPrice: resolveGasConfig(networkConfig.gasPrice),
-        url: networkConfig.url,
-        timeout: networkConfig.timeout ?? 20_000,
-        httpHeaders: networkConfig.httpHeaders ?? {},
-      };
+      },
+    },
+  };
+}
 
-      resolvedNetworks[networkName] = resolvedNetworkConfig;
+export async function resolveUserConfig(
+  userConfig: HardhatUserConfig,
+  resolveConfigurationVariable: (
+    variableOrString: ConfigurationVariable | string,
+  ) => ResolvedConfigurationVariable,
+  next: (
+    nextUserConfig: HardhatUserConfig,
+    nextResolveConfigurationVariable: (
+      variableOrString: ConfigurationVariable | string,
+    ) => ResolvedConfigurationVariable,
+  ) => Promise<HardhatConfig>,
+): Promise<HardhatConfig> {
+  const resolvedConfig = await next(userConfig, resolveConfigurationVariable);
+
+  const networks: Record<string, NetworkUserConfig> = userConfig.networks ?? {};
+
+  const resolvedNetworks: Record<string, NetworkConfig> = {};
+
+  for (const [networkName, networkConfig] of Object.entries(networks)) {
+    if (networkConfig.type !== "http") {
+      // eslint-disable-next-line no-restricted-syntax -- TODO
+      throw new Error("Only HTTP network is supported for now");
     }
 
-    return {
-      ...resolvedConfig,
-      defaultNetwork: resolvedConfig.defaultNetwork ?? "localhost",
-      defaultChainType: resolvedConfig.defaultChainType ?? "unknown",
-      networks: resolvedNetworks,
+    const resolvedNetworkConfig: HttpNetworkConfig = {
+      type: "http",
+      chainId: networkConfig.chainId,
+      chainType: networkConfig.chainType,
+      from: networkConfig.from,
+      gas: resolveGasConfig(networkConfig.gas),
+      gasMultiplier: networkConfig.gasMultiplier ?? 1,
+      gasPrice: resolveGasConfig(networkConfig.gasPrice),
+      url: networkConfig.url,
+      timeout: networkConfig.timeout ?? 20_000,
+      httpHeaders: networkConfig.httpHeaders ?? {},
     };
-  },
-});
+
+    resolvedNetworks[networkName] = resolvedNetworkConfig;
+  }
+
+  return {
+    ...resolvedConfig,
+    defaultChainType: resolvedConfig.defaultChainType ?? "unknown",
+    defaultNetwork: resolvedConfig.defaultNetwork ?? "localhost",
+    networks: resolvedNetworks,
+  };
+}
 
 function resolveGasConfig(value: GasUserConfig = "auto"): GasConfig {
   return value === "auto" ? value : BigInt(value);

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -1,4 +1,6 @@
 import type {
+  GasConfig,
+  GasUserConfig,
   HttpNetworkConfig,
   NetworkConfig,
   NetworkUserConfig,
@@ -6,17 +8,6 @@ import type {
 import type { ConfigHooks } from "../../../../types/hooks.js";
 
 import { validateUserConfig } from "../type-validation.js";
-
-function resolveBigIntOrAuto(
-  value: number | bigint | "auto" | undefined,
-): bigint | "auto" {
-  if (value === undefined || value === "auto") {
-    return "auto";
-  }
-
-  // TODO: Validate that it's a valid BigInt
-  return BigInt(value);
-}
 
 export default async (): Promise<Partial<ConfigHooks>> => ({
   extendUserConfig: async (config, next) => {
@@ -57,9 +48,9 @@ export default async (): Promise<Partial<ConfigHooks>> => ({
         chainId: networkConfig.chainId,
         chainType: networkConfig.chainType,
         from: networkConfig.from,
-        gas: resolveBigIntOrAuto(networkConfig.gas),
+        gas: resolveGasConfig(networkConfig.gas),
         gasMultiplier: networkConfig.gasMultiplier ?? 1,
-        gasPrice: resolveBigIntOrAuto(networkConfig.gasPrice),
+        gasPrice: resolveGasConfig(networkConfig.gasPrice),
         url: networkConfig.url,
         timeout: networkConfig.timeout ?? 20_000,
         httpHeaders: networkConfig.httpHeaders ?? {},
@@ -76,3 +67,7 @@ export default async (): Promise<Partial<ConfigHooks>> => ({
     };
   },
 });
+
+function resolveGasConfig(value: GasUserConfig = "auto"): GasConfig {
+  return value === "auto" ? value : BigInt(value);
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -112,7 +112,6 @@ export class HttpProvider extends EventEmitter implements EthereumProvider {
     this.#jsonRpcRequestWrapper = jsonRpcRequestWrapper;
   }
 
-  // TODO: We should test that the request is actually wrapped
   public async request(
     requestArguments: RequestArguments,
   ): Promise<SuccessfulJsonRpcResponse["result"]> {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -150,7 +150,6 @@ export class HttpProvider extends EventEmitter implements EthereumProvider {
     return jsonRpcResponse.result;
   }
 
-  // TODO: This should be tested
   public async close(): Promise<void> {
     // See https://github.com/nodejs/undici/discussions/3522#discussioncomment-10498734
     await this.#dispatcher.close();

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -71,6 +71,7 @@ export class NetworkManagerImplementation {
 
     if (
       networkConfigOverride !== undefined &&
+      "type" in networkConfigOverride &&
       networkConfigOverride.type !==
         this.#networkConfigs[resolvedNetworkName].type
     ) {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/config.ts
@@ -48,14 +48,16 @@ declare module "../../../../types/config.js" {
 
   export type NetworkUserConfig = HttpNetworkUserConfig | EdrNetworkUserConfig;
 
+  export type GasUserConfig = "auto" | number | bigint;
+
   export interface HttpNetworkUserConfig {
     type: "http";
     chainId?: number;
     chainType?: ChainType;
     from?: string;
-    gas?: "auto" | number | bigint;
+    gas?: GasUserConfig;
     gasMultiplier?: number;
-    gasPrice?: "auto" | number | bigint;
+    gasPrice?: GasUserConfig;
 
     // HTTP network specific
     url: string;
@@ -68,23 +70,25 @@ declare module "../../../../types/config.js" {
     chainId: number;
     chainType?: ChainType;
     from?: string;
-    gas: "auto" | number | bigint;
+    gas: GasUserConfig;
     gasMultiplier: number;
-    gasPrice: "auto" | number | bigint;
+    gasPrice: GasUserConfig;
 
     // EDR network specific
   }
 
   export type NetworkConfig = HttpNetworkConfig | EdrNetworkConfig;
 
+  export type GasConfig = "auto" | bigint;
+
   export interface HttpNetworkConfig {
     type: "http";
     chainId?: number;
     chainType?: ChainType;
     from?: string;
-    gas: "auto" | bigint;
+    gas: GasConfig;
     gasMultiplier: number;
-    gasPrice: "auto" | bigint;
+    gasPrice: GasConfig;
 
     // HTTP network specific
     url: string;
@@ -97,9 +101,9 @@ declare module "../../../../types/config.js" {
     chainId: number;
     chainType?: ChainType;
     from: string;
-    gas: "auto" | bigint;
+    gas: GasConfig;
     gasMultiplier: number;
-    gasPrice: "auto" | bigint;
+    gasPrice: GasConfig;
 
     // EDR network specific
   }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -5,6 +5,7 @@ import type {
 import type { HardhatUserConfigValidationError } from "../../../types/hooks.js";
 
 import {
+  conditionalUnionType,
   sensitiveUrlType,
   unionType,
   validateUserConfigZodType,
@@ -16,24 +17,23 @@ const chainTypeSchema = unionType(
   "Expected 'l1', 'optimism', or 'unknown'",
 );
 
+const userGasSchema = conditionalUnionType(
+  [
+    [(data) => typeof data === "string", z.literal("auto")],
+    [(data) => typeof data === "number", z.number().int().positive().safe()],
+    [(data) => typeof data === "bigint", z.bigint().positive()],
+  ],
+  "Expected 'auto', a safe int, or bigint",
+);
+
 const httpNetworkUserConfigSchema = z.object({
   type: z.literal("http"),
   chainId: z.optional(z.number().int()),
   chainType: z.optional(chainTypeSchema),
   from: z.optional(z.string()),
-  gas: z.optional(
-    unionType(
-      [z.literal("auto"), z.number().int().safe(), z.bigint()],
-      "Expected 'auto', a safe int, or bigint",
-    ),
-  ),
+  gas: z.optional(userGasSchema),
   gasMultiplier: z.optional(z.number()),
-  gasPrice: z.optional(
-    unionType(
-      [z.literal("auto"), z.number().int().safe(), z.bigint()],
-      "Expected 'auto', a safe int, or bigint",
-    ),
-  ),
+  gasPrice: z.optional(userGasSchema),
 
   // HTTP network specific
   url: sensitiveUrlType,
@@ -46,15 +46,9 @@ const edrNetworkUserConfigSchema = z.object({
   chainId: z.number().int(),
   chainType: z.optional(chainTypeSchema),
   from: z.optional(z.string()),
-  gas: unionType(
-    [z.literal("auto"), z.number().int().safe(), z.bigint()],
-    "Expected 'auto', a safe int, or bigint",
-  ),
+  gas: userGasSchema,
   gasMultiplier: z.number(),
-  gasPrice: unionType(
-    [z.literal("auto"), z.number().int().safe(), z.bigint()],
-    "Expected 'auto', a safe int, or bigint",
-  ),
+  gasPrice: userGasSchema,
 });
 
 const networkUserConfigSchema = z.discriminatedUnion("type", [
@@ -68,17 +62,22 @@ const userConfigSchema = z.object({
   networks: z.optional(z.record(networkUserConfigSchema)),
 });
 
+const gasSchema = conditionalUnionType(
+  [
+    [(data) => typeof data === "string", z.literal("auto")],
+    [(data) => typeof data === "bigint", z.bigint().positive()],
+  ],
+  "Expected 'auto' or bigint",
+);
+
 const httpNetworkConfigSchema = z.object({
   type: z.literal("http"),
   chainId: z.optional(z.number().int()),
   chainType: z.optional(chainTypeSchema),
   from: z.optional(z.string()),
-  gas: unionType([z.literal("auto"), z.bigint()], "Expected 'auto' or bigint"),
+  gas: gasSchema,
   gasMultiplier: z.number(),
-  gasPrice: unionType(
-    [z.literal("auto"), z.bigint()],
-    "Expected 'auto' or bigint",
-  ),
+  gasPrice: gasSchema,
 
   // HTTP network specific
   url: sensitiveUrlType,
@@ -91,12 +90,9 @@ const edrNetworkConfigSchema = z.object({
   chainId: z.number().int(),
   chainType: z.optional(chainTypeSchema),
   from: z.string(),
-  gas: unionType([z.literal("auto"), z.bigint()], "Expected 'auto' or bigint"),
+  gas: gasSchema,
   gasMultiplier: z.number(),
-  gasPrice: unionType(
-    [z.literal("auto"), z.bigint()],
-    "Expected 'auto' or bigint",
-  ),
+  gasPrice: gasSchema,
 });
 
 const networkConfigSchema = z.discriminatedUnion("type", [

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -6,7 +6,7 @@ import type { HardhatUserConfigValidationError } from "../../../types/hooks.js";
 
 import {
   conditionalUnionType,
-  sensitiveUrlType,
+  sensitiveUrlSchema,
   unionType,
   validateUserConfigZodType,
 } from "@ignored/hardhat-vnext-zod-utils";
@@ -36,7 +36,7 @@ const httpNetworkUserConfigSchema = z.object({
   gasPrice: z.optional(userGasSchema),
 
   // HTTP network specific
-  url: sensitiveUrlType,
+  url: sensitiveUrlSchema,
   timeout: z.optional(z.number()),
   httpHeaders: z.optional(z.record(z.string())),
 });
@@ -80,7 +80,7 @@ const httpNetworkConfigSchema = z.object({
   gasPrice: gasSchema,
 
   // HTTP network specific
-  url: sensitiveUrlType,
+  url: sensitiveUrlSchema,
   timeout: z.number(),
   httpHeaders: z.record(z.string()),
 });

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -23,15 +23,15 @@ const httpNetworkUserConfigSchema = z.object({
   from: z.optional(z.string()),
   gas: z.optional(
     unionType(
-      [z.literal("auto"), z.number().int(), z.bigint()],
-      "Expected 'auto', number, or bigint",
+      [z.literal("auto"), z.number().int().safe(), z.bigint()],
+      "Expected 'auto', a safe int, or bigint",
     ),
   ),
   gasMultiplier: z.optional(z.number()),
   gasPrice: z.optional(
     unionType(
-      [z.literal("auto"), z.number().int(), z.bigint()],
-      "Expected 'auto', number, or bigint",
+      [z.literal("auto"), z.number().int().safe(), z.bigint()],
+      "Expected 'auto', a safe int, or bigint",
     ),
   ),
 
@@ -47,13 +47,13 @@ const edrNetworkUserConfigSchema = z.object({
   chainType: z.optional(chainTypeSchema),
   from: z.optional(z.string()),
   gas: unionType(
-    [z.literal("auto"), z.number().int(), z.bigint()],
-    "Expected 'auto', number, or bigint",
+    [z.literal("auto"), z.number().int().safe(), z.bigint()],
+    "Expected 'auto', a safe int, or bigint",
   ),
   gasMultiplier: z.number(),
   gasPrice: unionType(
-    [z.literal("auto"), z.number().int(), z.bigint()],
-    "Expected 'auto', number, or bigint",
+    [z.literal("auto"), z.number().int().safe(), z.bigint()],
+    "Expected 'auto', a safe int, or bigint",
   ),
 });
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -70,7 +70,7 @@ const userConfigSchema = z.object({
 
 const httpNetworkConfigSchema = z.object({
   type: z.literal("http"),
-  chainId: z.number().int().optional(),
+  chainId: z.optional(z.number().int()),
   chainType: z.optional(chainTypeSchema),
   from: z.optional(z.string()),
   gas: unionType([z.literal("auto"), z.bigint()], "Expected 'auto' or bigint"),

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -317,7 +317,7 @@ describe("network-manager/hook-handlers/config", () => {
       );
       assert.equal(
         validationErrors[0].message,
-        "Expected 'auto', a safe int, or bigint",
+        `Invalid literal value, expected "auto"`,
       );
 
       const configWithNonSafeIntGas = {
@@ -340,10 +340,36 @@ describe("network-manager/hook-handlers/config", () => {
         validationErrors.length > 0,
         "validation errors should be present",
       );
-      // TODO: the error message should be "Expected 'auto', a safe int, or bigint"
+
       assert.equal(
         validationErrors[0].message,
         "Number must be less than or equal to 9007199254740991",
+      );
+
+      const configWithNegativeGas = {
+        networks: {
+          localhost: {
+            type: "http",
+            url: "http://localhost:8545",
+            gas: -100,
+          },
+        },
+      };
+
+      validationErrors = await validateUserConfig(
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- testing invalid network type for js users */
+        configWithNegativeGas as any,
+      );
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+
+      assert.equal(
+        validationErrors[0].message,
+        "Number must be greater than 0",
       );
     });
 
@@ -395,7 +421,7 @@ describe("network-manager/hook-handlers/config", () => {
       );
       assert.equal(
         validationErrors[0].message,
-        "Expected 'auto', a safe int, or bigint",
+        `Invalid literal value, expected "auto"`,
       );
 
       const configWithNonSafeIntGasPrice = {
@@ -419,10 +445,35 @@ describe("network-manager/hook-handlers/config", () => {
         "validation errors should be present",
       );
 
-      // TODO: the error message should be "Expected 'auto', a safe int, or bigint"
       assert.equal(
         validationErrors[0].message,
         "Number must be less than or equal to 9007199254740991",
+      );
+
+      const configWithNegativeGasPrice = {
+        networks: {
+          localhost: {
+            type: "http",
+            url: "http://localhost:8545",
+            gasPrice: -100,
+          },
+        },
+      };
+
+      validationErrors = await validateUserConfig(
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- testing invalid network type for js users */
+        configWithNegativeGasPrice as any,
+      );
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+
+      assert.equal(
+        validationErrors[0].message,
+        "Number must be greater than 0",
       );
     });
 

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -1,0 +1,669 @@
+import type { HardhatRuntimeEnvironment } from "../../../../../src/types/hre.js";
+import type {
+  HardhatConfig,
+  HardhatUserConfig,
+} from "@ignored/hardhat-vnext/types/config";
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+import { createHardhatRuntimeEnvironment } from "../../../../../src/hre.js";
+import {
+  extendUserConfig,
+  resolveUserConfig,
+} from "../../../../../src/internal/builtin-plugins/network-manager/hook-handlers/config.js";
+import { validateUserConfig } from "../../../../../src/internal/builtin-plugins/network-manager/type-validation.js";
+import { ResolvedConfigurationVariableImplementation } from "../../../../../src/internal/core/configuration-variables.js";
+
+describe("network-manager/hook-handlers/config", () => {
+  describe("extendUserConfig", () => {
+    it("should extend the user config with the localhost network", async () => {
+      const config: HardhatUserConfig = {};
+      const next = async (nextConfig: HardhatUserConfig) => nextConfig;
+
+      const extendedConfig = await extendUserConfig(config, next);
+      assert.ok(
+        extendedConfig.networks?.localhost !== undefined,
+        "localhost network should be defined",
+      );
+      assert.deepEqual(extendedConfig.networks?.localhost, {
+        url: "http://localhost:8545",
+        type: "http",
+      });
+    });
+
+    it("should allow setting other properties of the localhost network", async () => {
+      const config: HardhatUserConfig = {
+        networks: {
+          localhost: {
+            url: "http://localhost:8545",
+            type: "http",
+            timeout: 10_000,
+          },
+        },
+      };
+      const next = async (nextConfig: HardhatUserConfig) => nextConfig;
+
+      const extendedConfig = await extendUserConfig(config, next);
+      assert.deepEqual(extendedConfig.networks?.localhost, {
+        url: "http://localhost:8545",
+        type: "http",
+        timeout: 10_000,
+      });
+    });
+
+    it("should allow overriding the url of the localhost network", async () => {
+      const config: HardhatUserConfig = {
+        networks: {
+          localhost: {
+            url: "http://localhost:1234",
+            type: "http",
+          },
+        },
+      };
+      const next = async (nextConfig: HardhatUserConfig) => nextConfig;
+
+      const extendedConfig = await extendUserConfig(config, next);
+      assert.deepEqual(extendedConfig.networks?.localhost, {
+        url: "http://localhost:1234",
+        type: "http",
+      });
+    });
+
+    it("should not allow overriding the type of the localhost network", async () => {
+      const config = {
+        networks: {
+          localhost: {
+            type: "http2",
+          },
+        },
+      };
+      const next = async (nextConfig: HardhatUserConfig) => nextConfig;
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const extendedConfig = await extendUserConfig(config as any, next);
+      assert.deepEqual(extendedConfig.networks?.localhost, {
+        url: "http://localhost:8545",
+        type: "http",
+      });
+    });
+  });
+
+  describe("validateUserConfig", () => {
+    it("should pass if the config is valid", async () => {
+      const config: HardhatUserConfig = {
+        defaultChainType: "unknown",
+        defaultNetwork: "localhost",
+        networks: {
+          localhost: {
+            type: "http",
+            chainId: 1337,
+            chainType: "l1",
+            from: "0x123",
+            gas: "auto",
+            gasMultiplier: 1.5,
+            gasPrice: 100n,
+            url: "http://localhost:8545",
+            timeout: 10_000,
+            httpHeaders: {
+              "Content-Type": "application/json",
+            },
+          },
+        },
+      };
+
+      const validationErrors = await validateUserConfig(config);
+
+      assert.equal(validationErrors.length, 0);
+    });
+
+    it("should throw if the defaultChainType is not a valid chain type", async () => {
+      const config = {
+        defaultChainType: "invalid",
+      };
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const validationErrors = await validateUserConfig(config as any);
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Expected 'l1', 'optimism', or 'unknown'",
+      );
+    });
+
+    it("should throw if the defaultNetwork is not a string", async () => {
+      const config = {
+        defaultNetwork: 123,
+      };
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const validationErrors = await validateUserConfig(config as any);
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Expected string, received number",
+      );
+    });
+
+    it("should throw if the networks object is not a record", async () => {
+      const config = {
+        networks: 123,
+      };
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const validationErrors = await validateUserConfig(config as any);
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Expected object, received number",
+      );
+    });
+
+    it("should throw if the network type is not valid", async () => {
+      const config = {
+        networks: {
+          localhost: {
+            type: "invalid",
+          },
+        },
+      };
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const validationErrors = await validateUserConfig(config as any);
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Invalid discriminator value. Expected 'http' | 'edr'",
+      );
+    });
+
+    it("should throw if the network type is missing", async () => {
+      const config = {
+        networks: {
+          localhost: {},
+        },
+      };
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const validationErrors = await validateUserConfig(config as any);
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Invalid discriminator value. Expected 'http' | 'edr'",
+      );
+    });
+
+    it("should throw if the chainId is invalid", async () => {
+      const config = {
+        networks: {
+          localhost: {
+            type: "http",
+            url: "http://localhost:8545",
+            chainId: "invalid",
+          },
+        },
+      };
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const validationErrors = await validateUserConfig(config as any);
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Expected number, received string",
+      );
+    });
+
+    it("should throw if the chainType is invalid", async () => {
+      const config = {
+        networks: {
+          localhost: {
+            type: "http",
+            url: "http://localhost:8545",
+            chainType: "invalid",
+          },
+        },
+      };
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const validationErrors = await validateUserConfig(config as any);
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Expected 'l1', 'optimism', or 'unknown'",
+      );
+    });
+
+    it("should throw if the from is invalid", async () => {
+      const config = {
+        networks: {
+          localhost: {
+            type: "http",
+            url: "http://localhost:8545",
+            from: 123,
+          },
+        },
+      };
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const validationErrors = await validateUserConfig(config as any);
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Expected string, received number",
+      );
+    });
+
+    it("should throw if the gas is invalid", async () => {
+      const configWithInvalidGas = {
+        networks: {
+          localhost: {
+            type: "http",
+            url: "http://localhost:8545",
+            gas: "invalid",
+          },
+        },
+      };
+
+      let validationErrors = await validateUserConfig(
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- testing invalid network type for js users */
+        configWithInvalidGas as any,
+      );
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Expected 'auto', a safe int, or bigint",
+      );
+
+      const configWithNonSafeIntGas = {
+        networks: {
+          localhost: {
+            type: "http",
+            url: "http://localhost:8545",
+            gas: Number.MAX_SAFE_INTEGER + 1,
+          },
+        },
+      };
+
+      validationErrors = await validateUserConfig(
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- testing invalid network type for js users */
+        configWithNonSafeIntGas as any,
+      );
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      // TODO: the error message should be "Expected 'auto', a safe int, or bigint"
+      assert.equal(
+        validationErrors[0].message,
+        "Number must be less than or equal to 9007199254740991",
+      );
+    });
+
+    it("should throw if the gasMultiplier is invalid", async () => {
+      const config = {
+        networks: {
+          localhost: {
+            type: "http",
+            url: "http://localhost:8545",
+            gasMultiplier: "invalid",
+          },
+        },
+      };
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const validationErrors = await validateUserConfig(config as any);
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Expected number, received string",
+      );
+    });
+
+    it("should throw if the gasPrice is invalid", async () => {
+      const configWithInvalidGasPrice = {
+        networks: {
+          localhost: {
+            type: "http",
+            url: "http://localhost:8545",
+            gasPrice: "invalid",
+          },
+        },
+      };
+
+      let validationErrors = await validateUserConfig(
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- testing invalid network type for js users */
+        configWithInvalidGasPrice as any,
+      );
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+      assert.equal(
+        validationErrors[0].message,
+        "Expected 'auto', a safe int, or bigint",
+      );
+
+      const configWithNonSafeIntGasPrice = {
+        networks: {
+          localhost: {
+            type: "http",
+            url: "http://localhost:8545",
+            gasPrice: Number.MAX_SAFE_INTEGER + 1,
+          },
+        },
+      };
+
+      validationErrors = await validateUserConfig(
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- testing invalid network type for js users */
+        configWithNonSafeIntGasPrice as any,
+      );
+
+      assert.ok(
+        validationErrors.length > 0,
+        "validation errors should be present",
+      );
+
+      // TODO: the error message should be "Expected 'auto', a safe int, or bigint"
+      assert.equal(
+        validationErrors[0].message,
+        "Number must be less than or equal to 9007199254740991",
+      );
+    });
+
+    describe("http network specific fields", () => {
+      it("should throw if the url is missing", async () => {
+        const config = {
+          networks: {
+            localhost: {
+              type: "http",
+            },
+          },
+        };
+
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- testing invalid network type for js users */
+        const validationErrors = await validateUserConfig(config as any);
+
+        assert.ok(
+          validationErrors.length > 0,
+          "validation errors should be present",
+        );
+        assert.equal(
+          validationErrors[0].message,
+          "Expected a URL or a Configuration Variable",
+        );
+      });
+
+      it("should throw if the url is invalid", async () => {
+        const config = {
+          networks: {
+            localhost: {
+              type: "http",
+              url: "invalid",
+            },
+          },
+        };
+
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- testing invalid network type for js users */
+        const validationErrors = await validateUserConfig(config as any);
+
+        assert.ok(
+          validationErrors.length > 0,
+          "validation errors should be present",
+        );
+        // TODO: the error message should be "Expected a URL or a Configuration Variable"
+        assert.equal(validationErrors[0].message, "Invalid url");
+      });
+
+      it("should throw if the timeout is invalid", async () => {
+        const config = {
+          networks: {
+            localhost: {
+              type: "http",
+              url: "http://localhost:8545",
+              timeout: "invalid",
+            },
+          },
+        };
+
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- testing invalid network type for js users */
+        const validationErrors = await validateUserConfig(config as any);
+
+        assert.ok(
+          validationErrors.length > 0,
+          "validation errors should be present",
+        );
+        assert.equal(
+          validationErrors[0].message,
+          "Expected number, received string",
+        );
+      });
+
+      it("should throw if the httpHeaders is invalid", async () => {
+        const configWithStringHeaders = {
+          networks: {
+            localhost: {
+              type: "http",
+              url: "http://localhost:8545",
+              httpHeaders: "Content-Type: application/json",
+            },
+          },
+        };
+
+        let validationErrors = await validateUserConfig(
+          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          -- testing invalid network type for js users */
+          configWithStringHeaders as any,
+        );
+
+        assert.ok(
+          validationErrors.length > 0,
+          "validation errors should be present",
+        );
+        assert.equal(
+          validationErrors[0].message,
+          "Expected object, received string",
+        );
+
+        const configWithInvalidHeaderValue = {
+          networks: {
+            localhost: {
+              type: "http",
+              url: "http://localhost:8545",
+              httpHeaders: {
+                "Content-Type": 123,
+              },
+            },
+          },
+        };
+
+        validationErrors = await validateUserConfig(
+          /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          -- testing invalid network type for js users */
+          configWithInvalidHeaderValue as any,
+        );
+
+        assert.ok(
+          validationErrors.length > 0,
+          "validation errors should be present",
+        );
+        assert.equal(
+          validationErrors[0].message,
+          "Expected string, received number",
+        );
+      });
+    });
+  });
+
+  describe("resolveUserConfig", () => {
+    let hre: HardhatRuntimeEnvironment;
+
+    before(async () => {
+      hre = await createHardhatRuntimeEnvironment({});
+    });
+
+    it("should resolve an empty user config with the defaults", async () => {
+      // This is how the user config looks like after it's been extended
+      // by the extendUserConfig hook handler defined in the network-manager plugin.
+      const extendedConfig: HardhatUserConfig = {
+        networks: {
+          localhost: {
+            url: "http://localhost:8545",
+            type: "http",
+          },
+        },
+      };
+      const resolveConfigurationVariable = () =>
+        new ResolvedConfigurationVariableImplementation(hre.hooks, {
+          name: "foo",
+          _type: "ConfigurationVariable",
+        });
+      const next = async (
+        nextUserConfig: HardhatUserConfig,
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- Cast for simplicity as we won't test this */
+      ) => nextUserConfig as HardhatConfig;
+
+      const resolvedConfig = await resolveUserConfig(
+        extendedConfig,
+        resolveConfigurationVariable,
+        next,
+      );
+
+      assert.equal(resolvedConfig.defaultChainType, "unknown");
+      assert.equal(resolvedConfig.defaultNetwork, "localhost");
+      assert.deepEqual(resolvedConfig.networks, {
+        localhost: {
+          type: "http",
+          chainId: undefined,
+          chainType: undefined,
+          from: undefined,
+          gas: "auto",
+          gasMultiplier: 1,
+          gasPrice: "auto",
+          url: "http://localhost:8545",
+          timeout: 20_000,
+          httpHeaders: {},
+        },
+      });
+    });
+
+    it("should resolve with the user config", async () => {
+      const userConfig: HardhatUserConfig = {
+        // To change the defaultChainType, we need to augment the Hardhat types.
+        // Since this can't be done for a single test, we'll leave this untested.
+        defaultChainType: "unknown",
+        defaultNetwork: "myNetwork",
+        networks: {
+          myNetwork: {
+            type: "http",
+            chainId: 1234,
+            chainType: "l1",
+            from: "0x123",
+            gas: "auto",
+            gasMultiplier: 1.5,
+            gasPrice: 100n,
+            url: "http://node.myNetwork.com",
+            timeout: 10_000,
+            httpHeaders: {
+              "Content-Type": "application/json",
+            },
+          },
+        },
+      };
+      const resolveConfigurationVariable = () =>
+        new ResolvedConfigurationVariableImplementation(hre.hooks, {
+          name: "foo",
+          _type: "ConfigurationVariable",
+        });
+      const next = async (
+        nextUserConfig: HardhatUserConfig,
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- Cast for simplicity as we won't test this */
+      ) => nextUserConfig as HardhatConfig;
+
+      const resolvedConfig = await resolveUserConfig(
+        userConfig,
+        resolveConfigurationVariable,
+        next,
+      );
+
+      assert.equal(resolvedConfig.defaultChainType, "unknown");
+      assert.equal(resolvedConfig.defaultNetwork, "myNetwork");
+      assert.deepEqual(resolvedConfig.networks, {
+        myNetwork: {
+          type: "http",
+          chainId: 1234,
+          chainType: "l1",
+          from: "0x123",
+          gas: "auto",
+          gasMultiplier: 1.5,
+          gasPrice: 100n,
+          url: "http://node.myNetwork.com",
+          timeout: 10_000,
+          httpHeaders: {
+            "Content-Type": "application/json",
+          },
+        },
+      });
+    });
+  });
+});

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -519,8 +519,10 @@ describe("network-manager/hook-handlers/config", () => {
           validationErrors.length > 0,
           "validation errors should be present",
         );
-        // TODO: the error message should be "Expected a URL or a Configuration Variable"
-        assert.equal(validationErrors[0].message, "Invalid url");
+        assert.equal(
+          validationErrors[0].message,
+          "Expected a URL or a Configuration Variable",
+        );
       });
 
       it("should throw if the timeout is invalid", async () => {

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
@@ -1,7 +1,10 @@
+import type { JsonRpcRequestWrapperFunction } from "../../../../src/internal/builtin-plugins/network-manager/http-provider.js";
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { numberToHexString } from "@ignored/hardhat-vnext-utils/hex";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import {
@@ -381,6 +384,83 @@ describe("http-provider", () => {
         return;
       }
       assert.fail("Function did not throw any error");
+    });
+
+    it("should wrap the request in the jsonRpcRequestWrapper if it is set", async () => {
+      const jsonRpcChainIdRequest = {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_chainId",
+        params: [],
+      };
+      const jsonRpcChainIdResponse = {
+        jsonrpc: "2.0",
+        id: 1,
+        result: "0x1",
+      };
+      const jsonRpcBlockNumberRequest = {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "eth_blockNumber",
+        params: [],
+      };
+      const jsonRpcBlockNumberResponse = {
+        jsonrpc: "2.0",
+        id: 2,
+        result: "0x2",
+      };
+
+      interceptor
+        .intercept({
+          ...baseInterceptorOptions,
+          body: JSON.stringify(jsonRpcChainIdRequest),
+        })
+        .reply(200, jsonRpcChainIdResponse);
+      const expectedChainId = numberToHexString(31337);
+
+      const jsonRpcRequestWrapper: JsonRpcRequestWrapperFunction = async (
+        request,
+        fetch,
+      ) => {
+        if (request.method === "eth_chainId") {
+          return {
+            jsonrpc: "2.0",
+            id: request.id,
+            result: expectedChainId,
+          };
+        } else {
+          return fetch(request);
+        }
+      };
+
+      const provider = new HttpProvider(
+        "http://localhost",
+        "exampleNetwork",
+        {},
+        interceptor,
+        jsonRpcRequestWrapper,
+      );
+
+      // eth_chainId is handled by the wrapper and returns the hardhat chain ID
+      // instead of jsonRpcChainIdResponse.result
+      const chainIdResult = await provider.request({
+        method: "eth_chainId",
+      });
+      assert.equal(chainIdResult, expectedChainId);
+
+      interceptor
+        .intercept({
+          ...baseInterceptorOptions,
+          body: JSON.stringify(jsonRpcBlockNumberRequest),
+        })
+        .reply(200, jsonRpcBlockNumberResponse);
+
+      // eth_blockNumber is not handled by the wrapper and returns the actual
+      // response
+      const blockNumberResult = await provider.request({
+        method: "eth_blockNumber",
+      });
+      assert.equal(blockNumberResult, jsonRpcBlockNumberResponse.result);
     });
   });
 

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-connection.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-connection.ts
@@ -1,0 +1,57 @@
+import type { EthereumProvider } from "../../../../src/types/providers.js";
+import type { NetworkConfig } from "@ignored/hardhat-vnext/types/config";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { HttpProvider } from "../../../../src/internal/builtin-plugins/network-manager/http-provider.js";
+import { NetworkConnectionImplementation } from "../../../../src/internal/builtin-plugins/network-manager/network-connection.js";
+
+describe("NetworkConnectionImplementation", () => {
+  const localhostNetworkConfig: NetworkConfig = {
+    type: "http",
+    chainId: undefined,
+    chainType: undefined,
+    from: undefined,
+    gas: "auto",
+    gasMultiplier: 1,
+    gasPrice: "auto",
+    url: "http://localhost:8545",
+    timeout: 20_000,
+    httpHeaders: {},
+  };
+
+  describe("NetworkConnectionImplementation.create", () => {
+    it("should create a new network connection", async () => {
+      let expectedProvider: EthereumProvider | undefined;
+
+      const createProvider = async (): Promise<EthereumProvider> => {
+        expectedProvider = await HttpProvider.create({
+          url: localhostNetworkConfig.url,
+          networkName: "localhost",
+          extraHeaders: localhostNetworkConfig.httpHeaders,
+          timeout: localhostNetworkConfig.timeout,
+        });
+
+        return expectedProvider;
+      };
+
+      const closeConnection = async () => {};
+
+      const networkConnection = await NetworkConnectionImplementation.create(
+        1,
+        "localhost",
+        "unknown",
+        localhostNetworkConfig,
+        closeConnection,
+        createProvider,
+      );
+
+      assert.equal(networkConnection.id, 1);
+      assert.equal(networkConnection.networkName, "localhost");
+      assert.equal(networkConnection.chainType, "unknown");
+      assert.deepEqual(networkConnection.networkConfig, localhostNetworkConfig);
+      assert.deepEqual(networkConnection.provider, expectedProvider);
+    });
+  });
+});

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -1,0 +1,212 @@
+import type { NetworkHooks } from "../../../../src/types/hooks.js";
+import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
+import type {
+  NetworkConnection,
+  NetworkManager,
+} from "../../../../src/types/network.js";
+import type { NetworkConfig } from "@ignored/hardhat-vnext/types/config";
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
+import { expectTypeOf } from "expect-type";
+
+import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
+import { NetworkManagerImplementation } from "../../../../src/internal/builtin-plugins/network-manager/network-manager.js";
+
+describe("NetworkManagerImplementation", () => {
+  let hre: HardhatRuntimeEnvironment;
+  let networkManager: NetworkManager;
+  const networks: Record<string, NetworkConfig> = {
+    localhost: {
+      type: "http",
+      chainId: undefined,
+      chainType: undefined,
+      from: undefined,
+      gas: "auto",
+      gasMultiplier: 1,
+      gasPrice: "auto",
+      url: "http://localhost:8545",
+      timeout: 20_000,
+      httpHeaders: {},
+    },
+    customNetwork: {
+      type: "http",
+      chainId: undefined,
+      chainType: undefined,
+      from: undefined,
+      gas: "auto",
+      gasMultiplier: 1,
+      gasPrice: "auto",
+      url: "http://node.customNetwork.com",
+      timeout: 20_000,
+      httpHeaders: {},
+    },
+    myNetwork: {
+      type: "http",
+      chainId: undefined,
+      chainType: "optimism",
+      from: undefined,
+      gas: "auto",
+      gasMultiplier: 1,
+      gasPrice: "auto",
+      url: "http://node.myNetwork.com",
+      timeout: 20_000,
+      httpHeaders: {},
+    },
+  };
+
+  before(async () => {
+    hre = await createHardhatRuntimeEnvironment({});
+    networkManager = new NetworkManagerImplementation(
+      "localhost",
+      "unknown",
+      networks,
+      hre.hooks,
+    );
+  });
+
+  describe("connect", () => {
+    it("should connect to the default network and chain type if none are provided", async () => {
+      const networkConnection = await networkManager.connect();
+      assert.equal(networkConnection.networkName, "localhost");
+      assert.equal(networkConnection.chainType, "unknown");
+      assert.deepEqual(networkConnection.networkConfig, networks.localhost);
+    });
+
+    it("should connect to the specified network and default chain type if none are provided and the network doesn't have a chain type", async () => {
+      const networkConnection = await networkManager.connect("customNetwork");
+      assert.equal(networkConnection.networkName, "customNetwork");
+      assert.equal(networkConnection.chainType, "unknown");
+      assert.deepEqual(networkConnection.networkConfig, networks.customNetwork);
+    });
+
+    it("should connect to the specified network and use it's chain type if none is provided and the network has a chain type", async () => {
+      const networkConnection = await networkManager.connect("myNetwork");
+      assert.equal(networkConnection.networkName, "myNetwork");
+      assert.equal(networkConnection.chainType, "optimism");
+      assert.deepEqual(networkConnection.networkConfig, networks.myNetwork);
+    });
+
+    it("should connect to the specified network and chain type", async () => {
+      const networkConnection = await networkManager.connect(
+        "myNetwork",
+        "optimism",
+      );
+      assert.equal(networkConnection.networkName, "myNetwork");
+      assert.equal(networkConnection.chainType, "optimism");
+      assert.deepEqual(networkConnection.networkConfig, networks.myNetwork);
+    });
+
+    it("should override the network's chain config with the specified chain config", async () => {
+      const networkConnection = await networkManager.connect(
+        "myNetwork",
+        "optimism",
+        { chainId: 1234 },
+      );
+      assert.equal(networkConnection.networkName, "myNetwork");
+      assert.equal(networkConnection.chainType, "optimism");
+      assert.deepEqual(networkConnection.networkConfig, {
+        ...networks.myNetwork,
+        chainId: 1234,
+      });
+    });
+
+    it("should throw an error if the specified network doesn't exist", async () => {
+      await assertRejectsWithHardhatError(
+        networkManager.connect("unknownNetwork"),
+        HardhatError.ERRORS.NETWORK.NETWORK_NOT_FOUND,
+        { networkName: "unknownNetwork" },
+      );
+    });
+
+    it("should throw an error if the specified network config override tries to change the network's type", async () => {
+      await assertRejectsWithHardhatError(
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- Cast to test validation error */
+        networkManager.connect("myNetwork", "l1", { type: "l1" } as any),
+        HardhatError.ERRORS.NETWORK.INVALID_CONFIG_OVERRIDE,
+        {
+          errors: `\t* The type of the network cannot be changed.`,
+        },
+      );
+
+      await assertRejectsWithHardhatError(
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- Cast to test validation error */
+        networkManager.connect("myNetwork", "l1", { type: undefined } as any),
+        HardhatError.ERRORS.NETWORK.INVALID_CONFIG_OVERRIDE,
+        {
+          errors: `\t* The type of the network cannot be changed.`,
+        },
+      );
+    });
+
+    it("should throw an error if the specified network config override is invalid", async () => {
+      await assertRejectsWithHardhatError(
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- Cast to test validation error */
+        networkManager.connect("myNetwork", "optimism", {
+          chainId: "1234",
+        } as any),
+        HardhatError.ERRORS.NETWORK.INVALID_CONFIG_OVERRIDE,
+        {
+          errors: `\t* Error in chainId: Expected number, received string`,
+        },
+      );
+    });
+
+    it("should throw an error if the specified chain type doesn't match the network's chain type", async () => {
+      await assertRejectsWithHardhatError(
+        networkManager.connect("myNetwork", "l1"),
+        HardhatError.ERRORS.NETWORK.INVALID_CHAIN_TYPE,
+        {
+          networkName: "myNetwork",
+          chainType: "l1",
+          networkChainType: "optimism",
+        },
+      );
+    });
+
+    describe("network -> newConnection hook", () => {
+      it("should call the newConnection hook when connecting to a network", async () => {
+        let hookCalled = false;
+        const networkHooks: Partial<NetworkHooks> = {
+          newConnection: async (context, next) => {
+            hookCalled = true;
+            return next(context);
+          },
+        };
+
+        hre.hooks.registerHandlers("network", networkHooks);
+
+        await networkManager.connect();
+
+        hre.hooks.unregisterHandlers("network", networkHooks);
+
+        assert.ok(hookCalled, "The newConnection hook was not called");
+      });
+    });
+
+    describe("types", () => {
+      it("should create a NetworkConnection with the default chain type when no chain type is provided", async () => {
+        const networkConnection = await networkManager.connect("localhost");
+        expectTypeOf(networkConnection).toEqualTypeOf<
+          NetworkConnection<"unknown">
+        >();
+      });
+
+      it("should create a NetworkConnection with the provided chain type", async () => {
+        const networkConnection = await networkManager.connect(
+          "localhost",
+          "l1",
+        );
+        expectTypeOf(networkConnection).toEqualTypeOf<
+          NetworkConnection<"l1">
+        >();
+      });
+    });
+  });
+});

--- a/v-next/hardhat/test/utils.ts
+++ b/v-next/hardhat/test/utils.ts
@@ -52,6 +52,7 @@ export const initializeTestDispatcher = async (
 
   after(() => {
     mockAgent.enableNetConnect();
+    mockAgent.close();
   });
 
   return interceptor;


### PR DESCRIPTION
This PR addresses most of the tasks outlined in [this document](https://www.notion.so/nomicfoundation/Network-Manager-M1-missing-work-2d207a7d96944978a9cc13c4839a6a0a?pvs=4), except for the "Types" section, which will be addressed in a separate PR. I suggest reviewing one commit at a time for an easier review process.

Summary:
- Added tests for:
  - All config hooks (`extendUserConfig`, `validateUserConfig`, `resolveUserConfig`).
  - `HTTPProvider`: `jsonRpcWrapper` and `close` functions.
  - `NetworkManager`: `connect` function and all network hooks (`newConnection`, `closeConnection`, `onRequest`).
  - `NetworkConnection`: class initialization and `close` function (through `NetworkManager`)
- Fixed bugs found during testing.
- Refactored code for better readability and to facilitate testing.