### PR TITLE
fix: make the root paths in solidity test unique

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -66,6 +66,9 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
         }),
       ])
     ).flat(1);
+    // NOTE: We remove duplicates in case there is an intersection between
+    // the tests.solidity paths and the sources paths
+    rootFilePaths = Array.from(new Set(rootFilePaths));
   }
 
   const buildOptions: BuildOptions = {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -66,10 +66,10 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
         }),
       ])
     ).flat(1);
-    // NOTE: We remove duplicates in case there is an intersection between
-    // the tests.solidity paths and the sources paths
-    rootFilePaths = Array.from(new Set(rootFilePaths));
   }
+  // NOTE: We remove duplicates in case there is an intersection between
+  // the tests.solidity paths and the sources paths
+  rootFilePaths = Array.from(new Set(rootFilePaths));
 
   const buildOptions: BuildOptions = {
     force: false,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
@@ -133,7 +133,10 @@ export class DependencyGraphImplementation implements DependencyGraph {
   }
 
   #addFile(file: ResolvedFile): void {
-    assertHardhatInvariant(!this.hasFile(file), `File ${file.sourceName} already present`);
+    assertHardhatInvariant(
+      !this.hasFile(file),
+      `File ${file.sourceName} already present`,
+    );
 
     assertHardhatInvariant(
       this.#fileBySourceName.get(file.sourceName) === undefined,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
@@ -133,11 +133,11 @@ export class DependencyGraphImplementation implements DependencyGraph {
   }
 
   #addFile(file: ResolvedFile): void {
-    assertHardhatInvariant(!this.hasFile(file), "File already present");
+    assertHardhatInvariant(!this.hasFile(file), `File ${file.sourceName} already present`);
 
     assertHardhatInvariant(
       this.#fileBySourceName.get(file.sourceName) === undefined,
-      "File already present",
+      `File "${file.sourceName}" already present`,
     );
 
     this.#fileBySourceName.set(file.sourceName, file);

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
@@ -82,7 +82,7 @@ describe("DependencyGraphImplementation", () => {
         },
         HardhatError.ERRORS.INTERNAL.ASSERTION_ERROR,
         {
-          message: "File already present",
+          message: `File ${file.sourceName} already present`,
         },
       );
     });


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

I discovered that when `paths.sources` and `paths.tests.solidity` share common directories, we might end up with duplicate root paths. This PR ensures they are unique. Also, it adds the source file path information to the hardhat invariant violation error message which was helpful in debugging.

Context: https://nomicfoundation.slack.com/archives/C069TLP61BQ/p1739656187561829
