### PR TITLE
Rename the `hardhat3` cli to `hardhat`

### DIFF
--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -19,7 +19,7 @@
     "build": "tsc --build .",
     "clean": "rimraf dist",
     "pretest": "pnpm build && pnpm install",
-    "test": "hardhat3 test node && hardhat3 test mocha"
+    "test": "hardhat test node && hardhat test mocha"
   },
   "devDependencies": {
     "@ignored/hardhat-vnext": "workspace:^3.0.0-next.17",

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "types": "dist/src/index.d.ts",
   "bin": {
-    "hardhat3": "./dist/src/cli.js"
+    "hardhat": "./dist/src/cli.js"
   },
   "exports": {
     ".": "./dist/src/index.js",

--- a/v-next/hardhat/templates/01-node-test-runner-viem/README.md
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/README.md
@@ -33,14 +33,14 @@ Each file includes inline explanations of its purpose and highlights the changes
 To run all the tests in the project, execute the following command:
 
 ```shell
-npx hardhat3 test
+npx hardhat test
 ```
 
 You can also selectively run the Solidity or `node:test` tests:
 
 ```shell
-npx hardhat3 test solidity
-npx hardhat3 test node
+npx hardhat test solidity
+npx hardhat test node
 ```
 
 ### Sending a Transaction to Optimism Sepolia
@@ -50,7 +50,7 @@ This project includes an example script that sends a simple transaction to Optim
 To run the script with EDR in Optimism mode:
 
 ```shell
-npx hardhat3 run scripts/send-op-tx.ts --network edrOpSepolia
+npx hardhat run scripts/send-op-tx.ts --network edrOpSepolia
 ```
 
 To run the script with Optimism Sepolia, you need an account with funds to send the transaction. The provided Hardhat configuration includes a Configuration Variable called `OPTIMISM_SEPOLIA_PRIVATE_KEY`, which you can use to set the private key of the account you want to use.
@@ -62,13 +62,13 @@ You can set the `OPTIMISM_SEPOLIA_PRIVATE_KEY` variable using the `hardhat-keyst
 To set the `OPTIMISM_SEPOLIA_PRIVATE_KEY` config variable using `hardhat-keystore`:
 
 ```shell
-npx hardhat3 keystore set OPTIMISM_SEPOLIA_PRIVATE_KEY
+npx hardhat keystore set OPTIMISM_SEPOLIA_PRIVATE_KEY
 ```
 
 After setting the variable, you can run the script with the Optimism Sepolia network:
 
 ```shell
-npx hardhat3 run scripts/send-op-tx.ts --network opSepolia
+npx hardhat run scripts/send-op-tx.ts --network opSepolia
 ```
 
 ---

--- a/v-next/hardhat/templates/02-mocha-ethers/README.md
+++ b/v-next/hardhat/templates/02-mocha-ethers/README.md
@@ -33,14 +33,14 @@ Each file includes inline explanations of its purpose and highlights the changes
 To run all the tests in the project, execute the following command:
 
 ```shell
-npx hardhat3 test
+npx hardhat test
 ```
 
 You can also selectively run the Solidity or `mocha` tests:
 
 ```shell
-npx hardhat3 test solidity
-npx hardhat3 test mocha
+npx hardhat test solidity
+npx hardhat test mocha
 ```
 
 ### Sending a Transaction to Optimism Sepolia
@@ -50,7 +50,7 @@ This project includes an example script that sends a simple transaction to Optim
 To run the script with EDR in Optimism mode:
 
 ```shell
-npx hardhat3 run scripts/send-op-tx.ts --network edrOpSepolia
+npx hardhat run scripts/send-op-tx.ts --network edrOpSepolia
 ```
 
 To run the script with Optimism Sepolia, you need an account with funds to send the transaction. The provided Hardhat configuration includes a Configuration Variable called `OPTIMISM_SEPOLIA_PRIVATE_KEY`, which you can use to set the private key of the account you want to use.
@@ -62,13 +62,13 @@ You can set the `OPTIMISM_SEPOLIA_PRIVATE_KEY` variable using the `hardhat-keyst
 To set the `OPTIMISM_SEPOLIA_PRIVATE_KEY` config variable using `hardhat-keystore`:
 
 ```shell
-npx hardhat3 keystore set OPTIMISM_SEPOLIA_PRIVATE_KEY
+npx hardhat keystore set OPTIMISM_SEPOLIA_PRIVATE_KEY
 ```
 
 After setting the variable, you can run the script with the Optimism Sepolia network:
 
 ```shell
-npx hardhat3 run scripts/send-op-tx.ts --network opSepolia
+npx hardhat run scripts/send-op-tx.ts --network opSepolia
 ```
 
 ---


### PR DESCRIPTION
This is a general rename. To ensure it's complete, you can run

```sh
$ rg -i hardhat3 v-next
v-next/hardhat-viem/test/chains.ts
254:      const isHardhat3 = await isHardhatNetwork(provider2);
257:        isHardhat3,
```