### PR TITLE
fix: correct the Ignition module import in the ethers template script

### DIFF
--- a/v-next/hardhat/templates/02-mocha-ethers/scripts/deploy-rocket-from-script.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/scripts/deploy-rocket-from-script.ts
@@ -1,6 +1,7 @@
-import apolloModule from "../../../../example-project/ignition/modules/Apollo.js";
 import { createHardhatRuntimeEnvironment } from "@ignored/hardhat-vnext/hre";
 import hardhatIgnitionEthersPlugin from "@ignored/hardhat-vnext-ignition-ethers";
+
+import apolloModule from "../ignition/modules/Apollo.js";
 
 const hre = await createHardhatRuntimeEnvironment({
   plugins: [hardhatIgnitionEthersPlugin],


### PR DESCRIPTION
The `./scripts/deploy-rocket-from-script.ts` had an import that reached across the monorepo. This has been updated to directly point at the Ignition module within the package.
