### PR TITLE
Print the Node.js warning before loading main

### DIFF
--- a/v-next/hardhat/src/cli.ts
+++ b/v-next/hardhat/src/cli.ts
@@ -1,8 +1,15 @@
 #!/usr/bin/env node
 
+import { printNodeJsVersionWarningIfNecessary } from "./internal/cli/node-version.js";
+
 // We enable the sourcemaps before loading main, so that everything except this
 // small file is loaded with sourcemaps enabled.
 process.setSourceMapsEnabled(true);
+
+// We also print this warning before loading main, so that if there is some
+// unsupported js syntax or Node API elsewhere, we get to print it before
+// crashing.
+printNodeJsVersionWarningIfNecessary();
 
 // eslint-disable-next-line no-restricted-syntax -- Allow top-level await here
 const { main } = await import("./internal/cli/main.js");

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -35,7 +35,6 @@ import { createHardhatRuntimeEnvironment } from "../hre-intialization.js";
 import { printErrorMessages } from "./error-handler.js";
 import { getGlobalHelpString } from "./helpers/getGlobalHelpString.js";
 import { getHelpString } from "./helpers/getHelpString.js";
-import { printNodeJsVersionWarningIfNecessary } from "./node-version.js";
 import { ensureTelemetryConsent } from "./telemetry/telemetry-permissions.js";
 import { printVersionMessage } from "./version.js";
 
@@ -50,8 +49,6 @@ export async function main(
   options: MainOptions = {},
 ): Promise<void> {
   const print = options.print ?? console.log;
-
-  printNodeJsVersionWarningIfNecessary(print);
 
   const log = debug("hardhat:core:cli:main");
 

--- a/v-next/hardhat/src/internal/cli/node-version.ts
+++ b/v-next/hardhat/src/internal/cli/node-version.ts
@@ -32,17 +32,15 @@ function isNodeVersionSupported(): boolean {
   return true;
 }
 
-export function printNodeJsVersionWarningIfNecessary(
-  print: (message: string) => void,
-): void {
+export function printNodeJsVersionWarningIfNecessary(): void {
   if (isNodeVersionSupported()) {
     return;
   }
 
-  print("");
-  print(
+  console.log("");
+  console.log(
     chalk.bold(`${chalk.yellow("WARNING:")} You are using Node.js ${process.versions.node} which is not supported by Hardhat.
 Please upgrade to ${MIN_SUPPORTED_NODE_VERSION.join(".")} or a later version.`),
   );
-  print("");
+  console.log("");
 }


### PR DESCRIPTION
This PR moves the function call to print the Node.js version warning to the main CLI entrypoint, so that we do the check before loading main, as loading main can crash already if you have a pretty old version.