### PR TITLE
add skeleton EDR Solidity Testing integration

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1461,6 +1461,9 @@ importers:
 
   v-next/hardhat:
     dependencies:
+      '@ignored/edr':
+        specifier: 0.6.2-alpha.0
+        version: 0.6.2-alpha.0
       '@ignored/hardhat-vnext-build-system':
         specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-build-system
@@ -2799,6 +2802,38 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@ignored/edr-darwin-arm64@0.6.2-alpha.0':
+    resolution: {integrity: sha512-n4JNpWOuI522lzCi04qyOG9SExgR/AsrSWmfv5LmU+c6yjaQtSbzblSu3PjnEjvHDtXUZ9AJKtrMKuOQ9Ljvdw==}
+    engines: {node: '>= 18'}
+
+  '@ignored/edr-darwin-x64@0.6.2-alpha.0':
+    resolution: {integrity: sha512-5qmLwStOyB66r08n92ncOxKGT7y72ociOeRp1HN9nRT9/5i5TBySQwvFRo4RrLQw41OZasRAb2iSZIAHAfpgew==}
+    engines: {node: '>= 18'}
+
+  '@ignored/edr-linux-arm64-gnu@0.6.2-alpha.0':
+    resolution: {integrity: sha512-q9fR23ulwQ8sTbmW+b3cni7HNxAhP3S5JdcTUNP8846YXV4utdbJjqBZOUP0RHoJdi8iA5w7RKYSpB9MZ6nHkQ==}
+    engines: {node: '>= 18'}
+
+  '@ignored/edr-linux-arm64-musl@0.6.2-alpha.0':
+    resolution: {integrity: sha512-yU4nOQ0rMK3aShC0qwyz2xXo+caIvgQmoaai9s99Wct3im3EUgcZMO0eXC7wRyHbPUoX1PdbJaZ3C9f/xk7OQg==}
+    engines: {node: '>= 18'}
+
+  '@ignored/edr-linux-x64-gnu@0.6.2-alpha.0':
+    resolution: {integrity: sha512-FPE39nAiTSnbAuM7pYdECeXIkiQvNl/mzpCCAASipYmmd4L6ny+UZ+crRdrT2z7Z19buax/jU3vvRlrIRKV1rQ==}
+    engines: {node: '>= 18'}
+
+  '@ignored/edr-linux-x64-musl@0.6.2-alpha.0':
+    resolution: {integrity: sha512-2xdeo7OqXNYCRCLncJ85G5N6dcpKxlrLc+LBnOvotJe20IDIOngkKr5g5IvdvFTFPQEMXbk4TRV6KaRCcBAfvw==}
+    engines: {node: '>= 18'}
+
+  '@ignored/edr-win32-x64-msvc@0.6.2-alpha.0':
+    resolution: {integrity: sha512-DB8TqWBY+P+FOqeY0Ro1EmTVjN7qg/XUiHU+xWpXRI5NJCzo1s6jN3aW/qN+B5Y6CJOh6wWlDBI8dIGKipZ/8A==}
+    engines: {node: '>= 18'}
+
+  '@ignored/edr@0.6.2-alpha.0':
+    resolution: {integrity: sha512-+11Ko0C1dEh3eObH2ju10HoptUmzIQzJhwluuPrvRyypGUbYVzNYJyMQorRlT5SEKqmR9S/FcptUHD5AITl58A==}
+    engines: {node: '>= 18'}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -7378,6 +7413,37 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@ignored/edr-darwin-arm64@0.6.2-alpha.0':
+    optional: true
+
+  '@ignored/edr-darwin-x64@0.6.2-alpha.0':
+    optional: true
+
+  '@ignored/edr-linux-arm64-gnu@0.6.2-alpha.0':
+    optional: true
+
+  '@ignored/edr-linux-arm64-musl@0.6.2-alpha.0':
+    optional: true
+
+  '@ignored/edr-linux-x64-gnu@0.6.2-alpha.0':
+    optional: true
+
+  '@ignored/edr-linux-x64-musl@0.6.2-alpha.0':
+    optional: true
+
+  '@ignored/edr-win32-x64-msvc@0.6.2-alpha.0':
+    optional: true
+
+  '@ignored/edr@0.6.2-alpha.0':
+    optionalDependencies:
+      '@ignored/edr-darwin-arm64': 0.6.2-alpha.0
+      '@ignored/edr-darwin-x64': 0.6.2-alpha.0
+      '@ignored/edr-linux-arm64-gnu': 0.6.2-alpha.0
+      '@ignored/edr-linux-arm64-musl': 0.6.2-alpha.0
+      '@ignored/edr-linux-x64-gnu': 0.6.2-alpha.0
+      '@ignored/edr-linux-x64-musl': 0.6.2-alpha.0
+      '@ignored/edr-win32-x64-msvc': 0.6.2-alpha.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.16.0
-        version: 2.27.7
+        version: 2.27.8
       hardhat:
         specifier: workspace:*
         version: link:packages/hardhat-core
@@ -71,7 +71,7 @@ importers:
     dependencies:
       eslint-module-utils:
         specifier: ^2.8.0
-        version: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+        version: 2.11.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       requireindex:
         specifier: ^1.2.0
         version: 1.2.0
@@ -133,13 +133,13 @@ importers:
         version: 5.1.5
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/mocha':
         specifier: '>=9.1.0'
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
         version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint@8.57.0)(typescript@5.0.4)
@@ -190,7 +190,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
@@ -250,7 +250,7 @@ importers:
         version: 2.0.0
       debug:
         specifier: ^4.1.1
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       enquirer:
         specifier: ^2.3.0
         version: 2.4.1
@@ -307,7 +307,7 @@ importers:
         version: 6.3.1
       solc:
         specifier: 0.8.26
-        version: 0.8.26(debug@4.3.6)
+        version: 0.8.26(debug@4.3.7)
       source-map-support:
         specifier: ^0.5.13
         version: 0.5.21
@@ -341,7 +341,7 @@ importers:
         version: 0.2.4
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/chai-as-promised':
         specifier: ^7.1.3
         version: 7.1.8
@@ -371,7 +371,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@types/resolve':
         specifier: ^1.17.1
         version: 1.20.6
@@ -440,7 +440,7 @@ importers:
         version: 0.1.2
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
@@ -449,7 +449,7 @@ importers:
     dependencies:
       debug:
         specifier: ^4.1.1
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0
@@ -462,7 +462,7 @@ importers:
         version: link:../eslint-plugin-slow-imports
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/chai-as-promised':
         specifier: ^7.1.3
         version: 7.1.8
@@ -477,7 +477,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@types/sinon':
         specifier: ^9.0.8
         version: 9.0.11
@@ -531,7 +531,7 @@ importers:
         version: 9.2.4
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
@@ -550,13 +550,13 @@ importers:
         version: link:../eslint-plugin-slow-imports
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/mocha':
         specifier: '>=9.1.0'
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
         version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint@8.57.0)(typescript@5.0.4)
@@ -595,7 +595,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
@@ -607,7 +607,7 @@ importers:
         version: 6.18.0
       '@ledgerhq/hw-app-eth':
         specifier: 6.33.6
-        version: 6.33.6(debug@4.3.6)
+        version: 6.33.6(debug@4.3.7)
       '@ledgerhq/hw-transport':
         specifier: ^6.28.4
         version: 6.31.2
@@ -622,7 +622,7 @@ importers:
         version: 2.4.2
       debug:
         specifier: ^4.1.1
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       env-paths:
         specifier: ^2.2.0
         version: 2.2.1
@@ -647,7 +647,7 @@ importers:
         version: link:../eslint-plugin-slow-imports
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/fs-extra':
         specifier: ^5.1.0
         version: 5.1.0
@@ -656,7 +656,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@types/sinon':
         specifier: ^9.0.8
         version: 9.0.11
@@ -704,7 +704,7 @@ importers:
         version: 9.2.4
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
@@ -723,7 +723,7 @@ importers:
         version: link:../eslint-plugin-slow-imports
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/chai-as-promised':
         specifier: ^7.1.3
         version: 7.1.8
@@ -732,7 +732,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
         version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint@8.57.0)(typescript@5.0.4)
@@ -777,7 +777,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
@@ -789,7 +789,7 @@ importers:
         version: 0.0.3
       debug:
         specifier: ^4.1.1
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       semver:
         specifier: ^6.3.0
         version: 6.3.1
@@ -802,7 +802,7 @@ importers:
         version: link:../eslint-plugin-slow-imports
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/debug':
         specifier: ^4.1.4
         version: 4.1.12
@@ -814,7 +814,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@types/semver':
         specifier: ^6.0.2
         version: 6.2.7
@@ -856,7 +856,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
@@ -892,13 +892,13 @@ importers:
         version: 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.2)(typechain@8.3.2(typescript@5.0.4))(typescript@5.0.4))(ethers@6.13.2)(hardhat@packages+hardhat-core)(typechain@8.3.2(typescript@5.0.4))
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/mocha':
         specifier: '>=9.1.0'
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
         version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint@8.57.0)(typescript@5.0.4)
@@ -943,10 +943,10 @@ importers:
         version: 3.0.2
       solidity-coverage:
         specifier: ^0.8.1
-        version: 0.8.12(hardhat@packages+hardhat-core)
+        version: 0.8.13(hardhat@packages+hardhat-core)
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typechain:
         specifier: ^8.3.1
         version: 8.3.2(typescript@5.0.4)
@@ -968,7 +968,7 @@ importers:
         version: link:../eslint-plugin-slow-imports
       '@nomicfoundation/hardhat-ignition-viem':
         specifier: ^0.15.0
-        version: 0.15.5(@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@packages+hardhat-verify)(hardhat@packages+hardhat-core))(@nomicfoundation/hardhat-viem@packages+hardhat-viem)(@nomicfoundation/ignition-core@0.15.5)(hardhat@packages+hardhat-core)(viem@2.20.0(typescript@5.0.4)(zod@3.23.8))
+        version: 0.15.5(@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@packages+hardhat-verify)(hardhat@packages+hardhat-core))(@nomicfoundation/hardhat-viem@packages+hardhat-viem)(@nomicfoundation/ignition-core@0.15.5)(hardhat@packages+hardhat-core)(viem@2.21.4(typescript@5.0.4)(zod@3.23.8))
       '@nomicfoundation/hardhat-network-helpers':
         specifier: workspace:^1.0.0
         version: link:../hardhat-network-helpers
@@ -980,7 +980,7 @@ importers:
         version: link:../hardhat-viem
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/chai-as-promised':
         specifier: ^7.1.6
         version: 7.1.8
@@ -989,7 +989,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
         version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint@8.57.0)(typescript@5.0.4)
@@ -1031,16 +1031,16 @@ importers:
         version: 3.0.2
       solidity-coverage:
         specifier: ^0.8.1
-        version: 0.8.12(hardhat@packages+hardhat-core)
+        version: 0.8.13(hardhat@packages+hardhat-core)
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.4
         version: 5.0.4
       viem:
         specifier: ^2.7.6
-        version: 2.20.0(typescript@5.0.4)(zod@3.23.8)
+        version: 2.21.4(typescript@5.0.4)(zod@3.23.8)
 
   packages/hardhat-verify:
     dependencies:
@@ -1058,7 +1058,7 @@ importers:
         version: 2.4.2
       debug:
         specifier: ^4.1.1
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       lodash.clonedeep:
         specifier: ^4.5.0
         version: 4.5.0
@@ -1083,7 +1083,7 @@ importers:
         version: link:../hardhat-ethers
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/chai-as-promised':
         specifier: ^7.1.3
         version: 7.1.8
@@ -1098,7 +1098,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@types/semver':
         specifier: ^6.0.2
         version: 6.2.7
@@ -1161,7 +1161,7 @@ importers:
         version: 3.7.0(chai@4.5.0)(sinon@9.2.4)
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
@@ -1183,7 +1183,7 @@ importers:
         version: link:../eslint-plugin-slow-imports
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/chai-as-promised':
         specifier: ^7.1.3
         version: 7.1.8
@@ -1198,7 +1198,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@types/sinon':
         specifier: ^9.0.8
         version: 9.0.11
@@ -1252,19 +1252,19 @@ importers:
         version: 9.2.4
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
       viem:
         specifier: ^2.7.6
