### PR TITLE
Docs: Add JavaScript require statements for upgradeable smart contract via proxy in ignition docs

### DIFF
--- a/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
+++ b/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
@@ -227,6 +227,9 @@ module.exports = demoModule;
 Next it's time to upgrade our proxy to a new version. To do this, we'll create a new file within our `ignition/modules` directory called `UpgradeModule.js` (or `UpgradeModule.ts` if you're using TypeScript). Inside this file, we'll again break up our module into two parts. To start, we'll write our `UpgradeModule`:
 
 ```js
+const { buildModule } = require("@nomicfoundation/hardhat-ignition/modules");
+const proxyModule = require("./ProxyModule");
+
 const upgradeModule = buildModule("UpgradeModule", (m) => {
   const proxyAdminOwner = m.getAccount(0);
 


### PR DESCRIPTION
This includes JS require statements that were missing from the upgradeable smart contract ignition docs that are required for the code to execute properly.