### PR TITLE
chore: update the e2e tests for latest version of pnpm

### DIFF
--- a/e2e/run-fixture-projects.sh
+++ b/e2e/run-fixture-projects.sh
@@ -13,7 +13,7 @@ echo "[e2e] Building and packing hardhat-core"
 cd ../packages/hardhat-core
 pnpm install
 pnpm build
-HARDHAT_TGZ_FILE=$(pnpm pack)
+HARDHAT_TGZ_FILE=$(pnpm pack | grep "hardhat-*.*.*.tgz")
 echo "[e2e] Built $HARDHAT_TGZ_FILE"
 cd - >/dev/null
 

--- a/e2e/test-project-initialization.sh
+++ b/e2e/test-project-initialization.sh
@@ -35,7 +35,7 @@ echo "[e2e] Building and packing hardhat-core"
 cd ../packages/hardhat-core
 pnpm install
 pnpm build
-HARDHAT_TGZ_FILE=$(pnpm pack)
+HARDHAT_TGZ_FILE=$(pnpm pack | grep "hardhat-*.*.*.tgz")
 echo "[e2e] Built $HARDHAT_TGZ_FILE"
 cd - >/dev/null
 


### PR DESCRIPTION
pnpm 13 changed the `pnpm pack` output to include the entire contents. The scripts have been modified to grep out the only information we want, the tgz file generated by the pack.
