### PR TITLE
feat: add testFiles option to test solidity

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -11,6 +11,11 @@ const hardhatPlugin: HardhatPlugin = {
   },
   tasks: [
     task(["test", "solidity"], "Run the Solidity tests")
+      .addVariadicArgument({
+        name: "testFiles",
+        description: "An optional list of files to test",
+        defaultValue: [],
+      })
       .setAction(import.meta.resolve("./task-action.js"))
       .build(),
   ],


### PR DESCRIPTION
Resolved #6176

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This introduces an option to run only a subset of solidity tests. The CLI interface I implemented is exactly the same as with the `test node` task. 
