### PR TITLE
fix: explicitly enable forking when configuring it via override

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
@@ -71,6 +71,7 @@ const nodeAction: NewTaskActionFunction<NodeActionArguments> = async (
   // NOTE: --fork-block-number is only valid if --fork is specified
   if (args.fork !== "") {
     networkConfigOverride.forking = {
+      enabled: true,
       url: args.fork,
       ...(args.forkBlockNumber !== -1
         ? { blockNumber: args.forkBlockNumber }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

When we resolve the network config override, we only keep the values that are present in the override. In particular, even though resolved forking config would have `enabled: true` set, we remove it when resolving the override because the user didn't explicitly want to override that setting. So if the forking is disabled in the original network config, it will remain disabled after applying the override.

https://github.com/NomicFoundation/hardhat/blob/6f1f11084b8a6fd922c31a25e1ba06ff649a92bf/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts#L142-L149

This is not what we want when providing forking arguments to the `node` task. So I decided to explicitly enable forking in the override when the forking options are passed to that task.
