### PR TITLE
fix(hardhat-foundry): config clashes condition

### DIFF
--- a/packages/hardhat-foundry/src/index.ts
+++ b/packages/hardhat-foundry/src/index.ts
@@ -66,7 +66,7 @@ extendConfig((config, userConfig) => {
     config.paths.root,
     foundryConfig.cache_path
   );
-  if (config.paths.cache === foundryCachePath) {
+  if (config.paths.cache !== foundryCachePath) {
     config.paths.cache = "cache_hardhat";
   }
 


### PR DESCRIPTION

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

https://github.com/NomicFoundation/hardhat/blob/ad3df5b78691202d399cbfc5a726de16f83dc6e7/packages/hardhat-foundry/src/index.ts#L69-L71

The code above is to solve config collision between foundry and hardhat. However, the condition will cause a weird behavior when foundry config is the same as hardhat config.

## i.e.

foundry config:
```toml
[profile.default]
cache_path = "sample_cache"
```

hardhat config:
```js
/** @type import('hardhat/config').HardhatUserConfig */
module.exports = {
  paths: {
    cache: path.resolve(__dirname, "sample_cache"),
  }
}
```

Run `hardhat compile` and the cache folder will be generated in path `{project_root}/cache_hardhat`.