### PR TITLE
Define the `HookContext` as a partial view of the `HRE`

### DIFF
--- a/v-next/hardhat/src/types/hooks.ts
+++ b/v-next/hardhat/src/types/hooks.ts
@@ -4,9 +4,7 @@ import type {
   HardhatUserConfig,
   ResolvedConfigurationVariable,
 } from "./config.js";
-import type { GlobalOptions } from "./global-options.js";
 import type { HardhatRuntimeEnvironment } from "./hre.js";
-import type { UserInterruptionManager } from "./user-interruptions.js";
 import type {
   LastParameter,
   ParametersExceptFirst,
@@ -32,12 +30,7 @@ declare module "./hre.js" {
  * The `HookContext` offers a subset of the functionality that the
  * `HardhatRuntimeEnvironment` does.
  */
-export interface HookContext {
-  readonly config: HardhatConfig;
-  readonly globalOptions: GlobalOptions;
-  readonly interruptions: UserInterruptionManager;
-  readonly hooks: HookManager;
-}
+export type HookContext = Omit<HardhatRuntimeEnvironment, "tasks">;
 
 /**
  * The different hooks that a plugin can define handlers for.


### PR DESCRIPTION
This PR addresses a limitation in Hardhat's core architecture discovered by @ChristopherDedominici.

## Explanation of the problem

Chris is working on the first few hook handlers that use the builtin plugins, and in particular, the extensions to the `HRE` that they make.

This was problematic, as `HookHandler`s don't receive the `HRE`, but a `HookContext` instead. The problem was that any extension to the `HRE` wasn't reflected in the `HookContext`.

The' HookContext' intends to prevent `HookHandler`'s from accessing the `TaskManager` and running tasks, as these are separate concerns in v3, and not to prevent them from accessing the builtin plugins.

## Proposed solution

This solution has a type-level and runtime-level component.

### Types

Instead of defining the `HookContext` as a separate interface, define it as a derived type of the `HRE`:

```ts
export type HookContext = Omit<HardhatRuntimeEnvironment, "tasks">;
```

This way, every extension to the `HardhatRuntimeEnvironment` is also available in the `HookContext`.

### Runtime

To make the values (as in runtime values, not types) of the extensions available through the `HookContext`, without creating a new hook nor restructuring the system, I used `Object.create` to create the `HookContext`, and overwrote `tasks` with `undefined`.

Contrary to making a shallow copy at initialization, defining the HRE as its prototype means that any future modification to the HRE will also be visible.