-        version: 2.20.0(typescript@5.0.4)(zod@3.23.8)
+        version: 2.21.4(typescript@5.0.4)(zod@3.23.8)
 
   packages/hardhat-vyper:
     dependencies:
       debug:
         specifier: ^4.1.1
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       fs-extra:
         specifier: ^7.0.1
         version: 7.0.1
@@ -1286,7 +1286,7 @@ importers:
         version: link:../eslint-plugin-slow-imports
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/chai-as-promised':
         specifier: ^7.1.3
         version: 7.1.8
@@ -1304,7 +1304,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@types/semver':
         specifier: ^6.0.2
         version: 6.2.7
@@ -1349,7 +1349,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
@@ -1364,7 +1364,7 @@ importers:
         version: link:../eslint-plugin-slow-imports
       '@types/chai':
         specifier: ^4.2.0
-        version: 4.3.18
+        version: 4.3.19
       '@types/chai-as-promised':
         specifier: ^7.1.3
         version: 7.1.8
@@ -1373,7 +1373,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^18.0.0
-        version: 18.19.46
+        version: 18.19.50
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
         version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint@8.57.0)(typescript@5.0.4)
@@ -1415,7 +1415,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.8.0
-        version: 10.9.2(@types/node@18.19.46)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.19.50)(typescript@5.0.4)
       typescript:
         specifier: ~5.0.0
         version: 5.0.4
@@ -1445,7 +1445,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       mocha:
         specifier: ^10.0.0
         version: 10.7.3
@@ -1457,10 +1457,13 @@ importers:
         version: 5.5.4
       viem:
         specifier: ^2.7.6
-        version: 2.18.8(typescript@5.5.4)(zod@3.23.8)
+        version: 2.21.4(typescript@5.5.4)(zod@3.23.8)
 
   v-next/hardhat:
     dependencies:
+      '@ignored/hardhat-vnext-build-system':
+        specifier: workspace:^3.0.0-next.2
+        version: link:../hardhat-build-system
       '@ignored/hardhat-vnext-errors':
         specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-errors
@@ -1478,7 +1481,7 @@ importers:
         version: 5.3.0
       debug:
         specifier: ^4.1.1
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       enquirer:
         specifier: ^2.3.0
         version: 2.4.1
@@ -1490,7 +1493,7 @@ importers:
         version: 7.6.3
       tsx:
         specifier: ^4.11.0
-        version: 4.18.0
+        version: 4.19.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1509,7 +1512,7 @@ importers:
         version: 4.1.12
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
@@ -1553,10 +1556,10 @@ importers:
   v-next/hardhat-build-system:
     dependencies:
       '@ignored/hardhat-vnext-errors':
-        specifier: workspace:^3.0.0-next.0
+        specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-errors
       '@ignored/hardhat-vnext-utils':
-        specifier: workspace:^3.0.0-next.0
+        specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-utils
       '@nomicfoundation/ethereumjs-util':
         specifier: 9.0.4
@@ -1575,7 +1578,7 @@ importers:
         version: 5.3.0
       debug:
         specifier: ^4.1.1
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       env-paths:
         specifier: ^2.2.0
         version: 2.2.1
@@ -1605,7 +1608,7 @@ importers:
         version: 7.6.3
       solc:
         specifier: 0.7.3
-        version: 0.7.3(debug@4.3.6)
+        version: 0.7.3(debug@4.3.7)
       undici:
         specifier: ^6.16.1
         version: 6.19.8
@@ -1614,11 +1617,8 @@ importers:
         specifier: ^4.3.0
         version: 4.4.0(eslint@8.57.0)
       '@ignored/hardhat-vnext-node-test-reporter':
-        specifier: workspace:^3.0.0-next.0
+        specifier: workspace:^3.0.0-next.2
         version: link:../hardhat-node-test-reporter
-      '@nomicfoundation/hardhat-test-utils':
-        specifier: workspace:^
-        version: link:../hardhat-test-utils
       '@types/ci-info':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1636,7 +1636,7 @@ importers:
         version: 4.17.7
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       '@types/resolve':
         specifier: ^1.17.1
         version: 1.20.6
@@ -1684,7 +1684,7 @@ importers:
         version: 9.2.4
       tsx:
         specifier: ^4.11.0
-        version: 4.18.0
+        version: 4.19.0
       typescript:
         specifier: ~5.5.0
         version: 5.5.4
@@ -1706,7 +1706,7 @@ importers:
         version: link:../hardhat-node-test-reporter
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
@@ -1739,7 +1739,7 @@ importers:
         version: 5.0.10
       tsx:
         specifier: ^4.11.0
-        version: 4.18.0
+        version: 4.19.0
       typescript:
         specifier: ~5.5.0
         version: 5.5.4
@@ -1766,7 +1766,7 @@ importers:
         version: 5.3.0
       debug:
         specifier: ^4.1.1
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1848,7 +1848,7 @@ importers:
         version: 10.7.3
       tsx:
         specifier: ^4.11.0
-        version: 4.18.0
+        version: 4.19.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -1867,7 +1867,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
@@ -1989,7 +1989,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
@@ -2022,7 +2022,7 @@ importers:
         version: 5.0.10
       tsx:
         specifier: ^4.11.0
-        version: 4.18.0
+        version: 4.19.0
       typescript:
         specifier: ~5.5.0
         version: 5.5.4
@@ -2049,7 +2049,7 @@ importers:
         version: link:../hardhat-zod-utils
       tsx:
         specifier: ^4.11.0
-        version: 4.18.0
+        version: 4.19.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -2062,7 +2062,7 @@ importers:
         version: link:../hardhat-test-utils
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
@@ -2117,7 +2117,7 @@ importers:
         version: link:../hardhat-node-test-reporter
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
@@ -2150,7 +2150,7 @@ importers:
         version: 5.0.10
       tsx:
         specifier: ^4.11.0
-        version: 4.18.0
+        version: 4.19.0
       typescript:
         specifier: ~5.5.0
         version: 5.5.4
@@ -2162,7 +2162,7 @@ importers:
     dependencies:
       debug:
         specifier: ^4.1.1
-        version: 4.3.6(supports-color@8.1.1)
+        version: 4.3.7(supports-color@8.1.1)
       env-paths:
         specifier: ^2.2.0
         version: 2.2.1
@@ -2193,7 +2193,7 @@ importers:
         version: 4.1.12
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
@@ -2226,7 +2226,7 @@ importers:
         version: 5.0.10
       tsx:
         specifier: ^4.11.0
-        version: 4.18.0
+        version: 4.19.0
       typescript:
         specifier: ~5.5.0
         version: 5.5.4
@@ -2251,7 +2251,7 @@ importers:
         version: link:../hardhat-test-utils
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
@@ -2284,7 +2284,7 @@ importers:
         version: 5.0.10
       tsx:
         specifier: ^4.11.0
-        version: 4.18.0
+        version: 4.19.0
       typescript:
         specifier: ~5.5.0
         version: 5.5.4
@@ -2308,7 +2308,7 @@ importers:
         version: link:../hardhat-test-utils
       '@types/node':
         specifier: ^20.14.9
-        version: 20.16.1
+        version: 20.16.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
@@ -2341,7 +2341,7 @@ importers:
         version: 5.0.10
       tsx:
         specifier: ^4.11.0
-        version: 4.18.0
+        version: 4.19.0
       typescript:
         specifier: ~5.5.0
         version: 5.5.4
