### PR TITLE
Add hardforkHistory for avalanche network

### DIFF
--- a/.changeset/shiny-trees-laugh.md
+++ b/.changeset/shiny-trees-laugh.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add hardfork activation history for avalanche network

--- a/.github/config/regression-tests.yml
+++ b/.github/config/regression-tests.yml
@@ -794,13 +794,13 @@ runners:
 commands:
   forge build:
     pattern: 'Compiling (\d+) files with Solc \d+\.\d+'
-    template: 'Compiled ${0} file(s)'
+    template: "Compiled ${0} file(s)"
   forge test:
     pattern: 'Ran \d+ test suites in \d+\.\d+m?s \(\d+\.\d+m?s CPU time\): (\d+) tests passed, (\d+) failed, (\d+) skipped \((\d+) total tests\)'
-    template: 'Ran ${3} tests (${0} passed, ${1} failed, ${2} skipped)'
+    template: "Ran ${3} tests (${0} passed, ${1} failed, ${2} skipped)"
   hardhat compile:
     pattern: 'Compiled (\d+) Solidity files with solc \d+\.\d+'
-    template: 'Compiled ${0} file(s)'
+    template: "Compiled ${0} file(s)"
   hardhat test solidity:
     pattern: 'Run (?:Failed|Passed): (\d+) tests, (\d+) passed, (\d+) failed, (\d+) skipped \(duration: \d+ ms\)'
-    template: 'Ran ${0} tests (${1} passed, ${2} failed, ${3} skipped)'
+    template: "Ran ${0} tests (${1} passed, ${2} failed, ${3} skipped)"

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -7,11 +7,11 @@ on:
       hardhat-ref:
         required: true
         type: string
-        default: 'v-next'
+        default: "v-next"
       edr-ref:
         required: false
         type: string
-        default: ''
+        default: ""
       repositories:
         required: false
         type: string
@@ -400,7 +400,7 @@ jobs:
       - name: Download the results
         uses: actions/download-artifact@v4
         with:
-          pattern: 'repository-*;command-*;runner-*'
+          pattern: "repository-*;command-*;runner-*"
       - name: Summarize the results
         id: summary
         env:

--- a/packages/hardhat-core/src/internal/core/config/default-config.ts
+++ b/packages/hardhat-core/src/internal/core/config/default-config.ts
@@ -166,10 +166,10 @@ export const defaultHardhatNetworkParams: Omit<
     [
       43114, // avalanche
       {
-          hardforkHistory: new Map([
-              [HardforkName.SHANGHAI, 11404279],
-              [HardforkName.CANCUN, 41263126]
-          ]),
+        hardforkHistory: new Map([
+          [HardforkName.SHANGHAI, 11404279],
+          [HardforkName.CANCUN, 41263126],
+        ]),
       },
     ],
     [

--- a/packages/hardhat-core/src/internal/core/config/default-config.ts
+++ b/packages/hardhat-core/src/internal/core/config/default-config.ts
@@ -164,6 +164,15 @@ export const defaultHardhatNetworkParams: Omit<
       },
     ],
     [
+      43114, // avalanche
+      {
+          hardforkHistory: new Map([
+              [HardforkName.SHANGHAI, 11404279],
+              [HardforkName.CANCUN, 41263126]
+          ]),
+      },
+    ],
+    [
       421614, // arbitrum sepolia
       {
         hardforkHistory: new Map([[HardforkName.SHANGHAI, 0]]),


### PR DESCRIPTION
**Description:**
This PR extends the Hardhat config to setup hardfork history for Avalanche networks used when forking.

**Related issue(s):**
N/A

**Notes for reviewer:**
This PR follows the same approach as https://github.com/NomicFoundation/hardhat/issues/5511 but for `avax`.