### PR TITLE
fix: disable console for init tests

### DIFF
--- a/v-next/hardhat-test-utils/src/console.ts
+++ b/v-next/hardhat-test-utils/src/console.ts
@@ -1,0 +1,36 @@
+import { after, before } from "node:test";
+
+/**
+ * Disables the console functions that directly interact with stdout/stderr.
+ *
+ * This function is useful when you want to test a function that use console
+ * logging but you don't want to see the output in the test report.
+ * In particular, we have observed that using console.log can cause errors like:
+ *  - Error: Unable to deserialize cloned data due to invalid or unsupported version.
+ *
+ * This function overwrites the original console.log/console.warn/console.dir
+ * with no-op functions.
+ *
+ * If we ever want to inspect the stdout/stderr, we could accept
+ * NodeJS.WritableStream arguments and write formatted messages to them instead.
+ *
+ * Another interesting extension to this function would be not to disable the
+ * console streams if a DEBUG flag is set in the environment.
+ */
+export function disableConsole(): void {
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalDir = console.dir;
+
+  before(() => {
+    console.log = () => {};
+    console.warn = () => {};
+    console.dir = () => {};
+  });
+
+  after(() => {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.dir = originalDir;
+  });
+}

--- a/v-next/hardhat-test-utils/src/index.ts
+++ b/v-next/hardhat-test-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./console.js";
 export * from "./fixture-projects.js";
-export * from "./hardhat-error.js";
 export * from "./fs.js";
+export * from "./hardhat-error.js";

--- a/v-next/hardhat/test/internal/cli/init/init.ts
+++ b/v-next/hardhat/test/internal/cli/init/init.ts
@@ -11,6 +11,7 @@ import {
 } from "@ignored/hardhat-vnext-utils/fs";
 import {
   assertRejectsWithHardhatError,
+  disableConsole,
   useTmpDir,
 } from "@nomicfoundation/hardhat-test-utils";
 
@@ -27,6 +28,8 @@ import { getTemplates } from "../../../../src/internal/cli/init/template.js";
 
 // NOTE: This uses network to access the npm registry
 describe("printWelcomeMessage", () => {
+  disableConsole();
+
   it("should not throw if latest version of hardhat cannot be retrieved from the registry", async () => {
     await printWelcomeMessage();
   });
@@ -109,6 +112,8 @@ describe("ensureProjectPackageJson", () => {
 describe("copyProjectFiles", () => {
   useTmpDir("copyProjectFiles");
 
+  disableConsole();
+
   describe("when force is true", () => {
     it("should copy the template files to the workspace and overwrite existing files", async () => {
       const template = await getTemplate("empty-typescript");
@@ -150,6 +155,8 @@ describe("copyProjectFiles", () => {
 describe("installProjectDependencies", () => {
   useTmpDir("installProjectDependencies");
 
+  disableConsole();
+
   describe("when install is true", () => {
     // This test is skipped because installing dependencies over the network is slow
     it.skip("should install the project dependencies", async () => {
@@ -175,6 +182,8 @@ describe("installProjectDependencies", () => {
 // NOTE: This uses network to access the npm registry
 describe("initHardhat", async () => {
   useTmpDir("initHardhat");
+
+  disableConsole();
 
   const templates = await getTemplates();
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

As explored in https://github.com/NomicFoundation/hardhat/pull/5804, I have found that testing function that use `console.log` (i.e. write to `stdout`) can lead to `Unable to deserialize cloned data due to invalid or unsupported version.` errors.

In this PR, I introduce a helper function, which disables `console.log`/`console.warn`/`console.dir` (the `console` function which interact with either `stdout` or `stderr` directly). I also described how we could expand the helper in the future if needed.

An alternative I considered was overwriting the `process.stdout` and `process.stderr` streams directly, however I found that this can interfere with the reporter's output.
