### PR TITLE
Clean up and implement the ArtifactManager interface

### DIFF
--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -1488,7 +1488,7 @@ Please double check that your contracts have been compiled and double check your
       number: 1601,
       messageTemplate: `There are multiple artifacts for contract "{contractName}", please use a fully qualified name.
 
-Please replace %contractName% for one of these options wherever you are trying to read its artifact:
+Please replace {contractName} for one of these options wherever you are trying to read its artifact:
 
 {candidates}
 `,

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -91,6 +91,11 @@ export const ERROR_CATEGORIES: {
     max: 1599,
     websiteTitle: "Hardhat-chai-matchers errors",
   },
+  ARTIFACTS: {
+    min: 1600,
+    max: 1699,
+    websiteTitle: "Compilation artifacts related errors",
+  },
 };
 
 export const ERRORS = {
@@ -1467,6 +1472,30 @@ Please check Hardhat's output for more details.`,
         "withArgs called with both .emit and .revertedWithCustomError, but these assertions cannot be combined",
       websiteDescription:
         "withArgs called with both .emit and .revertedWithCustomError, but these assertions cannot be combined",
+    },
+  },
+  ARTIFACTS: {
+    NOT_FOUND: {
+      number: 1600,
+      messageTemplate:
+        'Artifact for contract "{contractName}" not found. {suggestion}',
+      websiteTitle: "Artifact not found",
+      websiteDescription: `Tried to import a nonexistent artifact.
+
+Please double check that your contracts have been compiled and double check your artifact's name.`,
+    },
+    MULTIPLE_FOUND: {
+      number: 1601,
+      messageTemplate: `There are multiple artifacts for contract "{contractName}", please use a fully qualified name.
+
+Please replace %contractName% for one of these options wherever you are trying to read its artifact:
+
+{candidates}
+`,
+      websiteTitle: "Multiple artifacts found",
+      websiteDescription: `There are multiple artifacts that match the given contract name, and Hardhat doesn't know which one to use.
+
+Please use the fully qualified name of the contract to disambiguate it.`,
     },
   },
 } as const;

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -1480,7 +1480,7 @@ Please check Hardhat's output for more details.`,
       messageTemplate:
         'Artifact for contract "{contractName}" not found. {suggestion}',
       websiteTitle: "Artifact not found",
-      websiteDescription: `Tried to import a nonexistent artifact.
+      websiteDescription: `Tried to read a nonexistent artifact.
 
 Please double check that your contracts have been compiled and double check your artifact's name.`,
     },

--- a/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
+++ b/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
@@ -8,7 +8,7 @@ import type { HardhatEthersSigner } from "../signers/signers.js";
 import type {
   Abi,
   Artifact,
-  ArtifactsManager,
+  ArtifactManager,
 } from "@ignored/hardhat-vnext/types/artifacts";
 import type { NetworkConfig } from "@ignored/hardhat-vnext/types/config";
 import type { ethers as EthersT } from "ethers";
@@ -28,13 +28,13 @@ export class HardhatHelpers {
   readonly #provider: HardhatEthersProvider;
   readonly #networkName: string;
   readonly #networkConfig: Readonly<NetworkConfig>;
-  readonly #artifactManager: ArtifactsManager;
+  readonly #artifactManager: ArtifactManager;
 
   constructor(
     provider: HardhatEthersProvider,
     networkName: string,
     networkConfig: NetworkConfig,
-    artifactManager: ArtifactsManager,
+    artifactManager: ArtifactManager,
   ) {
     this.#provider = provider;
     this.#networkName = networkName;

--- a/v-next/hardhat-ethers/src/internal/initialization.ts
+++ b/v-next/hardhat-ethers/src/internal/initialization.ts
@@ -1,5 +1,5 @@
 import type { HardhatEthers } from "../types.js";
-import type { ArtifactsManager } from "@ignored/hardhat-vnext/types/artifacts";
+import type { ArtifactManager } from "@ignored/hardhat-vnext/types/artifacts";
 import type { NetworkConfig } from "@ignored/hardhat-vnext/types/config";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
@@ -10,7 +10,7 @@ export async function initializeEthers(
   ethereumProvider: EthereumProvider,
   networkName: string,
   networkConfig: NetworkConfig,
-  artifactManager: ArtifactsManager,
+  artifactManager: ArtifactManager,
 ): Promise<HardhatEthers> {
   const ethers = await import("ethers");
 

--- a/v-next/hardhat-ethers/test/helpers/artifact-manager-mock.ts
+++ b/v-next/hardhat-ethers/test/helpers/artifact-manager-mock.ts
@@ -67,7 +67,7 @@ export class MockArtifactsManager implements ArtifactsManager {
     });
   }
 
-  public async getAllFullyQualifiedNames(): Promise<string[]> {
+  public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });
@@ -81,7 +81,7 @@ export class MockArtifactsManager implements ArtifactsManager {
     });
   }
 
-  public async getAllBuildInfoIds(): Promise<string[]> {
+  public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });
@@ -98,6 +98,12 @@ export class MockArtifactsManager implements ArtifactsManager {
   public async getBuildInfoOutputPath(
     _buildInfoId: string,
   ): Promise<string | undefined> {
+    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
+      message: "Not implemented in MockArtifactsManager",
+    });
+  }
+
+  public async clearCache(): Promise<void> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });

--- a/v-next/hardhat-ethers/test/helpers/artifact-manager-mock.ts
+++ b/v-next/hardhat-ethers/test/helpers/artifact-manager-mock.ts
@@ -81,7 +81,7 @@ export class MockArtifactsManager implements ArtifactsManager {
     });
   }
 
-  public async getBuildInfoIds(): Promise<string[]> {
+  public async getAllBuildInfoIds(): Promise<string[]> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });

--- a/v-next/hardhat-ethers/test/helpers/artifact-manager-mock.ts
+++ b/v-next/hardhat-ethers/test/helpers/artifact-manager-mock.ts
@@ -1,13 +1,8 @@
 import type {
   Artifact,
   ArtifactsManager,
-  BuildInfo,
   GetAtifactByName,
 } from "@ignored/hardhat-vnext/types/artifacts";
-import type {
-  CompilerInput,
-  CompilerOutput,
-} from "@ignored/hardhat-vnext/types/solidity";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
@@ -28,6 +23,10 @@ export class MockArtifactsManager implements ArtifactsManager {
         this.#artifactsPaths.set(artifactName, fileName);
       }
     }
+  }
+
+  public async saveArtifact(artifact: Artifact): Promise<void> {
+    this.#artifacts.set(artifact.contractName, artifact);
   }
 
   public async readArtifact<ContractNameT extends string>(
@@ -52,7 +51,15 @@ export class MockArtifactsManager implements ArtifactsManager {
     return artifact;
   }
 
-  public artifactExists(
+  public async getArtifactPath(
+    _contractNameOrFullyQualifiedName: string,
+  ): Promise<string> {
+    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
+      message: "Not implemented in MockArtifactsManager",
+    });
+  }
+
+  public async artifactExists(
     _contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
@@ -60,64 +67,37 @@ export class MockArtifactsManager implements ArtifactsManager {
     });
   }
 
-  public getAllFullyQualifiedNames(): Promise<string[]> {
+  public async getAllFullyQualifiedNames(): Promise<string[]> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });
   }
 
-  public getBuildInfo(
-    _fullyQualifiedName: string,
-  ): Promise<BuildInfo | undefined> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public getArtifactPaths(): Promise<string[]> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public getDebugFilePaths(): Promise<string[]> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public getBuildInfoPaths(): Promise<string[]> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public async saveArtifact(artifact: Artifact): Promise<void> {
-    this.#artifacts.set(artifact.contractName, artifact);
-  }
-
-  public saveBuildInfo(
-    _solcVersion: string,
-    _solcLongVersion: string,
-    _input: CompilerInput,
-    _output: CompilerOutput,
-  ): Promise<string> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public formArtifactPathFromFullyQualifiedName(
-    _fullyQualifiedName: string,
-  ): string {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public getArtifactPath(
+  public async getBuildInfoId(
     _contractNameOrFullyQualifiedName: string,
-  ): Promise<string> {
+  ): Promise<string | undefined> {
+    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
+      message: "Not implemented in MockArtifactsManager",
+    });
+  }
+
+  public async getBuildInfoIds(): Promise<string[]> {
+    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
+      message: "Not implemented in MockArtifactsManager",
+    });
+  }
+
+  public async getBuildInfoPath(
+    _buildInfoId: string,
+  ): Promise<string | undefined> {
+    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
+      message: "Not implemented in MockArtifactsManager",
+    });
+  }
+
+  public async getBuildInfoOutputPath(
+    _buildInfoId: string,
+  ): Promise<string | undefined> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });

