### PR TITLE
text correction README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ https://hardhat-lime.vercel.app/
 
 ## Adding content
 
-Website content is located in `*.md` files within `src/content` folder. It's written in Markdown syntax. Folders structure in `content` is reflected on the website.
+Website content is located in `*.md` files within `src/content` folder. Its written in Markdown syntax. Folder structure in `content` is reflected on the website.
 
 To adjust page behavior and appearance, also use optional `*.yaml` files with additional configurations.
 
@@ -173,7 +173,7 @@ Each component can be exposed with different states (stories) independently by p
 
 We also deploy updated storybook on each build. You can find it on https://hardhat-storybook.netlify.app/
 
-## Content generating technical details
+## Content-generating technical details
 
 There are two relatively independent processes in the build step:
 


### PR DESCRIPTION
1. **"folders structure" to "folder structure"**:
   - **Explanation**: The phrase "folders structure" is grammatically incorrect because "structure" is a singular noun that refers to the organization or arrangement of something. Since "structure" applies to the overall organization of "folder," it should be in the singular form. So, the correct phrase is **"folder structure"**.

2. **"content generating technical details" to "content-generation technical details"**:
   - **Explanation**: The original phrase "content generating" is awkward because it uses a present participle ("generating") as an adjective, which makes the phrase grammatically unclear. To correct this, we use the **compound noun "content-generation"** to clearly indicate that these are technical details related to the process of content generation. The hyphenation helps to properly form a single concept, making the phrase grammatically correct. Therefore, **"content-generation"** is the correct form.

3. **"it's" to "its"**:
   - **Explanation**: This is a common grammatical error. "It's" is the contraction for **"it is"** or **"it has"**, while **"its"** is the possessive form of "it" (showing ownership). In the sentence, you are referring to the **"content"** belonging to the **"folder"**, so you need the possessive form **"its"** to correctly indicate possession. Therefore, **"its"** is the grammatically correct form in this case.
