### PR TITLE
fix: use unexistent exportation from upgrade module

### DIFF
--- a/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
+++ b/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
@@ -230,7 +230,7 @@ Next it's time to upgrade our proxy to a new version. To do this, we'll create a
 const upgradeModule = buildModule("UpgradeModule", (m) => {
   const proxyAdminOwner = m.getAccount(0);
 
-  const { proxyAdmin, proxy } = m.useModule(proxyModule);
+  const { proxyAdmin, proxy } = m.useModule(demoModule);
 
   const demoV2 = m.contract("DemoV2");
 

--- a/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
+++ b/docs/src/content/ignition/docs/guides/upgradeable-proxies.md
@@ -312,7 +312,7 @@ Inside our `test` directory, we'll create a file called `ProxyDemo.js` (or `Prox
 import { expect } from "chai";
 import { ignition, ethers } from "hardhat";
 
-import ProxyModule from "../ignition/modules/ProxyModule";
+import DemoModule from "../ignition/modules/ProxyModule";
 import UpgradeModule from "../ignition/modules/UpgradeModule";
 
 describe("Demo Proxy", function () {
@@ -320,7 +320,7 @@ describe("Demo Proxy", function () {
     it("Should be interactable via proxy", async function () {
       const [, otherAccount] = await ethers.getSigners();
 
-      const { demo } = await ignition.deploy(ProxyModule);
+      const { demo } = await ignition.deploy(DemoModule);
 
       expect(await demo.connect(otherAccount).version()).to.equal("1.0.0");
     });
@@ -353,7 +353,7 @@ describe("Demo Proxy", function () {
 ```javascript
 const { expect } = require("chai");
 
-const ProxyModule = require("../ignition/modules/ProxyModule");
+const DemoModule = require("../ignition/modules/ProxyModule");
 const UpgradeModule = require("../ignition/modules/UpgradeModule");
 
 describe("Demo Proxy", function () {
@@ -361,7 +361,7 @@ describe("Demo Proxy", function () {
     it("Should be interactable via proxy", async function () {
       const [, otherAccount] = await ethers.getSigners();
 
-      const { demo } = await ignition.deploy(ProxyModule);
+      const { demo } = await ignition.deploy(DemoModule);
 
       expect(await demo.connect(otherAccount).version()).to.equal("1.0.0");
     });
@@ -391,7 +391,7 @@ describe("Demo Proxy", function () {
 
 ::::
 
-Here we use Hardhat Ignition to deploy our imported modules. First, we deploy our base `ProxyModule` that returns the first version of our `Demo` contract and tests it to ensure the proxy worked and retrieves the appropriate version string. Then, we deploy our `UpgradeModule` that returns an upgraded version of our `Demo` contract and tests it to ensure the proxy returns the updated version string. We also test that our initialization function was called, setting the `name` state variable to `"Example Name"`.
+Here we use Hardhat Ignition to deploy our imported modules. First, we deploy our base `DemoModule` that returns the first version of our `Demo` contract and tests it to ensure the proxy worked and retrieves the appropriate version string. Then, we deploy our `UpgradeModule` that returns an upgraded version of our `Demo` contract and tests it to ensure the proxy returns the updated version string. We also test that our initialization function was called, setting the `name` state variable to `"Example Name"`.
 
 ## Further reading
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
It's not much but it can cause confusion in the documentation. Above the documentation makes us export the "DemoModule" and here we use "useModule" with the proxy module which is not supposed to be exported, I therefore deduce that we must use the import which was introduced above.

Thank you for taking the time to read me and have a good day.