### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/src/components/CookiePopUp.tsx
+++ b/docs/src/components/CookiePopUp.tsx
@@ -21,7 +21,7 @@ const Container = styled.section`
   flex-direction: column;
   max-width: 332px;
   ${media.md} {
-    width: 332spx;
+    width: 332px;
     margin: 0px 24px;
     left: unset;
   }


### PR DESCRIPTION
Corrected `332spx` to `332px`