### PR TITLE
Translate path separators when parsing npm direct imports

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -1318,6 +1318,7 @@ export class ResolverImplementation implements Resolver {
         path: string;
       }
     | undefined {
+    // NOTE: We assume usage of path.posix.sep in the direct import
     const directImportPattern =
       /^(?<package>(?:@[a-z0-9-~._]+\/)?[a-z0-9-~][a-z0-9-~._]*)\/(?<path>.*)$/;
 
@@ -1332,7 +1333,11 @@ export class ResolverImplementation implements Resolver {
       "Groups should be defined because they are part of the pattern",
     );
 
-    return { package: match.groups.package, path: match.groups.path };
+    // NOTE: We replace path.posix.sep with path.sep here so that the returned
+    // path can be later safely treated as a system aware path
+    const parsedPath = match.groups.path.replaceAll(path.posix.sep, path.sep);
+
+    return { package: match.groups.package, path: parsedPath };
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Resolves #6051

The issue was that we used POSIX path separators in the `dependenciesToCompile`, but then we weren't translating them to system-aware paths anywhere along the way. Eventually, it made it all the way through to https://github.com/NomicFoundation/hardhat/blob/v-next/v-next/hardhat-utils/src/fs.ts#L120, which expects system-specific path separators, and that's where we errored out.

The resolver for npm paths is https://github.com/NomicFoundation/hardhat/blob/v-next/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts#L250. I added the path separator translator to https://github.com/NomicFoundation/hardhat/blob/v-next/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts#L254 because it seemed like the most natural option.