### PR TITLE
Fix regex pattern for bigint parameter validation

### DIFF
--- a/docs/src/content/ignition/docs/guides/deploy.md
+++ b/docs/src/content/ignition/docs/guides/deploy.md
@@ -70,7 +70,7 @@ npx hardhat ignition deploy ignition/modules/Apollo.js --parameters ignition/par
 
 ::::
 
-To pass a `bigint` as a Module parameter, you can encode it as a string. Any string parameter value that matches the regex `/d+n/` will be converted to a `bigint` before being passed to the module, for instance the `endowment` parameter in the following example:
+To pass a `bigint` as a Module parameter, you can encode it as a string. Any string parameter value that matches the regex `/\d+n/` will be converted to a `bigint` before being passed to the module, for instance the `endowment` parameter in the following example:
 
 ```json
 {


### PR DESCRIPTION


In file `docs/src/content/ignition/docs/guides/deploy.md`:

Changed:
- `/d+n/` → `/\d+n/`

Reason for change:
The original regex pattern `/d+n/` would incorrectly match one or more literal 'd' characters followed by 'n'. The corrected pattern `/\d+n/` properly matches one or more digits followed by 'n', which is the correct format for bigint literals in JavaScript (e.g. "1000n").

This fix ensures the documentation accurately describes how to specify bigint values in parameter files.