### PR TITLE
feat: create a mocha/ethers template project

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -35,6 +35,7 @@
     "template-empty-javascript": "0.0.1",
     "template-empty-typescript": "0.0.1",
     "template-javascript-with-examples": "0.0.1",
+    "template-mocha-ethers": "0.0.1",
     "template-typescript-with-examples": "0.0.1"
   },
   "changesets": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2356,6 +2356,42 @@ importers:
         specifier: workspace:^3.0.0-next.1
         version: link:../../../hardhat-node-test-runner
 
+  v-next/hardhat/templates/mocha-ethers:
+    devDependencies:
+      '@ignored/hardhat-vnext':
+        specifier: workspace:^3.0.0-next.5
+        version: link:../..
+      '@ignored/hardhat-vnext-ethers':
+        specifier: workspace:^3.0.0-next.1
+        version: link:../../../hardhat-ethers
+      '@ignored/hardhat-vnext-mocha-test-runner':
+        specifier: workspace:^3.0.0-next.1
+        version: link:../../../hardhat-mocha-test-runner
+      '@ignored/hardhat-vnext-network-helpers':
+        specifier: workspace:^3.0.0-next.1
+        version: link:../../../hardhat-network-helpers
+      '@types/chai':
+        specifier: ^4.2.0
+        version: 4.3.20
+      '@types/chai-as-promised':
+        specifier: ^8.0.1
+        version: 8.0.1
+      '@types/mocha':
+        specifier: '>=9.1.0'
+        version: 10.0.9
+      chai:
+        specifier: ^4.4.1
+        version: 4.5.0
+      chai-as-promised:
+        specifier: ^8.0.0
+        version: 8.0.0(chai@4.5.0)
+      mocha:
+        specifier: ^10.0.0
+        version: 10.7.3
+      typescript:
+        specifier: ~5.5.0
+        version: 5.5.4
+
   v-next/hardhat/templates/typescript-with-examples:
     devDependencies:
       '@ignored/hardhat-vnext':
@@ -3306,6 +3342,9 @@ packages:
   '@types/chai-as-promised@7.1.8':
     resolution: {integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==}
 
+  '@types/chai-as-promised@8.0.1':
+    resolution: {integrity: sha512-dAlDhLjJlABwAVYObo9TPWYTRg9NaQM5CXeaeJYcYAkvzUf0JRLIiog88ao2Wqy/20WUnhbbUZcgvngEbJ3YXQ==}
+
   '@types/chai@4.3.20':
     resolution: {integrity: sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==}
 
@@ -3377,9 +3416,6 @@ packages:
 
   '@types/node@18.19.59':
     resolution: {integrity: sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==}
-
-  '@types/node@20.16.11':
-    resolution: {integrity: sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==}
 
   '@types/node@20.17.1':
     resolution: {integrity: sha512-j2VlPv1NnwPJbaCNv69FO/1z4lId0QmGvpT41YxitRtWlg96g/j8qcv2RKsLKe2F6OJgyXhupN1Xo17b2m139Q==}
@@ -3995,6 +4031,11 @@ packages:
     peerDependencies:
       chai: '>= 2.1.2 < 6'
 
+  chai-as-promised@8.0.0:
+    resolution: {integrity: sha512-sMsGXTrS3FunP/wbqh/KxM8Kj/aLPXQGkNtvE5wPfSToq8wkkvBpTZo1LIiEVmC4BwkKpag+l5h/20lBMk6nUg==}
+    peerDependencies:
+      chai: '>= 2.1.2 < 6'
+
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
@@ -4023,6 +4064,10 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -8035,7 +8080,7 @@ snapshots:
 
   '@types/bn.js@4.11.6':
     dependencies:
-      '@types/node': 20.16.11
+      '@types/node': 18.19.59
 
   '@types/bn.js@5.1.6':
     dependencies:
@@ -8045,13 +8090,17 @@ snapshots:
     dependencies:
       '@types/chai': 4.3.20
 
+  '@types/chai-as-promised@8.0.1':
+    dependencies:
+      '@types/chai': 4.3.20
+
   '@types/chai@4.3.20': {}
 
   '@types/ci-info@2.0.0': {}
 
   '@types/concat-stream@1.6.1':
     dependencies:
-      '@types/node': 20.16.11
+      '@types/node': 18.19.59
 
   '@types/debug@4.1.12':
     dependencies:
