### PR TITLE
TYPO error-handling.md

### DIFF
--- a/docs/src/content/ignition/docs/guides/error-handling.md
+++ b/docs/src/content/ignition/docs/guides/error-handling.md
@@ -1,6 +1,6 @@
 # Handling errors
 
-There are many reasons that con lead to a failure when operating a smart contract. Hardhat Ignition uses different approaches for error handling depending on the error type. This guide explains these methods thoroughly.
+There are many reasons that can lead to a failure when operating a smart contract. Hardhat Ignition uses different approaches for error handling depending on the error type. This guide explains these methods thoroughly.
 
 ## Contract errors
 


### PR DESCRIPTION
### Description
This pull request updates the `error-handling.md` documentation by fixing a typographical error. The word "can" was previously mistyped as "con" in the sentence explaining potential reasons for smart contract failures. This correction ensures clarity and maintains the quality of the documentation.

### Checklist
- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] I didn't do anything of this.
<img width="868" alt="image" src="https://github.com/user-attachments/assets/1cc5548a-f18c-4705-998a-3a889518b7ee">
