### PR TITLE
feat: send EDR panics to sentry

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../../../types/config.js";
 import type {
   EthSubscription,
+  JsonRpcRequest,
   JsonRpcResponse,
   RequestArguments,
   SuccessfulJsonRpcResponse,
@@ -31,6 +32,7 @@ import {
   HardhatError,
 } from "@ignored/hardhat-vnext-errors";
 import { toSeconds } from "@ignored/hardhat-vnext-utils/date";
+import { ensureError } from "@ignored/hardhat-vnext-utils/error";
 import { numberToHexString } from "@ignored/hardhat-vnext-utils/hex";
 import { deepEqual } from "@ignored/hardhat-vnext-utils/lang";
 import debug from "debug";
@@ -39,7 +41,11 @@ import { EDR_NETWORK_REVERT_SNAPSHOT_EVENT } from "../../../constants.js";
 import { DEFAULT_HD_ACCOUNTS_CONFIG_PARAMS } from "../accounts/constants.js";
 import { BaseProvider } from "../base-provider.js";
 import { getJsonRpcRequest, isFailedJsonRpcResponse } from "../json-rpc.js";
-import { InvalidArgumentsError, ProviderError } from "../provider-errors.js";
+import {
+  InvalidArgumentsError,
+  ProviderError,
+  UnknownError,
+} from "../provider-errors.js";
 
 import { getGlobalEdrContext } from "./edr-context.js";
 import { createSolidityErrorWithStackTrace } from "./stack-traces/stack-trace-solidity-errors.js";
@@ -145,30 +151,41 @@ export class EdrProvider extends BaseProvider {
 
     const providerConfig = await getProviderConfig(networkConfig);
 
-    const context = await getGlobalEdrContext();
-    const provider = await context.createProvider(
-      hardhatChainTypeToEdrChainType(networkConfig.chainType),
-      providerConfig,
-      {
-        enable: loggerConfig.enabled,
-        decodeConsoleLogInputsCallback: ConsoleLogger.getDecodedLogs,
-        printLineCallback: (message: string, replace: boolean) => {
-          if (replace) {
-            replaceLastLineFn(message);
-          } else {
-            printLineFn(message);
-          }
-        },
-      },
-      {
-        subscriptionCallback: (event: SubscriptionEvent) => {
-          edrProvider.onSubscriptionEvent(event);
-        },
-      },
-      tracingConfig,
-    );
+    let edrProvider: EdrProvider;
 
-    const edrProvider = new EdrProvider(provider, jsonRpcRequestWrapper);
+    // We need to catch errors here, as the provider creation can panic unexpectedly,
+    // and we want to make sure such a crash is propagated as a ProviderError.
+    try {
+      const context = await getGlobalEdrContext();
+      const provider = await context.createProvider(
+        hardhatChainTypeToEdrChainType(networkConfig.chainType),
+        providerConfig,
+        {
+          enable: loggerConfig.enabled,
+          decodeConsoleLogInputsCallback: ConsoleLogger.getDecodedLogs,
+          printLineCallback: (message: string, replace: boolean) => {
+            if (replace) {
+              replaceLastLineFn(message);
+            } else {
+              printLineFn(message);
+            }
+          },
+        },
+        {
+          subscriptionCallback: (event: SubscriptionEvent) => {
+            edrProvider.onSubscriptionEvent(event);
+          },
+        },
+        tracingConfig,
+      );
+
+      edrProvider = new EdrProvider(provider, jsonRpcRequestWrapper);
+    } catch (error) {
+      ensureError(error);
+
+      // eslint-disable-next-line no-restricted-syntax -- allow throwing UnknownError
+      throw new UnknownError(error.message, error);
+    }
 
     return edrProvider;
   }
@@ -210,24 +227,10 @@ export class EdrProvider extends BaseProvider {
     if (this.#jsonRpcRequestWrapper !== undefined) {
       jsonRpcResponse = await this.#jsonRpcRequestWrapper(
         jsonRpcRequest,
-        async (request) => {
-          assertHardhatInvariant(
-            this.#provider !== undefined,
-            "The provider is not defined",
-          );
-
-          const stringifiedArgs = JSON.stringify(request);
-          const edrResponse =
-            await this.#provider.handleRequest(stringifiedArgs);
-
-          return this.#handleEdrResponse(edrResponse);
-        },
+        this.#handleRequest.bind(this),
       );
     } else {
-      const stringifiedArgs = JSON.stringify(jsonRpcRequest);
-      const edrResponse = await this.#provider.handleRequest(stringifiedArgs);
-
-      jsonRpcResponse = await this.#handleEdrResponse(edrResponse);
+      jsonRpcResponse = await this.#handleRequest(jsonRpcRequest);
     }
 
     // this can only happen if a wrapper doesn't call the default
@@ -351,6 +354,30 @@ export class EdrProvider extends BaseProvider {
       },
     };
     this.emit("message", message);
