### PR TITLE
docs: Fixed a minor typo Update README.md

### DIFF
--- a/packages/hardhat-ledger/README.md
+++ b/packages/hardhat-ledger/README.md
@@ -60,7 +60,7 @@ module.exports = {
 };
 ```
 
-This will make those three accounts available to the `LedgerProvider`. If you try to send a transaction or sign something using any of those accounts, the provider will try to connect to the Ledger wallet and find a derivation path for that address. By default, the derivation paths that are tried start from `m/44'/60'/0'/0'/0` and go way up to `m/44'/60'/20'/0'/0`.
+This will make those three accounts available to the `LedgerProvider`. If you try to send a transaction or sign something using any of those accounts, the provider will try to connect to the Ledger wallet and find a derivation path for that address. By default, the derivation paths that are tried start from `m/44'/60'/0'/0'/0` and go all the way up to `m/44'/60'/20'/0'/0`.
 
 An additional (optional) configuration is possible to specify the derivation path that should be used, allowing 'legacy' or otherwise non-standard addresses to still be used with the plugin. An example of such a configuration would be:
 


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

Hey there!

I noticed a typo in the documentation text. The phrase **"way up to"** seemed to be missing an article, and it should read **"and go all the way up to"** for better clarity and correctness. This change ensures the sentence flows properly.

Thanks!
