### PR TITLE
test: try running prb-math solidity tests in the example-project

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1424,6 +1424,10 @@ importers:
         version: 4.12.1(typescript@5.0.4)(zod@3.23.8)
 
   v-next/example-project:
+    dependencies:
+      forge-std:
+        specifier: https://github.com/foundry-rs/forge-std/tarball/v1.9.2
+        version: https://github.com/foundry-rs/forge-std/tarball/v1.9.2
     devDependencies:
       '@ignored/hardhat-vnext':
         specifier: workspace:^3.0.0-next.4
@@ -4748,6 +4752,10 @@ packages:
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  forge-std@https://github.com/foundry-rs/forge-std/tarball/v1.9.2:
+    resolution: {tarball: https://github.com/foundry-rs/forge-std/tarball/v1.9.2}
+    version: 1.9.2
 
   form-data@2.5.1:
     resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
@@ -9817,6 +9825,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
+
+  forge-std@https://github.com/foundry-rs/forge-std/tarball/v1.9.2: {}
 
   form-data@2.5.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1425,6 +1425,9 @@ importers:
 
   v-next/example-project:
     dependencies:
+      '@prb/math':
+        specifier: https://github.com/PaulRBerg/prb-math/tarball/v4.0.3
+        version: https://github.com/PaulRBerg/prb-math/tarball/v4.0.3
       forge-std:
         specifier: https://github.com/foundry-rs/forge-std/tarball/v1.9.2
         version: https://github.com/foundry-rs/forge-std/tarball/v1.9.2
@@ -3208,6 +3211,10 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@prb/math@https://github.com/PaulRBerg/prb-math/tarball/v4.0.3':
+    resolution: {tarball: https://github.com/PaulRBerg/prb-math/tarball/v4.0.3}
+    version: 4.0.3
 
   '@scure/base@1.1.8':
     resolution: {integrity: sha512-6CyAclxj3Nb0XT7GHK6K4zK6k2xJm6E4Ft0Ohjt4WgegiFUHEtFb2CGzmPmGBwoIhrLsqNLYfLr04Y1GePrzZg==}
@@ -7901,6 +7908,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@prb/math@https://github.com/PaulRBerg/prb-math/tarball/v4.0.3': {}
 
   '@scure/base@1.1.8': {}
 

--- a/v-next/example-project/contracts/prb-math/test/Base.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/Base.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { StdAssertions } from "forge-std/src/StdAssertions.sol";
+import { StdCheats } from "forge-std/src/StdCheats.sol";
+import { Vm } from "forge-std/src/Vm.sol";
+
+import { PRBMathAssertions } from "./utils/Assertions.sol";
+import { PRBMathUtils } from "./utils/Utils.sol";
+
+/// @notice Base test contract with common logic needed by all tests.
+abstract contract Base_Test is StdAssertions, StdCheats, PRBMathAssertions, PRBMathUtils {
+    /*//////////////////////////////////////////////////////////////////////////
+                                       STRUCTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    struct Users {
+        address alice;
+        address bob;
+        address eve;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    CHEATCODES
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev An instance of the Foundry VM, which contains cheatcodes for testing.
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     CONSTANTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    int256 internal constant MAX_INT256 = type(int256).max;
+
+    uint128 internal constant MAX_UINT128 = type(uint128).max;
+
+    uint128 internal constant MAX_UINT40 = type(uint40).max;
+
+    int256 internal constant MIN_INT256 = type(int256).min;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+
+    Users internal users;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                   SET-UP FUNCTION
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function setUp() public virtual {
+        // Create users for testing.
+        users = Users({ alice: makeAddr("Alice"), bob: makeAddr("Bob"), eve: makeAddr("Eve") });
+
+        // Make Alice the `msg.sender` and `tx.origin` for all subsequent calls.
+        vm.startPrank({ msgSender: users.alice, txOrigin: users.alice });
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint128.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint128.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import {
+    PRBMathCastingUint128 as CastingUint128,
+    PRBMath_IntoSD1x18_Overflow,
+    PRBMath_IntoUD2x18_Overflow
+} from "src/casting/Uint128.sol";
+import { uMAX_SD1x18 } from "src/sd1x18/Constants.sol";
+import { SD1x18 } from "src/sd1x18/ValueType.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { uMAX_UD2x18 } from "src/ud2x18/Constants.sol";
+import { UD2x18 } from "src/ud2x18/ValueType.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { Base_Test } from "../../Base.t.sol";
+
+/// @dev Collection of tests for the casting library available for uint128.
+contract CastingUint128_Test is Base_Test {
+    using CastingUint128 for uint128;
+
+    function testFuzz_RevertWhen_OverflowSD1x18(uint128 x) external {
+        x = boundUint128(x, uint128(uint64(uMAX_SD1x18)) + 1, MAX_UINT128);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_IntoSD1x18_Overflow.selector, x));
+        x.intoSD1x18();
+    }
+
+    function testFuzz_intoSD1x18(uint128 x) external pure {
+        x = boundUint128(x, 0, uint128(uint64(uMAX_SD1x18)));
+        SD1x18 actual = x.intoSD1x18();
+        SD1x18 expected = SD1x18.wrap(int64(uint64(x)));
+        assertEq(actual, expected, "uint128 intoSD1x18");
+    }
+
+    function testFuzz_intoSD59x18(uint128 x) external pure {
+        SD59x18 actual = x.intoSD59x18();
+        SD59x18 expected = SD59x18.wrap(int256(uint256(x)));
+        assertEq(actual, expected, "uint128 intoSD59x18");
+    }
+
+    function testFuzz_RevertWhen_OverflowUD2x18(uint128 x) external {
+        x = boundUint128(x, uint128(uMAX_UD2x18) + 1, MAX_UINT128);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_IntoUD2x18_Overflow.selector, x));
+        x.intoUD2x18();
+    }
+
+    function testFuzz_intoUD2x18(uint128 x) external pure {
+        x = boundUint128(x, 0, uint128(uMAX_UD2x18));
+        UD2x18 actual = x.intoUD2x18();
+        UD2x18 expected = UD2x18.wrap(uint64(x));
+        assertEq(actual, expected, "uint128 intoUD2x18");
+    }
+
+    function testFuzz_intoUD60x18(uint128 x) external pure {
+        UD60x18 actual = x.intoUD60x18();
+        UD60x18 expected = UD60x18.wrap(uint256(x));
+        assertEq(actual, expected, "uint128 intoUD60x18");
+    }
+
+    function boundUint128(uint128 x, uint128 min, uint128 max) internal pure returns (uint128 result) {
+        result = uint128(_bound(uint256(x), uint256(min), uint256(max)));
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint128.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint128.t.sol
@@ -5,13 +5,13 @@ import {
     PRBMathCastingUint128 as CastingUint128,
     PRBMath_IntoSD1x18_Overflow,
     PRBMath_IntoUD2x18_Overflow
-} from "src/casting/Uint128.sol";
-import { uMAX_SD1x18 } from "src/sd1x18/Constants.sol";
-import { SD1x18 } from "src/sd1x18/ValueType.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
-import { uMAX_UD2x18 } from "src/ud2x18/Constants.sol";
-import { UD2x18 } from "src/ud2x18/ValueType.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+} from "@prb/math/src/casting/Uint128.sol";
+import { uMAX_SD1x18 } from "@prb/math/src/sd1x18/Constants.sol";
+import { SD1x18 } from "@prb/math/src/sd1x18/ValueType.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
+import { uMAX_UD2x18 } from "@prb/math/src/ud2x18/Constants.sol";
+import { UD2x18 } from "@prb/math/src/ud2x18/ValueType.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { Base_Test } from "../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint256.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint256.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import {
+    PRBMathCastingUint256 as CastingUint256,
+    PRBMath_IntoSD1x18_Overflow,
+    PRBMath_IntoSD59x18_Overflow,
+    PRBMath_IntoUD2x18_Overflow
+} from "src/casting/Uint256.sol";
+import { uMAX_SD1x18 } from "src/sd1x18/Constants.sol";
+import { SD1x18 } from "src/sd1x18/ValueType.sol";
+import { uMAX_SD59x18 } from "src/sd59x18/Constants.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { uMAX_UD2x18 } from "src/ud2x18/Constants.sol";
+import { UD2x18 } from "src/ud2x18/ValueType.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { Base_Test } from "../../Base.t.sol";
+
+/// @dev Collection of tests for the casting library available for uint256.
+contract CastingUint256_Test is Base_Test {
+    using CastingUint256 for uint256;
+
+    function testFuzz_RevertWhen_OverflowSD1x18(uint256 x) external {
+        x = _bound(x, uint64(uMAX_SD1x18) + 1, type(uint256).max);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_IntoSD1x18_Overflow.selector, x));
+        x.intoSD1x18();
+    }
+
+    function testFuzz_intoSD1x18(uint256 x) external pure {
+        x = _bound(x, 0, uint64(uMAX_SD1x18));
+        SD1x18 actual = x.intoSD1x18();
+        SD1x18 expected = SD1x18.wrap(int64(uint64(x)));
+        assertEq(actual, expected, "uint256 intoSD1x18");
+    }
+
+    function testFuzz_RevertWhen_OverflowSD59x18(uint256 x) external {
+        x = _bound(x, uint256(uMAX_SD59x18) + 1, type(uint256).max);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_IntoSD59x18_Overflow.selector, x));
+        x.intoSD59x18();
+    }
+
+    function testFuzz_intoSD59x18(uint256 x) external pure {
+        x = _bound(x, 0, uint256(uMAX_SD59x18));
+        SD59x18 actual = x.intoSD59x18();
+        SD59x18 expected = SD59x18.wrap(int256(uint256(x)));
+        assertEq(actual, expected, "uint256 intoSD59x18");
+    }
+
+    function testFuzz_RevertWhen_OverflowUD2x18(uint256 x) external {
+        x = _bound(x, uint256(uMAX_UD2x18) + 1, type(uint256).max);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_IntoUD2x18_Overflow.selector, x));
+        x.intoUD2x18();
+    }
+
+    function testFuzz_intoUD2x18(uint256 x) external pure {
+        x = _bound(x, 0, uint256(uMAX_UD2x18));
+        UD2x18 actual = x.intoUD2x18();
+        UD2x18 expected = UD2x18.wrap(uint64(x));
+        assertEq(actual, expected, "uint256 intoUD2x18");
+    }
+
+    function testFuzz_intoUD60x18(uint256 x) external pure {
+        UD60x18 actual = x.intoUD60x18();
+        UD60x18 expected = UD60x18.wrap(x);
+        assertEq(actual, expected, "uint256 intoUD60x18");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint256.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint256.t.sol
@@ -6,14 +6,14 @@ import {
     PRBMath_IntoSD1x18_Overflow,
     PRBMath_IntoSD59x18_Overflow,
     PRBMath_IntoUD2x18_Overflow
-} from "src/casting/Uint256.sol";
-import { uMAX_SD1x18 } from "src/sd1x18/Constants.sol";
-import { SD1x18 } from "src/sd1x18/ValueType.sol";
-import { uMAX_SD59x18 } from "src/sd59x18/Constants.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
-import { uMAX_UD2x18 } from "src/ud2x18/Constants.sol";
-import { UD2x18 } from "src/ud2x18/ValueType.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+} from "@prb/math/src/casting/Uint256.sol";
+import { uMAX_SD1x18 } from "@prb/math/src/sd1x18/Constants.sol";
+import { SD1x18 } from "@prb/math/src/sd1x18/ValueType.sol";
+import { uMAX_SD59x18 } from "@prb/math/src/sd59x18/Constants.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
+import { uMAX_UD2x18 } from "@prb/math/src/ud2x18/Constants.sol";
+import { UD2x18 } from "@prb/math/src/ud2x18/ValueType.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { Base_Test } from "../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint40.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint40.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { PRBMathCastingUint40 as CastingUint40 } from "src/casting/Uint40.sol";
+import { SD1x18 } from "src/sd1x18/ValueType.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { UD2x18 } from "src/ud2x18/ValueType.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { Base_Test } from "../../Base.t.sol";
+
+/// @dev Collection of tests for the casting library available for uint40.
+contract CastingUint40_Test is Base_Test {
+    using CastingUint40 for uint40;
+
+    function testFuzz_intoSD1x18(uint40 x) external pure {
+        SD1x18 actual = x.intoSD1x18();
+        SD1x18 expected = SD1x18.wrap(int64(uint64(x)));
+        assertEq(actual, expected, "uint40 intoSD1x18");
+    }
+
+    function testFuzz_intoSD59x18(uint40 x) external pure {
+        SD59x18 actual = x.intoSD59x18();
+        SD59x18 expected = SD59x18.wrap(int256(uint256(x)));
+        assertEq(actual, expected, "uint40 intoSD59x18");
+    }
+
+    function testFuzz_intoUD2x18(uint40 x) external pure {
+        UD2x18 actual = x.intoUD2x18();
+        UD2x18 expected = UD2x18.wrap(uint64(x));
+        assertEq(actual, expected, "uint40 intoUD2x18");
+    }
+
+    function testFuzz_intoUD60x18(uint40 x) external pure {
+        UD60x18 actual = x.intoUD60x18();
+        UD60x18 expected = UD60x18.wrap(uint256(x));
+        assertEq(actual, expected, "uint40 intoUD60x18");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint40.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/casting/CastingUint40.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { PRBMathCastingUint40 as CastingUint40 } from "src/casting/Uint40.sol";
-import { SD1x18 } from "src/sd1x18/ValueType.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
-import { UD2x18 } from "src/ud2x18/ValueType.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { PRBMathCastingUint40 as CastingUint40 } from "@prb/math/src/casting/Uint40.sol";
+import { SD1x18 } from "@prb/math/src/sd1x18/ValueType.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
+import { UD2x18 } from "@prb/math/src/ud2x18/ValueType.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { Base_Test } from "../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/fuzz/sd1x18/casting/Casting.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/sd1x18/casting/Casting.t.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd1x18, wrap } from "src/sd1x18/Casting.sol";
+import { SD1x18 } from "src/sd1x18/ValueType.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { MAX_SD1x18, MIN_SD1x18 } from "src/sd1x18/Constants.sol";
+import {
+    PRBMath_SD1x18_ToUD2x18_Underflow,
+    PRBMath_SD1x18_ToUD60x18_Underflow,
+    PRBMath_SD1x18_ToUint128_Underflow,
+    PRBMath_SD1x18_ToUint256_Underflow,
+    PRBMath_SD1x18_ToUint40_Overflow,
+    PRBMath_SD1x18_ToUint40_Underflow
+} from "src/sd1x18/Errors.sol";
+import { UD2x18 } from "src/ud2x18/ValueType.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { Base_Test } from "../../../Base.t.sol";
+
+/// @dev Collection of tests for the casting functions available in SD1x18.
+contract Casting_Fuzz_Test is Base_Test {
+    function testFuzz_IntoSD59x18(SD1x18 x) external pure {
+        SD59x18 actual = x.intoSD59x18();
+        SD59x18 expected = SD59x18.wrap(int256(x.unwrap()));
+        assertEq(actual, expected, "SD1x18 intoSD59x18");
+    }
+
+    function testFuzz_RevertWhen_UnderflowUD2x18(SD1x18 x) external {
+        x = _bound(x, MIN_SD1x18, -1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD1x18_ToUD2x18_Underflow.selector, x));
+        x.intoUD2x18();
+    }
+
+    function testFuzz_IntoUD2x18(SD1x18 x) external pure {
+        x = _bound(x, 0, MAX_SD1x18);
+        UD2x18 actual = x.intoUD2x18();
+        UD2x18 expected = UD2x18.wrap(uint64(x.unwrap()));
+        assertEq(actual, expected, "SD1x18 intoUD2x18");
+    }
+
+    function testFuzz_RevertWhen_UnderflowUD60x18(SD1x18 x) external {
+        x = _bound(x, MIN_SD1x18, -1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD1x18_ToUD60x18_Underflow.selector, x));
+        x.intoUD60x18();
+    }
+
+    function testFuzz_IntoUD60x18(SD1x18 x) external pure {
+        x = _bound(x, 0, MAX_SD1x18);
+        UD60x18 actual = x.intoUD60x18();
+        UD60x18 expected = UD60x18.wrap(uint64(x.unwrap()));
+        assertEq(actual, expected, "SD1x18 intoUD60x18");
+    }
+
+    function testFuzz_RevertWhen_UnderflowUint256(SD1x18 x) external {
+        x = _bound(x, MIN_SD1x18, -1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD1x18_ToUint256_Underflow.selector, x));
+        x.intoUint256();
+    }
+
+    function testFuzz_IntoUint256(SD1x18 x) external pure {
+        x = _bound(x, 0, MAX_SD1x18);
+        uint256 actual = x.intoUint256();
+        uint256 expected = uint64(x.unwrap());
+        assertEq(actual, expected, "SD1x18 intoUint256");
+    }
+
+    function testFuzz_RevertWhen_UnderflowUint128(SD1x18 x) external {
+        x = _bound(x, MIN_SD1x18, -1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD1x18_ToUint128_Underflow.selector, x));
+        x.intoUint128();
+    }
+
+    function testFuzz_IntoUint128(SD1x18 x) external pure {
+        x = _bound(x, 0, MAX_SD1x18);
+        uint128 actual = x.intoUint128();
+        uint128 expected = uint64(x.unwrap());
+        assertEq(actual, expected, "SD1x18 intoUint128");
+    }
+
+    function testFuzz_RevertWhen_UnderflowUint40(SD1x18 x) external {
+        x = _bound(x, MIN_SD1x18, -1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD1x18_ToUint40_Underflow.selector, x));
+        x.intoUint40();
+    }
+
+    function testFuzz_RevertWhen_OverflowUint40(SD1x18 x) external {
+        x = _bound(x, int64(uint64(MAX_UINT40)) + 1, MAX_SD1x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD1x18_ToUint40_Overflow.selector, x));
+        x.intoUint40();
+    }
+
+    function testFuzz_IntoUint40(SD1x18 x) external pure {
+        x = _bound(x, 0, int64(uint64(MAX_UINT40)));
+        uint40 actual = x.intoUint40();
+        uint40 expected = uint40(uint64(x.unwrap()));
+        assertEq(actual, expected, "SD1x18 intoUint40");
+    }
+
+    function testFuzz_sd1x18(int64 x) external pure {
+        SD1x18 actual = sd1x18(x);
+        SD1x18 expected = SD1x18.wrap(x);
+        assertEq(actual, expected, "sd1x18");
+    }
+
+    function testFuzz_Unwrap(SD1x18 x) external pure {
+        int64 actual = x.unwrap();
+        int64 expected = SD1x18.unwrap(x);
+        assertEq(actual, expected, "SD1x18 unwrap");
+    }
+
+    function testFuzz_Wrap(int64 x) external pure {
+        SD1x18 actual = wrap(x);
+        SD1x18 expected = SD1x18.wrap(x);
+        assertEq(actual, expected, "SD1x18 wrap");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/sd1x18/casting/Casting.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/sd1x18/casting/Casting.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd1x18, wrap } from "src/sd1x18/Casting.sol";
-import { SD1x18 } from "src/sd1x18/ValueType.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
-import { MAX_SD1x18, MIN_SD1x18 } from "src/sd1x18/Constants.sol";
+import { sd1x18, wrap } from "@prb/math/src/sd1x18/Casting.sol";
+import { SD1x18 } from "@prb/math/src/sd1x18/ValueType.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
+import { MAX_SD1x18, MIN_SD1x18 } from "@prb/math/src/sd1x18/Constants.sol";
 import {
     PRBMath_SD1x18_ToUD2x18_Underflow,
     PRBMath_SD1x18_ToUD60x18_Underflow,
@@ -12,9 +12,9 @@ import {
     PRBMath_SD1x18_ToUint256_Underflow,
     PRBMath_SD1x18_ToUint40_Overflow,
     PRBMath_SD1x18_ToUint40_Underflow
-} from "src/sd1x18/Errors.sol";
-import { UD2x18 } from "src/ud2x18/ValueType.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+} from "@prb/math/src/sd1x18/Errors.sol";
+import { UD2x18 } from "@prb/math/src/ud2x18/ValueType.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/casting/Casting.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/casting/Casting.t.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { uMAX_SD1x18, uMIN_SD1x18 } from "src/sd1x18/Constants.sol";
+import { SD1x18 } from "src/sd1x18/ValueType.sol";
+import { sd, sd59x18, wrap } from "src/sd59x18/Casting.sol";
+import { MAX_SD59x18, MIN_SD59x18 } from "src/sd59x18/Constants.sol";
+import {
+    PRBMath_SD59x18_IntoSD1x18_Overflow,
+    PRBMath_SD59x18_IntoSD1x18_Underflow,
+    PRBMath_SD59x18_IntoUD60x18_Underflow,
+    PRBMath_SD59x18_IntoUint256_Underflow,
+    PRBMath_SD59x18_IntoUD2x18_Overflow,
+    PRBMath_SD59x18_IntoUD2x18_Underflow,
+    PRBMath_SD59x18_IntoUint128_Overflow,
+    PRBMath_SD59x18_IntoUint128_Underflow,
+    PRBMath_SD59x18_IntoUint40_Overflow,
+    PRBMath_SD59x18_IntoUint40_Underflow
+} from "src/sd59x18/Errors.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { uMAX_UD2x18 } from "src/ud2x18/Constants.sol";
+import { UD2x18 } from "src/ud2x18/ValueType.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { Base_Test } from "../../../Base.t.sol";
+
+/// @dev Collection of tests for the casting functions available in SD59x18.
+contract SD59x18_Casting_Fuzz_Test is Base_Test {
+    function testFuzz_IntoInt256(SD59x18 x) external pure {
+        int256 actual = x.intoInt256();
+        int256 expected = SD59x18.unwrap(x);
+        assertEq(actual, expected, "SD59x18 intoInt256");
+    }
+
+    function testFuzz_RevertWhen_UnderflowSD1x18(SD59x18 x) external {
+        x = _bound(x, MIN_SD59x18, int256(uMIN_SD1x18) - 1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_IntoSD1x18_Underflow.selector, x));
+        x.intoSD1x18();
+    }
+
+    function testFuzz_RevertWhen_OverflowSD1x18(SD59x18 x) external {
+        x = _bound(x, int256(uMAX_SD1x18) + 1, MAX_SD59x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_IntoSD1x18_Overflow.selector, x));
+        x.intoSD1x18();
+    }
+
+    function testFuzz_IntoSD1x18(SD59x18 x) external pure {
+        x = _bound(x, uMIN_SD1x18, uMAX_SD1x18);
+        SD1x18 actual = x.intoSD1x18();
+        SD1x18 expected = SD1x18.wrap(int64(x.unwrap()));
+        assertEq(actual, expected, "SD59x18 intoSD1x18");
+    }
+
+    function testFuzz_RevertWhen_UnderflowUD2x18(SD59x18 x) external {
+        x = _bound(x, MIN_SD59x18, -1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_IntoUD2x18_Underflow.selector, x));
+        x.intoUD2x18();
+    }
+
+    function testFuzz_RevertWhen_OverflowUD2x18(SD59x18 x) external {
+        x = _bound(x, int256(uint256(uMAX_UD2x18)) + 1, MAX_SD59x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_IntoUD2x18_Overflow.selector, x));
+        x.intoUD2x18();
+    }
+
+    function testFuzz_IntoUD2x18(SD59x18 x) external pure {
+        x = _bound(x, 0, int256(uint256(uMAX_UD2x18)));
+        UD2x18 actual = x.intoUD2x18();
+        UD2x18 expected = UD2x18.wrap(uint64(uint256(x.unwrap())));
+        assertEq(actual, expected, "SD59x18 intoUD2x18");
+    }
+
+    function testFuzz_RevertWhen_UnderflowUD60x18(SD59x18 x) external {
+        x = _bound(x, MIN_SD59x18, -1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_IntoUD60x18_Underflow.selector, x));
+        x.intoUD60x18();
+    }
+
+    function testFuzz_IntoUD60x18(SD59x18 x) external pure {
+        x = _bound(x, 0, MAX_SD59x18);
+        UD60x18 actual = x.intoUD60x18();
+        UD60x18 expected = UD60x18.wrap(uint256(x.unwrap()));
+        assertEq(actual, expected, "SD59x18 intoUD60x18");
+    }
+
+    function testFuzz_RevertWhen_UnderflowUint128(SD59x18 x) external {
+        x = _bound(x, MIN_SD59x18, -1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_IntoUint128_Underflow.selector, x));
+        x.intoUint128();
+    }
+
+    function testFuzz_RevertWhen_OverflowUint128(SD59x18 x) external {
+        x = _bound(x, int256(uint256(MAX_UINT128)) + 1, MAX_SD59x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_IntoUint128_Overflow.selector, x));
+        x.intoUint128();
+    }
+
+    function testFuzz_IntoUint128(SD59x18 x) external pure {
+        x = _bound(x, 0, int256(uint256(MAX_UINT128)));
+        uint128 actual = x.intoUint128();
+        uint128 expected = uint128(uint256(x.unwrap()));
+        assertEq(actual, expected, "SD59x18 intoUint128");
+    }
+
+    function testFuzz_RevertWhen_UnderflowUint256(SD59x18 x) external {
+        x = _bound(x, MIN_SD59x18, -1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_IntoUint256_Underflow.selector, x));
+        x.intoUint256();
+    }
+
+    function testFuzz_IntoUint256(SD59x18 x) external pure {
+        x = _bound(x, 0, MAX_SD59x18);
+        uint256 actual = x.intoUint256();
+        uint256 expected = uint256(x.unwrap());
+        assertEq(actual, expected, "SD59x18 intoUint256");
+    }
+
+    function testFuzz_RevertWhen_UnderflowUint40(SD59x18 x) external {
+        x = _bound(x, MIN_SD59x18, -1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_IntoUint40_Underflow.selector, x));
+        x.intoUint40();
+    }
+
+    function testFuzz_RevertWhen_OverflowUint40(SD59x18 x) external {
+        x = _bound(x, int256(uint256(MAX_UINT40)) + 1, MAX_SD59x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_IntoUint40_Overflow.selector, x));
+        x.intoUint40();
+    }
+
+    function testFuzz_IntoUint40(SD59x18 x) external pure {
+        x = _bound(x, 0, int256(uint256(MAX_UINT40)));
+        uint40 actual = x.intoUint40();
+        uint40 expected = uint40(uint256(x.unwrap()));
+        assertEq(actual, expected, "SD59x18 intoUint40");
+    }
+
+    function testFuzz_Sd(int256 x) external pure {
+        SD59x18 actual = sd(x);
+        SD59x18 expected = SD59x18.wrap(x);
+        assertEq(actual, expected, "sd");
+    }
+
+    function testFuzz_sd59x18(int256 x) external pure {
+        SD59x18 actual = sd59x18(x);
+        SD59x18 expected = SD59x18.wrap(x);
+        assertEq(actual, expected, "sd59x18");
+    }
+
+    function testFuzz_Unwrap(SD59x18 x) external pure {
+        int256 actual = x.unwrap();
+        int256 expected = SD59x18.unwrap(x);
+        assertEq(actual, expected, "SD59x18 unwrap");
+    }
+
+    function testFuzz_Wrap(int256 x) external pure {
+        SD59x18 actual = wrap(x);
+        SD59x18 expected = SD59x18.wrap(x);
+        assertEq(actual, expected, "SD59x18 wrap");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/casting/Casting.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/casting/Casting.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { uMAX_SD1x18, uMIN_SD1x18 } from "src/sd1x18/Constants.sol";
-import { SD1x18 } from "src/sd1x18/ValueType.sol";
-import { sd, sd59x18, wrap } from "src/sd59x18/Casting.sol";
-import { MAX_SD59x18, MIN_SD59x18 } from "src/sd59x18/Constants.sol";
+import { uMAX_SD1x18, uMIN_SD1x18 } from "@prb/math/src/sd1x18/Constants.sol";
+import { SD1x18 } from "@prb/math/src/sd1x18/ValueType.sol";
+import { sd, sd59x18, wrap } from "@prb/math/src/sd59x18/Casting.sol";
+import { MAX_SD59x18, MIN_SD59x18 } from "@prb/math/src/sd59x18/Constants.sol";
 import {
     PRBMath_SD59x18_IntoSD1x18_Overflow,
     PRBMath_SD59x18_IntoSD1x18_Underflow,
@@ -16,11 +16,11 @@ import {
     PRBMath_SD59x18_IntoUint128_Underflow,
     PRBMath_SD59x18_IntoUint40_Overflow,
     PRBMath_SD59x18_IntoUint40_Underflow
-} from "src/sd59x18/Errors.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
-import { uMAX_UD2x18 } from "src/ud2x18/Constants.sol";
-import { UD2x18 } from "src/ud2x18/ValueType.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+} from "@prb/math/src/sd59x18/Errors.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
+import { uMAX_UD2x18 } from "@prb/math/src/ud2x18/Constants.sol";
+import { UD2x18 } from "@prb/math/src/ud2x18/ValueType.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/helpers/Helpers.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/helpers/Helpers.t.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import {
+    add,
+    and,
+    eq,
+    gt,
+    gte,
+    isZero,
+    lshift,
+    lt,
+    lte,
+    mod,
+    neq,
+    or,
+    rshift,
+    sub,
+    unary,
+    uncheckedAdd,
+    uncheckedSub,
+    xor,
+    not
+} from "src/sd59x18/Helpers.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { Base_Test } from "../../../Base.t.sol";
+
+/// @dev Collection of tests for the helpers functions available in the SD59x18 type.
+contract SD59x18_Helpers_Fuzz_Test is Base_Test {
+    int256 internal constant HALF_MAX_INT256 = MAX_INT256 / 2;
+    int256 internal constant HALF_MIN_INT256 = MIN_INT256 / 2;
+
+    function testFuzz_Add(SD59x18 x, SD59x18 y) external pure {
+        x = _bound(x, HALF_MIN_INT256, HALF_MAX_INT256);
+        y = _bound(y, HALF_MIN_INT256, HALF_MAX_INT256);
+        SD59x18 expected = sd(x.unwrap() + y.unwrap());
+        assertEq(add(x, y), expected, "SD59x18 add");
+        assertEq(x + y, expected, "SD59x18 +");
+    }
+
+    function testFuzz_And(int256 x, int256 y) external pure {
+        SD59x18 expected = sd(x & y);
+        assertEq(and(sd(x), y), expected, "SD59x18 and");
+        assertEq(sd(x) & sd(y), expected, "SD59x18 &");
+    }
+
+    function testFuzz_Eq(int256 x) external pure {
+        int256 y = x;
+        assertTrue(eq(sd(x), sd(y)), "SD59x18 eq");
+        assertTrue(sd(x) == sd(y), "SD59x18 ==");
+    }
+
+    function testFuzz_Gt(int256 x, int256 y) external pure {
+        vm.assume(x > y);
+        assertTrue(gt(sd(x), sd(y)), "SD59x18 gt");
+        assertTrue(sd(x) > sd(y), "SD59x18 >");
+    }
+
+    function testFuzz_Gte(int256 x, int256 y) external pure {
+        vm.assume(x >= y);
+        assertTrue(gte(sd(x), sd(y)), "SD59x18 gte");
+        assertTrue(sd(x) >= sd(y), "SD59x18 >=");
+    }
+
+    function testFuzz_IsZero(SD59x18 x) external pure {
+        bool actual = isZero(x);
+        bool expected = x == sd(0);
+        assertEq(actual, expected, "SD59x18 isZero");
+    }
+
+    function testFuzz_Lshift(int256 x, uint256 y) external pure {
+        _bound(y, 0, 512);
+        SD59x18 expected = sd(x << y);
+        assertEq(lshift(sd(x), y), expected, "SD59x18 lshift");
+    }
+
+    function testFuzz_Lt(int256 x, int256 y) external pure {
+        vm.assume(x < y);
+        assertTrue(lt(sd(x), sd(y)), "SD59x18 lt");
+        assertTrue(sd(x) < sd(y), "SD59x18 <");
+    }
+
+    function testFuzz_Lte(int256 x, int256 y) external pure {
+        vm.assume(x <= y);
+        assertTrue(lte(sd(x), sd(y)), "SD59x18 lte");
+        assertTrue(sd(x) <= sd(y), "SD59x18 <=");
+    }
+
+    function testFuzz_Mod(int256 x, int256 y) external pure {
+        vm.assume(y != 0);
+        SD59x18 expected = sd(x % y);
+        assertEq(mod(sd(x), sd(y)), expected, "SD59x18 mod");
+        assertEq(sd(x) % sd(y), expected, "SD59x18 %");
+    }
+
+    function testFuzz_Neq(int256 x, int256 y) external pure {
+        vm.assume(x != y);
+        assertTrue(neq(sd(x), sd(y)), "SD59x18 neq");
+        assertTrue(sd(x) != sd(y), "SD59x18 !=");
+    }
+
+    function testFuzz_Not(int256 x) external pure {
+        SD59x18 expected = sd(~x);
+        assertEq(not(sd(x)), expected, "SD59x18 not");
+        assertEq(~sd(x), expected, "SD59x18 ~");
+    }
+
+    function testFuzz_Or(int256 x, int256 y) external pure {
+        SD59x18 expected = sd(x | y);
+        assertEq(or(sd(x), sd(y)), expected, "SD59x18 or");
+        assertEq(sd(x) | sd(y), expected, "SD59x18 |");
+    }
+
+    function testFuzz_Rshift(int256 x, uint256 y) external pure {
+        _bound(y, 0, 512);
+        SD59x18 expected = sd(x >> y);
+        assertEq(rshift(sd(x), y), expected, "SD59x18 rshift");
+    }
+
+    function testFuzz_Sub(SD59x18 x, SD59x18 y) external pure {
+        x = _bound(x, HALF_MIN_INT256, HALF_MAX_INT256);
+        y = _bound(y, HALF_MIN_INT256, HALF_MAX_INT256);
+        SD59x18 expected = sd(x.unwrap() - y.unwrap());
+        assertEq(sub(x, y), expected, "SD59x18 sub");
+        assertEq(x - y, expected, "SD59x18 -");
+    }
+
+    function testFuzz_Unary(int256 x) external pure {
+        // Cannot take unary of MIN_INT256, because its absolute value would be 1 unit larger than MAX_INT256.
+        x = _bound(x, MIN_INT256 + 1, MAX_INT256);
+        SD59x18 expected = sd(-x);
+        assertEq(unary(sd(x)), expected, "SD59x18 unary");
+        assertEq(-sd(x), expected, "SD59x18 -");
+    }
+
+    function testFuzz_UncheckedAdd(int256 x, int256 y) external pure {
+        unchecked {
+            SD59x18 expected = sd(x + y);
+            SD59x18 actual = uncheckedAdd(sd(x), sd(y));
+            assertEq(actual, expected, "SD59x18 uncheckedAdd");
+        }
+    }
+
+    function testFuzz_UncheckedSub(int256 x, int256 y) external pure {
+        unchecked {
+            SD59x18 expected = sd(x - y);
+            SD59x18 actual = uncheckedSub(sd(x), sd(y));
+            assertEq(actual, expected, "SD59x18 uncheckedSub");
+        }
+    }
+
+    function testFuzz_Xor(int256 x, int256 y) external pure {
+        SD59x18 expected = sd(x ^ y);
+        assertEq(xor(sd(x), sd(y)), expected, "SD59x18 xor");
+        assertEq(sd(x) ^ sd(y), expected, "SD59x18 ^");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/helpers/Helpers.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/helpers/Helpers.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
 import {
     add,
     and,
@@ -22,8 +22,8 @@ import {
     uncheckedSub,
     xor,
     not
-} from "src/sd59x18/Helpers.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+} from "@prb/math/src/sd59x18/Helpers.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/math/pow/pow.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/math/pow/pow.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { UNIT, ZERO } from "src/sd59x18/Constants.sol";
+import { pow } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { Base_Test } from "../../../../Base.t.sol";
+
+contract Pow_Fuzz_Test is Base_Test {
+    function testFuzz_Pow_BaseZero_ExponentNotZero(SD59x18 y) external pure {
+        vm.assume(y != ZERO);
+        SD59x18 x = ZERO;
+        SD59x18 actual = pow(x, y);
+        SD59x18 expected = ZERO;
+        assertEq(actual, expected, "SD59x18 pow");
+    }
+
+    modifier whenBaseNotZero() {
+        _;
+    }
+
+    function testFuzz_Pow_BaseUnit(SD59x18 y) external pure whenBaseNotZero {
+        SD59x18 x = UNIT;
+        SD59x18 actual = pow(x, y);
+        SD59x18 expected = UNIT;
+        assertEq(actual, expected, "SD59x18 pow");
+    }
+
+    modifier whenBaseNotUnit() {
+        _;
+    }
+
+    function testFuzz_Pow_ExponentZero(SD59x18 x) external pure whenBaseNotZero whenBaseNotUnit {
+        vm.assume(x != ZERO && x != UNIT);
+        SD59x18 y = ZERO;
+        SD59x18 actual = pow(x, y);
+        SD59x18 expected = UNIT;
+        assertEq(actual, expected, "SD59x18 pow");
+    }
+
+    modifier whenExponentNotZero() {
+        _;
+    }
+
+    function testFuzz_Pow_ExponentUnit(SD59x18 x) external pure whenBaseNotZero whenBaseNotUnit whenExponentNotZero {
+        vm.assume(x != ZERO && x != UNIT);
+        SD59x18 y = UNIT;
+        SD59x18 actual = pow(x, y);
+        SD59x18 expected = x;
+        assertEq(actual, expected, "SD59x18 pow");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/math/pow/pow.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/sd59x18/math/pow/pow.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { UNIT, ZERO } from "src/sd59x18/Constants.sol";
-import { pow } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { UNIT, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { pow } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { Base_Test } from "../../../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/fuzz/ud2x18/casting/Casting.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/ud2x18/casting/Casting.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { uMAX_SD1x18 } from "src/sd1x18/Constants.sol";
+import { SD1x18 } from "src/sd1x18/ValueType.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { ud2x18, wrap } from "src/ud2x18/Casting.sol";
+import { uMAX_UD2x18 } from "src/ud2x18/Constants.sol";
+import { PRBMath_UD2x18_IntoSD1x18_Overflow, PRBMath_UD2x18_IntoUint40_Overflow } from "src/ud2x18/Errors.sol";
+import { UD2x18 } from "src/ud2x18/ValueType.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { Base_Test } from "../../../Base.t.sol";
+
+/// @dev Collection of tests for the casting functions available in UD2x18.
+contract UD2x18_Casting_Fuzz_Test is Base_Test {
+    function testFuzz_RevertWhen_OverflowSD1x18(UD2x18 x) external {
+        x = _bound(x, uint64(uMAX_SD1x18) + 1, uMAX_UD2x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD2x18_IntoSD1x18_Overflow.selector, x));
+        x.intoSD1x18();
+    }
+
+    function testFuzz_IntoSD1x18(UD2x18 x) external pure {
+        x = _bound(x, 0, uint64(uMAX_SD1x18));
+        SD1x18 actual = x.intoSD1x18();
+        SD1x18 expected = SD1x18.wrap(int64(uint64(x.unwrap())));
+        assertEq(actual, expected, "UD2x18 intoSD1x18");
+    }
+
+    function testFuzz_IntoSD59x18(UD2x18 x) external pure {
+        SD59x18 actual = x.intoSD59x18();
+        SD59x18 expected = SD59x18.wrap(int256(uint256(x.unwrap())));
+        assertEq(actual, expected, "UD2x18 intoSD59x18");
+    }
+
+    function testFuzz_IntoUD60x18(UD2x18 x) external pure {
+        UD60x18 actual = x.intoUD60x18();
+        UD60x18 expected = UD60x18.wrap(uint256(x.unwrap()));
+        assertEq(actual, expected, "UD2x18 intoUD60x18");
+    }
+
+    function testFuzz_IntoUint128(UD2x18 x) external pure {
+        uint128 actual = x.intoUint128();
+        uint128 expected = uint128(x.unwrap());
+        assertEq(actual, expected, "UD2x18 intoUint128");
+    }
+
+    function testFuzz_IntoUint256(UD2x18 x) external pure {
+        uint256 actual = x.intoUint256();
+        uint256 expected = uint256(x.unwrap());
+        assertEq(actual, expected, "UD2x18 intoUint256");
+    }
+
+    function testFuzz_RevertWhen_OverflowUint40(UD2x18 x) external {
+        x = _bound(x, uint64(MAX_UINT40) + 1, uMAX_UD2x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD2x18_IntoUint40_Overflow.selector, x));
+        x.intoUint40();
+    }
+
+    function testFuzz_IntoUint40(UD2x18 x) external pure {
+        x = _bound(x, 0, uint64(MAX_UINT40));
+        uint40 actual = x.intoUint40();
+        uint40 expected = uint40(x.unwrap());
+        assertEq(actual, expected, "UD2x18 intoUint40");
+    }
+
+    function testFuzz_ud2x18(uint64 x) external pure {
+        UD2x18 actual = ud2x18(x);
+        UD2x18 expected = UD2x18.wrap(x);
+        assertEq(actual, expected, "ud2x18");
+    }
+
+    function testFuzz_Unwrap(UD2x18 x) external pure {
+        uint64 actual = x.unwrap();
+        uint64 expected = UD2x18.unwrap(x);
+        assertEq(actual, expected, "UD2x18 unwrap");
+    }
+
+    function testFuzz_Wrap(uint64 x) external pure {
+        UD2x18 actual = wrap(x);
+        UD2x18 expected = UD2x18.wrap(x);
+        assertEq(actual, expected, "UD2x18 wrap");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/ud2x18/casting/Casting.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/ud2x18/casting/Casting.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { uMAX_SD1x18 } from "src/sd1x18/Constants.sol";
-import { SD1x18 } from "src/sd1x18/ValueType.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
-import { ud2x18, wrap } from "src/ud2x18/Casting.sol";
-import { uMAX_UD2x18 } from "src/ud2x18/Constants.sol";
-import { PRBMath_UD2x18_IntoSD1x18_Overflow, PRBMath_UD2x18_IntoUint40_Overflow } from "src/ud2x18/Errors.sol";
-import { UD2x18 } from "src/ud2x18/ValueType.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { uMAX_SD1x18 } from "@prb/math/src/sd1x18/Constants.sol";
+import { SD1x18 } from "@prb/math/src/sd1x18/ValueType.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
+import { ud2x18, wrap } from "@prb/math/src/ud2x18/Casting.sol";
+import { uMAX_UD2x18 } from "@prb/math/src/ud2x18/Constants.sol";
+import { PRBMath_UD2x18_IntoSD1x18_Overflow, PRBMath_UD2x18_IntoUint40_Overflow } from "@prb/math/src/ud2x18/Errors.sol";
+import { UD2x18 } from "@prb/math/src/ud2x18/ValueType.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/casting/Casting.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/casting/Casting.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { uMAX_SD1x18 } from "src/sd1x18/Constants.sol";
+import { SD1x18 } from "src/sd1x18/ValueType.sol";
+import { uMAX_SD59x18 } from "src/sd59x18/Constants.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { uMAX_UD2x18 } from "src/ud2x18/Constants.sol";
+import { UD2x18 } from "src/ud2x18/ValueType.sol";
+import { ud, ud60x18, wrap } from "src/ud60x18/Casting.sol";
+import { MAX_UD60x18 } from "src/ud60x18/Constants.sol";
+import {
+    PRBMath_UD60x18_IntoSD1x18_Overflow,
+    PRBMath_UD60x18_IntoSD59x18_Overflow,
+    PRBMath_UD60x18_IntoUD2x18_Overflow,
+    PRBMath_UD60x18_IntoUint128_Overflow,
+    PRBMath_UD60x18_IntoUint40_Overflow
+} from "src/ud60x18/Errors.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { Base_Test } from "../../../Base.t.sol";
+
+/// @dev Collection of tests for the casting functions available in UD60x18.
+contract UD60x18_Casting_Fuzz_Test is Base_Test {
+    function testFuzz_RevertWhen_OverflowSD1x18(UD60x18 x) external {
+        x = _bound(x, ud(uint64(uMAX_SD1x18) + 1), MAX_UD60x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_IntoSD1x18_Overflow.selector, x));
+        x.intoSD1x18();
+    }
+
+    function testFuzz_intoSD1x18(UD60x18 x) external pure {
+        x = _bound(x, 0, ud(uint64(uMAX_SD1x18)));
+        SD1x18 actual = x.intoSD1x18();
+        SD1x18 expected = SD1x18.wrap(int64(uint64(x.unwrap())));
+        assertEq(actual, expected, "UD60x18 intoSD1x18");
+    }
+
+    function testFuzz_RevertWhen_OverflowSD59x18(UD60x18 x) external {
+        x = _bound(x, ud(uint256(uMAX_SD59x18) + 1), MAX_UD60x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_IntoSD59x18_Overflow.selector, x));
+        x.intoSD59x18();
+    }
+
+    function testFuzz_intoSD59x18(UD60x18 x) external pure {
+        x = _bound(x, 0, ud(uint256(uMAX_SD59x18)));
+        SD59x18 actual = x.intoSD59x18();
+        SD59x18 expected = SD59x18.wrap(int256(uint256(x.unwrap())));
+        assertEq(actual, expected, "UD60x18 intoSD59x18");
+    }
+
+    function testFuzz_RevertWhen_OverflowUD2x18(UD60x18 x) external {
+        x = _bound(x, ud(uint256(uMAX_UD2x18) + 1), MAX_UD60x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_IntoUD2x18_Overflow.selector, x));
+        x.intoUD2x18();
+    }
+
+    function testFuzz_intoUD2x18(UD60x18 x) external pure {
+        x = _bound(x, 0, ud(uint256(uMAX_UD2x18)));
+        UD2x18 actual = x.intoUD2x18();
+        UD2x18 expected = UD2x18.wrap(uint64(x.unwrap()));
+        assertEq(actual, expected, "UD60x18 intoUD2x18");
+    }
+
+    function testFuzz_RevertWhen_OverflowUint128(UD60x18 x) external {
+        x = _bound(x, ud(uint256(MAX_UINT128) + 1), MAX_UD60x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_IntoUint128_Overflow.selector, x));
+        x.intoUint128();
+    }
+
+    function testFuzz_intoUint128(UD60x18 x) external pure {
+        x = _bound(x, 0, ud(uint256(MAX_UINT128)));
+        uint128 actual = x.intoUint128();
+        uint128 expected = uint128(x.unwrap());
+        assertEq(actual, expected, "UD60x18 intoUint128");
+    }
+
+    function testFuzz_intoUint256(UD60x18 x) external pure {
+        uint256 actual = x.intoUint256();
+        uint256 expected = x.unwrap();
+        assertEq(actual, expected, "UD60x18 intoUint256");
+    }
+
+    function testFuzz_RevertWhen_OverflowUint40(UD60x18 x) external {
+        x = _bound(x, ud(uint256(MAX_UINT40) + 1), MAX_UD60x18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_IntoUint40_Overflow.selector, x));
+        x.intoUint40();
+    }
+
+    function testFuzz_intoUint40(UD60x18 x) external pure {
+        x = _bound(x, 0, ud(uint256(MAX_UINT40)));
+        uint40 actual = uint40(x.intoUint40());
+        uint40 expected = uint40(x.unwrap());
+        assertEq(actual, expected, "UD60x18 intoUint40");
+    }
+
+    function testFuzz_Ud(uint256 x) external pure {
+        UD60x18 actual = ud(x);
+        UD60x18 expected = UD60x18.wrap(x);
+        assertEq(actual, expected, "ud");
+    }
+
+    function testFuzz_UD60x18(uint256 x) external pure {
+        UD60x18 actual = ud60x18(x);
+        UD60x18 expected = UD60x18.wrap(x);
+        assertEq(actual, expected, "ud60x18");
+    }
+
+    function testFuzz_Unwrap(UD60x18 x) external pure {
+        uint256 actual = x.unwrap();
+        uint256 expected = UD60x18.unwrap(x);
+        assertEq(actual, expected, "UD60x18 unwrap");
+    }
+
+    function testFuzz_Wrap(uint256 x) external pure {
+        UD60x18 actual = wrap(x);
+        UD60x18 expected = UD60x18.wrap(x);
+        assertEq(actual, expected, "UD60x18 wrap");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/casting/Casting.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/casting/Casting.t.sol
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { uMAX_SD1x18 } from "src/sd1x18/Constants.sol";
-import { SD1x18 } from "src/sd1x18/ValueType.sol";
-import { uMAX_SD59x18 } from "src/sd59x18/Constants.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
-import { uMAX_UD2x18 } from "src/ud2x18/Constants.sol";
-import { UD2x18 } from "src/ud2x18/ValueType.sol";
-import { ud, ud60x18, wrap } from "src/ud60x18/Casting.sol";
-import { MAX_UD60x18 } from "src/ud60x18/Constants.sol";
+import { uMAX_SD1x18 } from "@prb/math/src/sd1x18/Constants.sol";
+import { SD1x18 } from "@prb/math/src/sd1x18/ValueType.sol";
+import { uMAX_SD59x18 } from "@prb/math/src/sd59x18/Constants.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
+import { uMAX_UD2x18 } from "@prb/math/src/ud2x18/Constants.sol";
+import { UD2x18 } from "@prb/math/src/ud2x18/ValueType.sol";
+import { ud, ud60x18, wrap } from "@prb/math/src/ud60x18/Casting.sol";
+import { MAX_UD60x18 } from "@prb/math/src/ud60x18/Constants.sol";
 import {
     PRBMath_UD60x18_IntoSD1x18_Overflow,
     PRBMath_UD60x18_IntoSD59x18_Overflow,
     PRBMath_UD60x18_IntoUD2x18_Overflow,
     PRBMath_UD60x18_IntoUint128_Overflow,
     PRBMath_UD60x18_IntoUint40_Overflow
-} from "src/ud60x18/Errors.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+} from "@prb/math/src/ud60x18/Errors.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/helpers/Helpers.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/helpers/Helpers.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { ud } from "src/ud60x18/Casting.sol";
+import {
+    add,
+    and,
+    eq,
+    gt,
+    gte,
+    isZero,
+    lshift,
+    lt,
+    lte,
+    mod,
+    neq,
+    or,
+    rshift,
+    sub,
+    uncheckedAdd,
+    uncheckedSub,
+    xor,
+    not
+} from "src/ud60x18/Helpers.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { Base_Test } from "../../../Base.t.sol";
+
+/// @dev Collection of tests for the helpers functions available in the UD60x18 type.
+contract UD60x18_Helpers_Fuzz_Test is Base_Test {
+    uint256 internal constant HALF_MAX_UINT256 = type(uint256).max / 2;
+
+    function testFuzz_Add(UD60x18 x, UD60x18 y) external pure {
+        x = _bound(x, 0, HALF_MAX_UINT256);
+        y = _bound(y, 0, HALF_MAX_UINT256);
+        UD60x18 expected = ud(x.unwrap() + y.unwrap());
+        assertEq(add(x, y), expected, "UD60x18 add");
+        assertEq(x + y, expected, "UD60x18 +");
+    }
+
+    function testFuzz_And(uint256 x, uint256 y) external pure {
+        UD60x18 expected = ud(x & y);
+        assertEq(and(ud(x), y), expected, "UD60x18 and");
+        assertEq(ud(x) & ud(y), expected, "UD60x18 &");
+    }
+
+    function testFuzz_Eq(uint256 x) external pure {
+        uint256 y = x;
+        assertTrue(eq(ud(x), ud(y)), "UD60x18 eq");
+        assertTrue(ud(x) == ud(y), "UD60x18 ==");
+    }
+
+    function testFuzz_Gt(uint256 x, uint256 y) external pure {
+        vm.assume(x > y);
+        assertTrue(gt(ud(x), ud(y)), "UD60x18 gt");
+        assertTrue(ud(x) > ud(y), "UD60x18 >");
+    }
+
+    function testFuzz_Gte(uint256 x, uint256 y) external pure {
+        vm.assume(x >= y);
+        assertTrue(gte(ud(x), ud(y)), "UD60x18 gte");
+        assertTrue(ud(x) >= ud(y), "UD60x18 >=");
+    }
+
+    function testFuzz_IsZero(UD60x18 x) external pure {
+        bool actual = isZero(x);
+        bool expected = x == ud(0);
+        assertEq(actual, expected, "SD59x18 isZero");
+    }
+
+    function testFuzz_Lshift(uint256 x, uint256 y) external pure {
+        vm.assume(y <= 512);
+        UD60x18 expected = ud(x << y);
+        assertEq(lshift(ud(x), y), expected, "UD60x18 lshift");
+    }
+
+    function testFuzz_Lt(uint256 x, uint256 y) external pure {
+        vm.assume(x < y);
+        assertTrue(lt(ud(x), ud(y)), "UD60x18 lt");
+        assertTrue(ud(x) < ud(y), "UD60x18 <");
+    }
+
+    function testFuzz_Lte(uint256 x, uint256 y) external pure {
+        vm.assume(x <= y);
+        assertTrue(lte(ud(x), ud(y)), "UD60x18 lte");
+        assertTrue(ud(x) <= ud(y), "UD60x18 <=");
+    }
+
+    function testFuzz_Mod(uint256 x, uint256 y) external pure {
+        vm.assume(y > 0);
+        UD60x18 expected = ud(x % y);
+        assertEq(mod(ud(x), ud(y)), expected, "UD60x18 mod");
+        assertEq(ud(x) % ud(y), expected, "UD60x18 %");
+    }
+
+    function testFuzz_Neq(uint256 x, uint256 y) external pure {
+        vm.assume(x != y);
+        assertTrue(neq(ud(x), ud(y)), "UD60x18 neq");
+        assertTrue(ud(x) != ud(y), "UD60x18 !=");
+    }
+
+    function testFuzz_Not(uint256 x) external pure {
+        UD60x18 expected = ud(~x);
+        assertEq(not(ud(x)), expected, "UD60x18 not");
+        assertEq(~ud(x), expected, "UD60x18 ~");
+    }
+
+    function testFuzz_Or(uint256 x, uint256 y) external pure {
+        UD60x18 expected = ud(x | y);
+        assertEq(or(ud(x), ud(y)), expected, "UD60x18 or");
+        assertEq(ud(x) | ud(y), expected, "UD60x18 |");
+    }
+
+    function testFuzz_Rshift(uint256 x, uint256 y) external pure {
+        vm.assume(y <= 512);
+        UD60x18 expected = ud(x >> y);
+        assertEq(rshift(ud(x), y), expected, "UD60x18 rshift");
+    }
+
+    function testFuzz_Sub(uint256 x, uint256 y) external pure {
+        vm.assume(x >= y);
+        UD60x18 expected = ud(x - y);
+        assertEq(sub(ud(x), ud(y)), expected, "UD60x18 sub");
+        assertEq(ud(x) - ud(y), expected, "UD60x18 -");
+    }
+
+    function testFuzz_UncheckedAdd(uint256 x, uint256 y) external pure {
+        unchecked {
+            UD60x18 expected = ud(x + y);
+            UD60x18 actual = uncheckedAdd(ud(x), ud(y));
+            assertEq(actual, expected, "UD60x18 uncheckedAdd");
+        }
+    }
+
+    function testFuzz_UncheckedSub(uint256 x, uint256 y) external pure {
+        unchecked {
+            UD60x18 expected = ud(x - y);
+            UD60x18 actual = uncheckedSub(ud(x), ud(y));
+            assertEq(actual, expected, "UD60x18 uncheckedSub");
+        }
+    }
+
+    function testFuzz_Xor(uint256 x, uint256 y) external pure {
+        UD60x18 expected = ud(x ^ y);
+        assertEq(xor(ud(x), ud(y)), expected, "UD60x18 xor");
+        assertEq(ud(x) ^ ud(y), expected, "UD60x18 ^");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/helpers/Helpers.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/helpers/Helpers.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { ud } from "src/ud60x18/Casting.sol";
+import { ud } from "@prb/math/src/ud60x18/Casting.sol";
 import {
     add,
     and,
@@ -21,8 +21,8 @@ import {
     uncheckedSub,
     xor,
     not
-} from "src/ud60x18/Helpers.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+} from "@prb/math/src/ud60x18/Helpers.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { Base_Test } from "../../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/math/pow/pow.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/math/pow/pow.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { UNIT, ZERO } from "src/ud60x18/Constants.sol";
+import { pow } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { Base_Test } from "../../../../Base.t.sol";
+
+contract Pow_Fuzz_Test is Base_Test {
+    function testFuzz_Pow_BaseZero_ExponentNotZero(UD60x18 y) external pure {
+        vm.assume(y != ZERO);
+        UD60x18 x = ZERO;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = ZERO;
+        assertEq(actual, expected, "UD60x18 pow");
+    }
+
+    modifier whenBaseNotZero() {
+        _;
+    }
+
+    function testFuzz_Pow_BaseUnit(UD60x18 y) external pure whenBaseNotZero {
+        UD60x18 x = UNIT;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = UNIT;
+        assertEq(actual, expected, "UD60x18 pow");
+    }
+
+    modifier whenBaseNotUnit() {
+        _;
+    }
+
+    function testFuzz_Pow_ExponentZero(UD60x18 x) external pure whenBaseNotZero whenBaseNotUnit {
+        vm.assume(x != ZERO && x != UNIT);
+        UD60x18 y = ZERO;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = UNIT;
+        assertEq(actual, expected, "UD60x18 pow");
+    }
+
+    modifier whenExponentNotZero() {
+        _;
+    }
+
+    function testFuzz_Pow_ExponentUnit(UD60x18 x) external pure whenBaseNotZero whenBaseNotUnit whenExponentNotZero {
+        vm.assume(x != ZERO && x != UNIT);
+        UD60x18 y = UNIT;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = x;
+        assertEq(actual, expected, "UD60x18 pow");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/math/pow/pow.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/fuzz/ud60x18/math/pow/pow.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { UNIT, ZERO } from "src/ud60x18/Constants.sol";
-import { pow } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { UNIT, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { pow } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { Base_Test } from "../../../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/SD59x18.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/SD59x18.t.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { console2 } from "forge-std/src/console2.sol";
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { ZERO } from "src/sd59x18/Constants.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { Base_Test } from "../../Base.t.sol";
+
+/// @notice Common logic needed by all SD59x18 unit tests.
+abstract contract SD59x18_Unit_Test is Base_Test {
+    /*//////////////////////////////////////////////////////////////////////////
+                                      CONSTANTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    SD59x18 internal constant MAX_SCALED_SD59x18 = SD59x18.wrap(57896044618658097711785492504343953926634_992332820282019728);
+    SD59x18 internal constant MIN_SCALED_SD59x18 = SD59x18.wrap(-57896044618658097711785492504343953926634_992332820282019728);
+    SD59x18 internal constant NEGATIVE_E = SD59x18.wrap(-2_718281828459045235);
+    SD59x18 internal constant NEGATIVE_PI = SD59x18.wrap(-3_141592653589793238);
+    SD59x18 internal constant SQRT_MAX_SD59x18 = SD59x18.wrap(240615969168004511545033772477_625056927114980741);
+    SD59x18 internal constant SQRT_MAX_UD60x18 = SD59x18.wrap(340282366920938463463374607431_768211455999999999);
+    SD59x18 internal constant NEGATIVE_SQRT_MAX_SD59x18 = SD59x18.wrap(-240615969168004511545033772477_625056927114980741);
+    SD59x18 internal constant NEGATIVE_SQRT_MAX_UD60x18 = SD59x18.wrap(-340282366920938463463374607431_768211455999999999);
+
+    /// @dev This is needed to be passed as the "expected" argument. The "set" function cannot be overridden
+    /// to have two implementations that each has two "int256" arguments.
+    SD59x18 internal constant NIL = ZERO;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                       STRUCTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    struct Set {
+        SD59x18 x;
+        SD59x18 y;
+        SD59x18 expected;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+
+    Set internal s;
+    Set[] internal sets;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      MODIFIERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    modifier parameterizedTest(Set[] memory testSets) {
+        uint256 length = testSets.length;
+        for (uint256 i = 0; i < length;) {
+            s = testSets[i];
+            _;
+            unchecked {
+                i += 1;
+            }
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                              CONSTANT HELPER FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function logSd(SD59x18 p0) internal pure {
+        console2.logInt(p0.unwrap());
+    }
+
+    function sdToUint(SD59x18 x) internal pure returns (uint256 result) {
+        result = uint256(x.unwrap());
+    }
+
+    function set(int256 x) internal pure returns (Set memory) {
+        return Set({ x: sd(x), y: ZERO, expected: ZERO });
+    }
+
+    function set(SD59x18 x) internal pure returns (Set memory) {
+        return Set({ x: x, y: ZERO, expected: ZERO });
+    }
+
+    function set(int256 x, int256 expected) internal pure returns (Set memory) {
+        return Set({ x: sd(x), y: ZERO, expected: sd(expected) });
+    }
+
+    function set(int256 x, SD59x18 expected) internal pure returns (Set memory) {
+        return Set({ x: sd(x), y: ZERO, expected: expected });
+    }
+
+    function set(SD59x18 x, int256 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: ZERO, expected: sd(expected) });
+    }
+
+    function set(SD59x18 x, SD59x18 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: ZERO, expected: expected });
+    }
+
+    function set(int256 x, int256 y, int256 expected) internal pure returns (Set memory) {
+        return Set({ x: sd(x), y: sd(y), expected: sd(expected) });
+    }
+
+    function set(int256 x, int256 y, SD59x18 expected) internal pure returns (Set memory) {
+        return Set({ x: sd(x), y: sd(y), expected: expected });
+    }
+
+    function set(int256 x, SD59x18 y, int256 expected) internal pure returns (Set memory) {
+        return Set({ x: sd(x), y: y, expected: sd(expected) });
+    }
+
+    function set(int256 x, SD59x18 y, SD59x18 expected) internal pure returns (Set memory) {
+        return Set({ x: sd(x), y: y, expected: expected });
+    }
+
+    function set(SD59x18 x, int256 y, int256 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: sd(y), expected: sd(expected) });
+    }
+
+    function set(SD59x18 x, SD59x18 y, int256 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: y, expected: sd(expected) });
+    }
+
+    function set(SD59x18 x, int256 y, SD59x18 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: sd(y), expected: expected });
+    }
+
+    function set(SD59x18 x, SD59x18 y, SD59x18 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: y, expected: expected });
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/SD59x18.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/SD59x18.t.sol
@@ -3,9 +3,9 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { console2 } from "forge-std/src/console2.sol";
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { ZERO } from "src/sd59x18/Constants.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 import { Base_Test } from "../../Base.t.sol";
 
 /// @notice Common logic needed by all SD59x18 unit tests.

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/conversion/convert-from/convertFrom.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/conversion/convert-from/convertFrom.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI } from "src/sd59x18/Constants.sol";
+import { convert } from "src/sd59x18/Conversions.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract ConvertFrom_Unit_Test is SD59x18_Unit_Test {
+    function ltAbsoluteUnit_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: -1e18 + 1 }));
+        sets.push(set({ x: -1 }));
+        sets.push(set({ x: 0 }));
+        sets.push(set({ x: 1 }));
+        sets.push(set({ x: 1e18 - 1 }));
+        return sets;
+    }
+
+    function test_ConvertFrom_LtAbsoluteUnit() external parameterizedTest(ltAbsoluteUnit_Sets()) {
+        int256 actual = convert(s.x);
+        int256 expected = 0;
+        assertEq(actual, expected, "SD59x18 convertFrom");
+    }
+
+    modifier whenGteAbsoluteUnit() {
+        _;
+    }
+
+    function gteAbsoluteUnit_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18, expected: MIN_SCALED_SD59x18 }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18, expected: MIN_SCALED_SD59x18 }));
+        sets.push(set({ x: -4.2e45, expected: -4.2e27 }));
+        sets.push(set({ x: -1729e18, expected: -0.000000000000001729e18 }));
+        sets.push(set({ x: NEGATIVE_PI, expected: -0.000000000000000003e18 }));
+        sets.push(set({ x: NEGATIVE_E, expected: -0.000000000000000002e18 }));
+        sets.push(set({ x: -2e18 - 1, expected: -0.000000000000000002e18 }));
+        sets.push(set({ x: -2e18, expected: -0.000000000000000002e18 }));
+        sets.push(set({ x: -2e18 + 1, expected: -0.000000000000000001e18 }));
+        sets.push(set({ x: -1e18, expected: -0.000000000000000001e18 }));
+        sets.push(set({ x: 1e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 1e18 + 1, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 2e18 - 1, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 2e18, expected: 0.000000000000000002e18 }));
+        sets.push(set({ x: 2e18 + 1, expected: 0.000000000000000002e18 }));
+        sets.push(set({ x: E, expected: 0.000000000000000002e18 }));
+        sets.push(set({ x: PI, expected: 0.000000000000000003e18 }));
+        sets.push(set({ x: 1729e18, expected: 0.000000000000001729e18 }));
+        sets.push(set({ x: 4.2e45, expected: 4.2e27 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, expected: MAX_SCALED_SD59x18 }));
+        sets.push(set({ x: MAX_SD59x18, expected: MAX_SCALED_SD59x18 }));
+        return sets;
+    }
+
+    function test_ConvertFrom() external parameterizedTest(gteAbsoluteUnit_Sets()) whenGteAbsoluteUnit {
+        int256 actual = convert(s.x);
+        int256 expected = s.expected.unwrap();
+        assertEq(actual, expected, "SD59x18 convertFrom");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/conversion/convert-from/convertFrom.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/conversion/convert-from/convertFrom.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI } from "src/sd59x18/Constants.sol";
-import { convert } from "src/sd59x18/Conversions.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI } from "@prb/math/src/sd59x18/Constants.sol";
+import { convert } from "@prb/math/src/sd59x18/Conversions.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/conversion/convert-to/convertTo.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/conversion/convert-to/convertTo.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { MAX_WHOLE_SD59x18, MIN_WHOLE_SD59x18 } from "src/sd59x18/Constants.sol";
+import { convert } from "src/sd59x18/Conversions.sol";
+import { PRBMath_SD59x18_Convert_Overflow, PRBMath_SD59x18_Convert_Underflow } from "src/sd59x18/Errors.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract ConvertTo_Unit_Test is SD59x18_Unit_Test {
+    function test_RevertWhen_LtMinPermitted() external {
+        int256 x = MIN_SCALED_SD59x18.unwrap() - 1;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Convert_Underflow.selector, x));
+        convert(x);
+    }
+
+    modifier whenGteMinPermitted() {
+        _;
+    }
+
+    function test_RevertWhen_GtMaxPermitted() external whenGteMinPermitted {
+        int256 x = MAX_SCALED_SD59x18.unwrap() + 1;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Convert_Overflow.selector, x));
+        convert(x);
+    }
+
+    modifier whenLteMaxPermitted() {
+        _;
+    }
+
+    function convertTo_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SCALED_SD59x18, expected: MIN_WHOLE_SD59x18 }));
+        sets.push(set({ x: -3.1415e42, expected: -3.1415e60 }));
+        sets.push(set({ x: -2.7182e38, expected: -2.7182e56 }));
+        sets.push(set({ x: -1e24, expected: -1e42 }));
+        sets.push(set({ x: -5e18, expected: -5e36 }));
+        sets.push(set({ x: -1e18, expected: -1e36 }));
+        sets.push(set({ x: -0.000000000000001729e18, expected: -1729e18 }));
+        sets.push(set({ x: -0.000000000000000002e18, expected: -2e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, expected: -1e18 }));
+        sets.push(set({ x: 0.000000000000000001e18, expected: 1e18 }));
+        sets.push(set({ x: 0.000000000000000002e18, expected: 2e18 }));
+        sets.push(set({ x: 0.000000000000001729e18, expected: 1729e18 }));
+        sets.push(set({ x: 1e18, expected: 1e36 }));
+        sets.push(set({ x: 5e18, expected: 5e36 }));
+        sets.push(set({ x: 2.7182e38, expected: 2.7182e56 }));
+        sets.push(set({ x: 3.1415e42, expected: 3.1415e60 }));
+        sets.push(set({ x: MAX_SCALED_SD59x18, expected: MAX_WHOLE_SD59x18 }));
+        return sets;
+    }
+
+    function test_ConvertTo() external parameterizedTest(convertTo_Sets()) whenGteMinPermitted whenLteMaxPermitted {
+        SD59x18 x = convert(s.x.unwrap());
+        assertEq(x, s.expected, "SD59x18 convert to");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/conversion/convert-to/convertTo.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/conversion/convert-to/convertTo.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { MAX_WHOLE_SD59x18, MIN_WHOLE_SD59x18 } from "src/sd59x18/Constants.sol";
-import { convert } from "src/sd59x18/Conversions.sol";
-import { PRBMath_SD59x18_Convert_Overflow, PRBMath_SD59x18_Convert_Underflow } from "src/sd59x18/Errors.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { MAX_WHOLE_SD59x18, MIN_WHOLE_SD59x18 } from "@prb/math/src/sd59x18/Constants.sol";
+import { convert } from "@prb/math/src/sd59x18/Conversions.sol";
+import { PRBMath_SD59x18_Convert_Overflow, PRBMath_SD59x18_Convert_Underflow } from "@prb/math/src/sd59x18/Errors.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/abs/abs.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/abs/abs.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Abs_MinSD59x18 } from "src/sd59x18/Errors.sol";
+import { abs } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Abs_Unit_Test is SD59x18_Unit_Test {
+    function test_Abs_Zero() external pure {
+        SD59x18 x = ZERO;
+        SD59x18 actual = abs(x);
+        SD59x18 expected = ZERO;
+        assertEq(actual, expected, "SD59x18 abs");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_MinSD59x18() external whenNotZero {
+        SD59x18 x = MIN_SD59x18;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Abs_MinSD59x18.selector));
+        abs(x);
+    }
+
+    modifier whenNotMinSD59x18() {
+        _;
+    }
+
+    function negative_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18 + sd(1), expected: MAX_SD59x18 }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18, expected: MAX_WHOLE_SD59x18 }));
+        sets.push(set({ x: -1e24, expected: 1e24 }));
+        sets.push(set({ x: -4.2e18, expected: 4.2e18 }));
+        sets.push(set({ x: NEGATIVE_PI, expected: PI }));
+        sets.push(set({ x: -2e18, expected: 2e18 }));
+        sets.push(set({ x: -1.125e18, expected: 1.125e18 }));
+        sets.push(set({ x: -1e18, expected: 1e18 }));
+        sets.push(set({ x: -0.5e18, expected: 0.5e18 }));
+        sets.push(set({ x: -0.1e18, expected: 0.1e18 }));
+        return sets;
+    }
+
+    function test_Abs_Negative() external parameterizedTest(negative_Sets()) whenNotZero whenNotMinSD59x18 {
+        SD59x18 actual = abs(s.x);
+        assertEq(actual, s.expected, "SD59x18 abs");
+    }
+
+    function positive_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.1e18, expected: 0.1e18 }));
+        sets.push(set({ x: 0.5e18, expected: 0.5e18 }));
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 1.125e18, expected: 1.125e18 }));
+        sets.push(set({ x: 2e18, expected: 2e18 }));
+        sets.push(set({ x: PI, expected: PI }));
+        sets.push(set({ x: 4.2e18, expected: 4.2e18 }));
+        sets.push(set({ x: 1e24, expected: 1e24 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, expected: MAX_WHOLE_SD59x18 }));
+        sets.push(set({ x: MAX_SD59x18, expected: MAX_SD59x18 }));
+        return sets;
+    }
+
+    function test_Abs() external parameterizedTest(positive_Sets()) whenNotZero whenNotMinSD59x18 {
+        SD59x18 actual = abs(s.x);
+        assertEq(actual, s.expected, "SD59x18 abs");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/abs/abs.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/abs/abs.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Abs_MinSD59x18 } from "src/sd59x18/Errors.sol";
-import { abs } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Abs_MinSD59x18 } from "@prb/math/src/sd59x18/Errors.sol";
+import { abs } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/avg/avg.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/avg/avg.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, ZERO } from "src/sd59x18/Constants.sol";
+import { avg } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Avg_Unit_Test is SD59x18_Unit_Test {
+    function test_Avg_BothOperandsZero() external pure {
+        SD59x18 x = ZERO;
+        SD59x18 y = ZERO;
+        SD59x18 actual = avg(x, y);
+        SD59x18 expected = ZERO;
+        assertEq(actual, expected, "SD59x18 avg");
+    }
+
+    function onlyOneOperandZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: -3e18, y: 0, expected: -1.5e18 }));
+        sets.push(set({ x: 0, y: -3e18, expected: -1.5e18 }));
+        sets.push(set({ x: 0, y: 3e18, expected: 1.5e18 }));
+        sets.push(set({ x: 3e18, y: 0, expected: 1.5e18 }));
+        return sets;
+    }
+
+    function test_Avg_OnlyOneOperandZero() external parameterizedTest(onlyOneOperandZero_Sets()) {
+        SD59x18 actual = avg(s.x, s.y);
+        assertEq(actual, s.expected, "SD59x18 avg");
+    }
+
+    modifier whenNeitherOperandZero() {
+        _;
+    }
+
+    function oneOperandNegativeTheOtherPositive_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18, y: MAX_SD59x18, expected: 0 }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18, y: MAX_WHOLE_SD59x18, expected: 0 }));
+        sets.push(set({ x: -4e18, y: -2e18, expected: -3e18 }));
+        sets.push(set({ x: -2e18, y: -2e18, expected: -2e18 }));
+        sets.push(set({ x: -0.000000000000000002e18, y: 0.000000000000000004e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: 0.000000000000000003e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: 0.000000000000000002e18, expected: 0 }));
+        return sets;
+    }
+
+    function test_Avg_OneOperandNegativeTheOtherPositive()
+        external
+        parameterizedTest(oneOperandNegativeTheOtherPositive_Sets())
+        whenNeitherOperandZero
+    {
+        SD59x18 actual = avg(s.x, s.y);
+        assertEq(actual, s.expected, "SD59x18 avg");
+    }
+
+    function bothOperandsNegative_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(
+            set({
+                x: MIN_WHOLE_SD59x18,
+                y: MIN_SD59x18,
+                expected: -57896044618658097711785492504343953926634992332820282019728_396001978282409984
+            })
+        );
+        sets.push(set({ x: -4e18, y: -2e18, expected: -3e18 }));
+        sets.push(set({ x: -2e18, y: -2e18, expected: -2e18 }));
+        sets.push(set({ x: -0.000000000000000002e18, y: -0.000000000000000004e18, expected: -0.000000000000000003e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: -0.000000000000000003e18, expected: -0.000000000000000002e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: -0.000000000000000002e18, expected: -0.000000000000000001e18 }));
+        return sets;
+    }
+
+    function test_Avg_BothOperandsNegative() external parameterizedTest(bothOperandsNegative_Sets()) whenNeitherOperandZero {
+        SD59x18 actual = avg(s.x, s.y);
+        assertEq(actual, s.expected, "SD59x18 avg");
+    }
+
+    modifier whenBothOperandsPositive() {
+        _;
+    }
+
+    function bothOperandsEven_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000002e18, y: 0.000000000000000004e18, expected: 0.000000000000000003e18 }));
+        sets.push(set({ x: 2e18, y: 2e18, expected: 2e18 }));
+        sets.push(set({ x: 4e18, y: 8e18, expected: 6e18 }));
+        sets.push(set({ x: 100e18, y: 200e18, expected: 150e18 }));
+        sets.push(set({ x: 1e24, y: 1e25, expected: 5.5e24 }));
+        return sets;
+    }
+
+    function test_Avg_BothOperandsEven()
+        external
+        parameterizedTest(bothOperandsEven_Sets())
+        whenNeitherOperandZero
+        whenBothOperandsPositive
+    {
+        SD59x18 actual = avg(s.x, s.y);
+        assertEq(actual, s.expected, "SD59x18 avg");
+    }
+
+    function bothOperandsOdd_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, y: 0.000000000000000003e18, expected: 0.000000000000000002e18 }));
+        sets.push(set({ x: 1e18 + 1, y: 1e18 + 1, expected: 1e18 + 1 }));
+        sets.push(set({ x: 3e18 + 1, y: 7e18 + 1, expected: 5e18 + 1 }));
+        sets.push(set({ x: 99e18 + 1, y: 199e18 + 1, expected: 149e18 + 1 }));
+        sets.push(set({ x: 1e24 + 1, y: 1e25 + 1, expected: 5.5e24 + 1 }));
+        sets.push(set({ x: MAX_SD59x18, y: MAX_SD59x18, expected: MAX_SD59x18 }));
+        return sets;
+    }
+
+    function test_Avg_BothOperandsOdd() external parameterizedTest(bothOperandsOdd_Sets()) {
+        SD59x18 actual = avg(s.x, s.y);
+        logSd(s.x);
+        logSd(s.y);
+        assertEq(actual, s.expected, "SD59x18 avg");
+    }
+
+    function oneOperandEvenTheOtherOdd_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, y: 0.000000000000000002e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 1e18 + 1, y: 2e18, expected: 1.5e18 }));
+        sets.push(set({ x: 3e18 + 1, y: 8e18, expected: 5.5e18 }));
+        sets.push(set({ x: 99e18, y: 200e18, expected: 149.5e18 }));
+        sets.push(set({ x: 1e24 + 1, y: 1e25 + 1e18, expected: 5.5e24 + 0.5e18 }));
+        sets.push(
+            set({
+                x: MAX_SD59x18,
+                y: MAX_WHOLE_SD59x18,
+                expected: 57896044618658097711785492504343953926634992332820282019728_396001978282409983
+            })
+        );
+        return sets;
+    }
+
+    function test_Avg_OneOperandEvenTheOtherOdd() external parameterizedTest(oneOperandEvenTheOtherOdd_Sets()) {
+        SD59x18 actual = avg(s.x, s.y);
+        assertEq(actual, s.expected, "SD59x18 avg");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/avg/avg.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/avg/avg.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, ZERO } from "src/sd59x18/Constants.sol";
-import { avg } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { avg } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/ceil/ceil.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/ceil/ceil.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Ceil_Overflow } from "src/sd59x18/Errors.sol";
+import { ceil } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Ceil_Unit_Test is SD59x18_Unit_Test {
+    function test_Ceil_Zero() external pure {
+        SD59x18 x = ZERO;
+        SD59x18 actual = ceil(x);
+        SD59x18 expected = ZERO;
+        assertEq(actual, expected, "SD59x18 ceil");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function negative_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18, expected: MIN_WHOLE_SD59x18 }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18, expected: MIN_WHOLE_SD59x18 }));
+        sets.push(set({ x: -1e24, expected: -1e24 }));
+        sets.push(set({ x: -4.2e18, expected: -4e18 }));
+        sets.push(set({ x: NEGATIVE_PI, expected: -3e18 }));
+        sets.push(set({ x: -2e18, expected: -2e18 }));
+        sets.push(set({ x: -1.125e18, expected: -1e18 }));
+        sets.push(set({ x: -1e18, expected: -1e18 }));
+        sets.push(set({ x: -0.5e18, expected: 0 }));
+        sets.push(set({ x: -0.1e18, expected: 0 }));
+        return sets;
+    }
+
+    function test_Ceil_Negative() external parameterizedTest(negative_Sets()) whenNotZero {
+        SD59x18 actual = ceil(s.x);
+        assertEq(actual, s.expected, "SD59x18 ceil");
+    }
+
+    function test_RevertWhen_GtMaxPermitted() external whenNotZero {
+        SD59x18 x = MAX_WHOLE_SD59x18 + sd(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Ceil_Overflow.selector, x));
+        ceil(x);
+    }
+
+    modifier whenLteMaxPermitted() {
+        _;
+    }
+
+    function positive_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.1e18, expected: 1e18 }));
+        sets.push(set({ x: 0.5e18, expected: 1e18 }));
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 1.125e18, expected: 2e18 }));
+        sets.push(set({ x: 2e18, expected: 2e18 }));
+        sets.push(set({ x: PI, expected: 4e18 }));
+        sets.push(set({ x: 4.2e18, expected: 5e18 }));
+        sets.push(set({ x: 1e24, expected: 1e24 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, expected: MAX_WHOLE_SD59x18 }));
+        return sets;
+    }
+
+    function test_Ceil_Positive() external parameterizedTest(positive_Sets()) whenNotZero whenLteMaxPermitted {
+        SD59x18 actual = ceil(s.x);
+        assertEq(actual, s.expected, "SD59x18 ceil");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/ceil/ceil.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/ceil/ceil.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Ceil_Overflow } from "src/sd59x18/Errors.sol";
-import { ceil } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Ceil_Overflow } from "@prb/math/src/sd59x18/Errors.sol";
+import { ceil } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/div/div.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/div/div.t.sol
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { stdError } from "forge-std/src/StdError.sol";
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Div_InputTooSmall, PRBMath_SD59x18_Div_Overflow } from "src/sd59x18/Errors.sol";
+import { div } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Div_Unit_Test is SD59x18_Unit_Test {
+    function test_RevertWhen_DenominatorZero_Function() external {
+        SD59x18 x = sd(1e18);
+        SD59x18 y = ZERO;
+        vm.expectRevert(stdError.divisionError);
+        div(x, y);
+    }
+
+    function test_RevertWhen_DenominatorZero_Operator() external {
+        SD59x18 x = sd(1e18);
+        SD59x18 y = ZERO;
+        vm.expectRevert(stdError.divisionError);
+        x / y;
+    }
+
+    modifier whenDenominatorNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_DenominatorMinSD59x18_Function() external whenDenominatorNotZero {
+        SD59x18 x = sd(1e18);
+        SD59x18 y = MIN_SD59x18;
+        vm.expectRevert(PRBMath_SD59x18_Div_InputTooSmall.selector);
+        div(x, y);
+    }
+
+    function test_RevertWhen_DenominatorMinSD59x18_Operator() external whenDenominatorNotZero {
+        SD59x18 x = sd(1e18);
+        SD59x18 y = MIN_SD59x18;
+        vm.expectRevert(PRBMath_SD59x18_Div_InputTooSmall.selector);
+        x / y;
+    }
+
+    modifier whenDenominatorNotMinSD59x18() {
+        _;
+    }
+
+    function numeratorZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0, y: NEGATIVE_PI, expected: 0 }));
+        sets.push(set({ x: 0, y: -1e24, expected: 0 }));
+        sets.push(set({ x: 0, y: -1e18, expected: 0 }));
+        sets.push(set({ x: 0, y: -0.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: 0, y: 0.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: 0, y: 1e18, expected: 0 }));
+        sets.push(set({ x: 0, y: PI, expected: 0 }));
+        sets.push(set({ x: 0, y: 1e24, expected: 0 }));
+        return sets;
+    }
+
+    function test_Div_NumeratorZero()
+        external
+        parameterizedTest(numeratorZero_Sets())
+        whenDenominatorNotZero
+        whenDenominatorNotMinSD59x18
+    {
+        assertEq(div(s.x, s.y), s.expected, "SD59x18 div");
+        assertEq(s.x / s.y, s.expected, "SD59x18 /");
+    }
+
+    modifier whenNumeratorNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_NumeratorMinSD59x18_Function()
+        external
+        whenDenominatorNotZero
+        whenDenominatorNotMinSD59x18
+        whenNumeratorNotZero
+    {
+        SD59x18 x = MIN_SD59x18;
+        SD59x18 y = sd(0.000000000000000001e18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Div_InputTooSmall.selector));
+        div(x, y);
+    }
+
+    function test_RevertWhen_NumeratorMinSD59x18_Operator()
+        external
+        whenDenominatorNotZero
+        whenDenominatorNotMinSD59x18
+        whenNumeratorNotZero
+    {
+        SD59x18 x = MIN_SD59x18;
+        SD59x18 y = sd(0.000000000000000001e18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Div_InputTooSmall.selector));
+        x / y;
+    }
+
+    modifier whenNumeratorNotMinSD59x18() {
+        _;
+    }
+
+    function test_RevertWhen_ResultOverflowSD59x18_Function()
+        external
+        whenDenominatorNotZero
+        whenDenominatorNotMinSD59x18
+        whenNumeratorNotZero
+        whenNumeratorNotMinSD59x18
+    {
+        SD59x18 x = MIN_SCALED_SD59x18 - sd(1);
+        SD59x18 y = sd(0.000000000000000001e18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Div_Overflow.selector, x, y));
+        div(x, y);
+    }
+
+    function test_RevertWhen_ResultOverflowSD59x18_Operator()
+        external
+        whenDenominatorNotZero
+        whenDenominatorNotMinSD59x18
+        whenNumeratorNotZero
+        whenNumeratorNotMinSD59x18
+    {
+        SD59x18 x = MIN_SCALED_SD59x18 - sd(1);
+        SD59x18 y = sd(0.000000000000000001e18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Div_Overflow.selector, x, y));
+        x / y;
+    }
+
+    modifier whenResultDoesNotOverflowSD59x18() {
+        _;
+    }
+
+    function numeratorDenominatorSameSign_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SCALED_SD59x18, y: -0.000000000000000001e18, expected: MAX_WHOLE_SD59x18 }));
+        sets.push(set({ x: -1e24, y: -1e18, expected: 1e24 }));
+        sets.push(set({ x: -2503e18, y: -918882.11e18, expected: 0.002723962054283546e18 }));
+        sets.push(set({ x: -772.05e18, y: -199.98e18, expected: 3_860636063606360636 }));
+        sets.push(set({ x: -100.135e18, y: -100.134e18, expected: 1_000009986617931971 }));
+        sets.push(set({ x: -22e18, y: -7e18, expected: 3_142857142857142857 }));
+        sets.push(set({ x: -4e18, y: -2e18, expected: 2e18 }));
+        sets.push(set({ x: -2e18, y: -5e18, expected: 0.4e18 }));
+        sets.push(set({ x: -2e18, y: -2e18, expected: 1e18 }));
+        sets.push(set({ x: -0.1e18, y: -0.01e18, expected: 1e19 }));
+        sets.push(set({ x: -0.05e18, y: -0.02e18, expected: 2.5e18 }));
+        sets.push(set({ x: -1e13, y: -0.00002e18, expected: 0.5e18 }));
+        sets.push(set({ x: -1e13, y: -1e13, expected: 1e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: -1e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: -1.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: MIN_SD59x18 + sd(1), expected: 0 }));
+        sets.push(set({ x: 0.000000000000000001e18, y: MAX_SD59x18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000001e18, y: 1.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000001e18, y: 1e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 1e13, y: 1e13, expected: 1e18 }));
+        sets.push(set({ x: 1e13, y: 0.00002e18, expected: 0.5e18 }));
+        sets.push(set({ x: 0.05e18, y: 0.02e18, expected: 2.5e18 }));
+        sets.push(set({ x: 0.1e18, y: 0.01e18, expected: 10e18 }));
+        sets.push(set({ x: 2e18, y: 2e18, expected: 1e18 }));
+        sets.push(set({ x: 2e18, y: 5e18, expected: 0.4e18 }));
+        sets.push(set({ x: 4e18, y: 2e18, expected: 2e18 }));
+        sets.push(set({ x: 22e18, y: 7e18, expected: 3_142857142857142857 }));
+        sets.push(set({ x: 100.135e18, y: 100.134e18, expected: 1_000009986617931971 }));
+        sets.push(set({ x: 772.05e18, y: 199.98e18, expected: 3_860636063606360636 }));
+        sets.push(set({ x: 2503e18, y: 918882.11e18, expected: 0.002723962054283546e18 }));
+        sets.push(set({ x: 1e24, y: 1e18, expected: 1e24 }));
+        sets.push(set({ x: MAX_SCALED_SD59x18, y: 0.000000000000000001e18, expected: MAX_WHOLE_SD59x18 }));
+        return sets;
+    }
+
+    function test_Div_NumeratorDenominatorSameSign()
+        external
+        parameterizedTest(numeratorDenominatorSameSign_Sets())
+        whenDenominatorNotZero
+        whenDenominatorNotMinSD59x18
+        whenNumeratorNotZero
+        whenNumeratorNotMinSD59x18
+        whenResultDoesNotOverflowSD59x18
+    {
+        assertEq(div(s.x, s.y), s.expected, "SD59x18 div");
+        assertEq(s.x / s.y, s.expected, "SD59x18 /");
+    }
+
+    function numeratorDenominatorDifferentSign_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SCALED_SD59x18, y: 0.000000000000000001e18, expected: MIN_WHOLE_SD59x18 }));
+        sets.push(set({ x: -1e24, y: 1e18, expected: -1e24 }));
+        sets.push(set({ x: -2503e18, y: 918882.11e18, expected: -0.002723962054283546e18 }));
+        sets.push(set({ x: -772.05e18, y: 199.98e18, expected: -3_860636063606360636 }));
+        sets.push(set({ x: -100.135e18, y: 100.134e18, expected: -1_000009986617931971 }));
+        sets.push(set({ x: -22e18, y: 7e18, expected: -3_142857142857142857 }));
+        sets.push(set({ x: -4e18, y: 2e18, expected: -2e18 }));
+        sets.push(set({ x: -2e18, y: 5e18, expected: -0.4e18 }));
+        sets.push(set({ x: -2e18, y: 2e18, expected: -1e18 }));
+        sets.push(set({ x: -0.1e18, y: 0.01e18, expected: -1e19 }));
+        sets.push(set({ x: -0.05e18, y: 0.02e18, expected: -2.5e18 }));
+        sets.push(set({ x: -1e13, y: 2e13, expected: -0.5e18 }));
+        sets.push(set({ x: -1e13, y: 1e13, expected: -1e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: 1e18, expected: -0.000000000000000001e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: 1.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: MAX_SD59x18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000001e18, y: MIN_SD59x18 + sd(1), expected: 0 }));
+        sets.push(set({ x: 0.000000000000000001e18, y: -1.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000001e18, y: -1e18, expected: -0.000000000000000001e18 }));
+        sets.push(set({ x: 1e13, y: -1e13, expected: -1e18 }));
+        sets.push(set({ x: 1e13, y: -2e13, expected: -0.5e18 }));
+        sets.push(set({ x: 0.05e18, y: -0.02e18, expected: -2.5e18 }));
+        sets.push(set({ x: 0.1e18, y: -0.01e18, expected: -10e18 }));
+        sets.push(set({ x: 2e18, y: -2e18, expected: -1e18 }));
+        sets.push(set({ x: 2e18, y: -5e18, expected: -0.4e18 }));
+        sets.push(set({ x: 4e18, y: -2e18, expected: -2e18 }));
+        sets.push(set({ x: 22e18, y: -7e18, expected: -3_142857142857142857 }));
+        sets.push(set({ x: 100.135e18, y: -100.134e18, expected: -1_000009986617931971 }));
+        sets.push(set({ x: 772.05e18, y: -199.98e18, expected: -3_860636063606360636 }));
+        sets.push(set({ x: 2503e18, y: -918882.11e18, expected: -0.002723962054283546e18 }));
+        sets.push(set({ x: 1e24, y: -1e18, expected: -1e24 }));
+        sets.push(set({ x: MAX_SCALED_SD59x18, y: 0.000000000000000001e18, expected: MAX_WHOLE_SD59x18 }));
+        return sets;
+    }
+
+    function test_Div_NumeratorDenominatorDifferentSign()
+        external
+        parameterizedTest(numeratorDenominatorDifferentSign_Sets())
+        whenDenominatorNotZero
+        whenDenominatorNotMinSD59x18
+        whenNumeratorNotZero
+        whenNumeratorNotMinSD59x18
+        whenResultDoesNotOverflowSD59x18
+    {
+        assertEq(div(s.x, s.y), s.expected, "SD59x18 div");
+        assertEq(s.x / s.y, s.expected, "SD59x18 /");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/div/div.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/div/div.t.sol
@@ -3,11 +3,11 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { stdError } from "forge-std/src/StdError.sol";
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Div_InputTooSmall, PRBMath_SD59x18_Div_Overflow } from "src/sd59x18/Errors.sol";
-import { div } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Div_InputTooSmall, PRBMath_SD59x18_Div_Overflow } from "@prb/math/src/sd59x18/Errors.sol";
+import { div } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/exp/exp.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/exp/exp.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { E, EXP_MAX_INPUT, EXP_MIN_THRESHOLD, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Exp_InputTooBig } from "src/sd59x18/Errors.sol";
+import { exp } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Exp_Unit_Test is SD59x18_Unit_Test {
+    function test_Exp_Zero() external pure {
+        SD59x18 x = ZERO;
+        SD59x18 actual = exp(x);
+        SD59x18 expected = UNIT;
+        assertEq(actual, expected, "SD59x18 exp");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function ltThreshold_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18 }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18 }));
+        sets.push(set({ x: EXP_MIN_THRESHOLD - sd(1) }));
+        return sets;
+    }
+
+    function test_Exp_Negative_LtThreshold() external parameterizedTest(ltThreshold_Sets()) whenNotZero {
+        SD59x18 actual = exp(s.x);
+        assertEq(actual, s.expected, "SD59x18 exp");
+    }
+
+    function negativeAndGteThreshold_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18, expected: 0 }));
+        sets.push(set({ x: EXP_MIN_THRESHOLD - sd(1), expected: 0 }));
+        sets.push(set({ x: EXP_MIN_THRESHOLD, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: -33.333333e18, expected: 0.000000000000003338e18 }));
+        sets.push(set({ x: -20.82e18, expected: 0.0000000009077973e18 }));
+        sets.push(set({ x: -16e18, expected: 0.000000112535174719e18 }));
+        sets.push(set({ x: -11.89215e18, expected: 0.000006843919254514e18 }));
+        sets.push(set({ x: -4e18, expected: 0.01831563888873418e18 }));
+        sets.push(set({ x: NEGATIVE_PI, expected: 0.043213918263772249e18 }));
+        sets.push(set({ x: -3e18, expected: 0.049787068367863943e18 }));
+        sets.push(set({ x: NEGATIVE_E, expected: 0.065988035845312537e18 }));
+        sets.push(set({ x: -2e18, expected: 0.135335283236612691e18 }));
+        sets.push(set({ x: -1e18, expected: 0.367879441171442321e18 }));
+        sets.push(set({ x: -1e3, expected: 0.999999999999999001e18 }));
+        sets.push(set({ x: -1, expected: 1e18 }));
+        return sets;
+    }
+
+    function test_Exp_Negative_GteMinPermitted() external parameterizedTest(negativeAndGteThreshold_Sets()) whenNotZero {
+        SD59x18 actual = exp(s.x);
+        assertEq(actual, s.expected, "SD59x18 exp");
+    }
+
+    function test_RevertWhen_Positive_GtMaxPermitted() external whenNotZero {
+        SD59x18 x = EXP_MAX_INPUT + sd(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Exp_InputTooBig.selector, x));
+        exp(x);
+    }
+
+    function positiveAndLteMaxPermitted_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, expected: 1e18 }));
+        sets.push(set({ x: 0.000000000000001e18, expected: 1.000000000000000999e18 }));
+        sets.push(set({ x: 1e18, expected: 2_718281828459045234 }));
+        sets.push(set({ x: 2e18, expected: 7_389056098930650223 }));
+        sets.push(set({ x: E, expected: 15_154262241479264171 }));
+        sets.push(set({ x: 3e18, expected: 20_085536923187667724 }));
+        sets.push(set({ x: PI, expected: 23_140692632779268962 }));
+        sets.push(set({ x: 4e18, expected: 54_598150033144239019 }));
+        sets.push(set({ x: 11.89215e18, expected: 146115_107851442195738190 }));
+        sets.push(set({ x: 16e18, expected: 8886110_520507872601090007 }));
+        sets.push(set({ x: 20.82e18, expected: 1101567497_354306722521735975 }));
+        sets.push(set({ x: 33.333333e18, expected: 299559147061116_199277615819889397 }));
+        sets.push(set({ x: 64e18, expected: 6235149080811616783682415370_612321304359995711 }));
+        sets.push(set({ x: 71.002e18, expected: 6851360256686183998595702657852_843771046889809565 }));
+        sets.push(set({ x: 88.722839111672999627e18, expected: 340282366920938463222979506443879150094_819893272894857679 }));
+        sets.push(set({ x: EXP_MAX_INPUT, expected: 6277101735386680754977611748738314679353920434623901771623e18 }));
+        return sets;
+    }
+
+    function test_Exp_Positive_LteMaxPermitted() external parameterizedTest(positiveAndLteMaxPermitted_Sets()) whenNotZero {
+        SD59x18 actual = exp(s.x);
+        assertEq(actual, s.expected, "SD59x18 exp");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/exp/exp.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/exp/exp.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { E, EXP_MAX_INPUT, EXP_MIN_THRESHOLD, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Exp_InputTooBig } from "src/sd59x18/Errors.sol";
-import { exp } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { E, EXP_MAX_INPUT, EXP_MIN_THRESHOLD, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Exp_InputTooBig } from "@prb/math/src/sd59x18/Errors.sol";
+import { exp } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/exp2/exp2.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/exp2/exp2.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { E, EXP2_MAX_INPUT, EXP2_MIN_THRESHOLD, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Exp2_InputTooBig } from "src/sd59x18/Errors.sol";
+import { exp2 } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Exp2_Unit_Test is SD59x18_Unit_Test {
+    function test_Exp2_Zero() external pure {
+        SD59x18 x = ZERO;
+        SD59x18 actual = exp2(x);
+        SD59x18 expected = UNIT;
+        assertEq(actual, expected, "SD59x18 exp2");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function negativeAndLtThreshold_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18, expected: 0 }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18, expected: 0 }));
+        sets.push(set({ x: EXP2_MIN_THRESHOLD - sd(1), expected: 0 }));
+        return sets;
+    }
+
+    function test_Exp2_Negative_LtThreshold() external parameterizedTest(negativeAndLtThreshold_Sets()) whenNotZero {
+        SD59x18 actual = exp2(s.x);
+        assertEq(actual, s.expected, "SD59x18 exp2");
+    }
+
+    function negativeAndGteMinPermitted_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18, expected: 0 }));
+        sets.push(set({ x: EXP2_MIN_THRESHOLD - sd(1), expected: 0 }));
+        sets.push(set({ x: EXP2_MIN_THRESHOLD, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: -33.333333e18, expected: 0.000000000092398923e18 }));
+        sets.push(set({ x: -20.82e18, expected: 0.000000540201132438e18 }));
+        sets.push(set({ x: -16e18, expected: 0.0000152587890625e18 }));
+        sets.push(set({ x: -11.89215e18, expected: 0.000263091088065207e18 }));
+        sets.push(set({ x: -4e18, expected: 0.0625e18 }));
+        sets.push(set({ x: NEGATIVE_PI, expected: 0.113314732296760873e18 }));
+        sets.push(set({ x: -3e18, expected: 0.125e18 }));
+        sets.push(set({ x: NEGATIVE_E, expected: 0.151955223257912965e18 }));
+        sets.push(set({ x: -2e18, expected: 0.25e18 }));
+        sets.push(set({ x: -1e18, expected: 0.5e18 }));
+        sets.push(set({ x: -0.000000000000001e18, expected: 0.999999999999999307e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, expected: 1e18 }));
+        return sets;
+    }
+
+    function test_Exp2_Negative_GteMinPermitted() external parameterizedTest(negativeAndGteMinPermitted_Sets()) whenNotZero {
+        SD59x18 actual = exp2(s.x);
+        assertEq(actual, s.expected, "SD59x18 exp2");
+    }
+
+    function test_RevertWhen_Positive_GtMaxPermitted() external whenNotZero {
+        SD59x18 x = EXP2_MAX_INPUT + sd(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Exp2_InputTooBig.selector, x));
+        exp2(x);
+    }
+
+    modifier whenLtMaxPermitted() {
+        _;
+    }
+
+    function positiveAndLTePermitted_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, expected: 1e18 }));
+        sets.push(set({ x: 1e3, expected: 1_000000000000000693 }));
+        sets.push(set({ x: 0.3212e18, expected: 1_249369313012024883 }));
+        sets.push(set({ x: 1e18, expected: 2e18 }));
+        sets.push(set({ x: 2e18, expected: 4e18 }));
+        sets.push(set({ x: E, expected: 6_580885991017920969 }));
+        sets.push(set({ x: 3e18, expected: 8e18 }));
+        sets.push(set({ x: PI, expected: 8_824977827076287621 }));
+        sets.push(set({ x: 4e18, expected: 16e18 }));
+        sets.push(set({ x: 11.89215e18, expected: 3800_964933301542754377 }));
+        sets.push(set({ x: 16e18, expected: 65536e18 }));
+        sets.push(set({ x: 20.82e18, expected: 1851162_354076939434682641 }));
+        sets.push(set({ x: 33.333333e18, expected: 10822636909_120553492168423503 }));
+        sets.push(set({ x: 64e18, expected: 18_446744073709551616e18 }));
+        sets.push(set({ x: 71.002e18, expected: 2364458806372010440881_644926416580874919 }));
+        sets.push(set({ x: 88.7494e18, expected: 520273250104929479163928177_984511174562086061 }));
+        sets.push(set({ x: 95e18, expected: 39614081257_132168796771975168e18 }));
+        sets.push(set({ x: 127e18, expected: 170141183460469231731_687303715884105728e18 }));
+        sets.push(set({ x: 152.9065e18, expected: 10701459987152828635116598811554803403437267307_663014047009710338 }));
+        sets.push(set({ x: EXP2_MAX_INPUT, expected: 6277101735386680759401282518710514696272033118492751795945e18 }));
+        return sets;
+    }
+
+    function test_Exp2_Positive_LTePermittedMax() external parameterizedTest(positiveAndLTePermitted_Sets()) whenNotZero {
+        SD59x18 actual = exp2(s.x);
+        assertEq(actual, s.expected, "SD59x18 exp2");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/exp2/exp2.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/exp2/exp2.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { E, EXP2_MAX_INPUT, EXP2_MIN_THRESHOLD, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Exp2_InputTooBig } from "src/sd59x18/Errors.sol";
-import { exp2 } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { E, EXP2_MAX_INPUT, EXP2_MIN_THRESHOLD, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, UNIT, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Exp2_InputTooBig } from "@prb/math/src/sd59x18/Errors.sol";
+import { exp2 } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/floor/floor.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/floor/floor.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Floor_Underflow } from "src/sd59x18/Errors.sol";
+import { floor } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Floor_Unit_Test is SD59x18_Unit_Test {
+    function test_Floor_Zero() external pure {
+        SD59x18 x = ZERO;
+        SD59x18 actual = floor(x);
+        SD59x18 expected = ZERO;
+        assertEq(actual, expected, "SD59x18 floor");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_Negative_LtMinPermitted() external whenNotZero {
+        SD59x18 x = MIN_WHOLE_SD59x18 - sd(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Floor_Underflow.selector, x));
+        floor(x);
+    }
+
+    function negativeAndGteMinPermitted_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_WHOLE_SD59x18, expected: MIN_WHOLE_SD59x18 }));
+        sets.push(set({ x: -1e24, expected: -1e24 }));
+        sets.push(set({ x: -4.2e18, expected: -5e18 }));
+        sets.push(set({ x: -2e18, expected: -2e18 }));
+        sets.push(set({ x: -1.125e18, expected: -2e18 }));
+        sets.push(set({ x: -1e18, expected: -1e18 }));
+        sets.push(set({ x: -0.5e18, expected: -1e18 }));
+        sets.push(set({ x: -0.1e18, expected: -1e18 }));
+        return sets;
+    }
+
+    function test_Floor_Negative_GteMinPermitted() external parameterizedTest(negativeAndGteMinPermitted_Sets()) whenNotZero {
+        SD59x18 actual = floor(s.x);
+        assertEq(actual, s.expected, "SD59x18 floor");
+    }
+
+    function positive_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.1e18, expected: 0 }));
+        sets.push(set({ x: 0.5e18, expected: 0 }));
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 1.125e18, expected: 1e18 }));
+        sets.push(set({ x: 2e18, expected: 2e18 }));
+        sets.push(set({ x: PI, expected: 3e18 }));
+        sets.push(set({ x: 4.2e18, expected: 4e18 }));
+        sets.push(set({ x: 1e24, expected: 1e24 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, expected: MAX_WHOLE_SD59x18 }));
+        sets.push(set({ x: MAX_SD59x18, expected: MAX_WHOLE_SD59x18 }));
+        return sets;
+    }
+
+    function test_Floor_Positive() external parameterizedTest(positive_Sets()) whenNotZero {
+        SD59x18 actual = floor(s.x);
+        assertEq(actual, s.expected, "SD59x18 floor");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/floor/floor.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/floor/floor.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Floor_Underflow } from "src/sd59x18/Errors.sol";
-import { floor } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Floor_Underflow } from "@prb/math/src/sd59x18/Errors.sol";
+import { floor } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/frac/frac.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/frac/frac.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { frac } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Frac_Unit_Test is SD59x18_Unit_Test {
+    function test_Frac_Zero() external pure {
+        SD59x18 x = ZERO;
+        SD59x18 actual = frac(x);
+        SD59x18 expected = ZERO;
+        assertEq(actual, expected, "SD59x18 frac");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function negative_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18, expected: -0.792003956564819968e18 }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18, expected: 0 }));
+        sets.push(set({ x: -1e24, expected: 0 }));
+        sets.push(set({ x: -4.2e18, expected: -0.2e18 }));
+        sets.push(set({ x: NEGATIVE_PI, expected: -0.141592653589793238e18 }));
+        sets.push(set({ x: -2e18, expected: 0 }));
+        sets.push(set({ x: -1.125e18, expected: -0.125e18 }));
+        sets.push(set({ x: -1e18, expected: 0 }));
+        sets.push(set({ x: -0.5e18, expected: -0.5e18 }));
+        sets.push(set({ x: -0.1e18, expected: -0.1e18 }));
+        return sets;
+    }
+
+    function test_Frac_Negative() external parameterizedTest(negative_Sets()) whenNotZero {
+        SD59x18 actual = frac(s.x);
+        assertEq(actual, s.expected, "SD59x18 frac");
+    }
+
+    function positive_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.1e18, expected: 0.1e18 }));
+        sets.push(set({ x: 0.5e18, expected: 0.5e18 }));
+        sets.push(set({ x: 1e18, expected: 0 }));
+        sets.push(set({ x: 1.125e18, expected: 0.125e18 }));
+        sets.push(set({ x: 2e18, expected: 0 }));
+        sets.push(set({ x: PI, expected: 0.141592653589793238e18 }));
+        sets.push(set({ x: 4.2e18, expected: 0.2e18 }));
+        sets.push(set({ x: 1e24, expected: 0 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, expected: 0 }));
+        sets.push(set({ x: MAX_SD59x18, expected: 0.792003956564819967e18 }));
+        return sets;
+    }
+
+    function test_Frac() external parameterizedTest(positive_Sets()) whenNotZero {
+        SD59x18 actual = frac(s.x);
+        assertEq(actual, s.expected, "SD59x18 frac");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/frac/frac.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/frac/frac.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { frac } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { frac } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/gm/gm.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/gm/gm.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Gm_Overflow, PRBMath_SD59x18_Gm_NegativeProduct } from "src/sd59x18/Errors.sol";
+import { gm } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Gm_Unit_Test is SD59x18_Unit_Test {
+    /// @dev Greatest number whose non-fixed-point square fits within int256
+    SD59x18 internal constant SQRT_MAX_INT256 = SD59x18.wrap(240615969168004511545_033772477625056927);
+    /// @dev Smallest number whose non-fixed-point square fits within int256
+    SD59x18 internal constant NEGATIVE_SQRT_MAX_INT256 = SD59x18.wrap(-240615969168004511545033772477625056927);
+
+    function oneOperandZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0, y: PI, expected: 0 }));
+        sets.push(set({ x: PI, y: 0, expected: 0 }));
+        return sets;
+    }
+
+    function test_Gm_OneOperandZero() external parameterizedTest(oneOperandZero_Sets()) {
+        SD59x18 actual = gm(s.x, s.y);
+        assertEq(actual, s.expected, "SD59x18 gm");
+    }
+
+    modifier whenOperandsNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_ProductNegative_A() external whenOperandsNotZero {
+        SD59x18 x = sd(-1e18);
+        SD59x18 y = PI;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Gm_NegativeProduct.selector, x, y));
+        gm(x, y);
+    }
+
+    function test_RevertWhen_ProductNegative_B() external whenOperandsNotZero {
+        SD59x18 x = PI;
+        SD59x18 y = sd(-1e18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Gm_NegativeProduct.selector, x, y));
+        gm(x, y);
+    }
+
+    modifier whenProductPositive() {
+        _;
+    }
+
+    function test_RevertWhen_ProductOverflow_A() external whenOperandsNotZero whenProductPositive {
+        SD59x18 x = MIN_SD59x18;
+        SD59x18 y = sd(0.000000000000000002e18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Gm_Overflow.selector, x, y));
+        gm(x, y);
+    }
+
+    function test_RevertWhen_ProductOverflow_B() external whenOperandsNotZero whenProductPositive {
+        SD59x18 x = NEGATIVE_SQRT_MAX_INT256;
+        SD59x18 y = NEGATIVE_SQRT_MAX_INT256 - sd(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Gm_Overflow.selector, x, y));
+        gm(x, y);
+    }
+
+    function test_RevertWhen_ProductOverflow_C() external whenOperandsNotZero whenProductPositive {
+        SD59x18 x = SQRT_MAX_INT256 + sd(1);
+        SD59x18 y = SQRT_MAX_INT256 + sd(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Gm_Overflow.selector, x, y));
+        gm(x, y);
+    }
+
+    function test_RevertWhen_ProductOverflow_D() external whenOperandsNotZero whenProductPositive {
+        SD59x18 x = MAX_SD59x18;
+        SD59x18 y = sd(0.000000000000000002e18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Gm_Overflow.selector, x, y));
+        gm(x, y);
+    }
+
+    modifier whenProductDoesNotOverflow() {
+        _;
+    }
+
+    function gm_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_WHOLE_SD59x18, y: -0.000000000000000001e18, expected: SQRT_MAX_INT256 }));
+        sets.push(set({ x: NEGATIVE_SQRT_MAX_INT256, y: NEGATIVE_SQRT_MAX_INT256, expected: SQRT_MAX_INT256 }));
+        sets.push(set({ x: -2404.8e18, y: -7899.210662e18, expected: 4358_442588812843362311 }));
+        sets.push(set({ x: -322.47e18, y: -674.77e18, expected: 466_468736251423392217 }));
+        sets.push(set({ x: NEGATIVE_PI, y: -8.2e18, expected: 5_075535416036056441 }));
+        sets.push(set({ x: NEGATIVE_E, y: -89.01e18, expected: 15_554879155787087514 }));
+        sets.push(set({ x: -2e18, y: -8e18, expected: 4e18 }));
+        sets.push(set({ x: -1e18, y: -4e18, expected: 2e18 }));
+        sets.push(set({ x: -1e18, y: -1e18, expected: 1e18 }));
+        sets.push(set({ x: 1e18, y: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 1e18, y: 4e18, expected: 2e18 }));
+        sets.push(set({ x: 2e18, y: 8e18, expected: 4e18 }));
+        sets.push(set({ x: E, y: 89.01e18, expected: 15_554879155787087514 }));
+        sets.push(set({ x: PI, y: 8.2e18, expected: 5_075535416036056441 }));
+        sets.push(set({ x: 322.47e18, y: 674.77e18, expected: 466_468736251423392217 }));
+        sets.push(set({ x: 2404.8e18, y: 7899.210662e18, expected: 4358_442588812843362311 }));
+        sets.push(set({ x: SQRT_MAX_INT256, y: SQRT_MAX_INT256, expected: SQRT_MAX_INT256 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, y: 0.000000000000000001e18, expected: SQRT_MAX_INT256 }));
+        sets.push(set({ x: MAX_SD59x18, y: 0.000000000000000001e18, expected: SQRT_MAX_INT256 }));
+        return sets;
+    }
+
+    function test_Gm() external parameterizedTest(gm_Sets()) whenOperandsNotZero whenProductPositive whenProductDoesNotOverflow {
+        SD59x18 actual = gm(s.x, s.y);
+        assertEq(actual, s.expected, "SD59x18 gm");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/gm/gm.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/gm/gm.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Gm_Overflow, PRBMath_SD59x18_Gm_NegativeProduct } from "src/sd59x18/Errors.sol";
-import { gm } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Gm_Overflow, PRBMath_SD59x18_Gm_NegativeProduct } from "@prb/math/src/sd59x18/Errors.sol";
+import { gm } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/inv/inv.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/inv/inv.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { stdError } from "forge-std/src/StdError.sol";
+
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { inv } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Inv_Unit_Test is SD59x18_Unit_Test {
+    function test_RevertWhen_Zero() external {
+        SD59x18 x = ZERO;
+        vm.expectRevert(stdError.divisionError);
+        inv(x);
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function negative_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18, expected: 0 }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18, expected: 0 }));
+        sets.push(set({ x: -1e36 - 1, expected: 0 }));
+        sets.push(set({ x: -1e36, expected: -1 }));
+        sets.push(set({ x: -2503e18, expected: -0.000399520575309628e18 }));
+        sets.push(set({ x: -772.05e18, expected: -0.001295252898128359e18 }));
+        sets.push(set({ x: -100.135e18, expected: -0.00998651820042942e18 }));
+        sets.push(set({ x: -22e18, expected: -0.045454545454545454e18 }));
+        sets.push(set({ x: -4e18, expected: -0.25e18 }));
+        sets.push(set({ x: NEGATIVE_PI, expected: -0.318309886183790671e18 }));
+        sets.push(set({ x: -2e18, expected: -0.5e18 }));
+        sets.push(set({ x: -1e18, expected: -1e18 }));
+        sets.push(set({ x: -0.1e18, expected: -10e18 }));
+        sets.push(set({ x: -0.05e18, expected: -20e18 }));
+        sets.push(set({ x: -0.00001e18, expected: -100_000e18 }));
+        sets.push(set({ x: -1, expected: -1e36 }));
+        return sets;
+    }
+
+    function test_Inv_Negative() external parameterizedTest(negative_Sets()) whenNotZero {
+        SD59x18 actual = inv(s.x);
+        assertEq(actual, s.expected, "SD59x18 inv");
+    }
+
+    function positive_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, expected: 1e36 }));
+        sets.push(set({ x: 0.00001e18, expected: 100_000e18 }));
+        sets.push(set({ x: 0.05e18, expected: 20e18 }));
+        sets.push(set({ x: 0.1e18, expected: 10e18 }));
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 2e18, expected: 0.5e18 }));
+        sets.push(set({ x: PI, expected: 0.318309886183790671e18 }));
+        sets.push(set({ x: 4e18, expected: 0.25e18 }));
+        sets.push(set({ x: 22e18, expected: 0.045454545454545454e18 }));
+        sets.push(set({ x: 100.135e18, expected: 0.00998651820042942e18 }));
+        sets.push(set({ x: 772.05e18, expected: 0.001295252898128359e18 }));
+        sets.push(set({ x: 2503e18, expected: 0.000399520575309628e18 }));
+        sets.push(set({ x: 1e36, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 1e36 + 1, expected: 0 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, expected: 0 }));
+        sets.push(set({ x: MAX_SD59x18, expected: 0 }));
+        return sets;
+    }
+
+    function test_Inv_Positive() external parameterizedTest(positive_Sets()) whenNotZero {
+        SD59x18 actual = inv(s.x);
+        assertEq(actual, s.expected, "SD59x18 inv");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/inv/inv.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/inv/inv.t.sol
@@ -3,9 +3,9 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { stdError } from "forge-std/src/StdError.sol";
 
-import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { inv } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { inv } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/ln/ln.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/ln/ln.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Log_InputTooSmall } from "src/sd59x18/Errors.sol";
+import { ln } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Ln_Unit_Test is SD59x18_Unit_Test {
+    function test_RevertWhen_Zero() external {
+        SD59x18 x = ZERO;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Log_InputTooSmall.selector, x));
+        ln(x);
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_Negative() external whenNotZero {
+        SD59x18 x = sd(-1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Log_InputTooSmall.selector, x));
+        ln(x);
+    }
+
+    modifier whenPositive() {
+        _;
+    }
+
+    function ln_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.1e18, expected: -2_302585092994045674 }));
+        sets.push(set({ x: 0.2e18, expected: -1_609437912434100365 }));
+        sets.push(set({ x: 0.3e18, expected: -1_203972804325935984 }));
+        sets.push(set({ x: 0.4e18, expected: -0.916290731874155055e18 }));
+        sets.push(set({ x: 0.5e18, expected: -0.693147180559945309e18 }));
+        sets.push(set({ x: 0.6e18, expected: -0.510825623765990674e18 }));
+        sets.push(set({ x: 0.7e18, expected: -0.356674943938732371e18 }));
+        sets.push(set({ x: 0.8e18, expected: -0.223143551314209746e18 }));
+        sets.push(set({ x: 0.9e18, expected: -0.105360515657826292e18 }));
+        sets.push(set({ x: 1e18, expected: 0 }));
+        sets.push(set({ x: 1.125e18, expected: 0.117783035656383442e18 }));
+        sets.push(set({ x: 2e18, expected: 0.693147180559945309e18 }));
+        sets.push(set({ x: E, expected: 0.99999999999999999e18 }));
+        sets.push(set({ x: PI, expected: 1_144729885849400163 }));
+        sets.push(set({ x: 4e18, expected: 1_386294361119890619 }));
+        sets.push(set({ x: 8e18, expected: 2_079441541679835928 }));
+        sets.push(set({ x: 1e24, expected: 13_815510557964274099 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, expected: 135_305999368893231615 }));
+        sets.push(set({ x: MAX_SD59x18, expected: 135_305999368893231615 }));
+        return sets;
+    }
+
+    function test_Ln() external parameterizedTest(ln_Sets()) whenNotZero whenPositive {
+        SD59x18 actual = ln(s.x);
+        assertEq(actual, s.expected, "SD59x18 ln");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/ln/ln.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/ln/ln.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Log_InputTooSmall } from "src/sd59x18/Errors.sol";
-import { ln } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Log_InputTooSmall } from "@prb/math/src/sd59x18/Errors.sol";
+import { ln } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/log10/log10.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/log10/log10.t.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Log_InputTooSmall } from "src/sd59x18/Errors.sol";
+import { log10 } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Log10_Unit_Test is SD59x18_Unit_Test {
+    function test_RevertWhen_Zero() external {
+        SD59x18 x = ZERO;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Log_InputTooSmall.selector, x));
+        log10(x);
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_Negative() external whenNotZero {
+        SD59x18 x = sd(-1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Log_InputTooSmall.selector, x));
+        log10(x);
+    }
+
+    modifier whenPositive() {
+        _;
+    }
+
+    function powerOfTen_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, expected: -18e18 }));
+        sets.push(set({ x: 0.00000000000000001e18, expected: -17e18 }));
+        sets.push(set({ x: 0.00000000000001e18, expected: -14e18 }));
+        sets.push(set({ x: 0.0000000001e18, expected: -10e18 }));
+        sets.push(set({ x: 0.00000001e18, expected: -8e18 }));
+        sets.push(set({ x: 0.0000001e18, expected: -7e18 }));
+        sets.push(set({ x: 0.001e18, expected: -3e18 }));
+        sets.push(set({ x: 0.1e18, expected: -1e18 }));
+        sets.push(set({ x: 1e18, expected: 0 }));
+        sets.push(set({ x: 10e18, expected: 1e18 }));
+        sets.push(set({ x: 100e18, expected: 2e18 }));
+        sets.push(set({ x: 1e24, expected: 6e18 }));
+        sets.push(set({ x: 1e67, expected: 49e18 }));
+        sets.push(set({ x: 1e75, expected: 57e18 }));
+        sets.push(set({ x: 1e76, expected: 58e18 }));
+        return sets;
+    }
+
+    function test_Log10_PowerOfTen() external parameterizedTest(powerOfTen_Sets()) whenNotZero whenPositive {
+        SD59x18 actual = log10(s.x);
+        assertEq(actual, s.expected, "SD59x18 log10");
+    }
+
+    function notPowerOfTen_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 7.892191e6, expected: -11_102802412872166458 }));
+        sets.push(set({ x: 0.0091e18, expected: -2_040958607678906397 }));
+        sets.push(set({ x: 0.083e18, expected: -1_080921907623926093 }));
+        sets.push(set({ x: 0.1982e18, expected: -702896349850743472 }));
+        sets.push(set({ x: 0.313e18, expected: -504455662453551511 }));
+        sets.push(set({ x: 0.4666e18, expected: -331055265542266175 }));
+        sets.push(set({ x: 1.00000000000001e18, expected: 0.000000000000004341e18 }));
+        sets.push(set({ x: E, expected: 0.434294481903251823e18 }));
+        sets.push(set({ x: PI, expected: 0.497149872694133849e18 }));
+        sets.push(set({ x: 4e18, expected: 0.60205999132796239e18 }));
+        sets.push(set({ x: 16e18, expected: 1_204119982655924781 }));
+        sets.push(set({ x: 32e18, expected: 1_505149978319905976 }));
+        sets.push(set({ x: 42.12e18, expected: 1_624488362513448905 }));
+        sets.push(set({ x: 1010.892143e18, expected: 3_004704821071980110 }));
+        sets.push(set({ x: 440934.1881e18, expected: 5_644373773418177966 }));
+        sets.push(set({ x: 1000000000000000000.000000000001e18, expected: 17_999999999999999999 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, expected: 58_762648894315204791 }));
+        sets.push(set({ x: MAX_SD59x18, expected: 58_762648894315204791 }));
+        return sets;
+    }
+
+    function test_Log10_NotPowerOfTen() external parameterizedTest(notPowerOfTen_Sets()) whenNotZero whenPositive {
+        SD59x18 actual = log10(s.x);
+        assertEq(actual, s.expected, "SD59x18 log10");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/log10/log10.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/log10/log10.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Log_InputTooSmall } from "src/sd59x18/Errors.sol";
-import { log10 } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Log_InputTooSmall } from "@prb/math/src/sd59x18/Errors.sol";
+import { log10 } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/log2/log2.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/log2/log2.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Log_InputTooSmall } from "src/sd59x18/Errors.sol";
+import { log2 } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Log2_Unit_Test is SD59x18_Unit_Test {
+    function test_RevertWhen_Zero() external {
+        SD59x18 x = ZERO;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Log_InputTooSmall.selector, x));
+        log2(x);
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_Negative() external whenNotZero {
+        SD59x18 x = sd(-1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Log_InputTooSmall.selector, x));
+        log2(x);
+    }
+
+    modifier whenPositive() {
+        _;
+    }
+
+    function powerOfTwo_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.0625e18, expected: -4e18 }));
+        sets.push(set({ x: 0.125e18, expected: -3e18 }));
+        sets.push(set({ x: 0.25e18, expected: -2e18 }));
+        sets.push(set({ x: 0.5e18, expected: -1e18 }));
+        sets.push(set({ x: 1e18, expected: 0 }));
+        sets.push(set({ x: 2e18, expected: 1e18 }));
+        sets.push(set({ x: 4e18, expected: 2e18 }));
+        sets.push(set({ x: 8e18, expected: 3e18 }));
+        sets.push(set({ x: 16e18, expected: 4e18 }));
+        sets.push(set({ x: 2 ** 195 * 1e18, expected: 195e18 }));
+        return sets;
+    }
+
+    function test_Log2_PowerOfTwo() external parameterizedTest(powerOfTwo_Sets()) whenNotZero whenPositive {
+        SD59x18 actual = log2(s.x);
+        assertEq(actual, s.expected, "SD59x18 log2");
+    }
+
+    function notPowerOfTwo_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.0091e18, expected: -6_779917739350753112 }));
+        sets.push(set({ x: 0.083e18, expected: -3_590744853315162277 }));
+        sets.push(set({ x: 0.1e18, expected: -3_321928094887362334 }));
+        sets.push(set({ x: 0.2e18, expected: -2_321928094887362334 }));
+        sets.push(set({ x: 0.3e18, expected: -1_736965594166206154 }));
+        sets.push(set({ x: 0.4e18, expected: -1_321928094887362334 }));
+        sets.push(set({ x: 0.6e18, expected: -0.736965594166206154e18 }));
+        sets.push(set({ x: 0.7e18, expected: -0.514573172829758229e18 }));
+        sets.push(set({ x: 0.8e18, expected: -0.321928094887362334e18 }));
+        sets.push(set({ x: 0.9e18, expected: -0.152003093445049973e18 }));
+        sets.push(set({ x: 1.125e18, expected: 0.169925001442312346e18 }));
+        sets.push(set({ x: E, expected: 1_442695040888963394 }));
+        sets.push(set({ x: PI, expected: 1_651496129472318782 }));
+        sets.push(set({ x: 1e24, expected: 19_931568569324174075 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, expected: 195_205294292027477728 }));
+        sets.push(set({ x: MAX_SD59x18, expected: 195_205294292027477728 }));
+        return sets;
+    }
+
+    function test_Log2_NotPowerOfTwo() external parameterizedTest(notPowerOfTwo_Sets()) whenNotZero whenPositive {
+        SD59x18 actual = log2(s.x);
+        assertEq(actual, s.expected, "SD59x18 log2");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/log2/log2.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/log2/log2.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Log_InputTooSmall } from "src/sd59x18/Errors.sol";
-import { log2 } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Log_InputTooSmall } from "@prb/math/src/sd59x18/Errors.sol";
+import { log2 } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/mul/mul.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/mul/mul.t.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { PRBMath_MulDiv18_Overflow } from "src/Common.sol";
+import { sd } from "src/sd59x18/Casting.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Mul_InputTooSmall, PRBMath_SD59x18_Mul_Overflow } from "src/sd59x18/Errors.sol";
+import { mul } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Mul_Unit_Test is SD59x18_Unit_Test {
+    function oneOperandZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18 + sd(1), y: 0, expected: 0 }));
+        sets.push(set({ x: 0, y: MIN_SD59x18 + sd(1), expected: 0 }));
+        sets.push(set({ x: 0, y: MAX_SD59x18, expected: 0 }));
+        sets.push(set({ x: MAX_SD59x18, y: 0, expected: 0 }));
+        return sets;
+    }
+
+    function test_Mul_OneOperandZero() external parameterizedTest(oneOperandZero_Sets()) {
+        assertEq(mul(s.x, s.y), s.expected, "SD59x18 mul");
+        assertEq(s.x * s.y, s.expected, "SD59x18 *");
+    }
+
+    modifier whenNeitherOperandZero() {
+        _;
+    }
+
+    function test_RevertWhen_OneOperandMinSD59x18_Function() external whenNeitherOperandZero {
+        SD59x18 x = MIN_SD59x18;
+        SD59x18 y = sd(0.000000000000000001e18);
+        vm.expectRevert(PRBMath_SD59x18_Mul_InputTooSmall.selector);
+        mul(x, y);
+    }
+
+    function test_RevertWhen_OneOperandMinSD59x18_Operator() external whenNeitherOperandZero {
+        SD59x18 x = sd(0.000000000000000001e18);
+        SD59x18 y = MIN_SD59x18;
+        vm.expectRevert(PRBMath_SD59x18_Mul_InputTooSmall.selector);
+        x * y;
+    }
+
+    modifier whenNeitherOperandMinSD59x18() {
+        _;
+    }
+
+    function test_RevertWhen_ResultOverflowSD59x18_A() external whenNeitherOperandZero whenNeitherOperandMinSD59x18 {
+        SD59x18 x = NEGATIVE_SQRT_MAX_SD59x18;
+        SD59x18 y = NEGATIVE_SQRT_MAX_SD59x18 - sd(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Mul_Overflow.selector, x, y));
+        mul(x, y);
+    }
+
+    function test_RevertWhen_ResultOverflowSD59x18_B() external whenNeitherOperandZero whenNeitherOperandMinSD59x18 {
+        SD59x18 x = SQRT_MAX_SD59x18;
+        SD59x18 y = SQRT_MAX_SD59x18 + sd(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Mul_Overflow.selector, x, y));
+        mul(x, y);
+    }
+
+    modifier whenResultDoesNotOverflowSD59x18() {
+        _;
+    }
+
+    function resultOverflowUint256_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18 + sd(1), y: MIN_SD59x18 + sd(1), expected: NIL }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18, y: MIN_WHOLE_SD59x18, expected: NIL }));
+        sets.push(set({ x: NEGATIVE_SQRT_MAX_UD60x18 - sd(1), y: NEGATIVE_SQRT_MAX_UD60x18 - sd(1), expected: NIL }));
+        sets.push(set({ x: SQRT_MAX_UD60x18 + sd(1), y: SQRT_MAX_UD60x18 + sd(1), expected: NIL }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18, y: MAX_WHOLE_SD59x18, expected: NIL }));
+        sets.push(set({ x: MAX_SD59x18, y: MAX_SD59x18, expected: NIL }));
+        return sets;
+    }
+
+    function test_RevertWhen_ResultOverflowUint256()
+        external
+        parameterizedTest(resultOverflowUint256_Sets())
+        whenNeitherOperandZero
+        whenNeitherOperandMinSD59x18
+        whenResultDoesNotOverflowSD59x18
+    {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                PRBMath_MulDiv18_Overflow.selector,
+                s.x.lt(ZERO) ? s.x.uncheckedUnary() : s.x,
+                s.y.lt(ZERO) ? s.y.uncheckedUnary() : s.y
+            )
+        );
+        mul(s.x, s.y);
+    }
+
+    modifier whenResultDoesNotOverflowUint256() {
+        _;
+    }
+
+    function operandsSameSign_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18 + sd(0.5e18 + 1), y: -0.000000000000000001e18, expected: MAX_SCALED_SD59x18 }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18 + sd(0.5e18), y: -0.000000000000000001e18, expected: MAX_SCALED_SD59x18 - sd(1) }));
+        sets.push(set({ x: -1e24, y: -1e20, expected: 1e26 }));
+        sets.push(set({ x: -12_983.989e18, y: -782.99e18, expected: 1_016_6333.54711e18 }));
+        sets.push(set({ x: -9_817e18, y: -2_348e18, expected: 23_050_316e18 }));
+        sets.push(set({ x: -314.271e18, y: -188.19e18, expected: 59_142.65949e18 }));
+        sets.push(set({ x: -18.3e18, y: -12.04e18, expected: 220.332e18 }));
+        sets.push(set({ x: NEGATIVE_PI, y: NEGATIVE_E, expected: 8_539734222673567063 }));
+        sets.push(set({ x: -2.098e18, y: -1.119e18, expected: 2.347662e18 }));
+        sets.push(set({ x: -1e18, y: -1e18, expected: 1e18 }));
+        sets.push(set({ x: -0.01e18, y: -0.05e18, expected: 0.0005e18 }));
+        sets.push(set({ x: -0.001e18, y: -0.01e18, expected: 0.00001e18 }));
+        sets.push(set({ x: -0.00001e18, y: -0.00001e18, expected: 0.0000000001e18 }));
+        sets.push(set({ x: -0.000000001e18, y: -0.000000001e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: -0.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: -0.000000000000000006e18, y: -0.1e18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000001e18, y: 0.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000006e18, y: 0.1e18, expected: 0 }));
+        sets.push(set({ x: 0.000000001e18, y: 0.000000001e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 0.00001e18, y: 0.00001e18, expected: 0.0000000001e18 }));
+        sets.push(set({ x: 0.001e18, y: 0.01e18, expected: 0.00001e18 }));
+        sets.push(set({ x: 0.01e18, y: 0.05e18, expected: 0.0005e18 }));
+        sets.push(set({ x: 1e18, y: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 2.098e18, y: 1.119e18, expected: 2.347662e18 }));
+        sets.push(set({ x: PI, y: E, expected: 8_539734222673567063 }));
+        sets.push(set({ x: 18.3e18, y: 12.04e18, expected: 220.332e18 }));
+        sets.push(set({ x: 314.271e18, y: 188.19e18, expected: 59_142.65949e18 }));
+        sets.push(set({ x: 9_817e18, y: 2_348e18, expected: 23_050_316e18 }));
+        sets.push(set({ x: 12_983.989e18, y: 782.99e18, expected: 1_016_6333.54711e18 }));
+        sets.push(set({ x: 1e24, y: 1e20, expected: 1e26 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18 - sd(0.5e18), y: 0.000000000000000001e18, expected: MAX_SCALED_SD59x18 - sd(1) }));
+        sets.push(set({ x: MAX_SD59x18 - sd(0.5e18), y: 0.000000000000000001e18, expected: MAX_SCALED_SD59x18 }));
+        return sets;
+    }
+
+    function test_Mul_OperandsSameSign()
+        external
+        parameterizedTest(operandsSameSign_Sets())
+        whenNeitherOperandZero
+        whenNeitherOperandMinSD59x18
+        whenResultDoesNotOverflowSD59x18
+        whenResultDoesNotOverflowUint256
+    {
+        assertEq(mul(s.x, s.y), s.expected, "SD59x18 mul");
+        assertEq(s.x * s.y, s.expected, "SD59x18 *");
+    }
+
+    function operandsDifferentSigns_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18 + sd(0.5e18 + 1), y: 0.000000000000000001e18, expected: MIN_SCALED_SD59x18 }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18 + sd(0.5e18), y: 0.000000000000000001e18, expected: MIN_SCALED_SD59x18 + sd(1) }));
+        sets.push(set({ x: -1e24, y: 1e20, expected: -1e26 }));
+        sets.push(set({ x: -12_983.989e18, y: 782.99e18, expected: -1_016_6333.54711e18 }));
+        sets.push(set({ x: -9_817e18, y: 2_348e18, expected: -23_050_316e18 }));
+        sets.push(set({ x: -314.271e18, y: 188.19e18, expected: -59_142.65949e18 }));
+        sets.push(set({ x: -18.3e18, y: 12.04e18, expected: -220.332e18 }));
+        sets.push(set({ x: NEGATIVE_PI, y: E, expected: -8_539734222673567063 }));
+        sets.push(set({ x: -2.098e18, y: 1.119e18, expected: -2.347662e18 }));
+        sets.push(set({ x: -1e18, y: 1e18, expected: -1e18 }));
+        sets.push(set({ x: -0.01e18, y: 0.05e18, expected: -0.0005e18 }));
+        sets.push(set({ x: -0.001e18, y: 0.01e18, expected: -0.00001e18 }));
+        sets.push(set({ x: -0.00001e18, y: 0.00001e18, expected: -0.0000000001e18 }));
+        sets.push(set({ x: -0.000000001e18, y: 0.000000001e18, expected: -0.000000000000000001e18 }));
+        sets.push(set({ x: -0.000000000000000001e18, y: 0.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: -0.000000000000000006e18, y: 0.1e18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000001e18, y: -0.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000006e18, y: -0.1e18, expected: 0 }));
+        sets.push(set({ x: 0.000000001e18, y: -0.000000001e18, expected: -0.000000000000000001e18 }));
+        sets.push(set({ x: 0.00001e18, y: -0.00001e18, expected: -0.0000000001e18 }));
+        sets.push(set({ x: 0.001e18, y: -0.01e18, expected: -0.00001e18 }));
+        sets.push(set({ x: 0.01e18, y: -0.05e18, expected: -0.0005e18 }));
+        sets.push(set({ x: 1e18, y: -1e18, expected: -1e18 }));
+        sets.push(set({ x: 2.098e18, y: -1.119e18, expected: -2.347662e18 }));
+        sets.push(set({ x: PI, y: NEGATIVE_E, expected: -8_539734222673567063 }));
+        sets.push(set({ x: 18.3e18, y: -12.04e18, expected: -220.332e18 }));
+        sets.push(set({ x: 314.271e18, y: -188.19e18, expected: -59_142.65949e18 }));
+        sets.push(set({ x: 9_817e18, y: -2_348e18, expected: -23_050_316e18 }));
+        sets.push(set({ x: 12_983.989e18, y: -782.99e18, expected: -1_016_6333.54711e18 }));
+        sets.push(set({ x: 1e24, y: -1e20, expected: -1e26 }));
+        sets.push(set({ x: MAX_WHOLE_SD59x18 - sd(0.5e18), y: -0.000000000000000001e18, expected: MIN_SCALED_SD59x18 + sd(1) }));
+        sets.push(set({ x: MAX_SD59x18 - sd(0.5e18), y: -0.000000000000000001e18, expected: MIN_SCALED_SD59x18 }));
+        return sets;
+    }
+
+    function test_Mul_OperandsDifferentSign()
+        external
+        parameterizedTest(operandsDifferentSigns_Sets())
+        whenNeitherOperandZero
+        whenNeitherOperandMinSD59x18
+        whenResultDoesNotOverflowSD59x18
+        whenResultDoesNotOverflowUint256
+    {
+        assertEq(mul(s.x, s.y), s.expected, "SD59x18 mul");
+        assertEq(s.x * s.y, s.expected, "SD59x18 *");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/mul/mul.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/mul/mul.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { PRBMath_MulDiv18_Overflow } from "src/Common.sol";
-import { sd } from "src/sd59x18/Casting.sol";
-import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Mul_InputTooSmall, PRBMath_SD59x18_Mul_Overflow } from "src/sd59x18/Errors.sol";
-import { mul } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { PRBMath_MulDiv18_Overflow } from "@prb/math/src/Common.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Mul_InputTooSmall, PRBMath_SD59x18_Mul_Overflow } from "@prb/math/src/sd59x18/Errors.sol";
+import { mul } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/pow/pow.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/pow/pow.t.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { E, PI, UNIT, ZERO } from "src/sd59x18/Constants.sol";
+import { pow } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Pow_Unit_Test is SD59x18_Unit_Test {
+    function test_Pow_BaseZero_ExponentZero() external pure {
+        SD59x18 x = ZERO;
+        SD59x18 y = ZERO;
+        SD59x18 actual = pow(x, y);
+        SD59x18 expected = UNIT;
+        assertEq(actual, expected, "SD59x18 pow");
+    }
+
+    function test_Pow_BaseZero_ExponentNotZero() external pure {
+        SD59x18 x = ZERO;
+        SD59x18 y = UNIT;
+        SD59x18 actual = pow(x, y);
+        SD59x18 expected = ZERO;
+        assertEq(actual, expected, "SD59x18 pow");
+    }
+
+    modifier whenBaseNotZero() {
+        _;
+    }
+
+    function test_Pow_BaseUnit() external pure whenBaseNotZero {
+        SD59x18 x = UNIT;
+        SD59x18 y = PI;
+        SD59x18 actual = pow(x, y);
+        SD59x18 expected = UNIT;
+        assertEq(actual, expected, "SD59x18 pow");
+    }
+
+    modifier whenBaseNotUnit() {
+        _;
+    }
+
+    function test_Pow_ExponentZero() external pure whenBaseNotZero whenBaseNotUnit {
+        SD59x18 x = PI;
+        SD59x18 y = ZERO;
+        SD59x18 actual = pow(x, y);
+        SD59x18 expected = UNIT;
+        assertEq(actual, expected, "SD59x18 pow");
+    }
+
+    modifier whenExponentNotZero() {
+        _;
+    }
+
+    function test_Pow_ExponentUnit() external pure whenBaseNotZero whenBaseNotUnit whenExponentNotZero {
+        SD59x18 x = PI;
+        SD59x18 y = UNIT;
+        SD59x18 actual = pow(x, y);
+        SD59x18 expected = x;
+        assertEq(actual, expected, "SD59x18 pow");
+    }
+
+    modifier whenExponentNotUnit() {
+        _;
+    }
+
+    function negativeExponent_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, y: -0.000000000000000001e18, expected: 1e18 + 40 }));
+        sets.push(set({ x: 0.000000000001e18, y: -4.4e9, expected: 1_000000121576500300 }));
+        sets.push(set({ x: 0.1e18, y: -0.8e18, expected: 6_309573444801932444 }));
+        sets.push(set({ x: 0.24e18, y: -11e18, expected: 6571678_991286039528731186 }));
+        sets.push(set({ x: 0.5e18, y: -0.7373e18, expected: 1_667053032211341971 }));
+        sets.push(set({ x: 0.799291e18, y: -69e18, expected: 5168450_048540730175583501 }));
+        sets.push(set({ x: 1e18, y: -1e18, expected: 1e18 }));
+        sets.push(set({ x: 1e18, y: NEGATIVE_PI, expected: 1e18 }));
+        sets.push(set({ x: 2e18, y: -1.5e18, expected: 0.353553390593273762e18 }));
+        sets.push(set({ x: E, y: NEGATIVE_E, expected: 0.065988035845312538e18 }));
+        sets.push(set({ x: E, y: -1.66976e18, expected: 0.18829225035644931e18 }));
+        sets.push(set({ x: PI, y: -1.5e18, expected: 0.179587122125166564e18 }));
+        sets.push(set({ x: 11e18, y: -28.5e18, expected: 0 }));
+        sets.push(set({ x: 32.15e18, y: -23.99e18, expected: 0 }));
+        sets.push(set({ x: 406e18, y: -0.25e18, expected: 0.222776046060941016e18 }));
+        sets.push(set({ x: 1729e18, y: -0.98e18, expected: 0.00067136841637396e18 }));
+        sets.push(set({ x: 33441e18, y: -2.1891e18, expected: 0.000000000124709713e18 }));
+        sets.push(set({ x: 2 ** 128 * 1e18 - 1, y: -1e18, expected: 0 }));
+        sets.push(set({ x: 2 ** 192 * 1e18 - 1, y: -1e18, expected: 0 }));
+        return sets;
+    }
+
+    function test_Pow_NegativeExponent()
+        external
+        parameterizedTest(negativeExponent_Sets())
+        whenBaseNotZero
+        whenBaseNotUnit
+        whenExponentNotZero
+        whenExponentNotUnit
+    {
+        SD59x18 actual = pow(s.x, s.y);
+        assertEq(actual, s.expected, "SD59x18 pow");
+    }
+
+    function positiveExponent_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, y: 0.000000000000000001e18, expected: 0.99999999999999996e18 }));
+        sets.push(set({ x: 1e6, y: 4.4e9, expected: 0.99999987842351448e18 }));
+        sets.push(set({ x: 0.1e18, y: 0.8e18, expected: 0.158489319246111349e18 }));
+        sets.push(set({ x: 0.24e18, y: 11e18, expected: 0.000000152168114316e18 }));
+        sets.push(set({ x: 0.5e18, y: 0.7373e18, expected: 0.59986094064056398e18 }));
+        sets.push(set({ x: 0.799291e18, y: 69e18, expected: 0.000000193481602919e18 }));
+        sets.push(set({ x: 1e18, y: 2e18, expected: 1e18 }));
+        sets.push(set({ x: 1e18, y: PI, expected: 1e18 }));
+        sets.push(set({ x: 2e18, y: 1.5e18, expected: 2_828427124746190097 }));
+        sets.push(set({ x: E, y: E, expected: 15_154262241479263793 }));
+        sets.push(set({ x: E, y: 1.66976e18, expected: 5_310893029888037560 }));
+        sets.push(set({ x: PI, y: PI, expected: 36_462159607207910473 }));
+        sets.push(set({ x: 11e18, y: 28.5e18, expected: 478290249106383504389245497918_050372801213485439 }));
+        sets.push(set({ x: 32.15e18, y: 23.99e18, expected: 1436387590627448555101723413293079116_943375472179194989 }));
+        sets.push(set({ x: 406e18, y: 0.25e18, expected: 4_488812947719016318 }));
+        sets.push(set({ x: 1729e18, y: 0.98e18, expected: 1489_495149922256917866 }));
+        sets.push(set({ x: 33441e18, y: 2.1891e18, expected: 8018621589_681923269491820156 }));
+        sets.push(
+            set({
+                x: 340282366920938463463374607431768211455e18,
+                y: 1e18 + 1,
+                expected: 340282366920938487757736552507248225013_000000000004316573
+            })
+        );
+        sets.push(
+            set({ x: 2 ** 192 * 1e18 - 1, y: 1e18 - 1, expected: 6277101735386679823624773486129835356722228023657461399187e18 })
+        );
+        return sets;
+    }
+
+    function test_Pow_PositiveExponent()
+        external
+        parameterizedTest(positiveExponent_Sets())
+        whenBaseNotZero
+        whenBaseNotUnit
+        whenExponentNotZero
+        whenExponentNotUnit
+    {
+        SD59x18 actual = pow(s.x, s.y);
+        assertEq(actual, s.expected, "SD59x18 pow");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/pow/pow.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/pow/pow.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { E, PI, UNIT, ZERO } from "src/sd59x18/Constants.sol";
-import { pow } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { E, PI, UNIT, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { pow } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/powu/powu.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/powu/powu.t.sol
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { PRBMath_MulDiv18_Overflow } from "src/Common.sol";
+import { sd } from "src/sd59x18/Casting.sol";
+import {
+    E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, uMAX_SD59x18, ZERO
+} from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Powu_Overflow } from "src/sd59x18/Errors.sol";
+import { powu } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Powu_Unit_Test is SD59x18_Unit_Test {
+    function test_Powu_BaseAndExponentZero() external pure {
+        SD59x18 x = ZERO;
+        uint256 y = 0;
+        SD59x18 actual = powu(x, y);
+        SD59x18 expected = sd(1e18);
+        assertEq(actual, expected, "SD59x18 powu");
+    }
+
+    function baseZeroExponentNotZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0, y: 1e18, expected: 0 }));
+        sets.push(set({ x: 0, y: 2, expected: 0 }));
+        sets.push(set({ x: 0, y: 3, expected: 0 }));
+        return sets;
+    }
+
+    function test_Powu_BaseZeroExponentNotZero() external parameterizedTest(baseZeroExponentNotZero_Sets()) {
+        SD59x18 actual = powu(s.x, sdToUint(s.y));
+        assertEq(actual, s.expected, "SD59x18 powu");
+    }
+
+    modifier whenBaseNotZero() {
+        _;
+    }
+
+    function exponentZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18 + sd(1), expected: 1e18 }));
+        sets.push(set({ x: NEGATIVE_PI, expected: 1e18 }));
+        sets.push(set({ x: -1e18, expected: 1e18 }));
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: PI, expected: 1e18 }));
+        sets.push(set({ x: MAX_SD59x18 - sd(1), expected: 1e18 }));
+        return sets;
+    }
+
+    function test_Powu_ExponentZero() external parameterizedTest(exponentZero_Sets()) whenBaseNotZero {
+        SD59x18 actual = powu(s.x, sdToUint(s.y));
+        assertEq(actual, s.expected, "SD59x18 powu");
+    }
+
+    modifier whenExponentNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_ResultOverflowUint256() external whenBaseNotZero whenExponentNotZero {
+        SD59x18 x = MIN_SD59x18 + sd(1);
+        uint256 y = 2;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_MulDiv18_Overflow.selector, uint256(uMAX_SD59x18), uint256(uMAX_SD59x18)));
+        powu(x, y);
+    }
+
+    modifier whenResultDoesNotOverflowUint256() {
+        _;
+    }
+
+    function test_RevertWhen_ResultUnderflowSD59x18()
+        external
+        whenBaseNotZero
+        whenExponentNotZero
+        whenResultDoesNotOverflowUint256
+    {
+        SD59x18 x = NEGATIVE_SQRT_MAX_SD59x18 - sd(1);
+        uint256 y = 2;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Powu_Overflow.selector, x, y));
+        powu(x, y);
+    }
+
+    function test_RevertWhen_ResultOverflowSD59x18()
+        external
+        whenBaseNotZero
+        whenExponentNotZero
+        whenResultDoesNotOverflowUint256
+    {
+        SD59x18 x = SQRT_MAX_SD59x18 + sd(1);
+        uint256 y = 2;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Powu_Overflow.selector, x, y));
+        powu(x, y);
+    }
+
+    modifier whenResultDoesNotOverflowOrUnderflowSD59x18() {
+        _;
+    }
+
+    function negativeBase_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: MIN_SD59x18 + sd(1), y: 1, expected: MIN_SD59x18 + sd(1) }));
+        sets.push(set({ x: MIN_WHOLE_SD59x18, y: 1, expected: MIN_WHOLE_SD59x18 }));
+        sets.push(
+            set({
+                x: NEGATIVE_SQRT_MAX_SD59x18,
+                y: 2,
+                expected: 57896044618658097711785492504343953926634992332789893003858_354368578996153260
+            })
+        );
+        sets.push(
+            set({
+                x: -38685626227668133590.597631999999999999e18,
+                y: 3,
+                expected: -57896044618658097711785492504343953922145259302939748254975_940481744194640509
+            })
+        );
+        sets.push(set({ x: -1e24, y: 3, expected: -1e36 }));
+        sets.push(set({ x: -6452.166e18, y: 7, expected: -4655204093726194074224341678_62736844121311696 }));
+        sets.push(
+            set({ x: -478.77e18, y: 20, expected: 400441047687151121501368529571950234763284476825512183_793320584974037932 })
+        );
+        sets.push(set({ x: -100e18, y: 4, expected: 1e26 }));
+        sets.push(set({ x: -5.491e18, y: 19, expected: -113077820843204_476043049664958463 }));
+        sets.push(set({ x: NEGATIVE_E, y: 2, expected: 7_389056098930650225 }));
+        sets.push(set({ x: NEGATIVE_PI, y: 3, expected: -31_006276680299820158 }));
+        sets.push(set({ x: -2e18, y: 100, expected: 1267650600228_229401496703205376e18 }));
+        sets.push(set({ x: -2e18, y: 5, expected: -32e18 }));
+        sets.push(set({ x: -1e18, y: 1, expected: -1e18 }));
+        sets.push(set({ x: -0.1e18, y: 2, expected: 0.01e18 }));
+        sets.push(set({ x: -0.001e18, y: 3, expected: -0.000000001e18 }));
+        return sets;
+    }
+
+    function test_Powu_NegativeBase()
+        external
+        parameterizedTest(negativeBase_Sets())
+        whenBaseNotZero
+        whenExponentNotZero
+        whenResultDoesNotOverflowUint256
+        whenResultDoesNotOverflowOrUnderflowSD59x18
+    {
+        SD59x18 actual = powu(s.x, sdToUint(s.y));
+        assertEq(actual, s.expected, "SD59x18 powu");
+    }
+
+    function positiveBase_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.001e18, y: 3, expected: 1e9 }));
+        sets.push(set({ x: 0.1e18, y: 2, expected: 1e16 }));
+        sets.push(set({ x: 1e18, y: 1, expected: 1e18 }));
+        sets.push(set({ x: 2e18, y: 5, expected: 32e18 }));
+        sets.push(set({ x: 2e18, y: 100, expected: 1267650600228_229401496703205376e18 }));
+        sets.push(set({ x: E, y: 2, expected: 7_389056098930650225 }));
+        sets.push(set({ x: PI, y: 3, expected: 31_006276680299820158 }));
+        sets.push(set({ x: 5.491e18, y: 19, expected: 113077820843204_476043049664958463 }));
+        sets.push(set({ x: 100e18, y: 4, expected: 1e26 }));
+        sets.push(set({ x: 478.77e18, y: 20, expected: 400441047687151121501368529571950234763284476825512183793320584974037932 }));
+        sets.push(set({ x: 6452.166e18, y: 7, expected: 4655204093726194074224341678_62736844121311696 }));
+        sets.push(set({ x: 1e24, y: 3, expected: 1e36 }));
+        sets.push(
+            set({
+                x: 38685626227668133590.597631999999999999e18,
+                y: 3,
+                expected: 57896044618658097711785492504343953922145259302939748254975_940481744194640509
+            })
+        );
+        sets.push(
+            set({
+                x: SQRT_MAX_SD59x18,
+                y: 2,
+                expected: 57896044618658097711785492504343953926634992332789893003858_354368578996153260
+            })
+        );
+        sets.push(set({ x: MAX_WHOLE_SD59x18, y: 1, expected: MAX_WHOLE_SD59x18 }));
+        sets.push(set({ x: MAX_SD59x18, y: 1, expected: MAX_SD59x18 }));
+        return sets;
+    }
+
+    function test_Powu_PositiveBase()
+        external
+        parameterizedTest(positiveBase_Sets())
+        whenBaseNotZero
+        whenExponentNotZero
+        whenResultDoesNotOverflowUint256
+        whenResultDoesNotOverflowOrUnderflowSD59x18
+    {
+        SD59x18 actual = powu(s.x, sdToUint(s.y));
+        assertEq(actual, s.expected, "SD59x18 powu");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/powu/powu.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/powu/powu.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { PRBMath_MulDiv18_Overflow } from "src/Common.sol";
-import { sd } from "src/sd59x18/Casting.sol";
+import { PRBMath_MulDiv18_Overflow } from "@prb/math/src/Common.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
 import {
     E, MAX_SD59x18, MAX_WHOLE_SD59x18, MIN_SD59x18, MIN_WHOLE_SD59x18, PI, uMAX_SD59x18, ZERO
-} from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Powu_Overflow } from "src/sd59x18/Errors.sol";
-import { powu } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+} from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Powu_Overflow } from "@prb/math/src/sd59x18/Errors.sol";
+import { powu } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/sqrt/sqrt.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/sqrt/sqrt.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { sd } from "src/sd59x18/Casting.sol";
+import { E, PI, ZERO } from "src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Sqrt_NegativeInput, PRBMath_SD59x18_Sqrt_Overflow } from "src/sd59x18/Errors.sol";
+import { sqrt } from "src/sd59x18/Math.sol";
+import { SD59x18 } from "src/sd59x18/ValueType.sol";
+
+import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
+
+contract Sqrt_Unit_Test is SD59x18_Unit_Test {
+    function test_Sqrt_Zero() external pure {
+        SD59x18 x = ZERO;
+        SD59x18 actual = sqrt(x);
+        SD59x18 expected = ZERO;
+        assertEq(actual, expected, "SD59x18 sqrt");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_Negative() external whenNotZero {
+        SD59x18 x = sd(-1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Sqrt_NegativeInput.selector, x));
+        sqrt(x);
+    }
+
+    modifier whenPositive() {
+        _;
+    }
+
+    function test_RevertWhen_GtMaxPermitted() external whenNotZero whenPositive {
+        SD59x18 x = MAX_SCALED_SD59x18 + sd(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_SD59x18_Sqrt_Overflow.selector, x));
+        sqrt(x);
+    }
+
+    modifier whenLteMaxPermitted() {
+        _;
+    }
+
+    function sqrt_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, expected: 0.000000001e18 }));
+        sets.push(set({ x: 0.000000000000001e18, expected: 0.000000031622776601e18 }));
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 2e18, expected: 1_414213562373095048 }));
+        sets.push(set({ x: E, expected: 1_648721270700128146 }));
+        sets.push(set({ x: 3e18, expected: 1_732050807568877293 }));
+        sets.push(set({ x: PI, expected: 1_772453850905516027 }));
+        sets.push(set({ x: 4e18, expected: 2e18 }));
+        sets.push(set({ x: 16e18, expected: 4e18 }));
+        sets.push(set({ x: 1e35, expected: 316227766_016837933199889354 }));
+        sets.push(set({ x: 12489131238983290393813_123784889921092801, expected: 111754781727_598977910452220959 }));
+        sets.push(set({ x: 1889920002192904839344128288891377_732371920009212883, expected: 43473210166640613973238162807779776 }));
+        sets.push(set({ x: 1e58, expected: 1e38 }));
+        sets.push(set({ x: 5e58, expected: 223606797749978969640_917366873127623544 }));
+        sets.push(set({ x: MAX_SCALED_SD59x18, expected: 240615969168004511545_033772477625056927 }));
+        return sets;
+    }
+
+    function test_Sqrt() external parameterizedTest(sqrt_Sets()) whenNotZero whenPositive whenLteMaxPermitted {
+        SD59x18 actual = sqrt(s.x);
+        assertEq(actual, s.expected, "SD59x18 sqrt");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/sqrt/sqrt.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/sd59x18/math/sqrt/sqrt.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { sd } from "src/sd59x18/Casting.sol";
-import { E, PI, ZERO } from "src/sd59x18/Constants.sol";
-import { PRBMath_SD59x18_Sqrt_NegativeInput, PRBMath_SD59x18_Sqrt_Overflow } from "src/sd59x18/Errors.sol";
-import { sqrt } from "src/sd59x18/Math.sol";
-import { SD59x18 } from "src/sd59x18/ValueType.sol";
+import { sd } from "@prb/math/src/sd59x18/Casting.sol";
+import { E, PI, ZERO } from "@prb/math/src/sd59x18/Constants.sol";
+import { PRBMath_SD59x18_Sqrt_NegativeInput, PRBMath_SD59x18_Sqrt_Overflow } from "@prb/math/src/sd59x18/Errors.sol";
+import { sqrt } from "@prb/math/src/sd59x18/Math.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
 
 import { SD59x18_Unit_Test } from "../../SD59x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/UD60x18.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/UD60x18.t.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { console2 } from "forge-std/src/console2.sol";
+
+import { ZERO } from "src/ud60x18/Constants.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { Base_Test } from "../../Base.t.sol";
+
+/// @notice Common logic needed by all UD60x18 unit tests.
+abstract contract UD60x18_Unit_Test is Base_Test {
+    /*//////////////////////////////////////////////////////////////////////////
+                                      CONSTANTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    UD60x18 internal constant MAX_SCALED_UD60x18 = UD60x18.wrap(115792089237316195423570985008687907853269_984665640564039457);
+    UD60x18 internal constant SQRT_MAX_UD60x18 = UD60x18.wrap(340282366920938463463374607431_768211455999999999);
+
+    /// @dev This is needed to be used as the `expected` parameter of {set}. Solidity functions cannot be overridden
+    /// to have two implementations that each has two "int256" arguments.
+    UD60x18 internal constant NIL = ZERO;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                       STRUCTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    struct Set {
+        UD60x18 x;
+        UD60x18 y;
+        UD60x18 expected;
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     VARIABLES
+    //////////////////////////////////////////////////////////////////////////*/
+
+    Set internal s;
+    Set[] internal sets;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      MODIFIERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    modifier parameterizedTest(Set[] memory testSets) {
+        uint256 length = testSets.length;
+        for (uint256 i = 0; i < length;) {
+            s = testSets[i];
+            _;
+            unchecked {
+                i += 1;
+            }
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                              CONSTANT HELPER FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function logUd(UD60x18 p0) internal pure {
+        console2.logUint(p0.unwrap());
+    }
+
+    function logUd(string memory p0, UD60x18 p1) internal pure {
+        console2.log(p0, p1.unwrap());
+    }
+
+    function set(uint256 x) internal pure returns (Set memory) {
+        return Set({ x: ud(x), y: ZERO, expected: ZERO });
+    }
+
+    function set(UD60x18 x) internal pure returns (Set memory) {
+        return Set({ x: x, y: ZERO, expected: ZERO });
+    }
+
+    function set(uint256 x, uint256 expected) internal pure returns (Set memory) {
+        return Set({ x: ud(x), y: ZERO, expected: ud(expected) });
+    }
+
+    function set(uint256 x, UD60x18 expected) internal pure returns (Set memory) {
+        return Set({ x: ud(x), y: ZERO, expected: expected });
+    }
+
+    function set(UD60x18 x, uint256 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: ZERO, expected: ud(expected) });
+    }
+
+    function set(UD60x18 x, UD60x18 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: ZERO, expected: expected });
+    }
+
+    function set(uint256 x, uint256 y, uint256 expected) internal pure returns (Set memory) {
+        return Set({ x: ud(x), y: ud(y), expected: ud(expected) });
+    }
+
+    function set(uint256 x, uint256 y, UD60x18 expected) internal pure returns (Set memory) {
+        return Set({ x: ud(x), y: ud(y), expected: expected });
+    }
+
+    function set(uint256 x, UD60x18 y, uint256 expected) internal pure returns (Set memory) {
+        return Set({ x: ud(x), y: y, expected: ud(expected) });
+    }
+
+    function set(uint256 x, UD60x18 y, UD60x18 expected) internal pure returns (Set memory) {
+        return Set({ x: ud(x), y: y, expected: expected });
+    }
+
+    function set(UD60x18 x, uint256 y, uint256 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: ud(y), expected: ud(expected) });
+    }
+
+    function set(UD60x18 x, UD60x18 y, uint256 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: y, expected: ud(expected) });
+    }
+
+    function set(UD60x18 x, uint256 y, UD60x18 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: ud(y), expected: expected });
+    }
+
+    function set(UD60x18 x, UD60x18 y, UD60x18 expected) internal pure returns (Set memory) {
+        return Set({ x: x, y: y, expected: expected });
+    }
+
+    function ud(uint256 x) internal pure returns (UD60x18 result) {
+        result = UD60x18.wrap(x);
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/UD60x18.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/UD60x18.t.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { console2 } from "forge-std/src/console2.sol";
 
-import { ZERO } from "src/ud60x18/Constants.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { Base_Test } from "../../Base.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/conversion/convert-from/convertFrom.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/conversion/convert-from/convertFrom.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { E, MAX_WHOLE_UD60x18, MAX_UD60x18, PI } from "src/ud60x18/Constants.sol";
+import { convert } from "src/ud60x18/Conversions.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract ConvertFrom_Unit_Test is UD60x18_Unit_Test {
+    function ltUnit_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0 }));
+        sets.push(set({ x: 1 }));
+        sets.push(set({ x: 1e18 - 1 }));
+        return sets;
+    }
+
+    function test_ConvertFrom_LtUnit() external parameterizedTest(ltUnit_Sets()) {
+        uint256 actual = convert(s.x);
+        uint256 expected = 0;
+        assertEq(actual, expected, "UD60x18 convertFrom");
+    }
+
+    modifier whenGteUnit() {
+        _;
+    }
+
+    function gteUnit_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 1e18 + 1, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 2e18 - 1, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 2e18, expected: 0.000000000000000002e18 }));
+        sets.push(set({ x: 2e18 + 1, expected: 0.000000000000000002e18 }));
+        sets.push(set({ x: E, expected: 0.000000000000000002e18 }));
+        sets.push(set({ x: PI, expected: 0.000000000000000003e18 }));
+        sets.push(set({ x: 1729e18, expected: 0.000000000000001729e18 }));
+        sets.push(set({ x: 4.2e45, expected: 4.2e27 }));
+        sets.push(set({ x: MAX_WHOLE_UD60x18, expected: MAX_SCALED_UD60x18 }));
+        sets.push(set({ x: MAX_UD60x18, expected: MAX_SCALED_UD60x18 }));
+        return sets;
+    }
+
+    function test_ConvertFrom() external parameterizedTest(gteUnit_Sets()) whenGteUnit {
+        uint256 actual = convert(s.x);
+        uint256 expected = s.expected.unwrap();
+        assertEq(actual, expected, "UD60x18 convertFrom");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/conversion/convert-from/convertFrom.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/conversion/convert-from/convertFrom.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { E, MAX_WHOLE_UD60x18, MAX_UD60x18, PI } from "src/ud60x18/Constants.sol";
-import { convert } from "src/ud60x18/Conversions.sol";
+import { E, MAX_WHOLE_UD60x18, MAX_UD60x18, PI } from "@prb/math/src/ud60x18/Constants.sol";
+import { convert } from "@prb/math/src/ud60x18/Conversions.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/conversion/convert-to/convertTo.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/conversion/convert-to/convertTo.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { MAX_WHOLE_UD60x18 } from "src/ud60x18/Constants.sol";
+import { convert } from "src/ud60x18/Conversions.sol";
+import { PRBMath_UD60x18_Convert_Overflow } from "src/ud60x18/Errors.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract ConvertTo_Unit_Test is UD60x18_Unit_Test {
+    function test_RevertWhen_GtMaxPermitted() external {
+        uint256 x = MAX_SCALED_UD60x18.unwrap() + 1;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Convert_Overflow.selector, x));
+        convert(x);
+    }
+
+    modifier whenLteMaxPermitted() {
+        _;
+    }
+
+    function convertTo_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, expected: 1e18 }));
+        sets.push(set({ x: 0.000000000000000002e18, expected: 2e18 }));
+        sets.push(set({ x: 0.000000000000001729e18, expected: 1729e18 }));
+        sets.push(set({ x: 1e18, expected: 1e36 }));
+        sets.push(set({ x: 5e18, expected: 5e36 }));
+        sets.push(set({ x: 2.7182e38, expected: 2.7182e56 }));
+        sets.push(set({ x: 3.1415e42, expected: 3.1415e60 }));
+        sets.push(set({ x: MAX_SCALED_UD60x18, expected: MAX_WHOLE_UD60x18 }));
+        return sets;
+    }
+
+    function test_ConvertTo() external parameterizedTest(convertTo_Sets()) whenLteMaxPermitted {
+        UD60x18 x = convert(s.x.unwrap());
+        assertEq(x, s.expected, "UD60x18 convertTo");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/conversion/convert-to/convertTo.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/conversion/convert-to/convertTo.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { MAX_WHOLE_UD60x18 } from "src/ud60x18/Constants.sol";
-import { convert } from "src/ud60x18/Conversions.sol";
-import { PRBMath_UD60x18_Convert_Overflow } from "src/ud60x18/Errors.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { MAX_WHOLE_UD60x18 } from "@prb/math/src/ud60x18/Constants.sol";
+import { convert } from "@prb/math/src/ud60x18/Conversions.sol";
+import { PRBMath_UD60x18_Convert_Overflow } from "@prb/math/src/ud60x18/Errors.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/avg/avg.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/avg/avg.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { MAX_UD60x18, MAX_WHOLE_UD60x18, ZERO } from "src/ud60x18/Constants.sol";
+import { avg } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Avg_Unit_Test is UD60x18_Unit_Test {
+    function test_Avg_BothOperandsZero() external pure {
+        UD60x18 x = ZERO;
+        UD60x18 y = ZERO;
+        UD60x18 actual = avg(x, y);
+        UD60x18 expected = ZERO;
+        assertEq(actual, expected, "UD60x18 avg");
+    }
+
+    function onlyOneOperandZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0, y: 3e18, expected: 1.5e18 }));
+        sets.push(set({ x: 3e18, y: 0, expected: 1.5e18 }));
+        return sets;
+    }
+
+    function test_Avg_OnlyOneOperandZero() external parameterizedTest(onlyOneOperandZero_Sets()) {
+        UD60x18 actual = avg(s.x, s.y);
+        assertEq(actual, s.expected, "UD60x18 avg");
+    }
+
+    modifier whenNeitherOperandZero() {
+        _;
+    }
+
+    function bothOperandsEven_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 2, y: 4, expected: 3 }));
+        sets.push(set({ x: 2e18, y: 2e18, expected: 2e18 }));
+        sets.push(set({ x: 4e18, y: 8e18, expected: 6e18 }));
+        sets.push(set({ x: 100e18, y: 200e18, expected: 150e18 }));
+        sets.push(set({ x: 1e24, y: 1e25, expected: 5.5e24 }));
+        return sets;
+    }
+
+    function test_Avg_NeitherOperandZero_BothOperandsEven()
+        external
+        parameterizedTest(bothOperandsEven_Sets())
+        whenNeitherOperandZero
+    {
+        UD60x18 actual = avg(s.x, s.y);
+        assertEq(actual, s.expected, "UD60x18 avg");
+    }
+
+    function bothOperandsOdd_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1, y: 3, expected: 2 }));
+        sets.push(set({ x: 1e18 + 1, y: 1e18 + 1, expected: 1e18 + 1 }));
+        sets.push(set({ x: 3e18 + 1, y: 7e18 + 1, expected: 5e18 + 1 }));
+        sets.push(set({ x: 99e18 + 1, y: 199e18 + 1, expected: 149e18 + 1 }));
+        sets.push(set({ x: 1e24 + 1, y: 1e25 + 1, expected: 5.5e24 + 1 }));
+        sets.push(set({ x: MAX_UD60x18, y: MAX_UD60x18, expected: MAX_UD60x18 }));
+        return sets;
+    }
+
+    function test_Avg_NeitherOperandZero_BothOperandsOdd()
+        external
+        parameterizedTest(bothOperandsOdd_Sets())
+        whenNeitherOperandZero
+    {
+        UD60x18 actual = avg(s.x, s.y);
+        assertEq(actual, s.expected, "UD60x18 avg");
+    }
+
+    function oneOperandEvenTheOtherOdd_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1, y: 2, expected: 1 }));
+        sets.push(set({ x: 1e18 + 1, y: 2e18, expected: 1.5e18 }));
+        sets.push(set({ x: 3e18 + 1, y: 8e18, expected: 5.5e18 }));
+        sets.push(set({ x: 99e18, y: 200e18, expected: 149.5e18 }));
+        sets.push(set({ x: 1e24 + 1, y: 1e25 + 1e18, expected: 5.5e24 + 0.5e18 }));
+        sets.push(
+            set({
+                x: MAX_UD60x18,
+                y: MAX_WHOLE_UD60x18,
+                expected: 115792089237316195423570985008687907853269984665640564039457_292003956564819967
+            })
+        );
+        return sets;
+    }
+
+    function test_Avg_NeitherOperandZero_OneOperandEvenTheOtherOdd()
+        external
+        parameterizedTest(oneOperandEvenTheOtherOdd_Sets())
+        whenNeitherOperandZero
+    {
+        UD60x18 actual = avg(s.x, s.y);
+        assertEq(actual, s.expected, "UD60x18 avg");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/avg/avg.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/avg/avg.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { MAX_UD60x18, MAX_WHOLE_UD60x18, ZERO } from "src/ud60x18/Constants.sol";
-import { avg } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { MAX_UD60x18, MAX_WHOLE_UD60x18, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { avg } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/ceil/ceil.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/ceil/ceil.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { ud } from "src/ud60x18/Casting.sol";
+import { MAX_WHOLE_UD60x18, PI, ZERO } from "src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Ceil_Overflow } from "src/ud60x18/Errors.sol";
+import { ceil } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract CeilTest is UD60x18_Unit_Test {
+    function test_Ceil_Zero() external pure {
+        UD60x18 x = ZERO;
+        UD60x18 actual = ceil(x);
+        UD60x18 expected = ZERO;
+        assertEq(actual, expected, "UD60x18 ceil");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_GtMaxPermitted() external whenNotZero {
+        UD60x18 x = MAX_WHOLE_UD60x18 + ud(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Ceil_Overflow.selector, x));
+        ceil(x);
+    }
+
+    modifier whenLteMaxWholeUD60x18() {
+        _;
+    }
+
+    function ceil_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.1e18, expected: 1e18 }));
+        sets.push(set({ x: 0.5e18, expected: 1e18 }));
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 1.125e18, expected: 2e18 }));
+        sets.push(set({ x: 2e18, expected: 2e18 }));
+        sets.push(set({ x: PI, expected: 4e18 }));
+        sets.push(set({ x: 4.2e18, expected: 5e18 }));
+        sets.push(set({ x: 1e24, expected: 1e24 }));
+        sets.push(set({ x: MAX_WHOLE_UD60x18, expected: MAX_WHOLE_UD60x18 }));
+        return sets;
+    }
+
+    function test_Ceil() external parameterizedTest(ceil_Sets()) whenNotZero whenLteMaxWholeUD60x18 {
+        UD60x18 actual = ceil(s.x);
+        assertEq(actual, s.expected, "UD60x18 ceil");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/ceil/ceil.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/ceil/ceil.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { ud } from "src/ud60x18/Casting.sol";
-import { MAX_WHOLE_UD60x18, PI, ZERO } from "src/ud60x18/Constants.sol";
-import { PRBMath_UD60x18_Ceil_Overflow } from "src/ud60x18/Errors.sol";
-import { ceil } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { ud } from "@prb/math/src/ud60x18/Casting.sol";
+import { MAX_WHOLE_UD60x18, PI, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Ceil_Overflow } from "@prb/math/src/ud60x18/Errors.sol";
+import { ceil } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/div/div.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/div/div.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { stdError } from "forge-std/src/StdError.sol";
+
+import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, uUNIT, ZERO } from "src/ud60x18/Constants.sol";
+import { div } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { PRBMath_MulDiv_Overflow } from "src/Common.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Div_Unit_Test is UD60x18_Unit_Test {
+    function test_RevertWhen_DenominatorZero_Function() external {
+        UD60x18 x = ud(1e18);
+        UD60x18 y = ZERO;
+        vm.expectRevert(stdError.divisionError);
+        div(x, y);
+    }
+
+    function test_RevertWhen_DenominatorZero_Operator() external {
+        UD60x18 x = ud(1e18);
+        UD60x18 y = ZERO;
+        vm.expectRevert(stdError.divisionError);
+        x / y;
+    }
+
+    modifier whenDenominatorNotZero() {
+        _;
+    }
+
+    function numeratorZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0, y: 0.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: 0, y: 1e18, expected: 0 }));
+        sets.push(set({ x: 0, y: PI, expected: 0 }));
+        sets.push(set({ x: 0, y: 1e24, expected: 0 }));
+        return sets;
+    }
+
+    function test_Div_NumeratorZero() external parameterizedTest(numeratorZero_Sets()) whenDenominatorNotZero {
+        assertEq(div(s.x, s.y), s.expected, "UD60x18 div");
+        assertEq(s.x / s.y, s.expected, "UD60x18 /");
+    }
+
+    function test_RevertWhen_ResultOverflowUD60x18_Function() external whenDenominatorNotZero {
+        UD60x18 x = MAX_SCALED_UD60x18 + ud(1);
+        UD60x18 y = ud(0.000000000000000001e18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_MulDiv_Overflow.selector, x.unwrap(), uUNIT, y.unwrap()));
+        div(x, y);
+    }
+
+    function test_RevertWhen_ResultOverflowUD60x18_Operator() external whenDenominatorNotZero {
+        UD60x18 x = MAX_SCALED_UD60x18 + ud(1);
+        UD60x18 y = ud(0.000000000000000001e18);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_MulDiv_Overflow.selector, x.unwrap(), uUNIT, y.unwrap()));
+        x / y;
+    }
+
+    modifier whenResultDoesNotOverflowUD60x18() {
+        _;
+    }
+
+    function div_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, y: MAX_UD60x18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000001e18, y: 1.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000001e18, y: 1e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 1e13, y: 1e13, expected: 1e18 }));
+        sets.push(set({ x: 1e13, y: 0.00002e18, expected: 0.5e18 }));
+        sets.push(set({ x: 0.05e18, y: 0.02e18, expected: 2.5e18 }));
+        sets.push(set({ x: 0.1e18, y: 0.01e18, expected: 10e18 }));
+        sets.push(set({ x: 2e18, y: 2e18, expected: 1e18 }));
+        sets.push(set({ x: 2e18, y: 5e18, expected: 0.4e18 }));
+        sets.push(set({ x: 4e18, y: 2e18, expected: 2e18 }));
+        sets.push(set({ x: 22e18, y: 7e18, expected: 3_142857142857142857 }));
+        sets.push(set({ x: 100.135e18, y: 100.134e18, expected: 1_000009986617931971 }));
+        sets.push(set({ x: 772.05e18, y: 199.98e18, expected: 3_860636063606360636 }));
+        sets.push(set({ x: 2503e18, y: 918882.11e18, expected: 0.002723962054283546e18 }));
+        sets.push(set({ x: 1e24, y: 1e18, expected: 1e24 }));
+        sets.push(set({ x: MAX_SCALED_UD60x18, y: 0.000000000000000001e18, expected: MAX_WHOLE_UD60x18 }));
+        return sets;
+    }
+
+    function test_Div() external parameterizedTest(div_Sets()) whenDenominatorNotZero whenResultDoesNotOverflowUD60x18 {
+        assertEq(div(s.x, s.y), s.expected, "UD60x18 div");
+        assertEq(s.x / s.y, s.expected, "UD60x18 /");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/div/div.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/div/div.t.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { stdError } from "forge-std/src/StdError.sol";
 
-import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, uUNIT, ZERO } from "src/ud60x18/Constants.sol";
-import { div } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
-import { PRBMath_MulDiv_Overflow } from "src/Common.sol";
+import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, uUNIT, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { div } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
+import { PRBMath_MulDiv_Overflow } from "@prb/math/src/Common.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/exp/exp.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/exp/exp.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { ud } from "src/ud60x18/Casting.sol";
+import { E, EXP_MAX_INPUT, PI, UNIT, ZERO } from "src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Exp_InputTooBig } from "src/ud60x18/Errors.sol";
+import { exp } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Exp_Unit_Test is UD60x18_Unit_Test {
+    function test_Exp_Zero() external pure {
+        UD60x18 x = ZERO;
+        UD60x18 actual = exp(x);
+        UD60x18 expected = UNIT;
+        assertEq(actual, expected, "UD60x18 exp");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_GtMaxPermitted() external whenNotZero {
+        UD60x18 x = EXP_MAX_INPUT + ud(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Exp_InputTooBig.selector, x));
+        exp(x);
+    }
+
+    modifier whenLteMaxPermitted() {
+        _;
+    }
+
+    function exp_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, expected: 1e18 }));
+        sets.push(set({ x: 0.000000000000001e18, expected: 1.000000000000000999e18 }));
+        sets.push(set({ x: 1e18, expected: 2_718281828459045234 }));
+        sets.push(set({ x: 2e18, expected: 7_389056098930650223 }));
+        sets.push(set({ x: E, expected: 15_154262241479264171 }));
+        sets.push(set({ x: 3e18, expected: 20_085536923187667724 }));
+        sets.push(set({ x: PI, expected: 23_140692632779268962 }));
+        sets.push(set({ x: 4e18, expected: 54_598150033144239019 }));
+        sets.push(set({ x: 11.89215e18, expected: 146115_107851442195738190 }));
+        sets.push(set({ x: 16e18, expected: 8886110_520507872601090007 }));
+        sets.push(set({ x: 20.82e18, expected: 1101567497_354306722521735975 }));
+        sets.push(set({ x: 33.333333e18, expected: 299559147061116_199277615819889397 }));
+        sets.push(set({ x: 64e18, expected: 6235149080811616783682415370_612321304359995711 }));
+        sets.push(set({ x: 71.002e18, expected: 6851360256686183998595702657852_843771046889809565 }));
+        sets.push(set({ x: 88.722839111672999627e18, expected: 340282366920938463222979506443879150094_819893272894857679 }));
+        sets.push(set({ x: EXP_MAX_INPUT, expected: 6277101735386680754977611748738314679353920434623901771623e18 }));
+        return sets;
+    }
+
+    function test_Exp() external parameterizedTest(exp_Sets()) whenNotZero whenLteMaxPermitted {
+        UD60x18 actual = exp(s.x);
+        assertEq(actual, s.expected, "UD60x18 exp");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/exp/exp.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/exp/exp.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { ud } from "src/ud60x18/Casting.sol";
-import { E, EXP_MAX_INPUT, PI, UNIT, ZERO } from "src/ud60x18/Constants.sol";
-import { PRBMath_UD60x18_Exp_InputTooBig } from "src/ud60x18/Errors.sol";
-import { exp } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { ud } from "@prb/math/src/ud60x18/Casting.sol";
+import { E, EXP_MAX_INPUT, PI, UNIT, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Exp_InputTooBig } from "@prb/math/src/ud60x18/Errors.sol";
+import { exp } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/exp2/exp2.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/exp2/exp2.t.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { ud } from "src/ud60x18/Casting.sol";
+import { E, PI, UNIT, ZERO } from "src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Exp2_InputTooBig } from "src/ud60x18/Errors.sol";
+import { exp2 } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Exp2_Unit_Test is UD60x18_Unit_Test {
+    UD60x18 internal constant MAX_PERMITTED = UD60x18.wrap(192e18 - 1);
+
+    function test_Exp2_Zero() external pure {
+        UD60x18 x = ZERO;
+        UD60x18 actual = exp2(x);
+        UD60x18 expected = UNIT;
+        assertEq(actual, expected, "UD60x18 exp2");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_GtMaxPermitted() external whenNotZero {
+        UD60x18 x = MAX_PERMITTED + ud(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Exp2_InputTooBig.selector, x));
+        exp2(x);
+    }
+
+    modifier whenLteMaxPermitted() {
+        _;
+    }
+
+    function exp2_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, expected: 1e18 }));
+        sets.push(set({ x: 1e3, expected: 1_000000000000000693 }));
+        sets.push(set({ x: 0.3212e18, expected: 1_249369313012024883 }));
+        sets.push(set({ x: 1e18, expected: 2e18 }));
+        sets.push(set({ x: 2e18, expected: 4e18 }));
+        sets.push(set({ x: E, expected: 6_580885991017920969 }));
+        sets.push(set({ x: 3e18, expected: 8e18 }));
+        sets.push(set({ x: PI, expected: 8_824977827076287621 }));
+        sets.push(set({ x: 4e18, expected: 16e18 }));
+        sets.push(set({ x: 11.89215e18, expected: 3800_964933301542754377 }));
+        sets.push(set({ x: 16e18, expected: 65536e18 }));
+        sets.push(set({ x: 20.82e18, expected: 1851162_354076939434682641 }));
+        sets.push(set({ x: 33.333333e18, expected: 10822636909_120553492168423503 }));
+        sets.push(set({ x: 64e18, expected: 18_446744073709551616e18 }));
+        sets.push(set({ x: 71.002e18, expected: 2364458806372010440881_644926416580874919 }));
+        sets.push(set({ x: 88.7494e18, expected: 520273250104929479163928177_984511174562086061 }));
+        sets.push(set({ x: 95e18, expected: 39614081257_132168796771975168e18 }));
+        sets.push(set({ x: 127e18, expected: 170141183460469231731_687303715884105728e18 }));
+        sets.push(set({ x: 152.9065e18, expected: 10701459987152828635116598811554803403437267307_663014047009710338 }));
+        sets.push(set({ x: MAX_PERMITTED, expected: 6277101735386680759401282518710514696272033118492751795945e18 }));
+        return sets;
+    }
+
+    function test_Exp2() external parameterizedTest(exp2_Sets()) whenNotZero whenLteMaxPermitted {
+        UD60x18 actual = exp2(s.x);
+        assertEq(actual, s.expected, "UD60x18 exp2");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/exp2/exp2.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/exp2/exp2.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { ud } from "src/ud60x18/Casting.sol";
-import { E, PI, UNIT, ZERO } from "src/ud60x18/Constants.sol";
-import { PRBMath_UD60x18_Exp2_InputTooBig } from "src/ud60x18/Errors.sol";
-import { exp2 } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { ud } from "@prb/math/src/ud60x18/Casting.sol";
+import { E, PI, UNIT, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Exp2_InputTooBig } from "@prb/math/src/ud60x18/Errors.sol";
+import { exp2 } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/floor/floor.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/floor/floor.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "src/ud60x18/Constants.sol";
+import { floor } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Floor_Unit_Test is UD60x18_Unit_Test {
+    function test_Floor_Zero() external pure {
+        UD60x18 x = ZERO;
+        UD60x18 actual = floor(x);
+        UD60x18 expected = ZERO;
+        assertEq(actual, expected, "UD60x18 floor");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function floor_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.1e18, expected: 0 }));
+        sets.push(set({ x: 0.5e18, expected: 0 }));
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 1.125e18, expected: 1e18 }));
+        sets.push(set({ x: 2e18, expected: 2e18 }));
+        sets.push(set({ x: PI, expected: 3e18 }));
+        sets.push(set({ x: 4.2e18, expected: 4e18 }));
+        sets.push(set({ x: 1e24, expected: 1e24 }));
+        sets.push(set({ x: MAX_WHOLE_UD60x18, expected: MAX_WHOLE_UD60x18 }));
+        sets.push(set({ x: MAX_UD60x18, expected: MAX_WHOLE_UD60x18 }));
+        return sets;
+    }
+
+    function test_Floor_Positive() external parameterizedTest(floor_Sets()) whenNotZero {
+        UD60x18 actual = floor(s.x);
+        assertEq(actual, s.expected, "UD60x18 floor");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/floor/floor.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/floor/floor.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "src/ud60x18/Constants.sol";
-import { floor } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { floor } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/frac/frac.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/frac/frac.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "src/ud60x18/Constants.sol";
+import { frac } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Frac_Unit_Test is UD60x18_Unit_Test {
+    function test_Frac_Zero() external pure {
+        UD60x18 x = ZERO;
+        UD60x18 actual = frac(x);
+        UD60x18 expected = ZERO;
+        assertEq(actual, expected, "UD60x18 frac");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function frac_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.1e18, expected: 0.1e18 }));
+        sets.push(set({ x: 0.5e18, expected: 0.5e18 }));
+        sets.push(set({ x: 1e18, expected: 0 }));
+        sets.push(set({ x: 1.125e18, expected: 0.125e18 }));
+        sets.push(set({ x: 2e18, expected: 0 }));
+        sets.push(set({ x: PI, expected: 0.141592653589793238e18 }));
+        sets.push(set({ x: 4.2e18, expected: 0.2e18 }));
+        sets.push(set({ x: 1e24, expected: 0 }));
+        sets.push(set({ x: MAX_WHOLE_UD60x18, expected: 0 }));
+        sets.push(set({ x: MAX_UD60x18, expected: 0.584007913129639935e18 }));
+        return sets;
+    }
+
+    function test_Frac() external parameterizedTest(frac_Sets()) whenNotZero {
+        UD60x18 actual = frac(s.x);
+        assertEq(actual, s.expected, "UD60x18 frac");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/frac/frac.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/frac/frac.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "src/ud60x18/Constants.sol";
-import { frac } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { frac } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/gm/gm.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/gm/gm.t.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI } from "src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Gm_Overflow } from "src/ud60x18/Errors.sol";
+import { gm } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Gm_Unit_Test is UD60x18_Unit_Test {
+    // Biggest number whose non-fixed-point square fits in uint256
+    uint256 internal constant SQRT_MAX_UINT256 = 340282366920938463463374607431768211455;
+
+    function oneOperandZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0, y: PI, expected: 0 }));
+        sets.push(set({ x: PI, y: 0, expected: 0 }));
+        return sets;
+    }
+
+    function test_Gm_OneOperandZero() external parameterizedTest(oneOperandZero_Sets()) {
+        UD60x18 actual = gm(s.x, s.y);
+        assertEq(actual, s.expected, "UD60x18 gm");
+    }
+
+    modifier whenOperandsNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_ProductOverflows() external whenOperandsNotZero {
+        UD60x18 x = SQRT_MAX_UD60x18 + ud(1);
+        UD60x18 y = SQRT_MAX_UD60x18 + ud(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Gm_Overflow.selector, x, y));
+        gm(x, y);
+    }
+
+    modifier whenProductDoesNotOverflow() {
+        _;
+    }
+
+    function gm_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1e18, y: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 1e18, y: 4e18, expected: 2e18 }));
+        sets.push(set({ x: 2e18, y: 8e18, expected: 4e18 }));
+        sets.push(set({ x: E, y: 89.01e18, expected: 15_554879155787087514 }));
+        sets.push(set({ x: PI, y: 8.2e18, expected: 5_075535416036056441 }));
+        sets.push(set({ x: 322.47e18, y: 674.77e18, expected: 466_468736251423392217 }));
+        sets.push(set({ x: 2404.8e18, y: 7899.210662e18, expected: 4358_442588812843362311 }));
+        sets.push(set({ x: SQRT_MAX_UINT256, y: SQRT_MAX_UINT256, expected: SQRT_MAX_UINT256 }));
+        sets.push(set({ x: MAX_WHOLE_UD60x18, y: 0.000000000000000001e18, expected: SQRT_MAX_UINT256 }));
+        sets.push(set({ x: MAX_UD60x18, y: 0.000000000000000001e18, expected: SQRT_MAX_UINT256 }));
+        return sets;
+    }
+
+    function test_Gm() external parameterizedTest(gm_Sets()) whenOperandsNotZero whenProductDoesNotOverflow {
+        UD60x18 actual = gm(s.x, s.y);
+        assertEq(actual, s.expected, "UD60x18 gm");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/gm/gm.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/gm/gm.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI } from "src/ud60x18/Constants.sol";
-import { PRBMath_UD60x18_Gm_Overflow } from "src/ud60x18/Errors.sol";
-import { gm } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI } from "@prb/math/src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Gm_Overflow } from "@prb/math/src/ud60x18/Errors.sol";
+import { gm } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/inv/inv.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/inv/inv.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { stdError } from "forge-std/src/StdError.sol";
+
+import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "src/ud60x18/Constants.sol";
+import { inv } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Inv_Unit_Test is UD60x18_Unit_Test {
+    function test_RevertWhen_Zero() external {
+        UD60x18 x = ZERO;
+        vm.expectRevert(stdError.divisionError);
+        inv(x);
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function inv_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, expected: 1e36 }));
+        sets.push(set({ x: 0.00001e18, expected: 100_000e18 }));
+        sets.push(set({ x: 0.05e18, expected: 20e18 }));
+        sets.push(set({ x: 0.1e18, expected: 10e18 }));
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 2e18, expected: 0.5e18 }));
+        sets.push(set({ x: PI, expected: 0.318309886183790671e18 }));
+        sets.push(set({ x: 4e18, expected: 0.25e18 }));
+        sets.push(set({ x: 22e18, expected: 0.045454545454545454e18 }));
+        sets.push(set({ x: 100.135e18, expected: 0.00998651820042942e18 }));
+        sets.push(set({ x: 772.05e18, expected: 0.001295252898128359e18 }));
+        sets.push(set({ x: 2503e18, expected: 0.000399520575309628e18 }));
+        sets.push(set({ x: 1e36, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 1e36 + 1, expected: 0 }));
+        sets.push(set({ x: MAX_WHOLE_UD60x18, expected: 0 }));
+        sets.push(set({ x: MAX_UD60x18, expected: 0 }));
+        return sets;
+    }
+
+    function test_Inv() external parameterizedTest(inv_Sets()) whenNotZero {
+        UD60x18 actual = inv(s.x);
+        assertEq(actual, s.expected, "UD60x18 inv");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/inv/inv.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/inv/inv.t.sol
@@ -3,9 +3,9 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { stdError } from "forge-std/src/StdError.sol";
 
-import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "src/ud60x18/Constants.sol";
-import { inv } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { inv } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/ln/ln.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/ln/ln.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { ud } from "src/ud60x18/Casting.sol";
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, UNIT } from "src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Log_InputTooSmall } from "src/ud60x18/Errors.sol";
+import { ln } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Ln_Unit_Test is UD60x18_Unit_Test {
+    function test_RevertWhen_LtUnit() external {
+        UD60x18 x = UNIT - ud(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Log_InputTooSmall.selector, x));
+        ln(x);
+    }
+
+    modifier whenGteUnit() {
+        _;
+    }
+
+    function ln_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1e18, expected: 0 }));
+        sets.push(set({ x: 1.125e18, expected: 0.117783035656383442e18 }));
+        sets.push(set({ x: 2e18, expected: 0.693147180559945309e18 }));
+        sets.push(set({ x: E, expected: 0.99999999999999999e18 }));
+        sets.push(set({ x: PI, expected: 1_144729885849400163 }));
+        sets.push(set({ x: 4e18, expected: 1_386294361119890619 }));
+        sets.push(set({ x: 8e18, expected: 2_079441541679835928 }));
+        sets.push(set({ x: 1e24, expected: 13_815510557964274099 }));
+        sets.push(set({ x: MAX_WHOLE_UD60x18, expected: 135_999146549453176925 }));
+        sets.push(set({ x: MAX_UD60x18, expected: 135_999146549453176925 }));
+        return sets;
+    }
+
+    function test_Ln() external parameterizedTest(ln_Sets()) whenGteUnit {
+        UD60x18 actual = ln(s.x);
+        assertEq(actual, s.expected, "UD60x18 ln");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/ln/ln.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/ln/ln.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { ud } from "src/ud60x18/Casting.sol";
-import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, UNIT } from "src/ud60x18/Constants.sol";
-import { PRBMath_UD60x18_Log_InputTooSmall } from "src/ud60x18/Errors.sol";
-import { ln } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { ud } from "@prb/math/src/ud60x18/Casting.sol";
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, UNIT } from "@prb/math/src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Log_InputTooSmall } from "@prb/math/src/ud60x18/Errors.sol";
+import { ln } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/log10/log10.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/log10/log10.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, UNIT } from "src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Log_InputTooSmall } from "src/ud60x18/Errors.sol";
+import { log10 } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Log10_Unit_Test is UD60x18_Unit_Test {
+    function test_RevertWhen_LtUnit() external {
+        UD60x18 x = UNIT - ud(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Log_InputTooSmall.selector, x));
+        log10(x);
+    }
+
+    modifier whenGteUnit() {
+        _;
+    }
+
+    function powerOfTen_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1e18, expected: 0 }));
+        sets.push(set({ x: 10e18, expected: 1e18 }));
+        sets.push(set({ x: 100e18, expected: 2e18 }));
+        sets.push(set({ x: 1e24, expected: 6e18 }));
+        sets.push(set({ x: 1e67, expected: 49e18 }));
+        sets.push(set({ x: 1e75, expected: 57e18 }));
+        sets.push(set({ x: 1e76, expected: 58e18 }));
+        return sets;
+    }
+
+    function test_Log10_PowerOfTen() external parameterizedTest(powerOfTen_Sets()) whenGteUnit {
+        UD60x18 actual = log10(s.x);
+        assertEq(actual, s.expected, "UD60x18 log10");
+    }
+
+    function notPowerOfTen_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1.00000000000001e18, expected: 0.000000000000004341e18 }));
+        sets.push(set({ x: E, expected: 0.434294481903251823e18 }));
+        sets.push(set({ x: PI, expected: 0.497149872694133849e18 }));
+        sets.push(set({ x: 4e18, expected: 0.60205999132796239e18 }));
+        sets.push(set({ x: 16e18, expected: 1_204119982655924781 }));
+        sets.push(set({ x: 32e18, expected: 1_505149978319905976 }));
+        sets.push(set({ x: 42.12e18, expected: 1_624488362513448905 }));
+        sets.push(set({ x: 1010.892143e18, expected: 3_004704821071980110 }));
+        sets.push(set({ x: 440934.1881e18, expected: 5_644373773418177966 }));
+        sets.push(set({ x: 1000000000000000000.000000000001e18, expected: 17_999999999999999999 }));
+        sets.push(set({ x: MAX_WHOLE_UD60x18, expected: 59_063678889979185987 }));
+        sets.push(set({ x: MAX_UD60x18, expected: 59_063678889979185987 }));
+        return sets;
+    }
+
+    function test_Log10_NotPowerOfTen() external parameterizedTest(notPowerOfTen_Sets()) whenGteUnit {
+        UD60x18 actual = log10(s.x);
+        assertEq(actual, s.expected, "UD60x18 log10");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/log10/log10.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/log10/log10.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, UNIT } from "src/ud60x18/Constants.sol";
-import { PRBMath_UD60x18_Log_InputTooSmall } from "src/ud60x18/Errors.sol";
-import { log10 } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, UNIT } from "@prb/math/src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Log_InputTooSmall } from "@prb/math/src/ud60x18/Errors.sol";
+import { log10 } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/log2/log2.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/log2/log2.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { ud } from "src/ud60x18/Casting.sol";
+import { E, PI, MAX_UD60x18, MAX_WHOLE_UD60x18, UNIT } from "src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Log_InputTooSmall } from "src/ud60x18/Errors.sol";
+import { log2 } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Log2_Unit_Test is UD60x18_Unit_Test {
+    function test_RevertWhen_LtUnit() external {
+        UD60x18 x = UNIT - ud(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Log_InputTooSmall.selector, x));
+        log2(x);
+    }
+
+    modifier whenGteUnit() {
+        _;
+    }
+
+    function powerOfTwo_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1e18, expected: 0 }));
+        sets.push(set({ x: 2e18, expected: 1e18 }));
+        sets.push(set({ x: 4e18, expected: 2e18 }));
+        sets.push(set({ x: 8e18, expected: 3e18 }));
+        sets.push(set({ x: 16e18, expected: 4e18 }));
+        sets.push(set({ x: 2 ** 195 * 1e18, expected: 195e18 }));
+        return sets;
+    }
+
+    function test_Log2_PowerOfTwo() external parameterizedTest(powerOfTwo_Sets()) whenGteUnit {
+        UD60x18 actual = log2(s.x);
+        assertEq(actual, s.expected, "UD60x18 log2");
+    }
+
+    function notPowerOfTwo_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1.125e18, expected: 0.169925001442312346e18 }));
+        sets.push(set({ x: E, expected: 1_442695040888963394 }));
+        sets.push(set({ x: PI, expected: 1_651496129472318782 }));
+        sets.push(set({ x: 1e24, expected: 19_931568569324174075 }));
+        sets.push(set({ x: MAX_WHOLE_UD60x18, expected: 196_205294292027477728 }));
+        sets.push(set({ x: MAX_UD60x18, expected: 196_205294292027477728 }));
+        return sets;
+    }
+
+    function test_Log2_NotPowerOfTwo() external parameterizedTest(notPowerOfTwo_Sets()) whenGteUnit {
+        UD60x18 actual = log2(s.x);
+        assertEq(actual, s.expected, "UD60x18 log2");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/log2/log2.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/log2/log2.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { ud } from "src/ud60x18/Casting.sol";
-import { E, PI, MAX_UD60x18, MAX_WHOLE_UD60x18, UNIT } from "src/ud60x18/Constants.sol";
-import { PRBMath_UD60x18_Log_InputTooSmall } from "src/ud60x18/Errors.sol";
-import { log2 } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { ud } from "@prb/math/src/ud60x18/Casting.sol";
+import { E, PI, MAX_UD60x18, MAX_WHOLE_UD60x18, UNIT } from "@prb/math/src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Log_InputTooSmall } from "@prb/math/src/ud60x18/Errors.sol";
+import { log2 } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/mul/mul.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/mul/mul.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { PRBMath_MulDiv18_Overflow } from "src/Common.sol";
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI } from "src/ud60x18/Constants.sol";
+import { mul } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Mul_Unit_Test is UD60x18_Unit_Test {
+    function oneOperandZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0, y: MAX_UD60x18, expected: 0 }));
+        sets.push(set({ x: MAX_UD60x18, y: 0, expected: 0 }));
+        return sets;
+    }
+
+    function test_Mul_OneOperandZero() external parameterizedTest(oneOperandZero_Sets()) {
+        assertEq(mul(s.x, s.y), s.expected, "UD60x18 mul");
+        assertEq(s.x * s.y, s.expected, "UD60x18 *");
+    }
+
+    modifier whenNeitherOperandZero() {
+        _;
+    }
+
+    function test_RevertWhen_ResultOverflowUD60x18_Function() external whenNeitherOperandZero {
+        UD60x18 x = SQRT_MAX_UD60x18 + ud(1);
+        UD60x18 y = SQRT_MAX_UD60x18 + ud(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_MulDiv18_Overflow.selector, x.unwrap(), y.unwrap()));
+        mul(x, y);
+    }
+
+    function test_RevertWhen_ResultOverflowUD60x18_Operator() external whenNeitherOperandZero {
+        UD60x18 x = SQRT_MAX_UD60x18 + ud(1);
+        UD60x18 y = SQRT_MAX_UD60x18 + ud(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_MulDiv18_Overflow.selector, x.unwrap(), y.unwrap()));
+        x * y;
+    }
+
+    modifier whenResultDoesNotOverflowUD60x18() {
+        _;
+    }
+
+    function mul_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, y: 0.000000000000000001e18, expected: 0 }));
+        sets.push(set({ x: 0.000000000000000006e18, y: 0.1e18, expected: 0 }));
+        sets.push(set({ x: 0.000000001e18, y: 0.000000001e18, expected: 0.000000000000000001e18 }));
+        sets.push(set({ x: 0.00001e18, y: 0.00001e18, expected: 0.0000000001e18 }));
+        sets.push(set({ x: 0.001e18, y: 0.01e18, expected: 0.00001e18 }));
+        sets.push(set({ x: 0.01e18, y: 0.05e18, expected: 0.0005e18 }));
+        sets.push(set({ x: 1e18, y: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 2.098e18, y: 1.119e18, expected: 2.347662e18 }));
+        sets.push(set({ x: PI, y: E, expected: 8_539734222673567063 }));
+        sets.push(set({ x: 18.3e18, y: 12.04e18, expected: 220.332e18 }));
+        sets.push(set({ x: 314.271e18, y: 188.19e18, expected: 59_142.65949e18 }));
+        sets.push(set({ x: 9_817e18, y: 2_348e18, expected: 23_050_316e18 }));
+        sets.push(set({ x: 12_983.989e18, y: 782.99e18, expected: 1_016_6333.54711e18 }));
+        sets.push(set({ x: 1e24, y: 1e20, expected: 1e26 }));
+        sets.push(
+            set({
+                x: SQRT_MAX_UD60x18,
+                y: SQRT_MAX_UD60x18,
+                expected: 115792089237316195423570985008687907853269984664959999305615_707080986380425072
+            })
+        );
+        sets.push(set({ x: MAX_WHOLE_UD60x18, y: 0.000000000000000001e18, expected: MAX_SCALED_UD60x18 }));
+        sets.push(set({ x: MAX_UD60x18 - ud(0.5e18), y: 0.000000000000000001e18, expected: MAX_SCALED_UD60x18 }));
+        return sets;
+    }
+
+    function test_Mul() external parameterizedTest(mul_Sets()) whenNeitherOperandZero whenResultDoesNotOverflowUD60x18 {
+        assertEq(mul(s.x, s.y), s.expected, "UD60x18 mul");
+        assertEq(s.x * s.y, s.expected, "UD60x18 *");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/mul/mul.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/mul/mul.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { PRBMath_MulDiv18_Overflow } from "src/Common.sol";
-import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI } from "src/ud60x18/Constants.sol";
-import { mul } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { PRBMath_MulDiv18_Overflow } from "@prb/math/src/Common.sol";
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI } from "@prb/math/src/ud60x18/Constants.sol";
+import { mul } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/pow/pow.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/pow/pow.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { E, PI, UNIT, ZERO } from "src/ud60x18/Constants.sol";
+import { pow } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Pow_Unit_Test is UD60x18_Unit_Test {
+    function test_Pow_BaseZero_ExponentZero() external pure {
+        UD60x18 x = ZERO;
+        UD60x18 y = ZERO;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = UNIT;
+        assertEq(actual, expected, "UD60x18 pow");
+    }
+
+    function test_Pow_BaseZero_ExponentNotZero() external pure {
+        UD60x18 x = ZERO;
+        UD60x18 y = PI;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = ZERO;
+        assertEq(actual, expected, "UD60x18 pow");
+    }
+
+    modifier whenBaseNotZero() {
+        _;
+    }
+
+    function test_Pow_BaseUnit() external pure whenBaseNotZero {
+        UD60x18 x = UNIT;
+        UD60x18 y = PI;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = UNIT;
+        assertEq(actual, expected, "UD60x18 pow");
+    }
+
+    modifier whenBaseNotUnit() {
+        _;
+    }
+
+    function test_Pow_ExponentZero() external pure whenBaseNotZero whenBaseNotUnit {
+        UD60x18 x = PI;
+        UD60x18 y = ZERO;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = UNIT;
+        assertEq(actual, expected, "UD60x18 pow");
+    }
+
+    modifier whenExponentNotZero() {
+        _;
+    }
+
+    function test_Pow_ExponentUnit(UD60x18 x) external pure whenBaseNotZero whenBaseNotUnit whenExponentNotZero {
+        vm.assume(x != ZERO && x != UNIT);
+        UD60x18 y = UNIT;
+        UD60x18 actual = pow(x, y);
+        UD60x18 expected = x;
+        assertEq(actual, expected, "UD60x18 pow");
+    }
+
+    modifier whenExponentNotUnit() {
+        _;
+    }
+
+    function baseGtUnit_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1e18 + 1, y: 2e18, expected: 1e18 }));
+        sets.push(set({ x: 2e18, y: 1.5e18, expected: 2_828427124746190097 }));
+        sets.push(set({ x: E, y: 1.66976e18, expected: 5_310893029888037560 }));
+        sets.push(set({ x: E, y: E, expected: 15_154262241479263793 }));
+        sets.push(set({ x: PI, y: PI, expected: 36_462159607207910473 }));
+        sets.push(set({ x: 11e18, y: 28.5e18, expected: 478290249106383504389245497918_050372801213485439 }));
+        sets.push(set({ x: 32.15e18, y: 23.99e18, expected: 1436387590627448555101723413293079116_943375472179194989 }));
+        sets.push(set({ x: 406e18, y: 0.25e18, expected: 4_488812947719016318 }));
+        sets.push(set({ x: 1729e18, y: 0.98e18, expected: 1489_495149922256917866 }));
+        sets.push(set({ x: 33441e18, y: 2.1891e18, expected: 8018621589_681923269491820156 }));
+        sets.push(
+            set({
+                x: 340282366920938463463374607431768211455e18,
+                y: 1e18 + 1,
+                expected: 340282366920938487757736552507248225013_000000000004316573
+            })
+        );
+        sets.push(
+            set({ x: 2 ** 192 * 1e18 - 1, y: 1e18 - 1, expected: 6277101735386679823624773486129835356722228023657461399187e18 })
+        );
+        return sets;
+    }
+
+    function test_Pow_BaseGtUnit()
+        external
+        parameterizedTest(baseGtUnit_Sets())
+        whenBaseNotZero
+        whenBaseNotUnit
+        whenExponentNotZero
+        whenExponentNotUnit
+    {
+        UD60x18 actual = pow(s.x, s.y);
+        assertEq(actual, s.expected);
+    }
+
+    function baseLtUnit_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, y: 1.78e18, expected: 0 }));
+        sets.push(set({ x: 0.01e18, y: E, expected: 0.000003659622955309e18 }));
+        sets.push(set({ x: 0.125e18, y: PI, expected: 0.001454987061394186e18 }));
+        sets.push(set({ x: 0.25e18, y: 3e18, expected: 0.015625e18 }));
+        sets.push(set({ x: 0.45e18, y: 2.2e18, expected: 0.172610627076774731e18 }));
+        sets.push(set({ x: 0.5e18, y: 0.481e18, expected: 0.716480825186549911e18 }));
+        sets.push(set({ x: 0.6e18, y: 0.95e18, expected: 0.615522152723696171e18 }));
+        sets.push(set({ x: 0.7e18, y: 3.1e18, expected: 0.330981655626097448e18 }));
+        sets.push(set({ x: 0.75e18, y: 4e18, expected: 0.316406250000000008e18 }));
+        sets.push(set({ x: 0.8e18, y: 5e18, expected: 0.327680000000000015e18 }));
+        sets.push(set({ x: 0.9e18, y: 2.5e18, expected: 0.768433471420916194e18 }));
+        sets.push(set({ x: 1e18 - 1, y: 0.08e18, expected: 1e18 }));
+        return sets;
+    }
+
+    function test_Pow_BaseLtUnit()
+        external
+        parameterizedTest(baseLtUnit_Sets())
+        whenBaseNotZero
+        whenBaseNotUnit
+        whenExponentNotZero
+        whenExponentNotUnit
+    {
+        UD60x18 actual = pow(s.x, s.y);
+        assertEq(actual, s.expected);
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/pow/pow.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/pow/pow.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { E, PI, UNIT, ZERO } from "src/ud60x18/Constants.sol";
-import { pow } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { E, PI, UNIT, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { pow } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/powu/powu.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/powu/powu.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { ud } from "src/ud60x18/Casting.sol";
+import { PRBMath_MulDiv18_Overflow } from "src/Common.sol";
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "src/ud60x18/Constants.sol";
+import { powu } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Powu_Unit_Test is UD60x18_Unit_Test {
+    function test_Powu_BaseAndExponentZero() external pure {
+        UD60x18 x = ZERO;
+        uint256 y = 0;
+        UD60x18 actual = powu(x, y);
+        UD60x18 expected = ud(1e18);
+        assertEq(actual, expected, "UD60x18 powu");
+    }
+
+    function baseZeroExponentNotZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0, y: 1, expected: 0 }));
+        sets.push(set({ x: 0, y: 2, expected: 0 }));
+        sets.push(set({ x: 0, y: 3, expected: 0 }));
+        return sets;
+    }
+
+    function test_Powu_BaseZeroExponentNotZero() external parameterizedTest(baseZeroExponentNotZero_Sets()) {
+        UD60x18 actual = powu(s.x, s.y.unwrap());
+        assertEq(actual, s.expected, "UD60x18 powu");
+    }
+
+    modifier whenBaseNotZero() {
+        _;
+    }
+
+    function exponentZero_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: PI, expected: 1e18 }));
+        sets.push(set({ x: MAX_UD60x18 - ud(1), expected: 1e18 }));
+        return sets;
+    }
+
+    function test_Powu_ExponentZero() external parameterizedTest(exponentZero_Sets()) whenBaseNotZero {
+        UD60x18 actual = powu(s.x, s.y.unwrap());
+        assertEq(actual, s.expected, "UD60x18 powu");
+    }
+
+    modifier whenExponentNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_ResultOverflowsUD60x18() external whenBaseNotZero whenExponentNotZero {
+        UD60x18 x = MAX_WHOLE_UD60x18;
+        uint256 y = 2;
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_MulDiv18_Overflow.selector, x.unwrap(), x.unwrap()));
+        powu(x, y);
+    }
+
+    modifier whenResultDoesNotOverflowUD60x18() {
+        _;
+    }
+
+    function powu_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.001e18, y: 3, expected: 1e9 }));
+        sets.push(set({ x: 0.1e18, y: 2, expected: 1e16 }));
+        sets.push(set({ x: 1e18, y: 1, expected: 1e18 }));
+        sets.push(set({ x: 2e18, y: 5, expected: 32e18 }));
+        sets.push(set({ x: 2e18, y: 100, expected: 1267650600228_229401496703205376e18 }));
+        sets.push(set({ x: E, y: 2, expected: 7_389056098930650225 }));
+        sets.push(set({ x: PI, y: 3, expected: 31_006276680299820158 }));
+        sets.push(set({ x: 5.491e18, y: 19, expected: 113077820843204_476043049664958463 }));
+        sets.push(set({ x: 100e18, y: 4, expected: 1e26 }));
+        sets.push(set({ x: 478.77e18, y: 20, expected: 400441047687151121501368529571950234763284476825512183793320584974037932 }));
+        sets.push(set({ x: 6452.166e18, y: 7, expected: 4655204093726194074224341678_62736844121311696 }));
+        sets.push(set({ x: 1e24, y: 3, expected: 1e36 }));
+        sets.push(
+            set({
+                x: 38685626227668133590.597631999999999999e18,
+                y: 3,
+                expected: 57896044618658097711785492504343953922145259302939748254975_940481744194640509
+            })
+        );
+        sets.push(
+            set({
+                x: SQRT_MAX_UD60x18,
+                y: 2,
+                expected: 115792089237316195423570985008687907853269984664959999305615_707080986380425072
+            })
+        );
+        sets.push(set({ x: MAX_WHOLE_UD60x18, y: 1, expected: MAX_WHOLE_UD60x18 }));
+        sets.push(set({ x: MAX_UD60x18, y: 1, expected: MAX_UD60x18 }));
+        return sets;
+    }
+
+    function test_Powu()
+        external
+        parameterizedTest(powu_Sets())
+        whenBaseNotZero
+        whenExponentNotZero
+        whenResultDoesNotOverflowUD60x18
+    {
+        UD60x18 actual = powu(s.x, s.y.unwrap());
+        assertEq(actual, s.expected, "UD60x18 powu");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/powu/powu.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/powu/powu.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { ud } from "src/ud60x18/Casting.sol";
-import { PRBMath_MulDiv18_Overflow } from "src/Common.sol";
-import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "src/ud60x18/Constants.sol";
-import { powu } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { ud } from "@prb/math/src/ud60x18/Casting.sol";
+import { PRBMath_MulDiv18_Overflow } from "@prb/math/src/Common.sol";
+import { E, MAX_UD60x18, MAX_WHOLE_UD60x18, PI, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { powu } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/sqrt/sqrt.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/sqrt/sqrt.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19 <0.9.0;
+
+import { E, PI, ZERO } from "src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Sqrt_Overflow } from "src/ud60x18/Errors.sol";
+import { sqrt } from "src/ud60x18/Math.sol";
+import { UD60x18 } from "src/ud60x18/ValueType.sol";
+
+import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
+
+contract Sqrt_Unit_Test is UD60x18_Unit_Test {
+    UD60x18 internal constant MAX_PERMITTED = UD60x18.wrap(115792089237316195423570985008687907853269_984665640564039457);
+
+    function test_Sqrt_Zero() external pure {
+        UD60x18 x = ZERO;
+        UD60x18 actual = sqrt(x);
+        UD60x18 expected = ZERO;
+        assertEq(actual, expected, "UD60x18 sqrt");
+    }
+
+    modifier whenNotZero() {
+        _;
+    }
+
+    function test_RevertWhen_GtMaxPermitted() external whenNotZero {
+        UD60x18 x = MAX_PERMITTED + ud(1);
+        vm.expectRevert(abi.encodeWithSelector(PRBMath_UD60x18_Sqrt_Overflow.selector, x));
+        sqrt(x);
+    }
+
+    modifier whenLteMaxPermitted() {
+        _;
+    }
+
+    function sqrt_Sets() internal returns (Set[] memory) {
+        delete sets;
+        sets.push(set({ x: 0.000000000000000001e18, expected: 0.000000001e18 }));
+        sets.push(set({ x: 0.000000000000001e18, expected: 0.000000031622776601e18 }));
+        sets.push(set({ x: 1e18, expected: 1e18 }));
+        sets.push(set({ x: 2e18, expected: 1_414213562373095048 }));
+        sets.push(set({ x: E, expected: 1_648721270700128146 }));
+        sets.push(set({ x: 3e18, expected: 1_732050807568877293 }));
+        sets.push(set({ x: PI, expected: 1_772453850905516027 }));
+        sets.push(set({ x: 4e18, expected: 2e18 }));
+        sets.push(set({ x: 16e18, expected: 4e18 }));
+        sets.push(set({ x: 1e35, expected: 316227766_016837933199889354 }));
+        sets.push(set({ x: 12489131238983290393813_123784889921092801, expected: 111754781727_598977910452220959 }));
+        sets.push(set({ x: 1889920002192904839344128288891377_732371920009212883, expected: 43473210166640613973238162807779776 }));
+        sets.push(set({ x: 1e58, expected: 1e38 }));
+        sets.push(set({ x: 5e58, expected: 223606797749978969640_917366873127623544 }));
+        sets.push(set({ x: MAX_PERMITTED, expected: 340282366920938463463_374607431768211455 }));
+        return sets;
+    }
+
+    function test_Sqrt() external parameterizedTest(sqrt_Sets()) whenNotZero whenLteMaxPermitted {
+        UD60x18 actual = sqrt(s.x);
+        assertEq(actual, s.expected, "UD60x18 sqrt");
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/sqrt/sqrt.t.sol
+++ b/v-next/example-project/contracts/prb-math/test/unit/ud60x18/math/sqrt/sqrt.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.19 <0.9.0;
 
-import { E, PI, ZERO } from "src/ud60x18/Constants.sol";
-import { PRBMath_UD60x18_Sqrt_Overflow } from "src/ud60x18/Errors.sol";
-import { sqrt } from "src/ud60x18/Math.sol";
-import { UD60x18 } from "src/ud60x18/ValueType.sol";
+import { E, PI, ZERO } from "@prb/math/src/ud60x18/Constants.sol";
+import { PRBMath_UD60x18_Sqrt_Overflow } from "@prb/math/src/ud60x18/Errors.sol";
+import { sqrt } from "@prb/math/src/ud60x18/Math.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 import { UD60x18_Unit_Test } from "../../UD60x18.t.sol";
 

--- a/v-next/example-project/contracts/prb-math/test/utils/Assertions.sol
+++ b/v-next/example-project/contracts/prb-math/test/utils/Assertions.sol
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19;
+
+import { StdAssertions } from "forge-std/src/StdAssertions.sol";
+
+import { SD1x18 } from "../../src/sd1x18/ValueType.sol";
+import { SD59x18 } from "../../src/sd59x18/ValueType.sol";
+import { UD2x18 } from "../../src/ud2x18/ValueType.sol";
+import { UD60x18 } from "../../src/ud60x18/ValueType.sol";
+
+contract PRBMathAssertions is StdAssertions {
+    /*//////////////////////////////////////////////////////////////////////////
+                                       SD1X18
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function assertEq(SD1x18 a, SD1x18 b) internal pure {
+        assertEq(SD1x18.unwrap(a), SD1x18.unwrap(b));
+    }
+
+    function assertEq(SD1x18 a, SD1x18 b, string memory err) internal pure {
+        assertEq(SD1x18.unwrap(a), SD1x18.unwrap(b), err);
+    }
+
+    function assertEq(SD1x18 a, int64 b) internal pure {
+        assertEq(SD1x18.unwrap(a), b);
+    }
+
+    function assertEq(SD1x18 a, int64 b, string memory err) internal pure {
+        assertEq(SD1x18.unwrap(a), b, err);
+    }
+
+    function assertEq(int64 a, SD1x18 b) internal pure {
+        assertEq(a, SD1x18.unwrap(b));
+    }
+
+    function assertEq(int64 a, SD1x18 b, string memory err) internal pure {
+        assertEq(a, SD1x18.unwrap(b), err);
+    }
+
+    function assertEq(SD1x18[] memory a, SD1x18[] memory b) internal pure {
+        int256[] memory castedA;
+        int256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB);
+    }
+
+    function assertEq(SD1x18[] memory a, SD1x18[] memory b, string memory err) internal pure {
+        int256[] memory castedA;
+        int256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB, err);
+    }
+
+    function assertEq(SD1x18[] memory a, int64[] memory b) internal pure {
+        int256[] memory castedA;
+        int256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB);
+    }
+
+    function assertEq(SD1x18[] memory a, int64[] memory b, string memory err) internal pure {
+        int256[] memory castedA;
+        int256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB, err);
+    }
+
+    function assertEq(int64[] memory a, SD1x18[] memory b) internal pure {
+        int256[] memory castedA;
+        int256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB);
+    }
+
+    function assertEq(int64[] memory a, SD1x18[] memory b, string memory err) internal pure {
+        int256[] memory castedA;
+        int256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB, err);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                       SD59X18
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function assertEq(SD59x18 a, SD59x18 b) internal pure {
+        assertEq(SD59x18.unwrap(a), SD59x18.unwrap(b));
+    }
+
+    function assertEq(SD59x18 a, SD59x18 b, string memory err) internal pure {
+        assertEq(SD59x18.unwrap(a), SD59x18.unwrap(b), err);
+    }
+
+    function assertEq(SD59x18 a, int256 b) internal pure {
+        assertEq(SD59x18.unwrap(a), b);
+    }
+
+    function assertEq(SD59x18 a, int256 b, string memory err) internal pure {
+        assertEq(SD59x18.unwrap(a), b, err);
+    }
+
+    function assertEq(int256 a, SD59x18 b) internal pure {
+        assertEq(a, SD59x18.unwrap(b));
+    }
+
+    function assertEq(int256 a, SD59x18 b, string memory err) internal pure {
+        assertEq(a, SD59x18.unwrap(b), err);
+    }
+
+    function assertEq(SD59x18[] memory a, SD59x18[] memory b) internal pure {
+        int256[] memory castedA;
+        int256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB);
+    }
+
+    function assertEq(SD59x18[] memory a, SD59x18[] memory b, string memory err) internal pure {
+        int256[] memory castedA;
+        int256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB, err);
+    }
+
+    function assertEq(SD59x18[] memory a, int256[] memory b) internal pure {
+        int256[] memory castedA;
+        assembly {
+            castedA := a
+        }
+        assertEq(castedA, b);
+    }
+
+    function assertEq(SD59x18[] memory a, int256[] memory b, string memory err) internal pure {
+        int256[] memory castedA;
+        assembly {
+            castedA := a
+        }
+        assertEq(castedA, b, err);
+    }
+
+    function assertEq(int256[] memory a, SD59x18[] memory b) internal {
+        int256[] memory castedB;
+        assembly {
+            castedB := b
+        }
+        assertEq(a, b);
+    }
+
+    function assertEq(int256[] memory a, SD59x18[] memory b, string memory err) internal {
+        int256[] memory castedB;
+        assembly {
+            castedB := b
+        }
+        assertEq(a, b, err);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                       UD2X18
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function assertEq(UD2x18 a, UD2x18 b) internal pure {
+        assertEq(UD2x18.unwrap(a), UD2x18.unwrap(b));
+    }
+
+    function assertEq(UD2x18 a, UD2x18 b, string memory err) internal pure {
+        assertEq(UD2x18.unwrap(a), UD2x18.unwrap(b), err);
+    }
+
+    function assertEq(UD2x18 a, uint64 b) internal pure {
+        assertEq(UD2x18.unwrap(a), uint256(b));
+    }
+
+    function assertEq(UD2x18 a, uint64 b, string memory err) internal pure {
+        assertEq(UD2x18.unwrap(a), uint256(b), err);
+    }
+
+    function assertEq(uint64 a, UD2x18 b) internal pure {
+        assertEq(uint256(a), UD2x18.unwrap(b));
+    }
+
+    function assertEq(uint64 a, UD2x18 b, string memory err) internal pure {
+        assertEq(uint256(a), UD2x18.unwrap(b), err);
+    }
+
+    function assertEq(UD2x18[] memory a, UD2x18[] memory b) internal pure {
+        uint256[] memory castedA;
+        uint256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB);
+    }
+
+    function assertEq(UD2x18[] memory a, UD2x18[] memory b, string memory err) internal pure {
+        uint256[] memory castedA;
+        uint256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB, err);
+    }
+
+    function assertEq(UD2x18[] memory a, uint64[] memory b) internal pure {
+        uint256[] memory castedA;
+        uint256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB);
+    }
+
+    function assertEq(UD2x18[] memory a, uint64[] memory b, string memory err) internal pure {
+        uint256[] memory castedA;
+        uint256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB, err);
+    }
+
+    function assertEq(uint64[] memory a, UD2x18[] memory b) internal pure {
+        uint256[] memory castedA;
+        uint256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB);
+    }
+
+    function assertEq(uint64[] memory a, UD2x18[] memory b, string memory err) internal pure {
+        uint256[] memory castedA;
+        uint256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB, err);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                       UD60X18
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function assertEq(UD60x18 a, UD60x18 b) internal pure {
+        assertEq(UD60x18.unwrap(a), UD60x18.unwrap(b));
+    }
+
+    function assertEq(UD60x18 a, UD60x18 b, string memory err) internal pure {
+        assertEq(UD60x18.unwrap(a), UD60x18.unwrap(b), err);
+    }
+
+    function assertEq(UD60x18 a, uint256 b) internal pure {
+        assertEq(UD60x18.unwrap(a), b);
+    }
+
+    function assertEq(UD60x18 a, uint256 b, string memory err) internal pure {
+        assertEq(UD60x18.unwrap(a), b, err);
+    }
+
+    function assertEq(uint256 a, UD60x18 b) internal pure {
+        assertEq(a, UD60x18.unwrap(b));
+    }
+
+    function assertEq(uint256 a, UD60x18 b, string memory err) internal pure {
+        assertEq(a, UD60x18.unwrap(b), err);
+    }
+
+    function assertEq(UD60x18[] memory a, UD60x18[] memory b) internal pure {
+        uint256[] memory castedA;
+        uint256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB);
+    }
+
+    function assertEq(UD60x18[] memory a, UD60x18[] memory b, string memory err) internal pure {
+        uint256[] memory castedA;
+        uint256[] memory castedB;
+        assembly {
+            castedA := a
+            castedB := b
+        }
+        assertEq(castedA, castedB, err);
+    }
+
+    function assertEq(UD60x18[] memory a, uint256[] memory b) internal pure {
+        uint256[] memory castedA;
+        assembly {
+            castedA := a
+        }
+        assertEq(castedA, b);
+    }
+
+    function assertEq(UD60x18[] memory a, uint256[] memory b, string memory err) internal pure {
+        uint256[] memory castedA;
+        assembly {
+            castedA := a
+        }
+        assertEq(castedA, b, err);
+    }
+
+    function assertEq(uint256[] memory a, SD59x18[] memory b) internal {
+        uint256[] memory castedB;
+        assembly {
+            castedB := b
+        }
+        assertEq(a, b);
+    }
+
+    function assertEq(uint256[] memory a, SD59x18[] memory b, string memory err) internal {
+        uint256[] memory castedB;
+        assembly {
+            castedB := b
+        }
+        assertEq(a, b, err);
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/utils/Assertions.sol
+++ b/v-next/example-project/contracts/prb-math/test/utils/Assertions.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.8.19;
 
 import { StdAssertions } from "forge-std/src/StdAssertions.sol";
 
-import { SD1x18 } from "../../src/sd1x18/ValueType.sol";
-import { SD59x18 } from "../../src/sd59x18/ValueType.sol";
-import { UD2x18 } from "../../src/ud2x18/ValueType.sol";
-import { UD60x18 } from "../../src/ud60x18/ValueType.sol";
+import { SD1x18 } from "@prb/math/src/sd1x18/ValueType.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
+import { UD2x18 } from "@prb/math/src/ud2x18/ValueType.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 contract PRBMathAssertions is StdAssertions {
     /*//////////////////////////////////////////////////////////////////////////

--- a/v-next/example-project/contracts/prb-math/test/utils/Utils.sol
+++ b/v-next/example-project/contracts/prb-math/test/utils/Utils.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.19;
+
+import { StdUtils } from "forge-std/src/StdUtils.sol";
+
+import { SD1x18 } from "../../src/sd1x18/ValueType.sol";
+import { SD59x18 } from "../../src/sd59x18/ValueType.sol";
+import { UD2x18 } from "../../src/ud2x18/ValueType.sol";
+import { UD60x18 } from "../../src/ud60x18/ValueType.sol";
+
+contract PRBMathUtils is StdUtils {
+    /*//////////////////////////////////////////////////////////////////////////
+                                      SD1x18
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Helper function to bound an SD1x18 number, which console logs the bounded result.
+    function bound(SD1x18 x, SD1x18 min, SD1x18 max) internal pure returns (SD1x18) {
+        return SD1x18.wrap(int64(bound(int256(x.unwrap()), int256(min.unwrap()), int256(max.unwrap()))));
+    }
+
+    /// @dev Helper function to bound an SD1x18 number.
+    function _bound(SD1x18 x, SD1x18 min, SD1x18 max) internal pure returns (SD1x18) {
+        return SD1x18.wrap(int64(_bound(int256(x.unwrap()), int256(min.unwrap()), int256(max.unwrap()))));
+    }
+
+    /// @dev Helper function to bound an SD1x18 number, which console logs the bounded result.
+    function bound(SD1x18 x, int64 min, SD1x18 max) internal pure returns (SD1x18) {
+        return SD1x18.wrap(int64(bound(int256(x.unwrap()), int256(min), int256(max.unwrap()))));
+    }
+
+    /// @dev Helper function to bound an SD1x18 number.
+    function _bound(SD1x18 x, int64 min, SD1x18 max) internal pure returns (SD1x18) {
+        return SD1x18.wrap(int64(_bound(int256(x.unwrap()), int256(min), int256(max.unwrap()))));
+    }
+
+    /// @dev Helper function to bound an SD1x18 number, which console logs the bounded result.
+    function bound(SD1x18 x, SD1x18 min, int64 max) internal pure returns (SD1x18) {
+        return SD1x18.wrap(int64(bound(int256(x.unwrap()), int256(min.unwrap()), int256(max))));
+    }
+
+    /// @dev Helper function to bound an SD1x18 number.
+    function _bound(SD1x18 x, SD1x18 min, int64 max) internal pure returns (SD1x18) {
+        return SD1x18.wrap(int64(_bound(int256(x.unwrap()), int256(min.unwrap()), int256(max))));
+    }
+
+    /// @dev Helper function to bound an SD1x18 number, which console logs the bounded result.
+    function bound(SD1x18 x, int64 min, int64 max) internal pure returns (SD1x18) {
+        return SD1x18.wrap(int64(bound(int256(x.unwrap()), int256(min), int256(max))));
+    }
+
+    /// @dev Helper function to bound an SD1x18 number.
+    function _bound(SD1x18 x, int64 min, int64 max) internal pure returns (SD1x18) {
+        return SD1x18.wrap(int64(_bound(int256(x.unwrap()), int256(min), int256(max))));
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      SD59X18
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Helper function to bound an SD59x18 number, which console logs the bounded result.
+    function bound(SD59x18 x, SD59x18 min, SD59x18 max) internal pure returns (SD59x18) {
+        return SD59x18.wrap(bound(x.unwrap(), min.unwrap(), max.unwrap()));
+    }
+
+    /// @dev Helper function to bound an SD59x18 number.
+    function _bound(SD59x18 x, SD59x18 min, SD59x18 max) internal pure returns (SD59x18) {
+        return SD59x18.wrap(_bound(x.unwrap(), min.unwrap(), max.unwrap()));
+    }
+
+    /// @dev Helper function to bound an SD59x18 number, which console logs the bounded result.
+    function bound(SD59x18 x, int256 min, SD59x18 max) internal pure returns (SD59x18) {
+        return SD59x18.wrap(bound(x.unwrap(), min, max.unwrap()));
+    }
+
+    /// @dev Helper function to bound an SD59x18 number.
+    function _bound(SD59x18 x, int256 min, SD59x18 max) internal pure returns (SD59x18) {
+        return SD59x18.wrap(_bound(x.unwrap(), min, max.unwrap()));
+    }
+
+    /// @dev Helper function to bound an SD59x18 number, which console logs the bounded result.
+    function bound(SD59x18 x, SD59x18 min, int256 max) internal pure returns (SD59x18) {
+        return SD59x18.wrap(bound(x.unwrap(), min.unwrap(), max));
+    }
+
+    /// @dev Helper function to bound an SD59x18 number.
+    function _bound(SD59x18 x, SD59x18 min, int256 max) internal pure returns (SD59x18) {
+        return SD59x18.wrap(_bound(x.unwrap(), min.unwrap(), max));
+    }
+
+    /// @dev Helper function to bound an SD59x18 number, which console logs the bounded result.
+    function bound(SD59x18 x, int256 min, int256 max) internal pure returns (SD59x18) {
+        return SD59x18.wrap(bound(x.unwrap(), min, max));
+    }
+
+    /// @dev Helper function to bound an SD59x18 number.
+    function _bound(SD59x18 x, int256 min, int256 max) internal pure returns (SD59x18) {
+        return SD59x18.wrap(_bound(x.unwrap(), min, max));
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      UD2x18
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Helper function to bound a UD2x18 number, which console logs the bounded result.
+    function bound(UD2x18 x, UD2x18 min, UD2x18 max) internal pure returns (UD2x18) {
+        return UD2x18.wrap(uint64(bound(uint256(x.unwrap()), uint256(min.unwrap()), uint256(max.unwrap()))));
+    }
+
+    /// @dev Helper function to bound a UD2x18 number.
+    function _bound(UD2x18 x, UD2x18 min, UD2x18 max) internal pure returns (UD2x18) {
+        return UD2x18.wrap(uint64(_bound(uint256(x.unwrap()), uint256(min.unwrap()), uint256(max.unwrap()))));
+    }
+
+    /// @dev Helper function to bound a UD2x18 number, which console logs the bounded result.
+    function bound(UD2x18 x, uint64 min, UD2x18 max) internal pure returns (UD2x18) {
+        return UD2x18.wrap(uint64(bound(uint256(x.unwrap()), uint256(min), uint256(max.unwrap()))));
+    }
+
+    /// @dev Helper function to bound a UD2x18 number.
+    function _bound(UD2x18 x, uint64 min, UD2x18 max) internal pure returns (UD2x18) {
+        return UD2x18.wrap(uint64(_bound(uint256(x.unwrap()), uint256(min), uint256(max.unwrap()))));
+    }
+
+    /// @dev Helper function to bound a UD2x18 number, which console logs the bounded result.
+    function bound(UD2x18 x, UD2x18 min, uint64 max) internal pure returns (UD2x18) {
+        return UD2x18.wrap(uint64(bound(uint256(x.unwrap()), uint256(min.unwrap()), uint256(max))));
+    }
+
+    /// @dev Helper function to bound a UD2x18 number.
+    function _bound(UD2x18 x, UD2x18 min, uint64 max) internal pure returns (UD2x18) {
+        return UD2x18.wrap(uint64(_bound(uint256(x.unwrap()), uint256(min.unwrap()), uint256(max))));
+    }
+
+    /// @dev Helper function to bound a UD2x18 number, which console logs the bounded result.
+    function bound(UD2x18 x, uint64 min, uint64 max) internal pure returns (UD2x18) {
+        return UD2x18.wrap(uint64(bound(uint256(x.unwrap()), uint256(min), uint256(max))));
+    }
+
+    /// @dev Helper function to bound a UD2x18 number.
+    function _bound(UD2x18 x, uint64 min, uint64 max) internal pure returns (UD2x18) {
+        return UD2x18.wrap(uint64(_bound(uint256(x.unwrap()), uint256(min), uint256(max))));
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      UD60X18
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Helper function to bound a UD60x18 number, which console logs the bounded result.
+    function bound(UD60x18 x, UD60x18 min, UD60x18 max) internal pure returns (UD60x18) {
+        return UD60x18.wrap(bound(x.unwrap(), min.unwrap(), max.unwrap()));
+    }
+
+    /// @dev Helper function to bound a UD60x18 number.
+    function _bound(UD60x18 x, UD60x18 min, UD60x18 max) internal pure returns (UD60x18) {
+        return UD60x18.wrap(_bound(x.unwrap(), min.unwrap(), max.unwrap()));
+    }
+
+    /// @dev Helper function to bound a UD60x18 number, which console logs the bounded result.
+    function bound(UD60x18 x, uint256 min, UD60x18 max) internal pure returns (UD60x18) {
+        return UD60x18.wrap(bound(x.unwrap(), min, max.unwrap()));
+    }
+
+    /// @dev Helper function to bound a UD60x18 number.
+    function _bound(UD60x18 x, uint256 min, UD60x18 max) internal pure returns (UD60x18) {
+        return UD60x18.wrap(_bound(x.unwrap(), min, max.unwrap()));
+    }
+
+    /// @dev Helper function to bound a UD60x18 number, which console logs the bounded result.
+    function bound(UD60x18 x, UD60x18 min, uint256 max) internal pure returns (UD60x18) {
+        return UD60x18.wrap(bound(x.unwrap(), min.unwrap(), max));
+    }
+
+    /// @dev Helper function to bound a UD60x18 number.
+    function _bound(UD60x18 x, UD60x18 min, uint256 max) internal pure returns (UD60x18) {
+        return UD60x18.wrap(_bound(x.unwrap(), min.unwrap(), max));
+    }
+
+    /// @dev Helper function to bound a UD60x18 number, which console logs the bounded result.
+    function bound(UD60x18 x, uint256 min, uint256 max) internal pure returns (UD60x18) {
+        return UD60x18.wrap(bound(x.unwrap(), min, max));
+    }
+
+    /// @dev Helper function to bound a UD60x18 number.
+    function _bound(UD60x18 x, uint256 min, uint256 max) internal pure returns (UD60x18) {
+        return UD60x18.wrap(_bound(x.unwrap(), min, max));
+    }
+}

--- a/v-next/example-project/contracts/prb-math/test/utils/Utils.sol
+++ b/v-next/example-project/contracts/prb-math/test/utils/Utils.sol
@@ -3,10 +3,10 @@ pragma solidity >=0.8.19;
 
 import { StdUtils } from "forge-std/src/StdUtils.sol";
 
-import { SD1x18 } from "../../src/sd1x18/ValueType.sol";
-import { SD59x18 } from "../../src/sd59x18/ValueType.sol";
-import { UD2x18 } from "../../src/ud2x18/ValueType.sol";
-import { UD60x18 } from "../../src/ud60x18/ValueType.sol";
+import { SD1x18 } from "@prb/math/src/sd1x18/ValueType.sol";
+import { SD59x18 } from "@prb/math/src/sd59x18/ValueType.sol";
+import { UD2x18 } from "@prb/math/src/ud2x18/ValueType.sol";
+import { UD60x18 } from "@prb/math/src/ud60x18/ValueType.sol";
 
 contract PRBMathUtils is StdUtils {
     /*//////////////////////////////////////////////////////////////////////////

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -32,5 +32,8 @@
     "prettier": "3.2.5",
     "typescript": "~5.5.0",
     "viem": "^2.7.6"
+  },
+  "dependencies": {
+    "forge-std": "https://github.com/foundry-rs/forge-std/tarball/v1.9.2"
   }
 }

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -34,6 +34,7 @@
     "viem": "^2.7.6"
   },
   "dependencies": {
+    "@prb/math": "https://github.com/PaulRBerg/prb-math/tarball/v4.0.3",
     "forge-std": "https://github.com/foundry-rs/forge-std/tarball/v1.9.2"
   }
 }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This PR is a showcase of running solidity tests of a real world project with Hardhat v3. The tests use the standard library.

Here's the successful output from `pnpm hardhat test:solidity`:
```
Compiled 96 Solidity files successfully (evm target: unknown evm version for solc version 0.8.25).

Running Solidity tests...

✔ Ceil_Unit_Test | test_Ceil_Negative()
✔ Ceil_Unit_Test | test_Ceil_Positive()
✔ Ceil_Unit_Test | test_Ceil_Zero()
✔ Ceil_Unit_Test | test_RevertWhen_GtMaxPermitted()
✔ ConvertFrom_Unit_Test | test_ConvertFrom()
✔ ConvertFrom_Unit_Test | test_ConvertFrom_LtAbsoluteUnit()
✔ Abs_Unit_Test | test_Abs()
✔ Abs_Unit_Test | test_Abs_Negative()
✔ Abs_Unit_Test | test_Abs_Zero()
✔ Abs_Unit_Test | test_RevertWhen_MinSD59x18()
✔ CastingUint40_Test | testFuzz_intoSD1x18(uint40) (256 runs)
✔ CastingUint40_Test | testFuzz_intoSD59x18(uint40) (256 runs)
✔ CastingUint40_Test | testFuzz_intoUD2x18(uint40) (256 runs)
✔ CastingUint40_Test | testFuzz_intoUD60x18(uint40) (256 runs)
✔ Avg_Unit_Test | test_Avg_BothOperandsEven()
✔ Avg_Unit_Test | test_Avg_BothOperandsNegative()
✔ Avg_Unit_Test | test_Avg_BothOperandsOdd()
✔ Avg_Unit_Test | test_Avg_BothOperandsZero()
✔ Avg_Unit_Test | test_Avg_OneOperandEvenTheOtherOdd()
✔ Avg_Unit_Test | test_Avg_OneOperandNegativeTheOtherPositive()
✔ Avg_Unit_Test | test_Avg_OnlyOneOperandZero()
✔ CeilTest | test_Ceil()
✔ CeilTest | test_Ceil_Zero()
✔ CeilTest | test_RevertWhen_GtMaxPermitted()
✔ ConvertFrom_Unit_Test | test_ConvertFrom()
✔ ConvertFrom_Unit_Test | test_ConvertFrom_LtUnit()
✔ ConvertTo_Unit_Test | test_ConvertTo()
✔ ConvertTo_Unit_Test | test_RevertWhen_GtMaxPermitted()
✔ ConvertTo_Unit_Test | test_RevertWhen_LtMinPermitted()
✔ ConvertTo_Unit_Test | test_ConvertTo()
✔ ConvertTo_Unit_Test | test_RevertWhen_GtMaxPermitted()
✔ CounterTest | testInc()
✔ CounterTest | testInitialValue()
✔ Div_Unit_Test | test_Div()
✔ Div_Unit_Test | test_Div_NumeratorZero()
✔ Div_Unit_Test | test_RevertWhen_DenominatorZero_Function()
✔ Div_Unit_Test | test_RevertWhen_DenominatorZero_Operator()
✔ Div_Unit_Test | test_RevertWhen_ResultOverflowUD60x18_Function()
✔ Div_Unit_Test | test_RevertWhen_ResultOverflowUD60x18_Operator()
✔ Exp2_Unit_Test | test_Exp2()
✔ Exp2_Unit_Test | test_Exp2_Zero()
✔ Exp2_Unit_Test | test_RevertWhen_GtMaxPermitted()
✔ CastingUint128_Test | testFuzz_RevertWhen_OverflowSD1x18(uint128) (256 runs)
✔ CastingUint128_Test | testFuzz_RevertWhen_OverflowUD2x18(uint128) (256 runs)
✔ CastingUint128_Test | testFuzz_intoSD1x18(uint128) (256 runs)
✔ CastingUint128_Test | testFuzz_intoSD59x18(uint128) (256 runs)
✔ CastingUint128_Test | testFuzz_intoUD2x18(uint128) (256 runs)
✔ CastingUint128_Test | testFuzz_intoUD60x18(uint128) (256 runs)
✔ Avg_Unit_Test | test_Avg_BothOperandsZero()
✔ Avg_Unit_Test | test_Avg_NeitherOperandZero_BothOperandsEven()
✔ Avg_Unit_Test | test_Avg_NeitherOperandZero_BothOperandsOdd()
✔ Avg_Unit_Test | test_Avg_NeitherOperandZero_OneOperandEvenTheOtherOdd()
✔ Avg_Unit_Test | test_Avg_OnlyOneOperandZero()
✔ Floor_Unit_Test | test_Floor_Positive()
✔ Floor_Unit_Test | test_Floor_Zero()
✔ Exp_Unit_Test | test_Exp()
✔ Exp_Unit_Test | test_Exp_Zero()
✔ Exp_Unit_Test | test_RevertWhen_GtMaxPermitted()
✔ Exp_Unit_Test | test_Exp_Negative_GteMinPermitted()
✔ Exp_Unit_Test | test_Exp_Negative_LtThreshold()
✔ Exp_Unit_Test | test_Exp_Positive_LteMaxPermitted()
✔ Exp_Unit_Test | test_Exp_Zero()
✔ Exp_Unit_Test | test_RevertWhen_Positive_GtMaxPermitted()
✔ Exp2_Unit_Test | test_Exp2_Negative_GteMinPermitted()
✔ Exp2_Unit_Test | test_Exp2_Negative_LtThreshold()
✔ Exp2_Unit_Test | test_Exp2_Positive_LTePermittedMax()
✔ Exp2_Unit_Test | test_Exp2_Zero()
✔ Exp2_Unit_Test | test_RevertWhen_Positive_GtMaxPermitted()
✔ Frac_Unit_Test | test_Frac()
✔ Frac_Unit_Test | test_Frac_Zero()
✔ Div_Unit_Test | test_Div_NumeratorDenominatorDifferentSign()
✔ Div_Unit_Test | test_Div_NumeratorDenominatorSameSign()
✔ Div_Unit_Test | test_Div_NumeratorZero()
✔ Div_Unit_Test | test_RevertWhen_DenominatorMinSD59x18_Function()
✔ Div_Unit_Test | test_RevertWhen_DenominatorMinSD59x18_Operator()
✔ Div_Unit_Test | test_RevertWhen_DenominatorZero_Function()
✔ Div_Unit_Test | test_RevertWhen_DenominatorZero_Operator()
✔ Div_Unit_Test | test_RevertWhen_NumeratorMinSD59x18_Function()
✔ Div_Unit_Test | test_RevertWhen_NumeratorMinSD59x18_Operator()
✔ Div_Unit_Test | test_RevertWhen_ResultOverflowSD59x18_Function()
✔ Div_Unit_Test | test_RevertWhen_ResultOverflowSD59x18_Operator()
✔ Gm_Unit_Test | test_Gm()
✔ Gm_Unit_Test | test_Gm_OneOperandZero()
✔ Gm_Unit_Test | test_RevertWhen_ProductNegative_A()
✔ Gm_Unit_Test | test_RevertWhen_ProductNegative_B()
✔ Gm_Unit_Test | test_RevertWhen_ProductOverflow_A()
✔ Gm_Unit_Test | test_RevertWhen_ProductOverflow_B()
✔ Gm_Unit_Test | test_RevertWhen_ProductOverflow_C()
✔ Gm_Unit_Test | test_RevertWhen_ProductOverflow_D()
✔ Inv_Unit_Test | test_Inv_Negative()
✔ Inv_Unit_Test | test_Inv_Positive()
✔ Inv_Unit_Test | test_RevertWhen_Zero()
✔ Gm_Unit_Test | test_Gm()
✔ Gm_Unit_Test | test_Gm_OneOperandZero()
✔ Gm_Unit_Test | test_RevertWhen_ProductOverflows()
✔ Inv_Unit_Test | test_Inv()
✔ Inv_Unit_Test | test_RevertWhen_Zero()
✔ Casting_Fuzz_Test | testFuzz_IntoSD59x18(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_IntoUD2x18(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_IntoUD60x18(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_IntoUint128(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_IntoUint256(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_IntoUint40(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowUint40(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowUD2x18(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowUD60x18(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowUint128(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowUint256(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowUint40(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_Unwrap(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_Wrap(int64) (256 runs)
✔ Casting_Fuzz_Test | testFuzz_sd1x18(int64) (256 runs)
✔ Frac_Unit_Test | test_Frac()
✔ Frac_Unit_Test | test_Frac_Negative()
✔ Frac_Unit_Test | test_Frac_Zero()
✔ Floor_Unit_Test | test_Floor_Negative_GteMinPermitted()
✔ Floor_Unit_Test | test_Floor_Positive()
✔ Floor_Unit_Test | test_Floor_Zero()
✔ Floor_Unit_Test | test_RevertWhen_Negative_LtMinPermitted()
✔ Ln_Unit_Test | test_Ln()
✔ Ln_Unit_Test | test_RevertWhen_LtUnit()
✔ Log10_Unit_Test | test_Log10_NotPowerOfTen()
✔ Log10_Unit_Test | test_Log10_PowerOfTen()
✔ Log10_Unit_Test | test_RevertWhen_LtUnit()
✔ Ln_Unit_Test | test_Ln()
✔ Ln_Unit_Test | test_RevertWhen_Negative()
✔ Ln_Unit_Test | test_RevertWhen_Zero()
✔ Log10_Unit_Test | test_Log10_NotPowerOfTen()
✔ Log10_Unit_Test | test_Log10_PowerOfTen()
✔ Log10_Unit_Test | test_RevertWhen_Negative()
✔ Log10_Unit_Test | test_RevertWhen_Zero()
✔ Log2_Unit_Test | test_Log2_NotPowerOfTwo()
✔ Log2_Unit_Test | test_Log2_PowerOfTwo()
✔ Log2_Unit_Test | test_RevertWhen_LtUnit()
✔ Mul_Unit_Test | test_Mul_OneOperandZero()
✔ Mul_Unit_Test | test_Mul_OperandsDifferentSign()
✔ Mul_Unit_Test | test_Mul_OperandsSameSign()
✔ Mul_Unit_Test | test_RevertWhen_OneOperandMinSD59x18_Function()
✔ Mul_Unit_Test | test_RevertWhen_OneOperandMinSD59x18_Operator()
✔ Mul_Unit_Test | test_RevertWhen_ResultOverflowSD59x18_A()
✔ Mul_Unit_Test | test_RevertWhen_ResultOverflowSD59x18_B()
✔ Mul_Unit_Test | test_RevertWhen_ResultOverflowUint256()
✔ Log2_Unit_Test | test_Log2_NotPowerOfTwo()
✔ Log2_Unit_Test | test_Log2_PowerOfTwo()
✔ Log2_Unit_Test | test_RevertWhen_Negative()
✔ Log2_Unit_Test | test_RevertWhen_Zero()
✔ Mul_Unit_Test | test_Mul()
✔ Mul_Unit_Test | test_Mul_OneOperandZero()
✔ Mul_Unit_Test | test_RevertWhen_ResultOverflowUD60x18_Function()
✔ Mul_Unit_Test | test_RevertWhen_ResultOverflowUD60x18_Operator()
✔ CastingUint256_Test | testFuzz_RevertWhen_OverflowSD1x18(uint256) (256 runs)
✔ CastingUint256_Test | testFuzz_RevertWhen_OverflowSD59x18(uint256) (256 runs)
✔ CastingUint256_Test | testFuzz_RevertWhen_OverflowUD2x18(uint256) (256 runs)
✔ CastingUint256_Test | testFuzz_intoSD1x18(uint256) (256 runs)
✔ CastingUint256_Test | testFuzz_intoSD59x18(uint256) (256 runs)
✔ CastingUint256_Test | testFuzz_intoUD2x18(uint256) (256 runs)
✔ CastingUint256_Test | testFuzz_intoUD60x18(uint256) (256 runs)
✔ Powu_Unit_Test | test_Powu_BaseAndExponentZero()
✔ Powu_Unit_Test | test_Powu_BaseZeroExponentNotZero()
✔ Powu_Unit_Test | test_Powu_ExponentZero()
✔ Powu_Unit_Test | test_Powu_NegativeBase()
✔ Powu_Unit_Test | test_Powu_PositiveBase()
✔ Powu_Unit_Test | test_RevertWhen_ResultOverflowSD59x18()
✔ Powu_Unit_Test | test_RevertWhen_ResultOverflowUint256()
✔ Powu_Unit_Test | test_RevertWhen_ResultUnderflowSD59x18()
✔ Powu_Unit_Test | test_Powu()
✔ Powu_Unit_Test | test_Powu_BaseAndExponentZero()
✔ Powu_Unit_Test | test_Powu_BaseZeroExponentNotZero()
✔ Powu_Unit_Test | test_Powu_ExponentZero()
✔ Powu_Unit_Test | test_RevertWhen_ResultOverflowsUD60x18()
✔ Sqrt_Unit_Test | test_RevertWhen_GtMaxPermitted()
✔ Sqrt_Unit_Test | test_RevertWhen_Negative()
✔ Sqrt_Unit_Test | test_Sqrt()
✔ Sqrt_Unit_Test | test_Sqrt_Zero()
✔ Sqrt_Unit_Test | test_RevertWhen_GtMaxPermitted()
✔ Sqrt_Unit_Test | test_Sqrt()
✔ Sqrt_Unit_Test | test_Sqrt_Zero()
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Add(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_And(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Eq(uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Gt(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Gte(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_IsZero(uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Lshift(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Lt(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Lte(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Mod(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Neq(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Not(uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Or(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Rshift(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Sub(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_UncheckedAdd(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_UncheckedSub(uint256,uint256) (256 runs)
✔ UD60x18_Helpers_Fuzz_Test | testFuzz_Xor(uint256,uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowSD1x18(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowSD59x18(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowUD2x18(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowUint128(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowUint40(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_UD60x18(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_Ud(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_Unwrap(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_Wrap(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_intoSD1x18(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_intoSD59x18(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_intoUD2x18(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_intoUint128(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_intoUint256(uint256) (256 runs)
✔ UD60x18_Casting_Fuzz_Test | testFuzz_intoUint40(uint256) (256 runs)
✔ Pow_Fuzz_Test | testFuzz_Pow_BaseUnit(int256) (256 runs)
✔ Pow_Fuzz_Test | testFuzz_Pow_BaseZero_ExponentNotZero(int256) (256 runs)
✔ Pow_Fuzz_Test | testFuzz_Pow_ExponentUnit(int256) (256 runs)
✔ Pow_Fuzz_Test | testFuzz_Pow_ExponentZero(int256) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_IntoSD1x18(uint64) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_IntoSD59x18(uint64) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_IntoUD60x18(uint64) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_IntoUint128(uint64) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_IntoUint256(uint64) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_IntoUint40(uint64) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowSD1x18(uint64) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowUint40(uint64) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_Unwrap(uint64) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_Wrap(uint64) (256 runs)
✔ UD2x18_Casting_Fuzz_Test | testFuzz_ud2x18(uint64) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Add(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_And(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Eq(int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Gt(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Gte(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_IsZero(int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Lshift(int256,uint256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Lt(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Lte(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Mod(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Neq(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Not(int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Or(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Rshift(int256,uint256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Sub(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Unary(int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_UncheckedAdd(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_UncheckedSub(int256,int256) (256 runs)
✔ SD59x18_Helpers_Fuzz_Test | testFuzz_Xor(int256,int256) (256 runs)
✔ Pow_Unit_Test | test_Pow_BaseGtUnit()
✔ Pow_Unit_Test | test_Pow_BaseLtUnit()
✔ Pow_Unit_Test | test_Pow_BaseUnit()
✔ Pow_Unit_Test | test_Pow_BaseZero_ExponentNotZero()
✔ Pow_Unit_Test | test_Pow_BaseZero_ExponentZero()
✔ Pow_Unit_Test | test_Pow_ExponentUnit(uint256) (256 runs)
✔ Pow_Unit_Test | test_Pow_ExponentZero()
✔ Pow_Fuzz_Test | testFuzz_Pow_BaseUnit(uint256) (256 runs)
✔ Pow_Fuzz_Test | testFuzz_Pow_BaseZero_ExponentNotZero(uint256) (256 runs)
✔ Pow_Fuzz_Test | testFuzz_Pow_ExponentUnit(uint256) (256 runs)
✔ Pow_Fuzz_Test | testFuzz_Pow_ExponentZero(uint256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_IntoInt256(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_IntoSD1x18(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_IntoUD2x18(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_IntoUD60x18(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_IntoUint128(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_IntoUint256(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_IntoUint40(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowSD1x18(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowUD2x18(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowUint128(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_RevertWhen_OverflowUint40(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowSD1x18(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowUD2x18(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowUD60x18(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowUint128(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowUint256(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_RevertWhen_UnderflowUint40(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_Sd(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_Unwrap(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_Wrap(int256) (256 runs)
✔ SD59x18_Casting_Fuzz_Test | testFuzz_sd59x18(int256) (256 runs)
✔ Pow_Unit_Test | test_Pow_BaseUnit()
✔ Pow_Unit_Test | test_Pow_BaseZero_ExponentNotZero()
✔ Pow_Unit_Test | test_Pow_BaseZero_ExponentZero()
✔ Pow_Unit_Test | test_Pow_ExponentUnit()
✔ Pow_Unit_Test | test_Pow_ExponentZero()
✔ Pow_Unit_Test | test_Pow_NegativeExponent()
✔ Pow_Unit_Test | test_Pow_PositiveExponent()
```

I also tried breaking a test to make sure we're actually running them 😜 

What did I do to make it work?
1. I imported the standard library with `pnpm` (`pnpm add https://github.com/foundry-rs/forge-std/tarball/v1.9.2`)
2. I imported the prb-math library with `pnpm` (`pnpm add https://github.com/PaulRBerg/prb-math/tarball/v4.0.3`; I did that so I wouldn't have to copy the `src` of `prb-math` to the `example-project`)
3. I copied the `test` directory from `node_modulels/@prb/math` to the `example-project` (I also removed `*.tree` files; these likely should have been gitignored in the first place)
4. I replaced all the absolute `src` imports (e.g. `import from "src/..."`) with imports from the node dependency (`@prb/math`)
5. I replaced all the relative `src` imports (e.g. `import from "../../src/..."`) with imports from the node dependency (`@prb/math`)
6. I run the solidity tests with hardhat (`pnpm hardhat test:solidity`)

Here's the `forge test` output for comparison:
```
$ forge test
[⠊] Compiling...
[⠊] Compiling 96 files with Solc 0.8.26
[⠒] Solc 0.8.26 finished in 4.03s
Compiler run successful!

Ran 3 tests for test/unit/ud60x18/math/ceil/ceil.t.sol:CeilTest
[PASS] test_Ceil() (gas: 512281)
[PASS] test_Ceil_Zero() (gas: 3615)
[PASS] test_RevertWhen_GtMaxPermitted() (gas: 3757)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 10.82ms (801.75µs CPU time)

Ran 2 tests for test/unit/ud60x18/math/inv/inv.t.sol:Inv_Unit_Test
[PASS] test_Inv() (gas: 775355)
[PASS] test_RevertWhen_Zero() (gas: 3555)
Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 10.84ms (846.83µs CPU time)

Ran 2 tests for test/unit/ud60x18/math/floor/floor.t.sol:Floor_Unit_Test
[PASS] test_Floor_Positive() (gas: 520693)
[PASS] test_Floor_Zero() (gas: 3528)
Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 10.81ms (809.46µs CPU time)

Ran 3 tests for test/unit/ud60x18/math/log2/log2.t.sol:Log2_Unit_Test
[PASS] test_Log2_NotPowerOfTwo() (gas: 402178)
[PASS] test_Log2_PowerOfTwo() (gas: 347227)
[PASS] test_RevertWhen_LtUnit() (gas: 3735)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 10.88ms (832.25µs CPU time)

Ran 8 tests for test/unit/sd59x18/math/powu/powu.t.sol:Powu_Unit_Test
[PASS] test_Powu_BaseAndExponentZero() (gas: 3876)
[PASS] test_Powu_BaseZeroExponentNotZero() (gas: 158104)
[PASS] test_Powu_ExponentZero() (gas: 367759)
[PASS] test_Powu_NegativeBase() (gas: 1210034)
[PASS] test_Powu_PositiveBase() (gas: 1208245)
[PASS] test_RevertWhen_ResultOverflowSD59x18() (gas: 4692)
[PASS] test_RevertWhen_ResultOverflowUint256() (gas: 4309)
[PASS] test_RevertWhen_ResultUnderflowSD59x18() (gas: 4778)
Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 11.37ms (1.41ms CPU time)

Ran 4 tests for test/unit/sd59x18/math/ceil/ceil.t.sol:Ceil_Unit_Test
[PASS] test_Ceil_Negative() (gas: 502467)
[PASS] test_Ceil_Positive() (gas: 513135)
[PASS] test_Ceil_Zero() (gas: 3693)
[PASS] test_RevertWhen_GtMaxPermitted() (gas: 3775)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 421.83µs (203.42µs CPU time)

Ran 4 tests for test/unit/sd59x18/math/floor/floor.t.sol:Floor_Unit_Test
[PASS] test_Floor_Negative_GteMinPermitted() (gas: 463991)
[PASS] test_Floor_Positive() (gas: 522348)
[PASS] test_Floor_Zero() (gas: 3714)
[PASS] test_RevertWhen_Negative_LtMinPermitted() (gas: 3796)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 488.38µs (195.67µs CPU time)

Ran 3 tests for test/unit/sd59x18/math/inv/inv.t.sol:Inv_Unit_Test
[PASS] test_Inv_Negative() (gas: 796496)
[PASS] test_Inv_Positive() (gas: 776640)
[PASS] test_RevertWhen_Zero() (gas: 3581)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 600.46µs (285.58µs CPU time)

Ran 2 tests for test/unit/ud60x18/conversion/convert-from/convertFrom.t.sol:ConvertFrom_Unit_Test
[PASS] test_ConvertFrom() (gas: 609813)
[PASS] test_ConvertFrom_LtUnit() (gas: 118406)
Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 329.96µs (133.08µs CPU time)

Ran 4 tests for test/unit/sd59x18/math/log2/log2.t.sol:Log2_Unit_Test
[PASS] test_Log2_NotPowerOfTwo() (gas: 960551)
[PASS] test_Log2_PowerOfTwo() (gas: 544978)
[PASS] test_RevertWhen_Negative() (gas: 3603)
[PASS] test_RevertWhen_Zero() (gas: 3637)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 771.83µs (563.00µs CPU time)

Ran 3 tests for test/unit/ud60x18/math/sqrt/sqrt.t.sol:Sqrt_Unit_Test
[PASS] test_RevertWhen_GtMaxPermitted() (gas: 3735)
[PASS] test_Sqrt() (gas: 817265)
[PASS] test_Sqrt_Zero() (gas: 3692)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 391.96µs (184.62µs CPU time)

Ran 2 tests for test/unit/ud60x18/math/ln/ln.t.sol:Ln_Unit_Test
[PASS] test_Ln() (gas: 580417)
[PASS] test_RevertWhen_LtUnit() (gas: 3790)
Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 405.71µs (206.83µs CPU time)

Ran 2 tests for test/unit/ud60x18/conversion/convert-to/convertTo.t.sol:ConvertTo_Unit_Test
[PASS] test_ConvertTo() (gas: 463507)
[PASS] test_RevertWhen_GtMaxPermitted() (gas: 3729)
Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 276.25µs (84.96µs CPU time)

Ran 4 tests for test/unit/sd59x18/math/sqrt/sqrt.t.sol:Sqrt_Unit_Test
[PASS] test_RevertWhen_GtMaxPermitted() (gas: 3941)
[PASS] test_RevertWhen_Negative() (gas: 3619)
[PASS] test_Sqrt() (gas: 819035)
[PASS] test_Sqrt_Zero() (gas: 3812)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 401.13µs (203.13µs CPU time)

Ran 4 tests for test/unit/ud60x18/math/mul/mul.t.sol:Mul_Unit_Test
[PASS] test_Mul() (gas: 1247597)
[PASS] test_Mul_OneOperandZero() (gas: 112570)
[PASS] test_RevertWhen_ResultOverflowUD60x18_Function() (gas: 4123)
[PASS] test_RevertWhen_ResultOverflowUD60x18_Operator() (gas: 4079)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 469.75µs (268.25µs CPU time)

Ran 2 tests for test/unit/sd59x18/conversion/convert-from/convertFrom.t.sol:ConvertFrom_Unit_Test
[PASS] test_ConvertFrom() (gas: 1100150)
[PASS] test_ConvertFrom_LtAbsoluteUnit() (gas: 176487)
Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 420.42µs (219.83µs CPU time)

Ran 4 tests for test/unit/sd59x18/math/abs/abs.t.sol:Abs_Unit_Test
[PASS] test_Abs() (gas: 561245)
[PASS] test_Abs_Negative() (gas: 562045)
[PASS] test_Abs_Zero() (gas: 3617)
[PASS] test_RevertWhen_MinSD59x18() (gas: 3479)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 391.42µs (195.08µs CPU time)

Ran 3 tests for test/unit/sd59x18/math/ln/ln.t.sol:Ln_Unit_Test
[PASS] test_Ln() (gas: 1082175)
[PASS] test_RevertWhen_Negative() (gas: 3658)
[PASS] test_RevertWhen_Zero() (gas: 3648)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 661.92µs (462.21µs CPU time)

Ran 3 tests for test/unit/sd59x18/conversion/convert-to/convertTo.t.sol:ConvertTo_Unit_Test
[PASS] test_ConvertTo() (gas: 907330)
[PASS] test_RevertWhen_GtMaxPermitted() (gas: 3973)
[PASS] test_RevertWhen_LtMinPermitted() (gas: 3829)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 361.46µs (168.08µs CPU time)

Ran 5 tests for test/unit/ud60x18/math/avg/avg.t.sol:Avg_Unit_Test
[PASS] test_Avg_BothOperandsZero() (gas: 3643)
[PASS] test_Avg_NeitherOperandZero_BothOperandsEven() (gas: 435671)
[PASS] test_Avg_NeitherOperandZero_BothOperandsOdd() (gas: 504581)
[PASS] test_Avg_NeitherOperandZero_OneOperandEvenTheOtherOdd() (gas: 504603)
[PASS] test_Avg_OnlyOneOperandZero() (gas: 169332)
Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 392.63µs (196.88µs CPU time)

Ran 3 tests for test/unit/ud60x18/math/log10/log10.t.sol:Log10_Unit_Test
[PASS] test_Log10_NotPowerOfTen() (gas: 737914)
[PASS] test_Log10_PowerOfTen() (gas: 401254)
[PASS] test_RevertWhen_LtUnit() (gas: 3758)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 610.88µs (397.71µs CPU time)

Ran 6 tests for test/unit/ud60x18/math/div/div.t.sol:Div_Unit_Test
[PASS] test_Div() (gas: 1177735)
[PASS] test_Div_NumeratorZero() (gas: 173801)
[PASS] test_RevertWhen_DenominatorZero_Function() (gas: 3688)
[PASS] test_RevertWhen_DenominatorZero_Operator() (gas: 3710)
[PASS] test_RevertWhen_ResultOverflowUD60x18_Function() (gas: 4123)
[PASS] test_RevertWhen_ResultOverflowUD60x18_Operator() (gas: 4102)
Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 491.63µs (292.54µs CPU time)

Ran 8 tests for test/unit/sd59x18/math/mul/mul.t.sol:Mul_Unit_Test
[PASS] test_Mul_OneOperandZero() (gas: 175880)
[PASS] test_Mul_OperandsDifferentSign() (gas: 2279113)
[PASS] test_Mul_OperandsSameSign() (gas: 2278820)
[PASS] test_RevertWhen_OneOperandMinSD59x18_Function() (gas: 3181)
[PASS] test_RevertWhen_OneOperandMinSD59x18_Operator() (gas: 3171)
[PASS] test_RevertWhen_ResultOverflowSD59x18_A() (gas: 4291)
[PASS] test_RevertWhen_ResultOverflowSD59x18_B() (gas: 4324)
[PASS] test_RevertWhen_ResultOverflowUint256() (gas: 359839)
Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 1.22ms (980.33µs CPU time)

Ran 2 tests for test/unit/ud60x18/math/frac/frac.t.sol:Frac_Unit_Test
[PASS] test_Frac() (gas: 480762)
[PASS] test_Frac_Zero() (gas: 3528)
Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 933.71µs (329.92µs CPU time)

Ran 3 tests for test/unit/sd59x18/math/frac/frac.t.sol:Frac_Unit_Test
[PASS] test_Frac() (gas: 481879)
[PASS] test_Frac_Negative() (gas: 481880)
[PASS] test_Frac_Zero() (gas: 3648)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 381.08µs (186.33µs CPU time)

Ran 4 tests for test/unit/sd59x18/math/log10/log10.t.sol:Log10_Unit_Test
[PASS] test_Log10_NotPowerOfTen() (gas: 1086187)
[PASS] test_Log10_PowerOfTen() (gas: 794934)
[PASS] test_RevertWhen_Negative() (gas: 3629)
[PASS] test_RevertWhen_Zero() (gas: 5452)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 886.13µs (671.62µs CPU time)

Ran 3 tests for test/unit/ud60x18/math/gm/gm.t.sol:Gm_Unit_Test
[PASS] test_Gm() (gas: 788856)
[PASS] test_Gm_OneOperandZero() (gas: 109723)
[PASS] test_RevertWhen_ProductOverflows() (gas: 4096)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 357.96µs (159.63µs CPU time)

Ran 11 tests for test/unit/sd59x18/math/div/div.t.sol:Div_Unit_Test
[PASS] test_Div_NumeratorDenominatorDifferentSign() (gas: 2280554)
[PASS] test_Div_NumeratorDenominatorSameSign() (gas: 2279570)
[PASS] test_Div_NumeratorZero() (gas: 300073)
[PASS] test_RevertWhen_DenominatorMinSD59x18_Function() (gas: 3193)
[PASS] test_RevertWhen_DenominatorMinSD59x18_Operator() (gas: 3170)
[PASS] test_RevertWhen_DenominatorZero_Function() (gas: 3863)
[PASS] test_RevertWhen_DenominatorZero_Operator() (gas: 3907)
[PASS] test_RevertWhen_NumeratorMinSD59x18_Function() (gas: 3497)
[PASS] test_RevertWhen_NumeratorMinSD59x18_Operator() (gas: 3519)
[PASS] test_RevertWhen_ResultOverflowSD59x18_Function() (gas: 4239)
[PASS] test_RevertWhen_ResultOverflowSD59x18_Operator() (gas: 4304)
Suite result: ok. 11 passed; 0 failed; 0 skipped; finished in 1.27ms (1.03ms CPU time)

Ran 8 tests for test/unit/sd59x18/math/gm/gm.t.sol:Gm_Unit_Test
[PASS] test_Gm() (gas: 1416936)
[PASS] test_Gm_OneOperandZero() (gas: 109746)
[PASS] test_RevertWhen_ProductNegative_A() (gas: 3890)
[PASS] test_RevertWhen_ProductNegative_B() (gas: 3880)
[PASS] test_RevertWhen_ProductOverflow_A() (gas: 3882)
[PASS] test_RevertWhen_ProductOverflow_B() (gas: 4007)
[PASS] test_RevertWhen_ProductOverflow_C() (gas: 4232)
[PASS] test_RevertWhen_ProductOverflow_D() (gas: 3848)
Suite result: ok. 8 passed; 0 failed; 0 skipped; finished in 512.92µs (305.38µs CPU time)

Ran 3 tests for test/unit/ud60x18/math/exp/exp.t.sol:Exp_Unit_Test
[PASS] test_Exp() (gas: 893254)
[PASS] test_Exp_Zero() (gas: 4050)
[PASS] test_RevertWhen_GtMaxPermitted() (gas: 3758)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 461.25µs (256.83µs CPU time)

Ran 5 tests for test/unit/sd59x18/math/exp/exp.t.sol:Exp_Unit_Test
[PASS] test_Exp_Negative_GteMinPermitted() (gas: 798729)
[PASS] test_Exp_Negative_LtThreshold() (gas: 138733)
[PASS] test_Exp_Positive_LteMaxPermitted() (gas: 893411)
[PASS] test_Exp_Zero() (gas: 4061)
[PASS] test_RevertWhen_Positive_GtMaxPermitted() (gas: 3824)
Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 713.50µs (498.08µs CPU time)

Ran 7 tests for test/unit/sd59x18/math/avg/avg.t.sol:Avg_Unit_Test
[PASS] test_Avg_BothOperandsEven() (gas: 435942)
[PASS] test_Avg_BothOperandsNegative() (gas: 504940)
[PASS] test_Avg_BothOperandsOdd() (gas: 513052)
[PASS] test_Avg_BothOperandsZero() (gas: 3673)
[PASS] test_Avg_OneOperandEvenTheOtherOdd() (gas: 504925)
[PASS] test_Avg_OneOperandNegativeTheOtherPositive() (gas: 494311)
[PASS] test_Avg_OnlyOneOperandZero() (gas: 267508)
Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 3.06ms (3.02ms CPU time)

Ran 7 tests for test/unit/sd59x18/math/pow/pow.t.sol:Pow_Unit_Test
[PASS] test_Pow_BaseUnit() (gas: 3665)
[PASS] test_Pow_BaseZero_ExponentNotZero() (gas: 3643)
[PASS] test_Pow_BaseZero_ExponentZero() (gas: 3685)
[PASS] test_Pow_ExponentUnit() (gas: 3732)
[PASS] test_Pow_ExponentZero() (gas: 3666)
[PASS] test_Pow_NegativeExponent() (gas: 1442754)
[PASS] test_Pow_PositiveExponent() (gas: 1550424)
Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 1.41ms (1.19ms CPU time)

Ran 3 tests for test/unit/ud60x18/math/exp2/exp2.t.sol:Exp2_Unit_Test
[PASS] test_Exp2() (gas: 1079986)
[PASS] test_Exp2_Zero() (gas: 3958)
[PASS] test_RevertWhen_GtMaxPermitted() (gas: 3757)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 467.58µs (262.67µs CPU time)

Ran 5 tests for test/unit/sd59x18/math/exp2/exp2.t.sol:Exp2_Unit_Test
[PASS] test_Exp2_Negative_GteMinPermitted() (gas: 786459)
[PASS] test_Exp2_Negative_LtThreshold() (gas: 138894)
[PASS] test_Exp2_Positive_LTePermittedMax() (gas: 1079619)
[PASS] test_Exp2_Zero() (gas: 3953)
[PASS] test_RevertWhen_Positive_GtMaxPermitted() (gas: 3823)
Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 675.00µs (460.50µs CPU time)

Ran 5 tests for test/unit/ud60x18/math/powu/powu.t.sol:Powu_Unit_Test
[PASS] test_Powu() (gas: 1204264)
[PASS] test_Powu_BaseAndExponentZero() (gas: 3641)
[PASS] test_Powu_BaseZeroExponentNotZero() (gas: 139726)
[PASS] test_Powu_ExponentZero() (gas: 218632)
[PASS] test_RevertWhen_ResultOverflowsUD60x18() (gas: 3925)
Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 2.71ms (2.47ms CPU time)

Ran 4 tests for test/fuzz/ud60x18/math/pow/pow.t.sol:Pow_Fuzz_Test
[PASS] testFuzz_Pow_BaseUnit(uint256) (runs: 256, μ: 3739, ~: 3739)
[PASS] testFuzz_Pow_BaseZero_ExponentNotZero(uint256) (runs: 256, μ: 4055, ~: 4055)
[PASS] testFuzz_Pow_ExponentUnit(uint256) (runs: 256, μ: 4151, ~: 4151)
[PASS] testFuzz_Pow_ExponentZero(uint256) (runs: 256, μ: 4121, ~: 4121)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 11.83ms (11.63ms CPU time)

Ran 7 tests for test/unit/ud60x18/math/pow/pow.t.sol:Pow_Unit_Test
[PASS] test_Pow_BaseGtUnit() (gas: 1012400)
[PASS] test_Pow_BaseLtUnit() (gas: 982361)
[PASS] test_Pow_BaseUnit() (gas: 3642)
[PASS] test_Pow_BaseZero_ExponentNotZero() (gas: 3665)
[PASS] test_Pow_BaseZero_ExponentZero() (gas: 3641)
[PASS] test_Pow_ExponentUnit(uint256) (runs: 256, μ: 4218, ~: 4218)
[PASS] test_Pow_ExponentZero() (gas: 3666)
Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 4.22ms (4.01ms CPU time)

Ran 6 tests for test/fuzz/casting/CastingUint128.t.sol:CastingUint128_Test
[PASS] testFuzz_RevertWhen_OverflowSD1x18(uint128) (runs: 256, μ: 4472, ~: 4761)
[PASS] testFuzz_RevertWhen_OverflowUD2x18(uint128) (runs: 256, μ: 4521, ~: 4749)
[PASS] testFuzz_intoSD1x18(uint128) (runs: 256, μ: 4138, ~: 3920)
[PASS] testFuzz_intoSD59x18(uint128) (runs: 256, μ: 3636, ~: 3636)
[PASS] testFuzz_intoUD2x18(uint128) (runs: 256, μ: 4139, ~: 3917)
[PASS] testFuzz_intoUD60x18(uint128) (runs: 256, μ: 3681, ~: 3681)
Suite result: ok. 6 passed; 0 failed; 0 skipped; finished in 38.13ms (28.09ms CPU time)

Ran 7 tests for test/fuzz/casting/CastingUint256.t.sol:CastingUint256_Test
[PASS] testFuzz_RevertWhen_OverflowSD1x18(uint256) (runs: 256, μ: 4270, ~: 4091)
[PASS] testFuzz_RevertWhen_OverflowSD59x18(uint256) (runs: 256, μ: 4601, ~: 4639)
[PASS] testFuzz_RevertWhen_OverflowUD2x18(uint256) (runs: 256, μ: 4255, ~: 4071)
[PASS] testFuzz_intoSD1x18(uint256) (runs: 256, μ: 4186, ~: 4391)
[PASS] testFuzz_intoSD59x18(uint256) (runs: 256, μ: 3897, ~: 3856)
[PASS] testFuzz_intoUD2x18(uint256) (runs: 256, μ: 4172, ~: 4374)
[PASS] testFuzz_intoUD60x18(uint256) (runs: 256, μ: 3575, ~: 3575)
Suite result: ok. 7 passed; 0 failed; 0 skipped; finished in 17.93ms (21.90ms CPU time)

Ran 15 tests for test/fuzz/sd1x18/casting/Casting.t.sol:Casting_Fuzz_Test
[PASS] testFuzz_IntoSD59x18(int64) (runs: 256, μ: 3696, ~: 3696)
[PASS] testFuzz_IntoUD2x18(int64) (runs: 256, μ: 5137, ~: 5396)
[PASS] testFuzz_IntoUD60x18(int64) (runs: 256, μ: 5167, ~: 5418)
[PASS] testFuzz_IntoUint128(int64) (runs: 256, μ: 5153, ~: 5412)
[PASS] testFuzz_IntoUint256(int64) (runs: 256, μ: 5076, ~: 5335)
[PASS] testFuzz_IntoUint40(int64) (runs: 256, μ: 5230, ~: 5392)
[PASS] testFuzz_RevertWhen_OverflowUint40(int64) (runs: 256, μ: 5492, ~: 5616)
[PASS] testFuzz_RevertWhen_UnderflowUD2x18(int64) (runs: 256, μ: 5140, ~: 4939)
[PASS] testFuzz_RevertWhen_UnderflowUD60x18(int64) (runs: 256, μ: 5124, ~: 4926)
[PASS] testFuzz_RevertWhen_UnderflowUint128(int64) (runs: 256, μ: 5146, ~: 4971)
[PASS] testFuzz_RevertWhen_UnderflowUint256(int64) (runs: 256, μ: 5170, ~: 4972)
[PASS] testFuzz_RevertWhen_UnderflowUint40(int64) (runs: 256, μ: 5133, ~: 4918)
[PASS] testFuzz_Unwrap(int64) (runs: 256, μ: 3706, ~: 3706)
[PASS] testFuzz_Wrap(int64) (runs: 256, μ: 3722, ~: 3722)
[PASS] testFuzz_sd1x18(int64) (runs: 256, μ: 3700, ~: 3700)
Suite result: ok. 15 passed; 0 failed; 0 skipped; finished in 79.37ms (77.30ms CPU time)

Ran 11 tests for test/fuzz/ud2x18/casting/Casting.t.sol:UD2x18_Casting_Fuzz_Test
[PASS] testFuzz_IntoSD1x18(uint64) (runs: 256, μ: 4027, ~: 3996)
[PASS] testFuzz_IntoSD59x18(uint64) (runs: 256, μ: 3688, ~: 3688)
[PASS] testFuzz_IntoUD60x18(uint64) (runs: 256, μ: 3710, ~: 3710)
[PASS] testFuzz_IntoUint128(uint64) (runs: 256, μ: 3627, ~: 3627)
[PASS] testFuzz_IntoUint256(uint64) (runs: 256, μ: 3692, ~: 3692)
[PASS] testFuzz_IntoUint40(uint64) (runs: 256, μ: 4159, ~: 3996)
[PASS] testFuzz_RevertWhen_OverflowSD1x18(uint64) (runs: 256, μ: 4746, ~: 4824)
[PASS] testFuzz_RevertWhen_OverflowUint40(uint64) (runs: 256, μ: 4586, ~: 4792)
[PASS] testFuzz_Unwrap(uint64) (runs: 256, μ: 3649, ~: 3649)
[PASS] testFuzz_Wrap(uint64) (runs: 256, μ: 3706, ~: 3706)
[PASS] testFuzz_ud2x18(uint64) (runs: 256, μ: 3660, ~: 3660)
Suite result: ok. 11 passed; 0 failed; 0 skipped; finished in 30.71ms (54.69ms CPU time)

Ran 15 tests for test/fuzz/ud60x18/casting/Casting.t.sol:UD60x18_Casting_Fuzz_Test
[PASS] testFuzz_RevertWhen_OverflowSD1x18(uint256) (runs: 256, μ: 4352, ~: 4304)
[PASS] testFuzz_RevertWhen_OverflowSD59x18(uint256) (runs: 256, μ: 4642, ~: 4688)
[PASS] testFuzz_RevertWhen_OverflowUD2x18(uint256) (runs: 256, μ: 4314, ~: 4262)
[PASS] testFuzz_RevertWhen_OverflowUint128(uint256) (runs: 256, μ: 4435, ~: 4722)
[PASS] testFuzz_RevertWhen_OverflowUint40(uint256) (runs: 256, μ: 4323, ~: 4047)
[PASS] testFuzz_UD60x18(uint256) (runs: 256, μ: 3619, ~: 3619)
[PASS] testFuzz_Ud(uint256) (runs: 256, μ: 3663, ~: 3663)
[PASS] testFuzz_Unwrap(uint256) (runs: 256, μ: 3580, ~: 3580)
[PASS] testFuzz_Wrap(uint256) (runs: 256, μ: 3640, ~: 3640)
[PASS] testFuzz_intoSD1x18(uint256) (runs: 256, μ: 4321, ~: 4560)
[PASS] testFuzz_intoSD59x18(uint256) (runs: 256, μ: 3968, ~: 3940)
[PASS] testFuzz_intoUD2x18(uint256) (runs: 256, μ: 4269, ~: 3931)
[PASS] testFuzz_intoUint128(uint256) (runs: 256, μ: 4082, ~: 3871)
[PASS] testFuzz_intoUint256(uint256) (runs: 256, μ: 3602, ~: 3602)
[PASS] testFuzz_intoUint40(uint256) (runs: 256, μ: 4246, ~: 4456)
Suite result: ok. 15 passed; 0 failed; 0 skipped; finished in 79.51ms (66.34ms CPU time)

Ran 21 tests for test/fuzz/sd59x18/casting/Casting.t.sol:SD59x18_Casting_Fuzz_Test
[PASS] testFuzz_IntoInt256(int256) (runs: 256, μ: 3626, ~: 3626)
[PASS] testFuzz_IntoSD1x18(int256) (runs: 256, μ: 4940, ~: 4732)
[PASS] testFuzz_IntoUD2x18(int256) (runs: 256, μ: 4911, ~: 5210)
[PASS] testFuzz_IntoUD60x18(int256) (runs: 256, μ: 4724, ~: 4484)
[PASS] testFuzz_IntoUint128(int256) (runs: 256, μ: 4817, ~: 4481)
[PASS] testFuzz_IntoUint256(int256) (runs: 256, μ: 4696, ~: 4444)
[PASS] testFuzz_IntoUint40(int256) (runs: 256, μ: 4900, ~: 5097)
[PASS] testFuzz_RevertWhen_OverflowSD1x18(int256) (runs: 256, μ: 5226, ~: 5386)
[PASS] testFuzz_RevertWhen_OverflowUD2x18(int256) (runs: 256, μ: 5253, ~: 5397)
[PASS] testFuzz_RevertWhen_OverflowUint128(int256) (runs: 256, μ: 5252, ~: 5407)
[PASS] testFuzz_RevertWhen_OverflowUint40(int256) (runs: 256, μ: 5153, ~: 5352)
[PASS] testFuzz_RevertWhen_UnderflowSD1x18(int256) (runs: 256, μ: 5446, ~: 5562)
[PASS] testFuzz_RevertWhen_UnderflowUD2x18(int256) (runs: 256, μ: 5280, ~: 5464)
[PASS] testFuzz_RevertWhen_UnderflowUD60x18(int256) (runs: 256, μ: 5239, ~: 5441)
[PASS] testFuzz_RevertWhen_UnderflowUint128(int256) (runs: 256, μ: 5269, ~: 5455)
[PASS] testFuzz_RevertWhen_UnderflowUint256(int256) (runs: 256, μ: 5194, ~: 5408)
[PASS] testFuzz_RevertWhen_UnderflowUint40(int256) (runs: 256, μ: 5279, ~: 5487)
[PASS] testFuzz_Sd(int256) (runs: 256, μ: 3667, ~: 3667)
[PASS] testFuzz_Unwrap(int256) (runs: 256, μ: 3582, ~: 3582)
[PASS] testFuzz_Wrap(int256) (runs: 256, μ: 3644, ~: 3644)
[PASS] testFuzz_sd59x18(int256) (runs: 256, μ: 3644, ~: 3644)
Suite result: ok. 21 passed; 0 failed; 0 skipped; finished in 46.42ms (92.02ms CPU time)

Ran 4 tests for test/fuzz/casting/CastingUint40.t.sol:CastingUint40_Test
[PASS] testFuzz_intoSD1x18(uint40) (runs: 256, μ: 3674, ~: 3674)
[PASS] testFuzz_intoSD59x18(uint40) (runs: 256, μ: 3637, ~: 3637)
[PASS] testFuzz_intoUD2x18(uint40) (runs: 256, μ: 3626, ~: 3626)
[PASS] testFuzz_intoUD60x18(uint40) (runs: 256, μ: 3659, ~: 3659)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 80.15ms (20.20ms CPU time)

Ran 18 tests for test/fuzz/ud60x18/helpers/Helpers.t.sol:UD60x18_Helpers_Fuzz_Test
[PASS] testFuzz_Add(uint256,uint256) (runs: 256, μ: 5387, ~: 5351)
[PASS] testFuzz_And(uint256,uint256) (runs: 256, μ: 4558, ~: 4558)
[PASS] testFuzz_Eq(uint256) (runs: 256, μ: 4306, ~: 4306)
[PASS] testFuzz_Gt(uint256,uint256) (runs: 256, μ: 4700, ~: 4700)
[PASS] testFuzz_Gte(uint256,uint256) (runs: 256, μ: 4715, ~: 4715)
[PASS] testFuzz_IsZero(uint256) (runs: 256, μ: 3639, ~: 3639)
[PASS] testFuzz_Lshift(uint256,uint256) (runs: 256, μ: 4060, ~: 4060)
[PASS] testFuzz_Lt(uint256,uint256) (runs: 256, μ: 4678, ~: 4678)
[PASS] testFuzz_Lte(uint256,uint256) (runs: 256, μ: 4758, ~: 4758)
[PASS] testFuzz_Mod(uint256,uint256) (runs: 256, μ: 5122, ~: 5122)
[PASS] testFuzz_Neq(uint256,uint256) (runs: 256, μ: 4757, ~: 4757)
[PASS] testFuzz_Not(uint256) (runs: 256, μ: 4515, ~: 4515)
[PASS] testFuzz_Or(uint256,uint256) (runs: 256, μ: 4594, ~: 4594)
[PASS] testFuzz_Rshift(uint256,uint256) (runs: 256, μ: 4038, ~: 4038)
[PASS] testFuzz_Sub(uint256,uint256) (runs: 256, μ: 5149, ~: 5149)
[PASS] testFuzz_UncheckedAdd(uint256,uint256) (runs: 256, μ: 3750, ~: 3750)
[PASS] testFuzz_UncheckedSub(uint256,uint256) (runs: 256, μ: 3726, ~: 3726)
[PASS] testFuzz_Xor(uint256,uint256) (runs: 256, μ: 4572, ~: 4572)
Suite result: ok. 18 passed; 0 failed; 0 skipped; finished in 59.02ms (155.61ms CPU time)

Ran 4 tests for test/fuzz/sd59x18/math/pow/pow.t.sol:Pow_Fuzz_Test
[PASS] testFuzz_Pow_BaseUnit(int256) (runs: 256, μ: 3695, ~: 3695)
[PASS] testFuzz_Pow_BaseZero_ExponentNotZero(int256) (runs: 256, μ: 4077, ~: 4077)
[PASS] testFuzz_Pow_ExponentUnit(int256) (runs: 256, μ: 4196, ~: 4196)
[PASS] testFuzz_Pow_ExponentZero(int256) (runs: 256, μ: 4120, ~: 4120)
Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 80.16ms (17.44ms CPU time)

Ran 19 tests for test/fuzz/sd59x18/helpers/Helpers.t.sol:SD59x18_Helpers_Fuzz_Test
[PASS] testFuzz_Add(int256,int256) (runs: 256, μ: 7320, ~: 7257)
[PASS] testFuzz_And(int256,int256) (runs: 256, μ: 4581, ~: 4581)
[PASS] testFuzz_Eq(int256) (runs: 256, μ: 4327, ~: 4327)
[PASS] testFuzz_Gt(int256,int256) (runs: 256, μ: 4680, ~: 4680)
[PASS] testFuzz_Gte(int256,int256) (runs: 256, μ: 4746, ~: 4746)
[PASS] testFuzz_IsZero(int256) (runs: 256, μ: 3594, ~: 3594)
[PASS] testFuzz_Lshift(int256,uint256) (runs: 256, μ: 4488, ~: 4555)
[PASS] testFuzz_Lt(int256,int256) (runs: 256, μ: 4678, ~: 4678)
[PASS] testFuzz_Lte(int256,int256) (runs: 256, μ: 4715, ~: 4715)
[PASS] testFuzz_Mod(int256,int256) (runs: 256, μ: 5143, ~: 5143)
[PASS] testFuzz_Neq(int256,int256) (runs: 256, μ: 4736, ~: 4736)
[PASS] testFuzz_Not(int256) (runs: 256, μ: 4537, ~: 4537)
[PASS] testFuzz_Or(int256,int256) (runs: 256, μ: 4573, ~: 4573)
[PASS] testFuzz_Rshift(int256,uint256) (runs: 256, μ: 4476, ~: 4535)
[PASS] testFuzz_Sub(int256,int256) (runs: 256, μ: 7246, ~: 7208)
[PASS] testFuzz_Unary(int256) (runs: 256, μ: 5700, ~: 5664)
[PASS] testFuzz_UncheckedAdd(int256,int256) (runs: 256, μ: 3750, ~: 3750)
[PASS] testFuzz_UncheckedSub(int256,int256) (runs: 256, μ: 3728, ~: 3728)
[PASS] testFuzz_Xor(int256,int256) (runs: 256, μ: 4595, ~: 4595)
Suite result: ok. 19 passed; 0 failed; 0 skipped; finished in 65.57ms (103.41ms CPU time)

Ran 48 test suites in 213.33ms (670.65ms CPU time): 281 tests passed, 0 failed, 0 skipped (281 total tests)
```