### PR TITLE
Fix typo Update CHANGELOG.md

### DIFF
--- a/packages/hardhat-core/CHANGELOG.md
+++ b/packages/hardhat-core/CHANGELOG.md
@@ -641,7 +641,7 @@
 ### Patch Changes
 
 - 99c17f43: Bump uuid package to remove a deprecation warning (thanks @yhuard!)
-- 8076c43b: Fixed how the cummulative gas is computed for receipts and added a missing field (Thanks @ngotchac!)
+- 8076c43b: Fixed how the cumulative gas is computed for receipts and added a missing field (Thanks @ngotchac!)
 - e6362902: Display similar artifact names in error output if given name is not found (#201)
 - e087bd0b: Improve validation of private keys in the Hardhat config
 - aa1a0080: Fix an issue with new versions of Node.js that prevented clients from connecting to Hardhat's node using 127.0.0.1


### PR DESCRIPTION
### Title:
Fix Typo in `CHANGELOG.md`

### Description:
This pull request fixes a typo in the `CHANGELOG.md` file. The word "cummulative" has been corrected to "cumulative."
