### PR TITLE
docs: describe how revertedWithCustomError uses the contract argument

### DIFF
--- a/docs/src/content/hardhat-chai-matchers/docs/overview.md
+++ b/docs/src/content/hardhat-chai-matchers/docs/overview.md
@@ -154,7 +154,7 @@ await expect(contract.divideBy(1)).not.to.be.revertedWithPanic(
 
 You can omit the panic code in order to assert that the transaction reverted with _any_ panic code.
 
-The `revertedWithCustomError` matcher allows you to assert that a transaction reverted with a specific [custom error](https://docs.soliditylang.org/en/v0.8.14/contracts.html#errors-and-the-revert-statement):
+The `revertedWithCustomError` matcher allows you to assert that a transaction reverted with a specific [custom error](https://docs.soliditylang.org/en/v0.8.14/contracts.html#errors-and-the-revert-statement). Please note that this matcher does not check whether the error was emitted by the contract. It merely uses the contract interface to determine the full signature of the expected error. You can use it as follows:
 
 ```js
 await expect(contract.call()).to.be.revertedWithCustomError(

--- a/docs/src/content/hardhat-chai-matchers/docs/reference.md
+++ b/docs/src/content/hardhat-chai-matchers/docs/reference.md
@@ -66,7 +66,7 @@ await expect(token.transfer(address, 0)).to.be.revertedWithCustomError(
 );
 ```
 
-The first argument must be the contract that defines the error.
+The first argument must be the contract that defines the error. The contract is used to determine the full signature of the expected error. The matcher does not check whether the error was emitted by the contract.
 
 If the error has arguments, the `.withArgs` matcher can be added:
 


### PR DESCRIPTION
Resolves #6148

---

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This PR clarifies how we use the `contract` argument in the `revertedWithCustomError` matcher since it can be confusing why the matcher doesn't check the error origin.

The context for the discussion can be found in https://nomicfoundation.slack.com/archives/C03F2119K4H/p1737098731987269
