### PR TITLE
feat: add doNotUseFetch helper to the test utils

### DIFF
--- a/v-next/hardhat-test-utils/src/global.ts
+++ b/v-next/hardhat-test-utils/src/global.ts
@@ -1,0 +1,16 @@
+import { after, before } from "node:test";
+
+export function doNotUseFetch(): void {
+  let originalFetch: typeof global.fetch;
+
+  before(async () => {
+    originalFetch = global.fetch;
+    global.fetch = async () => {
+      throw new Error("Network requests are disabled");
+    };
+  });
+
+  after(async () => {
+    global.fetch = originalFetch;
+  });
+}

--- a/v-next/hardhat-test-utils/src/index.ts
+++ b/v-next/hardhat-test-utils/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./fixture-projects.js";
-export * from "./hardhat-error.js";
 export * from "./fs.js";
+export * from "./global.js";
+export * from "./hardhat-error.js";


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

I found it helpful during the draft implementation of https://github.com/NomicFoundation/hardhat/pull/5774. 

The idea is to override the global reference to fetch with a function that always throws an error. This is a very crude approach to simulating network connectivity issues when using fetch. We can explore this area further in the future if needed. However, at this time, this met my needs.
