### PR TITLE
feat: format the solidity test output better

### DIFF
--- a/v-next/example-project/contracts/Counter.t.sol
+++ b/v-next/example-project/contracts/Counter.t.sol
@@ -14,8 +14,37 @@ contract CounterTest {
     require(counter.x() == 0, "Initial value should be 0");
   }
 
-  function testInc() public {
-    counter.inc();
-    require(counter.x() == 1, "Value after inc should be 1");
+  function testFuzzInc(uint8 x) public {
+    for (uint8 i = 0; i < x; i++) {
+      counter.inc();
+    }
+    require(counter.x() == x, "Value after calling inc x times should be x");
+  }
+
+  function invariant() public {
+    assert(true);
+  }
+}
+
+contract FailingCounterTest {
+  Counter counter;
+
+  function setUp() public {
+    counter = new Counter();
+  }
+
+  function testInitialValue() public view {
+    require(counter.x() == 1, "Initial value should be 1");
+  }
+
+  function testFuzzInc(uint8 x) public {
+    for (uint8 i = 0; i < x; i++) {
+      counter.inc();
+    }
+    require(counter.x() == x + 1, "Value after calling inc x times should be x + 1");
+  }
+
+  function invariant() public {
+    assert(false);
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/formatters.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/formatters.ts
@@ -1,5 +1,7 @@
 import type { ArtifactId } from "@ignored/edr";
 
+import chalk from "chalk";
+
 export function formatArtifactId(artifactId: ArtifactId): string {
-  return `${artifactId.source}:${artifactId.name} (v${artifactId.solcVersion})`;
+  return `${chalk.bold(`${artifactId.source}:${artifactId.name}`)} (v${artifactId.solcVersion})`;
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -3,8 +3,13 @@ import type {
   TestReporterResult,
   TestStatus,
 } from "./types.js";
+import type { TestResult } from "@ignored/edr";
+
+import { inspect } from "node:util";
 
 import chalk from "chalk";
+
+import { formatArtifactId } from "./formatters.js";
 
 /**
  * This is a solidity test reporter. It is intended to be composed with the
@@ -14,47 +19,119 @@ import chalk from "chalk";
 export async function* testReporter(
   source: TestEventSource,
 ): TestReporterResult {
-  let testResultCount = 0;
-  let successCount = 0;
-  let failureCount = 0;
-  let skippedCount = 0;
+  let runTestCount = 0;
+  let runSuccessCount = 0;
+  let runFailureCount = 0;
+  let runSkippedCount = 0;
+  let runDuration = 0n;
+
+  const failures: TestResult[] = [];
 
   for await (const event of source) {
     switch (event.type) {
       case "suite:result": {
         const { data: suiteResult } = event;
-        for (const testResult of suiteResult.testResults) {
-          testResultCount++;
-          let name = suiteResult.id.name + " | " + testResult.name;
-          if ("runs" in testResult?.kind) {
-            name += ` (${testResult.kind.runs} runs)`;
+        const suiteTestCount = suiteResult.testResults.length;
+
+        if (suiteTestCount === 0) {
+          continue;
+        }
+
+        let suiteSuccessCount = 0;
+        let suiteFailureCount = 0;
+        let suiteSkippedCount = 0;
+        const suiteDuration = suiteResult.durationMs;
+
+        yield `Ran ${suiteResult.testResults.length} tests for ${formatArtifactId(suiteResult.id)}\n`;
+
+        if (suiteResult.warnings.length > 0) {
+          for (const warning of suiteResult.warnings) {
+            yield `${chalk.yellow("Warning")}${chalk.grey(`: ${warning}`)}\n`;
           }
+        }
+
+        // NOTE: The test results are in reverse run order, so we reverse them
+        // again to display them in the correct order.
+        for (const testResult of suiteResult.testResults.reverse()) {
+          const name = testResult.name;
           const status: TestStatus = testResult.status;
+          const details = [
+            ["duration", `${testResult.durationMs} ms`],
+            ...Object.entries(testResult.kind),
+          ]
+            .map(([key, value]) => `${key}: ${value}`)
+            .join(", ");
+
           switch (status) {
             case "Success": {
-              yield chalk.green(`✔ ${name}`);
-              successCount++;
+              yield `${chalk.green("✔ Passed")}: ${name} ${chalk.grey(`(${details})`)}\n`;
+              suiteSuccessCount++;
               break;
             }
             case "Failure": {
-              yield chalk.red(`✖ ${name}`);
-              failureCount++;
+              failures.push(testResult);
+              yield `${chalk.red(`✘ Failed(${failures.length})`)}: ${name} ${chalk.grey(`(${details})`)}\n`;
+              suiteFailureCount++;
               break;
             }
             case "Skipped": {
-              yield chalk.yellow(`⚠️ ${name}`);
-              skippedCount++;
+              yield `${chalk.cyan(`- Skipped`)}: ${name}\n`;
+              suiteSkippedCount++;
               break;
             }
           }
-          yield "\n";
         }
+
+        const suiteSummary = `${suiteTestCount} tests, ${suiteSuccessCount} passed, ${suiteFailureCount} failed, ${suiteSkippedCount} skipped`;
+        const suiteDetails = `duration: ${suiteDuration} ms`;
+
+        if (suiteFailureCount === 0) {
+          yield `${chalk.bold(chalk.green("✔ Suite Passed"))}: ${suiteSummary} ${chalk.grey(`(${suiteDetails})`)}\n`;
+        } else {
+          yield `${chalk.bold(chalk.red("✘ Suite Failed"))}: ${suiteSummary} ${chalk.grey(`(${suiteDetails})`)}\n`;
+        }
+        yield "\n";
+
+        runTestCount += suiteTestCount;
+        runSuccessCount += suiteSuccessCount;
+        runFailureCount += suiteFailureCount;
+        runSkippedCount += suiteSkippedCount;
+        runDuration += suiteDuration;
+
         break;
       }
     }
   }
 
-  yield "\n";
-  yield `${testResultCount} tests found, ${successCount} passed, ${failureCount} failed, ${skippedCount} skipped`;
-  yield "\n";
+  const runSummary = `${runTestCount} tests, ${runSuccessCount} passed, ${runFailureCount} failed, ${runSkippedCount} skipped`;
+  const runDetails = `duration: ${runDuration} ms`;
+  if (runFailureCount !== 0) {
+    yield `${chalk.bold(chalk.red("✘ Run Failed"))}: ${runSummary} ${chalk.grey(`(${runDetails})`)}\n`;
+  } else {
+    yield `${chalk.bold(chalk.green("✔ Run Passed"))}: ${runSummary} ${chalk.grey(`(${runDetails})`)}\n`;
+  }
+
+  if (failures.length > 0) {
+    for (const [index, failure] of failures.entries()) {
+      yield `\n${chalk.bold(chalk.red(`Failure (${index + 1})`))}: ${failure.name}\n`;
+
+      if (failure.decodedLogs !== undefined && failure.decodedLogs.length > 0) {
+        yield `Decoded Logs${chalk.grey(`: ${failure.decodedLogs.join("\n")}\n`)}`;
+      }
+
+      if (failure.reason !== undefined && failure.reason !== "") {
+        yield `Reason${chalk.grey(`: ${failure.reason}\n`)}`;
+      }
+
+      if (failure.counterexample !== undefined) {
+        const counterexamples = Array.isArray(failure.counterexample)
+          ? failure.counterexample
+          : [failure.counterexample];
+
+        for (const counterexample of counterexamples) {
+          yield `Counterexample${chalk.grey(`: ${inspect(counterexample)}\n`)}`;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This PR builds up on https://github.com/NomicFoundation/hardhat/pull/5809 and introduces custom output formatting described in https://www.notion.so/nomicfoundation/Reporter-Output-Formatting-11f578cdeaf580408d12fb03e7799e81.

It has been tested manually and visually verified.

The the reporter produces for the example project after the changes:
<img width="1172" alt="Screenshot 2024-10-16 at 12 11 03" src="https://github.com/user-attachments/assets/24f2e39a-9efe-421f-acc4-cd74b1fd1055">