+  }
+
+  async #handleRequest(request: JsonRpcRequest): Promise<JsonRpcResponse> {
+    assertHardhatInvariant(
+      this.#provider !== undefined,
+      "The provider is not defined",
+    );
+
+    const stringifiedArgs = JSON.stringify(request);
+
+    let edrResponse: Response;
+
+    // We need to catch errors here, as the provider creation can panic unexpectedly,
+    // and we want to make sure such a crash is propagated as a ProviderError.
+    try {
+      edrResponse = await this.#provider.handleRequest(stringifiedArgs);
+    } catch (error) {
+      ensureError(error);
+
+      // eslint-disable-next-line no-restricted-syntax -- allow throwing UnknownError
+      throw new UnknownError(error.message, error);
+    }
+
+    return this.#handleEdrResponse(edrResponse);
   }
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/provider-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/provider-errors.ts
@@ -127,3 +127,11 @@ export class InvalidResponseError extends ProviderError {
     super(message, InvalidResponseError.CODE, parent);
   }
 }
+
+export class UnknownError extends ProviderError {
+  public static readonly CODE = -1;
+
+  constructor(message: string = "Unknown error", parent?: Error) {
+    super(message, UnknownError.CODE, parent);
+  }
+}

--- a/v-next/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
@@ -5,7 +5,10 @@ import {
 import { flush } from "@sentry/node";
 import debug from "debug";
 
-import { ProviderError } from "../../../builtin-plugins/network-manager/provider-errors.js";
+import {
+  ProviderError,
+  UnknownError,
+} from "../../../builtin-plugins/network-manager/provider-errors.js";
 import { getHardhatVersion } from "../../../utils/package.js";
 import { isTelemetryAllowed } from "../telemetry-permissions.js";
 
@@ -128,8 +131,11 @@ class Reporter {
       return false;
     }
 
-    if (ProviderError.isProviderError(error)) {
-      // We don't report network related errors
+    if (
+      ProviderError.isProviderError(error) &&
+      error.code !== UnknownError.CODE
+    ) {
+      // We don't report known network related errors
       return false;
     }
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Closes #6218

In this PR, I propose to:
- enclose each interactions with the [internal EDR provider](https://github.com/NomicFoundation/hardhat/blob/72b6e43b0bfbbf4021de56a33b2f989824817464/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts#L137) in a try-catch block
- wrap the unknown errors caught during such interactions in a newly introduced `UnknownError` which extends `ProviderError`
- wrap the unknown errors caught during fetch requests to the [HTTP provider](https://github.com/NomicFoundation/hardhat/blob/72b6e43b0bfbbf4021de56a33b2f989824817464/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts#L182) in the same `UnknownError`
- allow for the `UnknownError`s to be reported to sentry

Example report: https://nomic-labs.sentry.io/issues/6286399601/?project=4507685793103872&referrer=project-issue-stream

The alternative we discussed earlier is to search for `panic` string within the error message and allow for such errors to be reported. 