### PR TITLE
Fix typos and improve documentation clarity

### DIFF
--- a/docs/src/content/hardhat-chai-matchers/docs/reference.md
+++ b/docs/src/content/hardhat-chai-matchers/docs/reference.md
@@ -259,7 +259,7 @@ expect("0x1234").to.be.properHex(4);
 
 ### `.hexEqual`
 
-Assert that the given strings hexadecimal strings correspond to the same numerical value:
+Assert that the given hexadecimal strings correspond to the same numerical value:
 
 ```ts
 expect("0x00012AB").to.hexEqual("0x12ab");

--- a/docs/src/content/hardhat-runner/docs/supporter-guides/oracles.md
+++ b/docs/src/content/hardhat-runner/docs/supporter-guides/oracles.md
@@ -210,7 +210,7 @@ main().catch((error) => {
 });
 ```
 
-Finnaly, run the deployment script by typing:
+Finally, run the deployment script by typing:
 
 ```sh
 npx hardhat run scripts/deploy.ts --network goerli

--- a/packages/hardhat-web3-v4/README.md
+++ b/packages/hardhat-web3-v4/README.md
@@ -25,7 +25,7 @@ require("@nomicfoundation/hardhat-web3-v4");
 Or, if you are using TypeScript, add this to your `hardhat.config.ts`:
 
 ```js
-import "@nomifoundation/hardhat-web3-v4";
+import "@nomicfoundation/hardhat-web3-v4";
 ```
 
 By default, contract invocations will not be typesafe. Consider installing [@chainsafe/hardhat-ts-artifact-plugin](https://www.npmjs.com/package/@chainsafe/hardhat-ts-artifact-plugin) to obtain available contract methods and events. Read more about inferring types [here](https://docs.web3js.org/guides/smart_contracts/infer_contract_types_guide/).


### PR DESCRIPTION
Changes Made
1. In docs/src/content/hardhat-chai-matchers/docs/reference.md:
- Finnaly, run the deployment script by typing:
+ Finally, run the deployment script by typing:
Reason: Removed redundant word "strings" to improve readability and grammatical correctness.

2. In docs/src/content/hardhat-runner/docs/supporter-guides/oracles.md:
- Finnaly, run the deployment script by typing:
+ Finally, run the deployment script by typing:
Reason: Fixed spelling error in the word "Finally" (correct spelling has double 'l', not double 'n').

3. In packages/hardhat-web3-v4/README.md:
- import "@nomifoundation/hardhat-web3-v4";
+ import "@nomicfoundation/hardhat-web3-v4";
Reason: Fixed incorrect package name reference. The correct organization name is "nomicfoundation" not "nomifoundation".