### PR TITLE
chore: require readonly properties to be immutable

### DIFF
--- a/config-v-next/eslint.cjs
+++ b/config-v-next/eslint.cjs
@@ -42,8 +42,11 @@ function createConfig(
       "no-only-tests",
       "@typescript-eslint",
       "@eslint-community/eslint-comments",
+      "@galargh/immutable-readonly",
     ],
     rules: {
+      "@galargh/immutable-readonly/no-type-annotation": "error",
+      "@galargh/immutable-readonly/no-readonly-wrapper": "error",
       "@eslint-community/eslint-comments/require-description": [
         "error",
         { ignore: ["eslint-enable"] },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1534,6 +1534,9 @@ importers:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: ^4.3.0
         version: 4.4.1(eslint@8.57.0)
+      '@galargh/eslint-plugin-immutable-readonly':
+        specifier: 1.0.0
+        version: 1.0.0(eslint@8.57.0)(typescript@5.5.4)
       '@ignored/hardhat-vnext-node-test-reporter':
         specifier: workspace:^3.0.0-next.15
         version: link:../hardhat-node-test-reporter
@@ -2903,6 +2906,9 @@ packages:
     resolution: {integrity: sha512-bT/BSy8MJThrTebqTCjXRnGSgZWthHLigZ4k2AvfNtC79vPyBS1myaxw8gRU6RxIcdDD3HBtm7pOsOoyC086Zg==}
     engines: {node: '>=10'}
 
+  '@galargh/eslint-plugin-immutable-readonly@1.0.0':
+    resolution: {integrity: sha512-5cDkb69bPjrFztFBsNw1DxLl0cD8sJMjJeqkFg8usUcn7S+XbbaMqi2sMa0eQLZEK2qWcZoR1fMKmtSPP7ZhHA==, tarball: https://npm.pkg.github.com/download/@galargh/eslint-plugin-immutable-readonly/1.0.0/17359c9ebc3bc85dbabaf833d7c75454f6e9bf39}
+
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -3562,6 +3568,10 @@ packages:
     resolution: {integrity: sha512-PytBif2SF+9SpEUKynYn5g1RHFddJUcyynGpztX3l/ik7KmZEv19WCMhUBkHXPU9es/VWGD3/zg3wg90+Dh2rA==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
+  '@typescript-eslint/scope-manager@8.16.0':
+    resolution: {integrity: sha512-mwsZWubQvBki2t5565uxF0EYvG+FwdFb8bMtDuGQLdCCnGPrDEDvm1gtfynuKlnpzeBRqdFCkMf9jg1fnAK8sg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/type-utils@5.61.0':
     resolution: {integrity: sha512-kk8u//r+oVK2Aj3ph/26XdH0pbAkC2RiSjUYhKD+PExemG4XSjpGFeyZ/QM8lBOa7O8aGOU+/yEbMJgQv/DnCg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3608,6 +3618,10 @@ packages:
     resolution: {integrity: sha512-AmPmnGW1ZLTpWa+/2omPrPfR7BcbUU4oha5VIbSbS1a1Tv966bklvLNXxp3mrbc+P2j4MNOTfDffNsk4o0c6/w==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
+  '@typescript-eslint/types@8.16.0':
+    resolution: {integrity: sha512-NzrHj6thBAOSE4d9bsuRNMvk+BvaQvmY4dDglgkgGC0EW/tB3Kelnp3tAKH87GEwzoxgeQn9fNGRyFJM/xd+GQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@5.61.0':
     resolution: {integrity: sha512-Fud90PxONnnLZ36oR5ClJBLTLfU4pIWBmnvGwTbEa2cXIqj70AEDEmOmpkFComjBZ/037ueKrOdHuYmSFVD7Rw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3644,6 +3658,15 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.16.0':
+    resolution: {integrity: sha512-E2+9IzzXMc1iaBy9zmo+UYvluE3TW7bCGWSF41hVWUE01o8nzr1rvOQYSxelxr6StUvRcTMe633eY8mXASMaNw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/utils@5.61.0':
     resolution: {integrity: sha512-mV6O+6VgQmVE6+xzlA91xifndPW9ElFW8vbSF0xCT/czPXVhwDewKila1jOyRwa9AE19zKnrr7Cg5S3pJVrTWQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3668,6 +3691,16 @@ packages:
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@8.16.0':
+    resolution: {integrity: sha512-C1zRy/mOL8Pj157GiX4kaw7iyRLKfJXBR3L82hk5kS/GyHcOFmy4YUq/zfZti72I9wnuQtA/+xzft4wCC8PJdA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/visitor-keys@5.61.0':
     resolution: {integrity: sha512-50XQ5VdbWrX06mQXhy93WywSFZZGsv3EOjq+lqp6WC2t+j3mb6A9xYVdrRxafvK88vg9k9u+CT4l6D8PEatjKg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3683,6 +3716,10 @@ packages:
   '@typescript-eslint/visitor-keys@7.7.1':
     resolution: {integrity: sha512-gBL3Eq25uADw1LQ9kVpf3hRM+DWzs0uZknHYK3hq4jcTPqVCClHGDnB6UUUV2SFeBeA4KWHWbbLqmbGcZ4FYbw==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@8.16.0':
+    resolution: {integrity: sha512-pq19gbaMOmFE3CbL0ZB8J8BFCo2ckfHBfaIsaOZgBIF4EoISJIdLX5xRhd0FGB0LlHReNRuzoJoMGpTjq8F2CQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -4597,6 +4634,10 @@ packages:
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.0:
+    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
@@ -7560,6 +7601,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@galargh/eslint-plugin-immutable-readonly@1.0.0(eslint@8.57.0)(typescript@5.5.4)':
+    dependencies:
+      '@typescript-eslint/utils': 8.16.0(eslint@8.57.0)(typescript@5.5.4)
+      debug: 4.3.7(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -8364,6 +8414,11 @@ snapshots:
       '@typescript-eslint/types': 7.7.1
       '@typescript-eslint/visitor-keys': 7.7.1
 
+  '@typescript-eslint/scope-manager@8.16.0':
+    dependencies:
+      '@typescript-eslint/types': 8.16.0
+      '@typescript-eslint/visitor-keys': 8.16.0
+
   '@typescript-eslint/type-utils@5.61.0(eslint@8.57.0)(typescript@5.0.4)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.61.0(typescript@5.0.4)
@@ -8407,6 +8462,8 @@ snapshots:
   '@typescript-eslint/types@7.18.0': {}
 
   '@typescript-eslint/types@7.7.1': {}
+
+  '@typescript-eslint/types@8.16.0': {}
 
   '@typescript-eslint/typescript-estree@5.61.0(typescript@5.0.4)':
     dependencies:
@@ -8457,6 +8514,21 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.7.1
       debug: 4.3.7(supports-color@8.1.1)
       globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 1.3.0(typescript@5.5.4)
+    optionalDependencies:
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.16.0(typescript@5.5.4)':
+    dependencies:
+      '@typescript-eslint/types': 8.16.0
+      '@typescript-eslint/visitor-keys': 8.16.0
+      debug: 4.3.7(supports-color@8.1.1)
+      fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
@@ -8521,6 +8593,18 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@8.16.0(eslint@8.57.0)(typescript@5.5.4)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 8.16.0
+      '@typescript-eslint/types': 8.16.0
+      '@typescript-eslint/typescript-estree': 8.16.0(typescript@5.5.4)
+      eslint: 8.57.0
+    optionalDependencies:
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@5.61.0':
     dependencies:
       '@typescript-eslint/types': 5.61.0
@@ -8540,6 +8624,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.7.1
       eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.16.0':
+    dependencies:
+      '@typescript-eslint/types': 8.16.0
+      eslint-visitor-keys: 4.2.0
 
   '@ungap/structured-clone@1.2.0': {}
 
@@ -9594,6 +9683,8 @@ snapshots:
   eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.0: {}
 
   eslint@8.57.0:
     dependencies:

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -62,6 +62,7 @@
   ],
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
+    "@galargh/eslint-plugin-immutable-readonly": "1.0.0",
     "@ignored/hardhat-vnext-node-test-reporter": "workspace:^3.0.0-next.15",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/adm-zip": "^0.5.5",

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -98,9 +98,9 @@ export type JsonRpcRequestWrapperFunction = (
 ) => Promise<JsonRpcResponse>;
 
 export class EdrProvider extends EventEmitter implements EthereumProvider {
-  readonly #provider: Provider;
-  readonly #vmTraceDecoder: VmTraceDecoder;
-  readonly #jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
+  readonly #provider: Readonly<Provider>;
+  readonly #vmTraceDecoder: Readonly<VmTraceDecoder>;
+  readonly #jsonRpcRequestWrapper?: Readonly<JsonRpcRequestWrapperFunction>;
 
   #failedStackTraces: number = 0;
   /** Used for internal stack trace tests. */

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -100,7 +100,8 @@ export type JsonRpcRequestWrapperFunction = (
 export class EdrProvider extends EventEmitter implements EthereumProvider {
   readonly #provider: Readonly<Provider>;
   readonly #vmTraceDecoder: Readonly<VmTraceDecoder>;
-  readonly #jsonRpcRequestWrapper?: Readonly<JsonRpcRequestWrapperFunction>;
+  // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We shouldn't wrap the function type in a readonly wrapper
+  readonly #jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
 
   #failedStackTraces: number = 0;
   /** Used for internal stack trace tests. */

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/errors.ts
@@ -36,8 +36,8 @@ export class ProviderError extends CustomError implements ProviderRpcError {
   public code: number;
   public data?: unknown;
 
-  public readonly _parent?: Error;
-  readonly #isProviderError;
+  public readonly _parent?: Readonly<Error>;
+  readonly #isProviderError: boolean;
 
   constructor(message: string, code: number, parent?: Error) {
     super(message, parent);
@@ -49,7 +49,7 @@ export class ProviderError extends CustomError implements ProviderRpcError {
 }
 
 export class InvalidJsonInputError extends ProviderError {
-  public static readonly CODE = -32700;
+  public static readonly CODE: number = -32700;
 
   constructor(message: string, parent?: Error) {
     super(message, InvalidJsonInputError.CODE, parent);
@@ -57,7 +57,7 @@ export class InvalidJsonInputError extends ProviderError {
 }
 
 export class InvalidRequestError extends ProviderError {
-  public static readonly CODE = -32600;
+  public static readonly CODE: number = -32600;
 
   constructor(message: string, parent?: Error) {
     super(message, InvalidRequestError.CODE, parent);
@@ -65,7 +65,7 @@ export class InvalidRequestError extends ProviderError {
 }
 
 export class MethodNotFoundError extends ProviderError {
-  public static readonly CODE = -32601;
+  public static readonly CODE: number = -32601;
 
   constructor(message: string, parent?: Error) {
     super(message, MethodNotFoundError.CODE, parent);
@@ -73,7 +73,7 @@ export class MethodNotFoundError extends ProviderError {
 }
 
 export class InvalidArgumentsError extends ProviderError {
-  public static readonly CODE = -32602;
+  public static readonly CODE: number = -32602;
 
   constructor(message: string, parent?: Error) {
     super(message, InvalidArgumentsError.CODE, parent);
@@ -81,7 +81,7 @@ export class InvalidArgumentsError extends ProviderError {
 }
 
 export class InternalError extends ProviderError {
-  public static readonly CODE = -32603;
+  public static readonly CODE: number = -32603;
 
   constructor(message: string, parent?: Error) {
     super(message, InternalError.CODE, parent);
@@ -89,7 +89,7 @@ export class InternalError extends ProviderError {
 }
 
 export class InvalidInputError extends ProviderError {
-  public static readonly CODE = -32000;
+  public static readonly CODE: number = -32000;
 
   constructor(message: string, parent?: Error) {
     super(message, InvalidInputError.CODE, parent);
@@ -97,7 +97,7 @@ export class InvalidInputError extends ProviderError {
 }
 
 export class TransactionExecutionError extends ProviderError {
-  public static readonly CODE = -32003;
+  public static readonly CODE: number = -32003;
 
   // TODO: This should have the transaction id
   // TODO: Normalize this constructor
@@ -111,7 +111,7 @@ export class TransactionExecutionError extends ProviderError {
 }
 
 export class MethodNotSupportedError extends ProviderError {
-  public static readonly CODE = -32004;
+  public static readonly CODE: number = -32004;
 
   constructor(method: string, parent?: Error) {
     super(
@@ -123,7 +123,7 @@ export class MethodNotSupportedError extends ProviderError {
 }
 
 export class InvalidResponseError extends ProviderError {
-  public static readonly CODE = -32999;
+  public static readonly CODE: number = -32999;
 
   constructor(message: string, parent?: Error) {
     super(message, InvalidResponseError.CODE, parent);

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -290,7 +290,7 @@ function getMessageFromLastStackTraceEntry(
 //   use the code property to detect if they are dealing with a JSON-RPC error,
 //   and take control of errors.
 export class SolidityError extends Error {
-  public readonly stackTrace: SolidityStackTrace;
+  public readonly stackTrace: Readonly<SolidityStackTrace>;
 
   constructor(message: string, stackTrace: SolidityStackTrace) {
     super(message);

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -47,9 +47,9 @@ export type JsonRpcRequestWrapperFunction = (
 export class HttpProvider extends EventEmitter implements EthereumProvider {
   readonly #url: string;
   readonly #networkName: string;
-  readonly #extraHeaders: Record<string, string>;
-  readonly #dispatcher: Dispatcher;
-  readonly #jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
+  readonly #extraHeaders: Readonly<Record<string, string>>;
+  readonly #dispatcher: Readonly<Dispatcher>;
+  readonly #jsonRpcRequestWrapper?: Readonly<JsonRpcRequestWrapperFunction>;
 
   #nextRequestId = 1;
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -49,7 +49,8 @@ export class HttpProvider extends EventEmitter implements EthereumProvider {
   readonly #networkName: string;
   readonly #extraHeaders: Readonly<Record<string, string>>;
   readonly #dispatcher: Readonly<Dispatcher>;
-  readonly #jsonRpcRequestWrapper?: Readonly<JsonRpcRequestWrapperFunction>;
+  // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We shouldn't wrap the function type in a readonly wrapper
+  readonly #jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
 
   #nextRequestId = 1;
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/accounts/local-accounts.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/accounts/local-accounts.ts
@@ -28,7 +28,8 @@ import { validateParams } from "../../rpc/validate-params.js";
 import { ChainId } from "../chain-id/chain-id.js";
 
 export class LocalAccounts extends ChainId {
-  readonly #addressToPrivateKey: Map<string, Uint8Array> = new Map();
+  readonly #addressToPrivateKey: Readonly<Map<string, Readonly<Uint8Array>>> =
+    new Map();
 
   constructor(
     provider: EthereumProvider,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/accounts/sender.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/accounts/sender.ts
@@ -15,7 +15,7 @@ import { getRequestParams } from "../../json-rpc.js";
  * The class also provides a mechanism to retrieve the sender account, which must be implemented by subclasses.
  */
 export abstract class Sender {
-  protected readonly provider: EthereumProvider;
+  protected readonly provider: Readonly<EthereumProvider>;
 
   constructor(provider: EthereumProvider) {
     this.provider = provider;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/chain-id/chain-id.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/chain-id/chain-id.ts
@@ -13,7 +13,7 @@ import {
  * after being retrieved to avoid redundant requests.
  */
 export abstract class ChainId {
-  protected readonly provider: EthereumProvider;
+  protected readonly provider: Readonly<EthereumProvider>;
 
   #chainId: number | undefined;
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/gas-properties/automatic-gas-price.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/gas-properties/automatic-gas-price.ts
@@ -17,7 +17,7 @@ import { getRequestParams } from "../../json-rpc.js";
  * It ensures that gas prices are set correctly.
  */
 export class AutomaticGasPrice {
-  readonly #provider: EthereumProvider;
+  readonly #provider: Readonly<EthereumProvider>;
 
   // We pay the max base fee that can be required if the next
   // EIP1559_BASE_FEE_MAX_FULL_BLOCKS_PREFERENCE are full.
@@ -25,7 +25,7 @@ export class AutomaticGasPrice {
     3n;
 
   // See eth_feeHistory for an explanation of what this means
-  public static readonly EIP1559_REWARD_PERCENTILE = 50;
+  public static readonly EIP1559_REWARD_PERCENTILE: number = 50;
 
   constructor(provider: EthereumProvider) {
     this.#provider = provider;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/gas-properties/fixed-gas-price.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/gas-properties/fixed-gas-price.ts
@@ -8,7 +8,7 @@ import { getRequestParams } from "../../json-rpc.js";
  * For `eth_sendTransaction` requests, it sets the gasPrice field with the value provided via the class constructor, if it hasn't been specified already.
  */
 export class FixedGasPrice {
-  readonly #gasPrice: PrefixedHexString;
+  readonly #gasPrice: Readonly<PrefixedHexString>;
 
   constructor(gasPrice: PrefixedHexString) {
     this.#gasPrice = gasPrice;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/gas-properties/fixed-gas.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/gas-properties/fixed-gas.ts
@@ -8,7 +8,7 @@ import { getRequestParams } from "../../json-rpc.js";
  * For `eth_sendTransaction` requests, it sets the gas field with the value provided via the class constructor, if it hasn't been specified already.
  */
 export class FixedGas {
-  readonly #gas: PrefixedHexString;
+  readonly #gas: Readonly<PrefixedHexString>;
 
   constructor(gas: PrefixedHexString) {
     this.#gas = gas;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/gas-properties/multiplied-gas-estimation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/gas-properties/multiplied-gas-estimation.ts
@@ -14,7 +14,7 @@ import {
  * The block gas limit is cached after the first retrieval to optimize performance.
  */
 export abstract class MultipliedGasEstimation {
-  readonly #provider: EthereumProvider;
+  readonly #provider: Readonly<EthereumProvider>;
   readonly #gasMultiplier: number;
 
   #blockGasLimit: number | undefined;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/json-rpc-request-modifier.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/json-rpc-request-modifier.ts
@@ -34,8 +34,8 @@ import { isHttpNetworkConfig } from "./utils.js";
  * Requests are cloned to prevent interference with other handlers.
  */
 export class JsonRpcRequestModifier {
-  readonly #provider: EthereumProvider;
-  readonly #networkConfig: NetworkConfig;
+  readonly #provider: Readonly<EthereumProvider>;
+  readonly #networkConfig: Readonly<NetworkConfig>;
 
   // accounts
   #localAccounts: LocalAccounts | undefined;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-connection.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-connection.ts
@@ -13,13 +13,13 @@ export class NetworkConnectionImplementation<
   public readonly id: number;
   public readonly networkName: string;
   public readonly networkConfig: Readonly<NetworkConfig>;
-  public readonly chainType: Readonly<ChainTypeT>;
+  // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We shouldn't wrap the string type in a readonly wrapper
+  public readonly chainType: ChainTypeT;
 
   #provider!: EthereumProvider;
 
-  readonly #closeConnection: Readonly<
-    CloseConnectionFunction<Readonly<ChainTypeT>>
-  >;
+  // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We shouldn't wrap the function type in a readonly wrapper (nor the string type)
+  readonly #closeConnection: CloseConnectionFunction<ChainTypeT>;
 
   public static async create<ChainTypeT extends ChainType | string>(
     id: number,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-connection.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-connection.ts
@@ -12,12 +12,14 @@ export class NetworkConnectionImplementation<
 {
   public readonly id: number;
   public readonly networkName: string;
-  public readonly networkConfig: NetworkConfig;
-  public readonly chainType: ChainTypeT;
+  public readonly networkConfig: Readonly<NetworkConfig>;
+  public readonly chainType: Readonly<ChainTypeT>;
 
   #provider!: EthereumProvider;
 
-  readonly #closeConnection: CloseConnectionFunction<ChainTypeT>;
+  readonly #closeConnection: Readonly<
+    CloseConnectionFunction<Readonly<ChainTypeT>>
+  >;
 
   public static async create<ChainTypeT extends ChainType | string>(
     id: number,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -19,9 +19,9 @@ import { isNetworkConfig, validateNetworkConfig } from "./type-validation.js";
 
 export class NetworkManagerImplementation {
   readonly #defaultNetwork: string;
-  readonly #defaultChainType: DefaultChainType;
-  readonly #networkConfigs: Record<string, NetworkConfig>;
-  readonly #hookManager: HookManager;
+  readonly #defaultChainType: Readonly<DefaultChainType>;
+  readonly #networkConfigs: Readonly<Record<string, Readonly<NetworkConfig>>>;
+  readonly #hookManager: Readonly<HookManager>;
 
   #nextConnectionId = 0;
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/provider-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/provider-errors.ts
@@ -39,7 +39,7 @@ export class ProviderError extends CustomError implements ProviderRpcError {
 }
 
 export class LimitExceededError extends ProviderError {
-  public static readonly CODE = -32005;
+  public static readonly CODE: number = -32005;
 
   constructor(parent?: Error) {
     super("Request exceeds defined limit", LimitExceededError.CODE, parent);

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -58,7 +58,7 @@ import { SolcConfigSelector } from "./solc-config-selection.js";
 const log = debug("hardhat:core:solidity:build-system");
 
 export interface SolidityBuildSystemOptions {
-  readonly solidityConfig: SolidityConfig;
+  readonly solidityConfig: Readonly<SolidityConfig>;
   readonly projectRoot: string;
   readonly soliditySourcesPaths: string[];
   readonly artifactsPath: string;
@@ -66,8 +66,8 @@ export interface SolidityBuildSystemOptions {
 }
 
 export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
-  readonly #options: SolidityBuildSystemOptions;
-  readonly #defaultConcurrenty = Math.max(os.cpus().length - 1, 1);
+  readonly #options: Readonly<SolidityBuildSystemOptions>;
+  readonly #defaultConcurrenty: number = Math.max(os.cpus().length - 1, 1);
   #downloadedCompilers = false;
 
   constructor(options: SolidityBuildSystemOptions) {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job.ts
@@ -12,8 +12,8 @@ import { formatRemapping } from "./resolver/remappings.js";
 import { getEvmVersionFromSolcVersion } from "./solc-info.js";
 
 export class CompilationJobImplementation implements CompilationJob {
-  public readonly dependencyGraph: DependencyGraph;
-  public readonly solcConfig: SolcConfig;
+  public readonly dependencyGraph: Readonly<DependencyGraph>;
+  public readonly solcConfig: Readonly<SolcConfig>;
   public readonly solcLongVersion: string;
 
   readonly #remappings: Remapping[];

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/compiler.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/compiler.ts
@@ -28,7 +28,7 @@ export interface Compiler {
 const COMPILATION_SUBPROCESS_IO_BUFFER_SIZE = 1024 * 1024 * 500;
 
 export class SolcJsCompiler implements Compiler {
-  public readonly isSolcJs = true;
+  public readonly isSolcJs: boolean = true;
 
   constructor(
     public readonly version: string,
@@ -83,7 +83,7 @@ export class SolcJsCompiler implements Compiler {
 }
 
 export class NativeCompiler implements Compiler {
-  public readonly isSolcJs = false;
+  public readonly isSolcJs: boolean = false;
 
   constructor(
     public readonly version: string,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -133,7 +133,7 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
     }
   }
 
-  readonly #platform: CompilerPlatform;
+  readonly #platform: Readonly<CompilerPlatform>;
   readonly #compilersDir: string;
   readonly #downloadFunction: typeof download;
 

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
@@ -4,9 +4,14 @@ import type { ResolvedFile } from "../../../../types/solidity/resolved-file.js";
 import { assertHardhatInvariant } from "@ignored/hardhat-vnext-errors";
 
 export class DependencyGraphImplementation implements DependencyGraph {
-  readonly #fileBySourceName = new Map<string, ResolvedFile>();
-  readonly #rootByPublicSourceName = new Map<string, ResolvedFile>();
-  readonly #dependencies = new Map<ResolvedFile, Set<ResolvedFile>>();
+  readonly #fileBySourceName: Readonly<Map<string, Readonly<ResolvedFile>>> =
+    new Map<string, ResolvedFile>();
+  readonly #rootByPublicSourceName: Readonly<
+    Map<string, Readonly<ResolvedFile>>
+  > = new Map<string, ResolvedFile>();
+  readonly #dependencies: Readonly<
+    Map<Readonly<ResolvedFile>, Readonly<Set<Readonly<ResolvedFile>>>>
+  > = new Map<ResolvedFile, Set<ResolvedFile>>();
 
   /**
    * Adds a root file to the graph. All the roots of the dependency graph must

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -92,7 +92,7 @@ export class ResolverImplementation implements Resolver {
    * fields of this class. We do this by using the mutex in the public methods,
    * which don't call each other.
    */
-  readonly #mutex = new AsyncMutex();
+  readonly #mutex: Readonly<AsyncMutex> = new AsyncMutex();
 
   /**
    * A map of all the npm dependencies used in the project, and their
@@ -107,11 +107,15 @@ export class ResolverImplementation implements Resolver {
    *     the package is installed as the "installation name".
    *   - Imports from monorepo packages into the Hardhat project.
    */
-  readonly #dependencyMaps: Map<
-    ResolvedNpmPackage | typeof PROJECT_ROOT_SENTINEL,
+  readonly #dependencyMaps: Readonly<
     Map<
-      string, // The installation-name of the package that is being imported
-      ResolvedNpmPackage | typeof PROJECT_ROOT_SENTINEL // The package imported with that name
+      Readonly<ResolvedNpmPackage> | typeof PROJECT_ROOT_SENTINEL,
+      Readonly<
+        Map<
+          string, // The installation-name of the package that is being imported
+          Readonly<ResolvedNpmPackage> | typeof PROJECT_ROOT_SENTINEL // The package imported with that name
+        >
+      >
     >
   > = new Map();
 
@@ -125,13 +129,16 @@ export class ResolverImplementation implements Resolver {
    * To avoid this situation we set all the prefixes that `foo` needs unaffected
    * by the user remapping, with a higher presedence than user remappings.
    */
-  readonly #localPrefixesByPackage: Map<ResolvedNpmPackage, Set<string>> =
-    new Map();
+  readonly #localPrefixesByPackage: Readonly<
+    Map<Readonly<ResolvedNpmPackage>, Readonly<Set<string>>>
+  > = new Map();
 
   /**
    * We use this map to ensure that we only resolve each file once.
    **/
-  readonly #resolvedFileBySourceName: Map<string, ResolvedFile> = new Map();
+  readonly #resolvedFileBySourceName: Readonly<
+    Map<string, Readonly<ResolvedFile>>
+  > = new Map();
 
   /**
    * Creates a new Resolver.

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts
@@ -14,7 +14,7 @@ import { CompilationJobCreationErrorReason } from "../../../../types/solidity/bu
 
 export class SolcConfigSelector {
   readonly #buildProfileName: string;
-  readonly #buildProfile: SolidityBuildProfileConfig;
+  readonly #buildProfile: Readonly<SolidityBuildProfileConfig>;
 
   /**
    * Creates a new SolcConfigSelector that can be used to select the best solc

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
@@ -17,7 +17,7 @@ import type { SolidityBuildInfo } from "../../../../types/solidity.js";
 import type { SolidityBuildSystemOptions } from "../build-system/build-system.js";
 
 class LazySolidityBuildSystem implements SolidityBuildSystem {
-  readonly #options: SolidityBuildSystemOptions;
+  readonly #options: Readonly<SolidityBuildSystemOptions>;
 
   #buildSystem: SolidityBuildSystem | undefined;
 

--- a/v-next/hardhat/src/internal/core/async-mutex.ts
+++ b/v-next/hardhat/src/internal/core/async-mutex.ts
@@ -6,7 +6,7 @@
  */
 export class AsyncMutex {
   #acquired = false;
-  readonly #queue: Array<() => void> = [];
+  readonly #queue: Readonly<Array<() => void>> = [];
 
   /**
    * Aquires the mutex, running the provided function exclusively,

--- a/v-next/hardhat/src/internal/core/async-mutex.ts
+++ b/v-next/hardhat/src/internal/core/async-mutex.ts
@@ -6,7 +6,8 @@
  */
 export class AsyncMutex {
   #acquired = false;
-  readonly #queue: Readonly<Array<() => void>> = [];
+  // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We modify the queue in the #acquire method
+  readonly #queue: Array<() => void> = [];
 
   /**
    * Aquires the mutex, running the provided function exclusively,

--- a/v-next/hardhat/src/internal/core/configuration-variables.ts
+++ b/v-next/hardhat/src/internal/core/configuration-variables.ts
@@ -79,8 +79,8 @@ abstract class BaseResolvedConfigurationVariable
 }
 
 export class LazyResolvedConfigurationVariable extends BaseResolvedConfigurationVariable {
-  readonly #hooks: HookManager;
-  readonly #variable: ConfigurationVariable;
+  readonly #hooks: Readonly<HookManager>;
+  readonly #variable: Readonly<ConfigurationVariable>;
 
   public readonly name: string;
 

--- a/v-next/hardhat/src/internal/core/hook-manager.ts
+++ b/v-next/hardhat/src/internal/core/hook-manager.ts
@@ -34,9 +34,16 @@ export class HookManagerImplementation implements HookManager {
   /**
    * The intialized handler categories for each plugin.
    */
-  readonly #staticHookHandlerCategories: Map<
-    string,
-    Map<keyof HardhatHooks, Partial<HardhatHooks[keyof HardhatHooks]>>
+  readonly #staticHookHandlerCategories: Readonly<
+    Map<
+      string,
+      Readonly<
+        Map<
+          keyof HardhatHooks,
+          Readonly<Partial<HardhatHooks[keyof HardhatHooks]>>
+        >
+      >
+    >
   > = new Map();
 
   /**
@@ -44,9 +51,11 @@ export class HookManagerImplementation implements HookManager {
    *
    * Each array is a list of categories, in reverse order of registration.
    */
-  readonly #dynamicHookHandlerCategories: Map<
-    keyof HardhatHooks,
-    Array<Partial<HardhatHooks[keyof HardhatHooks]>>
+  readonly #dynamicHookHandlerCategories: Readonly<
+    Map<
+      keyof HardhatHooks,
+      Readonly<Array<Readonly<Partial<HardhatHooks[keyof HardhatHooks]>>>>
+    >
   > = new Map();
 
   constructor(projectRoot: string, plugins: HardhatPlugin[]) {

--- a/v-next/hardhat/src/internal/core/hook-manager.ts
+++ b/v-next/hardhat/src/internal/core/hook-manager.ts
@@ -54,7 +54,8 @@ export class HookManagerImplementation implements HookManager {
   readonly #dynamicHookHandlerCategories: Readonly<
     Map<
       keyof HardhatHooks,
-      Readonly<Array<Readonly<Partial<HardhatHooks[keyof HardhatHooks]>>>>
+      // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We modify the values of the dynamicHookHandlerCategories map in the registerHandlers method
+      Array<Readonly<Partial<HardhatHooks[keyof HardhatHooks]>>>
     >
   > = new Map();
 

--- a/v-next/hardhat/src/internal/core/hre.ts
+++ b/v-next/hardhat/src/internal/core/hre.ts
@@ -147,7 +147,7 @@ export class HardhatRuntimeEnvironmentImplementation
     return hre;
   }
 
-  public readonly tasks: TaskManager;
+  public readonly tasks: Readonly<TaskManager>;
 
   private constructor(
     public readonly userConfig: HardhatUserConfig,

--- a/v-next/hardhat/src/internal/core/tasks/builders.ts
+++ b/v-next/hardhat/src/internal/core/tasks/builders.ts
@@ -62,9 +62,9 @@ export class NewTaskDefinitionBuilderImplementation<
 > implements NewTaskDefinitionBuilder<TaskArgumentsT>
 {
   readonly #id: string[];
-  readonly #usedNames: Set<string> = new Set();
+  readonly #usedNames: Readonly<Set<string>> = new Set();
 
-  readonly #options: Record<string, OptionDefinition> = {};
+  readonly #options: Readonly<Record<string, Readonly<OptionDefinition>>> = {};
   readonly #positionalArgs: PositionalArgumentDefinition[] = [];
 
   #description: string;
@@ -243,7 +243,7 @@ export class TaskOverrideDefinitionBuilderImplementation<
 {
   readonly #id: string[];
 
-  readonly #options: Record<string, OptionDefinition> = {};
+  readonly #options: Readonly<Record<string, Readonly<OptionDefinition>>> = {};
 
   #description?: string;
 

--- a/v-next/hardhat/src/internal/core/tasks/builders.ts
+++ b/v-next/hardhat/src/internal/core/tasks/builders.ts
@@ -64,7 +64,8 @@ export class NewTaskDefinitionBuilderImplementation<
   readonly #id: string[];
   readonly #usedNames: Readonly<Set<string>> = new Set();
 
-  readonly #options: Readonly<Record<string, Readonly<OptionDefinition>>> = {};
+  // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We modify the options map in the addOption method
+  readonly #options: Record<string, Readonly<OptionDefinition>> = {};
   readonly #positionalArgs: PositionalArgumentDefinition[] = [];
 
   #description: string;
@@ -243,7 +244,8 @@ export class TaskOverrideDefinitionBuilderImplementation<
 {
   readonly #id: string[];
 
-  readonly #options: Readonly<Record<string, Readonly<OptionDefinition>>> = {};
+  // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We modify the options map in the addOption method
+  readonly #options: Record<string, Readonly<OptionDefinition>> = {};
 
   #description?: string;
 

--- a/v-next/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/v-next/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -25,7 +25,7 @@ import { formatTaskId } from "./utils.js";
 import { validateTaskArgumentValue } from "./validations.js";
 
 export class ResolvedTask implements Task {
-  readonly #hre: HardhatRuntimeEnvironment;
+  readonly #hre: Readonly<HardhatRuntimeEnvironment>;
 
   public static createEmptyTask(
     hre: HardhatRuntimeEnvironment,

--- a/v-next/hardhat/src/internal/core/tasks/task-manager.ts
+++ b/v-next/hardhat/src/internal/core/tasks/task-manager.ts
@@ -26,8 +26,11 @@ import {
 } from "./validations.js";
 
 export class TaskManagerImplementation implements TaskManager {
-  readonly #hre: HardhatRuntimeEnvironment;
-  readonly #rootTasks = new Map<string, Task>();
+  readonly #hre: Readonly<HardhatRuntimeEnvironment>;
+  readonly #rootTasks: Readonly<Map<string, Readonly<Task>>> = new Map<
+    string,
+    Task
+  >();
 
   constructor(
     hre: HardhatRuntimeEnvironment,

--- a/v-next/hardhat/src/internal/core/user-interruptions.ts
+++ b/v-next/hardhat/src/internal/core/user-interruptions.ts
@@ -8,8 +8,8 @@ import { AsyncMutex } from "./async-mutex.js";
 export class UserInterruptionManagerImplementation
   implements UserInterruptionManager
 {
-  readonly #hooks;
-  readonly #mutex = new AsyncMutex();
+  readonly #hooks: Readonly<HookManager>;
+  readonly #mutex: Readonly<AsyncMutex> = new AsyncMutex();
 
   constructor(hooks: HookManager) {
     this.#hooks = hooks;

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -127,7 +127,7 @@ export interface Artifact<AbiT extends Abi = Abi> {
   /**
    * The ABI of the contract.
    */
-  readonly abi: AbiT;
+  readonly abi: Readonly<AbiT>;
 
   /**
    * The bytecode used to deploy the contract.
@@ -137,7 +137,7 @@ export interface Artifact<AbiT extends Abi = Abi> {
   /**
    * The link references of the deployment bytecode.
    */
-  readonly linkReferences: LinkReferences;
+  readonly linkReferences: Readonly<LinkReferences>;
 
   /**
    * The deployed or runtime bytecode of the contract.
@@ -147,13 +147,13 @@ export interface Artifact<AbiT extends Abi = Abi> {
   /**
    * The link references of the deployed bytecode.
    */
-  readonly deployedLinkReferences: LinkReferences;
+  readonly deployedLinkReferences: Readonly<LinkReferences>;
 
   /**
    * The references to the immutable variables that get embedded in the deployed
    * bytecode.
    */
-  readonly immutableReferences?: ImmutableReferences;
+  readonly immutableReferences?: Readonly<ImmutableReferences>;
 
   /**
    * The id of the build info that was used to generate this artifact.

--- a/v-next/hardhat/src/types/hooks.ts
+++ b/v-next/hardhat/src/types/hooks.ts
@@ -19,7 +19,7 @@ import type {
 // hre.ts -> hooks.ts -> hre.ts
 declare module "./hre.js" {
   export interface HardhatRuntimeEnvironment {
-    readonly hooks: HookManager;
+    readonly hooks: Readonly<HookManager>;
   }
 }
 

--- a/v-next/hardhat/src/types/hre.ts
+++ b/v-next/hardhat/src/types/hre.ts
@@ -7,9 +7,9 @@ import type { HardhatConfig } from "../types/config.js";
  * all the functionality available through Hardhat.
  */
 export interface HardhatRuntimeEnvironment {
-  readonly config: HardhatConfig;
-  readonly globalOptions: GlobalOptions;
-  readonly interruptions: UserInterruptionManager;
+  readonly config: Readonly<HardhatConfig>;
+  readonly globalOptions: Readonly<GlobalOptions>;
+  readonly interruptions: Readonly<UserInterruptionManager>;
   // These fields are defined using module agumentation despite being part of
   // Hardhat's core:
   // readonly hooks: HookManager;

--- a/v-next/hardhat/src/types/network.ts
+++ b/v-next/hardhat/src/types/network.ts
@@ -53,9 +53,9 @@ export interface NetworkConnection<
 > {
   readonly id: number;
   readonly networkName: string;
-  readonly networkConfig: NetworkConfig;
-  readonly chainType: ChainTypeT;
-  readonly provider: EthereumProvider;
+  readonly networkConfig: Readonly<NetworkConfig>;
+  readonly chainType: Readonly<ChainTypeT>;
+  readonly provider: Readonly<EthereumProvider>;
 
   close(): Promise<void>;
 }

--- a/v-next/hardhat/src/types/network.ts
+++ b/v-next/hardhat/src/types/network.ts
@@ -54,7 +54,8 @@ export interface NetworkConnection<
   readonly id: number;
   readonly networkName: string;
   readonly networkConfig: Readonly<NetworkConfig>;
-  readonly chainType: Readonly<ChainTypeT>;
+  // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We shouldn't wrap the string type in a readonly wrapper
+  readonly chainType: ChainTypeT;
   readonly provider: Readonly<EthereumProvider>;
 
   close(): Promise<void>;

--- a/v-next/hardhat/src/types/solidity/solidity-artifacts.ts
+++ b/v-next/hardhat/src/types/solidity/solidity-artifacts.ts
@@ -33,12 +33,12 @@ export interface SolidityBuildInfo {
    *
    * @see import("../artifacts.js").Artifact.inputSourceName
    */
-  readonly publicSourceNameMap: Record<string, string>;
+  readonly publicSourceNameMap: Readonly<Record<string, string>>;
 
   /**
    * The compiler input, as provided to solc.
    */
-  readonly input: CompilerInput;
+  readonly input: Readonly<CompilerInput>;
 }
 
 /**
@@ -58,5 +58,5 @@ export interface SolidityBuildInfoOutput {
   /**
    * The `solc` output, verbatim (i.e. as returned by `solc`).
    */
-  readonly output: CompilerOutput;
+  readonly output: Readonly<CompilerOutput>;
 }

--- a/v-next/hardhat/src/types/tasks.ts
+++ b/v-next/hardhat/src/types/tasks.ts
@@ -11,7 +11,7 @@ import type { HardhatRuntimeEnvironment } from "./hre.js";
 // hre.ts -> tasks.ts -> hre.ts
 declare module "./hre.js" {
   export interface HardhatRuntimeEnvironment {
-    readonly tasks: TaskManager;
+    readonly tasks: Readonly<TaskManager>;
   }
 }
 

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/ethereum-mocked-provider.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/ethereum-mocked-provider.ts
@@ -13,10 +13,11 @@ export class EthereumMockedProvider
   implements EIP1193Provider
 {
   // Record<methodName, value>
-  readonly #returnValues: Readonly<Record<string, any>> = {};
+  // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We modify the returnValues map in the setReturnValue method
+  readonly #returnValues: Record<string, any> = {};
 
-  readonly #latestParams: Readonly<Record<string, RequestArguments["params"]>> =
-    {};
+  // eslint-disable-next-line @galargh/immutable-readonly/no-readonly-wrapper -- We modify the latestParams map in the request method
+  readonly #latestParams: Record<string, RequestArguments["params"]> = {};
 
   readonly #numberOfCalls: { [method: string]: number } = {};
 

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/ethereum-mocked-provider.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/json-rpc-request-modifiers/ethereum-mocked-provider.ts
@@ -13,9 +13,10 @@ export class EthereumMockedProvider
   implements EIP1193Provider
 {
   // Record<methodName, value>
-  readonly #returnValues: Record<string, any> = {};
+  readonly #returnValues: Readonly<Record<string, any>> = {};
 
-  readonly #latestParams: Record<string, RequestArguments["params"]> = {};
+  readonly #latestParams: Readonly<Record<string, RequestArguments["params"]>> =
+    {};
 
   readonly #numberOfCalls: { [method: string]: number } = {};
 

--- a/v-next/hardhat/test/test-helpers/mock-artifacts-manager.ts
+++ b/v-next/hardhat/test/test-helpers/mock-artifacts-manager.ts
@@ -11,7 +11,7 @@ import {
 } from "@ignored/hardhat-vnext-errors";
 
 export class MockArtifactsManager implements ArtifactsManager {
-  readonly #artifacts: Map<string, Artifact>;
+  readonly #artifacts: Readonly<Map<string, Readonly<Artifact>>>;
 
   constructor() {
     this.#artifacts = new Map();


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This draft showcases an example implementation of https://github.com/NomicFoundation/hardhat/issues/6005.

It enforces readonly props immutability via an ESLint plugin - https://github.com/galargh/eslint-plugin-immutable-readonly

It needs further discussion whether that's something that we want to enforce automatically.

It also needs further work as, currently, the plugin is only published to the GitHub packages (downloading from GitHub packages requires authentication with a GitHub token).
