### PR TITLE
Make arguments of Task.run() optional, defaulting to empty object

### DIFF
--- a/v-next/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/v-next/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -93,7 +93,7 @@ export class ResolvedTask implements Task {
    * @throws HardhatError if the task is empty, a required argument is missing,
    * a argument has an invalid type, or the file actions can't be resolved.
    */
-  public async run(taskArguments: TaskArguments): Promise<any> {
+  public async run(taskArguments: TaskArguments = {}): Promise<any> {
     if (this.isEmpty) {
       throw new HardhatError(HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK, {
         task: formatTaskId(this.id),

--- a/v-next/hardhat/src/types/tasks.ts
+++ b/v-next/hardhat/src/types/tasks.ts
@@ -387,7 +387,7 @@ export interface Task {
   /**
    * Runs a task.
    */
-  run(taskArguments: TaskArguments): Promise<any>;
+  run(taskArguments?: TaskArguments): Promise<any>;
 }
 
 /**

--- a/v-next/hardhat/test/internal/core/tasks/task-manager.ts
+++ b/v-next/hardhat/test/internal/core/tasks/task-manager.ts
@@ -1474,7 +1474,7 @@ describe("TaskManagerImplementation", () => {
 
       const task1 = hre.tasks.getTask("task1");
       assert.equal(taskRun, false);
-      await task1.run({});
+      await task1.run();
       assert.equal(taskRun, true);
     });
 
@@ -1496,7 +1496,7 @@ describe("TaskManagerImplementation", () => {
       );
 
       const task1 = hre.tasks.getTask("task1");
-      const result = await task1.run({});
+      const result = await task1.run();
       assert.equal(result, "task run successfully");
     });
 
@@ -1530,7 +1530,7 @@ describe("TaskManagerImplementation", () => {
       const task1 = hre.tasks.getTask("task1");
       assert.equal(taskRun, false);
       assert.equal(overrideTaskRun, false);
-      await task1.run({});
+      await task1.run();
       assert.equal(taskRun, true);
       assert.equal(overrideTaskRun, true);
     });
@@ -1588,7 +1588,7 @@ describe("TaskManagerImplementation", () => {
       assert.equal(override1TaskRun, false);
       assert.equal(override2TaskRun, false);
       assert.equal(override3TaskRun, false);
-      await task1.run({});
+      await task1.run();
       assert.equal(taskRun, true);
       assert.equal(override1TaskRun, true);
       assert.equal(override2TaskRun, true);
@@ -1624,7 +1624,7 @@ describe("TaskManagerImplementation", () => {
       const task1 = hre.tasks.getTask("task1");
       assert.equal(taskRun, false);
       assert.equal(overrideTaskRun, false);
-      await task1.run({});
+      await task1.run();
       assert.equal(taskRun, false);
       assert.equal(overrideTaskRun, true);
     });
@@ -1739,7 +1739,7 @@ describe("TaskManagerImplementation", () => {
       );
 
       const task1 = hre.tasks.getTask("task1");
-      await task1.run({});
+      await task1.run();
     });
 
     it("should run an empty task that was overriden", async () => {
@@ -1769,7 +1769,7 @@ describe("TaskManagerImplementation", () => {
 
       const task1 = hre.tasks.getTask("task1");
       assert.equal(overrideTaskRun, false);
-      await task1.run({});
+      await task1.run();
       assert.equal(overrideTaskRun, true);
     });
 
@@ -1857,7 +1857,7 @@ describe("TaskManagerImplementation", () => {
 
         const task1 = hre.tasks.getTask("task1");
         await assertRejectsWithHardhatError(
-          task1.run({}),
+          task1.run(),
           HardhatError.ERRORS.TASK_DEFINITIONS.EMPTY_TASK,
           {
             task: "task1",
@@ -2057,7 +2057,7 @@ describe("TaskManagerImplementation", () => {
 
         const task1 = hre.tasks.getTask("task1");
         await assertRejectsWithHardhatError(
-          task1.run({}),
+          task1.run(),
           HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION_URL,
           {
             action: "file://not-a-module",
@@ -2095,7 +2095,7 @@ describe("TaskManagerImplementation", () => {
         );
 
         await assertRejectsWithHardhatError(
-          hre.tasks.getTask("task1").run({}),
+          hre.tasks.getTask("task1").run(),
           HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
           {
             pluginId: "plugin1",
@@ -2129,7 +2129,7 @@ describe("TaskManagerImplementation", () => {
         );
 
         await assertRejectsWithHardhatError(
-          hre.tasks.getTask("task1").run({}),
+          hre.tasks.getTask("task1").run(),
           HardhatError.ERRORS.PLUGINS.PLUGIN_NOT_INSTALLED,
           {
             pluginId: "plugin2",
@@ -2160,7 +2160,7 @@ describe("TaskManagerImplementation", () => {
 
         const task1 = hre.tasks.getTask("task1");
         await assertRejectsWithHardhatError(
-          task1.run({}),
+          task1.run(),
           HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
           {
             action: actionUrl,
@@ -2192,7 +2192,7 @@ describe("TaskManagerImplementation", () => {
 
         const task1 = hre.tasks.getTask("task1");
         await assertRejectsWithHardhatError(
-          task1.run({}),
+          task1.run(),
           HardhatError.ERRORS.TASK_DEFINITIONS.INVALID_ACTION,
           {
             action: actionUrl,


### PR DESCRIPTION
This PR allows users to call Task.run() without passing any arguments. This will default to an empty object `{}`.

Closes #5982 