### PR TITLE
Unified test workflow and small improvements

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1461,6 +1461,9 @@ importers:
       prettier:
         specifier: 3.2.5
         version: 3.2.5
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
       typescript:
         specifier: ~5.5.0
         version: 5.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1447,7 +1447,7 @@ importers:
         specifier: workspace:^3.0.0-next.0
         version: link:../hardhat-viem
       '@openzeppelin/contracts':
-        specifier: ^5.1.0
+        specifier: 5.1.0
         version: 5.1.0
       '@types/mocha':
         specifier: '>=9.1.0'
@@ -1455,6 +1455,9 @@ importers:
       '@types/node':
         specifier: ^20.14.9
         version: 20.17.1
+      forge-std:
+        specifier: foundry-rs/forge-std#v1.9.4
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262
       mocha:
         specifier: ^10.0.0
         version: 10.7.3
@@ -4739,6 +4742,10 @@ packages:
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262}
+    version: 1.9.4
 
   form-data@2.5.2:
     resolution: {integrity: sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==}
@@ -9819,6 +9826,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262: {}
 
   form-data@2.5.2:
     dependencies:

--- a/v-next/example-project/contracts/WithForge.t.sol
+++ b/v-next/example-project/contracts/WithForge.t.sol
@@ -1,0 +1,20 @@
+import "forge-std/Test.sol";
+
+contract TestContract is Test {
+  ErrorsTest test;
+
+  function setUp() public {
+    test = new ErrorsTest();
+  }
+
+  function testExpectArithmetic() public {
+    vm.expectRevert(stdError.arithmeticError);
+    test.arithmeticError(10);
+  }
+}
+
+contract ErrorsTest {
+  function arithmeticError(uint256 a) public {
+    uint256 a = a - 100;
+  }
+}

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -154,7 +154,11 @@ const config: HardhatUserConfig = {
       },
     },
     dependenciesToCompile: ["@openzeppelin/contracts/token/ERC20/ERC20.sol"],
-    remappings: ["remapped/=npm/@openzeppelin/contracts@5.1.0/access/"],
+    remappings: [
+      "remapped/=npm/@openzeppelin/contracts@5.1.0/access/",
+      // This is necessary because most people import forge-std/Test.sol, and not forge-std/src/Test.sol
+      "forge-std/=npm/forge-std@1.9.4/src/",
+    ],
   },
 };
 

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -51,12 +51,6 @@ const exampleTaskOverride = task("example2")
   })
   .build();
 
