### PR TITLE
[build-system] Fix potential clash between user remappings and npm roots

### DIFF
--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -153,7 +153,10 @@ const config: HardhatUserConfig = {
         version: "0.8.2",
       },
     },
-    dependenciesToCompile: ["@openzeppelin/contracts/token/ERC20/ERC20.sol"],
+    dependenciesToCompile: [
+      "@openzeppelin/contracts/token/ERC20/ERC20.sol",
+      "forge-std/src/Test.sol",
+    ],
     remappings: [
       "remapped/=npm/@openzeppelin/contracts@5.1.0/access/",
       // This is necessary because most people import forge-std/Test.sol, and not forge-std/src/Test.sol

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph-building.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph-building.ts
@@ -27,7 +27,9 @@ export async function buildDependencyGraph(
 
     const rootPath = parseRootPath(file);
     if (isNpmParsedRootPath(rootPath)) {
-      resolvedFile = await resolver.resolveNpmDependencyFile(rootPath.npmPath);
+      resolvedFile = await resolver.resolveNpmDependencyFileAsRoot(
+        rootPath.npmPath,
+      );
       dependencyGraph.addRootFile(rootPath.npmPath, resolvedFile);
     } else {
       resolvedFile = await resolver.resolveProjectFile(rootPath.fsPath);

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -246,7 +246,7 @@ export class ResolverImplementation implements Resolver {
     });
   }
 
-  public async resolveNpmDependencyFile(
+  public async resolveNpmDependencyFileAsRoot(
     npmModule: string,
   ): Promise<NpmPackageResolvedFile> {
     return this.#mutex.exclusiveRun(async () => {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/types.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/types.ts
@@ -68,7 +68,9 @@ export interface Resolver {
    * `<package-name>/<file-path>`.
    * @returns The resolved file.
    */
-  resolveNpmDependencyFile(npmModule: string): Promise<NpmPackageResolvedFile>;
+  resolveNpmDependencyFileAsRoot(
+    npmModule: string,
+  ): Promise<NpmPackageResolvedFile>;
 
   /**
    * Resolves an import.


### PR DESCRIPTION
This PR fixes a bug that could happen if a user remapped an npm package to one of its internal folders and, at the same time, used one of its files as a root.

For example, if you had a remapping `foo/=foo/src/` and also treated `foo/src/A.sol` as a project root, that needs to be compiled.