### PR TITLE
Fix typos in documentation for using Viem and formatting instructions

### DIFF
--- a/docs/src/content/hardhat-runner/docs/advanced/using-viem.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/using-viem.md
@@ -137,7 +137,7 @@ await myToken.write.increaseSupply();
 // TS Error: Property 'setSupply' does not exist on type...
 const tokenPrice = await myToken.write.setSupply([5000000n]);
 
-// The first argument of the constructor arguments is expected to be an bigint
+// The first argument of the constructor arguments is expected to be a bigint
 // TS Error: No overload matches this call.
 const myToken2 = await hre.viem.deployContract("MyToken", ["1000000"]);
 ```

--- a/docs/src/content/hardhat-vscode/docs/formatting.md
+++ b/docs/src/content/hardhat-vscode/docs/formatting.md
@@ -8,7 +8,7 @@ If you currently have other solidity extensions installed, or have had previousl
 
 To set Hardhat for Visual Studio Code as your default formatter for solidity files:
 
-1. Within a Solidity file run the _Format Document With_ command, either through the Command Palette, or by right clicking and selecting through the context menu:
+1. Within a Solidity file run the _Format Document With_ command, either through the Command Palette, or by right-clicking and selecting through the context menu:
 
    ![Format Document With](/hardhat-vscode-images/format_document_with.png "Format Document With")
 


### PR DESCRIPTION
This pull request addresses minor typo corrections in the Hardhat documentation. The changes improve readability and grammatical accuracy in the following files:

1. **`using-viem.md`**: Corrected the usage of the article from "an" to "a" before "bigint" to align with proper grammatical rules.  
2. **`formatting.md`**: Added a hyphen in "right-clicking" to ensure correct spelling of the term.  

These are minor updates with no impact on functionality, intended to enhance the clarity and professionalism of the documentation.

---

### Checklist
- [x] Typographical corrections applied.
- [ ] No changes to functionality or code behavior.
- [ ] No new features introduced or discussed in an issue.

---

### Additional Information
- Maintainers are welcome to edit this PR for additional refinements.  
- This is a small fix with no breaking changes.  

