### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/src/content/ignition/docs/reference/environment-variables.md
+++ b/docs/src/content/ignition/docs/reference/environment-variables.md
@@ -3,4 +3,4 @@
 Hardhat Ignition supports special environment variables that affects how deployment works:
 
 - `HARDHAT_IGNITION_CONFIRM_DEPLOYMENT`: if set to `false`, Hardhat Ignition won't prompt the user asking for confirmation when deploying to a live network. This prompt is already not shown when running against the local Hardhat network (chainId: 31337), but you might want to set this variable if writing fully automated scripts that leverage Hardhat Ignition.
-- `HARDHAT_IGNITION_CONFIRM_RESET`: if set to `false`, Hardhat Ignition won't prompt the user asking for confirmation when overwritting the previous deployment via the `--reset` flag on Hardhat Ignition's `deploy` task.
+- `HARDHAT_IGNITION_CONFIRM_RESET`: if set to `false`, Hardhat Ignition won't prompt the user asking for confirmation when overwriting the previous deployment via the `--reset` flag on Hardhat Ignition's `deploy` task.

--- a/packages/hardhat-truffle4/src/artifacts.ts
+++ b/packages/hardhat-truffle4/src/artifacts.ts
@@ -113,7 +113,7 @@ export class TruffleEnvironmentArtifacts {
         if (library !== undefined) {
           const firstLinkData = linksData[0];
 
-          // link data is exressed in bytes, but the bytecode is hex encoded, so we
+          // link data is expressed in bytes, but the bytecode is hex encoded, so we
           // need to multiply everything by 2.
           const linkPlaceholder = destinationArtifact.bytecode.substr(
             firstLinkData.start * 2 + 2, // The + 2 is because of the 0x prefix

--- a/packages/hardhat-truffle5/src/artifacts.ts
+++ b/packages/hardhat-truffle5/src/artifacts.ts
@@ -114,7 +114,7 @@ export class TruffleEnvironmentArtifacts {
         if (library !== undefined) {
           const firstLinkData = linksData[0];
 
-          // link data is exressed in bytes, but the bytecode is hex encoded, so we
+          // link data is expressed in bytes, but the bytecode is hex encoded, so we
           // need to multiply everything by 2.
           const linkPlaceholder = destinationArtifact.bytecode.substr(
             firstLinkData.start * 2 + 2, // The + 2 is because of the 0x prefix


### PR DESCRIPTION
Description correction:
Corrected `overwritting` to `overwriting`
Corrected `exressed` to `expressed` x2
