### PR TITLE
Small improvements to the config resolution of EDR networks

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -158,7 +158,7 @@ export class EdrProvider extends EventEmitter implements EthereumProvider {
     const provider = await context.createProvider(
       config.chainType === "optimism"
         ? OPTIMISM_CHAIN_TYPE
-        : GENERIC_CHAIN_TYPE,
+        : GENERIC_CHAIN_TYPE, // TODO: l1 is missing here
       {
         allowBlocksWithSameTimestamp:
           config.allowBlocksWithSameTimestamp ?? false,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -112,12 +112,13 @@ export async function resolveUserConfig(
       const resolvedNetworkConfig: EdrNetworkConfig = {
         type: "edr",
         chainId: networkConfig.chainId,
-        chainType: networkConfig.chainType ?? "l1",
+        chainType: networkConfig.chainType,
         from: networkConfig.from,
         gas: resolveGasConfig(networkConfig.gas),
         gasMultiplier: networkConfig.gasMultiplier ?? 1,
         gasPrice: resolveGasConfig(networkConfig.gasPrice),
-
+        // TODO: This isn't how it's called in v2
+        forkConfig: networkConfig.forkConfig,
         hardfork: networkConfig.hardfork ?? "cancun",
         networkId: networkConfig.networkId ?? networkConfig.chainId,
         blockGasLimit: networkConfig.blockGasLimit ?? 12_500_000,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -143,8 +143,26 @@ export class NetworkManagerImplementation {
       );
 
       if (resolvedNetworkConfig.type === "edr") {
+        if (
+          resolvedChainType !== "optimism" &&
+          resolvedChainType !== "generic" &&
+          resolvedChainType !== "l1"
+        ) {
+          throw new HardhatError(
+            HardhatError.ERRORS.GENERAL.UNSUPPORTED_OPERATION,
+            { operation: `Simulating chain type ${resolvedChainType}` },
+          );
+        }
+
         return EdrProvider.create(
-          resolvedNetworkConfig,
+          // The resolvedNetworkConfig can have its chainType set to `undefined`
+          // so we default to the default chain type here.
+          {
+            ...resolvedNetworkConfig,
+            /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+            This case is safe because we have a check above */
+            chainType: resolvedChainType as ChainType,
+          },
           { enabled: false },
           {},
           (request, defaultBehavior) => {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/config.ts
@@ -102,11 +102,12 @@ declare module "../../../../types/config.js" {
     allowBlocksWithSameTimestamp?: boolean;
     enableTransientStorage?: boolean;
     enableRip7212?: boolean;
-
     initialBaseFeePerGas?: number;
     initialDate?: Date;
     coinbase?: string;
+    // TODO: This isn't how it's called in v2
     forkConfig?: ForkConfig;
+    // TODO: This isn't configurable in v2
     forkCachePath?: string;
   }
 


### PR DESCRIPTION
This is a small PR to that I put in place to be able to enable forking in EDR networks. It is not complete, though.

It does just a few things:

1. Changes the EDR network config resolution so that `chainType` can be left `undefined`, as that's important to be able to change them during connection.
2. Resolved the `chainType` during connection.
3. Added the `forkConfig` to the resolved network config, without any actual resolution.
4. Sparkled some TODOs.

The reason this PR is important is that optimism needs to be tested in forked mode.