### PR TITLE
Add missing interfaces for hardhat-network-helpers

### DIFF
--- a/v-next/hardhat-network-helpers/package.json
+++ b/v-next/hardhat-network-helpers/package.json
@@ -11,8 +11,10 @@
   "author": "Nomic Foundation",
   "license": "MIT",
   "type": "module",
+  "types": "dist/src/index.d.ts",
   "exports": {
-    ".": "./dist/src/index.js"
+    ".": "./dist/src/index.js",
+    "./types": "./dist/src/types.js"
   },
   "keywords": [
     "ethereum",

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/duration/duration.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/duration/duration.ts
@@ -1,98 +1,30 @@
-export class Duration {
-  /**
-   * Converts the given number of years into seconds.
-   *
-   * @param n - The number of years.
-   * @returns The equivalent duration in seconds.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const seconds = networkHelpers.time.duration.years(1);
-   */
+import type { Duration as DurationI } from "../../../types.js";
+
+export class Duration implements DurationI {
   public years(n: number): number {
     return this.days(n) * 365;
   }
 
-  /**
-   * Converts the given number of weeks into seconds.
-   *
-   * @param n - The number of weeks.
-   * @returns The equivalent duration in seconds.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const seconds = networkHelpers.time.duration.weeks(1);
-   */
   public weeks(n: number): number {
     return this.days(n) * 7;
   }
 
-  /**
-   * Converts the given number of days into seconds.
-   *
-   * @param n - The number of days.
-   * @returns The equivalent duration in seconds.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const seconds = networkHelpers.time.duration.days(1);
-   */
   public days(n: number): number {
     return this.hours(n) * 24;
   }
 
-  /**
-   * Converts the given number of hours into seconds.
-   *
-   * @param n - The number of hours.
-   * @returns The equivalent duration in seconds.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const seconds = networkHelpers.time.duration.hours(1);
-   */
   public hours(n: number): number {
     return this.minutes(n) * 60;
   }
 
-  /**
-   * Converts the given number of minutes into seconds.
-   *
-   * @param n - The number of minutes.
-   * @returns The equivalent duration in seconds.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const seconds = networkHelpers.time.duration.minutes(1);
-   */
   public minutes(n: number): number {
     return n * 60;
   }
 
-  /**
-   * Returns the number of seconds.
-   *
-   * @param n - The number of seconds.
-   * @returns The same number of seconds.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const seconds = networkHelpers.time.duration.seconds(1);
-   */
   public seconds(n: number): number {
     return n;
   }
 
-  /**
-   * Converts the given number of milliseconds into seconds, rounded down to the nearest whole number.
-   *
-   * @param n - The number of milliseconds.
-   * @returns The equivalent duration in seconds.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const seconds = networkHelpers.time.duration.millis(1500); // Returns 1
-   */
   public millis(n: number): number {
     return Math.floor(n / 1000);
   }

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/helpers/load-fixture.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/helpers/load-fixture.ts
@@ -1,5 +1,4 @@
-import type { Fixture, Snapshot } from "../../../types.js";
-import type { NetworkHelpers } from "../network-helpers.js";
+import type { Fixture, NetworkHelpers, Snapshot } from "../../../types.js";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/helpers/reset.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/helpers/reset.ts
@@ -1,5 +1,4 @@
-import type { NumberLike } from "../../../types.js";
-import type { NetworkHelpers } from "../network-helpers.js";
+import type { NetworkHelpers, NumberLike } from "../../../types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import { toNumber } from "../../conversion.js";

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
@@ -4,7 +4,6 @@ import type {
   NetworkHelpers as NetworkHelpersI,
   NumberLike,
   SnapshotRestorer,
-  Time as TimeI,
 } from "../../types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
@@ -30,7 +29,7 @@ import { Time } from "./time/time.js";
 
 export class NetworkHelpers implements NetworkHelpersI {
   readonly #provider: EthereumProvider;
-  public time: TimeI;
+  public time: Time;
 
   constructor(provider: EthereumProvider) {
     this.#provider = provider;

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
@@ -1,6 +1,7 @@
 import type {
   BlockTag,
   Fixture,
+  NetworkHelpers as NetworkHelpersI,
   NumberLike,
   SnapshotRestorer,
 } from "../../types.js";
@@ -26,7 +27,7 @@ import { stopImpersonatingAccount } from "./helpers/stop-impersonating-account.j
 import { takeSnapshot } from "./helpers/take-snapshot.js";
 import { Time } from "./time/time.js";
 
-export class NetworkHelpers {
+export class NetworkHelpers implements NetworkHelpersI {
   readonly #provider: EthereumProvider;
   public time: Time;
 
@@ -35,43 +36,14 @@ export class NetworkHelpers {
     this.time = new Time(this, provider);
   }
 
-  /**
-   * Clears every existing snapshot.
-   *
-   * @example
-   * // Clear all saved snapshots
-   * clearSnapshots();
-   */
   public clearSnapshots(): void {
     clearSnapshots();
   }
 
-  /**
-   * Removes the given transaction from the mempool, if it exists.
-   *
-   * @param txHash Transaction hash to be removed from the mempool.
-   * @returns `true` if successful, otherwise `false`.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const success = await networkHelpers.dropTransaction('0x123...');
-   */
   public dropTransaction(txHash: string): Promise<boolean> {
     return dropTransaction(this.#provider, txHash);
   }
 
-  /**
-   * Retrieves the data located at the given address, index, and block number.
-   *
-   * @param address The address to retrieve storage from.
-   * @param index The position in storage.
-   * @param block The block number, or one of "latest", "earliest", or "pending". Defaults to "latest".
-   * @returns A promise that resolves to a string containing the hexadecimal code retrieved.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const storageData = await networkHelpers.getStorageAt("0x123...", 0);
-   */
   public getStorageAt(
     address: string,
     index: NumberLike,
@@ -80,63 +52,14 @@ export class NetworkHelpers {
     return getStorageAt(this.#provider, address, index, block);
   }
 
-  /**
-   * Allows Hardhat Network to sign transactions as the given address.
-   *
-   * @param address The address to impersonate.
-   * @returns A promise that resolves once the account is impersonated.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.impersonateAccount("0x123...");
-   */
   public impersonateAccount(address: string): Promise<void> {
     return impersonateAccount(this.#provider, address);
   }
 
-  /**
-   * Loads a fixture and restores the blockchain to a snapshot state for repeated tests.
-   *
-   * The `loadFixture` function is useful in tests where you need to set up the blockchain to a desired state
-   * (like deploying contracts, minting tokens, etc.) and then run multiple tests based on that state.
-   *
-   * It executes the given fixture function, which should set up the blockchain state, and takes a snapshot of the blockchain.
-   * On subsequent calls to `loadFixture` with the same fixture function, the blockchain is restored to that snapshot
-   * rather than executing the fixture function again.
-   *
-   * ### Important:
-   * **Do not pass anonymous functions** as the fixture function. Passing an anonymous function like
-   * `loadFixture(async () => { ... })` will bypass the snapshot mechanism and result in the fixture being executed
-   * each time. Instead, always pass a named function, like `loadFixture(deployTokens)`.
-   *
-   * @param fixture A named asynchronous function that sets up the desired blockchain state and returns the fixture's data.
-   * @returns A promise that resolves to the data returned by the fixture, either from execution or a restored snapshot.
-   *
-   * @example
-   * async function setupContracts() { ... }
-   * const fixtureData = await loadFixture(setupContracts);
-   */
   public loadFixture<T>(fixture: Fixture<T>): Promise<T> {
     return loadFixture(this, fixture);
   }
 
-  /**
-   * Mines a specified number of blocks with an optional time interval between them.
-   *
-   * @param blocks The number of blocks to mine. Defaults to 1 if not specified.
-   * @param options.interval Configures the interval (in seconds) between the timestamps of each mined block. Defaults to 1.
-   * @returns A promise that resolves once the blocks have been mined.
-   *
-   * @example
-   * // Mine 1 block (default behavior)
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.mine();
-   *
-   * @example
-   * // Mine 10 blocks with an interval of 60 seconds between each block
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.mine(10, { interval: 60 });
-   */
   public mine(
     blocks: NumberLike = 1,
     options: { interval?: NumberLike } = { interval: 1 },
@@ -144,149 +67,42 @@ export class NetworkHelpers {
     return mine(this.#provider, blocks, options);
   }
 
-  /**
-   * Mines new blocks until the latest block number reaches `blockNumber`.
-   *
-   * @param blockNumber Must be greater than the latest block's number.
-   * @returns A promise that resolves once the required blocks have been mined.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.mineUpTo(150); // Mines until block with block number 150
-   */
   public mineUpTo(blockNumber: NumberLike): Promise<void> {
     return mineUpTo(this.#provider, blockNumber, this.time);
   }
 
-  /**
-   * Resets the Hardhat Network to its initial state or forks from a given URL and block number.
-   *
-   * @param url Optional JSON-RPC URL to fork from.
-   * @param blockNumber Optional block number to fork from.
-   * @returns A promise that resolves once the reset operation is completed.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.reset(); // Resets the network
-   * await networkHelpers.reset("https://mainnet.infura.io", 123456); // Resets and forks from a specific block
-   */
   public reset(url?: string, blockNumber?: NumberLike): Promise<void> {
     return reset(this, this.#provider, url, blockNumber);
   }
 
-  /**
-   * Sets the balance for the given address.
-   *
-   * @param address The address whose balance will be updated.
-   * @param balance The new balance to set for the given address, in wei.
-   * @returns A promise that resolves once the balance has been set.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.setBalance("0x123...", 1000000000000000000n); // Sets 1 ETH
-   */
   public setBalance(address: string, balance: NumberLike): Promise<void> {
     return setBalance(this.#provider, address, balance);
   }
 
-  /**
-   * Sets the gas limit for future blocks.
-   *
-   * @param blockGasLimit The gas limit to set for future blocks.
-   * @returns A promise that resolves once the gas limit has been set.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.setBlockGasLimit(1000000); // Set block gas limit to 1,000,000
-   */
   public setBlockGasLimit(blockGasLimit: NumberLike): Promise<void> {
     return setBlockGasLimit(this.#provider, blockGasLimit);
   }
 
-  /**
-   * Modifies the bytecode stored at an account's address.
-   *
-   * @param address The address where the given code should be stored.
-   * @param code The code to store (as a hex string).
-   * @returns A promise that resolves once the code is set.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.setCode("0x123...", "0x6001600101...");
-   */
   public setCode(address: string, code: string): Promise<void> {
     return setCode(this.#provider, address, code);
   }
 
-  /**
-   * Sets the coinbase address to be used in new blocks.
-   *
-   * @param address The new coinbase address.
-   * @returns A promise that resolves once the coinbase address has been set.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.setCoinbase("0x123...");
-   */
   public setCoinbase(address: string): Promise<void> {
     return setCoinbase(this.#provider, address);
   }
 
-  /**
-   * Sets the base fee of the next block.
-   *
-   * @param baseFeePerGas The new base fee to use.
-   * @returns A promise that resolves once the base fee is set.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.setNextBlockBaseFeePerGas(1000000); // Set base fee to 1,000,000
-   */
   public setNextBlockBaseFeePerGas(baseFeePerGas: NumberLike): Promise<void> {
     return setNextBlockBaseFeePerGas(this.#provider, baseFeePerGas);
   }
 
-  /**
-   * Modifies an account's nonce by overwriting it.
-   *
-   * @param address The address whose nonce is to be changed.
-   * @param nonce The new nonce.
-   * @returns A promise that resolves once the nonce is set.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.setNonce("0x123...", 10); // Set the nonce of the account to 10
-   */
   public setNonce(address: string, nonce: NumberLike): Promise<void> {
     return setNonce(this.#provider, address, nonce);
   }
 
-  /**
-   * Sets the PREVRANDAO value of the next block.
-   *
-   * @param prevRandao The new PREVRANDAO value to use.
-   * @returns A promise that resolves once the PREVRANDAO value is set.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.setPrevRandao(123456789); // Set the PREVRANDAO value
-   */
   public setPrevRandao(prevRandao: NumberLike): Promise<void> {
     return setPrevRandao(this.#provider, prevRandao);
   }
 
-  /**
-   * Writes a single position of an account's storage.
-   *
-   * @param address The address where the code should be stored.
-   * @param index The index in storage.
-   * @param value The value to store.
-   * @returns A promise that resolves once the storage value is set.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.setStorageAt("0x123...", 0, 0x0000...);
-   */
   public setStorageAt(
     address: string,
     index: NumberLike,
@@ -295,29 +111,10 @@ export class NetworkHelpers {
     return setStorageAt(this.#provider, address, index, value);
   }
 
-  /**
-   * Stops Hardhat Network from impersonating the given address.
-   *
-   * @param address The address to stop impersonating.
-   * @returns A promise that resolves once the impersonation is stopped.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.stopImpersonatingAccount("0x123...");
-   */
   public stopImpersonatingAccount(address: string): Promise<void> {
     return stopImpersonatingAccount(this.#provider, address);
   }
 
-  /**
-   * Takes a snapshot of the blockchain state at the current block.
-   * @returns A promise that resolves to a `SnapshotRestorer` object, which contains a `restore` method to reset the network to this snapshot.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const snapshot = await networkHelpers.takeSnapshot();
-   * await snapshot.restore(); // Restores the blockchain state
-   */
   public takeSnapshot(): Promise<SnapshotRestorer> {
     return takeSnapshot(this.#provider);
   }

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
@@ -4,6 +4,7 @@ import type {
   NetworkHelpers as NetworkHelpersI,
   NumberLike,
   SnapshotRestorer,
+  Time as TimeI,
 } from "../../types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
@@ -29,7 +30,7 @@ import { Time } from "./time/time.js";
 
 export class NetworkHelpers implements NetworkHelpersI {
   readonly #provider: EthereumProvider;
-  public time: Time;
+  public time: TimeI;
 
   constructor(provider: EthereumProvider) {
     this.#provider = provider;

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase-to.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase-to.ts
@@ -1,6 +1,8 @@
-import type { NumberLike } from "../../../../types.js";
-import type { Duration } from "../../duration/duration.js";
-import type { NetworkHelpers } from "../../network-helpers.js";
+import type {
+  Duration,
+  NetworkHelpers,
+  NumberLike,
+} from "../../../../types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import { toBigInt, toRpcQuantity } from "../../../conversion.js";

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase.ts
@@ -1,5 +1,4 @@
-import type { NumberLike } from "../../../../types.js";
-import type { NetworkHelpers } from "../../network-helpers.js";
+import type { NetworkHelpers, NumberLike } from "../../../../types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import { toBigInt, toRpcQuantity } from "../../../conversion.js";

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/time/helpers/set-next-block-timestamp.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/time/helpers/set-next-block-timestamp.ts
@@ -1,5 +1,4 @@
-import type { NumberLike } from "../../../../types.js";
-import type { Duration } from "../../duration/duration.js";
+import type { Duration, NumberLike } from "../../../../types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import { toRpcQuantity } from "../../../conversion.js";

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
@@ -1,4 +1,4 @@
-import type { NumberLike } from "../../../types.js";
+import type { NumberLike, Time as TimeI } from "../../../types.js";
 import type { NetworkHelpers } from "../network-helpers.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
@@ -10,7 +10,7 @@ import { latestBlock } from "./helpers/latest-block.js";
 import { latest } from "./helpers/latest.js";
 import { setNextBlockTimestamp } from "./helpers/set-next-block-timestamp.js";
 
-export class Time {
+export class Time implements TimeI {
   readonly #networkHelpers: NetworkHelpers;
   readonly #provider: EthereumProvider;
 
@@ -23,30 +23,10 @@ export class Time {
     this.duration = new Duration();
   }
 
-  /**
-   * Mines a new block whose timestamp is `amountInSeconds` after the latest block's timestamp.
-   *
-   * @param amountInSeconds Number of seconds to increase the next block's timestamp by.
-   * @return The timestamp of the mined block.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * await networkHelpers.time.increase(12);
-   */
   public async increase(amountInSeconds: NumberLike): Promise<number> {
     return increase(this.#provider, this.#networkHelpers, amountInSeconds);
   }
 
-  /**
-   * Mines a new block whose timestamp is `timestamp`.
-   *
-   * @param timestamp Can be `Date` or Epoch seconds. Must be greater than the latest block's timestamp.
-   * @return A promise that resolves when the block is successfully mined.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * networkHelpers.time.increaseTo(1700000000);
-   */
   public async increaseTo(timestamp: NumberLike | Date): Promise<void> {
     return increaseTo(
       this.#provider,
@@ -56,41 +36,14 @@ export class Time {
     );
   }
 
-  /**
-   * Returns the timestamp of the latest block.
-   *
-   * @return The timestamp of the latest block.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const timestamp = await networkHelpers.time.latest();
-   */
   public async latest(): Promise<number> {
     return latest(this.#provider);
   }
 
-  /**
-   * Retrieves the latest block number.
-   *
-   * @returns A promise that resolves to the latest block number.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * const blockNumber = await networkHelpers.time.latestBlock();
-   */
   public async latestBlock(): Promise<number> {
     return latestBlock(this.#provider);
   }
 
-  /**
-   * Sets the timestamp of the next block but doesn't mine one.
-   *
-   * @param timestamp Can be `Date` or Epoch seconds. Must be greater than the latest block's timestamp.
-   *
-   * @example
-   * const { networkHelpers } = await hre.network.connect();
-   * networkHelpers.time.setNextBlockTimestamp(1700000000);
-   */
   public async setNextBlockTimestamp(
     timestamp: NumberLike | Date,
   ): Promise<void> {

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
@@ -1,5 +1,4 @@
 import type {
-  Duration as DurationI,
   NetworkHelpers,
   NumberLike,
   Time as TimeI,
@@ -18,7 +17,7 @@ export class Time implements TimeI {
   readonly #networkHelpers: NetworkHelpers;
   readonly #provider: EthereumProvider;
 
-  public readonly duration: DurationI;
+  public readonly duration: Duration;
 
   constructor(networkHelpers: NetworkHelpers, provider: EthereumProvider) {
     this.#networkHelpers = networkHelpers;

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
@@ -1,5 +1,9 @@
-import type { NumberLike, Time as TimeI } from "../../../types.js";
-import type { NetworkHelpers } from "../network-helpers.js";
+import type {
+  Duration as DurationI,
+  NetworkHelpers,
+  NumberLike,
+  Time as TimeI,
+} from "../../../types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import { Duration } from "../duration/duration.js";
@@ -14,7 +18,7 @@ export class Time implements TimeI {
   readonly #networkHelpers: NetworkHelpers;
   readonly #provider: EthereumProvider;
 
-  public readonly duration: Duration;
+  public readonly duration: DurationI;
 
   constructor(networkHelpers: NetworkHelpers, provider: EthereumProvider) {
     this.#networkHelpers = networkHelpers;

--- a/v-next/hardhat-network-helpers/src/type-extensions.ts
+++ b/v-next/hardhat-network-helpers/src/type-extensions.ts
@@ -1,6 +1,5 @@
 import "@ignored/hardhat-vnext/types/network";
-
-import type { NetworkHelpers } from "./internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "./types.js";
 
 declare module "@ignored/hardhat-vnext/types/network" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- the ChainTypeT must be declared in the interface but in this scenario it's not used

--- a/v-next/hardhat-network-helpers/src/types.ts
+++ b/v-next/hardhat-network-helpers/src/types.ts
@@ -1,3 +1,401 @@
+export interface NetworkHelpers {
+  readonly time: Time;
+
+  /**
+   * Clears every existing snapshot.
+   *
+   * @example
+   * // Clear all saved snapshots
+   * clearSnapshots();
+   */
+  clearSnapshots(): void;
+
+  /**
+   * Removes the given transaction from the mempool, if it exists.
+   *
+   * @param txHash Transaction hash to be removed from the mempool.
+   * @returns `true` if successful, otherwise `false`.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const success = await networkHelpers.dropTransaction('0x123...');
+   */
+  dropTransaction(txHash: string): Promise<boolean>;
+
+  /**
+   * Retrieves the data located at the given address, index, and block number.
+   *
+   * @param address The address to retrieve storage from.
+   * @param index The position in storage.
+   * @param block The block number, or one of "latest", "earliest", or "pending". Defaults to "latest".
+   * @returns A promise that resolves to a string containing the hexadecimal code retrieved.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const storageData = await networkHelpers.getStorageAt("0x123...", 0);
+   */
+  getStorageAt(
+    address: string,
+    index: NumberLike,
+    block?: NumberLike | BlockTag,
+  ): Promise<string>;
+
+  /**
+   * Allows Hardhat Network to sign transactions as the given address.
+   *
+   * @param address The address to impersonate.
+   * @returns A promise that resolves once the account is impersonated.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.impersonateAccount("0x123...");
+   */
+  impersonateAccount(address: string): Promise<void>;
+
+  /**
+   * Loads a fixture and restores the blockchain to a snapshot state for repeated tests.
+   *
+   * The `loadFixture` function is useful in tests where you need to set up the blockchain to a desired state
+   * (like deploying contracts, minting tokens, etc.) and then run multiple tests based on that state.
+   *
+   * It executes the given fixture function, which should set up the blockchain state, and takes a snapshot of the blockchain.
+   * On subsequent calls to `loadFixture` with the same fixture function, the blockchain is restored to that snapshot
+   * rather than executing the fixture function again.
+   *
+   * ### Important:
+   * **Do not pass anonymous functions** as the fixture function. Passing an anonymous function like
+   * `loadFixture(async () => { ... })` will bypass the snapshot mechanism and result in the fixture being executed
+   * each time. Instead, always pass a named function, like `loadFixture(deployTokens)`.
+   *
+   * @param fixture A named asynchronous function that sets up the desired blockchain state and returns the fixture's data.
+   * @returns A promise that resolves to the data returned by the fixture, either from execution or a restored snapshot.
+   *
+   * @example
+   * async function setupContracts() { ... }
+   * const fixtureData = await loadFixture(setupContracts);
+   */
+  loadFixture<T>(fixture: Fixture<T>): Promise<T>;
+
+  /**
+   * Mines a specified number of blocks with an optional time interval between them.
+   *
+   * @param blocks The number of blocks to mine. Defaults to 1 if not specified.
+   * @param options.interval Configures the interval (in seconds) between the timestamps of each mined block. Defaults to 1.
+   * @returns A promise that resolves once the blocks have been mined.
+   *
+   * @example
+   * // Mine 1 block (default behavior)
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.mine();
+   *
+   * @example
+   * // Mine 10 blocks with an interval of 60 seconds between each block
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.mine(10, { interval: 60 });
+   */
+  mine(blocks?: NumberLike, options?: { interval?: NumberLike }): Promise<void>;
+
+  /**
+   * Mines new blocks until the latest block number reaches `blockNumber`.
+   *
+   * @param blockNumber Must be greater than the latest block's number.
+   * @returns A promise that resolves once the required blocks have been mined.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.mineUpTo(150); // Mines until block with block number 150
+   */
+  mineUpTo(blockNumber: NumberLike): Promise<void>;
+
+  /**
+   * Resets the Hardhat Network to its initial state or forks from a given URL and block number.
+   *
+   * @param url Optional JSON-RPC URL to fork from.
+   * @param blockNumber Optional block number to fork from.
+   * @returns A promise that resolves once the reset operation is completed.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.reset(); // Resets the network
+   * await networkHelpers.reset("https://mainnet.infura.io", 123456); // Resets and forks from a specific block
+   */
+  reset(url?: string, blockNumber?: NumberLike): Promise<void>;
+
+  /**
+   * Sets the balance for the given address.
+   *
+   * @param address The address whose balance will be updated.
+   * @param balance The new balance to set for the given address, in wei.
+   * @returns A promise that resolves once the balance has been set.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.setBalance("0x123...", 1000000000000000000n); // Sets 1 ETH
+   */
+  setBalance(address: string, balance: NumberLike): Promise<void>;
+
+  /**
+   * Sets the gas limit for future blocks.
+   *
+   * @param blockGasLimit The gas limit to set for future blocks.
+   * @returns A promise that resolves once the gas limit has been set.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.setBlockGasLimit(1000000); // Set block gas limit to 1,000,000
+   */
+  setBlockGasLimit(blockGasLimit: NumberLike): Promise<void>;
+
+  /**
+   * Modifies the bytecode stored at an account's address.
+   *
+   * @param address The address where the given code should be stored.
+   * @param code The code to store (as a hex string).
+   * @returns A promise that resolves once the code is set.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.setCode("0x123...", "0x6001600101...");
+   */
+  setCode(address: string, code: string): Promise<void>;
+
+  /**
+   * Sets the coinbase address to be used in new blocks.
+   *
+   * @param address The new coinbase address.
+   * @returns A promise that resolves once the coinbase address has been set.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.setCoinbase("0x123...");
+   */
+  setCoinbase(address: string): Promise<void>;
+
+  /**
+   * Sets the base fee of the next block.
+   *
+   * @param baseFeePerGas The new base fee to use.
+   * @returns A promise that resolves once the base fee is set.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.setNextBlockBaseFeePerGas(1000000); // Set base fee to 1,000,000
+   */
+  setNextBlockBaseFeePerGas(baseFeePerGas: NumberLike): Promise<void>;
+
+  /**
+   * Modifies an account's nonce by overwriting it.
+   *
+   * @param address The address whose nonce is to be changed.
+   * @param nonce The new nonce.
+   * @returns A promise that resolves once the nonce is set.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.setNonce("0x123...", 10); // Set the nonce of the account to 10
+   */
+  setNonce(address: string, nonce: NumberLike): Promise<void>;
+
+  /**
+   * Sets the PREVRANDAO value of the next block.
+   *
+   * @param prevRandao The new PREVRANDAO value to use.
+   * @returns A promise that resolves once the PREVRANDAO value is set.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.setPrevRandao(123456789); // Set the PREVRANDAO value
+   */
+  setPrevRandao(prevRandao: NumberLike): Promise<void>;
+
+  /**
+   * Writes a single position of an account's storage.
+   *
+   * @param address The address where the code should be stored.
+   * @param index The index in storage.
+   * @param value The value to store.
+   * @returns A promise that resolves once the storage value is set.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.setStorageAt("0x123...", 0, 0x0000...);
+   */
+  setStorageAt(
+    address: string,
+    index: NumberLike,
+    value: NumberLike,
+  ): Promise<void>;
+
+  /**
+   * Stops Hardhat Network from impersonating the given address.
+   *
+   * @param address The address to stop impersonating.
+   * @returns A promise that resolves once the impersonation is stopped.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.stopImpersonatingAccount("0x123...");
+   */
+  stopImpersonatingAccount(address: string): Promise<void>;
+
+  /**
+   * Takes a snapshot of the blockchain state at the current block.
+   * @returns A promise that resolves to a `SnapshotRestorer` object, which contains a `restore` method to reset the network to this snapshot.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const snapshot = await networkHelpers.takeSnapshot();
+   * await snapshot.restore(); // Restores the blockchain state
+   */
+  takeSnapshot(): Promise<SnapshotRestorer>;
+}
+
+export interface Time {
+  readonly duration: Duration;
+
+  /**
+   * Mines a new block whose timestamp is `amountInSeconds` after the latest block's timestamp.
+   *
+   * @param amountInSeconds Number of seconds to increase the next block's timestamp by.
+   * @return The timestamp of the mined block.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * await networkHelpers.time.increase(12);
+   */
+  increase(amountInSeconds: NumberLike): Promise<number>;
+
+  /**
+   * Mines a new block whose timestamp is `timestamp`.
+   *
+   * @param timestamp Can be `Date` or Epoch seconds. Must be greater than the latest block's timestamp.
+   * @return A promise that resolves when the block is successfully mined.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * networkHelpers.time.increaseTo(1700000000);
+   */
+  increaseTo(timestamp: NumberLike | Date): Promise<void>;
+
+  /**
+   * Returns the timestamp of the latest block.
+   *
+   * @return The timestamp of the latest block.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const timestamp = await networkHelpers.time.latest();
+   */
+  latest(): Promise<number>;
+
+  /**
+   * Retrieves the latest block number.
+   *
+   * @returns A promise that resolves to the latest block number.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const blockNumber = await networkHelpers.time.latestBlock();
+   */
+  latestBlock(): Promise<number>;
+
+  /**
+   * Sets the timestamp of the next block but doesn't mine one.
+   *
+   * @param timestamp Can be `Date` or Epoch seconds. Must be greater than the latest block's timestamp.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * networkHelpers.time.setNextBlockTimestamp(1700000000);
+   */
+  setNextBlockTimestamp(timestamp: NumberLike | Date): Promise<void>;
+}
+export interface Duration {
+  /**
+   * Converts the given number of years into seconds.
+   *
+   * @param n - The number of years.
+   * @returns The equivalent duration in seconds.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const seconds = networkHelpers.time.duration.years(1);
+   */
+  years(n: number): number;
+
+  /**
+   * Converts the given number of weeks into seconds.
+   *
+   * @param n - The number of weeks.
+   * @returns The equivalent duration in seconds.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const seconds = networkHelpers.time.duration.weeks(1);
+   */
+  weeks(n: number): number;
+
+  /**
+   * Converts the given number of days into seconds.
+   *
+   * @param n - The number of days.
+   * @returns The equivalent duration in seconds.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const seconds = networkHelpers.time.duration.days(1);
+   */
+  days(n: number): number;
+
+  /**
+   * Converts the given number of hours into seconds.
+   *
+   * @param n - The number of hours.
+   * @returns The equivalent duration in seconds.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const seconds = networkHelpers.time.duration.hours(1);
+   */
+  hours(n: number): number;
+
+  /**
+   * Converts the given number of minutes into seconds.
+   *
+   * @param n - The number of minutes.
+   * @returns The equivalent duration in seconds.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const seconds = networkHelpers.time.duration.minutes(1);
+   */
+  minutes(n: number): number;
+
+  /**
+   * Returns the number of seconds.
+   *
+   * @param n - The number of seconds.
+   * @returns The same number of seconds.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const seconds = networkHelpers.time.duration.seconds(1);
+   */
+  seconds(n: number): number;
+
+  /**
+   * Converts the given number of milliseconds into seconds, rounded down to the nearest whole number.
+   *
+   * @param n - The number of milliseconds.
+   * @returns The equivalent duration in seconds.
+   *
+   * @example
+   * const { networkHelpers } = await hre.network.connect();
+   * const seconds = networkHelpers.time.duration.millis(1500); // Returns 1
+   */
+  millis(n: number): number;
+}
+
 export type NumberLike = number | bigint | string;
 
 export type BlockTag = "latest" | "earliest" | "pending";

--- a/v-next/hardhat-network-helpers/test/index.ts
+++ b/v-next/hardhat-network-helpers/test/index.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../src/types.js";
 import type { HardhatRuntimeEnvironment } from "@ignored/hardhat-vnext/types/hre";
 
 import { beforeEach, describe, it } from "node:test";

--- a/v-next/hardhat-network-helpers/test/network-helpers/drop-transaction.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/drop-transaction.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/get-storage-at.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/get-storage-at.ts
@@ -1,5 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
-import type { BlockTag, NumberLike } from "../../src/types.js";
+import type { NetworkHelpers, BlockTag, NumberLike } from "../../src/types.js";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";

--- a/v-next/hardhat-network-helpers/test/network-helpers/impersonate-account.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/impersonate-account.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/load-fixture.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/load-fixture.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../../src/types.js";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";

--- a/v-next/hardhat-network-helpers/test/network-helpers/mine-up-to.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/mine-up-to.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../../src/types.js";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";

--- a/v-next/hardhat-network-helpers/test/network-helpers/mine.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/mine.ts
@@ -1,5 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
-import type { NumberLike } from "../../src/types.js";
+import type { NetworkHelpers, NumberLike } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/reset.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/reset.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../../src/types.js";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";

--- a/v-next/hardhat-network-helpers/test/network-helpers/set-balance.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/set-balance.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/set-block-gas-limit.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/set-block-gas-limit.ts
@@ -1,5 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
-import type { NumberLike } from "../../src/types.js";
+import type { NetworkHelpers, NumberLike } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/set-code.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/set-code.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/set-coinbase.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/set-coinbase.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/set-next-block-base-fee-per-gas.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/set-next-block-base-fee-per-gas.ts
@@ -1,5 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
-import type { NumberLike } from "../../src/types.js";
+import type { NetworkHelpers, NumberLike } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/set-nonce.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/set-nonce.ts
@@ -1,5 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
-import type { NumberLike } from "../../src/types.js";
+import type { NetworkHelpers, NumberLike } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/set-prevrandao.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/set-prevrandao.ts
@@ -1,5 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
-import type { NumberLike } from "../../src/types.js";
+import type { NetworkHelpers, NumberLike } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/set-storage-at.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/set-storage-at.ts
@@ -1,5 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
-import type { NumberLike } from "../../src/types.js";
+import type { NetworkHelpers, NumberLike } from "../../src/types.js";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";

--- a/v-next/hardhat-network-helpers/test/network-helpers/stop-impersonating-account.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/stop-impersonating-account.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/network-helpers/take-snapshot.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/take-snapshot.ts
@@ -1,4 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
+import type { NetworkHelpers } from "../../src/types.js";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";

--- a/v-next/hardhat-network-helpers/test/time/increase-to.ts
+++ b/v-next/hardhat-network-helpers/test/time/increase-to.ts
@@ -1,4 +1,4 @@
-import type { Time } from "../../src/internal/network-helpers/time/time.js";
+import type { Time } from "../../src/types.js";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";

--- a/v-next/hardhat-network-helpers/test/time/increase.ts
+++ b/v-next/hardhat-network-helpers/test/time/increase.ts
@@ -1,5 +1,4 @@
-import type { Time } from "../../src/internal/network-helpers/time/time.js";
-import type { NumberLike } from "../../src/types.js";
+import type { Time, NumberLike } from "../../src/types.js";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";

--- a/v-next/hardhat-network-helpers/test/time/latest-block.ts
+++ b/v-next/hardhat-network-helpers/test/time/latest-block.ts
@@ -1,5 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
-import type { Time } from "../../src/internal/network-helpers/time/time.js";
+import type { NetworkHelpers, Time } from "../../src/types.js";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";

--- a/v-next/hardhat-network-helpers/test/time/latest.ts
+++ b/v-next/hardhat-network-helpers/test/time/latest.ts
@@ -1,4 +1,4 @@
-import type { Time } from "../../src/internal/network-helpers/time/time.js";
+import type { Time } from "../../src/types.js";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";

--- a/v-next/hardhat-network-helpers/test/time/set-next-block-timestamp.ts
+++ b/v-next/hardhat-network-helpers/test/time/set-next-block-timestamp.ts
@@ -1,5 +1,4 @@
-import type { NetworkHelpers } from "../../src/internal/network-helpers/network-helpers.js";
-import type { Time } from "../../src/internal/network-helpers/time/time.js";
+import type { NetworkHelpers, Time } from "../../src/types.js";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";


### PR DESCRIPTION
HardhatNetworkHelpers should be exported as an interface in the plugin.

Changes:
- new interfaces added: HardhatNetworkHelpers, Time, Duration
- the functions docs have been moved from the classes to the interfaces
- the variables that were using the classes as types now use the interfaces