### PR TITLE
Remove async from describe callbacks

### DIFF
--- a/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
+++ b/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
@@ -316,7 +316,7 @@ import ProxyModule from "../ignition/modules/ProxyModule";
 import UpgradeModule from "../ignition/modules/UpgradeModule";
 
 describe("Demo Proxy", function () {
-  describe("Proxy interaction", async function () {
+  describe("Proxy interaction", function () {
     it("Should be interactable via proxy", async function () {
       const [, otherAccount] = await ethers.getSigners();
 
@@ -357,7 +357,7 @@ const ProxyModule = require("../ignition/modules/ProxyModule");
 const UpgradeModule = require("../ignition/modules/UpgradeModule");
 
 describe("Demo Proxy", function () {
-  describe("Proxy interaction", async function () {
+  describe("Proxy interaction", function () {
     it("Should be interactable via proxy", async function () {
       const [, otherAccount] = await ethers.getSigners();
 


### PR DESCRIPTION
Same as https://github.com/NomicFoundation/hardhat/pull/6150 but done by a real human, assuming you think that of me.

I also ran `rg 'describe.*async` and didn't find any other instance of this.