### PR TITLE
chore: format buffers in solidity test output as hex strings

### DIFF
--- a/v-next/hardhat-utils/src/hex.ts
+++ b/v-next/hardhat-utils/src/hex.ts
@@ -95,17 +95,7 @@ export function hexStringToNumber(hexString: string): number {
  * @returns PrefixedHexString The hexadecimal representation of the bytes.
  */
 export function bytesToHexString(bytes: Uint8Array): PrefixedHexString {
-  return bufferToHexString(Buffer.from(bytes));
-}
-
-/**
- * Converts a Buffer to a hexadecimal string.
- *
- * @param buffer The buffer to convert.
- * @returns PrefixedHexString The hexadecimal representation of the buffer.
- */
-export function bufferToHexString(buffer: Buffer): PrefixedHexString {
-  return `0x${buffer.toString("hex")}`;
+  return `0x${Buffer.from(bytes).toString("hex")}`;
 }
 
 /**

--- a/v-next/hardhat-utils/src/hex.ts
+++ b/v-next/hardhat-utils/src/hex.ts
@@ -95,7 +95,17 @@ export function hexStringToNumber(hexString: string): number {
  * @returns PrefixedHexString The hexadecimal representation of the bytes.
  */
 export function bytesToHexString(bytes: Uint8Array): PrefixedHexString {
-  return `0x${Buffer.from(bytes).toString("hex")}`;
+  return bufferToHexString(Buffer.from(bytes));
+}
+
+/**
+ * Converts a Buffer to a hexadecimal string.
+ *
+ * @param buffer The buffer to convert.
+ * @returns PrefixedHexString The hexadecimal representation of the buffer.
+ */
+export function bufferToHexString(buffer: Buffer): PrefixedHexString {
+  return `0x${buffer.toString("hex")}`;
 }
 
 /**

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -5,8 +5,7 @@ import type {
 } from "./types.js";
 import type { TestResult } from "@ignored/edr";
 
-import { inspect } from "node:util";
-
+import { bufferToHexString } from "@ignored/hardhat-vnext-utils/hex";
 import chalk from "chalk";
 
 import { formatArtifactId } from "./formatters.js";
@@ -59,7 +58,10 @@ export async function* testReporter(
             ["duration", `${testResult.durationMs} ms`],
             ...Object.entries(testResult.kind),
           ]
-            .map(([key, value]) => `${key}: ${value}`)
+            .map(
+              ([key, value]) =>
+                `${key}: ${Buffer.isBuffer(value) ? bufferToHexString(value) : value}`,
+            )
             .join(", ");
 
           switch (status) {
@@ -129,7 +131,13 @@ export async function* testReporter(
           : [failure.counterexample];
 
         for (const counterexample of counterexamples) {
-          yield `Counterexample${chalk.grey(`: ${inspect(counterexample)}\n`)}`;
+          const details = `{\n${Object.entries(counterexample)
+            .map(
+              ([key, value]) =>
+                `  ${key}: ${Buffer.isBuffer(value) ? bufferToHexString(value) : value}`,
+            )
+            .join(",\n")}\n}`;
+          yield `Counterexample${chalk.grey(`: ${details}\n`)}`;
         }
       }
     }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -5,7 +5,7 @@ import type {
 } from "./types.js";
 import type { TestResult } from "@ignored/edr";
 
-import { bufferToHexString } from "@ignored/hardhat-vnext-utils/hex";
+import { bytesToHexString } from "@ignored/hardhat-vnext-utils/hex";
 import chalk from "chalk";
 
 import { formatArtifactId } from "./formatters.js";
@@ -60,7 +60,7 @@ export async function* testReporter(
           ]
             .map(
               ([key, value]) =>
-                `${key}: ${Buffer.isBuffer(value) ? bufferToHexString(value) : value}`,
+                `${key}: ${Buffer.isBuffer(value) ? bytesToHexString(value) : value}`,
             )
             .join(", ");
 
@@ -134,7 +134,7 @@ export async function* testReporter(
           const details = `{\n${Object.entries(counterexample)
             .map(
               ([key, value]) =>
-                `  ${key}: ${Buffer.isBuffer(value) ? bufferToHexString(value) : value}`,
+                `  ${key}: ${Buffer.isBuffer(value) ? bytesToHexString(value) : value}`,
             )
             .join(",\n")}\n}`;
           yield `Counterexample${chalk.grey(`: ${details}\n`)}`;


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This is a follow-up to https://github.com/NomicFoundation/hardhat/pull/5828#discussion_r1813556874
