### PR TITLE
Fix typos and spelling errors in documentation

### DIFF
--- a/docs/src/content/hardhat-runner/docs/supporter-guides/oracles.md
+++ b/docs/src/content/hardhat-runner/docs/supporter-guides/oracles.md
@@ -226,7 +226,7 @@ There are multiple oracle applications you can integrate into your dapp:
 
 - [Kleros Oracle](https://kleros.io/oracle) - _Crowd-sourced on-chain smart contract oracle in collaboration with the Reality.eth cryptoeconomic mechanism for verifying real-world events on-chain, a subjective oracle solution able to answer any question with a publicly verifiable answer._
 
-- [UMA Oracle](https://umaproject.org/products/optimistic-oracle) - _UMA's optimistic oracle allows smart contracts to quickly and receive any kind of data for different applications, including insurance, financial derivatives, and prediction market._
+- [UMA Oracle](https://umaproject.org/products/optimistic-oracle) - _UMA's optimistic oracle allows smart contracts to quickly receive any kind of data for different applications, including insurance, financial derivatives, and prediction market._
 
 - [Tellor](https://tellor.io/) - _Tellor is a transparent and permissionless oracle protocol for your smart contract to easily get any data whenever it needs it._
 

--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -59,7 +59,7 @@ const communityPlugins: IPlugin[] = [
     authorUrl: "https://tenderly.co/",
     description:
       "Easily integrate your Hardhat project with Tenderly. Tenderly is an Ethereum monitoring, debugging and analytics platform.",
-    tags: ["Debuggin", "Monitoring", "Alerting", "Tasks", "Scripts"],
+    tags: ["Debugging", "Monitoring", "Alerting", "Tasks", "Scripts"],
   },
   {
     name: "hardhat-ethernal",

--- a/e2e/fixture-projects/gas-reporter/test.sh
+++ b/e2e/fixture-projects/gas-reporter/test.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env sh
 
-# fail if any commands fails
+# fail if any command fails
 set -e
 
 # import helpers functions


### PR DESCRIPTION
changes made:

Removed redundant "and": to quickly and receive - to quickly receive

Fixed misspelling: Debuggin - Debugging

Fixed grammar in comment: commands fails - command fails

I hope my corrections will help you. Thank you for your work.