### PR TITLE
test: fix the update after kill test

### DIFF
--- a/v-next/hardhat-ignition/test/deploy/rerun/rerun-after-kill.ts
+++ b/v-next/hardhat-ignition/test/deploy/rerun/rerun-after-kill.ts
@@ -22,10 +22,10 @@ describe("execution - rerun after kill", function () {
   it("should pickup deployment and run contracts to completion", async function () {
     const moduleDefinition = buildModule("FooModule", (m) => {
       const foo1 = m.contract("Foo", [], { id: "foo1" });
-      const foo2 = m.contract("Foo", [], { id: "foo2" });
-      const foo3 = m.contract("Foo", [], { id: "foo3" });
-      const foo4 = m.contract("Foo", [], { id: "foo4" });
-      const foo5 = m.contract("Foo", [], { id: "foo5" });
+      const foo2 = m.contract("Foo", [], { id: "foo2", after: [foo1] });
+      const foo3 = m.contract("Foo", [], { id: "foo3", after: [foo2] });
+      const foo4 = m.contract("Foo", [], { id: "foo4", after: [foo3] });
+      const foo5 = m.contract("Foo", [], { id: "foo5", after: [foo4] });
 
       return {
         foo1,


### PR DESCRIPTION
In the CI the `rerun after kill` would fail non-deterministically. The test manipulates the mempool and involves waits.

The comment and initial feature suggest that the contracts should be deployed batch at a time with `after`, but the test does not include it. Specifically here are the reproduction steps from the original issue:

```markdown
## Reproduction steps

    Update the examples/sample module to deploy 5 contracts one after the other using after (each in its own batch).
    Set the node so that automining is false and the interval to 1s.
    Start the first run and ctrl c after the first batch has started
    Rerun the deployment
    You should see the 405 error after the 3rd batch

```

I have added in the `after` and will monitor the CI to see if it deals with the non-deterministic failures.

## Testing

I manually forced reruns of the entire build 5 times to check that the test did not recur. There are other non-deterministic failures (e.g. compiler downloading) but I did not see the `rerun after kill` test fail. This is not conclusive proof, but an improvement at the least.
