### PR TITLE
Fix tsx.register() crash on Deno

### DIFF
--- a/v-next/hardhat/src/cli.ts
+++ b/v-next/hardhat/src/cli.ts
@@ -14,6 +14,15 @@ printNodeJsVersionWarningIfNecessary();
 // eslint-disable-next-line no-restricted-syntax -- Allow top-level await here
 const { main } = await import("./internal/cli/main.js");
 
-main(process.argv.slice(2), { registerTsx: true }).catch(() => {
+function isTsxRequired(): boolean {
+  const tsNativeRuntimes = ["Deno"];
+  // environments that support typescript natively don't need tsx
+  if (tsNativeRuntimes.some((env) => env in globalThis)) {
+    return false;
+  }
+  return true;
+}
+
+main(process.argv.slice(2), { registerTsx: isTsxRequired() }).catch(() => {
   process.exitCode = 1;
 });

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -41,12 +41,8 @@ import { printVersionMessage } from "./version.js";
 
 export interface MainOptions {
   print?: (message: string) => void;
-  registerTsx?: true;
+  registerTsx?: boolean;
   rethrowErrors?: true;
-}
-
-declare global {
-  const Deno: any;
 }
 
 export async function main(
@@ -102,10 +98,9 @@ export async function main(
       return;
     }
 
-    if (typeof Deno === "undefined") {
-      if (options.registerTsx) {
-        register();
-      }
+    
+    if (options.registerTsx) {
+      register();
     }
 
     const userConfig = await importUserConfig(configPath);

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -98,8 +98,7 @@ export async function main(
       return;
     }
 
-    
-    if (options.registerTsx) {
+    if (options.registerTsx === true) {
       register();
     }
 

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -45,6 +45,10 @@ export interface MainOptions {
   rethrowErrors?: true;
 }
 
+declare global {
+  const Deno: any;
+}
+
 export async function main(
   cliArguments: string[],
   options: MainOptions = {},
@@ -98,8 +102,10 @@ export async function main(
       return;
     }
 
-    if (options.registerTsx) {
-      register();
+    if (typeof Deno === "undefined") {
+      if (options.registerTsx) {
+        register();
+      }
     }
 
     const userConfig = await importUserConfig(configPath);


### PR DESCRIPTION
This fixes the issue mentioned [here](https://github.com/NomicFoundation/hardhat/issues/2888#issuecomment-2524080632)

This PR definitely doesn't make Deno easy to use because of the `forge` issue mentioned [here](https://github.com/NomicFoundation/hardhat/issues/2888#issuecomment-2496323103), but it at least makes it usable