### PR TITLE
fix: ignore new node test event type added in v22.10.0

### DIFF
--- a/v-next/hardhat-node-test-reporter/src/reporter.ts
+++ b/v-next/hardhat-node-test-reporter/src/reporter.ts
@@ -268,6 +268,13 @@ export function hardhatTestReporter(
           yield chalk.red("\nTest coverage not supported by this reporter\n");
           break;
         }
+        // @ts-expect-error -- A new event type was added in https://github.com/nodejs/node/pull/54851
+        // but @types/node doesn't know about it yet. Once it does, the dependency should be updated
+        // and this comment removed.
+        case "test:summary": {
+          // Do nothing
+          break;
+        }
         /* eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check --
         We have this extra check here becase we know the @types/node type is
         unreliable */


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

As per the comment, node v22.10.0 added a new test event type. 

Follow up tasks: 
- remove the ts ignore comment once @types/node knows about the new test event type, 
- make use of the new `test:summary` event in the reporter,
- make the integration test of the reporter optional as they often break with node version upgrades.
