### PR TITLE
Grammar Fix in Linaria Documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -186,7 +186,7 @@ Execution of `getStaticPaths` and `getStaticProps` is handled by NextJS on a bui
 
 ## Styling
 
-We utilize [Linaria](https://github.com/callstack/linaria) for styling components. It has the "Styled Components" syntax but generates css without runtime with works fine with SSG sites.
+We utilize [Linaria](https://github.com/callstack/linaria) for styling components. It has the "Styled Components" syntax but generates css without runtime which works fine with SSG sites.
 
 ## Theming
 
@@ -200,7 +200,7 @@ Landing pages don't support themes.
 
 ## Creating new landings
 
-Landing pages contains special "blocks" see src/components/landingBlocks. To create a new landing page start from copying `/pages/index.tsx` and `src/content/home.ts`. You can create another page by reordering existing blocks and passing another content to them. If necessary create new landing blocks.
+Landing pages contain special "blocks" see src/components/landingBlocks. To create a new landing page start from copying `/pages/index.tsx` and `src/content/home.ts`. You can create another page by reordering existing blocks and passing another content to them. If necessary create new landing blocks.
 
 ## CI/CD
 

--- a/docs/src/content/hardhat-runner/docs/config/index.md
+++ b/docs/src/content/hardhat-runner/docs/config/index.md
@@ -195,7 +195,7 @@ The `solidity` config is an optional field that can be one of the following:
 You can customize the different paths that Hardhat uses by providing an object to the `paths` field with the following keys:
 
 - `root`: The root of the Hardhat project. This path is resolved from `hardhat.config.js`'s directory. Default value: the directory containing the config file.
-- `sources`: The directory where your contract are stored. This path is resolved from the project's root. Default value: `'./contracts'`.
+- `sources`: The directory where your contracts are stored. This path is resolved from the project's root. Default value: `'./contracts'`.
 - `tests`: The directory where your tests are located. This path is resolved from the project's root. Default value: `'./test'`.
 
 - `cache`: The directory used by Hardhat to cache its internal stuff. This path is resolved from the project's root. Default value: `'./cache'`.

--- a/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
+++ b/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
@@ -84,7 +84,7 @@ contract DemoV2 {
 
 In addition to updating the version string, this contract also adds a `name` state variable and a `setName` function that allows us to set the value of `name`. We'll use this function later when we upgrade our proxy.
 
-Finally, we'll create a file called `Proxies.sol` to import our proxy contracts. This file will look a little different than the others:
+Finally, we'll create a file called `Proxies.sol` to import our proxy contracts. This file will look a little different from the others:
 
 ```solidity
 // SPDX-License-Identifier: UNLICENSED


### PR DESCRIPTION
1. File: docs/src/content/ignition/docs/guides/upgradeable-proxies.md
Old text: "This file will look a little different than the others"
New text: "This file will look a little different from the others"
Reason: Using "different from" is grammatically correct when comparing two things, while "different than" is incorrect in formal technical documentation.

2. File: docs/README.md
Old text: "with works fine with SSG sites"
New text: "which works fine with SSG sites"
Reason: The word "which" is the correct relative pronoun to connect the clauses and describe the functionality of Linaria's CSS generation. Using "with" was grammatically incorrect and made the sentence unclear.

Old text: "Landing pages contains"
New text: "Landing pages contain"
Reason: Fixed subject-verb agreement since "pages" is plural, the verb should be "contain" not "contains" to maintain proper grammar.

3. File:  docs/src/content/hardhat-runner/docs/config/index.md
Old text: "where your contract are stored"
New text: "where your contracts are stored"
Reason: The word needs to be plural since it refers to multiple smart contracts in the documentation context.