### PR TITLE
Fix typo in test 

### DIFF
--- a/packages/hardhat-web3-legacy/test/web3-provider-adapter.ts
+++ b/packages/hardhat-web3-legacy/test/web3-provider-adapter.ts
@@ -53,7 +53,7 @@ describe("Web3 provider adapter", function () {
     assert.isTrue(adaptedProvider.isConnected());
   });
 
-  it("Should return the same as the real provider for sigle requests", function (done) {
+  it("Should return the same as the real provider for single requests", function (done) {
     const request = createJsonRpcRequest("eth_accounts");
     realWeb3Provider.sendAsync(
       request,

--- a/packages/hardhat-web3/test/web3-provider-adapter.ts
+++ b/packages/hardhat-web3/test/web3-provider-adapter.ts
@@ -39,7 +39,7 @@ describe("Web3 provider adapter", function () {
     assert.isTrue(adaptedProvider.isConnected());
   });
 
-  it("Should return the same as the real provider for sigle requests", function (done) {
+  it("Should return the same as the real provider for single requests", function (done) {
     const request = createJsonRpcRequest("eth_accounts");
     realWeb3Provider.send(
       request,


### PR DESCRIPTION
This PR fixes a typo in the test description where "sigle" was incorrectly used instead of "single"
