### PR TITLE
Add hardhat-task-gen plugin

### DIFF
--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -1020,6 +1020,22 @@ const communityPlugins: IPlugin[] = [
       "transaction",
     ],
   },
+  {
+    name: "@adisakboonmark/hardhat-task-gen",
+    author: "ADISAKBOONMARK",
+    npmPackage: "@adisakboonmark/hardhat-task-gen",
+    authorUrl: "https://github.com/ADISAKBOONMARK",
+    description:
+      "Hardhat plugin for automatically generates tasks from ABI files",
+    tags: [
+      "ethereum",
+      "smart-contracts",
+      "hardhat",
+      "hardhat-plugin",
+      "tasks",
+      "scripts"
+    ],
+  },
 ];
 
 const officialPlugins: IPlugin[] = [

--- a/docs/src/content/hardhat-runner/plugins/plugins.ts
+++ b/docs/src/content/hardhat-runner/plugins/plugins.ts
@@ -1032,8 +1032,8 @@ const communityPlugins: IPlugin[] = [
       "smart-contracts",
       "hardhat",
       "hardhat-plugin",
-      "tasks",
-      "scripts"
+      "task",
+      "script",
     ],
   },
 ];


### PR DESCRIPTION
This PR adds a new community plugin: https://github.com/ADISAKBOONMARK/hardhat-task-gen

`hardhat-task-gen` is a Hardhat plugin that automatically generates tasks from ABI files.