### PR TITLE
Init projects with pnpm when invoking hardhat from pnpx

### DIFF
--- a/v-next/hardhat/src/internal/cli/init/package-manager.ts
+++ b/v-next/hardhat/src/internal/cli/init/package-manager.ts
@@ -19,10 +19,14 @@ export async function getPackageManager(
   const pathToYarnLock = path.join(workspace, "yarn.lock");
   const pathToPnpmLock = path.join(workspace, "pnpm-lock.yaml");
 
+  const invokedFromPnpm = (process.env.npm_config_user_agent ?? "").includes(
+    "pnpm",
+  );
+
   if (await exists(pathToYarnLock)) {
     return "yarn";
   }
-  if (await exists(pathToPnpmLock)) {
+  if ((await exists(pathToPnpmLock)) || invokedFromPnpm) {
     return "pnpm";
   }
   return "npm";

--- a/v-next/hardhat/test/internal/cli/init/package-manager.ts
+++ b/v-next/hardhat/test/internal/cli/init/package-manager.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 
 import { writeUtf8File } from "@ignored/hardhat-vnext-utils/fs";
 import { useTmpDir } from "@nomicfoundation/hardhat-test-utils";
@@ -13,10 +13,28 @@ import {
 describe("getPackageManager", () => {
   useTmpDir("getPackageManager");
 
+  let originalUserAgent: string | undefined;
+  beforeEach(() => {
+    originalUserAgent = process.env.npm_config_user_agent;
+    process.env.npm_config_user_agent = "npm"; // assume we are running npm by default
+  });
+
+  afterEach(() => {
+    process.env.npm_config_user_agent = originalUserAgent;
+  });
+
   it("should return pnpm if pnpm-lock.yaml exists", async () => {
     await writeUtf8File("pnpm-lock.yaml", "");
     assert.equal(await getPackageManager(process.cwd()), "pnpm");
   });
+
+  it("should return pnpm if invoked from pnpx", async () => {
+    assert.equal(await getPackageManager(process.cwd()), "npm");
+    process.env.npm_config_user_agent =
+      "pnpm/10.4.1 npm/? node/v23.2.0 linux x64";
+    assert.equal(await getPackageManager(process.cwd()), "pnpm");
+  });
+
   it("should return npm if package-lock.json exists", async () => {
     await writeUtf8File("package-lock.json", "");
     assert.equal(await getPackageManager(process.cwd()), "npm");


### PR DESCRIPTION
Uses the `npm_config_user_agent` env variable to tell if it's been invoked by `pnpm dlx` or `pnpx`

I also tried other 2 approaches but discarded them:
- Using `process.argv`: the binary is set as "node" even though initially invoked by pnpx
- Using `process._`: this doesnt work on windows cmd/powershell

From what I've researched and manually tested, `npm_config_user_agent` is set on both type of operating systems

Closes #6321 

