### PR TITLE
Enable debug logging via CLI flag 

### DIFF
--- a/v-next/hardhat/src/internal/builtin-global-options.ts
+++ b/v-next/hardhat/src/internal/builtin-global-options.ts
@@ -55,6 +55,18 @@ export const BUILTIN_GLOBAL_OPTIONS_DEFINITIONS: GlobalOptionDefinitions =
       },
     ],
     [
+      "verbose",
+      {
+        pluginId: "builtin",
+        option: globalOption({
+          name: "verbose",
+          description: "Enables Hardhat verbose logging.",
+          type: ArgumentType.BOOLEAN,
+          defaultValue: false,
+        }),
+      },
+    ],
+    [
       "version",
       {
         pluginId: "builtin",

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -259,6 +259,12 @@ export async function parseBuiltinGlobalOptions(
       version = true;
       continue;
     }
+
+    if (arg === "--verbose") {
+      usedCliArguments[i] = true;
+      debug.enable("hardhat*");
+      continue;
+    }
   }
 
   if (init && configPath !== undefined) {

--- a/v-next/hardhat/test/internal/cli/helpers/getGlobalHelpString.ts
+++ b/v-next/hardhat/test/internal/cli/helpers/getGlobalHelpString.ts
@@ -200,6 +200,7 @@ GLOBAL OPTIONS:
   --show-stack-traces      Show stack traces (always enabled on CI servers).
   --user-option-1          userOption1 description.
   --user-option-2          userOption2 description.
+  --verbose                Enables Hardhat verbose logging.
   --version                Shows hardhat's version.
 
 To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
@@ -298,6 +299,7 @@ GLOBAL OPTIONS:
   --show-stack-traces      Show stack traces (always enabled on CI servers).
   --user-option-1          userOption1 description.
   --user-option-2          userOption2 description.
+  --verbose                Enables Hardhat verbose logging.
   --version                Shows hardhat's version.
 
 To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -11,7 +11,7 @@ import type {
 } from "../../../src/types/tasks.js";
 
 import assert from "node:assert/strict";
-import { afterEach, before, describe, it } from "node:test";
+import { afterEach, before, describe, it, mock } from "node:test";
 import { pathToFileURL } from "node:url";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
@@ -22,6 +22,7 @@ import {
   useFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import chalk from "chalk";
+import debug from "debug";
 
 import {
   main,
@@ -103,6 +104,19 @@ describe("main", function () {
   describe("main", function () {
     afterEach(function () {
       resetGlobalHardhatRuntimeEnvironment();
+    });
+
+    describe("verbose", function () {
+      useFixtureProject("cli/parsing/base-project");
+
+      it("should enable the debug logs", async function () {
+        const spy = mock.method(debug, "enable");
+
+        const command = "npx hardhat --verbose";
+        await runMain(command);
+
+        assert.equal(spy.mock.calls.length, 1);
+      });
     });
 
     describe("version", function () {

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -228,6 +228,7 @@ GLOBAL OPTIONS:
   --init                   Initializes a Hardhat project.
   --network                The network to connect to
   --show-stack-traces      Show stack traces (always enabled on CI servers).
+  --verbose                Enables Hardhat verbose logging.
   --version                Shows hardhat's version.
 
 To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;

--- a/v-next/hardhat/test/internal/hre-intialization.ts
+++ b/v-next/hardhat/test/internal/hre-intialization.ts
@@ -189,6 +189,7 @@ describe("HRE intialization", () => {
           help: false,
           init: false,
           showStackTraces: false,
+          verbose: false,
           version: false,
           myGlobalOption: "default",
           network: "",


### PR DESCRIPTION
Add the `--verbose` flag to enable logging via the `debug` module
