### PR TITLE
fix: correctly identify test suites

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -7,9 +7,11 @@ import type {
   PathPermission,
   StorageCachingConfig,
   AddressLabel,
+  Artifact,
 } from "@ignored/edr";
 
 import { hexStringToBytes } from "@ignored/hardhat-vnext-utils/hex";
+import { Abi } from "../../../types/artifacts.js";
 
 function hexStringToBuffer(hexString: string): Buffer {
   return Buffer.from(hexStringToBytes(hexString));
@@ -97,4 +99,14 @@ export function solidityTestConfigToSolidityTestRunnerConfigArgs(
     blockCoinbase,
     rpcStorageCaching,
   };
+}
+
+export function isTestSuiteArtifact(artifact: Artifact): boolean {
+  const abi: Abi = JSON.parse(artifact.contract.abi);
+  return abi.some(({ type, name }) => {
+    if (type === "function" && name !== undefined) {
+      return name.startsWith("test") || name.startsWith("invariant");
+    }
+    return false;
+  });
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -13,7 +13,6 @@ import type {
 
 import { hexStringToBytes } from "@ignored/hardhat-vnext-utils/hex";
 
-
 function hexStringToBuffer(hexString: string): Buffer {
   return Buffer.from(hexStringToBytes(hexString));
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -1,4 +1,5 @@
 import type { RunOptions } from "./runner.js";
+import type { Abi } from "../../../types/artifacts.js";
 import type { SolidityTestConfig } from "../../../types/config.js";
 import type {
   SolidityTestRunnerConfigArgs,
@@ -11,7 +12,7 @@ import type {
 } from "@ignored/edr";
 
 import { hexStringToBytes } from "@ignored/hardhat-vnext-utils/hex";
-import { Abi } from "../../../types/artifacts.js";
+
 
 function hexStringToBuffer(hexString: string): Buffer {
   return Buffer.from(hexStringToBytes(hexString));
@@ -104,7 +105,7 @@ export function solidityTestConfigToSolidityTestRunnerConfigArgs(
 export function isTestSuiteArtifact(artifact: Artifact): boolean {
   const abi: Abi = JSON.parse(artifact.contract.abi);
   return abi.some(({ type, name }) => {
-    if (type === "function" && name !== undefined) {
+    if (type === "function" && typeof name === "string") {
       return name.startsWith("test") || name.startsWith("invariant");
     }
     return false;

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -22,6 +22,7 @@ import {
 } from "../solidity/build-results.js";
 
 import {
+  isTestSuiteArtifact,
   solidityTestConfigToRunOptions,
   solidityTestConfigToSolidityTestRunnerConfigArgs,
 } from "./helpers.js";
@@ -86,7 +87,9 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
 
   const buildInfos = await getBuildInfos(results, hre.artifacts);
   const artifacts = await getArtifacts(results);
-  const testSuiteIds = artifacts.map((artifact) => artifact.id);
+  const testSuiteIds = artifacts
+    .filter(isTestSuiteArtifact)
+    .map((artifact) => artifact.id);
 
   console.log("Running Solidity tests");
   console.log();

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -128,8 +128,14 @@ export interface ArtifactManager {
 
 /**
  * TODO: This type could be improved to better represent the ABI.
+ *
+ * Ref: https://docs.soliditylang.org/en/latest/abi-spec.html#json
  */
-export type Abi = readonly any[];
+interface FunctionDescription {
+  type: "function" | "constructor" | "receive" | "fallback";
+  name?: string;
+}
+export type Abi = readonly FunctionDescription[];
 
 /**
  * An Artifact represents the compilation output of a single contract.

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -128,14 +128,8 @@ export interface ArtifactManager {
 
 /**
  * TODO: This type could be improved to better represent the ABI.
- *
- * Ref: https://docs.soliditylang.org/en/latest/abi-spec.html#json
  */
-interface FunctionDescription {
-  type: "function" | "constructor" | "receive" | "fallback";
-  name?: string;
-}
-export type Abi = readonly FunctionDescription[];
+export type Abi = readonly any[];
 
 /**
  * An Artifact represents the compilation output of a single contract.


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This resolves https://www.notion.so/nomicfoundation/Public-Alpha-Solidity-Test-Comparison-19d578cdeaf58070a453c4059f3df4dd?pvs=4#19d578cdeaf5803da9f0ddc5b4a3ca20

This was tested in https://github.com/galargh/solidity-testing-testing/actions/runs/13395288956/job/37412700270 

The output no longer contains `EvmError: Revert in setUp()` errors in constructors.