### PR TITLE
Fix generation of type files in the typechain plugin

### DIFF
--- a/v-next/hardhat-typechain/src/internal/generate-types.ts
+++ b/v-next/hardhat-typechain/src/internal/generate-types.ts
@@ -34,7 +34,7 @@ export async function generateTypes(
     allFiles: artifactsPaths,
     outDir: config.outDir, // // If not set, it defaults to "types" when processed by the typeChain package
     target: "ethers-v6", // We only support this target
-    filesToProcess: [], // We ignore this property for now
+    filesToProcess: artifactsPaths,
     flags: {
       alwaysGenerateOverloads: config.alwaysGenerateOverloads,
       discriminateTypes: config.discriminateTypes,

--- a/v-next/hardhat-typechain/test/index.ts
+++ b/v-next/hardhat-typechain/test/index.ts
@@ -59,6 +59,14 @@ describe("hardhat-typechain", () => {
 
       // The import from a npm package should have ".js" extensions
       assert.equal(content.includes(`import { ethers } from 'ethers'`), true);
+
+      // Check that the types for the contract are generated
+      assert.equal(
+        await exists(
+          `${process.cwd()}/types/ethers-contracts/factories/A__factory.ts`,
+        ),
+        true,
+      );
     });
   });
 


### PR DESCRIPTION
Fixed a bug in the typechain plugin:

In the `typechain` configuration, the artifact paths must also be specified in the `filesToProcess` field. Previously, this property was not set.

Additionally, I added a test to verify that the type file is generated correctly.