### PR TITLE
chore: deduplicate build ids before getting build infos

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-results.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-results.ts
@@ -67,11 +67,12 @@ export async function getBuildInfos(
   results: SuccessfulSolidityBuildResults,
   artifactManager: ArtifactManager,
 ): Promise<BuildInfoAndOutput[]> {
-  const buildIds = await Promise.all(
+  let buildIds = await Promise.all(
     Array.from(new Set(results.values())).map(async ({ compilationJob }) =>
       compilationJob.getBuildId(),
     ),
   );
+  buildIds = Array.from(new Set(buildIds));
 
   return Promise.all(
     buildIds.map(async (buildId) => {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-results.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-results.ts
@@ -67,15 +67,15 @@ export async function getBuildInfos(
   results: SuccessfulSolidityBuildResults,
   artifactManager: ArtifactManager,
 ): Promise<BuildInfoAndOutput[]> {
-  let buildIds = await Promise.all(
+  const buildIds = await Promise.all(
     Array.from(new Set(results.values())).map(async ({ compilationJob }) =>
       compilationJob.getBuildId(),
     ),
   );
-  buildIds = Array.from(new Set(buildIds));
+  const uniqueBuildIds = Array.from(new Set(buildIds));
 
   return Promise.all(
-    buildIds.map(async (buildId) => {
+    uniqueBuildIds.map(async (buildId) => {
       const buildInfoPath = await artifactManager.getBuildInfoPath(buildId);
       const buildInfoOutputPath =
         await artifactManager.getBuildInfoOutputPath(buildId);


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This change greatly improves solidity testing performance. Before, we would read the same build infos over and over again (for every compilation resul - test root path).