### PR TITLE
Network manager cleanup Pt1

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -16,6 +16,7 @@ import type {
   CompilerInput,
   CompilerOutput,
 } from "../../../../types/solidity/compiler-io.js";
+import type { JsonRpcRequestWrapperFunction } from "../network-manager.js";
 import type {
   RawTrace,
   SubscriptionEvent,
@@ -91,11 +92,6 @@ export async function getGlobalEdrContext(): Promise<EdrContext> {
 
   return _globalEdrContext;
 }
-
-export type JsonRpcRequestWrapperFunction = (
-  request: JsonRpcRequest,
-  defaultBehavior: (r: JsonRpcRequest) => Promise<JsonRpcResponse>,
-) => Promise<JsonRpcResponse>;
 
 interface EdrProviderConfig {
   networkConfig: EdrNetworkConfig;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -97,6 +97,13 @@ export type JsonRpcRequestWrapperFunction = (
   defaultBehavior: (r: JsonRpcRequest) => Promise<JsonRpcResponse>,
 ) => Promise<JsonRpcResponse>;
 
+interface EdrProviderConfig {
+  networkConfig: EdrNetworkConfig;
+  loggerConfig: LoggerConfig;
+  tracingConfig?: TracingConfig;
+  jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
+}
+
 export class EdrProvider extends EventEmitter implements EthereumProvider {
   readonly #provider: Provider;
   readonly #vmTraceDecoder: VmTraceDecoder;
@@ -107,23 +114,22 @@ export class EdrProvider extends EventEmitter implements EthereumProvider {
   #vmTracer?: VMTracerT;
   #nextRequestId = 1;
 
-  // TODO: should take an object with all the config like the HTTP provider
-  public static async create(
-    config: EdrNetworkConfig,
-    loggerConfig: LoggerConfig,
-    tracingConfig?: TracingConfig,
-    jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction,
-  ): Promise<EdrProvider> {
-    const coinbase = config.coinbase ?? DEFAULT_COINBASE;
+  public static async create({
+    networkConfig,
+    loggerConfig,
+    tracingConfig,
+    jsonRpcRequestWrapper,
+  }: EdrProviderConfig): Promise<EdrProvider> {
+    const coinbase = networkConfig.coinbase ?? DEFAULT_COINBASE;
 
     let fork;
-    if (config.forkConfig !== undefined) {
+    if (networkConfig.forkConfig !== undefined) {
       let httpHeaders: HttpHeader[] | undefined;
-      if (config.forkConfig.httpHeaders !== undefined) {
+      if (networkConfig.forkConfig.httpHeaders !== undefined) {
         httpHeaders = [];
 
         for (const [name, value] of Object.entries(
-          config.forkConfig.httpHeaders,
+          networkConfig.forkConfig.httpHeaders,
         )) {
           httpHeaders.push({
             name,
@@ -133,18 +139,18 @@ export class EdrProvider extends EventEmitter implements EthereumProvider {
       }
 
       fork = {
-        jsonRpcUrl: config.forkConfig.jsonRpcUrl,
+        jsonRpcUrl: networkConfig.forkConfig.jsonRpcUrl,
         blockNumber:
-          config.forkConfig.blockNumber !== undefined
-            ? BigInt(config.forkConfig.blockNumber)
+          networkConfig.forkConfig.blockNumber !== undefined
+            ? BigInt(networkConfig.forkConfig.blockNumber)
             : undefined,
         httpHeaders,
       };
     }
 
     const initialDate =
-      config.initialDate !== undefined
-        ? BigInt(Math.floor(config.initialDate.getTime() / 1000))
+      networkConfig.initialDate !== undefined
+        ? BigInt(Math.floor(networkConfig.initialDate.getTime() / 1000))
         : undefined;
 
     const printLineFn = loggerConfig.printLineFn ?? printLine;
@@ -152,28 +158,28 @@ export class EdrProvider extends EventEmitter implements EthereumProvider {
 
     const vmTraceDecoder = await createVmTraceDecoder();
 
-    const hardforkName = getHardforkName(config.hardfork);
+    const hardforkName = getHardforkName(networkConfig.hardfork);
 
     const context = await getGlobalEdrContext();
     const provider = await context.createProvider(
-      config.chainType === "optimism"
+      networkConfig.chainType === "optimism"
         ? OPTIMISM_CHAIN_TYPE
         : GENERIC_CHAIN_TYPE, // TODO: l1 is missing here
       {
         allowBlocksWithSameTimestamp:
-          config.allowBlocksWithSameTimestamp ?? false,
-        allowUnlimitedContractSize: config.allowUnlimitedContractSize,
-        bailOnCallFailure: config.throwOnCallFailures,
-        bailOnTransactionFailure: config.throwOnTransactionFailures,
-        blockGasLimit: BigInt(config.blockGasLimit),
-        chainId: BigInt(config.chainId),
-        chains: this.#convertToEdrChains(config.chains),
-        cacheDir: config.forkCachePath,
+          networkConfig.allowBlocksWithSameTimestamp ?? false,
+        allowUnlimitedContractSize: networkConfig.allowUnlimitedContractSize,
+        bailOnCallFailure: networkConfig.throwOnCallFailures,
+        bailOnTransactionFailure: networkConfig.throwOnTransactionFailures,
+        blockGasLimit: BigInt(networkConfig.blockGasLimit),
+        chainId: BigInt(networkConfig.chainId),
+        chains: this.#convertToEdrChains(networkConfig.chains),
+        cacheDir: networkConfig.forkCachePath,
         coinbase: Buffer.from(coinbase.slice(2), "hex"),
-        enableRip7212: config.enableRip7212,
+        enableRip7212: networkConfig.enableRip7212,
         fork,
         hardfork: ethereumsjsHardforkToEdrSpecId(hardforkName),
-        genesisAccounts: config.genesisAccounts.map((account) => {
+        genesisAccounts: networkConfig.genesisAccounts.map((account) => {
           return {
             secretKey: account.privateKey,
             balance: BigInt(account.balance),
@@ -181,18 +187,22 @@ export class EdrProvider extends EventEmitter implements EthereumProvider {
         }),
         initialDate,
         initialBaseFeePerGas:
-          config.initialBaseFeePerGas !== undefined
-            ? BigInt(config.initialBaseFeePerGas)
+          networkConfig.initialBaseFeePerGas !== undefined
+            ? BigInt(networkConfig.initialBaseFeePerGas)
             : undefined,
-        minGasPrice: config.minGasPrice,
+        minGasPrice: networkConfig.minGasPrice,
         mining: {
-          autoMine: config.automine,
-          interval: ethereumjsIntervalMiningConfigToEdr(config.intervalMining),
+          autoMine: networkConfig.automine,
+          interval: ethereumjsIntervalMiningConfigToEdr(
+            networkConfig.intervalMining,
+          ),
           memPool: {
-            order: ethereumjsMempoolOrderToEdrMineOrdering(config.mempoolOrder),
+            order: ethereumjsMempoolOrderToEdrMineOrdering(
+              networkConfig.mempoolOrder,
+            ),
           },
         },
-        networkId: BigInt(config.networkId),
+        networkId: BigInt(networkConfig.networkId),
       },
       {
         enable: loggerConfig.enabled,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -110,6 +110,9 @@ export class EdrProvider extends EventEmitter implements EthereumProvider {
   #vmTracer?: VMTracerT;
   #nextRequestId = 1;
 
+  /**
+   * Creates a new instance of `EdrProvider`.
+   */
   public static async create({
     networkConfig,
     loggerConfig = { enabled: false },
@@ -237,6 +240,13 @@ export class EdrProvider extends EventEmitter implements EthereumProvider {
     return edrProvider;
   }
 
+  /**
+   * @private
+   *
+   * This constructor is intended for internal use only.
+   * Use the static method {@link EdrProvider.create} to create an instance of
+   * `EdrProvider`.
+   */
   private constructor(
     provider: Provider,
     vmTraceDecoder: VmTraceDecoder,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -95,7 +95,7 @@ export async function getGlobalEdrContext(): Promise<EdrContext> {
 
 interface EdrProviderConfig {
   networkConfig: EdrNetworkConfig;
-  loggerConfig: LoggerConfig;
+  loggerConfig?: LoggerConfig;
   tracingConfig?: TracingConfig;
   jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
 }
@@ -112,8 +112,8 @@ export class EdrProvider extends EventEmitter implements EthereumProvider {
 
   public static async create({
     networkConfig,
-    loggerConfig,
-    tracingConfig,
+    loggerConfig = { enabled: false },
+    tracingConfig = {},
     jsonRpcRequestWrapper,
   }: EdrProviderConfig): Promise<EdrProvider> {
     const coinbase = networkConfig.coinbase ?? DEFAULT_COINBASE;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -40,7 +40,6 @@ export async function extendUserConfig(
   const networks: Record<string, NetworkUserConfig> =
     extendedConfig.networks ?? {};
 
-  // TODO: we should address this casting when edr is implemented
   const localhostConfig: Omit<HttpNetworkUserConfig, "url"> = {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- This is always http
     ...(networks.localhost as HttpNetworkUserConfig),

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -44,6 +44,14 @@ export type JsonRpcRequestWrapperFunction = (
   defaultBehavior: (r: JsonRpcRequest) => Promise<JsonRpcResponse>,
 ) => Promise<JsonRpcResponse>;
 
+interface HttpProviderConfig {
+  url: string;
+  networkName: string;
+  extraHeaders?: Record<string, string>;
+  timeout: number;
+  jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
+}
+
 export class HttpProvider extends EventEmitter implements EthereumProvider {
   readonly #url: string;
   readonly #networkName: string;
@@ -62,13 +70,7 @@ export class HttpProvider extends EventEmitter implements EthereumProvider {
     extraHeaders = {},
     timeout,
     jsonRpcRequestWrapper,
-  }: {
-    url: string;
-    networkName: string;
-    extraHeaders?: Record<string, string>;
-    timeout: number;
-    jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
-  }): Promise<HttpProvider> {
+  }: HttpProviderConfig): Promise<HttpProvider> {
     if (!isValidUrl(url)) {
       throw new HardhatError(HardhatError.ERRORS.NETWORK.INVALID_URL, {
         value: url,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -1,3 +1,4 @@
+import type { JsonRpcRequestWrapperFunction } from "./network-manager.js";
 import type {
   EthereumProvider,
   JsonRpcRequest,
@@ -38,11 +39,6 @@ import { ProviderError, LimitExceededError } from "./provider-errors.js";
 const TOO_MANY_REQUEST_STATUS = 429;
 const MAX_RETRIES = 6;
 const MAX_RETRY_WAIT_TIME_SECONDS = 5;
-
-export type JsonRpcRequestWrapperFunction = (
-  request: JsonRpcRequest,
-  defaultBehavior: (r: JsonRpcRequest) => Promise<JsonRpcResponse>,
-) => Promise<JsonRpcResponse>;
 
 interface HttpProviderConfig {
   url: string;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -46,6 +46,7 @@ interface HttpProviderConfig {
   extraHeaders?: Record<string, string>;
   timeout: number;
   jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
+  testDispatcher?: Dispatcher;
 }
 
 export class HttpProvider extends EventEmitter implements EthereumProvider {
@@ -66,6 +67,7 @@ export class HttpProvider extends EventEmitter implements EthereumProvider {
     extraHeaders = {},
     timeout,
     jsonRpcRequestWrapper,
+    testDispatcher,
   }: HttpProviderConfig): Promise<HttpProvider> {
     if (!isValidUrl(url)) {
       throw new HardhatError(HardhatError.ERRORS.NETWORK.INVALID_URL, {
@@ -73,7 +75,8 @@ export class HttpProvider extends EventEmitter implements EthereumProvider {
       });
     }
 
-    const dispatcher = await getHttpDispatcher(url, timeout);
+    const dispatcher =
+      testDispatcher ?? (await getHttpDispatcher(url, timeout));
 
     const httpProvider = new HttpProvider(
       url,
@@ -93,8 +96,7 @@ export class HttpProvider extends EventEmitter implements EthereumProvider {
    * Use the static method {@link HttpProvider.create} to create an instance of
    * `HttpProvider`.
    */
-  // TODO: make the constructor private, but we need to fix the tests first
-  constructor(
+  private constructor(
     url: string,
     networkName: string,
     extraHeaders: Record<string, string>,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -11,10 +11,7 @@ import type {
   JsonRpcResponse,
 } from "../../../types/providers.js";
 
-import {
-  assertHardhatInvariant,
-  HardhatError,
-} from "@ignored/hardhat-vnext-errors";
+import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
 import { EdrProvider } from "./edr/edr-provider.js";
 import { HttpProvider } from "./http-provider.js";
@@ -145,12 +142,6 @@ export class NetworkManagerImplementation {
     const createProvider = async (
       networkConnection: NetworkConnectionImplementation<ChainTypeT>,
     ): Promise<EthereumProvider> => {
-      assertHardhatInvariant(
-        resolvedNetworkConfig.type === "edr" ||
-          resolvedNetworkConfig.type === "http",
-        `Invalid network type ${resolvedNetworkConfig.type}`,
-      );
-
       const jsonRpcRequestWrapper: JsonRpcRequestWrapperFunction = (
         request,
         defaultBehavior,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -154,26 +154,25 @@ export class NetworkManagerImplementation {
           );
         }
 
-        return EdrProvider.create(
+        return EdrProvider.create({
           // The resolvedNetworkConfig can have its chainType set to `undefined`
           // so we default to the default chain type here.
-          {
+          networkConfig: {
             ...resolvedNetworkConfig,
             /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
             This case is safe because we have a check above */
             chainType: resolvedChainType as ChainType,
           },
-          { enabled: false },
-          {},
-          (request, defaultBehavior) => {
-            return hookManager.runHandlerChain(
+          loggerConfig: { enabled: false },
+          tracingConfig: {},
+          jsonRpcRequestWrapper: (request, defaultBehavior) =>
+            hookManager.runHandlerChain(
               "network",
               "onRequest",
               [networkConnection, request],
               async (_context, _connection, req) => defaultBehavior(req),
-            );
-          },
-        );
+            ),
+        });
       }
 
       return HttpProvider.create({

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -174,8 +174,6 @@ export class NetworkManagerImplementation {
             This case is safe because we have a check above */
             chainType: resolvedChainType as ChainType,
           },
-          loggerConfig: { enabled: false },
-          tracingConfig: {},
           jsonRpcRequestWrapper,
         });
       }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -4,6 +4,7 @@ import type {
   ChainType,
   DefaultChainType,
   NetworkConnection,
+  NetworkManager,
 } from "../../../types/network.js";
 import type {
   EthereumProvider,
@@ -23,7 +24,7 @@ export type JsonRpcRequestWrapperFunction = (
   defaultBehavior: (r: JsonRpcRequest) => Promise<JsonRpcResponse>,
 ) => Promise<JsonRpcResponse>;
 
-export class NetworkManagerImplementation {
+export class NetworkManagerImplementation implements NetworkManager {
   readonly #defaultNetwork: string;
   readonly #defaultChainType: DefaultChainType;
   readonly #networkConfigs: Record<string, NetworkConfig>;

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
@@ -1,4 +1,4 @@
-import type { JsonRpcRequestWrapperFunction } from "../../../../src/internal/builtin-plugins/network-manager/http-provider.js";
+import type { JsonRpcRequestWrapperFunction } from "../../../../src/internal/builtin-plugins/network-manager/network-manager.js";
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
@@ -48,8 +48,7 @@ describe("http-provider", () => {
 
   /**
    * To test the HttpProvider#request method, we need to use an interceptor to
-   * mock the network requests. As the HttpProvider.create does not allow to
-   * pass a custom dispatcher, we use the constructor directly.
+   * mock the network requests.
    */
   describe("HttpProvider#request", async () => {
     const interceptor = await initializeTestDispatcher();
@@ -78,12 +77,12 @@ describe("http-provider", () => {
         })
         .reply(200, jsonRpcResponse);
 
-      const provider = new HttpProvider(
-        "http://localhost",
-        "exampleNetwork",
-        {},
-        interceptor,
-      );
+      const provider = await HttpProvider.create({
+        url: "http://localhost",
+        networkName: "exampleNetwork",
+        timeout: 20_000,
+        testDispatcher: interceptor,
+      });
 
       const result = await provider.request({
         method: "eth_chainId",
@@ -94,12 +93,12 @@ describe("http-provider", () => {
     });
 
     it("should throw if the params are an object", async () => {
-      const provider = new HttpProvider(
-        "http://localhost",
-        "exampleNetwork",
-        {},
-        interceptor,
-      );
+      const provider = await HttpProvider.create({
+        url: "http://localhost",
+        networkName: "exampleNetwork",
+        timeout: 20_000,
+        testDispatcher: interceptor,
+      });
 
       await assertRejectsWithHardhatError(
         provider.request({
@@ -161,12 +160,12 @@ describe("http-provider", () => {
         })
         .reply(200, jsonRpcResponse);
 
-      const provider = new HttpProvider(
-        "http://localhost",
-        "exampleNetwork",
-        {},
-        interceptor,
-      );
+      const provider = await HttpProvider.create({
+        url: "http://localhost",
+        networkName: "exampleNetwork",
+        timeout: 20_000,
+        testDispatcher: interceptor,
+      });
 
       const result = await provider.request({
         method: "eth_chainId",
@@ -202,12 +201,12 @@ describe("http-provider", () => {
         })
         .reply(200, jsonRpcResponse);
 
-      const provider = new HttpProvider(
-        "http://localhost",
-        "exampleNetwork",
-        {},
-        interceptor,
-      );
+      const provider = await HttpProvider.create({
+        url: "http://localhost",
+        networkName: "exampleNetwork",
+        timeout: 20_000,
+        testDispatcher: interceptor,
+      });
 
       const result = await provider.request({
         method: "eth_chainId",
@@ -238,12 +237,12 @@ describe("http-provider", () => {
           .reply(429);
       }
 
-      const provider = new HttpProvider(
-        "http://localhost",
-        "exampleNetwork",
-        {},
-        interceptor,
-      );
+      const provider = await HttpProvider.create({
+        url: "http://localhost",
+        networkName: "exampleNetwork",
+        timeout: 20_000,
+        testDispatcher: interceptor,
+      });
 
       try {
         await provider.request({
@@ -276,12 +275,12 @@ describe("http-provider", () => {
         .defaultReplyHeaders({ "retry-after": "6" })
         .reply(429);
 
-      const provider = new HttpProvider(
-        "http://localhost",
-        "exampleNetwork",
-        {},
-        interceptor,
-      );
+      const provider = await HttpProvider.create({
+        url: "http://localhost",
+        networkName: "exampleNetwork",
+        timeout: 20_000,
+        testDispatcher: interceptor,
+      });
 
       try {
         await provider.request({
@@ -316,12 +315,12 @@ describe("http-provider", () => {
         })
         .reply(200, invalidResponse);
 
-      const provider = new HttpProvider(
-        "http://localhost",
-        "exampleNetwork",
-        {},
-        interceptor,
-      );
+      const provider = await HttpProvider.create({
+        url: "http://localhost",
+        networkName: "exampleNetwork",
+        timeout: 20_000,
+        testDispatcher: interceptor,
+      });
 
       await assertRejectsWithHardhatError(
         provider.request({
@@ -361,12 +360,12 @@ describe("http-provider", () => {
         })
         .reply(200, jsonRpcResponse);
 
-      const provider = new HttpProvider(
-        "http://localhost",
-        "exampleNetwork",
-        {},
-        interceptor,
-      );
+      const provider = await HttpProvider.create({
+        url: "http://localhost",
+        networkName: "exampleNetwork",
+        timeout: 20_000,
+        testDispatcher: interceptor,
+      });
 
       try {
         await provider.request({
@@ -434,13 +433,13 @@ describe("http-provider", () => {
         }
       };
 
-      const provider = new HttpProvider(
-        "http://localhost",
-        "exampleNetwork",
-        {},
-        interceptor,
+      const provider = await HttpProvider.create({
+        url: "http://localhost",
+        networkName: "exampleNetwork",
+        timeout: 20_000,
         jsonRpcRequestWrapper,
-      );
+        testDispatcher: interceptor,
+      });
 
       // eth_chainId is handled by the wrapper and returns the hardhat chain ID
       // instead of jsonRpcChainIdResponse.result


### PR DESCRIPTION
### PR Description:
This PR addresses several TODOs in the network manager and refactors interfaces for improved clarity and consistency. **Key changes include:**

- **Clarity and consistency between provider types:**
  - Pass a configuration object to the `EdrProvider`.
  - Extract `HttpProvider.create` parameter types into an interface.
  - Set default values for `loggerConfig` and `tracingConfig`.
  - Make the `HttpProvider` constructor private and update tests accordingly. An optional `testDispatcher` is now passed to the `HttpProvider.create` function to facilitate this change.

- **Refactored `jsonRpcRequestWrapper`:**
  - Eliminated duplication by moving the type definition to `NetworkManager`.
  - Defined the function in `NetworkManager` before passing it to the providers.

- **Code cleanup in `NetworkManager`:**
  - Removed unneeded type assertion.