### PR TITLE
chore: add piotr to issue auto-assigner

### DIFF
--- a/.github/workflows/autoassign-issues.yml
+++ b/.github/workflows/autoassign-issues.yml
@@ -15,8 +15,9 @@ jobs:
           script: |
             // each user has a chance of (p - (previousP ?? 0)) to be assigned
             const potentialAssignees = [
-              ["kanej", 1/3],
-              ["schaable", 2/3],
+              ["kanej", 1/4],
+              ["schaable", 2/4],
+              ["galargh", 3/4],
               ["ChristopherDedominici", 1.0],
             ];
 


### PR DESCRIPTION
Include @galargh in the auto-assigner for triaging of incoming GitHub issues.
