### PR TITLE
Fix hardhat package resolution

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -20,8 +20,8 @@ import {
   getFileTrueCase,
   readJsonFile,
   readUtf8File,
-  getRealPath,
 } from "@ignored/hardhat-vnext-utils/fs";
+import { findClosestPackageJson } from "@ignored/hardhat-vnext-utils/package";
 import { shortenPath } from "@ignored/hardhat-vnext-utils/path";
 import { ResolutionError, resolve } from "@ignored/hardhat-vnext-utils/resolve";
 import { analyze } from "@nomicfoundation/solidity-analyzer";
@@ -1085,12 +1085,7 @@ export class ResolverImplementation implements Resolver {
       packageName === "hardhat"
         ? ({
             success: true,
-            absolutePath: await getRealPath(
-              path.resolve(
-                import.meta.dirname,
-                "../../../../../../package.json",
-              ),
-            ),
+            absolutePath: await findClosestPackageJson(import.meta.dirname),
           } as const)
         : resolve(packageName + "/package.json", baseResolutionDirectory);
 


### PR DESCRIPTION
The resolution was giving different results during testing than in production, due to everything being in `dist/` in production builds. Instead of using a path, I now look for the closest `package.json`, which is safer.