### PR TITLE
Fix typo Update CHANGELOG.md

### DIFF
--- a/packages/hardhat-verify/CHANGELOG.md
+++ b/packages/hardhat-verify/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Patch Changes
 
-- 73d5bea: Improved validation of contructor arguments (thanks @fwx5618177!)
+- 73d5bea: Improved validation of constructor arguments (thanks @fwx5618177!)
 
 ## 2.0.7
 


### PR DESCRIPTION
I fixed a typo in the CHANGELOG.md file, correcting "contructor" to "constructor." It was a small change (1 addition, 1 deletion), but it improves clarity and accuracy in the documentation.