### PR TITLE
ci: remove unused codepath in v-next ci

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -126,23 +126,9 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build
         run: pnpm build
-      # https://github.com/pnpm/pnpm/issues/6166
       - name: Deploy
         run: |
           pnpm deploy --config.shamefully-hoist=true --config.hoist=true --config.node-linker=true --config.shared-workspace-lockfile=false --filter="$(jq -r .name package.json)" --prod --no-optional bundle
-          # We need to move the node_modules links from v-next/hardhat/bundle to bundle because
-          # https://github.com/pnpm/pnpm/pull/8465 broke modules generation with the set of options we provide
-          for old_link in $(find v-next/hardhat/bundle -type l); do
-            echo "Processing link $old_link"
-            new_link="${old_link#v-next/hardhat/}"
-            new_link_dir="$(dirname "$new_link")"
-            old_link_target="$(readlink -f "$old_link")"
-            mkdir -p "$new_link_dir"
-            ln -rs "$old_link_target" "$new_link"
-            new_link_target="$(readlink "$new_link")"
-            echo "Created link $new_link -> $new_link_target"
-          done
-          rm -rf v-next
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.package }}


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

`for old_link in $(find v-next/hardhat/bundle -type l)` loops over nothing now. We can get rid of this codepath in the bundle creation entirely.
