### PR TITLE
perf: load slow modules dynamically

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/accounts/derive-private-keys.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/accounts/derive-private-keys.ts
@@ -1,17 +1,15 @@
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import { bytesToHexString } from "@ignored/hardhat-vnext-utils/bytes";
-import { mnemonicToSeedSync } from "ethereum-cryptography/bip39";
-import { HDKey } from "ethereum-cryptography/hdkey";
 
 const HD_PATH_REGEX = /^m(:?\/\d+'?)+\/?$/;
 
-export function derivePrivateKeys(
+export async function derivePrivateKeys(
   mnemonic: string,
   hdpath: string,
   initialIndex: number,
   count: number,
   passphrase: string,
-): string[] {
+): Promise<string[]> {
   if (!HD_PATH_REGEX.test(hdpath)) {
     throw new HardhatError(HardhatError.ERRORS.NETWORK.INVALID_HD_PATH, {
       path: hdpath,
@@ -25,7 +23,7 @@ export function derivePrivateKeys(
   const privateKeys: string[] = [];
 
   for (let i = initialIndex; i < initialIndex + count; i++) {
-    const privateKey = deriveKeyFromMnemonicAndPath(
+    const privateKey = await deriveKeyFromMnemonicAndPath(
       mnemonic,
       hdpath + i.toString(),
       passphrase,
@@ -44,11 +42,14 @@ export function derivePrivateKeys(
   return privateKeys;
 }
 
-function deriveKeyFromMnemonicAndPath(
+async function deriveKeyFromMnemonicAndPath(
   mnemonic: string,
   hdPath: string,
   passphrase: string,
-): string | undefined {
+): Promise<string | undefined> {
+  const { mnemonicToSeedSync } = await import("ethereum-cryptography/bip39");
+  const { HDKey } = await import("ethereum-cryptography/hdkey");
+
   // NOTE: If mnemonic has space or newline at the beginning or end, it will be trimmed.
   // This is because mnemonic containing them may generate different private keys.
   const trimmedMnemonic = mnemonic.trim();

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts
@@ -27,7 +27,7 @@ import {
   hexStringToBytes,
   normalizeHexString,
 } from "@ignored/hardhat-vnext-utils/hex";
-import { isObject } from "micro-eth-signer/utils";
+import { isObject } from "@ignored/hardhat-vnext-utils/lang";
 
 import { DEFAULT_HD_ACCOUNTS_CONFIG_PARAMS } from "./accounts/constants.js";
 import {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -255,15 +255,21 @@ async function normalizeEdrNetworkAccountsConfig(
     return accounts;
   }
 
-  const isDefaultConfig = await isDefaultEdrNetworkHDAccountsConfig(accounts);
+  const hdAccountConfig = {
+    ...accounts,
+    mnemonic: await accounts.mnemonic.get(),
+    passphrase: await accounts.passphrase.get(),
+  };
+  const isDefaultConfig =
+    await isDefaultEdrNetworkHDAccountsConfig(hdAccountConfig);
   const derivedPrivateKeys = isDefaultConfig
     ? EDR_NETWORK_DEFAULT_PRIVATE_KEYS
-    : derivePrivateKeys(
-        await accounts.mnemonic.get(),
-        accounts.path,
-        accounts.initialIndex,
-        accounts.count,
-        await accounts.passphrase.get(),
+    : await derivePrivateKeys(
+        hdAccountConfig.mnemonic,
+        hdAccountConfig.path,
+        hdAccountConfig.initialIndex,
+        hdAccountConfig.count,
+        hdAccountConfig.passphrase,
       );
 
   return derivedPrivateKeys.map((privateKey) => ({

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -15,7 +15,6 @@ import type {
 import { deepClone } from "@ignored/hardhat-vnext-utils/lang";
 
 import { isJsonRpcResponse } from "../json-rpc.js";
-import { createHandlersArray } from "../request-handlers/handlers-array.js";
 
 export default async (): Promise<Partial<NetworkHooks>> => {
   // This map is essential for managing multiple network connections in Hardhat V3.
@@ -39,6 +38,10 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         nextJsonRpcRequest: JsonRpcRequest,
       ) => Promise<JsonRpcResponse>,
     ) {
+      const { createHandlersArray } = await import(
+        "../request-handlers/handlers-array.js"
+      );
+
       let requestHandlers = requestHandlersPerConnection.get(networkConnection);
 
       if (requestHandlers === undefined) {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/hd-wallet-handler.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/hd-wallet-handler.ts
@@ -5,15 +5,15 @@ import { derivePrivateKeys } from "../../../accounts/derive-private-keys.js";
 import { LocalAccountsHandler } from "./local-accounts.js";
 
 export class HDWalletHandler extends LocalAccountsHandler {
-  constructor(
+  public static async create(
     provider: EthereumProvider,
     mnemonic: string,
     hdpath: string = "m/44'/60'/0'/0/",
     initialIndex: number = 0,
     count: number = 10,
     passphrase: string = "",
-  ) {
-    const privateKeys = derivePrivateKeys(
+  ): Promise<HDWalletHandler> {
+    const privateKeys = await derivePrivateKeys(
       mnemonic,
       hdpath,
       initialIndex,
@@ -21,6 +21,9 @@ export class HDWalletHandler extends LocalAccountsHandler {
       passphrase,
     );
 
+    return new HDWalletHandler(provider, privateKeys);
+  }
+  private constructor(provider: EthereumProvider, privateKeys: string[]) {
     super(provider, privateKeys);
   }
 }

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -39,7 +39,7 @@ describe("edr-provider", () => {
 
         await provider.request({
           method: "evm_revert",
-          params: ["0x1"], // any snapshot id should work
+          params: ["0x1"], // if the snapshotId does not exist, it will return false
         });
 
         await eventPromise;

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/hd-wallet.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/hd-wallet.ts
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { beforeEach, describe, it } from "node:test";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
-import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import {
   getJsonRpcRequest,
@@ -29,10 +29,14 @@ describe("HDWalletHandler", () => {
     "couch hunt wisdom giant regret supreme issue sing enroll ankle type husband";
   const hdpath = "m/44'/60'/0'/0/";
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockedProvider = new EthereumMockedProvider();
 
-    hdWalletHandler = new HDWalletHandler(mockedProvider, mnemonic, hdpath);
+    hdWalletHandler = await HDWalletHandler.create(
+      mockedProvider,
+      mnemonic,
+      hdpath,
+    );
   });
 
   it("should generate a valid address", async () => {
@@ -50,7 +54,7 @@ describe("HDWalletHandler", () => {
   it("should generate a valid address with passphrase", async () => {
     const passphrase = "this is a secret";
 
-    hdWalletHandler = new HDWalletHandler(
+    hdWalletHandler = await HDWalletHandler.create(
       mockedProvider,
       mnemonic,
       hdpath,
@@ -71,7 +75,12 @@ describe("HDWalletHandler", () => {
   });
 
   it("should generate a valid address when given a different index", async () => {
-    hdWalletHandler = new HDWalletHandler(mockedProvider, mnemonic, hdpath, 1);
+    hdWalletHandler = await HDWalletHandler.create(
+      mockedProvider,
+      mnemonic,
+      hdpath,
+      1,
+    );
 
     const jsonRpcRequest = getJsonRpcRequest(1, "eth_accounts");
 
@@ -85,7 +94,7 @@ describe("HDWalletHandler", () => {
   });
 
   it("should generate 2 accounts", async () => {
-    hdWalletHandler = new HDWalletHandler(
+    hdWalletHandler = await HDWalletHandler.create(
       mockedProvider,
       mnemonic,
       hdpath,
@@ -109,7 +118,7 @@ describe("HDWalletHandler", () => {
 
   describe("HDPath formatting", () => {
     it("should work if it doesn't end in a /", async () => {
-      hdWalletHandler = new HDWalletHandler(
+      hdWalletHandler = await HDWalletHandler.create(
         mockedProvider,
         mnemonic,
         "m/44'/60'/0'/0",
@@ -126,39 +135,39 @@ describe("HDWalletHandler", () => {
       assert.equal(result[0], "0x4f3e91d2cacd82fffd1f33a0d26d4078401986e9");
     });
 
-    it("should throw if the path is invalid", () => {
-      assertThrowsHardhatError(
-        () => new HDWalletHandler(mockedProvider, mnemonic, ""),
+    it("should throw if the path is invalid", async () => {
+      await assertRejectsWithHardhatError(
+        HDWalletHandler.create(mockedProvider, mnemonic, ""),
         HardhatError.ERRORS.NETWORK.INVALID_HD_PATH,
         { path: "" },
       );
 
-      assertThrowsHardhatError(
-        () => new HDWalletHandler(mockedProvider, mnemonic, "m/"),
+      await assertRejectsWithHardhatError(
+        HDWalletHandler.create(mockedProvider, mnemonic, "m/"),
         HardhatError.ERRORS.NETWORK.INVALID_HD_PATH,
         { path: "m/" },
       );
 
-      assertThrowsHardhatError(
-        () => new HDWalletHandler(mockedProvider, mnemonic, "m//"),
+      await assertRejectsWithHardhatError(
+        HDWalletHandler.create(mockedProvider, mnemonic, "m//"),
         HardhatError.ERRORS.NETWORK.INVALID_HD_PATH,
         { path: "m//" },
       );
 
-      assertThrowsHardhatError(
-        () => new HDWalletHandler(mockedProvider, mnemonic, "m/'"),
+      await assertRejectsWithHardhatError(
+        HDWalletHandler.create(mockedProvider, mnemonic, "m/'"),
         HardhatError.ERRORS.NETWORK.INVALID_HD_PATH,
         { path: "m/'" },
       );
 
-      assertThrowsHardhatError(
-        () => new HDWalletHandler(mockedProvider, mnemonic, "m/0''"),
+      await assertRejectsWithHardhatError(
+        HDWalletHandler.create(mockedProvider, mnemonic, "m/0''"),
         HardhatError.ERRORS.NETWORK.INVALID_HD_PATH,
         { path: "m/0''" },
       );
 
-      assertThrowsHardhatError(
-        () => new HDWalletHandler(mockedProvider, mnemonic, "ghj"),
+      await assertRejectsWithHardhatError(
+        HDWalletHandler.create(mockedProvider, mnemonic, "ghj"),
         HardhatError.ERRORS.NETWORK.INVALID_HD_PATH,
         { path: "ghj" },
       );


### PR DESCRIPTION
The `connect()` method in the network manager was experiencing noticeable slowdowns. This was caused by multiple factors:

1. Bug in `normalizeEdrNetworkAccountsConfig`:
 - A resolved HD account was being compared to the default HD account. The resolved account allows configuration variables for `mnemonic` and `passphrase`, while the default account uses `string` values for these fields.
 - The issue was temporarily fixed by `get()`ting the string values from the configuration variables before comparison.
 - **Next Steps:** evaluate whether it makes sense to use configuration variables in the EDR network accounts config, as the data is not expected to be real. Issue: https://github.com/NomicFoundation/hardhat/issues/6210

2. Slow Imports in `derivePrivateKeys` module:
 - The module that exports the `derivePrivateKeys` function imports two slow dependencies:
```
import { mnemonicToSeedSync } from "ethereum-cryptography/bip39";
import { HDKey } from "ethereum-cryptography/hdkey";
```
 - These imports were changed to be dynamic, so they are loaded only when the `derivePrivateKeys` function is called.
 - **Next Steps:** moving the key derivation process to EDR for further performance improvement.

3. Slow Imports in `createHandlersArray` module:
 - The module containing `createHandlersArray`, used within the `onRequest` handler, was slow to load.
 - The import was made dynamic, and additionally, the internal imports of this module were also made dynamic.
 - **Next Steps:** further investigation is needed to determine why this module is slow. Issue: https://github.com/NomicFoundation/hardhat/issues/6211