### PR TITLE
Make totalDifficulty field optional, as spec has changed.

### DIFF
--- a/packages/hardhat-core/src/internal/core/jsonrpc/types/output/block.ts
+++ b/packages/hardhat-core/src/internal/core/jsonrpc/types/output/block.ts
@@ -27,7 +27,8 @@ const baseBlockResponse = {
   receiptsRoot: rpcHash,
   miner: rpcAddress,
   difficulty: rpcQuantity,
-  totalDifficulty: rpcQuantity,
+  // now optional since https://github.com/ethereum/execution-apis/pull/570
+  totalDifficulty: optional(rpcQuantity),
   extraData: rpcData,
   size: rpcQuantity,
   gasLimit: rpcQuantity,


### PR DESCRIPTION
Make totalDifficulty field optional, as spec has changed. See https://github.com/ethereum/go-ethereum/issues/25505