### PR TITLE
chore: check if wasm compiler is already downloaded

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/index.ts
@@ -58,16 +58,18 @@ export async function downloadConfiguredCompilers(
   await wasmCompilerDownloader.updateCompilerListIfNeeded(versions);
 
   for (const version of versions) {
-    if (!quiet) {
-      console.log(`Downloading solc ${version} (WASM build)`);
-    }
+    if (!(await wasmCompilerDownloader.isCompilerDownloaded(version))) {
+      if (!quiet) {
+        console.log(`Downloading solc ${version} (WASM build)`);
+      }
 
-    const success = await wasmCompilerDownloader.downloadCompiler(version);
+      const success = await wasmCompilerDownloader.downloadCompiler(version);
 
-    if (!success) {
-      throw new HardhatError(HardhatError.ERRORS.SOLIDITY.DOWNLOAD_FAILED, {
-        remoteVersion: version,
-      });
+      if (!success) {
+        throw new HardhatError(HardhatError.ERRORS.SOLIDITY.DOWNLOAD_FAILED, {
+          remoteVersion: version,
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

When updating how solidity compilers are downloaded, I forgot to add a check if a compiler is already downloaded before the call to download the wasm compiler. This PR fixes that.
