### PR TITLE
Fix automatic sender hook handler

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/accounts/automatic-sender-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/accounts/automatic-sender-provider.ts
@@ -8,20 +8,23 @@ import { Sender } from "./sender.js";
  * ensuring dynamic selection of the sender for all JSON-RPC requests without requiring manual input.
  */
 export class AutomaticSender extends Sender {
+  #alreadyFetchedAccounts = false;
   #firstAccount: string | undefined;
 
-  protected async getSender(): Promise<string> {
-    if (this.#firstAccount === undefined) {
+  protected async getSender(): Promise<string | undefined> {
+    if (this.#alreadyFetchedAccounts === false) {
       const accounts = await this.provider.request({
         method: "eth_accounts",
       });
 
+      // TODO: This shouldn't be an exception but a failed JSON response!
       assertHardhatInvariant(
-        Array.isArray(accounts) && typeof accounts[0] === "string",
-        "accounts should be an array and accounts[0] should be a string",
+        Array.isArray(accounts),
+        "eth_accounts response should be an array",
       );
 
       this.#firstAccount = accounts[0];
+      this.#alreadyFetchedAccounts = true;
     }
 
     return this.#firstAccount;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/accounts/fixed-sender-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/accounts/fixed-sender-provider.ts
@@ -15,7 +15,7 @@ export class FixedSender extends Sender {
     this.#sender = sender;
   }
 
-  protected async getSender(): Promise<string> {
+  protected async getSender(): Promise<string | undefined> {
     return this.#sender;
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/accounts/sender.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/accounts/sender.ts
@@ -47,5 +47,5 @@ export abstract class Sender {
     }
   }
 
-  protected abstract getSender(): Promise<string>;
+  protected abstract getSender(): Promise<string | undefined>;
 }


### PR DESCRIPTION
This PR fixes the automatic sender hook handler, as it didn't support the case where no account was present.

@ChristopherDedominici can you take a look?

Also, some hook handlers throw errors where they should return JSON-RPC response with `InternalError`s.