### PR TITLE
build: upgrade to edr-optimism v0.6.5-alpha.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1486,8 +1486,8 @@ importers:
         specifier: 0.8.0-alpha.2
         version: 0.8.0-alpha.2
       '@ignored/edr-optimism':
-        specifier: 0.6.5-alpha.2
-        version: 0.6.5-alpha.2
+        specifier: 0.6.5-alpha.3
+        version: 0.6.5-alpha.3
       '@ignored/hardhat-vnext-errors':
         specifier: workspace:^3.0.0-next.16
         version: link:../hardhat-errors
@@ -3560,36 +3560,36 @@ packages:
     resolution: {integrity: sha512-9F1F0x+XfN6Hb/EYfDK4M/KIjGGeSdWnJqm5HkcGQjGjjTlvrzwis2P/qoWYBdcLmSGRb1Inc8FwD6emzJzCEQ==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-darwin-arm64@0.6.5-alpha.2':
-    resolution: {integrity: sha512-AEZ41XN8KJlPRUc1cSW89SmDNsc1a8XgKA2rX6JrBJvw2rDWCF1yewnJ4Uiov15eA7ppCUSUuXpNiX/P5+EjKw==}
+  '@ignored/edr-optimism-darwin-arm64@0.6.5-alpha.3':
+    resolution: {integrity: sha512-bJPjKzEl5eYa7j4If7Sc2O1VsMMayNgB8Zj2sJ1gpAmOHFOkaRX1/Jk9G4OczbYIhJeBL8WsKdkS1owxkAwlfw==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-darwin-x64@0.6.5-alpha.2':
-    resolution: {integrity: sha512-PR6aUOgUbPrAaaTxU6/VeLL/OiKcIOzzH3/Ss444giJlTMYinoYeJhEOF1yeuPY65fReWJ55Iq3tLyzBj/bheA==}
+  '@ignored/edr-optimism-darwin-x64@0.6.5-alpha.3':
+    resolution: {integrity: sha512-TDQVomNH8qbUvBwugfbfpUp8hR8Naz7eDY8ZmNmVNTfXwPVLfUaecptQyleOnQDAYSAANCAcRhD6L5N0BEguUw==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-arm64-gnu@0.6.5-alpha.2':
-    resolution: {integrity: sha512-72uUqsebdQd6VdbOe+kz1dsCNAgAX+NX2zeNJtryyXie0BrsKTRCHPwfWETg8ybqx8B7GPbx1pB4ubawSPknyw==}
+  '@ignored/edr-optimism-linux-arm64-gnu@0.6.5-alpha.3':
+    resolution: {integrity: sha512-DGFV8iE4fyfloK93wxKveBmeiLc4VBYvxYdkGzvg57kk6zZGcYgkArngGwp3ZpJVCVVgiZGh6WOPeWsKqMnsiA==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-arm64-musl@0.6.5-alpha.2':
-    resolution: {integrity: sha512-P5kAi8p+DnJQ5NkVYSNzptbG8Cy4ZEdSYCJgagUojGqK0dGjj4hQwpKtOahePD/fF6JtF+fG/g6MWEEe9NPnJg==}
+  '@ignored/edr-optimism-linux-arm64-musl@0.6.5-alpha.3':
+    resolution: {integrity: sha512-py+JLrUCDkKWBy9It1O6HH4RMdkOvV9k0rUigC4ggIaRDnYgTACH1MSrHtL86qe5UTjqALcsvbsUDjhKMkNc8Q==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-x64-gnu@0.6.5-alpha.2':
-    resolution: {integrity: sha512-CeRk0J/qKe0NCBQWcnhehk2rWUkBqwH44ipNQDwT5cw7ehv6tpgu9OqKV0hOJJOlQl/oGngaCaTzuIQtp9iGhg==}
+  '@ignored/edr-optimism-linux-x64-gnu@0.6.5-alpha.3':
+    resolution: {integrity: sha512-3CYkITGAEVSWxabAymqTNa52pYS+dfAVTSX8rSeqMMH40KBADknG/MgyHZcQ+JB2X14koAD/v/qd3r50CMqrGg==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-x64-musl@0.6.5-alpha.2':
-    resolution: {integrity: sha512-nH9kjYPRILjmteCAUfzkws8HsAyl+8EfOmj8a+U29p8yIjtvJLy83hCQWU7Usxdg1e3modTJQqArERlmdKZN3Q==}
+  '@ignored/edr-optimism-linux-x64-musl@0.6.5-alpha.3':
+    resolution: {integrity: sha512-MLxeToQGYzpF0Rw7iajldDRiC6hZYSTzLTrLFj6PghW+7tvBr49cns/h6O/p2HxDyRPR2xdEezdOqz6dlf3OUg==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-win32-x64-msvc@0.6.5-alpha.2':
-    resolution: {integrity: sha512-dfbHzuOrVwET2ptIIWifZG0lLGynJhPhhXmjXDhCt2b2JZ0qpPgleuOjPW5oeSsrelwVcHQ4mFOFX/Fz4FCHCg==}
+  '@ignored/edr-optimism-win32-x64-msvc@0.6.5-alpha.3':
+    resolution: {integrity: sha512-daMY9tdXowHJf3XD4EghQ/S9WOftv3gIPqMAz70qtxSXYfbRAqXpgwG4xMUH4wD6CD6AxAn6aILdVhGuJGMRXw==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism@0.6.5-alpha.2':
-    resolution: {integrity: sha512-AMgM23RRndJ63/pZ6T2tesqb/jg5cwgVgkeOPkVWCCtE74In6YQlsSgRItG7eemVkq+hkuXe14RwCIiJfi8KeQ==}
+  '@ignored/edr-optimism@0.6.5-alpha.3':
+    resolution: {integrity: sha512-2AK+erQEDOrQixxUVaXNIwa/bF8CgGS/oFqf0lBjJlKkNNdO8XAuHFUQcdDoCu0+pJQWJv+Ysp8qRfiR8OxOGg==}
     engines: {node: '>= 18'}
 
   '@ignored/edr-win32-x64-msvc@0.8.0-alpha.2':
@@ -9126,29 +9126,29 @@ snapshots:
   '@ignored/edr-linux-x64-musl@0.8.0-alpha.2':
     optional: true
 
-  '@ignored/edr-optimism-darwin-arm64@0.6.5-alpha.2': {}
+  '@ignored/edr-optimism-darwin-arm64@0.6.5-alpha.3': {}
 
-  '@ignored/edr-optimism-darwin-x64@0.6.5-alpha.2': {}
+  '@ignored/edr-optimism-darwin-x64@0.6.5-alpha.3': {}
 
-  '@ignored/edr-optimism-linux-arm64-gnu@0.6.5-alpha.2': {}
+  '@ignored/edr-optimism-linux-arm64-gnu@0.6.5-alpha.3': {}
 
-  '@ignored/edr-optimism-linux-arm64-musl@0.6.5-alpha.2': {}
+  '@ignored/edr-optimism-linux-arm64-musl@0.6.5-alpha.3': {}
 
-  '@ignored/edr-optimism-linux-x64-gnu@0.6.5-alpha.2': {}
+  '@ignored/edr-optimism-linux-x64-gnu@0.6.5-alpha.3': {}
 
-  '@ignored/edr-optimism-linux-x64-musl@0.6.5-alpha.2': {}
+  '@ignored/edr-optimism-linux-x64-musl@0.6.5-alpha.3': {}
 
-  '@ignored/edr-optimism-win32-x64-msvc@0.6.5-alpha.2': {}
+  '@ignored/edr-optimism-win32-x64-msvc@0.6.5-alpha.3': {}
 
-  '@ignored/edr-optimism@0.6.5-alpha.2':
+  '@ignored/edr-optimism@0.6.5-alpha.3':
     dependencies:
-      '@ignored/edr-optimism-darwin-arm64': 0.6.5-alpha.2
-      '@ignored/edr-optimism-darwin-x64': 0.6.5-alpha.2
-      '@ignored/edr-optimism-linux-arm64-gnu': 0.6.5-alpha.2
-      '@ignored/edr-optimism-linux-arm64-musl': 0.6.5-alpha.2
-      '@ignored/edr-optimism-linux-x64-gnu': 0.6.5-alpha.2
-      '@ignored/edr-optimism-linux-x64-musl': 0.6.5-alpha.2
-      '@ignored/edr-optimism-win32-x64-msvc': 0.6.5-alpha.2
+      '@ignored/edr-optimism-darwin-arm64': 0.6.5-alpha.3
+      '@ignored/edr-optimism-darwin-x64': 0.6.5-alpha.3
+      '@ignored/edr-optimism-linux-arm64-gnu': 0.6.5-alpha.3
+      '@ignored/edr-optimism-linux-arm64-musl': 0.6.5-alpha.3
+      '@ignored/edr-optimism-linux-x64-gnu': 0.6.5-alpha.3
+      '@ignored/edr-optimism-linux-x64-musl': 0.6.5-alpha.3
+      '@ignored/edr-optimism-win32-x64-msvc': 0.6.5-alpha.3
 
   '@ignored/edr-win32-x64-msvc@0.8.0-alpha.2':
     optional: true

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@ignored/edr": "0.8.0-alpha.2",
-    "@ignored/edr-optimism": "0.6.5-alpha.2",
+    "@ignored/edr-optimism": "0.6.5-alpha.3",
     "@ignored/hardhat-vnext-errors": "workspace:^3.0.0-next.16",
     "@ignored/hardhat-vnext-utils": "workspace:^3.0.0-next.16",
     "@ignored/hardhat-vnext-zod-utils": "workspace:^3.0.0-next.16",

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -1,6 +1,5 @@
 import type { SolidityStackTrace } from "./stack-traces/solidity-stack-trace.js";
 import type { LoggerConfig } from "./types/logger.js";
-import type { TracingConfig } from "./types/node-types.js";
 import type {
   EdrNetworkConfig,
   EdrNetworkHDAccountsConfig,
@@ -19,6 +18,7 @@ import type {
   Response,
   Provider,
   ProviderConfig,
+  TracingConfigWithBuffers,
 } from "@ignored/edr-optimism";
 
 import {
@@ -127,7 +127,7 @@ export const EDR_NETWORK_DEFAULT_PRIVATE_KEYS: string[] = [
 interface EdrProviderConfig {
   networkConfig: EdrNetworkConfig;
   loggerConfig?: LoggerConfig;
-  tracingConfig?: TracingConfig;
+  tracingConfig?: TracingConfigWithBuffers;
   jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
 }
 


### PR DESCRIPTION
Upgrades the `@ignored/edr-optimism` package to  v0.6.5-alpha.3

This includes:
- Fix for missing C Runtime on Windows (https://github.com/NomicFoundation/edr/pull/772)
- Optimism predeploys in local mode (https://github.com/NomicFoundation/edr/pull/798)

**To Do**
- [x] Fix compiler errors in Hardhat 3 due to changed interface for `TracingConfig`