### PR TITLE
Fix ESM_PROJECT_WITHOUT_CJS_CONFIG heuristic

### DIFF
--- a/.changeset/fluffy-sloths-walk.md
+++ b/.changeset/fluffy-sloths-walk.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix heuristic to detect that an ESM project doesn't have a Hardhat config with an explicit `.cjs` extension.

--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -29,11 +29,14 @@ export function importCsjOrEsModule(filePath: string): any {
     const imported = require(filePath);
     return imported.default !== undefined ? imported.default : imported;
   } catch (e: any) {
-    if (
-      e.code === "ERR_REQUIRE_ESM" ||
+    // An ESM project that has a Hardhat config with a .js extension will fail to be loaded,
+    // because Hardhat configs can only be CJS but a .js extension will be interpreted as ESM.
+    // The kind of error we get in these cases depends on the Node.js version.
+    const node20Heuristic = e.code === "ERR_REQUIRE_ESM";
+    const node22Heuristic =
       e.message === "module is not defined" ||
-      e.message === "require is not defined"
-    ) {
+      e.message === "require is not defined";
+    if (node20Heuristic || node22Heuristic) {
       throw new HardhatError(
         ERRORS.GENERAL.ESM_PROJECT_WITHOUT_CJS_CONFIG,
         {},

--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -29,7 +29,7 @@ export function importCsjOrEsModule(filePath: string): any {
     const imported = require(filePath);
     return imported.default !== undefined ? imported.default : imported;
   } catch (e: any) {
-    if (e.code === "ERR_REQUIRE_ESM") {
+    if (e.code === "ERR_REQUIRE_ESM" || e.message === "module is not defined" || e.message === "require is not defined") {
       throw new HardhatError(
         ERRORS.GENERAL.ESM_PROJECT_WITHOUT_CJS_CONFIG,
         {},

--- a/packages/hardhat-core/src/internal/core/config/config-loading.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-loading.ts
@@ -29,7 +29,11 @@ export function importCsjOrEsModule(filePath: string): any {
     const imported = require(filePath);
     return imported.default !== undefined ? imported.default : imported;
   } catch (e: any) {
-    if (e.code === "ERR_REQUIRE_ESM" || e.message === "module is not defined" || e.message === "require is not defined") {
+    if (
+      e.code === "ERR_REQUIRE_ESM" ||
+      e.message === "module is not defined" ||
+      e.message === "require is not defined"
+    ) {
       throw new HardhatError(
         ERRORS.GENERAL.ESM_PROJECT_WITHOUT_CJS_CONFIG,
         {},

--- a/packages/hardhat-solhint/test/fixture-projects/no-errors-project/contracts/Greeter.sol
+++ b/packages/hardhat-solhint/test/fixture-projects/no-errors-project/contracts/Greeter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.28;
 
 
 contract Greeter {


### PR DESCRIPTION
This fixes the "latest dependency versions" CI job. I don't know why this started happening now, but I confirmed manually that these extra checks are needed.