### PR TITLE
chore: ensure module type early in the init flow

### DIFF
--- a/v-next/hardhat/src/internal/cli/init/init.ts
+++ b/v-next/hardhat/src/internal/cli/init/init.ts
@@ -60,15 +60,15 @@ export interface InitHardhatOptions {
  * 1. Print the ascii logo.
  * 2. Print the welcome message.
  * 3. Optionally, ask the user for the workspace to initialize the project in.
- * 4. Optionally, ask the user for the template to use for the project initialization.
- * 5. Create the package.json file if it does not exist.
+ * 4. Validate that the package.json file is an esm package if it exists; otherwise, create it.
+ * 5. Optionally, ask the user for the template to use for the project initialization.
  * 6. Validate that the package.json file is an esm package.
  * 7. Optionally, ask the user if files should be overwritten.
  * 8. Copy the template files to the workspace.
- * 10. Print the commands to install the project dependencies.
- * 11. Optionally, ask the user if the project dependencies should be installed.
- * 12. Optionally, run the commands to install the project dependencies.
- * 13. Print a message to star the project on GitHub.
+ * 9. Print the commands to install the project dependencies.
+ * 10. Optionally, ask the user if the project dependencies should be installed.
+ * 11. Optionally, run the commands to install the project dependencies.
+ * 12. Print a message to star the project on GitHub.
  */
 export async function initHardhat(options?: InitHardhatOptions): Promise<void> {
   try {
@@ -80,13 +80,13 @@ export async function initHardhat(options?: InitHardhatOptions): Promise<void> {
     // if it was not provided, and validate that it is not already initialized
     const workspace = await getWorkspace(options?.workspace);
 
-    // Ask the user for the template to use for the project initialization
-    // if it was not provided, and validate that it exists
-    const template = await getTemplate(options?.template);
-
     // Create the package.json file if it does not exist
     // and validate that it is an esm package
     await ensureProjectPackageJson(workspace);
+
+    // Ask the user for the template to use for the project initialization
+    // if it was not provided, and validate that it exists
+    const template = await getTemplate(options?.template);
 
     // Copy the template files to the workspace
     // Overwrite existing files only if the user opts-in to it


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This implements a user experience improvement suggestion from https://nomicfoundation.slack.com/archives/C069TLP61BQ/p1734796294370569 

Namely, after the change, we'll ensure that the project where hardhat is being initialized is of module type earlier on in the flow of init.