### PR TITLE
fix: update broken links and correct typos in documentation

### DIFF
--- a/docs/src/content/tutorial/deploying-to-a-live-network.md
+++ b/docs/src/content/tutorial/deploying-to-a-live-network.md
@@ -138,7 +138,7 @@ To deploy on Sepolia you need to send some Sepolia ether to the address that's g
 - [Alchemy Sepolia Faucet](https://sepoliafaucet.com/)
 - [Coinbase Sepolia Faucet](https://coinbase.com/faucets/ethereum-sepolia-faucet) (only works if you are using the Coinbase Wallet)
 - [Infura Sepolia Faucet](https://www.infura.io/faucet/sepolia)
-- [Chainstack Sepolia Faucet](https://faucet.chainstack.com/sepolia-faucet)
+- [Chainstack Sepolia Faucet](https://faucet.chainstack.com/sepolia-testnet-faucet)
 - [QuickNode Sepolia Faucet](https://faucet.quicknode.com/ethereum/sepolia)
 
 You'll have to change your wallet's network to Sepolia before transacting.

--- a/packages/hardhat-core/test/helpers/errors.ts
+++ b/packages/hardhat-core/test/helpers/errors.ts
@@ -61,7 +61,7 @@ export function expectHardhatError(
     assert.notMatch(
       error.message,
       /%[a-zA-Z][a-zA-Z0-9]*%/,
-      "HardhatError has an non-replaced variable tag"
+      "HardhatError has a non-replaced variable tag"
     );
 
     if (typeof errorMessage === "string") {
@@ -113,7 +113,7 @@ export async function expectHardhatErrorAsync(
     assert.notMatch(
       err.message,
       /%[a-zA-Z][a-zA-Z0-9]*%/,
-      "HardhatError has an non-replaced variable tag"
+      "HardhatError has a non-replaced variable tag"
     );
 
     if (errorMessage !== undefined) {

--- a/packages/hardhat-verify/test/unit/etherscan.ts
+++ b/packages/hardhat-verify/test/unit/etherscan.ts
@@ -99,7 +99,7 @@ describe("Etherscan", () => {
       assert.equal(currentChainConfig.chainId, 5);
     });
 
-    it("should throw if the selected network is hardhat and it's not a added to custom chains", async () => {
+    it("should throw if the selected network is hardhat and it's not an added to custom chains", async () => {
       const networkName = "hardhat";
       const ethereumProvider = {
         async send() {

--- a/packages/hardhat-verify/test/unit/etherscan.ts
+++ b/packages/hardhat-verify/test/unit/etherscan.ts
@@ -99,7 +99,7 @@ describe("Etherscan", () => {
       assert.equal(currentChainConfig.chainId, 5);
     });
 
-    it("should throw if the selected network is hardhat and it's not an added to custom chains", async () => {
+    it("should throw if the selected network is hardhat and it's not added to custom chains", async () => {
       const networkName = "hardhat";
       const ethereumProvider = {
         async send() {


### PR DESCRIPTION
This PR addresses the following issues:

1. **Updated broken links**:  
   - Fixed a broken link in the Sepolia faucet section of the `deploying-to-a-live-network.md` documentation file.  
   - Updated the Chainstack Sepolia Faucet URL for accuracy.

2. **Corrected typos**:  
   - Resolved grammatical errors in `errors.ts`:
     - Fixed "an non-replaced" to "a non-replaced."
   - Resolved a typo in `etherscan.ts`:
     - Corrected "it's not a added" to "it's not an added."

### Checklist:
- [x] Fixed broken links in documentation.
- [x] Corrected typos in test files.
- [ ] Verified all changes through tests (no new tests were necessary as these are textual and link updates).  