### PR TITLE
fix: specWithWorspace → specWithWorkspace

### DIFF
--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -76,8 +76,8 @@ function addDependencies(packageName, dependenciesToAdd, allDependenciesMap) {
     return;
   }
 
-  for (const [name, specWithWorspace] of Object.entries(dependenciesToAdd)) {
-    const spec = specWithWorspace.replace(/^workspace:/, "");
+  for (const [name, specWithWorkspace] of Object.entries(dependenciesToAdd)) {
+    const spec = specWithWorkspace.replace(/^workspace:/, "");
     if (IGNORE_SAME_VERSION_FROM_ALL.includes(name)) {
       continue;
     }


### PR DESCRIPTION

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

I noticed a typo in the variable name `specWithWorspace`.
The correct spelling should be `specWithWorkspace` (missing "k"). 