@@ -8063,7 +8112,7 @@ snapshots:
 
   '@types/form-data@0.0.33':
     dependencies:
-      '@types/node': 20.16.11
+      '@types/node': 18.19.59
 
   '@types/fs-extra@5.1.0':
     dependencies:
@@ -8113,10 +8162,6 @@ snapshots:
   '@types/node@18.19.59':
     dependencies:
       undici-types: 5.26.5
-
-  '@types/node@20.16.11':
-    dependencies:
-      undici-types: 6.19.8
 
   '@types/node@20.17.1':
     dependencies:
@@ -8172,7 +8217,7 @@ snapshots:
 
   '@types/ws@8.5.3':
     dependencies:
-      '@types/node': 20.16.11
+      '@types/node': 18.19.59
 
   '@typescript-eslint/eslint-plugin@5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.0)(typescript@5.0.4))(eslint@8.57.0)(typescript@5.0.4)':
     dependencies:
@@ -8829,6 +8874,11 @@ snapshots:
       chai: 4.5.0
       check-error: 1.0.3
 
+  chai-as-promised@8.0.0(chai@4.5.0):
+    dependencies:
+      chai: 4.5.0
+      check-error: 2.1.1
+
   chai@4.5.0:
     dependencies:
       assertion-error: 1.1.0
@@ -8865,6 +8915,8 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
+
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:

--- a/v-next/hardhat/templates/mocha-ethers/.gitignore
+++ b/v-next/hardhat/templates/mocha-ethers/.gitignore
@@ -1,0 +1,14 @@
+# Node modules
+/node_modules
+
+# Compilation output
+/dist
+
+# pnpm deploy output
+/bundle
+
+# Hardhat Build Artifacts
+/artifacts
+
+# Hardhat compilation (v2) support directory
+/cache

--- a/v-next/hardhat/templates/mocha-ethers/README.md
+++ b/v-next/hardhat/templates/mocha-ethers/README.md
@@ -1,0 +1,16 @@
+# A TypeScript Hardhat project using Mocha and Ethers
+
+> WARNING: This demonstration project is still in development. It is part of the Hardhat v3 upgrade. It is not for production use.
+
+> NOTE: There are several plugins from the Hardhat toolbox that have not been ported to Hardhat v3 yet. In testing terms, the biggest ommision is `hardhat-chai-matchers`.
+
+This project demonstrates basic Hardhat usecases within a TypeScript project. It comes with a minimal Hardhat configuration file and a test.
+
+For integration testing it uses the Mocha test runner and the Ethers.js library for interacting with Ethereum nodes.
+
+Try running the following commands to see Hardhat in action:
+
+```shell
+# Run the mocha integration test suite
+npx hardhat3 test
+```

--- a/v-next/hardhat/templates/mocha-ethers/contracts/Lock.sol
+++ b/v-next/hardhat/templates/mocha-ethers/contracts/Lock.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+// Uncomment this line to use console.log
+// import "hardhat/console.sol";
+
+contract Lock {
+    uint public unlockTime;
+    address payable public owner;
+
+    event Withdrawal(uint amount, uint when);
+
+    constructor(uint _unlockTime) payable {
+        require(
+            block.timestamp < _unlockTime,
+            "Unlock time should be in the future"
+        );
+
+        unlockTime = _unlockTime;
+        owner = payable(msg.sender);
+    }
+
+    function withdraw() public {
+        // Uncomment this line, and the import of "hardhat/console.sol", to print a log in your terminal
+        // console.log("Unlock time is %o and block timestamp is %o", unlockTime, block.timestamp);
+
+        require(block.timestamp >= unlockTime, "You can't withdraw yet");
+        require(msg.sender == owner, "You aren't the owner");
+
+        emit Withdrawal(address(this).balance, block.timestamp);
+
+        owner.transfer(address(this).balance);
+    }
+}

--- a/v-next/hardhat/templates/mocha-ethers/hardhat.config.ts
+++ b/v-next/hardhat/templates/mocha-ethers/hardhat.config.ts
@@ -1,0 +1,12 @@
+import type { HardhatUserConfig } from "@ignored/hardhat-vnext/types/config";
+
+import HardhatMochaTestRunner from "@ignored/hardhat-vnext-mocha-test-runner";
+import HardhatEthers from "@ignored/hardhat-vnext-ethers";
+import HardhatNetworkHelpers from "@ignored/hardhat-vnext-network-helpers";
+
+const config: HardhatUserConfig = {
+  plugins: [HardhatMochaTestRunner, HardhatEthers, HardhatNetworkHelpers],
+  solidity: "0.8.24",
+};
+
+export default config;

