### PR TITLE
add ignition to the viem template

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3108,6 +3108,12 @@ importers:
       '@ignored/hardhat-vnext':
         specifier: workspace:^3.0.0-next.18
         version: link:../..
+      '@ignored/hardhat-vnext-ignition':
+        specifier: workspace:^2.0.0
+        version: link:../../../hardhat-ignition
+      '@ignored/hardhat-vnext-ignition-viem':
+        specifier: workspace:^2.0.0
+        version: link:../../../hardhat-ignition-viem
       '@ignored/hardhat-vnext-keystore':
         specifier: workspace:^3.0.0-next.14
         version: link:../../../hardhat-keystore

--- a/v-next/hardhat/templates/01-node-test-runner-viem/contracts/Rocket.sol
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/contracts/Rocket.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+contract Rocket {
+  string public name;
+  string public status;
+
+  constructor(string memory _name) {
+    name = _name;
+    status = "ignition";
+  }
+
+  function launch() public {
+    status = "lift-off";
+  }
+}

--- a/v-next/hardhat/templates/01-node-test-runner-viem/hardhat.config.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/hardhat.config.ts
@@ -7,6 +7,7 @@ import HardhatNodeTestRunner from "@ignored/hardhat-vnext-node-test-runner";
 import HardhatViem from "@ignored/hardhat-vnext-viem";
 import HardhatNetworkHelpers from "@ignored/hardhat-vnext-network-helpers";
 import HardhatKeystore from "@ignored/hardhat-vnext-keystore";
+import HardhatIgnitionViem from "@ignored/hardhat-vnext-ignition-viem";
 
 const config: HardhatUserConfig = {
   /*
@@ -21,6 +22,7 @@ const config: HardhatUserConfig = {
     HardhatViem,
     HardhatNetworkHelpers,
     HardhatKeystore,
+    HardhatIgnitionViem,
   ],
   solidity: {
     /*

--- a/v-next/hardhat/templates/01-node-test-runner-viem/ignition/modules/Apollo.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/ignition/modules/Apollo.ts
@@ -1,0 +1,9 @@
+import { buildModule } from "@ignored/hardhat-vnext-ignition/modules";
+
+export default buildModule("Apollo", (m) => {
+  const apollo = m.contract("Rocket", ["Saturn V"]);
+
+  m.call(apollo, "launch", []);
+
+  return { apollo };
+});

--- a/v-next/hardhat/templates/01-node-test-runner-viem/package.json
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/package.json
@@ -6,6 +6,8 @@
   "type": "module",
   "devDependencies": {
     "@ignored/hardhat-vnext": "workspace:^3.0.0-next.18",
+    "@ignored/hardhat-vnext-ignition": "workspace:^2.0.0",
+    "@ignored/hardhat-vnext-ignition-viem": "workspace:^2.0.0",
     "@ignored/hardhat-vnext-keystore": "workspace:^3.0.0-next.14",
     "@ignored/hardhat-vnext-node-test-runner": "workspace:^3.0.0-next.14",
     "@ignored/hardhat-vnext-network-helpers": "workspace:^3.0.0-next.14",

--- a/v-next/hardhat/templates/01-node-test-runner-viem/scripts/deploy-rocket-from-script.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/scripts/deploy-rocket-from-script.ts
@@ -1,0 +1,19 @@
+import hre from "@ignored/hardhat-vnext";
+
+import apolloModule from "../ignition/modules/Apollo.js";
+
+const { ignition } = await hre.network.connect();
+
+const { apollo } = await ignition.deploy(apolloModule);
+
+const address = apollo.address;
+const name = await apollo.read.name();
+const status = await apollo.read.status();
+
+console.log(
+  `Deployed rocket with Ignition and Viem from a Hardhat Script 🚀
+
+  address: ${address}
+  name: ${name}
+  status: ${status}`,
+);


### PR DESCRIPTION
This adds the Rocket example and its module based on the Ignition Getting Started Guide.

It will updated/removed as we iterate on the Public Alpha examples.
