### PR TITLE
feat: add bytecode module with resolveLinkedBytecode and linkBytecode…

### DIFF
--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -13,6 +13,7 @@
   "type": "module",
   "exports": {
     "./bigint": "./dist/src/bigint.js",
+    "./bytecode": "./dist/src/bytecode.js",
     "./bytes": "./dist/src/bytes.js",
     "./ci": "./dist/src/ci.js",
     "./common-errors": "./dist/src/common-errors.js",

--- a/v-next/hardhat-utils/src/bytecode.ts
+++ b/v-next/hardhat-utils/src/bytecode.ts
@@ -1,34 +1,17 @@
 import type { PrefixedHexString } from "./hex.js";
+import type {
+  Artifact,
+  LibraryAddresses,
+  LibraryLink,
+} from "./internal/bytecode.js";
 
-import {
-  AmbiguousLibraryNameError,
-  InvalidLibraryAddressError,
-  MissingLibrariesError,
-  OverlappingLibrariesError,
-  UnnecessaryLibraryError,
-} from "./errors/bytecode.js";
-import { isAddress } from "./eth.js";
 import { getPrefixedHexString, getUnprefixedHexString } from "./hex.js";
-
-interface Artifact {
-  bytecode: string;
-  linkReferences: {
-    [sourceName: string]: {
-      [libraryName: string]: Array<{ start: number; length: number }>;
-    };
-  };
-}
-
-interface LibraryLink {
-  sourceName: string;
-  libraryName: string;
-  libraryFqn: string;
-  address: string;
-}
-
-interface LibraryAddresses {
-  [contractName: string]: PrefixedHexString;
-}
+import {
+  checkAmbiguousOrUnnecessaryLinks,
+  checkMissingLibraryAddresses,
+  checkOverlappingLibraryNames,
+  checkProvidedLibraryAddresses,
+} from "./internal/bytecode.js";
 
 /**
  * Resolves the linked bytecode for a given contract artifact by ensuring all
@@ -90,7 +73,8 @@ export function linkBytecode(
   let linkedBytecode = bytecode;
 
   for (const { sourceName, libraryName, address } of libraries) {
-    const contractLinkReferences = linkReferences[sourceName]?.[libraryName];
+    const contractLinkReferences =
+      linkReferences[sourceName]?.[libraryName] ?? [];
     const unprefixedAddress = getUnprefixedHexString(address);
 
     for (const { start, length } of contractLinkReferences) {
@@ -102,125 +86,4 @@ export function linkBytecode(
   }
 
   return getPrefixedHexString(linkedBytecode);
-}
-
-/**
- * Check that the provided library addresses are valid Ethereum addresses.
- * If any of them are not, an InvalidLibraryAddressError is thrown.
- */
-function checkProvidedLibraryAddresses(providedLibraries: LibraryAddresses) {
-  const librariesWithInvalidAddresses = Object.entries(
-    providedLibraries,
-  ).filter(([, address]) => !isAddress(address));
-
-  if (librariesWithInvalidAddresses.length === 0) {
-    return;
-  }
-
-  const formattedLibraries = librariesWithInvalidAddresses
-    .map(([libraryName, address]) => `\t* "${libraryName}": "${address}"`)
-    .join("\n");
-
-  throw new InvalidLibraryAddressError(formattedLibraries);
-}
-
-/**
- * Check that the provided libraries can't be resolved to multiple libraries, or
- * that they are not needed by the contract. If any of these conditions are met,
- * an AmbiguousLibraryNameError or an UnnecessaryLibraryError is thrown.
- */
-function checkAmbiguousOrUnnecessaryLinks(
-  providedLibraries: LibraryAddresses,
-  neededLibraries: LibraryLink[],
-) {
-  const ambiguousLibraries: Array<{
-    providedLibraryName: string;
-    matchingLibraries: LibraryLink[];
-  }> = [];
-  const unnecessaryLibraries: string[] = [];
-
-  for (const providedLibraryName of Object.keys(providedLibraries)) {
-    const matchingLibraries = neededLibraries.filter(
-      ({ libraryName, libraryFqn }) =>
-        libraryName === providedLibraryName ||
-        libraryFqn === providedLibraryName,
-    );
-
-    if (matchingLibraries.length > 1) {
-      ambiguousLibraries.push({
-        providedLibraryName,
-        matchingLibraries,
-      });
-    } else if (matchingLibraries.length === 0) {
-      unnecessaryLibraries.push(providedLibraryName);
-    }
-  }
-
-  if (ambiguousLibraries.length > 0) {
-    const formattedLibraries = ambiguousLibraries
-      .map(
-        ({ providedLibraryName, matchingLibraries }) =>
-          `\t* "${providedLibraryName}":\n${matchingLibraries
-            .map(({ libraryFqn }) => `\t\t* "${libraryFqn}"`)
-            .join("\n")}`,
-      )
-      .join("\n");
-
-    throw new AmbiguousLibraryNameError(formattedLibraries);
-  }
-
-  if (unnecessaryLibraries.length > 0) {
-    const formattedLibraries = unnecessaryLibraries
-      .map((libraryName) => `\t* "${libraryName}"`)
-      .join("\n");
-
-    throw new UnnecessaryLibraryError(formattedLibraries);
-  }
-}
-
-/**
- * Check that each library is only provided once, either by its name or its
- * fully qualified name. If a library is provided more than once, an
- * OverlappingLibrariesError is thrown.
- */
-function checkOverlappingLibraryNames(
-  providedLibraries: LibraryAddresses,
-  neededLibraries: LibraryLink[],
-) {
-  const overlappingLibraries = neededLibraries.filter(
-    ({ libraryName, libraryFqn }) =>
-      providedLibraries[libraryFqn] !== undefined &&
-      providedLibraries[libraryName] !== undefined,
-  );
-
-  if (overlappingLibraries.length === 0) {
-    return;
-  }
-
-  const formattedLibraries = overlappingLibraries
-    .map(({ libraryFqn }) => `\t* "${libraryFqn}"`)
-    .join("\n");
-
-  throw new OverlappingLibrariesError(formattedLibraries);
-}
-
-/**
- * Check if the needed libraries have all their addresses resolved. If an
- * address is missing, it means that the user didn't provide it in the
- * providedLibraries map. In that case, an MissingLibrariesError is thrown.
- */
-function checkMissingLibraryAddresses(neededLibraries: LibraryLink[]) {
-  const missingLibraries = neededLibraries.filter(
-    ({ address }) => address === undefined,
-  );
-
-  if (missingLibraries.length === 0) {
-    return;
-  }
-
-  const formattedLibraries = missingLibraries
-    .map(({ libraryFqn }) => `\t* "${libraryFqn}"`)
-    .join("\n");
-
-  throw new MissingLibrariesError(formattedLibraries);
 }

--- a/v-next/hardhat-utils/src/bytecode.ts
+++ b/v-next/hardhat-utils/src/bytecode.ts
@@ -1,0 +1,226 @@
+import type { PrefixedHexString } from "./hex.js";
+
+import {
+  AmbiguousLibraryNameError,
+  InvalidLibraryAddressError,
+  MissingLibrariesError,
+  OverlappingLibrariesError,
+  UnnecessaryLibraryError,
+} from "./errors/bytecode.js";
+import { isAddress } from "./eth.js";
+import { getPrefixedHexString, getUnprefixedHexString } from "./hex.js";
+
+interface Artifact {
+  bytecode: string;
+  linkReferences: {
+    [sourceName: string]: {
+      [libraryName: string]: Array<{ start: number; length: number }>;
+    };
+  };
+}
+
+interface LibraryLink {
+  sourceName: string;
+  libraryName: string;
+  libraryFqn: string;
+  address: string;
+}
+
+interface LibraryAddresses {
+  [contractName: string]: PrefixedHexString;
+}
+
+/**
+ * Resolves the linked bytecode for a given contract artifact by ensuring all
+ * required libraries are correctly linked.
+ *
+ * @param artifact The contract artifact containing the bytecode and link references.
+ * @param providedLibraries An object containing library names as keys and their addresses as values.
+ * @returns The linked bytecode with all required libraries correctly linked.
+ * @throws InvalidLibraryAddressError If any provided library address is invalid.
+ * @throws AmbiguousLibraryNameError If any provided library name matches multiple needed libraries.
+ * @throws UnnecessaryLibraryError If any provided library name is not needed by the contract.
+ * @throws OverlappingLibrariesError If any library is provided more than once.
+ * @throws MissingLibrariesError If any needed library address is missing.
+ */
+export function resolveLinkedBytecode(
+  artifact: Artifact,
+  providedLibraries: LibraryAddresses,
+): PrefixedHexString {
+  checkProvidedLibraryAddresses(providedLibraries);
+
+  const neededLibraries: LibraryLink[] = [];
+  for (const [sourceName, sourceLibraries] of Object.entries(
+    artifact.linkReferences,
+  )) {
+    for (const libraryName of Object.keys(sourceLibraries)) {
+      const libraryFqn = `${sourceName}:${libraryName}`;
+      const address =
+        providedLibraries[libraryFqn] ?? providedLibraries[libraryName];
+
+      neededLibraries.push({
+        sourceName,
+        libraryName,
+        libraryFqn,
+        address,
+      });
+    }
+  }
+
+  checkAmbiguousOrUnnecessaryLinks(providedLibraries, neededLibraries);
+  checkOverlappingLibraryNames(providedLibraries, neededLibraries);
+  checkMissingLibraryAddresses(neededLibraries);
+
+  return linkBytecode(artifact, neededLibraries);
+}
+
+/**
+ * Links the bytecode of a contract artifact with the provided library addresses.
+ * This function does not perform any validation on the provided libraries.
+ *
+ * @param artifact The contract artifact containing the bytecode and link references.
+ * @param libraries An array of LibraryLink objects representing the libraries to be linked.
+ * @returns The linked bytecode with all provided libraries correctly linked.
+ */
+export function linkBytecode(
+  artifact: Artifact,
+  libraries: LibraryLink[],
+): PrefixedHexString {
+  const { bytecode, linkReferences } = artifact;
+  let linkedBytecode = bytecode;
+
+  for (const { sourceName, libraryName, address } of libraries) {
+    const contractLinkReferences = linkReferences[sourceName]?.[libraryName];
+    const unprefixedAddress = getUnprefixedHexString(address);
+
+    for (const { start, length } of contractLinkReferences) {
+      linkedBytecode =
+        linkedBytecode.substring(0, 2 + start * 2) +
+        unprefixedAddress +
+        linkedBytecode.substring(2 + (start + length) * 2);
+    }
+  }
+
+  return getPrefixedHexString(linkedBytecode);
+}
+
+/**
+ * Check that the provided library addresses are valid Ethereum addresses.
+ * If any of them are not, an InvalidLibraryAddressError is thrown.
+ */
+function checkProvidedLibraryAddresses(providedLibraries: LibraryAddresses) {
+  const librariesWithInvalidAddresses = Object.entries(
+    providedLibraries,
+  ).filter(([, address]) => !isAddress(address));
+
+  if (librariesWithInvalidAddresses.length === 0) {
+    return;
+  }
+
+  const formattedLibraries = librariesWithInvalidAddresses
+    .map(([libraryName, address]) => `\t* "${libraryName}": "${address}"`)
+    .join("\n");
+
+  throw new InvalidLibraryAddressError(formattedLibraries);
+}
+
+/**
+ * Check that the provided libraries can't be resolved to multiple libraries, or
+ * that they are not needed by the contract. If any of these conditions are met,
+ * an AmbiguousLibraryNameError or an UnnecessaryLibraryError is thrown.
+ */
+function checkAmbiguousOrUnnecessaryLinks(
+  providedLibraries: LibraryAddresses,
+  neededLibraries: LibraryLink[],
+) {
+  const ambiguousLibraries: Array<{
+    providedLibraryName: string;
+    matchingLibraries: LibraryLink[];
+  }> = [];
+  const unnecessaryLibraries: string[] = [];
+
+  for (const providedLibraryName of Object.keys(providedLibraries)) {
+    const matchingLibraries = neededLibraries.filter(
+      ({ libraryName, libraryFqn }) =>
+        libraryName === providedLibraryName ||
+        libraryFqn === providedLibraryName,
+    );
+
+    if (matchingLibraries.length > 1) {
+      ambiguousLibraries.push({
+        providedLibraryName,
+        matchingLibraries,
+      });
+    } else if (matchingLibraries.length === 0) {
+      unnecessaryLibraries.push(providedLibraryName);
+    }
+  }
+
+  if (ambiguousLibraries.length > 0) {
+    const formattedLibraries = ambiguousLibraries
+      .map(
+        ({ providedLibraryName, matchingLibraries }) =>
+          `\t* "${providedLibraryName}":\n${matchingLibraries
+            .map(({ libraryFqn }) => `\t\t* "${libraryFqn}"`)
+            .join("\n")}`,
+      )
+      .join("\n");
+
+    throw new AmbiguousLibraryNameError(formattedLibraries);
+  }
+
+  if (unnecessaryLibraries.length > 0) {
+    const formattedLibraries = unnecessaryLibraries
+      .map((libraryName) => `\t* "${libraryName}"`)
+      .join("\n");
+
+    throw new UnnecessaryLibraryError(formattedLibraries);
+  }
+}
+
+/**
+ * Check that each library is only provided once, either by its name or its
+ * fully qualified name. If a library is provided more than once, an
+ * OverlappingLibrariesError is thrown.
+ */
+function checkOverlappingLibraryNames(
+  providedLibraries: LibraryAddresses,
+  neededLibraries: LibraryLink[],
+) {
+  const overlappingLibraries = neededLibraries.filter(
+    ({ libraryName, libraryFqn }) =>
+      providedLibraries[libraryFqn] !== undefined &&
+      providedLibraries[libraryName] !== undefined,
+  );
+
+  if (overlappingLibraries.length === 0) {
+    return;
+  }
+
+  const formattedLibraries = overlappingLibraries
+    .map(({ libraryFqn }) => `\t* "${libraryFqn}"`)
+    .join("\n");
+
+  throw new OverlappingLibrariesError(formattedLibraries);
+}
+
+/**
+ * Check if the needed libraries have all their addresses resolved. If an
+ * address is missing, it means that the user didn't provide it in the
+ * providedLibraries map. In that case, an MissingLibrariesError is thrown.
+ */
+function checkMissingLibraryAddresses(neededLibraries: LibraryLink[]) {
+  const missingLibraries = neededLibraries.filter(
+    ({ address }) => address === undefined,
+  );
+
+  if (missingLibraries.length === 0) {
+    return;
+  }
+
+  const formattedLibraries = missingLibraries
+    .map(({ libraryFqn }) => `\t* "${libraryFqn}"`)
+    .join("\n");
+
+  throw new MissingLibrariesError(formattedLibraries);
+}

--- a/v-next/hardhat-utils/src/bytecode.ts
+++ b/v-next/hardhat-utils/src/bytecode.ts
@@ -14,8 +14,9 @@ import {
 } from "./internal/bytecode.js";
 
 /**
- * Resolves the linked bytecode for a given contract artifact by ensuring all
- * required libraries are correctly linked.
+ * Resolves the linked bytecode for a given contract artifact by substituting
+ * the required library placeholders within the bytecode with the provided 
+ * library addresses.
  *
  * @param artifact The contract artifact containing the bytecode and link references.
  * @param providedLibraries An object containing library names as keys and their addresses as values.

--- a/v-next/hardhat-utils/src/bytecode.ts
+++ b/v-next/hardhat-utils/src/bytecode.ts
@@ -15,7 +15,7 @@ import {
 
 /**
  * Resolves the linked bytecode for a given contract artifact by substituting
- * the required library placeholders within the bytecode with the provided 
+ * the required library placeholders within the bytecode with the provided
  * library addresses.
  *
  * @param artifact The contract artifact containing the bytecode and link references.

--- a/v-next/hardhat-utils/src/errors/bytecode.ts
+++ b/v-next/hardhat-utils/src/errors/bytecode.ts
@@ -1,0 +1,48 @@
+import { CustomError } from "../error.js";
+
+export class InvalidLibraryAddressError extends CustomError {
+  constructor(formattedLibraries: string) {
+    super(`The following libraries have invalid addresses:
+${formattedLibraries}
+
+Please provide valid Ethereum addresses for these libraries.`);
+  }
+}
+
+export class AmbiguousLibraryNameError extends CustomError {
+  constructor(formattedLibraries: string) {
+    super(`The following libraries may resolve to multiple libraries:
+${formattedLibraries}
+
+Please provide the fully qualified name for these libraries.`);
+  }
+}
+
+export class UnnecessaryLibraryError extends CustomError {
+  constructor(formattedLibraries: string) {
+    super(`The following libraries are not referenced by the contract:
+${formattedLibraries}
+
+Please provide only the libraries that are actually needed.`);
+  }
+}
+
+export class OverlappingLibrariesError extends CustomError {
+  constructor(formattedLibraries: string) {
+    super(`The following libraries are provided more than once:
+${formattedLibraries}
+
+Please ensure that each library is provided only once, either by its name or its fully qualified name.`);
+  }
+}
+
+export class MissingLibrariesError extends CustomError {
+  constructor(formattedLibraries: string) {
+    super(
+      `The following libraries are missing:
+${formattedLibraries}
+
+Please provide all the required libraries.`,
+    );
+  }
+}

--- a/v-next/hardhat-utils/src/errors/bytecode.ts
+++ b/v-next/hardhat-utils/src/errors/bytecode.ts
@@ -1,7 +1,13 @@
+import type { LibraryAddresses, LibraryLink } from "../internal/bytecode.js";
+
 import { CustomError } from "../error.js";
 
 export class InvalidLibraryAddressError extends CustomError {
-  constructor(formattedLibraries: string) {
+  constructor(libraries: LibraryAddresses) {
+    const formattedLibraries = Object.entries(libraries)
+      .map(([libraryName, address]) => `\t* "${libraryName}": "${address}"`)
+      .join("\n");
+
     super(`The following libraries have invalid addresses:
 ${formattedLibraries}
 
@@ -10,7 +16,16 @@ Please provide valid Ethereum addresses for these libraries.`);
 }
 
 export class AmbiguousLibraryNameError extends CustomError {
-  constructor(formattedLibraries: string) {
+  constructor(libraries: Record<string, LibraryLink[]>) {
+    const formattedLibraries = Object.entries(libraries)
+      .map(
+        ([providedLibraryName, matchingLibraries]) =>
+          `\t* "${providedLibraryName}":\n${matchingLibraries
+            .map(({ libraryFqn }) => `\t\t* "${libraryFqn}"`)
+            .join("\n")}`,
+      )
+      .join("\n");
+
     super(`The following libraries may resolve to multiple libraries:
 ${formattedLibraries}
 
@@ -19,7 +34,11 @@ Please provide the fully qualified name for these libraries.`);
 }
 
 export class UnnecessaryLibraryError extends CustomError {
-  constructor(formattedLibraries: string) {
+  constructor(libraries: string[]) {
+    const formattedLibraries = libraries
+      .map((libraryName) => `\t* "${libraryName}"`)
+      .join("\n");
+
     super(`The following libraries are not referenced by the contract:
 ${formattedLibraries}
 
@@ -28,7 +47,11 @@ Please provide only the libraries that are needed.`);
 }
 
 export class OverlappingLibrariesError extends CustomError {
-  constructor(formattedLibraries: string) {
+  constructor(libraries: string[]) {
+    const formattedLibraries = libraries
+      .map((libraryFqn) => `\t* "${libraryFqn}"`)
+      .join("\n");
+
     super(`The following libraries are provided more than once:
 ${formattedLibraries}
 
@@ -37,7 +60,11 @@ Please ensure that each library is provided only once, either by its name or its
 }
 
 export class MissingLibrariesError extends CustomError {
-  constructor(formattedLibraries: string) {
+  constructor(libraries: string[]) {
+    const formattedLibraries = libraries
+      .map((libraryFqn) => `\t* "${libraryFqn}"`)
+      .join("\n");
+
     super(
       `The following libraries are missing:
 ${formattedLibraries}

--- a/v-next/hardhat-utils/src/errors/bytecode.ts
+++ b/v-next/hardhat-utils/src/errors/bytecode.ts
@@ -23,7 +23,7 @@ export class UnnecessaryLibraryError extends CustomError {
     super(`The following libraries are not referenced by the contract:
 ${formattedLibraries}
 
-Please provide only the libraries that are actually needed.`);
+Please provide only the libraries that are needed.`);
   }
 }
 

--- a/v-next/hardhat-utils/src/internal/bytecode.ts
+++ b/v-next/hardhat-utils/src/internal/bytecode.ts
@@ -1,0 +1,155 @@
+import type { PrefixedHexString } from "../hex.js";
+
+import {
+  AmbiguousLibraryNameError,
+  InvalidLibraryAddressError,
+  MissingLibrariesError,
+  OverlappingLibrariesError,
+  UnnecessaryLibraryError,
+} from "../errors/bytecode.js";
+import { isAddress } from "../eth.js";
+
+export interface Artifact {
+  bytecode: string;
+  linkReferences: {
+    [sourceName: string]: {
+      [libraryName: string]: Array<{ start: number; length: number }>;
+    };
+  };
+}
+
+export interface LibraryLink {
+  sourceName: string;
+  libraryName: string;
+  libraryFqn: string;
+  address: string;
+}
+
+export interface LibraryAddresses {
+  [contractName: string]: PrefixedHexString;
+}
+
+/**
+ * Check that the provided library addresses are valid Ethereum addresses.
+ * If any of them are not, an InvalidLibraryAddressError is thrown.
+ */
+export function checkProvidedLibraryAddresses(
+  providedLibraries: LibraryAddresses,
+): void {
+  const librariesWithInvalidAddresses = Object.entries(
+    providedLibraries,
+  ).filter(([, address]) => !isAddress(address));
+
+  if (librariesWithInvalidAddresses.length === 0) {
+    return;
+  }
+
+  const formattedLibraries = librariesWithInvalidAddresses
+    .map(([libraryName, address]) => `\t* "${libraryName}": "${address}"`)
+    .join("\n");
+
+  throw new InvalidLibraryAddressError(formattedLibraries);
+}
+
+/**
+ * Check that the provided libraries can't be resolved to multiple libraries, or
+ * that they are not needed by the contract. If any of these conditions are met,
+ * an AmbiguousLibraryNameError or an UnnecessaryLibraryError is thrown.
+ */
+export function checkAmbiguousOrUnnecessaryLinks(
+  providedLibraries: LibraryAddresses,
+  neededLibraries: LibraryLink[],
+): void {
+  const ambiguousLibraries: Array<{
+    providedLibraryName: string;
+    matchingLibraries: LibraryLink[];
+  }> = [];
+  const unnecessaryLibraries: string[] = [];
+
+  for (const providedLibraryName of Object.keys(providedLibraries)) {
+    const matchingLibraries = neededLibraries.filter(
+      ({ libraryName, libraryFqn }) =>
+        libraryName === providedLibraryName ||
+        libraryFqn === providedLibraryName,
+    );
+
+    if (matchingLibraries.length > 1) {
+      ambiguousLibraries.push({
+        providedLibraryName,
+        matchingLibraries,
+      });
+    } else if (matchingLibraries.length === 0) {
+      unnecessaryLibraries.push(providedLibraryName);
+    }
+  }
+
+  if (ambiguousLibraries.length > 0) {
+    const formattedLibraries = ambiguousLibraries
+      .map(
+        ({ providedLibraryName, matchingLibraries }) =>
+          `\t* "${providedLibraryName}":\n${matchingLibraries
+            .map(({ libraryFqn }) => `\t\t* "${libraryFqn}"`)
+            .join("\n")}`,
+      )
+      .join("\n");
+
+    throw new AmbiguousLibraryNameError(formattedLibraries);
+  }
+
+  if (unnecessaryLibraries.length > 0) {
+    const formattedLibraries = unnecessaryLibraries
+      .map((libraryName) => `\t* "${libraryName}"`)
+      .join("\n");
+
+    throw new UnnecessaryLibraryError(formattedLibraries);
+  }
+}
+
+/**
+ * Check that each library is only provided once, either by its name or its
+ * fully qualified name. If a library is provided more than once, an
+ * OverlappingLibrariesError is thrown.
+ */
+export function checkOverlappingLibraryNames(
+  providedLibraries: LibraryAddresses,
+  neededLibraries: LibraryLink[],
+): void {
+  const overlappingLibraries = neededLibraries.filter(
+    ({ libraryName, libraryFqn }) =>
+      providedLibraries[libraryFqn] !== undefined &&
+      providedLibraries[libraryName] !== undefined,
+  );
+
+  if (overlappingLibraries.length === 0) {
+    return;
+  }
+
+  const formattedLibraries = overlappingLibraries
+    .map(({ libraryFqn }) => `\t* "${libraryFqn}"`)
+    .join("\n");
+
+  throw new OverlappingLibrariesError(formattedLibraries);
+}
+
+/**
+ * Check if the needed libraries have all their addresses resolved. If an
+ * address is missing, it means that the user didn't provide it in the
+ * providedLibraries map. In that case, an MissingLibrariesError is thrown.
+ */
+export function checkMissingLibraryAddresses(
+  neededLibraries: LibraryLink[],
+): void {
+  const missingLibraries = neededLibraries.filter(
+    ({ address }) => address === undefined,
+  );
+
+  if (missingLibraries.length === 0) {
+    return;
+  }
+
+  const formattedLibraries = missingLibraries
+    .map(({ libraryFqn }) => `\t* "${libraryFqn}"`)
+    .join("\n");
+
+  throw new MissingLibrariesError(formattedLibraries);
+}

--- a/v-next/hardhat-utils/test/bytecode.ts
+++ b/v-next/hardhat-utils/test/bytecode.ts
@@ -1,0 +1,327 @@
+import type { PrefixedHexString } from "../src/hex.js";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { resolveLinkedBytecode, linkBytecode } from "../src/bytecode.js";
+import { getUnprefixedHexString } from "../src/hex.js";
+
+interface LibraryAddresses {
+  [contractName: string]: PrefixedHexString;
+}
+
+describe("bytecode", () => {
+  describe("resolveLinkedBytecode", () => {
+    describe("validation", () => {
+      it("should throw InvalidLibraryAddressError if a library address is invalid", () => {
+        const artifact = {
+          bytecode:
+            "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
+          linkReferences: {
+            "contracts/Library.sol": {
+              Library: [{ start: 12, length: 20 }],
+            },
+          },
+        };
+
+        const libraries: LibraryAddresses = {
+          Library: "0xnotanaddress",
+        };
+
+        assert.throws(() => resolveLinkedBytecode(artifact, libraries), {
+          name: "InvalidLibraryAddressError",
+          message: `The following libraries have invalid addresses:
+\t* "Library": "0xnotanaddress"
+
+Please provide valid Ethereum addresses for these libraries.`,
+        });
+      });
+
+      it("should throw AmbiguousLibraryNameError if a library name matches multiple needed libraries", () => {
+        const artifact = {
+          bytecode:
+            "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode__$placeholderplaceholderplaceholderp$__",
+          linkReferences: {
+            "contracts/Foo.sol": {
+              Library: [{ start: 12, length: 20 }],
+            },
+            "contracts/Bar.sol": {
+              Library: [{ start: 36, length: 20 }],
+            },
+          },
+        };
+
+        const libraries: LibraryAddresses = {
+          Library: "0x1234567890123456789012345678901234567890",
+        };
+
+        assert.throws(() => resolveLinkedBytecode(artifact, libraries), {
+          name: "AmbiguousLibraryNameError",
+          message: `The following libraries may resolve to multiple libraries:
+\t* "Library":
+\t\t* "contracts/Foo.sol:Library"
+\t\t* "contracts/Bar.sol:Library"
+
+Please provide the fully qualified name for these libraries.`,
+        });
+      });
+
+      it("should throw UnnecessaryLibraryError if an unnecessary library is provided", () => {
+        const artifact = {
+          bytecode: "0xbytecodebytecodebytecode",
+          linkReferences: {},
+        };
+
+        const libraries: LibraryAddresses = {
+          Library: "0x1234567890123456789012345678901234567890",
+        };
+
+        assert.throws(() => resolveLinkedBytecode(artifact, libraries), {
+          name: "UnnecessaryLibraryError",
+          message: `The following libraries are not referenced by the contract:
+\t* "Library"
+
+Please provide only the libraries that are actually needed.`,
+        });
+      });
+
+      it("should throw OverlappingLibrariesError if a library is provided more than once", () => {
+        const artifact = {
+          bytecode:
+            "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
+          linkReferences: {
+            "contracts/Library.sol": {
+              Library: [{ start: 12, length: 20 }],
+            },
+          },
+        };
+
+        const libraries: LibraryAddresses = {
+          "contracts/Library.sol:Library":
+            "0x1234567890123456789012345678901234567890",
+          Library: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        };
+
+        assert.throws(() => resolveLinkedBytecode(artifact, libraries), {
+          name: "OverlappingLibrariesError",
+          message: `The following libraries are provided more than once:
+\t* "contracts/Library.sol:Library"
+
+Please ensure that each library is provided only once, either by its name or its fully qualified name.`,
+        });
+      });
+
+      it("should throw MissingLibrariesError if a needed library is missing", () => {
+        const artifact = {
+          bytecode:
+            "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
+          linkReferences: {
+            "contracts/Library.sol": {
+              Library: [{ start: 12, length: 20 }],
+            },
+          },
+        };
+
+        assert.throws(() => resolveLinkedBytecode(artifact, {}), {
+          name: "MissingLibrariesError",
+          message: `The following libraries are missing:
+\t* "contracts/Library.sol:Library"
+
+Please provide all the required libraries.`,
+        });
+      });
+    });
+
+    describe("linking", () => {
+      it("should link a contract with a library", () => {
+        const artifact = {
+          bytecode:
+            "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
+          linkReferences: {
+            "contracts/Library.sol": {
+              // The start position of the reference doesn't take into account
+              // the "0x" prefix of the bytecode.
+              Library: [{ start: 12, length: 20 }],
+            },
+          },
+        };
+        const library1Fqn = "contracts/Library.sol:Library";
+        const libraries: LibraryAddresses = {
+          [library1Fqn]: "0x1234567890123456789012345678901234567890",
+        };
+        const expectedBytecode = `0xbytecodebytecodebytecode${getUnprefixedHexString(libraries[library1Fqn])}bytecode`;
+
+        assert.equal(
+          resolveLinkedBytecode(artifact, libraries),
+          expectedBytecode,
+        );
+      });
+
+      it("should link a contract with multiple libraries", () => {
+        const artifact = {
+          bytecode:
+            "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode__$placeholderplaceholderplaceholderp$__bytecodebytecodebytecode__$placeholderplaceholderplaceholderp$____$placeholderplaceholderplaceholderp$__",
+          linkReferences: {
+            "contracts/Foo.sol": {
+              Library1: [
+                { start: 12, length: 20 },
+                { start: 36, length: 20 },
+              ],
+              Library2: [{ start: 88, length: 20 }],
+            },
+            "contracts/Bar.sol": {
+              Library3: [{ start: 68, length: 20 }],
+            },
+          },
+        };
+        const library1Fqn = "contracts/Foo.sol:Library1";
+        const library2Fqn = "contracts/Foo.sol:Library2";
+        const library3Fqn = "contracts/Bar.sol:Library3";
+        const libraries: LibraryAddresses = {
+          [library1Fqn]: "0x1234567890123456789012345678901234567890",
+          [library2Fqn]: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          [library3Fqn]: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        };
+
+        const expectedBytecode = `0xbytecodebytecodebytecode${getUnprefixedHexString(libraries[library1Fqn])}bytecode${getUnprefixedHexString(libraries[library1Fqn])}bytecodebytecodebytecode${getUnprefixedHexString(libraries[library3Fqn])}${getUnprefixedHexString(libraries[library2Fqn])}`;
+
+        assert.equal(
+          resolveLinkedBytecode(artifact, libraries),
+          expectedBytecode,
+        );
+      });
+
+      it("should allow library names without source names if they are unique", () => {
+        const artifact = {
+          bytecode:
+            "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode__$placeholderplaceholderplaceholderp$__bytecodebytecodebytecode__$placeholderplaceholderplaceholderp$____$placeholderplaceholderplaceholderp$__",
+          linkReferences: {
+            "contracts/Foo.sol": {
+              Library1: [
+                { start: 12, length: 20 },
+                { start: 36, length: 20 },
+              ],
+              Library2: [{ start: 88, length: 20 }],
+            },
+            "contracts/Bar.sol": {
+              Library3: [{ start: 68, length: 20 }],
+            },
+          },
+        };
+        const libraries: LibraryAddresses = {
+          Library1: "0x1234567890123456789012345678901234567890",
+          Library2: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          Library3: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        };
+
+        const expectedBytecode = `0xbytecodebytecodebytecode${getUnprefixedHexString(libraries.Library1)}bytecode${getUnprefixedHexString(libraries.Library1)}bytecodebytecodebytecode${getUnprefixedHexString(libraries.Library3)}${getUnprefixedHexString(libraries.Library2)}`;
+
+        assert.equal(
+          resolveLinkedBytecode(artifact, libraries),
+          expectedBytecode,
+        );
+      });
+    });
+  });
+
+  describe("linkBytecode", () => {
+    it("should link a contract with a library", () => {
+      const artifact = {
+        bytecode:
+          "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
+        linkReferences: {
+          "contracts/Library.sol": {
+            // The start position of the reference doesn't take into account
+            // the "0x" prefix of the bytecode.
+            Library: [{ start: 12, length: 20 }],
+          },
+        },
+      };
+      const libraries = [
+        {
+          sourceName: "contracts/Library.sol",
+          libraryName: "Library",
+          libraryFqn: "contracts/Library.sol:Library",
+          address: "0x1234567890123456789012345678901234567890",
+        },
+      ];
+      const expectedBytecode = `0xbytecodebytecodebytecode${getUnprefixedHexString(libraries[0].address)}bytecode`;
+
+      assert.equal(linkBytecode(artifact, libraries), expectedBytecode);
+    });
+
+    it("should link a contract with multiple libraries", () => {
+      const artifact = {
+        bytecode:
+          "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode__$placeholderplaceholderplaceholderp$__bytecodebytecodebytecode__$placeholderplaceholderplaceholderp$____$placeholderplaceholderplaceholderp$__",
+        linkReferences: {
+          "contracts/Foo.sol": {
+            Library1: [
+              { start: 12, length: 20 },
+              { start: 36, length: 20 },
+            ],
+            Library2: [{ start: 88, length: 20 }],
+          },
+          "contracts/Bar.sol": {
+            Library3: [{ start: 68, length: 20 }],
+          },
+        },
+      };
+      const libraries = [
+        {
+          sourceName: "contracts/Foo.sol",
+          libraryName: "Library1",
+          libraryFqn: "contracts/Foo.sol:Library1",
+          address: "0x1234567890123456789012345678901234567890",
+        },
+        {
+          sourceName: "contracts/Foo.sol",
+          libraryName: "Library2",
+          libraryFqn: "contracts/Foo.sol:Library2",
+          address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+        {
+          sourceName: "contracts/Bar.sol",
+          libraryName: "Library3",
+          libraryFqn: "contracts/Bar.sol:Library3",
+          address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        },
+      ];
+      const [library1, library2, library3] = libraries;
+
+      const expectedBytecode = `0xbytecodebytecodebytecode${getUnprefixedHexString(library1.address)}bytecode${getUnprefixedHexString(library1.address)}bytecodebytecodebytecode${getUnprefixedHexString(library3.address)}${getUnprefixedHexString(library2.address)}`;
+
+      assert.equal(linkBytecode(artifact, libraries), expectedBytecode);
+    });
+
+    it("should return the same bytecode if no libraries are provided", () => {
+      const artifact = {
+        bytecode:
+          "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
+        linkReferences: {
+          "contracts/Library.sol": {
+            Library: [{ start: 12, length: 20 }],
+          },
+        },
+      };
+
+      assert.equal(linkBytecode(artifact, []), artifact.bytecode);
+    });
+
+    it("should return the same bytecode if there are no libraries to link", () => {
+      const artifact = {
+        bytecode: "0xbytecodebytecodebytecode",
+        linkReferences: {},
+      };
+      const libraries = [
+        {
+          sourceName: "contracts/Library.sol",
+          libraryName: "Library",
+          libraryFqn: "contracts/Library.sol:Library",
+          address: "0x1234567890123456789012345678901234567890",
+        },
+      ];
+      assert.equal(linkBytecode(artifact, libraries), artifact.bytecode);
+    });
+  });
+});

--- a/v-next/hardhat-utils/test/bytecode.ts
+++ b/v-next/hardhat-utils/test/bytecode.ts
@@ -1,4 +1,4 @@
-import type { PrefixedHexString } from "../src/hex.js";
+import type { Artifact, LibraryAddresses } from "../src/internal/bytecode.js";
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
@@ -6,15 +6,11 @@ import { describe, it } from "node:test";
 import { resolveLinkedBytecode, linkBytecode } from "../src/bytecode.js";
 import { getUnprefixedHexString } from "../src/hex.js";
 
-interface LibraryAddresses {
-  [contractName: string]: PrefixedHexString;
-}
-
 describe("bytecode", () => {
   describe("resolveLinkedBytecode", () => {
     describe("validation", () => {
       it("should throw InvalidLibraryAddressError if a library address is invalid", () => {
-        const artifact = {
+        const artifact: Artifact = {
           bytecode:
             "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
           linkReferences: {
@@ -38,7 +34,7 @@ Please provide valid Ethereum addresses for these libraries.`,
       });
 
       it("should throw AmbiguousLibraryNameError if a library name matches multiple needed libraries", () => {
-        const artifact = {
+        const artifact: Artifact = {
           bytecode:
             "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode__$placeholderplaceholderplaceholderp$__",
           linkReferences: {
@@ -67,7 +63,7 @@ Please provide the fully qualified name for these libraries.`,
       });
 
       it("should throw UnnecessaryLibraryError if an unnecessary library is provided", () => {
-        const artifact = {
+        const artifact: Artifact = {
           bytecode: "0xbytecodebytecodebytecode",
           linkReferences: {},
         };
@@ -86,7 +82,7 @@ Please provide only the libraries that are needed.`,
       });
 
       it("should throw OverlappingLibrariesError if a library is provided more than once", () => {
-        const artifact = {
+        const artifact: Artifact = {
           bytecode:
             "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
           linkReferences: {
@@ -112,7 +108,7 @@ Please ensure that each library is provided only once, either by its name or its
       });
 
       it("should throw MissingLibrariesError if a needed library is missing", () => {
-        const artifact = {
+        const artifact: Artifact = {
           bytecode:
             "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
           linkReferences: {
@@ -134,7 +130,7 @@ Please provide all the required libraries.`,
 
     describe("linking", () => {
       it("should link a contract with a library", () => {
-        const artifact = {
+        const artifact: Artifact = {
           bytecode:
             "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
           linkReferences: {
@@ -158,7 +154,7 @@ Please provide all the required libraries.`,
       });
 
       it("should link a contract with multiple libraries", () => {
-        const artifact = {
+        const artifact: Artifact = {
           bytecode:
             "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode__$placeholderplaceholderplaceholderp$__bytecodebytecodebytecode__$placeholderplaceholderplaceholderp$____$placeholderplaceholderplaceholderp$__",
           linkReferences: {
@@ -192,7 +188,7 @@ Please provide all the required libraries.`,
       });
 
       it("should allow library names without source names if they are unique", () => {
-        const artifact = {
+        const artifact: Artifact = {
           bytecode:
             "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode__$placeholderplaceholderplaceholderp$__bytecodebytecodebytecode__$placeholderplaceholderplaceholderp$____$placeholderplaceholderplaceholderp$__",
           linkReferences: {
@@ -226,7 +222,7 @@ Please provide all the required libraries.`,
 
   describe("linkBytecode", () => {
     it("should link a contract with a library", () => {
-      const artifact = {
+      const artifact: Artifact = {
         bytecode:
           "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
         linkReferences: {
@@ -251,7 +247,7 @@ Please provide all the required libraries.`,
     });
 
     it("should link a contract with multiple libraries", () => {
-      const artifact = {
+      const artifact: Artifact = {
         bytecode:
           "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode__$placeholderplaceholderplaceholderp$__bytecodebytecodebytecode__$placeholderplaceholderplaceholderp$____$placeholderplaceholderplaceholderp$__",
         linkReferences: {
@@ -295,7 +291,7 @@ Please provide all the required libraries.`,
     });
 
     it("should return the same bytecode if no libraries are provided", () => {
-      const artifact = {
+      const artifact: Artifact = {
         bytecode:
           "0xbytecodebytecodebytecode__$placeholderplaceholderplaceholderp$__bytecode",
         linkReferences: {
@@ -309,7 +305,7 @@ Please provide all the required libraries.`,
     });
 
     it("should return the same bytecode if there are no libraries to link", () => {
-      const artifact = {
+      const artifact: Artifact = {
         bytecode: "0xbytecodebytecodebytecode",
         linkReferences: {},
       };

--- a/v-next/hardhat-utils/test/bytecode.ts
+++ b/v-next/hardhat-utils/test/bytecode.ts
@@ -81,7 +81,7 @@ Please provide the fully qualified name for these libraries.`,
           message: `The following libraries are not referenced by the contract:
 \t* "Library"
 
-Please provide only the libraries that are actually needed.`,
+Please provide only the libraries that are needed.`,
         });
       });
 


### PR DESCRIPTION
Added a `bytecode` module which exports two functions:
 - `resolveLinkedBytecode`: which takes a contract artifact and a map of library names to their addresses, performs validations, and returns the linked bytecode.
 - `linkBytecode`: which takes a contract artifact and the resolved library links, and returns the linked bytecode without performing any validations.

Links:
[Design document](https://www.notion.so/nomicfoundation/Bytecode-library-linking-11b578cdeaf580faa434ca6951860b99?pvs=4)