--- a/v-next/hardhat/templates/mocha-ethers/package.json
+++ b/v-next/hardhat/templates/mocha-ethers/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "template-mocha-ethers",
+  "private": true,
+  "version": "0.0.1",
+  "description": "A Typescript Hardhat project using Mocha and Ethers.js",
+  "type": "module",
+  "devDependencies": {
+    "@ignored/hardhat-vnext": "workspace:^3.0.0-next.5",
+    "@ignored/hardhat-vnext-ethers": "workspace:^3.0.0-next.1",
+    "@ignored/hardhat-vnext-mocha-test-runner": "workspace:^3.0.0-next.1",
+    "@ignored/hardhat-vnext-network-helpers": "workspace:^3.0.0-next.1",
+    "@types/chai": "^4.2.0",
+    "@types/chai-as-promised": "^8.0.1",
+    "@types/mocha": ">=9.1.0",
+    "chai": "^4.4.1",
+    "chai-as-promised": "^8.0.0",
+    "mocha": "^10.0.0",
+    "typescript": "~5.5.0"
+  }
+}

--- a/v-next/hardhat/templates/mocha-ethers/test/Lock.ts
+++ b/v-next/hardhat/templates/mocha-ethers/test/Lock.ts
@@ -1,0 +1,166 @@
+import hre from "@ignored/hardhat-vnext";
+import { NetworkConnection } from "@ignored/hardhat-vnext/types/network";
+import { describe, it, before } from "mocha";
+
+// TODO: Chai as promised support needs to be added either directly
+// or through the updated `chai-matchers` package.
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+describe("Lock", function () {
+  let networkConnection: NetworkConnection<"l1">;
+
+  // We define a fixture to reuse the same setup in every test.
+  // We use loadFixture to run this setup once, snapshot that state,
+  // and reset Hardhat Network to that snapshot in every test.
+  async function deployOneYearLockFixture() {
+    const ONE_YEAR_IN_SECS = 365 * 24 * 60 * 60;
+    const ONE_GWEI = 1_000_000_000;
+
+    const lockedAmount = ONE_GWEI;
+
+    const unlockTime =
+      (await networkConnection.networkHelpers.time.latest()) + ONE_YEAR_IN_SECS;
+
+    // Contracts are deployed using the first signer/account by default
+    const [owner, otherAccount] = await networkConnection.ethers.getSigners();
+
+    const Lock = await networkConnection.ethers.getContractFactory("Lock");
+    const lock = await Lock.deploy(unlockTime, { value: lockedAmount });
+
+    return { lock, unlockTime, lockedAmount, owner, otherAccount };
+  }
+
+  before(async function () {
+    networkConnection = await hre.network.connect();
+  });
+
+  describe("Deployment", function () {
+    it("Should set the right unlockTime", async function () {
+      const { lock, unlockTime } =
+        await networkConnection.networkHelpers.loadFixture(
+          deployOneYearLockFixture,
+        );
+
+      expect(await lock.unlockTime()).to.equal(BigInt(unlockTime));
+    });
+
+    it("Should set the right owner", async function () {
+      const { lock, owner } =
+        await networkConnection.networkHelpers.loadFixture(
+          deployOneYearLockFixture,
+        );
+
+      expect(await lock.owner()).to.equal(owner.address);
+    });
+
+    it("Should receive and store the funds to lock", async function () {
+      const { lock, lockedAmount } =
+        await networkConnection.networkHelpers.loadFixture(
+          deployOneYearLockFixture,
+        );
+
+      expect(
+        await networkConnection.ethers.provider.getBalance(lock.target),
+      ).to.equal(BigInt(lockedAmount));
+    });
+
+    it("Should fail if the unlockTime is not in the future", async function () {
+      // We don't use the fixture here because we want a different deployment
+      const latestTime = await networkConnection.networkHelpers.time.latest();
+      const Lock = await networkConnection.ethers.getContractFactory("Lock");
+
+      // TODO: bring back the original test assertion `hardhat-chai-matchers`
+      // is available with `revertedWith`.
+      await expect(
+        Lock.deploy(latestTime, { value: 1 }),
+      ).to.eventually.be.rejectedWith("Unlock time should be in the future");
+    });
+  });
+
+  describe("Withdrawals", function () {
+    describe("Validations", function () {
+      it("Should revert with the right error if called too soon", async function () {
+        const { lock } = await networkConnection.networkHelpers.loadFixture(
+          deployOneYearLockFixture,
+        );
+
+        await expect(lock.withdraw()).to.eventually.be.rejectedWith(
+          "You can't withdraw yet",
+        );
+      });
+
+      it("Should revert with the right error if called from another account", async function () {
+        const { lock, unlockTime, otherAccount } =
+          await networkConnection.networkHelpers.loadFixture(
+            deployOneYearLockFixture,
+          );
+
+        // We can increase the time in Hardhat Network
+        await networkConnection.networkHelpers.time.increaseTo(unlockTime);
+
+        // We use lock.connect() to send a transaction from another account
+        await expect(
+          (lock.connect(otherAccount) as any).withdraw(),
+        ).to.eventually.be.rejectedWith("You aren't the owner");
+      });
+
+      it("Shouldn't fail if the unlockTime has arrived and the owner calls it", async function () {
+        const { lock, unlockTime } =
+          await networkConnection.networkHelpers.loadFixture(
+            deployOneYearLockFixture,
+          );
+
+        // Transactions are sent using the first signer by default
+        await networkConnection.networkHelpers.time.increaseTo(unlockTime);
+
+        await expect(lock.withdraw()).to.eventually.be.fulfilled;
+      });
+    });
+
+    describe("Events", function () {
+      // TODO: bring back the original test once `hardhat-chai-matchers`
+      // is available for asserting on events.
+      it("Should emit an event on withdrawals", async function () {
+        const { lock, unlockTime, lockedAmount } =
+          await networkConnection.networkHelpers.loadFixture(
+            deployOneYearLockFixture,
+          );
+
+        await networkConnection.networkHelpers.time.increaseTo(unlockTime);
+
+        const withdrawResult = await lock.withdraw();
+
+        const receipt = await withdrawResult.wait();
+
+        expect(receipt.logs.length).to.equal(1);
+        expect(
+          receipt.logs.filter((l: any) => l.fragment.name === "Withdrawal")
+            .length,
+        ).to.equal(1);
+      });
+    });
+
+    describe("Transfers", function () {
+      // TODO: bring back the original Transfers test once
+      // `hardhat-chai-matchers` has been ported.
+      it("Should transfer the funds out of the timelock", async function () {
+        const { lock, unlockTime } =
+          await networkConnection.networkHelpers.loadFixture(
+            deployOneYearLockFixture,
+          );
+
+        await networkConnection.networkHelpers.time.increaseTo(unlockTime);
+
+        await lock.withdraw();
+
+        const afterLockedBalance =
+          await networkConnection.ethers.provider.getBalance(lock);
+
+        expect(afterLockedBalance).to.equal(0n);
+      });
+    });
+  });
+});

--- a/v-next/hardhat/templates/mocha-ethers/tsconfig.json
+++ b/v-next/hardhat/templates/mocha-ethers/tsconfig.json
@@ -1,0 +1,17 @@
+/* Imported https://github.com/tsconfig/bases/blob/be6b3bb160889347b8614e8d18e1e88c40f8ecc9/bases/node20.json */
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 20",
+  "_version": "20.1.0",
+
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "module": "node16",
+    "target": "es2022",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node16"
+  }
+}


### PR DESCRIPTION
As part of the Alpha prep this adds a mocha/ethers template project (used during `hardhat --init`), that tries to recreate the functionality (we are currently able to support`f of the v2 Ethers typescript project in v3.

It pulls in the `v-next` versions of the mocha test runner, the test helpers and `hardhat-ethers`.

It adds a the `Lock.sol` and `Lock.ts` test file. The test file has been modified to allow for running the tests while we still have rough edges.

Specifically the rough edges are:
- we need to import plugin types to get the full connection type
- we need new patterns for sharing `connection` among tests (I added a `beforeEach`)
- we don't have chai matchers so I added `chai-as-promised` and adapted the tests, sometime crudely.
