### PR TITLE
add v-next keystore to the templates

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2343,6 +2343,9 @@ importers:
       '@ignored/hardhat-vnext-ethers':
         specifier: workspace:^3.0.0-next.8
         version: link:../../../hardhat-ethers
+      '@ignored/hardhat-vnext-keystore':
+        specifier: workspace:^3.0.0-next.8
+        version: link:../../../hardhat-keystore
       '@ignored/hardhat-vnext-mocha-test-runner':
         specifier: workspace:^3.0.0-next.8
         version: link:../../../hardhat-mocha-test-runner
@@ -2382,6 +2385,9 @@ importers:
       '@ignored/hardhat-vnext':
         specifier: workspace:^3.0.0-next.12
         version: link:../..
+      '@ignored/hardhat-vnext-keystore':
+        specifier: workspace:^3.0.0-next.8
+        version: link:../../../hardhat-keystore
       '@ignored/hardhat-vnext-network-helpers':
         specifier: workspace:^3.0.0-next.8
         version: link:../../../hardhat-network-helpers

--- a/v-next/hardhat/templates/mocha-ethers/hardhat.config.ts
+++ b/v-next/hardhat/templates/mocha-ethers/hardhat.config.ts
@@ -1,14 +1,17 @@
-import {
-  HardhatUserConfig,
-  configVariable,
-} from "@ignored/hardhat-vnext/config";
+import { HardhatUserConfig } from "@ignored/hardhat-vnext/config";
 
 import HardhatMochaTestRunner from "@ignored/hardhat-vnext-mocha-test-runner";
 import HardhatEthers from "@ignored/hardhat-vnext-ethers";
 import HardhatNetworkHelpers from "@ignored/hardhat-vnext-network-helpers";
+import HardhatKeystore from "@ignored/hardhat-vnext-keystore";
 
 const config: HardhatUserConfig = {
-  plugins: [HardhatMochaTestRunner, HardhatEthers, HardhatNetworkHelpers],
+  plugins: [
+    HardhatMochaTestRunner,
+    HardhatEthers,
+    HardhatNetworkHelpers,
+    HardhatKeystore,
+  ],
   solidity: {
     version: "0.8.24",
     remappings: [

--- a/v-next/hardhat/templates/mocha-ethers/package.json
+++ b/v-next/hardhat/templates/mocha-ethers/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "@ignored/hardhat-vnext": "workspace:^3.0.0-next.12",
     "@ignored/hardhat-vnext-ethers": "workspace:^3.0.0-next.8",
+    "@ignored/hardhat-vnext-keystore": "workspace:^3.0.0-next.8",
     "@ignored/hardhat-vnext-mocha-test-runner": "workspace:^3.0.0-next.8",
     "@ignored/hardhat-vnext-network-helpers": "workspace:^3.0.0-next.8",
     "@types/chai": "^4.2.0",

--- a/v-next/hardhat/templates/node-test-runner-viem/hardhat.config.ts
+++ b/v-next/hardhat/templates/node-test-runner-viem/hardhat.config.ts
@@ -3,9 +3,15 @@ import type { HardhatUserConfig } from "@ignored/hardhat-vnext/config";
 import HardhatNodeTestRunner from "@ignored/hardhat-vnext-node-test-runner";
 import HardhatViem from "@ignored/hardhat-vnext-viem";
 import HardhatNetworkHelpers from "@ignored/hardhat-vnext-network-helpers";
+import HardhatKeystore from "@ignored/hardhat-vnext-keystore";
 
 const config: HardhatUserConfig = {
-  plugins: [HardhatNodeTestRunner, HardhatViem, HardhatNetworkHelpers],
+  plugins: [
+    HardhatNodeTestRunner,
+    HardhatViem,
+    HardhatNetworkHelpers,
+    HardhatKeystore,
+  ],
   solidity: {
     version: "0.8.24",
     remappings: [

--- a/v-next/hardhat/templates/node-test-runner-viem/package.json
+++ b/v-next/hardhat/templates/node-test-runner-viem/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "devDependencies": {
     "@ignored/hardhat-vnext": "workspace:^3.0.0-next.12",
+    "@ignored/hardhat-vnext-keystore": "workspace:^3.0.0-next.8",
     "@ignored/hardhat-vnext-node-test-runner": "workspace:^3.0.0-next.8",
     "@ignored/hardhat-vnext-network-helpers": "workspace:^3.0.0-next.8",
     "@ignored/hardhat-vnext-viem": "workspace:^3.0.0-next.7",


### PR DESCRIPTION
This is to allow users to try the new config variable setup based on values set in the file based (unencrypted) keystore.
