### PR TITLE
fix: propagate abort during telemetry consent enquiry

### DIFF
--- a/v-next/hardhat/src/internal/cli/prompt/prompt.ts
+++ b/v-next/hardhat/src/internal/cli/prompt/prompt.ts
@@ -35,13 +35,6 @@ export async function confirmationPromptWithTimeout(
     }
 
     return result;
-  } catch (e) {
-    if (e === "") {
-      // If the user cancels the prompt, we quit
-      return undefined;
-    }
-
-    throw e;
   } finally {
     // We can always clear the timeout, even if not set, this API is safe to
     // call with invalid values.

--- a/v-next/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
@@ -109,9 +109,16 @@ async function getTelemetryConsent(telemetryConsentFilePath?: string) {
 
   if (await exists(telemetryConsentFilePath)) {
     // Telemetry consent was already provided, hence return the answer
-    return (await readJsonFile<TelemetryConsent>(telemetryConsentFilePath))
-      .consent;
+    const consent = (
+      await readJsonFile<TelemetryConsent>(telemetryConsentFilePath)
+    ).consent;
+
+    log(`Telemetry consent value: ${consent}`);
+
+    return consent;
   }
+
+  log("No telemetry consent file found");
 
   return undefined;
 }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Resolves #5960

This PR adds more logging around telemetry consent retrieval that I found useful when debugging this issue.

It also addresses the issue itself by removing the catch block from the confirmation prompt. Before, reaching the timeout and aborting during the prompt would lead to the same result - `undefined`. Now, if a user aborts the prompt, the error that this produces will be propagated up as expected.
