### PR TITLE
Implement SolidityCallSite.toString()

### DIFF
--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { SolidityCallSite } from "../../../../../../src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.js";
+
+describe("SolidityCallSite", function () {
+  describe("toString", function () {
+    it("works when no properties are present", async () => {
+      const callSite = new SolidityCallSite(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      assert.equal(callSite.toString(), "null.<anonymous> (unknown)");
+    });
+
+    it("works when only the sourcename and the line number are present", async () => {
+      const callSite = new SolidityCallSite(
+        "Source.sol",
+        undefined,
+        undefined,
+        1,
+      );
+
+      assert.equal(callSite.toString(), "null.<anonymous> (Source.sol:1)");
+    });
+
+    it("works when all properties are present", async () => {
+      const callSite = new SolidityCallSite(
+        "Source.sol",
+        "Contract",
+        "functionName",
+        1,
+      );
+
+      assert.equal(callSite.toString(), "Contract.functionName (Source.sol:1)");
+    });
+  });
+});


### PR DESCRIPTION
Solidity stack traces should be stringified properly now.

Extracted the logic from source-map-support package.

Closes #6067