### PR TITLE
Fix typo Update CHANGELOG.md

### DIFF
--- a/packages/hardhat-verify/CHANGELOG.md
+++ b/packages/hardhat-verify/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Patch Changes
 
-- 73d5bea: Improved validation of contructor arguments (thanks @fwx5618177!)
+- 73d5bea: Improved validation of constructor arguments (thanks @fwx5618177!)
 
 ## 2.0.7
 


### PR DESCRIPTION
## Title: Fix Typo in `CHANGELOG.md`

### Description:
This pull request corrects a typo in the `CHANGELOG.md` file under the `packages/hardhat-verify/` directory.

### Changes:
- Fixed the typo "contructor" to "constructor" in the changelog.