--- a/v-next/hardhat-ethers/test/helpers/artifact-manager-mock.ts
+++ b/v-next/hardhat-ethers/test/helpers/artifact-manager-mock.ts
@@ -1,12 +1,12 @@
 import type {
   Artifact,
-  ArtifactsManager,
+  ArtifactManager,
   GetAtifactByName,
 } from "@ignored/hardhat-vnext/types/artifacts";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 
-export class MockArtifactsManager implements ArtifactsManager {
+export class MockArtifactManager implements ArtifactManager {
   readonly #artifacts: Map<string, Artifact>;
   readonly #artifactsPaths: Map<string, string>;
 
@@ -40,7 +40,7 @@ export class MockArtifactsManager implements ArtifactsManager {
       throw new HardhatError(
         HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR,
         {
-          message: `Not implemented in MockArtifactsManager - no mocked artifact found with name "${contractNameOrFullyQualifiedName}"`,
+          message: `Not implemented in MockArtifactManager - no mocked artifact found with name "${contractNameOrFullyQualifiedName}"`,
         },
       );
     }
@@ -55,7 +55,7 @@ export class MockArtifactsManager implements ArtifactsManager {
     _contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
@@ -63,13 +63,13 @@ export class MockArtifactsManager implements ArtifactsManager {
     _contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
   public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
@@ -77,13 +77,13 @@ export class MockArtifactsManager implements ArtifactsManager {
     _contractNameOrFullyQualifiedName: string,
   ): Promise<string | undefined> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
   public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
@@ -91,7 +91,7 @@ export class MockArtifactsManager implements ArtifactsManager {
     _buildInfoId: string,
   ): Promise<string | undefined> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
@@ -99,13 +99,13 @@ export class MockArtifactsManager implements ArtifactsManager {
     _buildInfoId: string,
   ): Promise<string | undefined> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
   public async clearCache(): Promise<void> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 }

--- a/v-next/hardhat-ethers/test/helpers/helpers.ts
+++ b/v-next/hardhat-ethers/test/helpers/helpers.ts
@@ -1,5 +1,5 @@
 import type { HardhatEthers } from "../../src/types.js";
-import type { ArtifactsManager } from "@ignored/hardhat-vnext/types/artifacts";
+import type { ArtifactManager } from "@ignored/hardhat-vnext/types/artifacts";
 import type { NetworkConfig } from "@ignored/hardhat-vnext/types/config";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 import type { ContractRunner, Signer } from "ethers";
@@ -10,7 +10,7 @@ import { createHardhatRuntimeEnvironment } from "@ignored/hardhat-vnext/hre";
 
 import { initializeEthers } from "../../src/internal/initialization.js";
 
-import { MockArtifactsManager } from "./artifact-manager-mock.js";
+import { MockArtifactManager } from "./artifact-manager-mock.js";
 
 export async function initializeTestEthers(
   mockedArtifacts?: Array<{ artifactName: string; fileName: string }>,
@@ -19,7 +19,7 @@ export async function initializeTestEthers(
   provider: EthereumProvider;
   networkName: string;
   networkConfig: NetworkConfig;
-  artifactsManager: ArtifactsManager;
+  artifactManager: ArtifactManager;
 }> {
   const hre = await createHardhatRuntimeEnvironment({});
 
@@ -29,13 +29,13 @@ export async function initializeTestEthers(
   const networkName = connection.networkName;
   const networkConfig = connection.networkConfig;
 
-  const artifactsManager = new MockArtifactsManager(mockedArtifacts);
+  const artifactManager = new MockArtifactManager(mockedArtifacts);
 
   const ethers = await initializeEthers(
     provider,
     connection.networkName,
     connection.networkConfig,
-    artifactsManager,
+    artifactManager,
   );
 
   return {
@@ -43,7 +43,7 @@ export async function initializeTestEthers(
     provider,
     networkName,
     networkConfig,
-    artifactsManager,
+    artifactManager,
   };
 }
 

--- a/v-next/hardhat-ethers/test/no-accounts.ts
+++ b/v-next/hardhat-ethers/test/no-accounts.ts
@@ -1,5 +1,5 @@
 import type { HardhatEthers } from "../src/types.js";
-import type { ArtifactsManager } from "@ignored/hardhat-vnext/types/artifacts";
+import type { ArtifactManager } from "@ignored/hardhat-vnext/types/artifacts";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
 import assert from "node:assert/strict";
@@ -14,13 +14,13 @@ import { initializeTestEthers } from "./helpers/helpers.js";
 describe("hardhat-ethers plugin", () => {
   let ethers: HardhatEthers;
   let ethereumProvider: EthereumProvider;
-  let artifactsManager: ArtifactsManager;
+  let artifactManager: ArtifactManager;
 
   beforeEach(async () => {
     ({
       ethers,
       provider: ethereumProvider,
-      artifactsManager,
+      artifactManager: artifactManager,
     } = await initializeTestEthers([
       {
         artifactName: "Greeter",
@@ -96,8 +96,7 @@ describe("hardhat-ethers plugin", () => {
           // const signers = await ethers.getSigners();
           // assert.equal(signers.length, 0);
 
-          const greeterArtifact =
-            await artifactsManager.readArtifact("Greeter");
+          const greeterArtifact = await artifactManager.readArtifact("Greeter");
 
           const contract = await ethers.getContractAt(
             greeterArtifact.abi,

--- a/v-next/hardhat-ethers/test/plugin-functionalities.ts
+++ b/v-next/hardhat-ethers/test/plugin-functionalities.ts
@@ -5,7 +5,7 @@ import type {
 import type { HardhatEthers, HardhatEthersSigner } from "../src/types.js";
 import type {
   Artifact,
-  ArtifactsManager,
+  ArtifactManager,
 } from "@ignored/hardhat-vnext/types/artifacts";
 import type * as EthersT from "ethers";
 
@@ -23,11 +23,11 @@ import {
 
 describe("Ethers plugin", () => {
   let ethers: HardhatEthers;
-  let artifactsManager: ArtifactsManager;
+  let artifactManager: ArtifactManager;
 
   beforeEach(async () => {
     // Declare all the artifacts that we need during the test
-    ({ ethers, artifactsManager } = await initializeTestEthers([
+    ({ ethers, artifactManager } = await initializeTestEthers([
       { artifactName: "Greeter", fileName: "greeter" },
       { artifactName: "IGreeter", fileName: "igreeter" },
       { artifactName: "TestContractLib", fileName: "test-contract-lib" },
@@ -79,8 +79,8 @@ describe("Ethers plugin", () => {
       beforeEach(async () => {
         signers = await ethers.getSigners();
 
-        greeterArtifact = await artifactsManager.readArtifact("Greeter");
-        iGreeterArtifact = await artifactsManager.readArtifact("IGreeter");
+        greeterArtifact = await artifactManager.readArtifact("Greeter");
+        iGreeterArtifact = await artifactManager.readArtifact("IGreeter");
       });
 
       describe("getSigners", () => {
@@ -526,7 +526,7 @@ describe("Ethers plugin", () => {
           const libraryFactory = await ethers.getContractFactory("TestLibrary");
           const library = await libraryFactory.deploy();
           const testContractLibArtifact =
-            await artifactsManager.readArtifact("TestContractLib");
+            await artifactManager.readArtifact("TestContractLib");
           const contractFactory = await ethers.getContractFactoryFromArtifact<
             [],
             TestContractLib

--- a/v-next/hardhat-viem/src/internal/contracts.ts
+++ b/v-next/hardhat-viem/src/internal/contracts.ts
@@ -8,7 +8,7 @@ import type {
   SendDeploymentTransactionConfig,
   WalletClient,
 } from "../types.js";
-import type { ArtifactsManager } from "@ignored/hardhat-vnext/types/artifacts";
+import type { ArtifactManager } from "@ignored/hardhat-vnext/types/artifacts";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 import type { PrefixedHexString } from "@ignored/hardhat-vnext-utils/hex";
 import type { Abi as ViemAbi, Address as ViemAddress } from "viem";
@@ -23,7 +23,7 @@ import { getDefaultWalletClient, getPublicClient } from "./clients.js";
 
 export async function deployContract<ContractName extends string>(
   provider: EthereumProvider,
-  artifactManager: ArtifactsManager,
+  artifactManager: ArtifactManager,
   contractName: ContractName,
   constructorArgs: unknown[] = [],
   deployContractConfig: DeployContractConfig = {},
@@ -103,7 +103,7 @@ export async function deployContract<ContractName extends string>(
 
 export async function sendDeploymentTransaction<ContractName extends string>(
   provider: EthereumProvider,
-  artifactManager: ArtifactsManager,
+  artifactManager: ArtifactManager,
   contractName: ContractName,
   constructorArgs: unknown[] = [],
   sendDeploymentTransactionConfig: SendDeploymentTransactionConfig = {},
@@ -166,7 +166,7 @@ export async function sendDeploymentTransaction<ContractName extends string>(
 
 export async function getContractAt<ContractName extends string>(
   provider: EthereumProvider,
-  artifactManager: ArtifactsManager,
+  artifactManager: ArtifactManager,
   contractName: ContractName,
   address: ViemAddress,
   getContractAtConfig: GetContractAtConfig = {},
@@ -209,7 +209,7 @@ function createContractInstance<ContractName extends string>(
 }
 
 async function getContractAbiAndBytecode(
-  artifacts: ArtifactsManager,
+  artifacts: ArtifactManager,
   contractName: string,
   libraries: Libraries,
 ) {

--- a/v-next/hardhat-viem/src/internal/initialization.ts
+++ b/v-next/hardhat-viem/src/internal/initialization.ts
@@ -1,5 +1,5 @@
 import type { HardhatViemHelpers } from "../types.js";
-import type { ArtifactsManager } from "@ignored/hardhat-vnext/types/artifacts";
+import type { ArtifactManager } from "@ignored/hardhat-vnext/types/artifacts";
 import type { ChainType } from "@ignored/hardhat-vnext/types/network";
 import type { EthereumProvider } from "@ignored/hardhat-vnext/types/providers";
 
@@ -18,7 +18,7 @@ import {
 export function initializeViem<ChainTypeT extends ChainType | string>(
   chainType: ChainTypeT,
   provider: EthereumProvider,
-  artifactManager: ArtifactsManager,
+  artifactManager: ArtifactManager,
 ): HardhatViemHelpers<ChainTypeT> {
   return {
     getPublicClient: (publicClientConfig) =>

--- a/v-next/hardhat/src/index.ts
+++ b/v-next/hardhat/src/index.ts
@@ -1,4 +1,4 @@
-import type { ArtifactsManager } from "./types/artifacts.js";
+import type { ArtifactManager } from "./types/artifacts.js";
 import type { HardhatConfig } from "./types/config.js";
 import type { GlobalOptions } from "./types/global-options.js";
 import type { HookManager } from "./types/hooks.js";
@@ -27,7 +27,7 @@ export const interruptions: UserInterruptionManager = hre.interruptions;
 // NOTE: This is a small architectural violation, as the network manager comes
 // from a builtin plugin, and plugins can't add their own exports here.
 export const network: NetworkManager = hre.network;
-export const artifacts: ArtifactsManager = hre.artifacts;
+export const artifacts: ArtifactManager = hre.artifacts;
 export const solidity: SolidityBuildSystem = hre.solidity;
 
 export default hre;

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -240,6 +240,12 @@ export class ArtifactManagerImplementation implements ArtifactManager {
     contractNameOrFullyQualifiedName: string,
     similarNames: string[],
   ): string {
+    const contractNameType = this.#isFullyQualifiedName(
+      contractNameOrFullyQualifiedName,
+    )
+      ? "fully qualified contract name"
+      : "contract name";
+
     switch (similarNames.length) {
       case 0:
         return "";
@@ -250,7 +256,7 @@ export class ArtifactManagerImplementation implements ArtifactManager {
 
 ${similarNames.map((n) => `  * ${n}`).join(EOL)}
 
-Please replace "${contractNameOrFullyQualifiedName}" for the correct contract name wherever you are trying to read its artifact.
+Please replace "${contractNameOrFullyQualifiedName}" with the correct ${contractNameType} wherever you are trying to read its artifact.
 `;
     }
   }

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -1,5 +1,5 @@
 import type {
-  ArtifactsManager,
+  ArtifactManager,
   GetAtifactByName,
 } from "../../../types/artifacts.js";
 
@@ -32,7 +32,7 @@ interface FsData {
   fullyQualifiedNameToArtifactPath: Map<string, string>;
 }
 
-export class ArticlesManagerImplementation implements ArtifactsManager {
+export class ArtifactManagerImplementation implements ArtifactManager {
   readonly #artifactsPath: string;
 
   // This function can be overriden in the constructor for testing purposes.

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -94,9 +94,9 @@ export class ArtifactManagerImplementation implements ArtifactManager {
   }
 
   public async getBuildInfoId(
-    fullyQualifiedName: string,
+    contractNameOrFullyQualifiedName: string,
   ): Promise<string | undefined> {
-    const artifact = await this.readArtifact(fullyQualifiedName);
+    const artifact = await this.readArtifact(contractNameOrFullyQualifiedName);
 
     return artifact.buildInfoId;
   }

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifacts-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifacts-manager.ts
@@ -104,10 +104,7 @@ export class ArticlesManagerImplementation implements ArtifactsManager {
 
       this.#allArtifactPaths = await getAllFilesMatching(
         this.#artifactsPath,
-        (p) =>
-          !p.startsWith(buildInfosDir) &&
-          p.endsWith(".json") &&
-          !p.includes(".sol" + path.sep),
+        (p) => !p.startsWith(buildInfosDir) && p.endsWith(".json"),
       );
     }
 
@@ -146,7 +143,7 @@ export class ArticlesManagerImplementation implements ArtifactsManager {
       );
     }
 
-    return fqns[1];
+    return fqns[0];
   }
 
   async #getBareNameToFullyQualifiedNameMap(): Promise<Map<string, string[]>> {

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifacts-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifacts-manager.ts
@@ -71,7 +71,7 @@ export class ArticlesManagerImplementation implements ArtifactsManager {
     );
   }
 
-  public async getBuildInfoIds(): Promise<string[]> {
+  public async getAllBuildInfoIds(): Promise<string[]> {
     const paths = await getAllFilesMatching(
       path.join(this.#artifactsPath, BUILD_INFO_DIR_NAME),
       (p) => p.endsWith(".json") && !p.endsWith(".output.json"),

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifacts-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifacts-manager.ts
@@ -3,31 +3,43 @@ import type {
   GetAtifactByName,
 } from "../../../types/artifacts.js";
 
+import { EOL } from "node:os";
 import path from "node:path";
 
 import { HardhatError } from "@ignored/hardhat-vnext-errors";
 import {
-  exists,
   getAllFilesMatching,
   readJsonFile,
 } from "@ignored/hardhat-vnext-utils/fs";
 
 export const BUILD_INFO_DIR_NAME = "build-info";
+export const EDIT_DISTANCE_THRESHOLD = 3;
+
+/**
+ * We cache the info that we read from the file system, otherwise we would
+ * have to traverse the filesystem every time we need to get the an artifact.
+ *
+ * To keep our view of the filesystem consistent, we cache everything at the
+ * same time, using this interface to organize the data.
+ */
+interface FsData {
+  bareNameToFullyQualifiedNameMap: Map<string, ReadonlySet<string>>;
+  allArtifactPaths: ReadonlySet<string>;
+  allFullyQualifiedNames: ReadonlySet<string>;
+}
 
 export class ArticlesManagerImplementation implements ArtifactsManager {
   readonly #artifactsPath: string;
 
-  // We cache the map of bare names to fully qualified names to avoid
-  // having to traverse the filesystem every time we need to get the
-  // fully qualified name of a contract.
-  readonly #bareNameToFullyQualifiedNameMap?: Map<string, string[]>;
+  // This function can be overriden in the constructor for testing purposes.
+  // This class will call it whenever the fsData is not already cached, and will
+  // cache the result.
+  readonly #readFsData: () => Promise<FsData>;
+  #fsData?: FsData;
 
-  // We also cache the list of artifact paths to make sure that we return a
-  // consistent result with respect to the #bareNameToFullyQualifiedNameMap.
-  #allArtifactPaths?: string[];
-
-  constructor(artifactsPath: string) {
+  constructor(artifactsPath: string, readFsData?: () => Promise<FsData>) {
     this.#artifactsPath = artifactsPath;
+    this.#readFsData = readFsData ?? (() => this.#readFsDataFromFileSystem());
   }
 
   public async readArtifact<ContractNameT extends string>(
@@ -53,7 +65,20 @@ export class ArticlesManagerImplementation implements ArtifactsManager {
   public async artifactExists(
     contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
-    return exists(await this.getArtifactPath(contractNameOrFullyQualifiedName));
+    try {
+      // This throw if the artifact doesn't exist
+      await this.getArtifactPath(contractNameOrFullyQualifiedName);
+
+      return true;
+    } catch (error) {
+      if (HardhatError.isHardhatError(error)) {
+        if (error.number === HardhatError.ERRORS.ARTIFACTS.NOT_FOUND.number) {
+          return false;
+        }
+      }
+
+      throw error;
+    }
   }
 
   public async getBuildInfoId(
@@ -64,20 +89,18 @@ export class ArticlesManagerImplementation implements ArtifactsManager {
     return artifact.buildInfoId;
   }
 
-  public async getAllFullyQualifiedNames(): Promise<string[]> {
-    const allArtifactPaths = await this.#getAllArtifactAbsolutePaths();
-    return allArtifactPaths.map((p) =>
-      this.#getFullyQualifiedNameFromArtifactAbsolutePath(p),
-    );
+  public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
+    const { allFullyQualifiedNames } = await this.#getFsData();
+    return allFullyQualifiedNames;
   }
 
-  public async getAllBuildInfoIds(): Promise<string[]> {
+  public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
     const paths = await getAllFilesMatching(
       path.join(this.#artifactsPath, BUILD_INFO_DIR_NAME),
       (p) => p.endsWith(".json") && !p.endsWith(".output.json"),
     );
 
-    return paths.map((p) => path.basename(p, ".json"));
+    return new Set(paths.map((p) => path.basename(p, ".json")));
   }
 
   public async getBuildInfoPath(buildInfoId: string): Promise<string> {
@@ -98,76 +121,68 @@ export class ArticlesManagerImplementation implements ArtifactsManager {
     );
   }
 
-  async #getAllArtifactAbsolutePaths(): Promise<string[]> {
-    if (this.#allArtifactPaths === undefined) {
-      const buildInfosDir = path.join(this.#artifactsPath, BUILD_INFO_DIR_NAME);
-
-      this.#allArtifactPaths = await getAllFilesMatching(
-        this.#artifactsPath,
-        (p) => !p.startsWith(buildInfosDir) && p.endsWith(".json"),
-      );
-    }
-
-    return this.#allArtifactPaths;
+  public async clearCache(): Promise<void> {
+    this.#fsData = undefined;
   }
 
   async #getFullyQualifiedName(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
+    const { bareNameToFullyQualifiedNameMap, allFullyQualifiedNames } =
+      await this.#getFsData();
+
     if (this.#isFullyQualifiedName(contractNameOrFullyQualifiedName)) {
-      return contractNameOrFullyQualifiedName;
-    }
+      if (allFullyQualifiedNames.has(contractNameOrFullyQualifiedName)) {
+        return contractNameOrFullyQualifiedName;
+      }
 
-    const fqnMap = await this.#getBareNameToFullyQualifiedNameMap();
-
-    const fqns = fqnMap.get(contractNameOrFullyQualifiedName);
-
-    if (fqns === undefined) {
-      // TODO: Throw the right error, suggesting similar names
-      throw new HardhatError(
-        HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR,
-        {
-          message: "Artifact doesn't exist — Error not implemented yet",
-        },
+      this.#throwNotFoundError(
+        contractNameOrFullyQualifiedName,
+        bareNameToFullyQualifiedNameMap,
       );
     }
 
-    if (fqns.length !== 1) {
-      // TODO: Throw the right error, suggesting the FQNs
-      throw new HardhatError(
-        HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR,
-        {
-          message:
-            "Artifact bare name is ambiguous — Error not implemented yet",
-        },
+    const fqns = bareNameToFullyQualifiedNameMap.get(
+      contractNameOrFullyQualifiedName,
+    );
+
+    if (fqns === undefined || fqns.size === 0) {
+      this.#throwNotFoundError(
+        contractNameOrFullyQualifiedName,
+        bareNameToFullyQualifiedNameMap,
       );
     }
 
-    return fqns[0];
+    if (fqns.size !== 1) {
+      throw new HardhatError(HardhatError.ERRORS.ARTIFACTS.MULTIPLE_FOUND, {
+        contractName: contractNameOrFullyQualifiedName,
+        candidates: Array.from(fqns).join(EOL),
+      });
+    }
+
+    const [fqn] = fqns;
+
+    return fqn;
   }
 
-  async #getBareNameToFullyQualifiedNameMap(): Promise<Map<string, string[]>> {
-    if (this.#bareNameToFullyQualifiedNameMap !== undefined) {
-      return this.#bareNameToFullyQualifiedNameMap;
-    }
+  #throwNotFoundError(
+    contractNameOrFullyQualifiedName: string,
+    bareNameToFullyQualifiedNameMap: Map<string, ReadonlySet<string>>,
+  ): never {
+    const similarNames = this.#getSimilarContractNames(
+      contractNameOrFullyQualifiedName,
+      bareNameToFullyQualifiedNameMap,
+    );
 
-    const paths = await this.#getAllArtifactAbsolutePaths();
+    const suggestion = this.#formatSimilarNameSuggestions(
+      contractNameOrFullyQualifiedName,
+      similarNames,
+    );
 
-    const fqnMap = new Map<string, string[]>();
-
-    for (const p of paths) {
-      const bareName = path.basename(p, ".json");
-      const fqn = this.#getFullyQualifiedNameFromArtifactAbsolutePath(p);
-
-      const fqns = fqnMap.get(bareName);
-      if (fqns === undefined) {
-        fqnMap.set(bareName, [fqn]);
-      } else {
-        fqns.push(fqn);
-      }
-    }
-
-    return fqnMap;
+    throw new HardhatError(HardhatError.ERRORS.ARTIFACTS.NOT_FOUND, {
+      contractName: contractNameOrFullyQualifiedName,
+      suggestion,
+    });
   }
 
   #isFullyQualifiedName(name: string): boolean {
@@ -197,4 +212,194 @@ export class ArticlesManagerImplementation implements ArtifactsManager {
     const contractName = path.basename(relativePath, ".json");
     return `${sourceName}:${contractName}`;
   }
+
+  #getSimilarContractNames(
+    contractNameOrFullyQualifiedName: string,
+    bareNameToFullyQualifiedNameMap: Map<string, ReadonlySet<string>>,
+  ): string[] {
+    const names = this.#isFullyQualifiedName(contractNameOrFullyQualifiedName)
+      ? Array.from(bareNameToFullyQualifiedNameMap?.values() ?? [])
+          .map((s) => [...s])
+          .flat(1)
+      : Array.from(bareNameToFullyQualifiedNameMap?.keys() ?? []);
+
+    return names
+      .map(
+        (name) =>
+          [name, editDistance(name, contractNameOrFullyQualifiedName)] as const,
+      )
+      .sort(([_, d1], [__, d2]) => d1 - d2)
+      .filter(([_, d]) => d <= EDIT_DISTANCE_THRESHOLD)
+      .map(([name]) => name);
+  }
+
+  #formatSimilarNameSuggestions(
+    contractNameOrFullyQualifiedName: string,
+    similarNames: string[],
+  ): string {
+    switch (similarNames.length) {
+      case 0:
+        return "";
+      case 1:
+        return `Did you mean "${similarNames[0]}"?`;
+      default:
+        return `We found some that were similar:
+
+${similarNames.map((n) => `  * ${n}`).join(EOL)}
+
+Please replace "${contractNameOrFullyQualifiedName}" for the correct contract name wherever you are trying to read its artifact.
+`;
+    }
+  }
+
+  async #getFsData(): Promise<FsData> {
+    if (this.#fsData === undefined) {
+      this.#fsData = await this.#readFsData();
+    }
+
+    return this.#fsData;
+  }
+
+  async #readFsDataFromFileSystem(): Promise<FsData> {
+    const buildInfosDir = path.join(this.#artifactsPath, BUILD_INFO_DIR_NAME);
+
+    const allArtifactPaths = await getAllFilesMatching(
+      this.#artifactsPath,
+      (p) => !p.startsWith(buildInfosDir) && p.endsWith(".json"),
+    );
+
+    const allFullyQualifiedNames = new Set<string>();
+    const bareNameToFullyQualifiedNameMap = new Map<string, Set<string>>();
+
+    for (const p of allArtifactPaths) {
+      const bareName = path.basename(p, ".json");
+      const fqn = this.#getFullyQualifiedNameFromArtifactAbsolutePath(p);
+      allFullyQualifiedNames.add(fqn);
+
+      const fqns = bareNameToFullyQualifiedNameMap.get(bareName);
+      if (fqns === undefined) {
+        bareNameToFullyQualifiedNameMap.set(bareName, new Set([fqn]));
+      } else {
+        fqns.add(fqn);
+      }
+    }
+
+    return {
+      allArtifactPaths: new Set(allArtifactPaths),
+      bareNameToFullyQualifiedNameMap,
+      allFullyQualifiedNames,
+    };
+  }
+}
+
+/**
+ * Returns the edit-distance between two given strings using Levenshtein distance.
+ *
+ * @param a First string being compared
+ * @param b Second string being compared
+ * @returns distance between the two strings (lower number == more similar)
+ * @see https://github.com/gustf/js-levenshtein
+ * @license MIT - https://github.com/gustf/js-levenshtein/blob/master/LICENSE
+ */
+export function editDistance(a: string, b: string): number {
+  function _min(
+    _d0: number,
+    _d1: number,
+    _d2: number,
+    _bx: number,
+    _ay: number,
+  ): number {
+    return _d0 < _d1 || _d2 < _d1
+      ? _d0 > _d2
+        ? _d2 + 1
+        : _d0 + 1
+      : _bx === _ay
+        ? _d1
+        : _d1 + 1;
+  }
+
+  if (a === b) {
+    return 0;
+  }
+
+  if (a.length > b.length) {
+    [a, b] = [b, a];
+  }
+
+  let la = a.length;
+  let lb = b.length;
+
+  while (la > 0 && a.charCodeAt(la - 1) === b.charCodeAt(lb - 1)) {
+    la--;
+    lb--;
+  }
+
+  let offset = 0;
+
+  while (offset < la && a.charCodeAt(offset) === b.charCodeAt(offset)) {
+    offset++;
+  }
+
+  la -= offset;
+  lb -= offset;
+
+  if (la === 0 || lb < 3) {
+    return lb;
+  }
+
+  let x = 0;
+  let y: number;
+  let d0: number;
+  let d1: number;
+  let d2: number;
+  let d3: number;
+  let dd: number = 0; // typescript gets angry if we don't assign here
+  let dy: number;
+  let ay: number;
+  let bx0: number;
+  let bx1: number;
+  let bx2: number;
+  let bx3: number;
+
+  const vector = [];
+
+  for (y = 0; y < la; y++) {
+    vector.push(y + 1);
+    vector.push(a.charCodeAt(offset + y));
+  }
+
+  const len = vector.length - 1;
+
+  for (; x < lb - 3; ) {
+    bx0 = b.charCodeAt(offset + (d0 = x));
+    bx1 = b.charCodeAt(offset + (d1 = x + 1));
+    bx2 = b.charCodeAt(offset + (d2 = x + 2));
+    bx3 = b.charCodeAt(offset + (d3 = x + 3));
+    dd = x += 4;
+    for (y = 0; y < len; y += 2) {
+      dy = vector[y];
+      ay = vector[y + 1];
+      d0 = _min(dy, d0, d1, bx0, ay);
+      d1 = _min(d0, d1, d2, bx1, ay);
+      d2 = _min(d1, d2, d3, bx2, ay);
+      dd = _min(d2, d3, dd, bx3, ay);
+      vector[y] = dd;
+      d3 = d2;
+      d2 = d1;
+      d1 = d0;
+      d0 = dy;
+    }
+  }
+
+  for (; x < lb; ) {
+    bx0 = b.charCodeAt(offset + (d0 = x));
+    dd = ++x;
+    for (y = 0; y < len; y += 2) {
+      dy = vector[y];
+      vector[y] = dd = _min(dy, d0, dd, bx0, vector[y + 1]);
+      d0 = dy;
+    }
+  }
+
+  return dd;
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -1,6 +1,5 @@
 import type {
   ArtifactsManager,
-  BuildInfo,
   GetAtifactByName,
 } from "../../../../types/artifacts.js";
 import type { HardhatRuntimeEnvironmentHooks } from "../../../../types/hooks.js";
@@ -21,6 +20,13 @@ class LazyArtifactsManager implements ArtifactsManager {
     return artifactsManager.readArtifact(contractNameOrFullyQualifiedName);
   }
 
+  public async getArtifactPath(
+    contractNameOrFullyQualifiedName: string,
+  ): Promise<string> {
+    const artifactsManager = await this.#getArtifactsManager();
+    return artifactsManager.getArtifactPath(contractNameOrFullyQualifiedName);
+  }
+
   public async artifactExists(
     contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
@@ -33,37 +39,38 @@ class LazyArtifactsManager implements ArtifactsManager {
     return artifactsManager.getAllFullyQualifiedNames();
   }
 
-  public async getBuildInfo(
-    fullyQualifiedName: string,
-  ): Promise<BuildInfo | undefined> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getBuildInfo(fullyQualifiedName);
-  }
-
-  public async getArtifactPaths(): Promise<string[]> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getArtifactPaths();
-  }
-
-  public async getBuildInfoPaths(): Promise<string[]> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getBuildInfoPaths();
-  }
-
-  public async getArtifactPath(
+  public async getBuildInfoId(
     contractNameOrFullyQualifiedName: string,
-  ): Promise<string> {
+  ): Promise<string | undefined> {
     const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getArtifactPath(contractNameOrFullyQualifiedName);
+    return artifactsManager.getBuildInfoId(contractNameOrFullyQualifiedName);
+  }
+
+  public async getBuildInfoIds(): Promise<string[]> {
+    const artifactsManager = await this.#getArtifactsManager();
+    return artifactsManager.getBuildInfoIds();
+  }
+
+  public async getBuildInfoPath(
+    buildInfoId: string,
+  ): Promise<string | undefined> {
+    const artifactsManager = await this.#getArtifactsManager();
+    return artifactsManager.getBuildInfoPath(buildInfoId);
+  }
+
+  public async getBuildInfoOutputPath(
+    buildInfoId: string,
+  ): Promise<string | undefined> {
+    const artifactsManager = await this.#getArtifactsManager();
+    return artifactsManager.getBuildInfoOutputPath(buildInfoId);
   }
 
   async #getArtifactsManager(): Promise<ArtifactsManager> {
-    const { ArtifactsManagerImplementation } = await import(
-      "../artifacts-manager.js"
-    );
-
     if (this.#artifactsManager === undefined) {
-      this.#artifactsManager = new ArtifactsManagerImplementation(
+      const { ArticlesManagerImplementation } = await import(
+        "../artifacts-manager.js"
+      );
+      this.#artifactsManager = new ArticlesManagerImplementation(
         this.#artifactsPath,
       );
     }

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -34,7 +34,7 @@ class LazyArtifactsManager implements ArtifactsManager {
     return artifactsManager.artifactExists(contractNameOrFullyQualifiedName);
   }
 
-  public async getAllFullyQualifiedNames(): Promise<string[]> {
+  public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
     const artifactsManager = await this.#getArtifactsManager();
     return artifactsManager.getAllFullyQualifiedNames();
   }
@@ -46,7 +46,7 @@ class LazyArtifactsManager implements ArtifactsManager {
     return artifactsManager.getBuildInfoId(contractNameOrFullyQualifiedName);
   }
 
-  public async getAllBuildInfoIds(): Promise<string[]> {
+  public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
     const artifactsManager = await this.#getArtifactsManager();
     return artifactsManager.getAllBuildInfoIds();
   }
@@ -63,6 +63,11 @@ class LazyArtifactsManager implements ArtifactsManager {
   ): Promise<string | undefined> {
     const artifactsManager = await this.#getArtifactsManager();
     return artifactsManager.getBuildInfoOutputPath(buildInfoId);
+  }
+
+  public async clearCache(): Promise<void> {
+    const artifactsManager = await this.#getArtifactsManager();
+    return artifactsManager.clearCache();
   }
 
   async #getArtifactsManager(): Promise<ArtifactsManager> {

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -46,9 +46,9 @@ class LazyArtifactsManager implements ArtifactsManager {
     return artifactsManager.getBuildInfoId(contractNameOrFullyQualifiedName);
   }
 
-  public async getBuildInfoIds(): Promise<string[]> {
+  public async getAllBuildInfoIds(): Promise<string[]> {
     const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getBuildInfoIds();
+    return artifactsManager.getAllBuildInfoIds();
   }
 
   public async getBuildInfoPath(

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -1,93 +1,93 @@
 import type {
-  ArtifactsManager,
+  ArtifactManager,
   GetAtifactByName,
 } from "../../../../types/artifacts.js";
 import type { HardhatRuntimeEnvironmentHooks } from "../../../../types/hooks.js";
 
-class LazyArtifactsManager implements ArtifactsManager {
+class LazyArtifactManager implements ArtifactManager {
   readonly #artifactsPath: string;
-  #artifactsManager: ArtifactsManager | undefined;
+  #artifactManager: ArtifactManager | undefined;
 
   constructor(artifactsPath: string) {
-    this.#artifactsManager = undefined;
+    this.#artifactManager = undefined;
     this.#artifactsPath = artifactsPath;
   }
 
   public async readArtifact<ContractNameT extends string>(
     contractNameOrFullyQualifiedName: ContractNameT,
   ): Promise<GetAtifactByName<ContractNameT>> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.readArtifact(contractNameOrFullyQualifiedName);
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.readArtifact(contractNameOrFullyQualifiedName);
   }
 
   public async getArtifactPath(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getArtifactPath(contractNameOrFullyQualifiedName);
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.getArtifactPath(contractNameOrFullyQualifiedName);
   }
 
   public async artifactExists(
     contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.artifactExists(contractNameOrFullyQualifiedName);
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.artifactExists(contractNameOrFullyQualifiedName);
   }
 
   public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getAllFullyQualifiedNames();
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.getAllFullyQualifiedNames();
   }
 
   public async getBuildInfoId(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string | undefined> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getBuildInfoId(contractNameOrFullyQualifiedName);
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.getBuildInfoId(contractNameOrFullyQualifiedName);
   }
 
   public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getAllBuildInfoIds();
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.getAllBuildInfoIds();
   }
 
   public async getBuildInfoPath(
     buildInfoId: string,
   ): Promise<string | undefined> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getBuildInfoPath(buildInfoId);
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.getBuildInfoPath(buildInfoId);
   }
 
   public async getBuildInfoOutputPath(
     buildInfoId: string,
   ): Promise<string | undefined> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.getBuildInfoOutputPath(buildInfoId);
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.getBuildInfoOutputPath(buildInfoId);
   }
 
   public async clearCache(): Promise<void> {
-    const artifactsManager = await this.#getArtifactsManager();
-    return artifactsManager.clearCache();
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.clearCache();
   }
 
-  async #getArtifactsManager(): Promise<ArtifactsManager> {
-    if (this.#artifactsManager === undefined) {
-      const { ArticlesManagerImplementation } = await import(
-        "../artifacts-manager.js"
+  async #getArtifactManager(): Promise<ArtifactManager> {
+    if (this.#artifactManager === undefined) {
+      const { ArtifactManagerImplementation } = await import(
+        "../artifact-manager.js"
       );
-      this.#artifactsManager = new ArticlesManagerImplementation(
+      this.#artifactManager = new ArtifactManagerImplementation(
         this.#artifactsPath,
       );
     }
 
-    return this.#artifactsManager;
+    return this.#artifactManager;
   }
 }
 
 export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => {
   const handlers: Partial<HardhatRuntimeEnvironmentHooks> = {
     created: async (_context, hre): Promise<void> => {
-      hre.artifacts = new LazyArtifactsManager(hre.config.paths.artifacts);
+      hre.artifacts = new LazyArtifactManager(hre.config.paths.artifacts);
     },
   };
 

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/type-extensions.ts
@@ -1,7 +1,7 @@
-import type { ArtifactsManager } from "../../../types/artifacts.js";
+import type { ArtifactManager } from "../../../types/artifacts.js";
 
 declare module "../../../types/hre.js" {
   interface HardhatRuntimeEnvironment {
-    artifacts: ArtifactsManager;
+    artifacts: ArtifactManager;
   }
 }

--- a/v-next/hardhat/src/internal/core/hre.ts
+++ b/v-next/hardhat/src/internal/core/hre.ts
@@ -1,5 +1,5 @@
 import type { UnsafeHardhatRuntimeEnvironmentOptions } from "./types.js";
-import type { ArtifactsManager } from "../../types/artifacts.js";
+import type { ArtifactManager } from "../../types/artifacts.js";
 import type {
   HardhatUserConfig,
   HardhatConfig,
@@ -42,7 +42,7 @@ export class HardhatRuntimeEnvironmentImplementation
   // here, because they are added by plugins. But as those plugins are builtin,
   // their type extensions also affect this module.
   public network!: NetworkManager;
-  public artifacts!: ArtifactsManager;
+  public artifacts!: ArtifactManager;
   public solidity!: SolidityBuildSystem;
 
   public static async create(

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -38,12 +38,19 @@ export interface ArtifactsManager {
   ): Promise<GetAtifactByName<ContractNameT>>;
 
   /**
+   * Returns the absolute path to the given artifact.
+   *
+   * @param contractNameOrFullyQualifiedName The name or fully qualified name
+   * of the contract.
+   */
+  getArtifactPath(contractNameOrFullyQualifiedName: string): Promise<string>;
+
+  /**
    * Returns true if an artifact exists.
    *
    * This function doesn't throw if the name is not unique.
    *
    * @param contractNameOrFullyQualifiedName Contract or fully qualified name.
-   *
    */
   artifactExists(contractNameOrFullyQualifiedName: string): Promise<boolean>;
 
@@ -53,36 +60,46 @@ export interface ArtifactsManager {
   getAllFullyQualifiedNames(): Promise<string[]>;
 
   /**
-   * Returns the BuildInfo associated with the solc run that compiled a
+   * Returns the BuildInfo id associated with the solc run that compiled a
    * contract.
    *
-   * Note that if your contract hasn't been compiled with Hardhat's build system
-   * this method can return undefined.
-   */
-  getBuildInfo(fullyQualifiedName: string): Promise<BuildInfo | undefined>;
-
-  /**
-   * Returns an array with the absolute paths of all the existing artifacts.
+   * Note that it may return `undefined` if the contract wasn't compiled with
+   * Hardhat's build system.
    *
-   * Note that there's an artifact per contract.
+   * If it it does return an id, it's not guaranteed that the build info is
+   * present.
+   *
+   * @param contractNameOrFullyQualifiedName Contract or fully qualified name, whose artifact must exist.
    */
-  getArtifactPaths(): Promise<string[]>;
+  getBuildInfoId(
+    contractNameOrFullyQualifiedName: string,
+  ): Promise<string | undefined>;
 
   /**
-   * Returns an array with the absolute paths of all the existing build infos.
+   * Returns an array with the ids of all the existing build infos.
    *
    * Note that there's one build info per run of solc, so they can be shared
    * by different contracts.
    */
-  getBuildInfoPaths(): Promise<string[]>;
+  getBuildInfoIds(): Promise<string[]>;
 
   /**
-   * Returns the absolute path to the given artifact.
+   * Returns the absolute path to the given build info, or undefined if it
+   * doesn't exist.
    *
-   * @param contractNameOrFullyQualifiedName The name or fully qualified name
-   * of the contract.
+   * @param buildInfoId The id of an existing build info.
    */
-  getArtifactPath(contractNameOrFullyQualifiedName: string): Promise<string>;
+  getBuildInfoPath(buildInfoId: string): Promise<string | undefined>;
+
+  /**
+   * Returns the absolute path to the output of the given build info,
+   * if present.
+   *
+   * Note that the build info may exist, but it's output may not.
+   *
+   * @param buildInfoId The id of an existing build info.
+   */
+  getBuildInfoOutputPath(buildInfoId: string): Promise<string | undefined>;
 }
 
 /**

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -32,6 +32,7 @@ export interface ArtifactsManager {
    *
    * @throws Throws an error if a non-unique contract name is used,
    *   indicating which fully qualified names can be used instead.
+   * @throws Throws an error if the artifact doesn't exist.
    */
   readArtifact<ContractNameT extends string>(
     contractNameOrFullyQualifiedName: ContractNameT,
@@ -42,6 +43,9 @@ export interface ArtifactsManager {
    *
    * @param contractNameOrFullyQualifiedName The name or fully qualified name
    * of the contract.
+   * @throws Throws an error if a non-unique contract name is used,
+   *   indicating which fully qualified names can be used instead.
+   * @throws Throws an error if the artifact doesn't exist.
    */
   getArtifactPath(contractNameOrFullyQualifiedName: string): Promise<string>;
 
@@ -50,7 +54,9 @@ export interface ArtifactsManager {
    *
    * This function doesn't throw if the name is not unique.
    *
-   * @param contractNameOrFullyQualifiedName Contract or fully qualified name.
+   * @param contractNameOrFullyQualifiedName Contract or fully qualified name.\
+   * @throws Throws an error if a non-unique contract name is used,
+   *   indicating which fully qualified names can be used instead.
    */
   artifactExists(contractNameOrFullyQualifiedName: string): Promise<boolean>;
 
@@ -63,13 +69,19 @@ export interface ArtifactsManager {
    * Returns the BuildInfo id associated with the solc run that compiled a
    * contract.
    *
-   * Note that it may return `undefined` if the contract wasn't compiled with
-   * Hardhat's build system.
+   * Note that it may return `undefined` if the artifact doesn't have a build
+   * id, which can happen if the artifact wasn't compiled with Hardhat 3's build
+   * system.
    *
    * If it it does return an id, it's not guaranteed that the build info is
    * present.
    *
    * @param contractNameOrFullyQualifiedName Contract or fully qualified name, whose artifact must exist.
+   * @throws Throws an error if a non-unique contract name is used,
+   *   indicating which fully qualified names can be used instead.
+   * @throws Throws an error if the artifact doesn't exist.
+   * @returns The build info id, or undefined if the artifact doesn't have a
+   *   build info id.
    */
   getBuildInfoId(
     contractNameOrFullyQualifiedName: string,

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -73,7 +73,7 @@ export interface ArtifactManager {
    * id, which can happen if the artifact wasn't compiled with Hardhat 3's build
    * system.
    *
-   * If it it does return an id, it's not guaranteed that the build info is
+   * If it does return an id, it's not guaranteed that the build info is
    * present.
    *
    * @param contractNameOrFullyQualifiedName Contract or fully qualified name, whose artifact must exist.

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -100,6 +100,18 @@ export interface ArtifactsManager {
    * @param buildInfoId The id of an existing build info.
    */
   getBuildInfoOutputPath(buildInfoId: string): Promise<string | undefined>;
+
+  /**
+   * An artifact manager may cache information about the artifacts present in
+   * the project, for performance reasons. For example, it may read the entire
+   * list of artifacts from the file system, and cache it in memory.
+   *
+   * This method clears the artifact manager's cache, if any.
+   *
+   * This method is not meant to be used by end users, but by the Hardhat team
+   * and build-system-related plugins.
+   */
+  clearCache(): Promise<void>;
 }
 
 /**

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -18,10 +18,10 @@ export type GetAtifactByName<ContractNameT extends string> =
     : Artifact;
 
 /**
- * The ArtifactsManager is responsible for reading and writing artifacts from
+ * The ArtifactManager is responsible for reading and writing artifacts from
  * the Hardhat build system.
  */
-export interface ArtifactsManager {
+export interface ArtifactManager {
   /**
    * Reads an artifact.
    *

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -55,9 +55,9 @@ export interface ArtifactsManager {
   artifactExists(contractNameOrFullyQualifiedName: string): Promise<boolean>;
 
   /**
-   * Returns an array with the fully qualified names of all the artifacts.
+   * Returns a set with the fully qualified names of all the artifacts.
    */
-  getAllFullyQualifiedNames(): Promise<string[]>;
+  getAllFullyQualifiedNames(): Promise<ReadonlySet<string>>;
 
   /**
    * Returns the BuildInfo id associated with the solc run that compiled a
@@ -76,12 +76,12 @@ export interface ArtifactsManager {
   ): Promise<string | undefined>;
 
   /**
-   * Returns an array with the ids of all the existing build infos.
+   * Returns an set with the ids of all the existing build infos.
    *
    * Note that there's one build info per run of solc, so they can be shared
    * by different contracts.
    */
-  getAllBuildInfoIds(): Promise<string[]>;
+  getAllBuildInfoIds(): Promise<ReadonlySet<string>>;
 
   /**
    * Returns the absolute path to the given build info, or undefined if it

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -81,7 +81,7 @@ export interface ArtifactsManager {
    * Note that there's one build info per run of solc, so they can be shared
    * by different contracts.
    */
-  getBuildInfoIds(): Promise<string[]>;
+  getAllBuildInfoIds(): Promise<string[]>;
 
   /**
    * Returns the absolute path to the given build info, or undefined if it

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -88,7 +88,7 @@ export interface ArtifactManager {
   ): Promise<string | undefined>;
 
   /**
-   * Returns an set with the ids of all the existing build infos.
+   * Returns a set with the ids of all the existing build infos.
    *
    * Note that there's one build info per run of solc, so they can be shared
    * by different contracts.

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -54,7 +54,7 @@ export interface ArtifactManager {
    *
    * This function doesn't throw if the name is not unique.
    *
-   * @param contractNameOrFullyQualifiedName Contract or fully qualified name.\
+   * @param contractNameOrFullyQualifiedName Contract or fully qualified name.
    * @throws Throws an error if a non-unique contract name is used,
    *   indicating which fully qualified names can be used instead.
    */

--- a/v-next/hardhat/test/test-helpers/create-mock-hardhat-runtime-environment.ts
+++ b/v-next/hardhat/test/test-helpers/create-mock-hardhat-runtime-environment.ts
@@ -9,22 +9,22 @@ import "../../src/internal/builtin-plugins/artifacts/type-extensions.js";
 import { createHardhatRuntimeEnvironment } from "../../src/hre.js";
 import artifacts from "../../src/internal/builtin-plugins/artifacts/index.js";
 
-import { MockArtifactsManager } from "./mock-artifacts-manager.js";
+import { MockArtifactManager } from "./mock-artifact-manager.js";
 
 export async function createMockHardhatRuntimeEnvironment(
   config: HardhatUserConfig,
   userProvidedGlobalOptions: Partial<GlobalOptions> = {},
   projectRoot?: string,
   unsafeOptions: UnsafeHardhatRuntimeEnvironmentOptions = {},
-): Promise<HardhatRuntimeEnvironment & { artifacts: MockArtifactsManager }> {
+): Promise<HardhatRuntimeEnvironment & { artifacts: MockArtifactManager }> {
   /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
-  We know that the mockArtifactPlugin sets `hre.artifacts` to `MockArtifactsManager */
+  We know that the mockArtifactPlugin sets `hre.artifacts` to `MockArtifactManager */
   return createHardhatRuntimeEnvironment(
     { ...config, plugins: [mockArtifactsPlugin, ...(config.plugins ?? [])] },
     userProvidedGlobalOptions,
     projectRoot,
     unsafeOptions,
-  ) as Promise<HardhatRuntimeEnvironment & { artifacts: MockArtifactsManager }>;
+  ) as Promise<HardhatRuntimeEnvironment & { artifacts: MockArtifactManager }>;
 }
 
 const mockArtifactsPlugin: HardhatPlugin = {
@@ -34,7 +34,7 @@ const mockArtifactsPlugin: HardhatPlugin = {
     hre: async () => {
       return {
         created: async (_context, hre): Promise<void> => {
-          hre.artifacts = new MockArtifactsManager();
+          hre.artifacts = new MockArtifactManager();
         },
       };
     },

--- a/v-next/hardhat/test/test-helpers/mock-artifact-manager.ts
+++ b/v-next/hardhat/test/test-helpers/mock-artifact-manager.ts
@@ -1,5 +1,5 @@
 import type {
-  ArtifactsManager,
+  ArtifactManager,
   Artifact,
   GetAtifactByName,
 } from "../../src/types/artifacts.js";
@@ -9,7 +9,7 @@ import {
   HardhatError,
 } from "@ignored/hardhat-vnext-errors";
 
-export class MockArtifactsManager implements ArtifactsManager {
+export class MockArtifactManager implements ArtifactManager {
   readonly #artifacts: Map<string, Artifact>;
 
   constructor() {
@@ -41,7 +41,7 @@ export class MockArtifactsManager implements ArtifactsManager {
     _contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
@@ -49,13 +49,13 @@ export class MockArtifactsManager implements ArtifactsManager {
     _contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
   public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
@@ -63,13 +63,13 @@ export class MockArtifactsManager implements ArtifactsManager {
     _contractNameOrFullyQualifiedName: string,
   ): Promise<string | undefined> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
   public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
@@ -77,7 +77,7 @@ export class MockArtifactsManager implements ArtifactsManager {
     _buildInfoId: string,
   ): Promise<string | undefined> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
@@ -85,13 +85,13 @@ export class MockArtifactsManager implements ArtifactsManager {
     _buildInfoId: string,
   ): Promise<string | undefined> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 
   public async clearCache(): Promise<void> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
+      message: "Not implemented in MockArtifactManager",
     });
   }
 }

--- a/v-next/hardhat/test/test-helpers/mock-artifacts-manager.ts
+++ b/v-next/hardhat/test/test-helpers/mock-artifacts-manager.ts
@@ -53,7 +53,7 @@ export class MockArtifactsManager implements ArtifactsManager {
     });
   }
 
-  public async getAllFullyQualifiedNames(): Promise<string[]> {
+  public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });
@@ -67,7 +67,7 @@ export class MockArtifactsManager implements ArtifactsManager {
     });
   }
 
-  public async getAllBuildInfoIds(): Promise<string[]> {
+  public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });
@@ -84,6 +84,12 @@ export class MockArtifactsManager implements ArtifactsManager {
   public async getBuildInfoOutputPath(
     _buildInfoId: string,
   ): Promise<string | undefined> {
+    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
+      message: "Not implemented in MockArtifactsManager",
+    });
+  }
+
+  public async clearCache(): Promise<void> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });

--- a/v-next/hardhat/test/test-helpers/mock-artifacts-manager.ts
+++ b/v-next/hardhat/test/test-helpers/mock-artifacts-manager.ts
@@ -1,7 +1,6 @@
 import type {
   ArtifactsManager,
   Artifact,
-  BuildInfo,
   GetAtifactByName,
 } from "../../src/types/artifacts.js";
 
@@ -15,6 +14,10 @@ export class MockArtifactsManager implements ArtifactsManager {
 
   constructor() {
     this.#artifacts = new Map();
+  }
+
+  public async saveArtifact(artifact: Artifact): Promise<void> {
+    this.#artifacts.set(artifact.contractName, artifact);
   }
 
   public async readArtifact<ContractNameT extends string>(
@@ -34,7 +37,15 @@ export class MockArtifactsManager implements ArtifactsManager {
     return artifact as GetAtifactByName<ContractNameT>;
   }
 
-  public artifactExists(
+  public async getArtifactPath(
+    _contractNameOrFullyQualifiedName: string,
+  ): Promise<string> {
+    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
+      message: "Not implemented in MockArtifactsManager",
+    });
+  }
+
+  public async artifactExists(
     _contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
@@ -42,53 +53,37 @@ export class MockArtifactsManager implements ArtifactsManager {
     });
   }
 
-  public getAllFullyQualifiedNames(): Promise<string[]> {
+  public async getAllFullyQualifiedNames(): Promise<string[]> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });
   }
 
-  public getBuildInfo(
-    _fullyQualifiedName: string,
-  ): Promise<BuildInfo | undefined> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public getArtifactPaths(): Promise<string[]> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public getDebugFilePaths(): Promise<string[]> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public getBuildInfoPaths(): Promise<string[]> {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public async saveArtifact(artifact: Artifact): Promise<void> {
-    this.#artifacts.set(artifact.contractName, artifact);
-  }
-
-  public formArtifactPathFromFullyQualifiedName(
-    _fullyQualifiedName: string,
-  ): string {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message: "Not implemented in MockArtifactsManager",
-    });
-  }
-
-  public getArtifactPath(
+  public async getBuildInfoId(
     _contractNameOrFullyQualifiedName: string,
-  ): Promise<string> {
+  ): Promise<string | undefined> {
+    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
+      message: "Not implemented in MockArtifactsManager",
+    });
+  }
+
+  public async getBuildInfoIds(): Promise<string[]> {
+    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
+      message: "Not implemented in MockArtifactsManager",
+    });
+  }
+
+  public async getBuildInfoPath(
+    _buildInfoId: string,
+  ): Promise<string | undefined> {
+    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
+      message: "Not implemented in MockArtifactsManager",
+    });
+  }
+
+  public async getBuildInfoOutputPath(
+    _buildInfoId: string,
+  ): Promise<string | undefined> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });

--- a/v-next/hardhat/test/test-helpers/mock-artifacts-manager.ts
+++ b/v-next/hardhat/test/test-helpers/mock-artifacts-manager.ts
@@ -67,7 +67,7 @@ export class MockArtifactsManager implements ArtifactsManager {
     });
   }
 
-  public async getBuildInfoIds(): Promise<string[]> {
+  public async getAllBuildInfoIds(): Promise<string[]> {
     throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
       message: "Not implemented in MockArtifactsManager",
     });


### PR DESCRIPTION
While looking at a part of the codebase I noticed that we never addressed tons of TODOs in the `ArtifactManager` interface.

This PR does that, cleaning up the interface, and updating the different implementations.