### PR TITLE
ci: make list-packages outputs smaller

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.filter.outputs.changes }}
-      files: ${{ toJSON(steps.filter.outputs) }}
+      should_bundle: ${{ contains(steps.filter.outputs.hardhat_files, '.github/workflows/v-next-ci.yml') || contains(steps.filter.outputs.hardhat_files, 'pnpm-lock.yaml') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -96,15 +96,14 @@ jobs:
         with:
           list-files: json
           filters: ${{ steps.generate.outputs.filters }}
+          base: v-next # TODO: Remove once v-next becomes the default branch
 
   bundle:
     # Depending on list-packages only to check whether pnpm-lock.yaml has changed
     # This could be handled by a simpler job, but an extra runner would have to be allocated for it
     needs: list-packages
 
-    if: |
-      contains(fromJSON(needs.list-packages.outputs.files).hardhat_files, '.github/workflows/v-next-ci.yml') ||
-        contains(fromJSON(needs.list-packages.outputs.files).hardhat_files, 'pnpm-lock.yaml')
+    if: needs.list-packages.outputs.should_bundle == 'true'
 
     # Using a matrix strategy even though there's only one package
     # because we will want to add, at least, hardhat-toolbox in the future


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

In this PR, I address the issue described here - https://nomicfoundation.slack.com/archives/C03P6B72ZHU/p1738270381236179

`list-packages` started producing too big outputs.

To address this, I:
- added the `base` parameter to the call to `dorny/paths-filter` (this way, this workflow will be detecting changed files in relation to `v-next` rather than `main; we should have had it set in the first place)
- moved the check whether `bundle` should be run or not to  inside the `list-packages` job (this way, we don't have to put all the changed files in the `list-packages` job outputs)
