### PR TITLE
feat: update not implemented message on ignition verify tasks

### DIFF
--- a/v-next/hardhat-ignition/src/internal/tasks/deploy.ts
+++ b/v-next/hardhat-ignition/src/internal/tasks/deploy.ts
@@ -17,6 +17,7 @@ import {
   remove,
   writeJsonFile,
 } from "@ignored/hardhat-vnext-utils/fs";
+import chalk from "chalk";
 import Prompt from "prompts";
 
 import { HardhatArtifactResolver } from "../../helpers/hardhat-artifact-resolver.js";
@@ -52,10 +53,11 @@ const taskDeploy: NewTaskActionFunction<TaskDeployArguments> = async (
   hre: HardhatRuntimeEnvironment,
 ): Promise<DeploymentResult | null> => {
   if (verify) {
-    throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-      message:
-        "Verifying deployments is not available yet. It will be available in a future version of the Harhdat 3 Alpha",
-    });
+    console.log(
+      chalk.yellow(
+        "Verifying deployments will be implemented soon. Check back soon for more updates.",
+      ),
+    );
 
     // TODO: HH3 Bring back with the port of hardhat-verify
     // if (
@@ -67,6 +69,8 @@ const taskDeploy: NewTaskActionFunction<TaskDeployArguments> = async (
     //     HardhatError.ERRORS.IGNITION.ETHERSCAN_API_KEY_NOT_CONFIGURED,
     //   );
     // }
+
+    return null;
   }
 
   const connection = await hre.network.connect();

--- a/v-next/hardhat-ignition/src/internal/tasks/verify.ts
+++ b/v-next/hardhat-ignition/src/internal/tasks/verify.ts
@@ -1,7 +1,7 @@
 import type { HardhatRuntimeEnvironment } from "@ignored/hardhat-vnext/types/hre";
 import type { NewTaskActionFunction } from "@ignored/hardhat-vnext/types/tasks";
 
-import { HardhatError } from "@ignored/hardhat-vnext-errors";
+import chalk from "chalk";
 
 interface TaskVerifyArguments {
   deploymentId: string;
@@ -12,10 +12,13 @@ const verifyTask: NewTaskActionFunction<TaskVerifyArguments> = async (
   _args,
   _hre: HardhatRuntimeEnvironment,
 ) => {
-  throw new HardhatError(HardhatError.ERRORS.INTERNAL.NOT_IMPLEMENTED_ERROR, {
-    message:
-      "Verifying deployments is not available yet. It will be available in a future version of the Harhdat 3 Alpha",
-  });
+  console.log(
+    chalk.yellow(
+      "This task will be implemented soon. Check back soon for more updates.",
+    ),
+  );
+
+  return;
 
   // const { getVerificationInformation } = await import(
   //   "@ignored/hardhat-vnext-ignition-core"


### PR DESCRIPTION
Specifically the message when running `deploy` with the `--verify` flag and the standalone `hardhat ignition verify` task.

This brings the text and styling inline with the other not implemented messages.
