### PR TITLE
fix: display all unused diagnostics at the end of the test report

### DIFF
--- a/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/asynchronous-activity-test/result.svg
+++ b/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/asynchronous-activity-test/result.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="770.467mm" height="83.2556mm"
+ viewBox="0 0 2184 236"
+ xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  version="1.2" baseProfile="tiny">
+<title>Qt Svg Document</title>
+<desc>Generated with Qt</desc>
+<defs>
+</defs>
+<g fill="none" stroke="black" stroke-width="1" fill-rule="evenodd" stroke-linecap="square" stroke-linejoin="bevel" >
+
+<g fill="#ffffff" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L2184,0 L2184,236 L0,236 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L2184,0 L2184,236 L0,236 L0,0"/>
+</g>
+
+<g fill="#000000" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L2184,0 L2184,236 L0,236 L0,0"/>
+</g>
+
+<g fill="#ffffff" fill-opacity="1" stroke="#ffffff" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="39" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >  </text>
+</g>
+
+<g fill="#00ff00" fill-opacity="1" stroke="#00ff00" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#00ff00" fill-opacity="1" stroke="none" xml:space="preserve" x="24" y="39" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >✔</text>
+</g>
+
+<g fill="#696969" fill-opacity="1" stroke="#696969" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#696969" fill-opacity="1" stroke="none" xml:space="preserve" x="32" y="39" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ > foo</text>
+</g>
+
+<g fill="#ffffff" fill-opacity="1" stroke="#ffffff" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="69" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >  </text>
+</g>
+
+<g fill="#ff0000" fill-opacity="1" stroke="#ff0000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ff0000" fill-opacity="1" stroke="none" xml:space="preserve" x="24" y="69" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >1) integration-tests/fixture-tests/asynchronous-activity-test/test.ts</text>
+</g>
+
+<g fill="#ffffff" fill-opacity="1" stroke="#ffffff" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="562" y="69" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ > </text>
+</g>
+
+<g fill="#ff0000" fill-opacity="1" stroke="#ff0000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="italic" 
+>
+<text fill="#ff0000" fill-opacity="1" stroke="none" xml:space="preserve" x="570" y="69" font-family="Courier New" font-size="13" font-weight="400" font-style="italic" 
+ >(203ms)</text>
+</g>
+
+<g fill="#00ff00" fill-opacity="1" stroke="#00ff00" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#00ff00" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="114" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >1 passing</text>
+</g>
+
+<g fill="#696969" fill-opacity="1" stroke="#696969" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#696969" fill-opacity="1" stroke="none" xml:space="preserve" x="78" y="114" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ > (234ms)</text>
+</g>
+
+<g fill="#ff0000" fill-opacity="1" stroke="#ff0000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ff0000" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="129" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >1 failing</text>
+</g>
+
+<g fill="#3333ff" fill-opacity="1" stroke="#3333ff" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#3333ff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="144" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >ℹ</text>
+</g>
+
+<g fill="#ffffff" fill-opacity="1" stroke="#ffffff" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="17" y="144" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ > Error: Test &quot;foo&quot; at integration-tests/fixture-tests/asynchronous-activity-test/test.ts:1:29 generated asynchronous activity after the test ended. This activity created the error &quot;Error&quot; and would have caused the test to fail, but instead triggered an uncaughtException event.</text>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="174" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >  1) integration-tests/fixture-tests/asynchronous-activity-test/test.ts:</text>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="204" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >   </text>
+</g>
+
+<g fill="#ff0000" fill-opacity="1" stroke="#ff0000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ff0000" fill-opacity="1" stroke="none" xml:space="preserve" x="31" y="204" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >Test file execution failed (exit code 1).</text>
+</g>
+</g>
+</svg>

--- a/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/asynchronous-activity-test/result.txt
+++ b/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/asynchronous-activity-test/result.txt
@@ -1,0 +1,14 @@
+
+  [90m[32m✔[39m[90m foo[39m
+
+  [31m1) integration-tests/fixture-tests/asynchronous-activity-test/test.ts[39m [31m[3m(203ms)[23m[39m
+
+
+[32m1 passing[39m[90m (234ms)[39m[31m[39m
+[31m1 failing[39m
+[34mℹ[39m Error: Test "foo" at integration-tests/fixture-tests/asynchronous-activity-test/test.ts:1:29 generated asynchronous activity after the test ended. This activity created the error "Error" and would have caused the test to fail, but instead triggered an uncaughtException event.
+
+  1) integration-tests/fixture-tests/asynchronous-activity-test/test.ts:
+
+   [31mTest file execution failed (exit code 1).[39m
+

--- a/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/asynchronous-activity-test/test.ts
+++ b/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/asynchronous-activity-test/test.ts
@@ -1,0 +1,7 @@
+import test from "node:test";
+
+test("foo", () => {
+  setTimeout(() => {
+    throw new Error();
+  }, 100);
+});

--- a/v-next/hardhat-node-test-reporter/integration-tests/index.ts
+++ b/v-next/hardhat-node-test-reporter/integration-tests/index.ts
@@ -133,12 +133,9 @@ function normalizeOutput(name: string, output: string): string {
   }
 
   const testFileRegex = new RegExp(
-    path.join(
-      "integration-tests",
-      "fixture-tests",
-      `[^${path.sep}]+`,
-      "test.ts",
-    ),
+    path
+      .join("integration-tests", "fixture-tests", `[^${path.sep}]+`, "test.ts")
+      .replaceAll("\\", "\\\\"),
     "g",
   );
 

--- a/v-next/hardhat-node-test-reporter/integration-tests/index.ts
+++ b/v-next/hardhat-node-test-reporter/integration-tests/index.ts
@@ -132,6 +132,16 @@ function normalizeOutput(name: string, output: string): string {
     normalizedOutput = normalizedOutput.replace(slowTestRegex, "");
   }
 
+  const testFileRegex = new RegExp(
+    path.join(
+      "integration-tests",
+      "fixture-tests",
+      `[^${path.sep}]+`,
+      "test.ts",
+    ),
+    "g",
+  );
+
   return (
     normalizedOutput
       // Normalize the time it took to run the test
@@ -141,6 +151,10 @@ function normalizeOutput(name: string, output: string): string {
       // Normalize path separators to `/` within the (file:line:column)
       // part of the stack traces
       .replaceAll(/\(.*?:\d+:\d+\)/g, (match) => {
+        return match.replaceAll(path.sep, "/");
+      })
+      // Normalize path separators to `/` within the test file paths
+      .replaceAll(testFileRegex, (match) => {
         return match.replaceAll(path.sep, "/");
       })
       // Remove lines like `at TestHook.run (node:internal/test_runner/test:1107:18)`

--- a/v-next/hardhat-node-test-reporter/src/formatting.ts
+++ b/v-next/hardhat-node-test-reporter/src/formatting.ts
@@ -130,6 +130,7 @@ export function formatUnusedDiagnostics(
       if (isTestOnlyMessage(message)) {
         return testOnlyMessage ?? message;
       }
+      return message;
     })
     .map((message) => `${INFO_SYMBOL} ${message}`);
   return Array.from(new Set(messages)).join("\n");


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This is a quick fix for an issue where we wouldn't display error details that were passed to us via `test:diagnostics` events. This was due to the fact that we accidentally swallowed such messages when formatting the unused diagnostics events.

As a follow-up to this, when the diagnostic message has a file property and that test file has failed to execute, we should display the message next to the file failure instead.
