### PR TITLE
Fix typo in Bash script Update run-fixture-projects.sh

### DIFF
--- a/e2e/run-fixture-projects.sh
+++ b/e2e/run-fixture-projects.sh
@@ -46,7 +46,7 @@ for dir in ${FIXTURE_PROJECTS_DIR}/*; do
 
     echo "[e2e] Installing modules in $dir"
     npm add $HARDHAT_CORE_FOLDER_PATH/$HARDHAT_TGZ_FILE >/dev/null 2>&1
-    npm install >/dev/null 2>&1 # install moduled specified in the package.json
+    npm install >/dev/null 2>&1 # install modules specified in the package.json
     echo "[e2e] All modules have been installed in $dir"
 
     echo "[e2e] Starting test in $dir"


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

A typo in a comment within the Bash script for running e2e tests.  

The incorrect word **`moduled`** has been replaced with the correct term **`modules`** in the following line:  
```bash
npm install >/dev/null 2>&1 # install modules specified in the package.json
```

The updated comment now reads:  
```bash
npm install >/dev/null 2>&1 # install modules specified in the package.json
```

Thanks!