### PR TITLE
fix: Fixed Typo in Variable Name Update check-dependencies.js

### DIFF
--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -76,8 +76,8 @@ function addDependencies(packageName, dependenciesToAdd, allDependenciesMap) {
     return;
   }
 
-  for (const [name, specWithWorspace] of Object.entries(dependenciesToAdd)) {
-    const spec = specWithWorspace.replace(/^workspace:/, "");
+  for (const [name, specWithWorkspace] of Object.entries(dependenciesToAdd)) {
+    const spec = specWithWorkspace.replace(/^workspace:/, "");
     if (IGNORE_SAME_VERSION_FROM_ALL.includes(name)) {
       continue;
     }


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

I noticed a issue in the `addDependencies` function. It looks like the variable `specWithWorspace` was used, but it seems like a typo, and it should be `specWithWorkspace`.

I’ve corrected the name to avoid any confusion and to make the code more consistent.
