### PR TITLE
Documentation Grammar and Spelling Improvements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ To preview content locally, launch the app with `pnpm dev` and open http://127.0
 All content is organized by hierarchy levels and the top-level entries are layouts. The layout represents a set of folders and provides navigation within them. Currently, a folder should belong to one of the layouts. In terms of UI, the layout is equivalent to a sidebar navigation menu with two-level items. Layout settings can be found in the `src/content/layouts.yaml` file. It contains all layouts (currently "documentation" and "tutorial"). Each layout can have the following settings:
 
 - title (optional)
-- folders - the list of folders should be included in this layout
+- folders - the list of folders that should be included in this layout
 
 ### Folders
 
@@ -190,7 +190,7 @@ We utilize [Linaria](https://github.com/callstack/linaria) for styling component
 
 ## Theming
 
-The documentation section is Themable. A user can switch between light, dark and high contrast themes for their convenience. There is also an "Auto" setting when theme is selected based on a user system settings.
+The documentation section is Themeable. A user can switch between light, dark and high contrast themes for their convenience. There is also an "Auto" setting when theme is selected based on a user system settings.
 
 Theming solution provides abilities to switch themes, keep the selected value in user's local storage, seamlessly keep selected page on navigating and page refreshing.
 

--- a/docs/src/content/hardhat-runner/docs/guides/deploying.md
+++ b/docs/src/content/hardhat-runner/docs/guides/deploying.md
@@ -50,7 +50,7 @@ You can deploy in the `localhost` network following these steps:
 
    ::::
 
-As general rule, you can target any network from your Hardhat config using:
+As a general rule, you can target any network from your Hardhat config using:
 
 ```
 npx hardhat ignition deploy ./ignition/modules/Lock.js --network <your-network>


### PR DESCRIPTION



### In docs/README.md:

1. Changed:
```diff
- folders - the list of folders should be included in this layout
+ folders - the list of folders that should be included in this layout
```
- Adds missing relative pronoun "that"
- Improves sentence structure and readability

2. Changed:
```diff
- The documentation section is Themable
+ The documentation section is Themeable
```
- Corrects spelling of technical term
- Maintains consistency with standard spelling conventions

### In docs/src/content/hardhat-runner/docs/guides/deploying.md:

3. Changed:
```diff
- As general rule
+ As a general rule
```
- Adds missing article "a"
- Follows proper English phrase construction

