### PR TITLE
fix: error when re-using the solc settings object

### DIFF
--- a/.changeset/witty-clouds-compete.md
+++ b/.changeset/witty-clouds-compete.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix error when re-using the solc settings object

--- a/packages/hardhat-core/src/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-resolution.ts
@@ -401,7 +401,7 @@ function normalizeSolidityConfig(
 function resolveCompiler(compiler: SolcUserConfig): SolcConfig {
   const resolved: SolcConfig = {
     version: compiler.version,
-    settings: compiler.settings ?? {},
+    settings: { ...(compiler.settings ?? {}) },
   };
 
   if (semver.gte(resolved.version, "0.8.20")) {

--- a/packages/hardhat-core/test/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-resolution.ts
@@ -82,6 +82,29 @@ describe("Config resolution", () => {
         } as any);
       });
 
+      it("should not mutate the user config", () => {
+        const settings = {};
+        const { solidity } = resolveConfig(__filename, {
+          solidity: {
+            compilers: [
+              {
+                version: "0.5.15",
+                settings,
+              },
+              {
+                version: "0.6.7",
+                settings,
+              },
+            ],
+          },
+        });
+        assert.notStrictEqual(
+          solidity.compilers[0].settings,
+          solidity.compilers[1].settings
+        );
+        assert.deepEqual(settings, {} as any);
+      });
+
       it("should return the config merged ", () => {
         assert.lengthOf(config.solidity.compilers, 1);
         assert.equal(config.solidity.compilers[0].version, "0.5.15");


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Closes #6204

This fix ensures that we don't mutate the `comiler.settings` when resolving the compiler.