### PR TITLE
Fix typo in MetaMask error message (v2710 instead of V 2710) Update index.md

### DIFF
--- a/docs/src/content/hardhat-network/docs/metamask-issue/index.md
+++ b/docs/src/content/hardhat-network/docs/metamask-issue/index.md
@@ -8,7 +8,7 @@ prev: false
 If you are using MetaMask with Hardhat Network, you might get an error like this when you send a transaction:
 
 ```
-Incompatible EIP155-based V 2710 and chain id 31337. See the second parameter of the Transaction constructor to set the chain id.
+Incompatible EIP155-based v2710 and chain id 31337. See the second parameter of the Transaction constructor to set the chain id.
 ```
 
 This is because MetaMask mistakenly assumes all networks in `http://127.0.0.1:8545` to have a chain id of `1337`, but Hardhat uses a different number by default. **Please upvote [the MetaMask issue about it](https://github.com/MetaMask/metamask-extension/issues/10290) if you want this fixed.**


### PR DESCRIPTION
- [x] I didn't do anything of this.

---

Here’s an example of a GitHub pull request description in English for fixing the issue:

---

**Description:**

This PR addresses a small but important typo in the MetaMask error message displayed when the chain ID mismatch occurs. The current error message reads:

```
Incompatible EIP155-based V 2710 and chain id 31337.
```

The correct version should be:

```
Incompatible EIP155-based v2710 and chain id 31337.
```

**Explanation of the fix:**

The error message incorrectly uses a capital "V" followed by a space. The correct format is lowercase "v" without a space, as per the EIP-155 specification. The version number should be written as `v2710` rather than `V 2710` to follow the proper versioning convention and maintain consistency with other version references.

**Why this is important:**

While this may seem like a minor issue, maintaining proper error messages is crucial for clarity, especially for developers troubleshooting issues. Correctly displaying version information prevents confusion and ensures users have the most accurate feedback when working with MetaMask and Hardhat Network.

