### PR TITLE
update HardhatUserConfig import path in templates

### DIFF
--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -1,4 +1,4 @@
-import type { HardhatUserConfig } from "@ignored/hardhat-vnext/types/config";
+import type { HardhatUserConfig } from "@ignored/hardhat-vnext/config";
 
 import { HardhatPluginError } from "@ignored/hardhat-vnext/plugins";
 

--- a/v-next/hardhat-viem/test/fixture-projects/default-ts-project/hardhat.config.ts
+++ b/v-next/hardhat-viem/test/fixture-projects/default-ts-project/hardhat.config.ts
@@ -1,4 +1,4 @@
-import type { HardhatUserConfig } from "@ignored/hardhat-vnext/types/config";
+import type { HardhatUserConfig } from "@ignored/hardhat-vnext/config";
 
 import HardhatViem from "../../../src/index.js";
 

--- a/v-next/hardhat/templates/empty-typescript/hardhat.config.ts
+++ b/v-next/hardhat/templates/empty-typescript/hardhat.config.ts
@@ -1,4 +1,4 @@
-import type { HardhatUserConfig } from "@ignored/hardhat-vnext/types/config";
+import type { HardhatUserConfig } from "@ignored/hardhat-vnext/config";
 
 const config: HardhatUserConfig = {};
 

--- a/v-next/hardhat/templates/typescript-with-examples/hardhat.config.ts
+++ b/v-next/hardhat/templates/typescript-with-examples/hardhat.config.ts
@@ -1,4 +1,4 @@
-import type { HardhatUserConfig } from "@ignored/hardhat-vnext/types/config";
+import type { HardhatUserConfig } from "@ignored/hardhat-vnext/config";
 
 import HardhatNodeTestRunner from "@ignored/hardhat-vnext-node-test-runner";
 

--- a/v-next/hardhat/templates/typescript-with-examples/package.json
+++ b/v-next/hardhat/templates/typescript-with-examples/package.json
@@ -2,7 +2,7 @@
   "name": "template-typescript-with-examples",
   "private": true,
   "version": "0.0.1",
-  "description": "A TypeScrpit Hardhat project with examples",
+  "description": "A TypeScript Hardhat project with examples",
   "type": "module",
   "devDependencies": {
     "@ignored/hardhat-vnext": "workspace:^3.0.0-next.5",


### PR DESCRIPTION
Change the import path to `@ignored/hardhat-vnext/config` in the template projects (i.e. the projects created by `npx hardhat3 --init`) so that the built-in type extensions are loaded.