@@ -2379,8 +2379,8 @@ packages:
     resolution: {integrity: sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.25.5':
-    resolution: {integrity: sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==}
+  '@babel/generator@7.25.6':
+    resolution: {integrity: sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.25.2':
@@ -2413,83 +2413,83 @@ packages:
     resolution: {integrity: sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.25.0':
-    resolution: {integrity: sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==}
+  '@babel/helpers@7.25.6':
+    resolution: {integrity: sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.25.4':
-    resolution: {integrity: sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==}
+  '@babel/parser@7.25.6':
+    resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/runtime@7.25.4':
-    resolution: {integrity: sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==}
+  '@babel/runtime@7.25.6':
+    resolution: {integrity: sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.25.0':
     resolution: {integrity: sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.25.4':
-    resolution: {integrity: sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==}
+  '@babel/traverse@7.25.6':
+    resolution: {integrity: sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.25.4':
-    resolution: {integrity: sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==}
+  '@babel/types@7.25.6':
+    resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@changesets/apply-release-plan@7.0.4':
-    resolution: {integrity: sha512-HLFwhKWayKinWAul0Vj+76jVx1Pc2v55MGPVjZ924Y/ROeSsBMFutv9heHmCUj48lJyRfOTJG5+ar+29FUky/A==}
+  '@changesets/apply-release-plan@7.0.5':
+    resolution: {integrity: sha512-1cWCk+ZshEkSVEZrm2fSj1Gz8sYvxgUL4Q78+1ZZqeqfuevPTPk033/yUZ3df8BKMohkqqHfzj0HOOrG0KtXTw==}
 
-  '@changesets/assemble-release-plan@6.0.3':
-    resolution: {integrity: sha512-bLNh9/Lgl1VwkjWZTq8JmRqH+hj7/Yzfz0jsQ/zJJ+FTmVqmqPj3szeKOri8O/hEM8JmHW019vh2gTO9iq5Cuw==}
+  '@changesets/assemble-release-plan@6.0.4':
+    resolution: {integrity: sha512-nqICnvmrwWj4w2x0fOhVj2QEGdlUuwVAwESrUo5HLzWMI1rE5SWfsr9ln+rDqWB6RQ2ZyaMZHUcU7/IRaUJS+Q==}
 
   '@changesets/changelog-git@0.2.0':
     resolution: {integrity: sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==}
 
-  '@changesets/cli@2.27.7':
-    resolution: {integrity: sha512-6lr8JltiiXPIjDeYg4iM2MeePP6VN/JkmqBsVA5XRiy01hGS3y629LtSDvKcycj/w/5Eur1rEwby/MjcYS+e2A==}
+  '@changesets/cli@2.27.8':
+    resolution: {integrity: sha512-gZNyh+LdSsI82wBSHLQ3QN5J30P4uHKJ4fXgoGwQxfXwYFTJzDdvIJasZn8rYQtmKhyQuiBj4SSnLuKlxKWq4w==}
     hasBin: true
 
-  '@changesets/config@3.0.2':
-    resolution: {integrity: sha512-cdEhS4t8woKCX2M8AotcV2BOWnBp09sqICxKapgLHf9m5KdENpWjyrFNMjkLqGJtUys9U+w93OxWT0czorVDfw==}
+  '@changesets/config@3.0.3':
+    resolution: {integrity: sha512-vqgQZMyIcuIpw9nqFIpTSNyc/wgm/Lu1zKN5vECy74u95Qx/Wa9g27HdgO4NkVAaq+BGA8wUc/qvbvVNs93n6A==}
 
   '@changesets/errors@0.2.0':
     resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
 
-  '@changesets/get-dependents-graph@2.1.1':
-    resolution: {integrity: sha512-LRFjjvigBSzfnPU2n/AhFsuWR5DK++1x47aq6qZ8dzYsPtS/I5mNhIGAS68IAxh1xjO9BTtz55FwefhANZ+FCA==}
+  '@changesets/get-dependents-graph@2.1.2':
+    resolution: {integrity: sha512-sgcHRkiBY9i4zWYBwlVyAjEM9sAzs4wYVwJUdnbDLnVG3QwAaia1Mk5P8M7kraTOZN+vBET7n8KyB0YXCbFRLQ==}
 
-  '@changesets/get-release-plan@4.0.3':
-    resolution: {integrity: sha512-6PLgvOIwTSdJPTtpdcr3sLtGatT+Jr22+cQwEBJBy6wP0rjB4yJ9lv583J9fVpn1bfQlBkDa8JxbS2g/n9lIyA==}
+  '@changesets/get-release-plan@4.0.4':
+    resolution: {integrity: sha512-SicG/S67JmPTrdcc9Vpu0wSQt7IiuN0dc8iR5VScnnTVPfIaLvKmEGRvIaF0kcn8u5ZqLbormZNTO77bCEvyWw==}
 
   '@changesets/get-version-range-type@0.4.0':
     resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
 
-  '@changesets/git@3.0.0':
-    resolution: {integrity: sha512-vvhnZDHe2eiBNRFHEgMiGd2CT+164dfYyrJDhwwxTVD/OW0FUD6G7+4DIx1dNwkwjHyzisxGAU96q0sVNBns0w==}
+  '@changesets/git@3.0.1':
+    resolution: {integrity: sha512-pdgHcYBLCPcLd82aRcuO0kxCDbw/yISlOtkmwmE8Odo1L6hSiZrBOsRl84eYG7DRCab/iHnOkWqExqc4wxk2LQ==}
 
-  '@changesets/logger@0.1.0':
-    resolution: {integrity: sha512-pBrJm4CQm9VqFVwWnSqKEfsS2ESnwqwH+xR7jETxIErZcfd1u2zBSqrHbRHR7xjhSgep9x2PSKFKY//FAshA3g==}
+  '@changesets/logger@0.1.1':
+    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
 
   '@changesets/parse@0.4.0':
     resolution: {integrity: sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==}
 
-  '@changesets/pre@2.0.0':
-    resolution: {integrity: sha512-HLTNYX/A4jZxc+Sq8D1AMBsv+1qD6rmmJtjsCJa/9MSRybdxh0mjbTvE6JYZQ/ZiQ0mMlDOlGPXTm9KLTU3jyw==}
+  '@changesets/pre@2.0.1':
+    resolution: {integrity: sha512-vvBJ/If4jKM4tPz9JdY2kGOgWmCowUYOi5Ycv8dyLnEE8FgpYYUo1mgJZxcdtGGP3aG8rAQulGLyyXGSLkIMTQ==}
 
-  '@changesets/read@0.6.0':
-    resolution: {integrity: sha512-ZypqX8+/im1Fm98K4YcZtmLKgjs1kDQ5zHpc2U1qdtNBmZZfo/IBiG162RoP0CUF05tvp2y4IspH11PLnPxuuw==}
+  '@changesets/read@0.6.1':
+    resolution: {integrity: sha512-jYMbyXQk3nwP25nRzQQGa1nKLY0KfoOV7VLgwucI0bUO8t8ZLCr6LZmgjXsiKuRDc+5A6doKPr9w2d+FEJ55zQ==}
 
-  '@changesets/should-skip-package@0.1.0':
-    resolution: {integrity: sha512-FxG6Mhjw7yFStlSM7Z0Gmg3RiyQ98d/9VpQAZ3Fzr59dCOM9G6ZdYbjiSAt0XtFr9JR5U2tBaJWPjrkGGc618g==}
+  '@changesets/should-skip-package@0.1.1':
+    resolution: {integrity: sha512-H9LjLbF6mMHLtJIc/eHR9Na+MifJ3VxtgP/Y+XLn4BF7tDTEN1HNYtH6QMcjP1uxp9sjaFYmW8xqloaCi/ckTg==}
 
   '@changesets/types@4.1.0':
     resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
@@ -2497,8 +2497,8 @@ packages:
   '@changesets/types@6.0.0':
     resolution: {integrity: sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==}
 
-  '@changesets/write@0.3.1':
-    resolution: {integrity: sha512-SyGtMXzH3qFqlHKcvFY2eX+6b0NGiFcNav8AFsYwy5l8hejOeoeTDemu5Yjmke2V5jpzY+pBvM0vCCQ3gdZpfw==}
+  '@changesets/write@0.3.2':
+    resolution: {integrity: sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2900,6 +2900,10 @@ packages:
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
 
+  '@noble/hashes@1.5.0':
+    resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/secp256k1@1.7.1':
     resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
 
@@ -3051,8 +3055,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@scure/base@1.1.7':
-    resolution: {integrity: sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==}
+  '@scure/base@1.1.8':
+    resolution: {integrity: sha512-6CyAclxj3Nb0XT7GHK6K4zK6k2xJm6E4Ft0Ohjt4WgegiFUHEtFb2CGzmPmGBwoIhrLsqNLYfLr04Y1GePrzZg==}
 
   '@scure/bip32@1.1.5':
     resolution: {integrity: sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==}
@@ -3065,6 +3069,9 @@ packages:
 
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
+
+  '@scure/bip39@1.4.0':
+    resolution: {integrity: sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==}
 
   '@sentry/core@5.30.0':
     resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
@@ -3154,8 +3161,8 @@ packages:
   '@types/chai-as-promised@7.1.8':
     resolution: {integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==}
 
-  '@types/chai@4.3.18':
-    resolution: {integrity: sha512-2UfJzigyNa8kYTKn7o4hNMPphkxtu4WTJyobK3m4FBpyj7EK5xgtPcOtxLm7Dznk/Qxr0QXn+gQbkg7mCZKdfg==}
+  '@types/chai@4.3.19':
+    resolution: {integrity: sha512-2hHHvQBVE2FiSK4eN0Br6snX9MtolHaTo/batnLjlGRhoQzlCL61iVpxoqO7SfFyOw+P/pwv+0zNHzKoGWz9Cw==}
 
   '@types/ci-info@2.0.0':
     resolution: {integrity: sha512-5R2/MHILQLDCzTuhs1j4Qqq8AaKUf7Ma4KSSkCtc12+fMs47zfa34qhto9goxpyX00tQK1zxB885VCiawZ5Qhg==}
@@ -3226,11 +3233,14 @@ packages:
   '@types/node@18.15.13':
     resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
 
-  '@types/node@18.19.46':
-    resolution: {integrity: sha512-vnRgMS7W6cKa1/0G3/DTtQYpVrZ8c0Xm6UkLaVFrb9jtcVC3okokW09Ki1Qdrj9ISokszD69nY4WDLRlvHlhAA==}
+  '@types/node@18.19.50':
+    resolution: {integrity: sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==}
 
   '@types/node@20.16.1':
     resolution: {integrity: sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==}
+
+  '@types/node@20.16.5':
+    resolution: {integrity: sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==}
 
   '@types/node@8.10.66':
     resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
@@ -3523,8 +3533,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.3.3:
-    resolution: {integrity: sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==}
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
 
   acorn@8.12.1:
@@ -3583,8 +3593,8 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.0.1:
-    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
     engines: {node: '>=12'}
 
   ansi-styles@1.0.0:
@@ -3694,8 +3704,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.7.5:
-    resolution: {integrity: sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==}
+  axios@1.7.7:
+    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -3820,8 +3830,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001653:
-    resolution: {integrity: sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==}
+  caniuse-lite@1.0.30001660:
+    resolution: {integrity: sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==}
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
@@ -4051,8 +4061,8 @@ packages:
       supports-color:
         optional: true
 
-  debug@4.3.6:
-    resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -4160,8 +4170,8 @@ packages:
   eip55@2.1.1:
     resolution: {integrity: sha512-WcagVAmNu2Ww2cDUfzuWVntYwFxbvZ5MvIyLZpMjTTkjD6sCvkGOiS86jTppzu9/gWsc8isLHAeMBWK02OnZmA==}
 
-  electron-to-chromium@1.5.13:
-    resolution: {integrity: sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==}
+  electron-to-chromium@1.5.18:
+    resolution: {integrity: sha512-1OfuVACu+zKlmjsNdcJuVQuVE61sZOLbNM4JAQ1Rvh6EOj0/EUKhMJjRH73InPlXSh8HIJk1cVZ8pyOV/FMdUQ==}
 
   elliptic@6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
@@ -4228,8 +4238,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  escalade@3.1.2:
-    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   escape-string-regexp@1.0.5:
@@ -4286,8 +4296,8 @@ packages:
       eslint-plugin-import-x:
         optional: true
 
-  eslint-module-utils@2.8.2:
-    resolution: {integrity: sha512-3XnC5fDyc8M4J2E8pt8pmSVRX2M+5yWMCfI/kDZwauQeFgzQOuhcRBFKjTeJagqgk4sFKxe1mvNVnaWwImx/Tg==}
+  eslint-module-utils@2.11.0:
+    resolution: {integrity: sha512-gbBE5Hitek/oG6MUVj6sFuzEjA/ClzNflVrLovHi/JgLdC7fiN5gLAY1WIPW1a0V5I999MnsrvVrCOGmmVqDBQ==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -4558,9 +4568,6 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  find-yarn-workspace-root2@1.2.16:
-    resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
-
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4572,8 +4579,8 @@ packages:
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
-  follow-redirects@1.15.6:
-    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -4680,8 +4687,8 @@ packages:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.7.6:
-    resolution: {integrity: sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==}
+  get-tsconfig@4.8.0:
+    resolution: {integrity: sha512-Pgba6TExTZ0FJAn1qkJAjIeKoDJ3CsI2ChuLohJnZl/tTU8MVrq3b+2t5UOPfRa4RMsorClBjJALkJUMjG1PAw==}
 
   ghost-testrpc@0.0.2:
     resolution: {integrity: sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==}
@@ -4929,8 +4936,8 @@ packages:
     resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
     engines: {node: '>=6'}
 
-  is-bun-module@1.1.0:
-    resolution: {integrity: sha512-4mTAVPlrXpaN3jtF0lsnPCMGnq4+qZjVIKq0HCpfcqf8OC1SM5oATCIAPM5V5FN05qp2NNnFndphmdZS9CV3hA==}
+  is-bun-module@1.2.1:
+    resolution: {integrity: sha512-AmidtEM6D6NmUiLOvvU7+IePxjEjOzra2h0pSrsfSAcXwl/83zLLXDByafUJy9k/rKK0pvXMLdwKwGHlX2Ke6Q==}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -5189,10 +5196,6 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  load-yaml-file@0.2.0:
-    resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
-    engines: {node: '>=6'}
-
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
@@ -5360,9 +5363,6 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
-  ms@2.1.2:
-    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -5414,8 +5414,8 @@ packages:
       encoding:
         optional: true
 
-  node-gyp-build@4.8.1:
-    resolution: {integrity: sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==}
+  node-gyp-build@4.8.2:
+    resolution: {integrity: sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==}
     hasBin: true
 
   node-hid@2.1.2:
@@ -5566,6 +5566,9 @@ packages:
   package-json-from-dist@1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
 
+  package-manager-detector@0.2.0:
+    resolution: {integrity: sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -5618,8 +5621,8 @@ packages:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
     engines: {node: '>=0.12'}
 
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
+  picocolors@1.1.0:
+    resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -5641,10 +5644,6 @@ packages:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
     engines: {node: '>=10'}
     hasBin: true
-
-  preferred-pm@3.1.4:
-    resolution: {integrity: sha512-lEHd+yEm22jXdCphDrkvIJQU66EuLojPPtvZkpKIkiD+l0DMThF/niqZKJSoU8Vl7iuvtmzyMhir9LdVy5WMnA==}
-    engines: {node: '>=10'}
 
   prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -6006,8 +6005,8 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  solidity-coverage@0.8.12:
-    resolution: {integrity: sha512-8cOB1PtjnjFRqOgwFiD8DaUsYJtVJ6+YdXQtSZDrLGf8cdhhh8xzTtGzVTGeBf15kTv0v7lYPJlV/az7zLEPJw==}
+  solidity-coverage@0.8.13:
+    resolution: {integrity: sha512-RiBoI+kF94V3Rv0+iwOj3HQVSqNzA9qm/qDP1ZDXK5IX0Cvho1qiz8hAXTsAo6KOIUeP73jfscq0KlLqVxzGWA==}
     hasBin: true
     peerDependencies:
       hardhat: ^2.11.0
@@ -6255,6 +6254,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tsx@4.19.0:
+    resolution: {integrity: sha512-bV30kM7bsLZKZIOCHeMNVMJ32/LuJzLVajkQI/qf92J2Qr08ueLQvW00PUZGiuLPP760UINwupgUj8qrSCPUKg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -6364,8 +6368,8 @@ packages:
     resolution: {integrity: sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==}
     engines: {node: '>=8'}
 
-  uglify-js@3.19.2:
-    resolution: {integrity: sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==}
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
 
@@ -6435,16 +6439,8 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  viem@2.18.8:
-    resolution: {integrity: sha512-Fi5d9fd/LBiVtJ5eV2c99yrdt4dJH5Vbkf2JajwCqHYuV4ErSk/sm+L6Ru3rzT67rfRHSOQibTZxByEBua/WLw==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  viem@2.20.0:
-    resolution: {integrity: sha512-cM4vs81HnSNbfceI1MLkx4pCVzbVjl9xiNSv5SCutYjUyFFOVSPDlEyhpg2iHinxx1NM4Qne3END5eLT8rvUdg==}
+  viem@2.21.4:
+    resolution: {integrity: sha512-4E61XWhErjuXh5ObEoosKSy4iMvYnkuQq9jGLW5Isod68dNrENnyNV0QlVpn0LB3qunJ4ZMFMhYdfTjETqe7cQ==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -6548,10 +6544,6 @@ packages:
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
-
-  which-pm@2.2.0:
-    resolution: {integrity: sha512-MOiaDbA5ZZgUjkeMWM5EkJp4loW5ZRoa5bc3/aeMox/PJelMhE6t7S/mLuiY43DBupyxH+S0U1bTui9kWUlmsw==}
-    engines: {node: '>=8.15'}
 
   which-typed-array@1.1.15:
     resolution: {integrity: sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==}
@@ -6726,7 +6718,7 @@ snapshots:
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.0.1
+      picocolors: 1.1.0
 
   '@babel/compat-data@7.25.4': {}
 
@@ -6734,25 +6726,25 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.5
+      '@babel/generator': 7.25.6
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
-      '@babel/helpers': 7.25.0
-      '@babel/parser': 7.25.4
+      '@babel/helpers': 7.25.6
+      '@babel/parser': 7.25.6
       '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.4
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6
+      '@babel/types': 7.25.6
       convert-source-map: 2.0.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.25.5':
+  '@babel/generator@7.25.6':
     dependencies:
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
@@ -6767,8 +6759,8 @@ snapshots:
 
   '@babel/helper-module-imports@7.24.7':
     dependencies:
-      '@babel/traverse': 7.25.4
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6
+      '@babel/types': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
@@ -6778,14 +6770,14 @@ snapshots:
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.4
+      '@babel/traverse': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-simple-access@7.24.7':
     dependencies:
-      '@babel/traverse': 7.25.4
-      '@babel/types': 7.25.4
+      '@babel/traverse': 7.25.6
+      '@babel/types': 7.25.6
     transitivePeerDependencies:
       - supports-color
 
@@ -6795,45 +6787,45 @@ snapshots:
 
   '@babel/helper-validator-option@7.24.8': {}
 
-  '@babel/helpers@7.25.0':
+  '@babel/helpers@7.25.6':
     dependencies:
       '@babel/template': 7.25.0
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
 
   '@babel/highlight@7.24.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.0
 
-  '@babel/parser@7.25.4':
+  '@babel/parser@7.25.6':
     dependencies:
-      '@babel/types': 7.25.4
+      '@babel/types': 7.25.6
 
-  '@babel/runtime@7.25.4':
+  '@babel/runtime@7.25.6':
     dependencies:
       regenerator-runtime: 0.14.1
 
   '@babel/template@7.25.0':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.25.4
-      '@babel/types': 7.25.4
+      '@babel/parser': 7.25.6
+      '@babel/types': 7.25.6
 
-  '@babel/traverse@7.25.4':
+  '@babel/traverse@7.25.6':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.5
-      '@babel/parser': 7.25.4
+      '@babel/generator': 7.25.6
+      '@babel/parser': 7.25.6
       '@babel/template': 7.25.0
-      '@babel/types': 7.25.4
-      debug: 4.3.6(supports-color@8.1.1)
+      '@babel/types': 7.25.6
+      debug: 4.3.7(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.25.4':
+  '@babel/types@7.25.6':
     dependencies:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
@@ -6841,13 +6833,12 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@changesets/apply-release-plan@7.0.4':
+  '@changesets/apply-release-plan@7.0.5':
     dependencies:
-      '@babel/runtime': 7.25.4
-      '@changesets/config': 3.0.2
+      '@changesets/config': 3.0.3
       '@changesets/get-version-range-type': 0.4.0
-      '@changesets/git': 3.0.0
-      '@changesets/should-skip-package': 0.1.0
+      '@changesets/git': 3.0.1
+      '@changesets/should-skip-package': 0.1.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       detect-indent: 6.1.0
@@ -6858,12 +6849,11 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.6.3
 
-  '@changesets/assemble-release-plan@6.0.3':
+  '@changesets/assemble-release-plan@6.0.4':
     dependencies:
-      '@babel/runtime': 7.25.4
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.1
-      '@changesets/should-skip-package': 0.1.0
+      '@changesets/get-dependents-graph': 2.1.2
+      '@changesets/should-skip-package': 0.1.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       semver: 7.6.3
@@ -6872,46 +6862,44 @@ snapshots:
     dependencies:
       '@changesets/types': 6.0.0
 
-  '@changesets/cli@2.27.7':
+  '@changesets/cli@2.27.8':
     dependencies:
-      '@babel/runtime': 7.25.4
-      '@changesets/apply-release-plan': 7.0.4
-      '@changesets/assemble-release-plan': 6.0.3
+      '@changesets/apply-release-plan': 7.0.5
+      '@changesets/assemble-release-plan': 6.0.4
       '@changesets/changelog-git': 0.2.0
-      '@changesets/config': 3.0.2
+      '@changesets/config': 3.0.3
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.1
-      '@changesets/get-release-plan': 4.0.3
-      '@changesets/git': 3.0.0
-      '@changesets/logger': 0.1.0
-      '@changesets/pre': 2.0.0
-      '@changesets/read': 0.6.0
-      '@changesets/should-skip-package': 0.1.0
+      '@changesets/get-dependents-graph': 2.1.2
+      '@changesets/get-release-plan': 4.0.4
+      '@changesets/git': 3.0.1
+      '@changesets/logger': 0.1.1
+      '@changesets/pre': 2.0.1
+      '@changesets/read': 0.6.1
+      '@changesets/should-skip-package': 0.1.1
       '@changesets/types': 6.0.0
-      '@changesets/write': 0.3.1
+      '@changesets/write': 0.3.2
       '@manypkg/get-packages': 1.1.3
       '@types/semver': 7.5.8
       ansi-colors: 4.1.3
-      chalk: 2.4.2
       ci-info: 3.9.0
       enquirer: 2.4.1
       external-editor: 3.1.0
       fs-extra: 7.0.1
-      human-id: 1.0.2
       mri: 1.2.0
       outdent: 0.5.0
       p-limit: 2.3.0
-      preferred-pm: 3.1.4
+      package-manager-detector: 0.2.0
+      picocolors: 1.1.0
       resolve-from: 5.0.0
       semver: 7.6.3
       spawndamnit: 2.0.0
       term-size: 2.2.1
 
-  '@changesets/config@3.0.2':
+  '@changesets/config@3.0.3':
     dependencies:
       '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.1
-      '@changesets/logger': 0.1.0
+      '@changesets/get-dependents-graph': 2.1.2
+      '@changesets/logger': 0.1.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
@@ -6921,67 +6909,60 @@ snapshots:
     dependencies:
       extendable-error: 0.1.7
 
-  '@changesets/get-dependents-graph@2.1.1':
+  '@changesets/get-dependents-graph@2.1.2':
     dependencies:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      chalk: 2.4.2
-      fs-extra: 7.0.1
+      picocolors: 1.1.0
       semver: 7.6.3
 
-  '@changesets/get-release-plan@4.0.3':
+  '@changesets/get-release-plan@4.0.4':
     dependencies:
-      '@babel/runtime': 7.25.4
-      '@changesets/assemble-release-plan': 6.0.3
-      '@changesets/config': 3.0.2
-      '@changesets/pre': 2.0.0
-      '@changesets/read': 0.6.0
+      '@changesets/assemble-release-plan': 6.0.4
+      '@changesets/config': 3.0.3
+      '@changesets/pre': 2.0.1
+      '@changesets/read': 0.6.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
 
   '@changesets/get-version-range-type@0.4.0': {}
 
-  '@changesets/git@3.0.0':
+  '@changesets/git@3.0.1':
     dependencies:
-      '@babel/runtime': 7.25.4
       '@changesets/errors': 0.2.0
-      '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       is-subdir: 1.2.0
       micromatch: 4.0.8
       spawndamnit: 2.0.0
 
-  '@changesets/logger@0.1.0':
+  '@changesets/logger@0.1.1':
     dependencies:
-      chalk: 2.4.2
+      picocolors: 1.1.0
 
   '@changesets/parse@0.4.0':
     dependencies:
       '@changesets/types': 6.0.0
       js-yaml: 3.14.1
 
-  '@changesets/pre@2.0.0':
+  '@changesets/pre@2.0.1':
     dependencies:
-      '@babel/runtime': 7.25.4
       '@changesets/errors': 0.2.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       fs-extra: 7.0.1
 
-  '@changesets/read@0.6.0':
+  '@changesets/read@0.6.1':
     dependencies:
-      '@babel/runtime': 7.25.4
-      '@changesets/git': 3.0.0
-      '@changesets/logger': 0.1.0
+      '@changesets/git': 3.0.1
+      '@changesets/logger': 0.1.1
       '@changesets/parse': 0.4.0
       '@changesets/types': 6.0.0
-      chalk: 2.4.2
       fs-extra: 7.0.1
       p-filter: 2.1.0
+      picocolors: 1.1.0
 
-  '@changesets/should-skip-package@0.1.0':
+  '@changesets/should-skip-package@0.1.1':
     dependencies:
-      '@babel/runtime': 7.25.4
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
 
@@ -6989,9 +6970,8 @@ snapshots:
 
   '@changesets/types@6.0.0': {}
 
-  '@changesets/write@0.3.1':
+  '@changesets/write@0.3.2':
     dependencies:
-      '@babel/runtime': 7.25.4
       '@changesets/types': 6.0.0
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -7089,7 +7069,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -7379,7 +7359,7 @@ snapshots:
 
   '@fvictorio/tabtab@0.0.3':
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       enquirer: 2.4.1
       minimist: 1.2.8
       mkdirp: 1.0.4
@@ -7390,7 +7370,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7455,12 +7435,12 @@ snapshots:
       rxjs: 7.8.1
       semver: 7.6.3
 
-  '@ledgerhq/domain-service@1.2.3(debug@4.3.6)':
+  '@ledgerhq/domain-service@1.2.3(debug@4.3.7)':
     dependencies:
       '@ledgerhq/errors': 6.18.0
       '@ledgerhq/logs': 6.12.0
       '@ledgerhq/types-live': 6.50.0
-      axios: 1.7.5(debug@4.3.6)
+      axios: 1.7.7(debug@4.3.7)
       eip55: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7469,17 +7449,17 @@ snapshots:
 
   '@ledgerhq/errors@6.18.0': {}
 
-  '@ledgerhq/hw-app-eth@6.33.6(debug@4.3.6)':
+  '@ledgerhq/hw-app-eth@6.33.6(debug@4.3.7)':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/rlp': 5.7.0
       '@ledgerhq/cryptoassets': 9.13.0
-      '@ledgerhq/domain-service': 1.2.3(debug@4.3.6)
+      '@ledgerhq/domain-service': 1.2.3(debug@4.3.7)
       '@ledgerhq/errors': 6.18.0
       '@ledgerhq/hw-transport': 6.31.2
       '@ledgerhq/hw-transport-mocker': 6.29.2
       '@ledgerhq/logs': 6.12.0
-      axios: 1.7.5(debug@4.3.6)
+      axios: 1.7.7(debug@4.3.7)
       bignumber.js: 9.1.2
       crypto-js: 4.2.0
     transitivePeerDependencies:
@@ -7526,14 +7506,14 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.25.4
+      '@babel/runtime': 7.25.6
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.25.4
+      '@babel/runtime': 7.25.6
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -7565,6 +7545,8 @@ snapshots:
   '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
+
+  '@noble/hashes@1.5.0': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -7656,13 +7638,13 @@ snapshots:
       ethers: 6.13.2
       hardhat: link:packages/hardhat-core
 
-  '@nomicfoundation/hardhat-ignition-viem@0.15.5(@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@packages+hardhat-verify)(hardhat@packages+hardhat-core))(@nomicfoundation/hardhat-viem@packages+hardhat-viem)(@nomicfoundation/ignition-core@0.15.5)(hardhat@packages+hardhat-core)(viem@2.20.0(typescript@5.0.4)(zod@3.23.8))':
+  '@nomicfoundation/hardhat-ignition-viem@0.15.5(@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@packages+hardhat-verify)(hardhat@packages+hardhat-core))(@nomicfoundation/hardhat-viem@packages+hardhat-viem)(@nomicfoundation/ignition-core@0.15.5)(hardhat@packages+hardhat-core)(viem@2.21.4(typescript@5.0.4)(zod@3.23.8))':
     dependencies:
       '@nomicfoundation/hardhat-ignition': 0.15.5(@nomicfoundation/hardhat-verify@packages+hardhat-verify)(hardhat@packages+hardhat-core)
       '@nomicfoundation/hardhat-viem': link:packages/hardhat-viem
       '@nomicfoundation/ignition-core': 0.15.5
       hardhat: link:packages/hardhat-core
-      viem: 2.20.0(typescript@5.0.4)(zod@3.23.8)
+      viem: 2.21.4(typescript@5.0.4)(zod@3.23.8)
 
   '@nomicfoundation/hardhat-ignition@0.15.5(@nomicfoundation/hardhat-verify@packages+hardhat-verify)(hardhat@packages+hardhat-core)':
     dependencies:
@@ -7670,7 +7652,7 @@ snapshots:
       '@nomicfoundation/ignition-core': 0.15.5
       '@nomicfoundation/ignition-ui': 0.15.5
       chalk: 4.1.2
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       fs-extra: 10.1.0
       hardhat: link:packages/hardhat-core
       prompts: 2.4.2
@@ -7684,7 +7666,7 @@ snapshots:
       '@ethersproject/address': 5.6.1
       '@nomicfoundation/solidity-analyzer': 0.1.2
       cbor: 9.0.2
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ethers: 6.13.2
       fs-extra: 10.1.0
       immer: 10.0.2
@@ -7731,29 +7713,34 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@scure/base@1.1.7': {}
+  '@scure/base@1.1.8': {}
 
   '@scure/bip32@1.1.5':
     dependencies:
       '@noble/hashes': 1.2.0
       '@noble/secp256k1': 1.7.1
-      '@scure/base': 1.1.7
+      '@scure/base': 1.1.8
 
   '@scure/bip32@1.4.0':
     dependencies:
-      '@noble/curves': 1.4.2
+      '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.7
+      '@scure/base': 1.1.8
 
   '@scure/bip39@1.1.1':
     dependencies:
       '@noble/hashes': 1.2.0
-      '@scure/base': 1.1.7
+      '@scure/base': 1.1.8
 
   '@scure/bip39@1.3.0':
     dependencies:
       '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.7
+      '@scure/base': 1.1.8
+
+  '@scure/bip39@1.4.0':
+    dependencies:
+      '@noble/hashes': 1.5.0
+      '@scure/base': 1.1.8
 
   '@sentry/core@5.30.0':
     dependencies:
@@ -7862,13 +7849,13 @@ snapshots:
 
   '@types/bn.js@5.1.5':
     dependencies:
-      '@types/node': 18.19.46
+      '@types/node': 18.19.50
 
   '@types/chai-as-promised@7.1.8':
     dependencies:
-      '@types/chai': 4.3.18
+      '@types/chai': 4.3.19
 
-  '@types/chai@4.3.18': {}
+  '@types/chai@4.3.19': {}
 
   '@types/ci-info@2.0.0': {}
 
@@ -7890,12 +7877,12 @@ snapshots:
 
   '@types/fs-extra@5.1.0':
     dependencies:
-      '@types/node': 18.19.46
+      '@types/node': 18.19.50
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.19.46
+      '@types/node': 18.19.50
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -7905,7 +7892,7 @@ snapshots:
 
   '@types/keccak@3.0.4':
     dependencies:
-      '@types/node': 18.19.46
+      '@types/node': 18.19.50
 
   '@types/lodash.clonedeep@4.5.9':
     dependencies:
@@ -7935,11 +7922,15 @@ snapshots:
 
   '@types/node@18.15.13': {}
 
-  '@types/node@18.19.46':
+  '@types/node@18.19.50':
     dependencies:
       undici-types: 5.26.5
 
   '@types/node@20.16.1':
+    dependencies:
+      undici-types: 6.19.8
+
+  '@types/node@20.16.5':
     dependencies:
       undici-types: 6.19.8
 
@@ -7970,7 +7961,7 @@ snapshots:
 
   '@types/sinon-chai@3.2.12':
     dependencies:
-      '@types/chai': 4.3.18
+      '@types/chai': 4.3.19
       '@types/sinon': 9.0.11
 
   '@types/sinon@9.0.11':
@@ -7985,7 +7976,7 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 18.19.46
+      '@types/node': 18.19.50
 
   '@types/ws@8.5.3':
     dependencies:
@@ -7998,7 +7989,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.61.0
       '@typescript-eslint/type-utils': 5.61.0(eslint@8.57.0)(typescript@5.0.4)
       '@typescript-eslint/utils': 5.61.0(eslint@8.57.0)(typescript@5.0.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -8036,7 +8027,7 @@ snapshots:
       '@typescript-eslint/type-utils': 7.7.1(eslint@8.57.0)(typescript@5.5.4)
       '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 7.7.1
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -8053,7 +8044,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.61.0
       '@typescript-eslint/types': 5.61.0
       '@typescript-eslint/typescript-estree': 5.61.0(typescript@5.0.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.0.4
@@ -8066,7 +8057,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.5.4
@@ -8079,7 +8070,7 @@ snapshots:
       '@typescript-eslint/types': 7.7.1
       '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 7.7.1
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.5.4
@@ -8110,7 +8101,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.61.0(typescript@5.0.4)
       '@typescript-eslint/utils': 5.61.0(eslint@8.57.0)(typescript@5.0.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@5.0.4)
     optionalDependencies:
@@ -8122,7 +8113,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.4)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.5.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.5.4)
     optionalDependencies:
@@ -8134,7 +8125,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.7.1(typescript@5.5.4)
       '@typescript-eslint/utils': 7.7.1(eslint@8.57.0)(typescript@5.5.4)
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.5.4)
     optionalDependencies:
@@ -8154,7 +8145,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.61.0
       '@typescript-eslint/visitor-keys': 5.61.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -8168,7 +8159,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -8182,7 +8173,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8197,7 +8188,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.7.1
       '@typescript-eslint/visitor-keys': 7.7.1
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8312,7 +8303,7 @@ snapshots:
     dependencies:
       acorn: 8.12.1
 
-  acorn-walk@8.3.3:
+  acorn-walk@8.3.4:
     dependencies:
       acorn: 8.12.1
 
@@ -8328,7 +8319,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8368,7 +8359,7 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.0.1: {}
+  ansi-regex@6.1.0: {}
 
   ansi-styles@1.0.0: {}
 
@@ -8477,9 +8468,9 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  axios@1.7.5(debug@4.3.6):
+  axios@1.7.7(debug@4.3.7):
     dependencies:
-      follow-redirects: 1.15.6(debug@4.3.6)
+      follow-redirects: 1.15.9(debug@4.3.7)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -8562,8 +8553,8 @@ snapshots:
 
   browserslist@4.23.3:
     dependencies:
-      caniuse-lite: 1.0.30001653
-      electron-to-chromium: 1.5.13
+      caniuse-lite: 1.0.30001660
+      electron-to-chromium: 1.5.18
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
 
@@ -8629,7 +8620,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001653: {}
+  caniuse-lite@1.0.30001660: {}
 
   caseless@0.12.0: {}
 
@@ -8880,9 +8871,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.3.6(supports-color@8.1.1):
+  debug@4.3.7(supports-color@8.1.1):
     dependencies:
-      ms: 2.1.2
+      ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
 
@@ -8935,7 +8926,7 @@ snapshots:
   detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8971,7 +8962,7 @@ snapshots:
     dependencies:
       keccak: 3.0.4
 
-  electron-to-chromium@1.5.13: {}
+  electron-to-chromium@1.5.18: {}
 
   elliptic@6.5.4:
     dependencies:
@@ -9121,7 +9112,7 @@ snapshots:
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
 
-  escalade@3.1.2: {}
+  escalade@3.2.0: {}
 
   escape-string-regexp@1.0.5: {}
 
@@ -9179,13 +9170,13 @@ snapshots:
   eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
-      get-tsconfig: 4.7.6
-      is-bun-module: 1.1.0
+      get-tsconfig: 4.8.0
+      is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
@@ -9195,7 +9186,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.2(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9205,7 +9196,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9238,7 +9229,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.2(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       has: 1.0.4
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -9264,7 +9255,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -9294,7 +9285,7 @@ snapshots:
       builtins: 5.1.0
       eslint: 8.57.0
       eslint-plugin-es-x: 7.8.0(eslint@8.57.0)
-      get-tsconfig: 4.7.6
+      get-tsconfig: 4.8.0
       globals: 13.24.0
       ignore: 5.3.2
       is-builtin-module: 3.2.1
@@ -9345,7 +9336,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -9404,7 +9395,7 @@ snapshots:
   eth-gas-reporter@0.2.27:
     dependencies:
       '@solidity-parser/parser': 0.14.5
-      axios: 1.7.5(debug@4.3.6)
+      axios: 1.7.7(debug@4.3.7)
       cli-table3: 0.5.1
       colors: 1.4.0
       ethereum-cryptography: 1.2.0
@@ -9423,7 +9414,7 @@ snapshots:
 
   ethereum-bloom-filters@1.2.0:
     dependencies:
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.5.0
 
   ethereum-cryptography@0.1.3:
     dependencies:
@@ -9618,11 +9609,6 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  find-yarn-workspace-root2@1.2.16:
-    dependencies:
-      micromatch: 4.0.8
-      pkg-dir: 4.2.0
-
   flat-cache@3.2.0:
     dependencies:
       flatted: 3.3.1
@@ -9633,9 +9619,9 @@ snapshots:
 
   flatted@3.3.1: {}
 
-  follow-redirects@1.15.6(debug@4.3.6):
+  follow-redirects@1.15.9(debug@4.3.7):
     optionalDependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
 
   for-each@0.3.3:
     dependencies:
@@ -9746,7 +9732,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
 
-  get-tsconfig@4.7.6:
+  get-tsconfig@4.8.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -9864,7 +9850,7 @@ snapshots:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.19.2
+      uglify-js: 3.19.3
 
   hardhat-gas-reporter@1.0.10(hardhat@packages+hardhat-core):
     dependencies:
@@ -9956,7 +9942,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10037,7 +10023,7 @@ snapshots:
     dependencies:
       builtin-modules: 3.3.0
 
-  is-bun-module@1.1.0:
+  is-bun-module@1.2.1:
     dependencies:
       semver: 7.6.3
 
@@ -10170,7 +10156,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -10250,7 +10236,7 @@ snapshots:
   keccak@3.0.4:
     dependencies:
       node-addon-api: 2.0.2
-      node-gyp-build: 4.8.1
+      node-gyp-build: 4.8.2
       readable-stream: 3.6.2
 
   keyv@4.5.4:
@@ -10276,13 +10262,6 @@ snapshots:
       type-check: 0.4.0
 
   lines-and-columns@1.2.4: {}
-
-  load-yaml-file@0.2.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      js-yaml: 3.14.1
-      pify: 4.0.1
-      strip-bom: 3.0.0
 
   locate-path@2.0.0:
     dependencies:
@@ -10425,7 +10404,7 @@ snapshots:
       ansi-colors: 4.1.3
       browser-stdout: 1.3.1
       chokidar: 3.6.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       diff: 5.2.0
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
@@ -10444,8 +10423,6 @@ snapshots:
       yargs-unparser: 2.0.0
 
   mri@1.2.0: {}
-
-  ms@2.1.2: {}
 
   ms@2.1.3: {}
 
@@ -10496,7 +10473,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-gyp-build@4.8.1: {}
+  node-gyp-build@4.8.2: {}
 
   node-hid@2.1.2:
     dependencies:
@@ -10684,6 +10661,8 @@ snapshots:
 
   package-json-from-dist@1.0.0: {}
 
+  package-manager-detector@0.2.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -10730,7 +10709,7 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  picocolors@1.0.1: {}
+  picocolors@1.1.0: {}
 
   picomatch@2.3.1: {}
 
@@ -10756,13 +10735,6 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
-
-  preferred-pm@3.1.4:
-    dependencies:
-      find-up: 5.0.0
-      find-yarn-workspace-root2: 1.2.16
-      path-exists: 4.0.0
-      which-pm: 2.2.0
 
   prelude-ls@1.1.2: {}
 
@@ -11022,7 +10994,7 @@ snapshots:
     dependencies:
       elliptic: 6.5.7
       node-addon-api: 2.0.2
-      node-gyp-build: 4.8.1
+      node-gyp-build: 4.8.2
 
   semver@5.7.2: {}
 
@@ -11127,11 +11099,11 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
-  solc@0.7.3(debug@4.3.6):
+  solc@0.7.3(debug@4.3.7):
     dependencies:
       command-exists: 1.2.9
       commander: 3.0.2
-      follow-redirects: 1.15.6(debug@4.3.6)
+      follow-redirects: 1.15.9(debug@4.3.7)
       fs-extra: 0.30.0
       js-sha3: 0.8.0
       memorystream: 0.3.1
@@ -11141,11 +11113,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  solc@0.8.26(debug@4.3.6):
+  solc@0.8.26(debug@4.3.7):
     dependencies:
       command-exists: 1.2.9
       commander: 8.3.0
-      follow-redirects: 1.15.6(debug@4.3.6)
+      follow-redirects: 1.15.9(debug@4.3.7)
       js-sha3: 0.8.0
       memorystream: 0.3.1
       semver: 5.7.2
@@ -11153,7 +11125,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  solidity-coverage@0.8.12(hardhat@packages+hardhat-core):
+  solidity-coverage@0.8.13(hardhat@packages+hardhat-core):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@solidity-parser/parser': 0.18.0
@@ -11272,7 +11244,7 @@ snapshots:
 
   strip-ansi@7.1.0:
     dependencies:
-      ansi-regex: 6.0.1
+      ansi-regex: 6.1.0
 
   strip-bom@3.0.0: {}
 
@@ -11410,16 +11382,16 @@ snapshots:
     dependencies:
       typescript: 5.0.4
 
-  ts-node@10.9.2(@types/node@18.19.46)(typescript@5.0.4):
+  ts-node@10.9.2(@types/node@18.19.50)(typescript@5.0.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.46
+      '@types/node': 18.19.50
       acorn: 8.12.1
-      acorn-walk: 8.3.3
+      acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
@@ -11456,7 +11428,14 @@ snapshots:
   tsx@4.18.0:
     dependencies:
       esbuild: 0.23.1
-      get-tsconfig: 4.7.6
+      get-tsconfig: 4.8.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tsx@4.19.0:
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.8.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -11497,7 +11476,7 @@ snapshots:
   typechain@8.3.2(typescript@5.0.4):
     dependencies:
       '@types/prettier': 2.7.3
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       fs-extra: 7.0.1
       glob: 7.1.7
       js-sha3: 0.8.0
@@ -11567,7 +11546,7 @@ snapshots:
 
   typical@5.2.0: {}
 
-  uglify-js@3.19.2:
+  uglify-js@3.19.3:
     optional: true
 
   unbox-primitive@1.0.2:
@@ -11598,8 +11577,8 @@ snapshots:
   update-browserslist-db@1.1.0(browserslist@4.23.3):
     dependencies:
       browserslist: 4.23.3
-      escalade: 3.1.2
-      picocolors: 1.0.1
+      escalade: 3.2.0
+      picocolors: 1.1.0
 
   uri-js@4.4.1:
     dependencies:
@@ -11609,7 +11588,7 @@ snapshots:
     dependencies:
       '@types/w3c-web-usb': 1.0.10
       node-addon-api: 6.1.0
-      node-gyp-build: 4.8.1
+      node-gyp-build: 4.8.2
 
   utf8@3.0.0: {}
 
@@ -11633,37 +11612,37 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  viem@2.18.8(typescript@5.5.4)(zod@3.23.8):
+  viem@2.21.4(typescript@5.0.4)(zod@3.23.8):
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
-      '@scure/bip39': 1.3.0
-      abitype: 1.0.5(typescript@5.5.4)(zod@3.23.8)
-      isows: 1.0.4(ws@8.17.1)
-      webauthn-p256: 0.0.5
-      ws: 8.17.1
-    optionalDependencies:
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.20.0(typescript@5.0.4)(zod@3.23.8):
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@scure/bip32': 1.4.0
-      '@scure/bip39': 1.3.0
+      '@scure/bip39': 1.4.0
       abitype: 1.0.5(typescript@5.0.4)(zod@3.23.8)
       isows: 1.0.4(ws@8.17.1)
       webauthn-p256: 0.0.5
       ws: 8.17.1
     optionalDependencies:
       typescript: 5.0.4
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.21.4(typescript@5.5.4)(zod@3.23.8):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.0
+      '@noble/curves': 1.4.0
+      '@noble/hashes': 1.4.0
+      '@scure/bip32': 1.4.0
+      '@scure/bip39': 1.4.0
+      abitype: 1.0.5(typescript@5.5.4)(zod@3.23.8)
+      isows: 1.0.4(ws@8.17.1)
+      webauthn-p256: 0.0.5
+      ws: 8.17.1
+    optionalDependencies:
+      typescript: 5.5.4
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11911,7 +11890,7 @@ snapshots:
 
   webauthn-p256@0.0.5:
     dependencies:
-      '@noble/curves': 1.4.2
+      '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
 
   webidl-conversions@3.0.1: {}
@@ -11930,11 +11909,6 @@ snapshots:
       is-symbol: 1.0.4
 
   which-module@2.0.1: {}
-
-  which-pm@2.2.0:
-    dependencies:
-      load-yaml-file: 0.2.0
-      path-exists: 4.0.0
 
   which-typed-array@1.1.15:
     dependencies:
@@ -12043,7 +12017,7 @@ snapshots:
   yargs@16.2.0:
     dependencies:
       cliui: 7.0.4
-      escalade: 3.1.2
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -12053,7 +12027,7 @@ snapshots:
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.2
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3

--- a/v-next/example-project/.gitignore
+++ b/v-next/example-project/.gitignore
@@ -6,3 +6,9 @@
 
 # pnpm deploy output
 /bundle
+
+# Hardhat Build Artifacts
+/artifacts
+
+# Hardhat compilation (v2) support directory
+/cache

--- a/v-next/example-project/contracts/Counter.sol
+++ b/v-next/example-project/contracts/Counter.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Counter {
+  uint public x;
+
+  function inc() public {
+    x++;
+  }
+}

--- a/v-next/example-project/contracts/Counter.t.sol
+++ b/v-next/example-project/contracts/Counter.t.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./Counter.sol";
+
+contract CounterTest {
+  Counter counter;
+
+  function setUp() public {
+    counter = new Counter();
+  }
+
+  function testInitialValue() public view {
+    require(counter.x() == 0, "Initial value should be 0");
+  }
+
+  function testInc() public {
+    counter.inc();
+    require(counter.x() == 1, "Value after inc should be 1");
+  }
+}

--- a/v-next/example-project/contracts/Rocket.sol
+++ b/v-next/example-project/contracts/Rocket.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract Rocket {
+    string public name;
+    string public status;
+
+    constructor(string memory _name) {
+        name = _name;
+        status = "ignition";
+    }
+
+    function launch() public {
+        status = "lift-off";
+    }
+}

--- a/v-next/hardhat-build-system/package.json
+++ b/v-next/hardhat-build-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ignored/hardhat-vnext-build-system",
   "private": true,
-  "version": "2.0.1-next.0",
+  "version": "3.0.0-next.2",
   "description": "Build and Solidity compilation system for Hardhat",
   "homepage": "https://github.com/nomicfoundation/hardhat/tree/main/v-next/hardhat-build-system",
   "repository": {
@@ -13,6 +13,9 @@
   "license": "MIT",
   "type": "module",
   "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": "./dist/src/index.js"
+  },
   "keywords": [
     "ethereum",
     "smart-contracts",
@@ -38,8 +41,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@ignored/hardhat-vnext-errors": "workspace:^3.0.0-next.0",
-    "@ignored/hardhat-vnext-utils": "workspace:^3.0.0-next.0",
+    "@ignored/hardhat-vnext-errors": "workspace:^3.0.0-next.2",
+    "@ignored/hardhat-vnext-utils": "workspace:^3.0.0-next.2",
     "@nomicfoundation/ethereumjs-util": "9.0.4",
     "@nomicfoundation/solidity-analyzer": "^0.1.0",
     "adm-zip": "^0.4.16",
@@ -60,8 +63,7 @@
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
-    "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.0",
-    "@nomicfoundation/hardhat-test-utils": "workspace:^",
+    "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.2",
     "@types/ci-info": "^2.0.0",
     "@types/debug": "^4.1.4",
     "@types/find-up": "^2.1.1",

--- a/v-next/hardhat-build-system/src/internal/solidity/compiler/compiler-input.ts
+++ b/v-next/hardhat-build-system/src/internal/solidity/compiler/compiler-input.ts
@@ -1,5 +1,18 @@
 import type { CompilationJob, CompilerInput } from "../../types/index.js";
 
+const defaultSolcOutputSelection = {
+  "*": {
+    "*": [
+      "abi",
+      "evm.bytecode",
+      "evm.deployedBytecode",
+      "evm.methodIdentifiers",
+      "metadata",
+    ],
+    "": ["ast"],
+  },
+} as const;
+
 export function getInputFromCompilationJob(
   compilationJob: CompilationJob,
 ): CompilerInput {
@@ -18,9 +31,50 @@ export function getInputFromCompilationJob(
 
   const { settings } = compilationJob.getSolcConfig();
 
-  return {
+  const result = {
     language: "Solidity",
     sources,
-    settings,
+    settings: settings ?? {},
   };
+
+  // This code is pulled in from `resolveCompiler` in
+  // `packages/hardhat-core/src/internal/core/config/config-resolution.ts`
+  //
+  // In v2 the config loading sets the default values that will be passed
+  // to the compiler. I am pulling it to here for the moment to keep
+  // the build system encapsulated.
+  result.settings.optimizer = {
+    enabled: false,
+    runs: 200,
+    ...result.settings.optimizer,
+  };
+
+  if (result.settings.outputSelection === undefined) {
+    result.settings.outputSelection = {};
+  }
+
+  for (const [file, contractSelection] of Object.entries(
+    defaultSolcOutputSelection,
+  )) {
+    if (result.settings.outputSelection[file] === undefined) {
+      result.settings.outputSelection[file] = {};
+    }
+
+    for (const [contract, outputs] of Object.entries(contractSelection)) {
+      if (result.settings.outputSelection[file][contract] === undefined) {
+        result.settings.outputSelection[file][contract] = [];
+      }
+
+      for (const output of outputs) {
+        const includesOutput: boolean =
+          result.settings.outputSelection[file][contract].includes(output);
+
+        if (!includesOutput) {
+          result.settings.outputSelection[file][contract].push(output);
+        }
+      }
+    }
+  }
+
+  return result;
 }

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -73,6 +73,11 @@ export const ERROR_CATEGORIES: {
     max: 999,
     websiteTitle: "Network-helpers errors",
   },
+  SOLIDITY_TESTS: {
+    min: 1000,
+    max: 1099,
+    websiteTitle: "Solidity tests errors",
+  },
 };
 
 export const ERRORS = {
@@ -683,6 +688,14 @@ Learn more at (https://hardhat.org/hardhat-network-helpers/docs/reference#fixtur
 This might be caused by using hardhat_reset and loadFixture calls in a testcase.`,
       websiteTitle: "Error while reverting snapshot",
       websiteDescription: "Error while reverting snapshot",
+    },
+  },
+  SOLIDITY_TESTS: {
+    BUILD_INFO_NOT_FOUND_FOR_CONTRACT: {
+      number: 1000,
+      messageTemplate: `Build info not found for contract {fqn}`,
+      websiteTitle: `Build info not found for contract`,
+      websiteDescription: `Build info not found for contract while compiling Solidity test contracts.`,
     },
   },
 } as const;

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -77,6 +77,7 @@
     "typescript-eslint": "7.7.1"
   },
   "dependencies": {
+    "@ignored/edr": "0.6.2-alpha.0",
     "@ignored/hardhat-vnext-build-system": "workspace:^3.0.0-next.2",
     "@ignored/hardhat-vnext-errors": "workspace:^3.0.0-next.2",
     "@ignored/hardhat-vnext-utils": "workspace:^3.0.0-next.2",

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -77,6 +77,7 @@
     "typescript-eslint": "7.7.1"
   },
   "dependencies": {
+    "@ignored/hardhat-vnext-build-system": "workspace:^3.0.0-next.2",
     "@ignored/hardhat-vnext-errors": "workspace:^3.0.0-next.2",
     "@ignored/hardhat-vnext-utils": "workspace:^3.0.0-next.2",
     "@ignored/hardhat-vnext-zod-utils": "workspace:^3.0.0-next.2",

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifacts-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifacts-manager.ts
@@ -21,6 +21,16 @@ import {
 
 export const BUILD_INFO_DIR_NAME = "build-info";
 
+/**
+ * This class is a temporary shim implementation of the ArtifactsManager.
+ * It has pulled across Hardhat v2 code to ease some development tasks.
+ * It will be replaced in its entirety by the new ArtifactsManager with
+ * the completion of the new build system.
+ *
+ * Code within it should be kept as self-contained as possible.
+ *
+ * TODO: Replace this class with the new ArtifactsManager in Hardhat v3.
+ */
 export class ArtifactsManagerImplementation implements ArtifactsManager {
   readonly #artifactsPath: string;
 
@@ -45,11 +55,6 @@ export class ArtifactsManagerImplementation implements ArtifactsManager {
    * If the name is fully qualified, the path is computed from it.  If not, an
    * artifact that matches the given name is searched in the existing artifacts.
    * If there is an ambiguity, an error is thrown.
-   *
-   * @throws {HardhatError} with descriptor:
-   * - {@link ERRORS.ARTIFACTS.WRONG_CASING} if the path case doesn't match the one in the filesystem.
-   * - {@link ERRORS.ARTIFACTS.MULTIPLE_FOUND} if there are multiple artifacts matching the given contract name.
-   * - {@link ERRORS.ARTIFACTS.NOT_FOUND} if the artifact is not found.
    */
   async #getArtifactPath(name: string): Promise<string> {
     let result: string;

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifacts-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifacts-manager.ts
@@ -6,15 +6,176 @@ import type {
   CompilerOutput,
 } from "../../../types/artifacts.js";
 
-import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import path from "node:path";
+
+import {
+  assertHardhatInvariant,
+  HardhatError,
+} from "@ignored/hardhat-vnext-errors";
+import {
+  exists,
+  getAllFilesMatching,
+  getFileTrueCase,
+  readJsonFile,
+} from "@ignored/hardhat-vnext-utils/fs";
+
+export const BUILD_INFO_DIR_NAME = "build-info";
 
 export class ArtifactsManagerImplementation implements ArtifactsManager {
-  public readArtifact(
-    _contractNameOrFullyQualifiedName: string,
+  readonly #artifactsPath: string;
+
+  constructor(artifactsPath: string) {
+    this.#artifactsPath = artifactsPath;
+  }
+
+  public async readArtifact(
+    contractNameOrFullyQualifiedName: string,
   ): Promise<Artifact> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in fake artifacts manager",
+    const artifactPath = await this.#getArtifactPath(
+      contractNameOrFullyQualifiedName,
+    );
+
+    return readJsonFile(artifactPath);
+  }
+
+  /**
+   * Returns the absolute path to the artifact that corresponds to the given
+   * name.
+   *
+   * If the name is fully qualified, the path is computed from it.  If not, an
+   * artifact that matches the given name is searched in the existing artifacts.
+   * If there is an ambiguity, an error is thrown.
+   *
+   * @throws {HardhatError} with descriptor:
+   * - {@link ERRORS.ARTIFACTS.WRONG_CASING} if the path case doesn't match the one in the filesystem.
+   * - {@link ERRORS.ARTIFACTS.MULTIPLE_FOUND} if there are multiple artifacts matching the given contract name.
+   * - {@link ERRORS.ARTIFACTS.NOT_FOUND} if the artifact is not found.
+   */
+  async #getArtifactPath(name: string): Promise<string> {
+    let result: string;
+    if (this.#isFullyQualifiedName(name)) {
+      result = await this.#getValidArtifactPathFromFullyQualifiedName(name);
+    } else {
+      const files = await this.getArtifactPaths();
+      result = this.#getArtifactPathFromFiles(name, files);
+    }
+
+    return result;
+  }
+
+  #getArtifactPathFromFiles(contractName: string, files: string[]): string {
+    const matchingFiles = files.filter((file) => {
+      return path.basename(file) === `${contractName}.json`;
     });
+
+    if (matchingFiles.length === 0) {
+      throw new HardhatError(HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR, {
+        message: `No artifacts found for contract name "${contractName}"`,
+      });
+    }
+
+    if (matchingFiles.length > 1) {
+      const candidates = matchingFiles.map((file) =>
+        this.#getFullyQualifiedNameFromPath(file),
+      );
+
+      throw new HardhatError(HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR, {
+        message: `Multiple artifacts found for contract name "${contractName}": ${candidates.join(",")}`,
+      });
+    }
+
+    return matchingFiles[0];
+  }
+
+  /**
+   * Returns true if a name is fully qualified, and not just a bare contract name.
+   */
+  #isFullyQualifiedName(name: string): boolean {
+    return name.includes(":");
+  }
+
+  /**
+   * Returns the absolute path to the artifact that corresponds to the given
+   * fully qualified name.
+   * @param fullyQualifiedName The fully qualified name of the contract.
+   * @returns The absolute path to the artifact.
+   * @throws {HardhatError} with descriptor:
+   * - {@link ERRORS.CONTRACT_NAMES.INVALID_FULLY_QUALIFIED_NAME} If the name is not fully qualified.
+   * - {@link ERRORS.ARTIFACTS.WRONG_CASING} If the path case doesn't match the one in the filesystem.
+   * - {@link ERRORS.ARTIFACTS.NOT_FOUND} If the artifact is not found.
+   */
+  async #getValidArtifactPathFromFullyQualifiedName(
+    fullyQualifiedName: string,
+  ): Promise<string> {
+    const artifactPath =
+      this.#formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
+
+    const trueCasePath = path.join(
+      this.#artifactsPath,
+      await getFileTrueCase(
+        this.#artifactsPath,
+        path.relative(this.#artifactsPath, artifactPath),
+      ),
+    );
+
+    if (artifactPath !== trueCasePath) {
+      throw new HardhatError(HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR, {
+        message: "Artifact path and true case path should be the same",
+      });
+    }
+
+    return trueCasePath;
+  }
+
+  /**
+   * Returns the absolute path to the given artifact
+   * @throws {HardhatError} If the name is not fully qualified.
+   */
+  #formArtifactPathFromFullyQualifiedName(fullyQualifiedName: string): string {
+    const { sourceName, contractName } =
+      this.#parseFullyQualifiedName(fullyQualifiedName);
+
+    return path.join(this.#artifactsPath, sourceName, `${contractName}.json`);
+  }
+
+  /**
+   * Parses a fully qualified name.
+   *
+   * @param fullyQualifiedName It MUST be a fully qualified name.
+   * @throws {HardhatError} If the name is not fully qualified.
+   */
+  #parseFullyQualifiedName(fullyQualifiedName: string): {
+    sourceName: string;
+    contractName: string;
+  } {
+    const { sourceName, contractName } = this.#parseName(fullyQualifiedName);
+
+    if (sourceName === undefined) {
+      throw new HardhatError(HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR, {
+        message: `Failed to parse source name for ${fullyQualifiedName}`,
+      });
+    }
+
+    return { sourceName, contractName };
+  }
+
+  /**
+   * Parses a name, which can be a bare contract name, or a fully qualified name.
+   */
+  #parseName(name: string): {
+    sourceName?: string;
+    contractName: string;
+  } {
+    const parts = name.split(":");
+
+    if (parts.length === 1) {
+      return { contractName: parts[0] };
+    }
+
+    const contractName = parts[parts.length - 1];
+    const sourceName = parts.slice(0, parts.length - 1).join(":");
+
+    return { sourceName, contractName };
   }
 
   public artifactExists(
@@ -25,24 +186,115 @@ export class ArtifactsManagerImplementation implements ArtifactsManager {
     });
   }
 
-  public getAllFullyQualifiedNames(): Promise<string[]> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in fake artifacts manager",
-    });
+  public async getAllFullyQualifiedNames(): Promise<string[]> {
+    const paths = await this.getArtifactPaths();
+    return paths.map((p) => this.#getFullyQualifiedNameFromPath(p)).sort();
   }
 
-  public getBuildInfo(
-    _fullyQualifiedName: string,
+  /**
+   * Returns the FQN of a contract giving the absolute path to its artifact.
+   *
+   * For example, given a path like
+   * `/path/to/project/artifacts/contracts/Foo.sol/Bar.json`, it'll return the
+   * FQN `contracts/Foo.sol:Bar`
+   */
+  #getFullyQualifiedNameFromPath(absolutePath: string): string {
+    const sourceName = this.#replaceBackslashes(
+      path.relative(this.#artifactsPath, path.dirname(absolutePath)),
+    );
+
+    const contractName = path.basename(absolutePath).replace(".json", "");
+
+    return this.#getFullyQualifiedName(sourceName, contractName);
+  }
+
+  /**
+   * Returns a fully qualified name from a sourceName and contractName.
+   */
+  #getFullyQualifiedName(sourceName: string, contractName: string): string {
+    return `${sourceName}:${contractName}`;
+  }
+
+  /**
+   * This function replaces backslashes (\\) with slashes (/).
+   *
+   * Note that a source name must not contain backslashes.
+   */
+  #replaceBackslashes(str: string): string {
+    // Based in the npm module slash
+    const isExtendedLengthPath = /^\\\\\?\\/.test(str);
+    const hasNonAscii = /[^\u0000-\u0080]+/.test(str);
+
+    if (isExtendedLengthPath || hasNonAscii) {
+      return str;
+    }
+
+    return str.replace(/\\/g, "/");
+  }
+
+  public async getBuildInfo(
+    fullyQualifiedName: string,
   ): Promise<BuildInfo | undefined> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in fake artifacts manager",
-    });
+    const artifactPath =
+      this.#formArtifactPathFromFullyQualifiedName(fullyQualifiedName);
+
+    const debugFilePath = this.#getDebugFilePath(artifactPath);
+    const buildInfoPath = await this.#getBuildInfoFromDebugFile(debugFilePath);
+
+    if (buildInfoPath === undefined) {
+      return undefined;
+    }
+
+    return readJsonFile(buildInfoPath);
   }
 
-  public getArtifactPaths(): Promise<string[]> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in fake artifacts manager",
-    });
+  #getDebugFilePath(artifactPath: string): string {
+    return artifactPath.replace(/\.json$/, ".dbg.json");
+  }
+
+  /**
+   * Given the path to a debug file, returns the absolute path to its
+   * corresponding build info file if it exists, or undefined otherwise.
+   */
+  async #getBuildInfoFromDebugFile(
+    debugFilePath: string,
+  ): Promise<string | undefined> {
+    if (await exists(debugFilePath)) {
+      const debugFile = await readJsonFile(debugFilePath);
+
+      assertHardhatInvariant(
+        typeof debugFile === "object" &&
+          debugFile !== null &&
+          "buildInfo" in debugFile &&
+          typeof debugFile.buildInfo === "string",
+        "Invalid debug file",
+      );
+
+      const buildInfo = debugFile.buildInfo;
+
+      return path.resolve(path.dirname(debugFilePath), buildInfo);
+    }
+
+    return undefined;
+  }
+
+  public async getArtifactPaths(): Promise<string[]> {
+    const paths = await getAllFilesMatching(this.#artifactsPath, (f) =>
+      this.#isArtifactPath(f),
+    );
+
+    const result = paths.sort();
+
+    return result;
+  }
+
+  #isArtifactPath(file: string) {
+    return (
+      file.endsWith(".json") &&
+      file !== path.join(this.#artifactsPath, "package.json") &&
+      !file.startsWith(path.join(this.#artifactsPath, BUILD_INFO_DIR_NAME)) &&
+      !file.endsWith(".dbg.json")
+    );
   }
 
   public getBuildInfoPaths(): Promise<string[]> {

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -7,7 +7,9 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => {
         "../artifacts-manager.js"
       );
 
-      hre.artifacts = new ArtifactsManagerImplementation();
+      hre.artifacts = new ArtifactsManagerImplementation(
+        hre.config.paths.artifacts,
+      );
     },
   };
 

--- a/v-next/hardhat/src/internal/builtin-plugins/compile/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/compile/index.ts
@@ -1,0 +1,18 @@
+import type { HardhatPlugin } from "../../../types/plugins.js";
+
+import { task } from "../../core/config.js";
+
+const hardhatPlugin: HardhatPlugin = {
+  id: "compile",
+  tasks: [
+    task("compile", "Compiles the entire project, building all artifacts")
+      .addFlag({
+        name: "quiet",
+        description: "Makes the compilation process less verbose",
+      })
+      .setAction(import.meta.resolve("./task-action.js"))
+      .build(),
+  ],
+};
+
+export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/builtin-plugins/compile/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/compile/task-action.ts
@@ -43,6 +43,9 @@ async function _resolveCompilationConfigFrom(hre: HardhatRuntimeEnvironment) {
     solidity: {
       compilers: [
         {
+          // WARNING: The version of the compiler has been hardcoded here,
+          // attempts to test with different versions will not work,
+          // and will have to await the new build system.
           version: "0.8.25",
           settings: {
             optimizer: {

--- a/v-next/hardhat/src/internal/builtin-plugins/compile/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/compile/task-action.ts
@@ -1,0 +1,62 @@
+import type { HardhatRuntimeEnvironment } from "../../../types/hre.js";
+import type { NewTaskActionFunction } from "../../../types/tasks.js";
+
+import path from "node:path";
+
+import { BuildSystem } from "@ignored/hardhat-vnext-build-system";
+import { getCacheDir } from "@ignored/hardhat-vnext-utils/global-dir";
+
+interface CompileActionArguments {
+  quiet: boolean;
+}
+
+const compileWithHardhat: NewTaskActionFunction<
+  CompileActionArguments
+> = async ({ quiet }, hre) => {
+  const config = await _resolveCompilationConfigFrom(hre);
+
+  const buildSystem = new BuildSystem(config);
+
+  await buildSystem.build({
+    quiet,
+  });
+};
+
+async function _resolveCompilationConfigFrom(hre: HardhatRuntimeEnvironment) {
+  const root = hre.config.paths.root;
+  const cache: string =
+    hre.config.paths.cache !== ""
+      ? hre.config.paths.cache
+      : // TODO(#5599): Replace with hre.config.paths.cache once it is available
+        await getCacheDir();
+
+  const artifacts = path.join(root, "artifacts");
+  const sources = path.join(root, "contracts");
+
+  const compilationConfig = {
+    paths: {
+      root,
+      cache,
+      artifacts,
+      sources,
+    },
+    solidity: {
+      compilers: [
+        {
+          version: "0.8.25",
+          settings: {
+            optimizer: {
+              enabled: true,
+              runs: 200,
+            },
+          },
+        },
+      ],
+      overrides: {},
+    },
+  };
+
+  return compilationConfig;
+}
+
+export default compileWithHardhat;

--- a/v-next/hardhat/src/internal/builtin-plugins/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/index.ts
@@ -7,11 +7,13 @@ import console from "./console/index.js";
 import networkManager from "./network-manager/index.js";
 import run from "./run/index.js";
 import solidity from "./solidity/index.js";
+import solidityTest from "./solidity-test/index.js";
 
 // Note: When importing a plugin, you have to export its types, so that its
 // type extensions, if any, also get loaded.
 export type * from "./artifacts/index.js";
 export type * from "./solidity/index.js";
+export type * from "./solidity-test/index.js";
 export type * from "./network-manager/index.js";
 export type * from "./clean/index.js";
 export type * from "./compile/index.js";
@@ -21,6 +23,7 @@ export type * from "./run/index.js";
 export const builtinPlugins: HardhatPlugin[] = [
   artifacts,
   solidity,
+  solidityTest,
   networkManager,
   clean,
   compile,

--- a/v-next/hardhat/src/internal/builtin-plugins/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/index.ts
@@ -2,6 +2,7 @@ import type { HardhatPlugin } from "../../types/plugins.js";
 
 import artifacts from "./artifacts/index.js";
 import clean from "./clean/index.js";
+import compile from "./compile/index.js";
 import console from "./console/index.js";
 import networkManager from "./network-manager/index.js";
 import run from "./run/index.js";
@@ -13,6 +14,7 @@ export type * from "./artifacts/index.js";
 export type * from "./solidity/index.js";
 export type * from "./network-manager/index.js";
 export type * from "./clean/index.js";
+export type * from "./compile/index.js";
 export type * from "./console/index.js";
 export type * from "./run/index.js";
 
@@ -21,6 +23,7 @@ export const builtinPlugins: HardhatPlugin[] = [
   solidity,
   networkManager,
   clean,
+  compile,
   console,
   run,
 ];

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -12,6 +12,12 @@ import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
 /**
  * Run all the given solidity tests and returns the whole results after finishing.
+ *
+ * This function is a direct port of the example v2 integration in the
+ * EDR repo (see  https://github.com/NomicFoundation/edr/blob/feat/solidity-tests/js/helpers/src/index.ts).
+ * The signature of the function should be considered a draft and may change in the future.
+ *
+ * TODO: Reconsider the signature and feedback to EDR team.
  */
 export async function runAllSolidityTests(
   artifacts: Artifact[],

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -1,0 +1,88 @@
+import type { ArtifactsManager } from "../../../types/artifacts.js";
+import type {
+  ArtifactId,
+  SuiteResult,
+  Artifact,
+  SolidityTestRunnerConfigArgs,
+  TestResult,
+} from "@ignored/edr";
+
+import { runSolidityTests } from "@ignored/edr";
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
+
+/**
+ * Run all the given solidity tests and returns the whole results after finishing.
+ */
+export async function runAllSolidityTests(
+  artifacts: Artifact[],
+  testSuites: ArtifactId[],
+  configArgs: SolidityTestRunnerConfigArgs,
+  testResultCallback: (
+    suiteResult: SuiteResult,
+    testResult: TestResult,
+  ) => void = () => {},
+): Promise<SuiteResult[]> {
+  return new Promise((resolve, reject) => {
+    const resultsFromCallback: SuiteResult[] = [];
+
+    runSolidityTests(
+      artifacts,
+      testSuites,
+      configArgs,
+      (suiteResult: SuiteResult) => {
+        for (const testResult of suiteResult.testResults) {
+          testResultCallback(suiteResult, testResult);
+        }
+
+        resultsFromCallback.push(suiteResult);
+        if (resultsFromCallback.length === testSuites.length) {
+          resolve(resultsFromCallback);
+        }
+      },
+      reject,
+    );
+  });
+}
+
+export async function buildSolidityTestsInput(
+  hardhatArtifacts: ArtifactsManager,
+  isTestArtifact: (artifact: Artifact) => boolean = () => true,
+): Promise<{ artifacts: Artifact[]; testSuiteIds: ArtifactId[] }> {
+  const fqns = await hardhatArtifacts.getAllFullyQualifiedNames();
+  const artifacts: Artifact[] = [];
+  const testSuiteIds: ArtifactId[] = [];
+
+  for (const fqn of fqns) {
+    const hardhatArtifact = await hardhatArtifacts.readArtifact(fqn);
+    const buildInfo = await hardhatArtifacts.getBuildInfo(fqn);
+
+    if (buildInfo === undefined) {
+      throw new HardhatError(
+        HardhatError.ERRORS.SOLIDITY_TESTS.BUILD_INFO_NOT_FOUND_FOR_CONTRACT,
+        {
+          fqn,
+        },
+      );
+    }
+
+    const id = {
+      name: hardhatArtifact.contractName,
+      solcVersion: buildInfo.solcVersion,
+      source: hardhatArtifact.sourceName,
+    };
+
+    const contract = {
+      abi: JSON.stringify(hardhatArtifact.abi),
+      bytecode: hardhatArtifact.bytecode,
+      deployedBytecode: hardhatArtifact.deployedBytecode,
+    };
+
+    const artifact = { id, contract };
+    artifacts.push(artifact);
+    if (isTestArtifact(artifact)) {
+      testSuiteIds.push(artifact.id);
+    }
+  }
+
+  return { artifacts, testSuiteIds };
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -1,0 +1,14 @@
+import type { HardhatPlugin } from "../../../types/plugins.js";
+
+import { task } from "../../core/config.js";
+
+const hardhatPlugin: HardhatPlugin = {
+  id: "builtin:solidity-test",
+  tasks: [
+    task(["test:solidity"], "Run the Solidity tests")
+      .setAction(import.meta.resolve("./task-action.js"))
+      .build(),
+  ],
+};
+
+export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -1,0 +1,71 @@
+import type { NewTaskActionFunction } from "../../../types/tasks.js";
+
+import { spec } from "node:test/reporters";
+
+import { buildSolidityTestsInput, runAllSolidityTests } from "./helpers.js";
+
+const runSolidityTests: NewTaskActionFunction = async (_arguments, hre) => {
+  await hre.tasks.getTask("compile").run({ quiet: false });
+
+  console.log("\nRunning Solidity tests...\n");
+
+  const specReporter = new spec();
+
+  specReporter.pipe(process.stdout);
+
+  let totalTests = 0;
+  let failedTests = 0;
+
+  const { artifacts, testSuiteIds } = await buildSolidityTestsInput(
+    hre.artifacts,
+    (artifact) => {
+      const sourceName = artifact.id.source;
+      const isTestArtifact =
+        sourceName.endsWith(".t.sol") &&
+        sourceName.startsWith("contracts/") &&
+        !sourceName.startsWith("contracts/forge-std/") &&
+        !sourceName.startsWith("contracts/ds-test/");
+
+      return isTestArtifact;
+    },
+  );
+
+  const config = {
+    projectRoot: hre.config.paths.root,
+  };
+
+  await runAllSolidityTests(
+    artifacts,
+    testSuiteIds,
+    config,
+    (suiteResult, testResult) => {
+      let name = suiteResult.id.name + " | " + testResult.name;
+      if ("runs" in testResult?.kind) {
+        name += ` (${testResult.kind.runs} runs)`;
+      }
+
+      totalTests++;
+
+      const failed = testResult.status === "Failure";
+      if (failed) {
+        failedTests++;
+      }
+
+      specReporter.write({
+        type: failed ? "test:fail" : "test:pass",
+        data: {
+          name,
+        },
+      });
+    },
+  );
+
+  console.log(`\n${totalTests} tests found, ${failedTests} failed`);
+
+  if (failedTests > 0) {
+    process.exitCode = 1;
+    return;
+  }
+};
+
+export default runSolidityTests;

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -227,6 +227,7 @@ AVAILABLE TASKS:
   console                  Opens a hardhat console
   run                      Runs a user-defined script after compiling the project
   task                     A task that uses arg1
+  test:solidity            Run the Solidity tests
 
 GLOBAL OPTIONS:
 

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -223,6 +223,7 @@ Usage: hardhat [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUM
 AVAILABLE TASKS:
 
   clean                    Clears the cache and deletes all artifacts
+  compile                  Compiles the entire project, building all artifacts
   console                  Opens a hardhat console
   run                      Runs a user-defined script after compiling the project
   task                     A task that uses arg1

--- a/v-next/hardhat/tsconfig.json
+++ b/v-next/hardhat/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "../../config-v-next/tsconfig.json",
   "references": [
     {
+      "path": "../hardhat-build-system"
+    },
+    {
       "path": "../hardhat-errors"
     },
     {


### PR DESCRIPTION
Add a skeleton Solidity Test built-in plugin using `@ignored/edr` with its Solidity Test Runner, to add a `npx hardhat test:solidity` task.

This PR comes in two commits:
- temporary hack to add `compile` task based on old build system and extend ArtifactsManager to read from artifacts directory
- skeleton builtin plugin for Solidity Test, leveraging the _hacked_ artifacts manager to read the compiled artifacts and pass that meta-info into EDR's Solidity Test Runner

## Running locally

```
pnpm install
cd ./v-next/example-project
pnpm build
pnpm hardhat test:solidity
```