### PR TITLE
Remove async 

### DIFF
--- a/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
+++ b/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
@@ -316,7 +316,7 @@ import ProxyModule from "../ignition/modules/ProxyModule";
 import UpgradeModule from "../ignition/modules/UpgradeModule";
 
 describe("Demo Proxy", function () {
-  describe("Proxy interaction", async function () {
+  describe("Proxy interaction", function () {
     it("Should be interactable via proxy", async function () {
       const [, otherAccount] = await ethers.getSigners();
 
@@ -357,7 +357,7 @@ const ProxyModule = require("../ignition/modules/ProxyModule");
 const UpgradeModule = require("../ignition/modules/UpgradeModule");
 
 describe("Demo Proxy", function () {
-  describe("Proxy interaction", async function () {
+  describe("Proxy interaction", function () {
     it("Should be interactable via proxy", async function () {
       const [, otherAccount] = await ethers.getSigners();
 


### PR DESCRIPTION
Remove async  in upgradeable-proxies.md

Changes in docs/src/content/ignition/docs/guides/upgradeable-proxies.md:
- describe("Proxy interaction", async function () {
+ describe("Proxy interaction", function () {

Reason:
The async keyword was removed from the describe block as it's not needed for test organization blocks. The async keyword should only be used in it() blocks where actual asynchronous operations are performed. This change follows Mocha's best practices for test structure.
