### PR TITLE
feat: cleanup provider and stack traces logic

### DIFF
--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -692,6 +692,13 @@ Try using another mnemonic or deriving less keys.`,
       websiteDescription:
         "The transaction to the null address cannot have undefined data",
     },
+    PROVIDER_CLOSED: {
+      number: 722,
+      messageTemplate: "The provider has been closed.",
+      websiteTitle: "Provider closed",
+      websiteDescription:
+        "The provider your are trying to use has been closed. Please create a new one using hre.network.connect() and try again.",
+    },
   },
   KEYSTORE: {
     INVALID_KEYSTORE_FILE_FORMAT: {

--- a/v-next/hardhat-utils/src/hex.ts
+++ b/v-next/hardhat-utils/src/hex.ts
@@ -95,7 +95,7 @@ export function hexStringToNumber(hexString: string): number {
  * @returns PrefixedHexString The hexadecimal representation of the bytes.
  */
 export function bytesToHexString(bytes: Uint8Array): PrefixedHexString {
-  return `0x${Buffer.from(bytes).toString("hex")}`;
+  return getPrefixedHexString(Buffer.from(bytes).toString("hex"));
 }
 
 /**
@@ -141,9 +141,7 @@ export function normalizeHexString(hexString: string): PrefixedHexString {
     );
   }
 
-  return isPrefixedHexString(normalizedHexString)
-    ? normalizedHexString
-    : `0x${normalizedHexString}`;
+  return getPrefixedHexString(normalizedHexString);
 }
 
 /**

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -3,6 +3,7 @@ import type { LoggerConfig } from "./types/logger.js";
 import type { TracingConfig } from "./types/node-types.js";
 import type { EdrNetworkConfig } from "../../../../types/config.js";
 import type {
+  EthSubscription,
   JsonRpcResponse,
   RequestArguments,
   SuccessfulJsonRpcResponse,
@@ -332,13 +333,14 @@ export class EdrProvider extends BaseProvider {
   }
 
   #emitEip1193SubscriptionEvent(subscription: string, result: unknown) {
-    this.emit("message", {
+    const message: EthSubscription = {
       type: "eth_subscription",
       data: {
         subscription,
         result,
       },
-    });
+    };
+    this.emit("message", message);
   }
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -3,8 +3,6 @@ import type { LoggerConfig } from "./types/logger.js";
 import type { TracingConfig } from "./types/node-types.js";
 import type { EdrNetworkConfig } from "../../../../types/config.js";
 import type {
-  EthSubscription,
-  FailedJsonRpcResponse,
   JsonRpcResponse,
   RequestArguments,
   SuccessfulJsonRpcResponse,
@@ -15,7 +13,6 @@ import type {
   SubscriptionEvent,
   Response,
   Provider,
-  DebugTraceResult,
   ProviderConfig,
 } from "@ignored/edr-optimism";
 
@@ -25,25 +22,20 @@ import {
   l1GenesisState,
   l1HardforkFromString,
 } from "@ignored/edr-optimism";
+import { assertHardhatInvariant } from "@ignored/hardhat-vnext-errors";
 import { toSeconds } from "@ignored/hardhat-vnext-utils/date";
+import { numberToHexString } from "@ignored/hardhat-vnext-utils/hex";
 import { deepEqual } from "@ignored/hardhat-vnext-utils/lang";
 import debug from "debug";
 
-import {
-  EDR_NETWORK_RESET_EVENT,
-  EDR_NETWORK_REVERT_SNAPSHOT_EVENT,
-} from "../../../constants.js";
+import { EDR_NETWORK_REVERT_SNAPSHOT_EVENT } from "../../../constants.js";
 import { DEFAULT_HD_ACCOUNTS_CONFIG_PARAMS } from "../accounts/constants.js";
 import { BaseProvider } from "../base-provider.js";
 import { getJsonRpcRequest, isFailedJsonRpcResponse } from "../json-rpc.js";
 
 import { getGlobalEdrContext } from "./edr-context.js";
-import {
-  InvalidArgumentsError,
-  InvalidInputError,
-  ProviderError,
-} from "./errors.js";
-import { encodeSolidityStackTrace } from "./stack-traces/stack-trace-solidity-errors.js";
+import { InvalidArgumentsError, ProviderError } from "./errors.js";
+import { createSolidityErrorWithStackTrace } from "./stack-traces/stack-trace-solidity-errors.js";
 import { clientVersion } from "./utils/client-version.js";
 import { ConsoleLogger } from "./utils/console-logger.js";
 import {
@@ -55,6 +47,7 @@ import {
   hardhatChainsToEdrChains,
   hardhatForkingConfigToEdrForkConfig,
   hardhatChainTypeToEdrChainType,
+  isDebugTraceResult,
 } from "./utils/convert-to-edr.js";
 import { printLine, replaceLastLine } from "./utils/logger.js";
 
@@ -177,27 +170,22 @@ export class EdrProvider extends BaseProvider {
     super();
 
     this.#provider = provider;
-
     this.#jsonRpcRequestWrapper = jsonRpcRequestWrapper;
   }
 
-  public async request(args: RequestArguments): Promise<unknown> {
-    if (args.params !== undefined && !Array.isArray(args.params)) {
-      // eslint-disable-next-line no-restricted-syntax -- TODO: review whether this should be a HH error
-      throw new InvalidInputError(
-        "Hardhat Network doesn't support JSON-RPC params sent as an object",
-      );
-    }
-
-    const params = args.params ?? [];
+  public async request(
+    requestArguments: RequestArguments,
+  ): Promise<SuccessfulJsonRpcResponse["result"]> {
+    const { method, params } = requestArguments;
 
     const jsonRpcRequest = getJsonRpcRequest(
       this.#nextRequestId++,
-      args.method,
+      method,
       params,
     );
 
     let jsonRpcResponse: JsonRpcResponse;
+
     if (this.#jsonRpcRequestWrapper !== undefined) {
       jsonRpcResponse = await this.#jsonRpcRequestWrapper(
         jsonRpcRequest,
@@ -216,12 +204,6 @@ export class EdrProvider extends BaseProvider {
       jsonRpcResponse = await this.#handleEdrResponse(edrResponse);
     }
 
-    if (args.method === "hardhat_reset") {
-      this.emit(EDR_NETWORK_RESET_EVENT);
-    } else if (args.method === "evm_revert") {
-      this.emit(EDR_NETWORK_REVERT_SNAPSHOT_EVENT);
-    }
-
     // this can only happen if a wrapper doesn't call the default
     // behavior as the default throws on FailedJsonRpcResponse
     if (isFailedJsonRpcResponse(jsonRpcResponse)) {
@@ -235,19 +217,27 @@ export class EdrProvider extends BaseProvider {
       throw error;
     }
 
+    if (jsonRpcRequest.method === "evm_revert") {
+      this.emit(EDR_NETWORK_REVERT_SNAPSHOT_EVENT);
+    }
+
     // Override EDR version string with Hardhat version string with EDR backend,
     // e.g. `HardhatNetwork/2.19.0/@ignored/edr-optimism/0.2.0-dev`
-    if (args.method === "web3_clientVersion") {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TODO
-      return clientVersion(jsonRpcResponse.result as string);
-    } else if (
-      args.method === "debug_traceTransaction" ||
-      args.method === "debug_traceCall"
-    ) {
-      return edrRpcDebugTraceToHardhat(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TODO
-        jsonRpcResponse.result as DebugTraceResult,
+    if (jsonRpcRequest.method === "web3_clientVersion") {
+      assertHardhatInvariant(
+        typeof jsonRpcResponse.result === "string",
+        "Invalid client version response",
       );
+      return clientVersion(jsonRpcResponse.result);
+    } else if (
+      jsonRpcRequest.method === "debug_traceTransaction" ||
+      jsonRpcRequest.method === "debug_traceCall"
+    ) {
+      assertHardhatInvariant(
+        isDebugTraceResult(jsonRpcResponse.result),
+        "Invalid debug trace response",
+      );
+      return edrRpcDebugTraceToHardhat(jsonRpcResponse.result);
     } else {
       return jsonRpcResponse.result;
     }
@@ -255,10 +245,6 @@ export class EdrProvider extends BaseProvider {
 
   public async close(): Promise<void> {
     // TODO: what needs cleaned up?
-  }
-
-  #isErrorResponse(response: any): response is FailedJsonRpcResponse {
-    return typeof response.error !== "undefined";
   }
 
   async #handleEdrResponse(
@@ -272,7 +258,8 @@ export class EdrProvider extends BaseProvider {
       jsonRpcResponse = edrResponse.data;
     }
 
-    if (this.#isErrorResponse(jsonRpcResponse)) {
+    if (isFailedJsonRpcResponse(jsonRpcResponse)) {
+      const responseError = jsonRpcResponse.error;
       let error;
 
       let stackTrace: SolidityStackTrace | null = null;
@@ -283,34 +270,31 @@ export class EdrProvider extends BaseProvider {
       }
 
       if (stackTrace !== null) {
-        error = encodeSolidityStackTrace(
-          jsonRpcResponse.error.message,
-          stackTrace,
-        );
-
         // Pass data and transaction hash from the original error
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TODO: can we improve this `any
-        (error as any).data =
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TODO: can we improve this `any
-          (jsonRpcResponse as any).error.data?.data ?? undefined;
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- If we have a stack trace, we know that the json rpc response data
+        is an object with the data and transactionHash fields */
+        const responseErrorData = responseError.data as {
+          data?: string;
+          transactionHash?: string;
+        };
 
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TODO: can we improve this `any`
-        (error as any).transactionHash =
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- TODO: this really needs fixed
-          (jsonRpcResponse as any).error.data?.transactionHash ?? undefined;
+        error = createSolidityErrorWithStackTrace(
+          responseError.message,
+          stackTrace,
+          responseErrorData?.data,
+          responseErrorData?.transactionHash,
+        );
       } else {
-        if (jsonRpcResponse.error.code === InvalidArgumentsError.CODE) {
-          error = new InvalidArgumentsError(jsonRpcResponse.error.message);
-        } else {
-          error = new ProviderError(
-            jsonRpcResponse.error.message,
-            jsonRpcResponse.error.code,
-          );
-        }
-        error.data = jsonRpcResponse.error.data;
+        error =
+          responseError.code === InvalidArgumentsError.CODE
+            ? new InvalidArgumentsError(responseError.message)
+            : new ProviderError(responseError.message, responseError.code);
+        error.data = responseError.data;
       }
 
-      // eslint-disable-next-line no-restricted-syntax -- we may throw non-Hardaht errors inside of an EthereumProvider
+      /* eslint-disable-next-line no-restricted-syntax -- we may throw
+      non-Hardaht errors inside of an EthereumProvider */
       throw error;
     }
 
@@ -318,7 +302,7 @@ export class EdrProvider extends BaseProvider {
   }
 
   public onSubscriptionEvent(event: SubscriptionEvent): void {
-    const subscription = `0x${event.filterId.toString(16)}`;
+    const subscription = numberToHexString(event.filterId);
     const results = Array.isArray(event.result) ? event.result : [event.result];
     for (const result of results) {
       this.#emitLegacySubscriptionEvent(subscription, result);
@@ -326,7 +310,7 @@ export class EdrProvider extends BaseProvider {
     }
   }
 
-  #emitLegacySubscriptionEvent(subscription: string, result: any) {
+  #emitLegacySubscriptionEvent(subscription: string, result: unknown) {
     this.emit("notification", {
       subscription,
       result,
@@ -334,15 +318,13 @@ export class EdrProvider extends BaseProvider {
   }
 
   #emitEip1193SubscriptionEvent(subscription: string, result: unknown) {
-    const message: EthSubscription = {
+    this.emit("message", {
       type: "eth_subscription",
       data: {
         subscription,
         result,
       },
-    };
-
-    this.emit("message", message);
+    });
   }
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/errors.ts
@@ -88,14 +88,6 @@ export class InternalError extends ProviderError {
   }
 }
 
-export class InvalidInputError extends ProviderError {
-  public static readonly CODE = -32000;
-
-  constructor(message: string, parent?: Error) {
-    super(message, InvalidInputError.CODE, parent);
-  }
-}
-
 export class TransactionExecutionError extends ProviderError {
   public static readonly CODE = -32003;
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/panic-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/panic-errors.ts
@@ -1,11 +1,13 @@
+import { numberToHexString } from "@ignored/hardhat-vnext-utils/hex";
+
 export function panicErrorCodeToMessage(errorCode: bigint): string {
   const reason = panicErrorCodeToReason(errorCode);
 
   if (reason !== undefined) {
-    return `reverted with panic code 0x${errorCode.toString(16)} (${reason})`;
+    return `reverted with panic code ${numberToHexString(errorCode)} (${reason})`;
   }
 
-  return `reverted with unknown panic code 0x${errorCode.toString(16)}`;
+  return `reverted with unknown panic code ${numberToHexString(errorCode)}`;
 }
 
 function panicErrorCodeToReason(errorCode: bigint): string | undefined {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -237,9 +237,7 @@ function getMessageFromLastStackTraceEntry(
       }
 
       if (!returnData.isEmpty()) {
-        const buffer = Buffer.from(returnData.value).toString("hex");
-
-        return `VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x${buffer})`;
+        return `VM Exception while processing transaction: reverted with an unrecognized custom error (return data: ${bytesToHexString(returnData.value)})`;
       }
 
       if (stackTraceEntry.isInvalidOpcodeError) {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -20,7 +20,7 @@ import {
 export function createSolidityErrorWithStackTrace(
   fallbackMessage: string,
   stackTrace: SolidityStackTrace,
-  data?: string,
+  data: string,
   transactionHash?: string,
 ): SolidityError {
   const originalPrepareStackTrace = Error.prepareStackTrace;
@@ -298,7 +298,7 @@ export class SolidityError extends Error {
   constructor(
     message: string,
     public readonly stackTrace: SolidityStackTrace,
-    public readonly data?: string,
+    public readonly data: string,
     public readonly transactionHash?: string,
   ) {
     super(message);

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions
--- TODO: remove me once constant values are exported from the EDR package
-to replace the enum values in the switch statement */
 import type {
   SolidityStackTrace,
   SolidityStackTraceEntry,
@@ -20,48 +17,52 @@ import {
   UNRECOGNIZED_FUNCTION_NAME,
 } from "./solidity-stack-trace.js";
 
-export function encodeSolidityStackTrace(
+export function createSolidityErrorWithStackTrace(
   fallbackMessage: string,
   stackTrace: SolidityStackTrace,
-  previousStack?: NodeJS.CallSite[],
+  data?: string,
+  transactionHash?: string,
 ): SolidityError {
-  const previousPrepareStackTrace = Error.prepareStackTrace;
-  Error.prepareStackTrace = (error, stack) => {
-    if (previousStack !== undefined) {
-      stack = previousStack;
-    } else {
-      // We remove error management related stack traces
-      stack.splice(0, 1);
-    }
+  const originalPrepareStackTrace = Error.prepareStackTrace;
 
-    for (const entry of stackTrace) {
-      const callsite = encodeStackTraceEntry(entry);
-      if (callsite === undefined) {
-        continue;
+  try {
+    Error.prepareStackTrace = (error, stack) => {
+      // Skip error management related stack traces
+      const adjustedStack = stack.slice(1);
+
+      for (const entry of stackTrace) {
+        const callsite = encodeStackTraceEntry(entry);
+        if (callsite !== undefined) {
+          adjustedStack.unshift(callsite);
+        }
       }
 
-      stack.unshift(callsite);
-    }
+      return originalPrepareStackTrace !== undefined
+        ? originalPrepareStackTrace(error, adjustedStack)
+        : // This should never happen, but just in case we add a fallback
+          `Error: ${error.message}\n    at ${adjustedStack.join("\n    at ")}`;
+    };
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TODO: look at this pattern
-    return previousPrepareStackTrace!(error, stack);
-  };
+    const message =
+      getMessageFromLastStackTraceEntry(stackTrace[stackTrace.length - 1]) ??
+      fallbackMessage;
 
-  const msg = getMessageFromLastStackTraceEntry(
-    stackTrace[stackTrace.length - 1],
-  );
+    const solidityError = new SolidityError(
+      message,
+      stackTrace,
+      data,
+      transactionHash,
+    );
 
-  const solidityError = new SolidityError(
-    msg !== undefined ? msg : fallbackMessage,
-    stackTrace,
-  );
+    /* eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    -- As the stack property is lazy-loaded in JavaScript, we need to access it
+    to trigger the custom prepareStackTrace logic */
+    solidityError.stack;
 
-  // This hack is here because prepare stack is lazy
-  solidityError.stack = solidityError.stack;
-
-  Error.prepareStackTrace = previousPrepareStackTrace;
-
-  return solidityError;
+    return solidityError;
+  } finally {
+    Error.prepareStackTrace = originalPrepareStackTrace;
+  }
 }
 
 function encodeStackTraceEntry(
@@ -172,9 +173,7 @@ function sourceReferenceToSolidityCallsite(
   return new SolidityCallSite(
     sourceReference.sourceName,
     sourceReference.contract,
-    sourceReference.function !== undefined
-      ? sourceReference.function
-      : UNKNOWN_FUNCTION_NAME,
+    sourceReference.function ?? UNKNOWN_FUNCTION_NAME,
     sourceReference.line,
   );
 }
@@ -182,7 +181,6 @@ function sourceReferenceToSolidityCallsite(
 function getMessageFromLastStackTraceEntry(
   stackTraceEntry: SolidityStackTraceEntry,
 ): string | undefined {
-  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- TODO: We should cover all cases
   switch (stackTraceEntry.type) {
     case StackTraceEntryType.PRECOMPILE_ERROR:
       return `Transaction reverted: call to precompile ${stackTraceEntry.precompile} failed`;
@@ -280,27 +278,38 @@ function getMessageFromLastStackTraceEntry(
 
     case StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR:
       return "Transaction reverted: contract call run out of gas and made the transaction revert";
+
+    /* These types are not expected to be the last entry in the stack trace, as
+    their presence indicates that another frame should follow in the call stack. */
+    case StackTraceEntryType.CALLSTACK_ENTRY:
+    case StackTraceEntryType.UNRECOGNIZED_CREATE_CALLSTACK_ENTRY:
+    case StackTraceEntryType.UNRECOGNIZED_CONTRACT_CALLSTACK_ENTRY:
+    case StackTraceEntryType.INTERNAL_FUNCTION_CALLSTACK_ENTRY:
+      return undefined;
   }
 }
 
-// TODO: see TODO at line 301
-// const inspect = Symbol.for("nodejs.util.inspect.custom");
-
-// Note: This error class MUST NOT extend ProviderError, as libraries
-//   use the code property to detect if they are dealing with a JSON-RPC error,
-//   and take control of errors.
+/**
+ * Note: This error class MUST NOT extend ProviderError, as libraries use the
+ * code property to detect if they are dealing with a JSON-RPC error, and take
+ * control of errors.
+ **/
 export class SolidityError extends Error {
-  public readonly stackTrace: SolidityStackTrace;
-
-  constructor(message: string, stackTrace: SolidityStackTrace) {
+  constructor(
+    message: string,
+    public readonly stackTrace: SolidityStackTrace,
+    public readonly data?: string,
+    public readonly transactionHash?: string,
+  ) {
     super(message);
-    this.stackTrace = stackTrace;
-  }
 
-  // TODO: Can we bring this back with isolated declarations?
-  // public [inspect](): string {
-  //   return this.inspect();
-  // }
+    Object.defineProperty(this, Symbol.for("nodejs.util.inspect.custom"), {
+      value: this.inspect,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+  }
 
   public inspect(): string {
     return this.stack !== undefined

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -5,6 +5,7 @@ import type {
 } from "./solidity-stack-trace.js";
 
 import { ReturnData } from "@ignored/edr-optimism";
+import { assertHardhatInvariant } from "@ignored/hardhat-vnext-errors";
 import { bytesToHexString } from "@ignored/hardhat-vnext-utils/bytes";
 
 import { panicErrorCodeToMessage } from "./panic-errors.js";
@@ -37,10 +38,12 @@ export function createSolidityErrorWithStackTrace(
         }
       }
 
-      return originalPrepareStackTrace !== undefined
-        ? originalPrepareStackTrace(error, adjustedStack)
-        : // This should never happen, but just in case we add a fallback
-          `Error: ${error.message}\n    at ${adjustedStack.join("\n    at ")}`;
+      assertHardhatInvariant(
+        originalPrepareStackTrace !== undefined,
+        "Error.prepareStackTrace should be defined",
+      );
+
+      return originalPrepareStackTrace(error, adjustedStack);
     };
 
     const message =

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -307,17 +307,14 @@ export class SolidityError extends Error {
     super(message);
 
     Object.defineProperty(this, Symbol.for("nodejs.util.inspect.custom"), {
-      value: this.inspect,
+      value: () =>
+        this.stack !== undefined
+          ? this.stack
+          : "Internal error when encoding SolidityError",
       writable: false,
       enumerable: false,
       configurable: true,
     });
-  }
-
-  public inspect(): string {
-    return this.stack !== undefined
-      ? this.stack
-      : "Internal error when encoding SolidityError";
   }
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -58,7 +58,7 @@ export function createSolidityErrorWithStackTrace(
     );
 
     /* eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    -- As the stack property is lazy-loaded in JavaScript, we need to access it
+    -- As the stack property is lazy-loaded in v8, we need to access it
     to trigger the custom prepareStackTrace logic */
     solidityError.stack;
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/type-validation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/type-validation.ts
@@ -1,0 +1,25 @@
+import type { DebugTraceResult } from "@ignored/edr-optimism";
+
+import { isObject } from "@ignored/hardhat-vnext-utils/lang";
+
+export function isDebugTraceResult(
+  result: unknown,
+): result is DebugTraceResult {
+  return (
+    isObject(result) &&
+    "pass" in result &&
+    "gasUsed" in result &&
+    "structLogs" in result
+  );
+}
+
+interface EdrProviderErrorData {
+  data: string;
+  transactionHash?: string;
+}
+
+export function isEdrProviderErrorData(
+  errorData: unknown,
+): errorData is EdrProviderErrorData {
+  return isObject(errorData) && "data" in errorData;
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/types/output.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/types/output.ts
@@ -8,7 +8,7 @@ export interface RpcStructLog {
   stack?: string[];
   storage?: Record<string, string>;
   memSize?: number;
-  error?: object;
+  error?: Record<string, string>;
 }
 
 export interface RpcDebugTraceOutput {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -40,7 +40,10 @@ import {
   L1_CHAIN_TYPE as EDR_L1_CHAIN_TYPE,
   GENERIC_CHAIN_TYPE as EDR_GENERIC_CHAIN_TYPE,
 } from "@ignored/edr-optimism";
-import { getUnprefixedHexString } from "@ignored/hardhat-vnext-utils/hex";
+import {
+  bytesToHexString,
+  getUnprefixedHexString,
+} from "@ignored/hardhat-vnext-utils/hex";
 
 import { L1_CHAIN_TYPE, OPTIMISM_CHAIN_TYPE } from "../../../../constants.js";
 import { FixedValueConfigurationVariable } from "../../../../core/configuration-variables.js";
@@ -214,12 +217,15 @@ export function edrRpcDebugTraceToHardhat(
   });
 
   // REVM trace adds initial STOP that Hardhat doesn't expect
-  // ASK: is this still valid?
+  // TODO: double check with EDR team that this is still the case
   if (structLogs.length > 0 && structLogs[0].op === "STOP") {
     structLogs.shift();
   }
 
-  let returnValue = debugTraceResult.output?.toString("hex") ?? "";
+  let returnValue =
+    debugTraceResult.output !== undefined
+      ? bytesToHexString(debugTraceResult.output)
+      : "";
   if (returnValue === "0x") {
     returnValue = "";
   }
@@ -227,7 +233,7 @@ export function edrRpcDebugTraceToHardhat(
   return {
     failed: !debugTraceResult.pass,
     gas: Number(debugTraceResult.gasUsed),
-    returnValue, // ASK: do we expect an unprefixed hex string here?
+    returnValue,
     structLogs,
   };
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -41,7 +41,6 @@ import {
   GENERIC_CHAIN_TYPE as EDR_GENERIC_CHAIN_TYPE,
 } from "@ignored/edr-optimism";
 import { getUnprefixedHexString } from "@ignored/hardhat-vnext-utils/hex";
-import { isObject } from "@ignored/hardhat-vnext-utils/lang";
 
 import { L1_CHAIN_TYPE, OPTIMISM_CHAIN_TYPE } from "../../../../constants.js";
 import { FixedValueConfigurationVariable } from "../../../../core/configuration-variables.js";
@@ -231,17 +230,6 @@ export function edrRpcDebugTraceToHardhat(
     returnValue, // ASK: do we expect an unprefixed hex string here?
     structLogs,
   };
-}
-
-export function isDebugTraceResult(
-  result: unknown,
-): result is DebugTraceResult {
-  return (
-    isObject(result) &&
-    "pass" in result &&
-    "gasUsed" in result &&
-    "structLogs" in result
-  );
 }
 
 export async function hardhatAccountsToEdrOwnedAccounts(

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -22,10 +22,7 @@ import {
   ResponseStatusCodeError,
 } from "@ignored/hardhat-vnext-utils/request";
 
-import {
-  EDR_NETWORK_RESET_EVENT,
-  EDR_NETWORK_REVERT_SNAPSHOT_EVENT,
-} from "../../constants.js";
+import { EDR_NETWORK_REVERT_SNAPSHOT_EVENT } from "../../constants.js";
 import { getHardhatVersion } from "../../utils/package.js";
 
 import { BaseProvider } from "./base-provider.js";
@@ -123,7 +120,7 @@ export class HttpProvider extends BaseProvider {
       params,
     );
 
-    let jsonRpcResponse;
+    let jsonRpcResponse: JsonRpcResponse;
 
     if (this.#jsonRpcRequestWrapper !== undefined) {
       jsonRpcResponse = await this.#jsonRpcRequestWrapper(
@@ -145,9 +142,6 @@ export class HttpProvider extends BaseProvider {
       throw error;
     }
 
-    if (jsonRpcRequest.method === "hardhat_reset") {
-      this.emit(EDR_NETWORK_RESET_EVENT);
-    }
     if (jsonRpcRequest.method === "evm_revert") {
       this.emit(EDR_NETWORK_REVERT_SNAPSHOT_EVENT);
     }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/artifacts.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/artifacts.ts
@@ -9,6 +9,8 @@ import type {
   SolidityBuildInfoOutput,
 } from "../../../../types/solidity/solidity-artifacts.js";
 
+import { getPrefixedHexString } from "@ignored/hardhat-vnext-utils/hex";
+
 export function getContractArtifact(
   buildInfoId: string,
   publicSourceName: string,
@@ -17,18 +19,16 @@ export function getContractArtifact(
   contract: CompilerOutputContract,
 ): Artifact {
   const evmBytecode = contract.evm?.bytecode;
-  let bytecode: string = evmBytecode?.object ?? "";
-
-  if (bytecode.slice(0, 2).toLowerCase() !== "0x") {
-    bytecode = `0x${bytecode}`;
-  }
+  const bytecode: string =
+    evmBytecode?.object !== undefined
+      ? getPrefixedHexString(evmBytecode.object)
+      : "";
 
   const evmDeployedBytecode = contract.evm?.deployedBytecode;
-  let deployedBytecode: string = evmDeployedBytecode?.object ?? "";
-
-  if (deployedBytecode.slice(0, 2).toLowerCase() !== "0x") {
-    deployedBytecode = `0x${deployedBytecode}`;
-  }
+  const deployedBytecode: string =
+    evmDeployedBytecode?.object !== undefined
+      ? getPrefixedHexString(evmDeployedBytecode.object)
+      : "";
 
   const linkReferences = evmBytecode?.linkReferences ?? {};
   const deployedLinkReferences = evmDeployedBytecode?.linkReferences ?? {};

--- a/v-next/hardhat/src/internal/constants.ts
+++ b/v-next/hardhat/src/internal/constants.ts
@@ -2,7 +2,6 @@ export const HARDHAT_PACKAGE_NAME = "hardhat";
 export const HARDHAT_NAME = "Hardhat";
 export const HARDHAT_WEBSITE_URL = "https://hardhat.org/";
 
-export const EDR_NETWORK_RESET_EVENT = "hardhatNetworkReset";
 export const EDR_NETWORK_REVERT_SNAPSHOT_EVENT = "hardhatNetworkRevertSnapshot";
 
 export const GENERIC_CHAIN_TYPE = "generic";

--- a/v-next/hardhat/src/types/providers.ts
+++ b/v-next/hardhat/src/types/providers.ts
@@ -89,6 +89,17 @@ export interface EthereumProvider extends EIP1193Provider {
 }
 
 /**
+ * A message emitted by the provider as a result of an eth_subscription.
+ */
+export interface EthSubscription {
+  readonly type: "eth_subscription";
+  readonly data: {
+    readonly subscription: string;
+    readonly result: unknown;
+  };
+}
+
+/**
  * A JSON-RPC 2.0 request object.
  *
  * For typing a JSON-RPC notification request, use `JsonRpcNotificationRequest`.

--- a/v-next/hardhat/src/types/providers.ts
+++ b/v-next/hardhat/src/types/providers.ts
@@ -89,17 +89,6 @@ export interface EthereumProvider extends EIP1193Provider {
 }
 
 /**
- * A message emitted by the provider as a result of an eth_subscription.
- */
-export interface EthSubscription {
-  readonly type: "eth_subscription";
-  readonly data: {
-    readonly subscription: string;
-    readonly result: unknown;
-  };
-}
-
-/**
  * A JSON-RPC 2.0 request object.
  *
  * For typing a JSON-RPC notification request, use `JsonRpcNotificationRequest`.

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
@@ -4,7 +4,6 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
-import { ensureError } from "@ignored/hardhat-vnext-utils/error";
 import { numberToHexString } from "@ignored/hardhat-vnext-utils/hex";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
@@ -498,25 +497,14 @@ describe("http-provider", () => {
       });
 
       await provider.close();
-      try {
-        await provider.request({
+
+      await assertRejectsWithHardhatError(
+        provider.request({
           method: "eth_chainId",
-        });
-      } catch (error) {
-        ensureError(error);
-
-        assert.ok(
-          error.cause !== undefined && error.cause instanceof Error,
-          "Error does not have a cause",
-        );
-
-        // If the client is still open, the error will be a connection error
-        if (error.cause.message === "getaddrinfo ENOTFOUND loocalhost") {
-          assert.fail("Client is still open");
-        }
-
-        assert.equal(error.cause.message, "The client is destroyed");
-      }
+        }),
+        HardhatError.ERRORS.NETWORK.PROVIDER_CLOSED,
+        {},
+      );
     });
   });
 });


### PR DESCRIPTION
This is the final cleanup PR for the network stack in preparation for the alpha (and ideally the beta). It includes:

 - Normalized the EDR and HTTP providers to make them as similar as possible.
 - Removed the emission of the `hardhatNetworkReset` event in the `request` method, as it no longer makes sense in v3.
 - Free resources for garbage collection on `close` (unset the `provider` for the EDR provider and the `dispatcher` for the HTTP provider) and throw an error if the `request` method is called after closing.
 - EDR Provider – `request` method:
   - Removed `InvalidInputError` logic, as it is already handled by `getJsonRpcRequest`.
   - Replaced assertions on `jsonRpcResponse.result` with `assertHardhatInvariant`.
   - Cleaned up the `#handleEdrResponse` function.
 - Improved functions in `stack-trace-solidity-errors.ts` by removing TODOs and enhancing overall code flow.
 - Made other minor adjustments to improve code clarity and flow.