### PR TITLE
Suggest running hardhat --init when no config file is found

### DIFF
--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -108,7 +108,8 @@ Please double check whether you have multiple versions of the same plugin instal
     },
     NO_CONFIG_FILE_FOUND: {
       number: 3,
-      messageTemplate: "No Hardhat config file found",
+      messageTemplate:
+        "No Hardhat config file found.\n\nYou can initialize a new project by running Hardhat with --init",
       websiteTitle: "No Hardhat config file found",
       websiteDescription:
         "Hardhat couldn't find a config file in the current directory or any of its parents.",


### PR DESCRIPTION
When running hardhat and no config file is found, besides throwing the error now it's suggested to run hardhat with the --init flag. The wording is consistent with the "For more info ..." part.

![image](https://github.com/user-attachments/assets/3254b6ad-016d-4733-80d7-1910636d557b)
