### PR TITLE
Upgrade EDR

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1477,11 +1477,11 @@ importers:
   v-next/hardhat:
     dependencies:
       '@ignored/edr':
-        specifier: 0.6.4-alpha.1
-        version: 0.6.4-alpha.1
+        specifier: 0.6.4-alpha.2
+        version: 0.6.4-alpha.2
       '@ignored/edr-optimism':
-        specifier: ^0.6.4
-        version: 0.6.4
+        specifier: 0.6.5-alpha.0
+        version: 0.6.5-alpha.0
       '@ignored/hardhat-vnext-errors':
         specifier: workspace:^3.0.0-next.14
         version: link:../hardhat-errors
@@ -2916,68 +2916,68 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
-  '@ignored/edr-darwin-arm64@0.6.4-alpha.1':
-    resolution: {integrity: sha512-k+esPQ4hajOI7X/GqQ+d87s6pwOQoVHDW3EVNVOZOA8/7xFLjUMHtm18G64hpJjM2ap5FLgNu/F/SOdj9QojCw==}
+  '@ignored/edr-darwin-arm64@0.6.4-alpha.2':
+    resolution: {integrity: sha512-pL3+BUBXCzZmJtE613BzGrVFc8zzjCSPx30aekBJDusWfzXziaNn+ShfORN9VuZbYkWd8G8YxCfvjPgsZIjxRg==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-darwin-x64@0.6.4-alpha.1':
-    resolution: {integrity: sha512-PakfiVkuawU4EgFWTzpdizJPp68y7m8hrWze/Z34wsQpDrIWE9cU6K8WZeK8bdOtmty3JBZ+uFFXX7CJsO6xNA==}
+  '@ignored/edr-darwin-x64@0.6.4-alpha.2':
+    resolution: {integrity: sha512-Ny4GqQVS7VGSDj5rGP1uVb7qWRJrTdiW3mDlFQekxzxvz4ms8R79vmA8RfIEbrBmwuETpnx26EwyYa6krkcbmg==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-linux-arm64-gnu@0.6.4-alpha.1':
-    resolution: {integrity: sha512-lQSrtWicyrsxhY2a0hF5MEY951FY4joCtrwK+rp+i4QnjkloCggrtW0W/Q1WX2V7zt07+wplGYHq1Wpd+RBj+g==}
+  '@ignored/edr-linux-arm64-gnu@0.6.4-alpha.2':
+    resolution: {integrity: sha512-V0hf3i09fXxbszHrjqIcoNjMiU9gi/6nrhmB+o7kKwdi0IVuAwiBEbjfcyDlTDfAX2jDFGnxYfEhiSYermpvWA==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-linux-arm64-musl@0.6.4-alpha.1':
-    resolution: {integrity: sha512-hdURs7nUUMNwMiy+b9lg0gBzjVgPHJmEnxitd4ZudIgDkLHnOT6IQ4nhV9B97Ae1I5EyHmOq72vEC7OnqLoZ3g==}
+  '@ignored/edr-linux-arm64-musl@0.6.4-alpha.2':
+    resolution: {integrity: sha512-1yKOaj3nZK7hQs3AhNlTp8NeUGZa6S0P6Fnlu5GUvTNh/wpjuubiPd8aNKpDxraVkywBisjfU9W2xRijvGdwXA==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-linux-x64-gnu@0.6.4-alpha.1':
-    resolution: {integrity: sha512-pZnVaybdBgLAgftLgOsPJuKfQRlRw7fZ54E7bVCSMklWHFFLZg6sjCUAByPVx0p3b3V/t0YiYZ9BwLKTvdEiEA==}
+  '@ignored/edr-linux-x64-gnu@0.6.4-alpha.2':
+    resolution: {integrity: sha512-iceOX3VIgSuyzR92tY8qXhqn8EV4EZqcC2Qls6Zu4cFeOSJCYVdrsZ7qJo4Vb/k0d+JTw8vcJwHKea8rTJksvg==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-linux-x64-musl@0.6.4-alpha.1':
-    resolution: {integrity: sha512-Mw/HC1nBfRXJAUZVKHwQrYffuWI6nVQtpR6cX1zxTSrBc87aKCR2oSiPQCLxqLlxcjOqRkSVWWwhBPhWdIt8Bw==}
+  '@ignored/edr-linux-x64-musl@0.6.4-alpha.2':
+    resolution: {integrity: sha512-GIHda/5xosqWELyse+wZGTWwwOWxKl1fWh5M5oykTla84TSmM++7VJPvM4Hnt+T+jj9OL2lW1zybvrwwFzxLAQ==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-darwin-arm64@0.6.4':
-    resolution: {integrity: sha512-c/GAqX9sCp+5o+GLlCbE6Hx2k69Z9DXXej2t6LUuYmcRXu8agVWIbqaUy3uSbI1ALThIZEBZtxAH8rBr4vNqhg==}
+  '@ignored/edr-optimism-darwin-arm64@0.6.5-alpha.0':
+    resolution: {integrity: sha512-umEVWWr8M3g5uMwmAufkbYWEz0i2cm50ddm3Y2V4yi8qg2W4x4KPkklEILqkYEgeG7HTfODD9gk/ekz71nUR4Q==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-darwin-x64@0.6.4':
-    resolution: {integrity: sha512-1FuhbDY2mNCbMKp6LQ1Tfg56u88x05fgTkXvV+8WyCaELoA0NJ/WDZxliq4J8cWOQJP5LfYtb8afRysT8XidHQ==}
+  '@ignored/edr-optimism-darwin-x64@0.6.5-alpha.0':
+    resolution: {integrity: sha512-Vrd0Nt5KT4PrBhb+7FKcyoMQT1YV6nSqoREjHP60gL5KO11IjNFCbVMv3InBeHwNm46wFJjENdCMAcw+Pj+JvA==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-arm64-gnu@0.6.4':
-    resolution: {integrity: sha512-XNpx36xtWYDddJhUkTEMUq22I/II8IB0SIZdyMlDkjNq5c9lFJIkrIRy1RXW8QQcDLcA5cwZIdwmGQ0U/xHPTQ==}
+  '@ignored/edr-optimism-linux-arm64-gnu@0.6.5-alpha.0':
+    resolution: {integrity: sha512-lvMFt6K/gN+a9Yu4vc55VPXP6qVRQyj+/Gsz6yjTLNkbzwP6hD32T9oliWJJ1aRzOjTwz7/1HBYIwLtuPg6/VA==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-arm64-musl@0.6.4':
-    resolution: {integrity: sha512-LTdQfmZg7XJOzj3RYXpKa5ui4J7pjGdeend8ia0PHra/YEsfdA8S07RM2X3YFZJSngbs7m3xvrRfAbDjX0ep3g==}
+  '@ignored/edr-optimism-linux-arm64-musl@0.6.5-alpha.0':
+    resolution: {integrity: sha512-3mA+Tl59nt7J3+K79vlpGy1evbtr7q2LfUE2bd2gDegb5JfneeuJGQVPH/zd/3sIZnk624xKkTUTf6psW+r9iw==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-x64-gnu@0.6.4':
-    resolution: {integrity: sha512-3CK5K21a0mVLDhdAjfhANcnGyDo9yWBYv07d3cxJ9R/e1h148pzPecjSkJxDJD0ARovhroLCiS16MlDlrKgjAw==}
+  '@ignored/edr-optimism-linux-x64-gnu@0.6.5-alpha.0':
+    resolution: {integrity: sha512-lFsTGtDY2N24L6hgL+wCLCH0uXVaaYUyT32qGajNGt3FHNEtEGCuHYnCqQcDTcOXzXBVocIUkNihLVb/9MpgqA==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-x64-musl@0.6.4':
-    resolution: {integrity: sha512-/lwndCOJ0rrsHG9CCQPL0lIem2oAuI8ToQ1CFHTkoZwuvlsa0cFfEvCCY/TxdZlrQGds0tU1OEbgEK+5e6A2rg==}
+  '@ignored/edr-optimism-linux-x64-musl@0.6.5-alpha.0':
+    resolution: {integrity: sha512-6lXLOW3e/Bw1z8l/nQmaG7S1Ady1MMxb21fJ9rf6/nod30cBfF4PgefhF2o8D0xGVqfW4FcHhqWtpGj/oV9xZg==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-win32-x64-msvc@0.6.4':
-    resolution: {integrity: sha512-bHLDhiFVpK6q/yPbRLMGY6ZuAaF/tzkQpPVodtVsJ4t5W/xgYkNEMEZBTBCw3Zk3Qh63ic11En63yR+kpf8tpQ==}
+  '@ignored/edr-optimism-win32-x64-msvc@0.6.5-alpha.0':
+    resolution: {integrity: sha512-gz29UrSw+3Bj/sWa9JGewHcD9CIj5xi9Zjn9POmwmUUOF/q48SkAJ01XA+BOhpdsR0bx91wWd8lGrAPZghGmIg==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism@0.6.4':
-    resolution: {integrity: sha512-62hm/8tdbDtvkLUwLecGDK4lOma0XC2Zp9WmrVJ9RkeLU4C/sK25a+5rCdm40+7whpXkF8nEHTn7rgBmtTEhfw==}
+  '@ignored/edr-optimism@0.6.5-alpha.0':
+    resolution: {integrity: sha512-RTMiCC6Y5tOW+q+V+ARpUw3ErmkvBVMYWj+5drq8MEZYOEcrLKXlavm3BM1QqkwWaeO2j+zTrIuI4lRCePj9oQ==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-win32-x64-msvc@0.6.4-alpha.1':
-    resolution: {integrity: sha512-N4IIy2KZGMIwMiYGl1erEGoA5nT0k0KAvnSccopR6kQo04COHa46L50U1wAu0Ice+h1tybn+qfcVM6EBJE77NQ==}
+  '@ignored/edr-win32-x64-msvc@0.6.4-alpha.2':
+    resolution: {integrity: sha512-QZxYQRMTeYCFKa7/3jbkYkGgtwAI2X9JXIxFbWgOOYQSTsWJsw+igcyW+WAeMUHAvXEAWO1Ex/hrcra4tOqlqQ==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr@0.6.4-alpha.1':
-    resolution: {integrity: sha512-NXJvV1SaK5sbO4j5IbA2wPD6Fkm1bPotUrmL/w1XuCPDm9wZbuaE012ZWon3vY2Zt+OrDGWLHsmxY37wmH86rg==}
+  '@ignored/edr@0.6.4-alpha.2':
+    resolution: {integrity: sha512-gp5v/wCKO0W2S00diHT2cV+lCRxRTh2TyP+Xxg/zWZLE+5KcSAlOV0VElVMAiH37sv/7cHhE2AXGcnMnPHW/DA==}
     engines: {node: '>= 18'}
 
   '@isaacs/cliui@8.0.2':
@@ -7572,60 +7572,60 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@ignored/edr-darwin-arm64@0.6.4-alpha.1':
+  '@ignored/edr-darwin-arm64@0.6.4-alpha.2':
     optional: true
 
-  '@ignored/edr-darwin-x64@0.6.4-alpha.1':
+  '@ignored/edr-darwin-x64@0.6.4-alpha.2':
     optional: true
 
-  '@ignored/edr-linux-arm64-gnu@0.6.4-alpha.1':
+  '@ignored/edr-linux-arm64-gnu@0.6.4-alpha.2':
     optional: true
 
-  '@ignored/edr-linux-arm64-musl@0.6.4-alpha.1':
+  '@ignored/edr-linux-arm64-musl@0.6.4-alpha.2':
     optional: true
 
-  '@ignored/edr-linux-x64-gnu@0.6.4-alpha.1':
+  '@ignored/edr-linux-x64-gnu@0.6.4-alpha.2':
     optional: true
 
-  '@ignored/edr-linux-x64-musl@0.6.4-alpha.1':
+  '@ignored/edr-linux-x64-musl@0.6.4-alpha.2':
     optional: true
 
-  '@ignored/edr-optimism-darwin-arm64@0.6.4': {}
+  '@ignored/edr-optimism-darwin-arm64@0.6.5-alpha.0': {}
 
-  '@ignored/edr-optimism-darwin-x64@0.6.4': {}
+  '@ignored/edr-optimism-darwin-x64@0.6.5-alpha.0': {}
 
-  '@ignored/edr-optimism-linux-arm64-gnu@0.6.4': {}
+  '@ignored/edr-optimism-linux-arm64-gnu@0.6.5-alpha.0': {}
 
-  '@ignored/edr-optimism-linux-arm64-musl@0.6.4': {}
+  '@ignored/edr-optimism-linux-arm64-musl@0.6.5-alpha.0': {}
 
-  '@ignored/edr-optimism-linux-x64-gnu@0.6.4': {}
+  '@ignored/edr-optimism-linux-x64-gnu@0.6.5-alpha.0': {}
 
-  '@ignored/edr-optimism-linux-x64-musl@0.6.4': {}
+  '@ignored/edr-optimism-linux-x64-musl@0.6.5-alpha.0': {}
 
-  '@ignored/edr-optimism-win32-x64-msvc@0.6.4': {}
+  '@ignored/edr-optimism-win32-x64-msvc@0.6.5-alpha.0': {}
 
-  '@ignored/edr-optimism@0.6.4':
+  '@ignored/edr-optimism@0.6.5-alpha.0':
     dependencies:
-      '@ignored/edr-optimism-darwin-arm64': 0.6.4
-      '@ignored/edr-optimism-darwin-x64': 0.6.4
-      '@ignored/edr-optimism-linux-arm64-gnu': 0.6.4
-      '@ignored/edr-optimism-linux-arm64-musl': 0.6.4
-      '@ignored/edr-optimism-linux-x64-gnu': 0.6.4
-      '@ignored/edr-optimism-linux-x64-musl': 0.6.4
-      '@ignored/edr-optimism-win32-x64-msvc': 0.6.4
+      '@ignored/edr-optimism-darwin-arm64': 0.6.5-alpha.0
+      '@ignored/edr-optimism-darwin-x64': 0.6.5-alpha.0
+      '@ignored/edr-optimism-linux-arm64-gnu': 0.6.5-alpha.0
+      '@ignored/edr-optimism-linux-arm64-musl': 0.6.5-alpha.0
+      '@ignored/edr-optimism-linux-x64-gnu': 0.6.5-alpha.0
+      '@ignored/edr-optimism-linux-x64-musl': 0.6.5-alpha.0
+      '@ignored/edr-optimism-win32-x64-msvc': 0.6.5-alpha.0
 
-  '@ignored/edr-win32-x64-msvc@0.6.4-alpha.1':
+  '@ignored/edr-win32-x64-msvc@0.6.4-alpha.2':
     optional: true
 
-  '@ignored/edr@0.6.4-alpha.1':
+  '@ignored/edr@0.6.4-alpha.2':
     optionalDependencies:
-      '@ignored/edr-darwin-arm64': 0.6.4-alpha.1
-      '@ignored/edr-darwin-x64': 0.6.4-alpha.1
-      '@ignored/edr-linux-arm64-gnu': 0.6.4-alpha.1
-      '@ignored/edr-linux-arm64-musl': 0.6.4-alpha.1
-      '@ignored/edr-linux-x64-gnu': 0.6.4-alpha.1
-      '@ignored/edr-linux-x64-musl': 0.6.4-alpha.1
-      '@ignored/edr-win32-x64-msvc': 0.6.4-alpha.1
+      '@ignored/edr-darwin-arm64': 0.6.4-alpha.2
+      '@ignored/edr-darwin-x64': 0.6.4-alpha.2
+      '@ignored/edr-linux-arm64-gnu': 0.6.4-alpha.2
+      '@ignored/edr-linux-arm64-musl': 0.6.4-alpha.2
+      '@ignored/edr-linux-x64-gnu': 0.6.4-alpha.2
+      '@ignored/edr-linux-x64-musl': 0.6.4-alpha.2
+      '@ignored/edr-win32-x64-msvc': 0.6.4-alpha.2
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/v-next/example-project/contracts/Counter.t.sol
+++ b/v-next/example-project/contracts/Counter.t.sol
@@ -21,9 +21,9 @@ contract CounterTest {
     require(counter.x() == x, "Value after calling inc x times should be x");
   }
 
-  function invariant() public pure {
-    assert(true);
-  }
+  // function invariant() public pure {
+  //   assert(true);
+  // }
 }
 
 contract FailingCounterTest {
@@ -47,7 +47,7 @@ contract FailingCounterTest {
     );
   }
 
-  function invariant() public pure {
-    assert(false);
-  }
+  // function invariant() public pure {
+  //   assert(false);
+  // }
 }

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -126,6 +126,19 @@ const config: HardhatUserConfig = {
         jsonRpcUrl: "https://mainnet.optimism.io",
       },
     },
+    opSepolia: {
+      type: "http",
+      chainType: "optimism",
+      url: "https://sepolia.optimism.io",
+      accounts: [configVariable("OP_SEPOLIA_SENDER")],
+    },
+    edrOpSepolia: {
+      type: "edr",
+      chainType: "optimism",
+      forkConfig: {
+        jsonRpcUrl: "https://sepolia.optimism.io",
+      },
+    },
   },
   tasks: [
     exampleTaskOverride,

--- a/v-next/example-project/scripts/send-op-tx-viem.ts
+++ b/v-next/example-project/scripts/send-op-tx-viem.ts
@@ -46,8 +46,8 @@ async function sendL2Transaction(networkConfigName: string) {
   console.log("Transaction receipt:", receipt);
 }
 
-await sendL2Transaction("op");
+await sendL2Transaction("opSepolia");
 console.log("");
 console.log("");
 console.log("");
-await sendL2Transaction("edrOp");
+await sendL2Transaction("edrOpSepolia");

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -82,8 +82,8 @@
     "typescript-eslint": "7.7.1"
   },
   "dependencies": {
-    "@ignored/edr": "0.6.4-alpha.1",
-    "@ignored/edr-optimism": "^0.6.4",
+    "@ignored/edr": "0.6.4-alpha.2",
+    "@ignored/edr-optimism": "0.6.5-alpha.0",
     "@ignored/hardhat-vnext-errors": "workspace:^3.0.0-next.14",
     "@ignored/hardhat-vnext-utils": "workspace:^3.0.0-next.14",
     "@ignored/hardhat-vnext-zod-utils": "workspace:^3.0.0-next.14",

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -5,7 +5,6 @@ import type {
   SolidityStackTrace,
   SolidityStackTraceEntry,
   SourceReference,
-  StackTraceEntryType,
 } from "./solidity-stack-trace.js";
 
 import { ReturnData } from "@ignored/edr-optimism";
@@ -13,6 +12,7 @@ import { bytesToHexString } from "@ignored/hardhat-vnext-utils/bytes";
 
 import { panicErrorCodeToMessage } from "./panic-errors.js";
 import {
+  StackTraceEntryType,
   CONSTRUCTOR_FUNCTION_NAME,
   PRECOMPILE_FUNCTION_NAME,
   UNKNOWN_FUNCTION_NAME,
@@ -64,35 +64,31 @@ export function encodeSolidityStackTrace(
   return solidityError;
 }
 
-// TODO: using numbers casted to the enum types is a hack to workaround
-// "Cannot access ambient const enums when 'isolatedModules' is enabled."
-// error. We should fix this properly by exporting the values as constants
-// from the EDR package.
 function encodeStackTraceEntry(
   stackTraceEntry: SolidityStackTraceEntry,
 ): SolidityCallSite {
   switch (stackTraceEntry.type) {
-    case 11 as StackTraceEntryType.UNRECOGNIZED_FUNCTION_WITHOUT_FALLBACK_ERROR:
-    case 12 as StackTraceEntryType.MISSING_FALLBACK_OR_RECEIVE_ERROR:
+    case StackTraceEntryType.UNRECOGNIZED_FUNCTION_WITHOUT_FALLBACK_ERROR:
+    case StackTraceEntryType.MISSING_FALLBACK_OR_RECEIVE_ERROR:
       return sourceReferenceToSolidityCallsite({
         ...stackTraceEntry.sourceReference,
         function: UNRECOGNIZED_FUNCTION_NAME,
       });
 
-    case 0 as StackTraceEntryType.CALLSTACK_ENTRY:
-    case 4 as StackTraceEntryType.REVERT_ERROR:
-    case 6 as StackTraceEntryType.CUSTOM_ERROR:
-    case 7 as StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR:
-    case 8 as StackTraceEntryType.INVALID_PARAMS_ERROR:
-    case 9 as StackTraceEntryType.FALLBACK_NOT_PAYABLE_ERROR:
-    case 10 as StackTraceEntryType.FALLBACK_NOT_PAYABLE_AND_NO_RECEIVE_ERROR:
-    case 13 as StackTraceEntryType.RETURNDATA_SIZE_ERROR:
-    case 14 as StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR:
-    case 15 as StackTraceEntryType.CALL_FAILED_ERROR:
-    case 16 as StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR:
+    case StackTraceEntryType.CALLSTACK_ENTRY:
+    case StackTraceEntryType.REVERT_ERROR:
+    case StackTraceEntryType.CUSTOM_ERROR:
+    case StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR:
+    case StackTraceEntryType.INVALID_PARAMS_ERROR:
+    case StackTraceEntryType.FALLBACK_NOT_PAYABLE_ERROR:
+    case StackTraceEntryType.FALLBACK_NOT_PAYABLE_AND_NO_RECEIVE_ERROR:
+    case StackTraceEntryType.RETURNDATA_SIZE_ERROR:
+    case StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR:
+    case StackTraceEntryType.CALL_FAILED_ERROR:
+    case StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR:
       return sourceReferenceToSolidityCallsite(stackTraceEntry.sourceReference);
 
-    case 1 as StackTraceEntryType.UNRECOGNIZED_CREATE_CALLSTACK_ENTRY:
+    case StackTraceEntryType.UNRECOGNIZED_CREATE_CALLSTACK_ENTRY:
       return new SolidityCallSite(
         undefined,
         UNRECOGNIZED_CONTRACT_NAME,
@@ -100,7 +96,7 @@ function encodeStackTraceEntry(
         undefined,
       );
 
-    case 2 as StackTraceEntryType.UNRECOGNIZED_CONTRACT_CALLSTACK_ENTRY:
+    case StackTraceEntryType.UNRECOGNIZED_CONTRACT_CALLSTACK_ENTRY:
       return new SolidityCallSite(
         bytesToHexString(stackTraceEntry.address),
         UNRECOGNIZED_CONTRACT_NAME,
@@ -108,7 +104,7 @@ function encodeStackTraceEntry(
         undefined,
       );
 
-    case 3 as StackTraceEntryType.PRECOMPILE_ERROR:
+    case StackTraceEntryType.PRECOMPILE_ERROR:
       return new SolidityCallSite(
         undefined,
         `<PrecompileContract ${stackTraceEntry.precompile}>`,
@@ -116,7 +112,7 @@ function encodeStackTraceEntry(
         undefined,
       );
 
-    case 17 as StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR:
+    case StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR:
       return new SolidityCallSite(
         undefined,
         UNRECOGNIZED_CONTRACT_NAME,
@@ -124,7 +120,7 @@ function encodeStackTraceEntry(
         undefined,
       );
 
-    case 18 as StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR:
+    case StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR:
       return new SolidityCallSite(
         bytesToHexString(stackTraceEntry.address),
         UNRECOGNIZED_CONTRACT_NAME,
@@ -132,14 +128,14 @@ function encodeStackTraceEntry(
         undefined,
       );
 
-    case 22 as StackTraceEntryType.INTERNAL_FUNCTION_CALLSTACK_ENTRY:
+    case StackTraceEntryType.INTERNAL_FUNCTION_CALLSTACK_ENTRY:
       return new SolidityCallSite(
         stackTraceEntry.sourceReference.sourceName,
         stackTraceEntry.sourceReference.contract,
         `internal@${stackTraceEntry.pc}`,
         undefined,
       );
-    case 23 as StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR:
+    case StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR:
       if (stackTraceEntry.sourceReference !== undefined) {
         return sourceReferenceToSolidityCallsite(
           stackTraceEntry.sourceReference,
@@ -153,10 +149,10 @@ function encodeStackTraceEntry(
         undefined,
       );
 
-    case 19 as StackTraceEntryType.OTHER_EXECUTION_ERROR:
-    case 21 as StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR:
-    case 5 as StackTraceEntryType.PANIC_ERROR:
-    case 20 as StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR:
+    case StackTraceEntryType.OTHER_EXECUTION_ERROR:
+    case StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR:
+    case StackTraceEntryType.PANIC_ERROR:
+    case StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR:
       if (stackTraceEntry.sourceReference === undefined) {
         return new SolidityCallSite(
           undefined,
@@ -183,56 +179,52 @@ function sourceReferenceToSolidityCallsite(
   );
 }
 
-// TODO: using numbers casted to the enum types is a hack to workaround
-// "Cannot access ambient const enums when 'isolatedModules' is enabled."
-// error. We should fix this properly by exporting the values as constants
-// from the EDR package.
 function getMessageFromLastStackTraceEntry(
   stackTraceEntry: SolidityStackTraceEntry,
 ): string | undefined {
   // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- TODO: We should cover all cases
   switch (stackTraceEntry.type) {
-    case 3 as StackTraceEntryType.PRECOMPILE_ERROR:
+    case StackTraceEntryType.PRECOMPILE_ERROR:
       return `Transaction reverted: call to precompile ${stackTraceEntry.precompile} failed`;
 
-    case 7 as StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR:
+    case StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR:
       return `Transaction reverted: non-payable function was called with value ${stackTraceEntry.value.toString(
         10,
       )}`;
 
-    case 8 as StackTraceEntryType.INVALID_PARAMS_ERROR:
+    case StackTraceEntryType.INVALID_PARAMS_ERROR:
       return `Transaction reverted: function was called with incorrect parameters`;
 
-    case 9 as StackTraceEntryType.FALLBACK_NOT_PAYABLE_ERROR:
+    case StackTraceEntryType.FALLBACK_NOT_PAYABLE_ERROR:
       return `Transaction reverted: fallback function is not payable and was called with value ${stackTraceEntry.value.toString(
         10,
       )}`;
 
-    case 10 as StackTraceEntryType.FALLBACK_NOT_PAYABLE_AND_NO_RECEIVE_ERROR:
+    case StackTraceEntryType.FALLBACK_NOT_PAYABLE_AND_NO_RECEIVE_ERROR:
       return `Transaction reverted: there's no receive function, fallback function is not payable and was called with value ${stackTraceEntry.value.toString(
         10,
       )}`;
 
-    case 11 as StackTraceEntryType.UNRECOGNIZED_FUNCTION_WITHOUT_FALLBACK_ERROR:
+    case StackTraceEntryType.UNRECOGNIZED_FUNCTION_WITHOUT_FALLBACK_ERROR:
       return `Transaction reverted: function selector was not recognized and there's no fallback function`;
 
-    case 12 as StackTraceEntryType.MISSING_FALLBACK_OR_RECEIVE_ERROR:
+    case StackTraceEntryType.MISSING_FALLBACK_OR_RECEIVE_ERROR:
       return `Transaction reverted: function selector was not recognized and there's no fallback nor receive function`;
 
-    case 13 as StackTraceEntryType.RETURNDATA_SIZE_ERROR:
+    case StackTraceEntryType.RETURNDATA_SIZE_ERROR:
       return `Transaction reverted: function returned an unexpected amount of data`;
 
-    case 14 as StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR:
+    case StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR:
       return `Transaction reverted: function call to a non-contract account`;
 
-    case 15 as StackTraceEntryType.CALL_FAILED_ERROR:
+    case StackTraceEntryType.CALL_FAILED_ERROR:
       return `Transaction reverted: function call failed to execute`;
 
-    case 16 as StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR:
+    case StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR:
       return `Transaction reverted: library was called directly`;
 
-    case 17 as StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR:
-    case 18 as StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR: {
+    case StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR:
+    case StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR: {
       const returnData = new ReturnData(stackTraceEntry.returnData);
       if (returnData.isErrorReturnData()) {
         return `VM Exception while processing transaction: reverted with reason string '${returnData.decodeError()}'`;
@@ -256,7 +248,7 @@ function getMessageFromLastStackTraceEntry(
       return "Transaction reverted without a reason string";
     }
 
-    case 4 as StackTraceEntryType.REVERT_ERROR: {
+    case StackTraceEntryType.REVERT_ERROR: {
       const returnData = new ReturnData(stackTraceEntry.returnData);
       if (returnData.isErrorReturnData()) {
         return `VM Exception while processing transaction: reverted with reason string '${returnData.decodeError()}'`;
@@ -269,24 +261,24 @@ function getMessageFromLastStackTraceEntry(
       return "Transaction reverted without a reason string";
     }
 
-    case 5 as StackTraceEntryType.PANIC_ERROR:
+    case StackTraceEntryType.PANIC_ERROR:
       const panicMessage = panicErrorCodeToMessage(stackTraceEntry.errorCode);
       return `VM Exception while processing transaction: ${panicMessage}`;
 
-    case 6 as StackTraceEntryType.CUSTOM_ERROR:
+    case StackTraceEntryType.CUSTOM_ERROR:
       return `VM Exception while processing transaction: ${stackTraceEntry.message}`;
 
-    case 19 as StackTraceEntryType.OTHER_EXECUTION_ERROR:
+    case StackTraceEntryType.OTHER_EXECUTION_ERROR:
       // TODO: What if there was returnData?
       return `Transaction reverted and Hardhat couldn't infer the reason.`;
 
-    case 20 as StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR:
+    case StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR:
       return "Transaction reverted without a reason string and without a valid sourcemap provided by the compiler. Some line numbers may be off. We strongly recommend upgrading solc and always using revert reasons.";
 
-    case 21 as StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR:
+    case StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR:
       return "Transaction reverted: trying to deploy a contract whose code is too large";
 
-    case 23 as StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR:
+    case StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR:
       return "Transaction reverted: contract call run out of gas and made the transaction revert";
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -2,13 +2,10 @@
 import type { IntervalMiningConfig } from "../../../../../types/config.js";
 import type { MempoolOrder } from "../types/node-types.js";
 import type { RpcDebugTraceOutput, RpcStructLog } from "../types/output.js";
-import type {
-  IntervalRange,
-  DebugTraceResult,
-  MineOrdering,
-} from "@ignored/edr-optimism";
+import type { IntervalRange, DebugTraceResult } from "@ignored/edr-optimism";
 
 import {
+  MineOrdering,
   FRONTIER,
   HOMESTEAD,
   DAO_FORK,
@@ -137,22 +134,14 @@ export function ethereumjsIntervalMiningConfigToEdr(
   }
 }
 
-// TODO: returning literals casted to the type is a hack to workaround
-// "Cannot access ambient const enums when 'isolatedModules' is enabled."
-// error. We should fix this properly by exporting the values as constants
-// from the EDR package.
 export function ethereumjsMempoolOrderToEdrMineOrdering(
   mempoolOrder: MempoolOrder,
 ): MineOrdering {
   switch (mempoolOrder) {
     case "fifo":
-      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      -- Casting is required here as we are returning a literal */
-      return "Fifo" as MineOrdering.Fifo;
+      return MineOrdering.Fifo;
     case "priority":
-      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      -- Casting is required here as we are returning a literal */
-      return "Priority" as MineOrdering.Priority;
+      return MineOrdering.Priority;
   }
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/runner.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/runner.ts
@@ -7,10 +7,20 @@ import type {
 
 import { Readable } from "node:stream";
 
-import { runSolidityTests } from "@ignored/edr";
+import { runSolidityTests, EdrContext } from "@ignored/edr";
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
 import { formatArtifactId } from "./formatters.js";
+
+let edrContext: EdrContext | undefined;
+
+function getEdrContext(): EdrContext {
+  if (edrContext === undefined) {
+    edrContext = new EdrContext();
+  }
+
+  return edrContext;
+}
 
 export interface RunOptions {
   /**
@@ -64,6 +74,10 @@ export function run(
           }),
         );
       }, duration);
+
+      // TODO: Just getting the context here to get it initialized, but this
+      // is not currently tied to the `runSolidityTests` function.
+      getEdrContext();
 
       runSolidityTests(
         artifacts,


### PR DESCRIPTION
This PR upgrades both versions of EDR.

* `@ignored/edr` now supports `RUST_LOG=debug`
* `@ignored/edr-optimism` can now fork OP Sepolia
* `@ignored/edr-optimism` can use a different chain id than the network it's forking