### PR TITLE
Add missing properties in v3 plugins

### DIFF
--- a/v-next/hardhat-chai-matchers/src/index.ts
+++ b/v-next/hardhat-chai-matchers/src/index.ts
@@ -7,6 +7,15 @@ const hardhatChaiMatchersPlugin: HardhatPlugin = {
   hookHandlers: {
     network: import.meta.resolve("./internal/hook-handlers/network.js"),
   },
+  npmPackage: "@ignored/hardhat-vnext-chai-matchers",
+  dependencies: [
+    async () => {
+      const { default: hardhatEthersPlugin } = await import(
+        "@ignored/hardhat-vnext-ethers"
+      );
+      return hardhatEthersPlugin;
+    },
+  ],
 };
 
 export default hardhatChaiMatchersPlugin;


### PR DESCRIPTION
Add the `dependencies` and `npmPackage` properties if they are missing in the new v3 plugins