### PR TITLE
Remove shell lang from some md snippets

### DIFF
--- a/docs/src/content/ignition/docs/advanced/migrating.md
+++ b/docs/src/content/ignition/docs/advanced/migrating.md
@@ -251,7 +251,7 @@ npx hardhat ignition deploy ./ignition/modules/Token.ts
 
 Which, if working correctly, will output the contract’s deployed address:
 
-```sh
+```
 You are running Hardhat Ignition against an in-process instance of Hardhat Network.
 This will execute the deployment, but the results will be lost.
 You can use --network <network-name> to deploy to a different network.

--- a/docs/src/content/ignition/docs/guides/create2.md
+++ b/docs/src/content/ignition/docs/guides/create2.md
@@ -151,7 +151,7 @@ npx hardhat ignition deploy ignition/modules/Apollo.js --network sepolia --strat
 
 The `--strategy create2` flag tells Ignition to deploy the module using `create2`. You should see output similar to the following:
 
-```sh
+```
 Compiled 1 Solidity file successfully (evm target: paris).
 Hardhat Ignition 🚀
 

--- a/docs/src/content/ignition/docs/guides/ledger.md
+++ b/docs/src/content/ignition/docs/guides/ledger.md
@@ -117,7 +117,7 @@ npx hardhat ignition deploy ignition/modules/Apollo.ts --network sepolia
 
 This will deploy as usual, however, you will now be prompted on your Ledger device to confirm each transaction before it's sent to the network. You should see a message like the following in your terminal:
 
-```sh
+```
 Hardhat Ignition 🚀
 
 Deploying [ Apollo ]

--- a/docs/src/content/ignition/docs/reference/cli-commands.md
+++ b/docs/src/content/ignition/docs/reference/cli-commands.md
@@ -14,7 +14,7 @@ The Hardhat Ignition CLI provides a set of commands to interact with the deploym
 
 Deploy a module to the specified network
 
-```sh
+```
 Usage: hardhat [GLOBAL OPTIONS] ignition deploy [--default-sender <STRING>] [--deployment-id <STRING>] [--parameters <STRING>] [--reset] [--strategy <STRING>] [--verify] [--write-localhost-deployment] modulePath
 
 OPTIONS:
@@ -36,7 +36,7 @@ POSITIONAL ARGUMENTS:
 
 List all deployment IDs
 
-```sh
+```
 Usage: hardhat [GLOBAL OPTIONS] ignition deployments
 ```
 
@@ -44,7 +44,7 @@ Usage: hardhat [GLOBAL OPTIONS] ignition deployments
 
 Show the current status of a deployment
 
-```sh
+```
 Usage: hardhat [GLOBAL OPTIONS] ignition status deploymentId
 
 POSITIONAL ARGUMENTS:
@@ -56,7 +56,7 @@ POSITIONAL ARGUMENTS:
 
 Show all transactions for a given deployment
 
-```sh
+```
 Usage: hardhat [GLOBAL OPTIONS] ignition transactions deploymentId
 
 POSITIONAL ARGUMENTS:
@@ -68,7 +68,7 @@ POSITIONAL ARGUMENTS:
 
 Verify contracts from a deployment against the configured block explorers
 
-```sh
+```
 Usage: hardhat [GLOBAL OPTIONS] ignition verify [--include-unrelated-contracts] deploymentId
 
 OPTIONS:
@@ -84,7 +84,7 @@ POSITIONAL ARGUMENTS:
 
 Visualize a module as an HTML report
 
-```sh
+```
 Usage: hardhat [GLOBAL OPTIONS] ignition visualize [--no-open] modulePath
 
 OPTIONS:
@@ -100,7 +100,7 @@ POSITIONAL ARGUMENTS:
 
 Reset a deployment's future to allow rerunning
 
-```sh
+```
 Usage: hardhat [GLOBAL OPTIONS] ignition wipe deploymentId futureId
 
 POSITIONAL ARGUMENTS:


### PR DESCRIPTION
There are many markdown snippets that have `sh` as the info string but whose content is not shell code. This makes them be incorrectly highlighted. But the main issue is that some angle brackets are escaped:

![image](https://github.com/user-attachments/assets/5e0da3ca-48df-4b13-903c-76daed8f47e4)

To be honest, the fact that removing the info string fixes this doesn't make a lot of sense to me. I don't know why they are escaped only when a language is specified. I looked down the remark/rehype rabbit hole, but it was too deep so I went with the fix that works but that I don't understand.