### PR TITLE
chore: prevent network configuration properties from being modified

### DIFF
--- a/v-next/hardhat-ethers/src/internal/hardhat-ethers-provider/hardhat-ethers-provider.ts
+++ b/v-next/hardhat-ethers/src/internal/hardhat-ethers-provider/hardhat-ethers-provider.ts
@@ -85,7 +85,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
 
   readonly #hardhatProvider: EthereumProvider;
   readonly #networkName: string;
-  readonly #networkConfig: NetworkConfig;
+  readonly #networkConfig: Readonly<NetworkConfig>;
 
   // event-emitter related fields
   #latestBlockNumberPolled: number | undefined;

--- a/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
+++ b/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
@@ -27,7 +27,7 @@ interface Link {
 export class HardhatHelpers {
   readonly #provider: HardhatEthersProvider;
   readonly #networkName: string;
-  readonly #networkConfig: NetworkConfig;
+  readonly #networkConfig: Readonly<NetworkConfig>;
   readonly #artifactManager: ArtifactsManager;
 
   constructor(

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/json-rpc-request-modifier.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/json-rpc-request-modifier.ts
@@ -35,7 +35,7 @@ import { isHttpNetworkConfig } from "./utils.js";
  */
 export class JsonRpcRequestModifier {
   readonly #provider: EthereumProvider;
-  readonly #networkConfig: NetworkConfig;
+  readonly #networkConfig: Readonly<NetworkConfig>;
 
   // accounts
   #localAccounts: LocalAccounts | undefined;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-connection.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-connection.ts
@@ -12,7 +12,7 @@ export class NetworkConnectionImplementation<
 {
   public readonly id: number;
   public readonly networkName: string;
-  public readonly networkConfig: NetworkConfig;
+  public readonly networkConfig: Readonly<NetworkConfig>;
   public readonly chainType: ChainTypeT;
 
   #provider!: EthereumProvider;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -20,7 +20,7 @@ import { isNetworkConfig, validateNetworkConfig } from "./type-validation.js";
 export class NetworkManagerImplementation {
   readonly #defaultNetwork: string;
   readonly #defaultChainType: DefaultChainType;
-  readonly #networkConfigs: Record<string, NetworkConfig>;
+  readonly #networkConfigs: Readonly<Record<string, Readonly<NetworkConfig>>>;
   readonly #hookManager: HookManager;
 
   #nextConnectionId = 0;

--- a/v-next/hardhat/src/types/network.ts
+++ b/v-next/hardhat/src/types/network.ts
@@ -53,7 +53,7 @@ export interface NetworkConnection<
 > {
   readonly id: number;
   readonly networkName: string;
-  readonly networkConfig: NetworkConfig;
+  readonly networkConfig: Readonly<NetworkConfig>;
   readonly chainType: ChainTypeT;
   readonly provider: EthereumProvider;
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Resolves #5831

As per https://nomicfoundation.slack.com/archives/C03P6B72ZHU/p1732272638933179, this PR ensures that readonly properties referencing NetworkConfig are immutable.


