### PR TITLE
Fix spelling and grammar in documentation

### DIFF
--- a/docs/src/content/tutorial/setting-up-the-environment.md
+++ b/docs/src/content/tutorial/setting-up-the-environment.md
@@ -49,7 +49,7 @@ Make sure you also [have `git` installed on WSL](https://docs.microsoft.com/en-u
 
 ## Upgrading your Node.js installation
 
-If your version of Node.js is older and [not supported by Hardhat](../hardhat-runner/docs/reference/stability-guarantees.md#node.js-versions-support) follow the instructions below to upgrade.
+If your version of Node.js is older and [is not supported by Hardhat](../hardhat-runner/docs/reference/stability-guarantees.md#node.js-versions-support) follow the instructions below to upgrade.
 
 ### Linux
 

--- a/packages/hardhat-verify/CHANGELOG.md
+++ b/packages/hardhat-verify/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Patch Changes
 
-- 73d5bea: Improved validation of contructor arguments (thanks @fwx5618177!)
+- 73d5bea: Improved validation of constructor arguments (thanks @fwx5618177!)
 
 ## 2.0.7
 


### PR DESCRIPTION


- Fix spelling: "contructor" → "constructor" in hardhat-verify/CHANGELOG.md
- Add missing "is" in Node.js version check sentence in setting-up-the-environment.md

These changes improve documentation clarity and fix technical terminology.

Changes:
packages/hardhat-verify/CHANGELOG.md:
- Improved validation of contructor arguments
+ Improved validation of constructor arguments

docs/src/content/tutorial/setting-up-the-environment.md:
- If your version of Node.js is older and [not supported by Hardhat]
+ If your version of Node.js is older and [is not supported by Hardhat]