-const testSolidityTask = task(["test", "solidity"], "Runs Solidity tests")
-  .setAction(async () => {
-    console.log("Running Solidity tests");
-  })
-  .build();
-
 const greeting = task("hello", "Prints a greeting")
   .addOption({
     name: "greeting",
@@ -114,7 +108,6 @@ const pluginExample = {
 const config: HardhatUserConfig = {
   tasks: [
     exampleTaskOverride,
-    testSolidityTask,
     exampleEmptyTask,
     exampleEmptySubtask,
     greeting,
@@ -125,8 +118,7 @@ const config: HardhatUserConfig = {
     pluginExample,
     hardhatEthersPlugin,
     HardhatKeystore,
-    // HardhatMochaTestRunner,
-    // if testing node plugin, use the following line instead
+    HardhatMochaTestRunner,
     hardhatNetworkHelpersPlugin,
     HardhatNodeTestRunner,
     HardhatViem,

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -27,7 +27,7 @@
     "@ignored/hardhat-vnext-network-helpers": "workspace:^3.0.0-next.1",
     "@ignored/hardhat-vnext-node-test-runner": "workspace:^3.0.0-next.1",
     "@ignored/hardhat-vnext-viem": "workspace:^3.0.0-next.0",
-    "@openzeppelin/contracts": "^5.1.0",
+    "@openzeppelin/contracts": "5.1.0",
     "@types/mocha": ">=9.1.0",
     "@types/node": "^20.14.9",
     "mocha": "^10.0.0",

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -21,17 +21,18 @@
   },
   "devDependencies": {
     "@ignored/hardhat-vnext": "workspace:^3.0.0-next.5",
-    "@ignored/hardhat-vnext-node-test-runner": "workspace:^3.0.0-next.1",
-    "@ignored/hardhat-vnext-network-helpers": "workspace:^3.0.0-next.1",
-    "@ignored/hardhat-vnext-mocha-test-runner": "workspace:^3.0.0-next.1",
-    "@ignored/hardhat-vnext-keystore": "workspace:^3.0.0-next.1",
     "@ignored/hardhat-vnext-ethers": "workspace:^3.0.0-next.1",
+    "@ignored/hardhat-vnext-keystore": "workspace:^3.0.0-next.1",
+    "@ignored/hardhat-vnext-mocha-test-runner": "workspace:^3.0.0-next.1",
+    "@ignored/hardhat-vnext-network-helpers": "workspace:^3.0.0-next.1",
+    "@ignored/hardhat-vnext-node-test-runner": "workspace:^3.0.0-next.1",
     "@ignored/hardhat-vnext-viem": "workspace:^3.0.0-next.0",
     "@openzeppelin/contracts": "^5.1.0",
     "@types/mocha": ">=9.1.0",
     "@types/node": "^20.14.9",
     "mocha": "^10.0.0",
     "prettier": "3.2.5",
+    "rimraf": "^5.0.5",
     "typescript": "~5.5.0",
     "viem": "^2.21.17"
   }

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -34,6 +34,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "typescript": "~5.5.0",
-    "viem": "^2.21.17"
+    "viem": "^2.21.17",
+    "forge-std": "foundry-rs/forge-std#v1.9.4"
   }
 }

--- a/v-next/example-project/scripts/viem-plugin-example.ts
+++ b/v-next/example-project/scripts/viem-plugin-example.ts
@@ -78,7 +78,7 @@ async function testContracts() {
 
   // this does not work, as dec is not part of the abi
   try {
-    // @ts-error
+    // @ts-ignore
     await counter.write.dec();
   } catch (e) {
     console.error(e);
@@ -86,7 +86,7 @@ async function testContracts() {
 
   // this does not work, as rocket expects a string instead
   // of a number as the first constructor argument
-  // @ts-error
+  // @ts-ignore
   const rocket1 = await networkConnection.viem.deployContract("Rocket", [1n]);
   console.log("Rocket launched at", rocket1.address);
   const rocket1name = await rocket1.read.name();

--- a/v-next/hardhat-mocha-test-runner/src/index.ts
+++ b/v-next/hardhat-mocha-test-runner/src/index.ts
@@ -5,7 +5,7 @@ import { task } from "@ignored/hardhat-vnext/config";
 import "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
-  id: "test",
+  id: "hardhat-mocha",
   tasks: [
     task("test", "Runs tests using the Mocha test runner")
       .addVariadicArgument({

--- a/v-next/hardhat-mocha-test-runner/src/index.ts
+++ b/v-next/hardhat-mocha-test-runner/src/index.ts
@@ -22,6 +22,10 @@ const hardhatPlugin: HardhatPlugin = {
         description: "Only run tests matching the given string or regexp",
         defaultValue: "",
       })
+      .addFlag({
+        name: "noCompile",
+        description: "Don't compile the project before running the test",
+      })
       .setAction(import.meta.resolve("./task-action.js"))
       .build(),
   ],

--- a/v-next/hardhat-mocha-test-runner/src/index.ts
+++ b/v-next/hardhat-mocha-test-runner/src/index.ts
@@ -7,7 +7,7 @@ import "./type-extensions.js";
 const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-mocha",
   tasks: [
-    task("test", "Runs tests using the Mocha test runner")
+    task(["test", "mocha"], "Runs tests using the Mocha test runner")
       .addVariadicArgument({
         name: "testFiles",
         description: "An optional list of files to test",

--- a/v-next/hardhat-mocha-test-runner/src/task-action.ts
+++ b/v-next/hardhat-mocha-test-runner/src/task-action.ts
@@ -12,6 +12,7 @@ interface TestActionArguments {
   testFiles: string[];
   bail: boolean;
   grep: string;
+  noCompile: boolean;
 }
 
 function isTypescriptFile(path: string): boolean {
@@ -42,9 +43,13 @@ async function getTestFiles(
 
 let testsAlreadyRun = false;
 const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
-  { testFiles, bail, grep },
+  { testFiles, bail, grep, noCompile },
   hre,
 ) => {
+  if (!noCompile) {
+    await hre.tasks.getTask("compile").run({ quiet: true });
+  }
+
   const files = await getTestFiles(testFiles, hre.config);
 
   const tsx = fileURLToPath(import.meta.resolve("tsx/esm"));

--- a/v-next/hardhat-mocha-test-runner/test/index.ts
+++ b/v-next/hardhat-mocha-test-runner/test/index.ts
@@ -22,7 +22,7 @@ describe("Hardhat Mocha plugin", () => {
 
       const hre = await createHardhatRuntimeEnvironment(hardhatConfig.default);
 
-      const result = await hre.tasks.getTask("test").run({});
+      const result = await hre.tasks.getTask(["test", "mocha"]).run({});
 
       assert.equal(result, 0);
     });

--- a/v-next/hardhat-node-test-runner/src/index.ts
+++ b/v-next/hardhat-node-test-runner/src/index.ts
@@ -7,7 +7,7 @@ import "./type-extensions.js";
 const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-node-test-runner",
   tasks: [
-    task("test", "Runs tests using the NodeJS test runner")
+    task(["test", "node"], "Runs tests using the NodeJS test runner")
       .addVariadicArgument({
         name: "testFiles",
         description: "An optional list of files to test",

--- a/v-next/hardhat-node-test-runner/src/index.ts
+++ b/v-next/hardhat-node-test-runner/src/index.ts
@@ -22,6 +22,10 @@ const hardhatPlugin: HardhatPlugin = {
         description: "Only run tests matching the given string or regexp",
         defaultValue: "",
       })
+      .addFlag({
+        name: "noCompile",
+        description: "Don't compile the project before running the test",
+      })
       .setAction(import.meta.resolve("./task-action.js"))
       .build(),
   ],

--- a/v-next/hardhat-node-test-runner/src/index.ts
+++ b/v-next/hardhat-node-test-runner/src/index.ts
@@ -5,7 +5,7 @@ import { task } from "@ignored/hardhat-vnext/config";
 import "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
-  id: "test",
+  id: "hardhat-node-test-runner",
   tasks: [
     task("test", "Runs tests using the NodeJS test runner")
       .addVariadicArgument({

--- a/v-next/hardhat-node-test-runner/src/task-action.ts
+++ b/v-next/hardhat-node-test-runner/src/task-action.ts
@@ -13,6 +13,7 @@ interface TestActionArguments {
   testFiles: string[];
   only: boolean;
   grep: string;
+  noCompile: boolean;
 }
 
 function isTypescriptFile(path: string): boolean {
@@ -50,9 +51,13 @@ async function getTestFiles(
  * Note that we are testing this manually for now as you can't run a node:test within a node:test
  */
 const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
-  { testFiles, only, grep },
+  { testFiles, only, grep, noCompile },
   hre,
 ) => {
+  if (!noCompile) {
+    await hre.tasks.getTask("compile").run({ quiet: true });
+  }
+
   const files = await getTestFiles(testFiles, hre.config);
 
   const tsx = fileURLToPath(import.meta.resolve("tsx/esm"));

--- a/v-next/hardhat/src/cli.ts
+++ b/v-next/hardhat/src/cli.ts
@@ -7,6 +7,6 @@ process.setSourceMapsEnabled(true);
 // eslint-disable-next-line no-restricted-syntax -- Allow top-level await here
 const { main } = await import("./internal/cli/main.js");
 
-main(process.argv.slice(2), undefined, true).catch(() => {
+main(process.argv.slice(2), { registerTsx: true }).catch(() => {
   process.exitCode = 1;
 });

--- a/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -23,6 +23,14 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .build(),
   ],
+  dependencies: [
+    async () => {
+      const { default: solidityBuiltinPlugin } = await import(
+        "../solidity/index.js"
+      );
+      return solidityBuiltinPlugin;
+    },
+  ],
 };
 
 export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -14,7 +14,7 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .addFlag({
         name: "noCompile",
-        description: "Don't compile before running this task",
+        description: "Don't compile the project before starting the console",
       })
       .addVariadicArgument({
         name: "commands",

--- a/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
@@ -3,7 +3,6 @@ import type { REPLServer } from "node:repl";
 
 import repl from "node:repl";
 
-import { getCacheDir } from "@ignored/hardhat-vnext-utils/global-dir";
 import { resolveFromRoot } from "@ignored/hardhat-vnext-utils/path";
 import debug from "debug";
 
@@ -24,8 +23,7 @@ const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
   // Resolve the history path if it is not empty
   let historyPath: string | undefined;
   if (history !== "") {
-    // TODO(#5599): Replace with hre.config.paths.cache once it is available
-    const cacheDir = await getCacheDir();
+    const cacheDir = hre.config.paths.cache;
     historyPath = resolveFromRoot(cacheDir, history);
   }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/task-action.ts
@@ -29,9 +29,8 @@ const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
     historyPath = resolveFromRoot(cacheDir, history);
   }
 
-  // If noCompile is false, run the compile task first
   if (!noCompile) {
-    // TODO(#5600): run compile task
+    await hre.tasks.getTask("compile").run({ quiet: true });
   }
 
   return new Promise<REPLServer>(async (resolve) => {

--- a/v-next/hardhat/src/internal/builtin-plugins/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/index.ts
@@ -7,20 +7,25 @@ import networkManager from "./network-manager/index.js";
 import run from "./run/index.js";
 import solidity from "./solidity/index.js";
 import solidityTest from "./solidity-test/index.js";
+import test from "./test/index.js";
 
 // Note: When importing a plugin, you have to export its types, so that its
 // type extensions, if any, also get loaded.
 export type * from "./artifacts/index.js";
 export type * from "./solidity/index.js";
+export type * from "./test/index.js";
 export type * from "./solidity-test/index.js";
 export type * from "./network-manager/index.js";
 export type * from "./clean/index.js";
 export type * from "./console/index.js";
 export type * from "./run/index.js";
 
+// This array should be kept in order, respecting the dependencies between the
+// plugins.
 export const builtinPlugins: HardhatPlugin[] = [
   artifacts,
   solidity,
+  test,
   solidityTest,
   networkManager,
   clean,

--- a/v-next/hardhat/src/internal/builtin-plugins/run/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/run/index.ts
@@ -12,7 +12,7 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .addFlag({
         name: "noCompile",
-        description: "Don't compile before running this task",
+        description: "Don't compile the project before running the script",
       })
       .setAction(import.meta.resolve("./task-action.js"))
       .build(),

--- a/v-next/hardhat/src/internal/builtin-plugins/run/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/run/index.ts
@@ -17,6 +17,14 @@ const hardhatPlugin: HardhatPlugin = {
       .setAction(import.meta.resolve("./task-action.js"))
       .build(),
   ],
+  dependencies: [
+    async () => {
+      const { default: solidityBuiltinPlugin } = await import(
+        "../solidity/index.js"
+      );
+      return solidityBuiltinPlugin;
+    },
+  ],
 };
 
 export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/builtin-plugins/run/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/run/task-action.ts
@@ -14,7 +14,7 @@ interface RunActionArguments {
 
 const runScriptWithHardhat: NewTaskActionFunction<RunActionArguments> = async (
   { script, noCompile },
-  _hre,
+  hre,
 ) => {
   const normalizedPath = resolveFromRoot(process.cwd(), script);
 
@@ -26,7 +26,7 @@ const runScriptWithHardhat: NewTaskActionFunction<RunActionArguments> = async (
   }
 
   if (!noCompile) {
-    // TODO(#5600): run compile task
+    await hre.tasks.getTask("compile").run({ quiet: true });
   }
 
   try {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -6,7 +6,7 @@ import { task } from "../../core/config.js";
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:solidity-tests",
   tasks: [
-    task(["test:solidity"], "Run the Solidity tests")
+    task(["test", "solidity"], "Run the Solidity tests")
       .setAction(import.meta.resolve("./task-action.js"))
       .addOption({
         name: "timeout",

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -17,6 +17,18 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .build(),
   ],
+  dependencies: [
+    async () => {
+      const { default: solidityBuiltinPlugin } = await import(
+        "../solidity/index.js"
+      );
+      return solidityBuiltinPlugin;
+    },
+    async () => {
+      const { default: testBuiltinPlugin } = await import("../test/index.js");
+      return testBuiltinPlugin;
+    },
+  ],
 };
 
 export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -15,6 +15,10 @@ const hardhatPlugin: HardhatPlugin = {
         type: ArgumentType.INT,
         defaultValue: 60 * 60 * 1000,
       })
+      .addFlag({
+        name: "noCompile",
+        description: "Don't compile the project before running the tests",
+      })
       .build(),
   ],
   dependencies: [

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -43,7 +43,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
 
   const runStream = run(artifacts, testSuiteIds, config, options);
 
-  runStream
+  const testReporterStream = runStream
     .on("data", (event: TestEvent) => {
       if (event.type === "suite:result") {
         if (event.data.testResults.some(({ status }) => status === "Failure")) {
@@ -51,13 +51,21 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
         }
       }
     })
-    .compose(testReporter)
-    .pipe(process.stdout);
+    .compose(testReporter);
 
-  // NOTE: We're awaiting the original run stream to finish instead of the
-  // composed reporter stream to catch any errors produced by the runner.
+  testReporterStream.pipe(process.stdout);
+
   try {
+    // NOTE: We're awaiting the original run stream to finish to catch any
+    // errors produced by the runner.
     await finished(runStream);
+
+    // We also await the test reporter stream to finish to catch any error, and
+    // to avoid returning before the whole output was generated.
+    //
+    // NOTE: We don't await the restult of piping it to stdout, as that is
+    // ignored.
+    await finished(testReporterStream);
   } catch (error) {
     console.error(error);
     includesErrors = true;

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -8,10 +8,18 @@ import { getArtifacts, isTestArtifact } from "./helpers.js";
 import { testReporter } from "./reporter.js";
 import { run } from "./runner.js";
 
-const runSolidityTests: NewTaskActionFunction = async ({ timeout }, hre) => {
-  await hre.tasks.getTask("compile").run({ quiet: false });
+interface TestActionArguments {
+  timeout: number;
+  noCompile: boolean;
+}
 
-  console.log("\nRunning Solidity tests...\n");
+const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
+  { timeout, noCompile },
+  hre,
+) => {
+  if (!noCompile) {
+    await hre.tasks.getTask("compile").run({ quiet: true });
+  }
 
   const artifacts = await getArtifacts(hre.artifacts);
   const testSuiteIds = (

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -170,9 +170,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
         ),
       );
 
-      if (options?.quiet !== true) {
-        this.#printSolcErrorsAndWarnings(errors);
-      }
+      this.#printSolcErrorsAndWarnings(errors);
 
       const successfulResult = !this.#hasCompilationErrors(result);
 

--- a/v-next/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -1,0 +1,26 @@
+import type { HardhatPlugin } from "../../../types/plugins.js";
+
+import { task } from "../../core/config.js";
+
+const hardhatPlugin: HardhatPlugin = {
+  id: "builtin:test",
+  tasks: [
+    task("test", "Runs all your tests")
+      .addFlag({
+        name: "noCompile",
+        description: "Don't compile the project before running the tests",
+      })
+      .setAction(import.meta.resolve("./task-action.js"))
+      .build(),
+  ],
+  dependencies: [
+    async () => {
+      const { default: solidityBuiltinPlugin } = await import(
+        "../solidity/index.js"
+      );
+      return solidityBuiltinPlugin;
+    },
+  ],
+};
+
+export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -8,7 +8,7 @@ interface TestActionArguments {
   noCompile: boolean;
 }
 
-const runScriptWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
+const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
   { noCompile },
   hre,
 ) => {
@@ -31,4 +31,4 @@ const runScriptWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   }
 };
 
-export default runScriptWithHardhat;
+export default runAllTests;

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -1,0 +1,34 @@
+import type { NewTaskActionFunction } from "../../../types/tasks.js";
+
+import chalk from "chalk";
+
+import { formatTaskId } from "../../core/tasks/utils.js";
+
+interface TestActionArguments {
+  noCompile: boolean;
+}
+
+const runScriptWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
+  { noCompile },
+  hre,
+) => {
+  const thisTask = hre.tasks.getTask("test");
+
+  if (!noCompile) {
+    await hre.tasks.getTask("compile").run({ quiet: true });
+  }
+
+  for (const subtask of thisTask.subtasks.values()) {
+    console.log(
+      chalk.bold(`Running the subtask "${formatTaskId(subtask.id)}"`),
+    );
+    await subtask.run({ noCompile: true });
+    console.log();
+  }
+
+  if (process.exitCode !== 0) {
+    console.error("Test run failed");
+  }
+};
+
+export default runScriptWithHardhat;

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -38,11 +38,18 @@ import { getHelpString } from "./helpers/getHelpString.js";
 import { ensureTelemetryConsent } from "./telemetry/telemetry-permissions.js";
 import { printVersionMessage } from "./version.js";
 
+export interface MainOptions {
+  print?: (message: string) => void;
+  registerTsx?: true;
+  rethrowErrors?: true;
+}
+
 export async function main(
   cliArguments: string[],
-  print: (message: string) => void = console.log,
-  registerTsx = false,
+  options: MainOptions = {},
 ): Promise<void> {
+  const print = options.print ?? console.log;
+
   const log = debug("hardhat:core:cli:main");
 
   let builtinGlobalOptions;
@@ -80,8 +87,7 @@ export async function main(
 
     const projectRoot = await resolveProjectRoot(configPath);
 
-    // Register tsx
-    if (registerTsx) {
+    if (options.registerTsx) {
       register();
     }
 
@@ -166,6 +172,10 @@ export async function main(
     await task.run(taskArguments);
   } catch (error) {
     printErrorMessages(error, builtinGlobalOptions?.showStackTraces);
+
+    if (options.rethrowErrors) {
+      throw error;
+    }
   }
 }
 

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/default-values/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/default-values/hardhat.config.ts
@@ -2,7 +2,7 @@ import type { HardhatUserConfig } from "../../../../../src/config.js";
 
 import { task } from "../../../../../src/config.js";
 
-const customTask = task("test", "subtask")
+const customTask = task("test-task", "description")
   .setAction(async () => {})
   .addOption({
     name: "opt",

--- a/v-next/hardhat/test/fixture-projects/run-js-script/hardhat.config.js
+++ b/v-next/hardhat/test/fixture-projects/run-js-script/hardhat.config.js
@@ -2,7 +2,7 @@ import { task } from "@ignored/hardhat-vnext/config";
 
 export default {
   tasks: [
-    task("test", "Prints a test")
+    task("test-task", "Prints a test")
       .setAction(async () => {
         console.log("test!");
       })

--- a/v-next/hardhat/test/fixture-projects/run-js-script/scripts/success.js
+++ b/v-next/hardhat/test/fixture-projects/run-js-script/scripts/success.js
@@ -1,5 +1,5 @@
 import hre from "@ignored/hardhat-vnext";
 
-if (!hre.tasks.rootTasks.has("test")) {
+if (!hre.tasks.rootTasks.has("test-task")) {
   throw new Error("test task not found");
 }

--- a/v-next/hardhat/test/fixture-projects/run-ts-script/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/run-ts-script/hardhat.config.ts
@@ -4,7 +4,7 @@ import { task } from "@ignored/hardhat-vnext/config";
 
 const config: HardhatUserConfig = {
   tasks: [
-    task("test", "Prints a test")
+    task("test-task", "Prints a test")
       .setAction(async () => {
         console.log("test!");
       })

--- a/v-next/hardhat/test/fixture-projects/run-ts-script/scripts/success.ts
+++ b/v-next/hardhat/test/fixture-projects/run-ts-script/scripts/success.ts
@@ -1,5 +1,5 @@
 import maybeHre from "@ignored/hardhat-vnext";
 
-if (!maybeHre.tasks.rootTasks.has("test")) {
+if (!maybeHre.tasks.rootTasks.has("test-task")) {
   throw new Error("test task not found");
 }

--- a/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/console/task-action.ts
@@ -48,7 +48,7 @@ describe("console/task-action", function () {
         {
           commands: ['await import("./scripts/non-existent.js");', ".exit"],
           history: "",
-          noCompile: false,
+          noCompile: true,
           options,
         },
         hre,
@@ -61,7 +61,7 @@ describe("console/task-action", function () {
         {
           commands: [".help", 'await import("./scripts/success.js");', ".exit"],
           history: "",
-          noCompile: false,
+          noCompile: true,
           options,
         },
         hre,
@@ -74,7 +74,7 @@ describe("console/task-action", function () {
         {
           commands: ['await import("./scripts/throws.js");', ".exit"],
           history: "",
-          noCompile: false,
+          noCompile: true,
           options,
         },
         hre,
@@ -91,7 +91,7 @@ describe("console/task-action", function () {
         {
           commands: ['await import("./scripts/non-existent.ts");', ".exit"],
           history: "",
-          noCompile: false,
+          noCompile: true,
           options,
         },
         hre,
@@ -104,7 +104,7 @@ describe("console/task-action", function () {
         {
           commands: ['await import("./scripts/success.ts");', ".exit"],
           history: "",
-          noCompile: false,
+          noCompile: true,
           options,
         },
         hre,
@@ -117,7 +117,7 @@ describe("console/task-action", function () {
         {
           commands: ['await import("./scripts/throws.ts");', ".exit"],
           history: "",
-          noCompile: false,
+          noCompile: true,
           options,
         },
         hre,
@@ -132,7 +132,7 @@ describe("console/task-action", function () {
         {
           commands: ["console.log(hre);", ".exit"],
           history: "",
-          noCompile: false,
+          noCompile: true,
           options,
         },
         hre,
@@ -173,7 +173,7 @@ describe("console/task-action", function () {
         {
           commands: [".help", ".exit"],
           history,
-          noCompile: false,
+          noCompile: true,
           options,
         },
         hre,

--- a/v-next/hardhat/test/internal/builtin-plugins/run/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/run/task-action.ts
@@ -24,7 +24,7 @@ describe("run/task-action", function () {
     it("should throw if script does not exist", async function () {
       await assertRejectsWithHardhatError(
         runScriptWithHardhat(
-          { script: "./scripts/non-existent.js", noCompile: false },
+          { script: "./scripts/non-existent.js", noCompile: true },
           hre,
         ),
         HardhatError.ERRORS.BUILTIN_TASKS.RUN_FILE_NOT_FOUND,
@@ -36,7 +36,7 @@ describe("run/task-action", function () {
 
     it("should run a script successfully", async function () {
       await runScriptWithHardhat(
-        { script: "./scripts/success.js", noCompile: false },
+        { script: "./scripts/success.js", noCompile: true },
         hre,
       );
     });
@@ -44,7 +44,7 @@ describe("run/task-action", function () {
     it("should throw if the script throws", async function () {
       await assertRejectsWithHardhatError(
         runScriptWithHardhat(
-          { script: "./scripts/throws.js", noCompile: false },
+          { script: "./scripts/throws.js", noCompile: true },
           hre,
         ),
         HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
@@ -62,7 +62,7 @@ describe("run/task-action", function () {
     it("should throw if script does not exist", async function () {
       await assertRejectsWithHardhatError(
         runScriptWithHardhat(
-          { script: "./scripts/non-existent.ts", noCompile: false },
+          { script: "./scripts/non-existent.ts", noCompile: true },
           hre,
         ),
         HardhatError.ERRORS.BUILTIN_TASKS.RUN_FILE_NOT_FOUND,
@@ -74,7 +74,7 @@ describe("run/task-action", function () {
 
     it("should run a script successfully", async function () {
       await runScriptWithHardhat(
-        { script: "./scripts/success.ts", noCompile: false },
+        { script: "./scripts/success.ts", noCompile: true },
         hre,
       );
     });
@@ -83,7 +83,7 @@ describe("run/task-action", function () {
       it("should throw RUN_SCRIPT_ERROR if the script throws a non-HardhatError", async function () {
         await assertRejectsWithHardhatError(
           runScriptWithHardhat(
-            { script: "./scripts/throws.ts", noCompile: false },
+            { script: "./scripts/throws.ts", noCompile: true },
             hre,
           ),
           HardhatError.ERRORS.BUILTIN_TASKS.RUN_SCRIPT_ERROR,
@@ -97,7 +97,7 @@ describe("run/task-action", function () {
       it("should throw the HardhatError if the script throws a HardhatError", async function () {
         await assertRejectsWithHardhatError(
           runScriptWithHardhat(
-            { script: "./scripts/throws-hardhat-error.ts", noCompile: false },
+            { script: "./scripts/throws-hardhat-error.ts", noCompile: true },
             hre,
           ),
           HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR,

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -135,11 +135,10 @@ describe("main", function () {
     describe("one of the hardhat default task with global flags and arguments", async function () {
       useFixtureProject("cli/parsing/base-project");
 
-      // TODO: update with a real task as soon as they are implemented
-      it.todo("should run one of the hardhat default task", async function () {
+      it("should run one of the hardhat default task", async function () {
         const lines: string[] = [];
 
-        const command = "npx hardhat --show-stack-traces example";
+        const command = "npx hardhat --show-stack-traces clean";
         const cliArguments = command.split(" ").slice(2);
 
         await main(cliArguments, (msg) => {

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -227,7 +227,11 @@ AVAILABLE TASKS:
   console                  Opens a hardhat console
   run                      Runs a user-defined script after compiling the project
   task                     A task that uses arg1
-  test:solidity            Run the Solidity tests
+  test                     Runs all your tests
+
+AVAILABLE SUBTASKS:
+
+  test solidity            Run the Solidity tests
 
 GLOBAL OPTIONS:
 
@@ -274,16 +278,16 @@ Usage: hardhat [GLOBAL OPTIONS] empty-task <SUBTASK> [SUBTASK OPTIONS] [--] [SUB
         it("should print the default values for the task's subtask", async function () {
           let lines: string = "";
 
-          const command = "npx hardhat test subtask --help";
+          const command = "npx hardhat test-task --help";
           const cliArguments = command.split(" ").slice(2);
 
           await main(cliArguments, (msg) => {
             lines = msg;
           });
 
-          const expected = `${chalk.bold("subtask")}
+          const expected = `${chalk.bold("description")}
 
-Usage: hardhat [GLOBAL OPTIONS] test [--opt <STRING>] [--] pos1 [pos2] [var1]
+Usage: hardhat [GLOBAL OPTIONS] test-task [--opt <STRING>] [--] pos1 [pos2] [var1]
 
 OPTIONS:
 


### PR DESCRIPTION
This is a PR with some small improvements to have a first iteration of a unified test workflow for the alpha. This will be improved later.

It does a few things:

1. Set proper names to the `node:test` and `mocha` plugins.
2. Introduces a `builtin:test` plugin, which defines a `test` task, which runs all of its subtasks.
3. Updates the `mocha`, and `node:test` plugins so that they define subtasks — This allows them to coexist 🥳 /cc @kanej 
4. Sets the solidity test runner as a subtask.
5. Fix a bug in the solidity test runner that made the task return before the output was printed.
6. Sets all the required `dependencies:` in the builtin plugins.


Unrelated improvements:

1. Fix `pnpm run clean` in the example project.
2. Fix a viem example in the example project.
3. Implement `noCompile` everywhere it was needed (mostly replacing TODOs)
4. Implemented a TODO in the `console` task. 
5. Make the build-system print warnings and errors in quiet mode.

I also added a test in the example project which uses `forge-std`.