### PR TITLE
Run `v-next`'s CI on chained PRs

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - v-next
   pull_request:
-    # TODO: Remove the filter when v-next is merged into main
-    branches:
-      - v-next
   workflow_dispatch:
 
 concurrency:
@@ -16,8 +13,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  is-v-next:
+    runs-on: ubuntu-latest
+    outputs:
+      is_v_next: ${{ steps.check.outputs.folder_exists }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check if the folder v-next exists
+        id: check
+        run: |
+          if [ -d "./v-next" ]; then
+            echo "folder_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "folder_exists=false" >> $GITHUB_OUTPUT
+          fi
+
   check_dependencies:
     name: Check dependency versions
+    needs: is-v-next
+    if: ${{ needs.is-v-next.outputs.is_v_next == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +46,8 @@ jobs:
 
   check_npm_scripts:
     name: Check that the npm scripts are consistent
+    needs: is-v-next
+    if: ${{ needs.is-v-next.outputs.is_v_next == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +59,8 @@ jobs:
 
   list-packages:
     name: List packages
+    needs: is-v-next
+    if: ${{ needs.is-v-next.outputs.is_v_next == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.filter.outputs.changes }}
@@ -91,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ['hardhat']
+        package: ["hardhat"]
 
     name: "[${{ matrix.package }}] bundle"
     runs-on: ubuntu-latest


### PR DESCRIPTION
As we move towards polishing the next version, we are probably going to be creating a ton of chained/dependent PRs.

Currently, `v-next-ci` doesn't run for those, leading to undetected errors until you merge some PRs.

In this PR I changed how we filter which PRs to run this workflow on. The workflow always runs, but I first check if the `./v-next` folder exists. If it doesn't exist, I skip the main jobs, leading to all the jobs being skipped.