### PR TITLE
Add pnpm to tabgroup at hardhat-and-foundry.md

### DIFF
--- a/docs/src/content/hardhat-runner/docs/advanced/hardhat-and-foundry.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/hardhat-and-foundry.md
@@ -49,7 +49,7 @@ yarn add --dev @nomicfoundation/hardhat-foundry
 :::tab{value=pnpm}
 
 ```
-pnpm add -D @nomicfoundation/hardhat-foundry
+pnpm add --save-dev @nomicfoundation/hardhat-foundry
 ```
 
 ::::
@@ -91,7 +91,7 @@ Then install Hardhat, the [Hardhat Toolbox](/hardhat-runner/plugins/nomicfoundat
 :::tab{value="npm 7+"}
 
 ```
-npm install --save-dev @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-foundry
+npm install --save-dev hardhat @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-foundry
 ```
 
 :::
@@ -99,7 +99,7 @@ npm install --save-dev @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat
 :::tab{value="npm 6"}
 
 ```
-npm install --save-dev @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-foundry
+npm install --save-dev hardhat @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-foundry
 ```
 
 :::
@@ -115,7 +115,7 @@ yarn add --dev hardhat @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat
 :::tab{value=pnpm}
 
 ```
-pnpm add -D hardhat @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-foundry
+pnpm add --save-dev hardhat @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-foundry
 ```
 
 :::

--- a/docs/src/content/hardhat-runner/docs/advanced/hardhat-and-foundry.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/hardhat-and-foundry.md
@@ -20,7 +20,7 @@ First, run `forge --version` to make sure that you have Foundry installed. If yo
 
 After that, install the [`@nomicfoundation/hardhat-foundry`](/hardhat-runner/plugins/nomicfoundation-hardhat-foundry) plugin:
 
-::::tabsgroup{options="npm 7+,npm 6,yarn"}
+::::tabsgroup{options="npm 7+,npm 6,yarn,pnpm"}
 
 :::tab{value="npm 7+"}
 
@@ -45,6 +45,12 @@ yarn add --dev @nomicfoundation/hardhat-foundry
 ```
 
 :::
+
+:::tab{value=pnpm}
+
+```
+pnpm add -D @nomicfoundation/hardhat-foundry
+```
 
 ::::
 
@@ -80,7 +86,7 @@ First, if you don't have a `package.json` already in your project, create one wi
 
 Then install Hardhat, the [Hardhat Toolbox](/hardhat-runner/plugins/nomicfoundation-hardhat-toolbox), and the [`@nomicfoundation/hardhat-foundry`](/hardhat-runner/plugins/nomicfoundation-hardhat-foundry) plugin:
 
-::::tabsgroup{options="npm 7+,npm 6,yarn"}
+::::tabsgroup{options="npm 7+,npm 6,yarn,pnpm"}
 
 :::tab{value="npm 7+"}
 
@@ -102,6 +108,14 @@ npm install --save-dev @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat
 
 ```
 yarn add --dev hardhat @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-foundry
+```
+
+:::
+
+:::tab{value=pnpm}
+
+```
+pnpm add -D hardhat @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-foundry
 ```
 
 :::


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

I was just reading the docs and I saw that at getting started there's a pnpm command to install hardhat but there's no pnpm command in the tab group at the integration with foundry page
