### PR TITLE
Fixed Broken Discord Link in Final Thoughts Tutorial

### DIFF
--- a/docs/src/content/tutorial/final-thoughts.md
+++ b/docs/src/content/tutorial/final-thoughts.md
@@ -8,7 +8,7 @@ Here are some links you might find useful throughout your journey:
 - [Hardhat's documentation site](/docs/)
 - [Hardhat Toolbox's documentation](/hardhat-runner/plugins/nomicfoundation-hardhat-toolbox)
 - [Hardhat Ignition's documentation](/ignition)
-- [Hardhat Support Discord server](/discord)
+- [Hardhat Support Discord server](https://discord.com/invite/TETZs2KK4k)
 - [Ethers.js Documentation](https://docs.ethers.org/v6/)
 - [Mocha Documentation](https://mochajs.org/)
 - [Chai Documentation](https://www.chaijs.com/)


### PR DESCRIPTION
**In the file `docs/src/content/tutorial/final-thoughts.md`, I updated the Discord link because the previous one was leading to a GitHub 404 error page."**

This keeps everything clear and professional. Let me know if you need any adjustments! 🚀