### PR TITLE
Add @medga/hardhat-clone plugin

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -996,6 +996,14 @@ const communityPlugins: IPlugin[] = [
       "Hardhat plugin for enabling on-the-fly network switching within your Hardhat scripts and tasks",
     tags: ["Tasks", "Scripts", "Testing"],
   },
+  {
+    name: "@medga/hardhat-clone",
+    author: "The MEDGA Team",
+    authorUrl: "https://medga.org",
+    description:
+      "Clone an on-chain contract and integrate into your Hardhat project",
+    tags: ["etherscan", "clone", "verified contract"],
+  },
 ];
 
 const officialPlugins: IPlugin[] = [


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
This PR adds https://github.com/MEDGA-eth/hardhat-clone into the community plugin list.

@medga/hardhat-clone is a plugin that takes the address of a verified contract deployed on the blockchain (any EVM-compatible blockchain, e.g., Ethereum, Binanace Smart Chain, Optimism, etc.) and clone the contract source into the current Hardhat project. The cloned contracts are reorganized such that it can be compiled together with other contracts in the Hardhat project.


