### PR TITLE
[Cli parsing] When you run `npx hardhat task unexpected-argument` it doesn't fail if task is an empty task

### DIFF
--- a/.changeset/short-beans-rest.md
+++ b/.changeset/short-beans-rest.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-errors": patch
+"hardhat": patch
+---
+
+Added a check to throw an error if a non-existing subtask is executed

--- a/.changeset/short-beans-rest.md
+++ b/.changeset/short-beans-rest.md
@@ -3,4 +3,4 @@
 "hardhat": patch
 ---
 
-Added a check to throw an error if a non-existing subtask is executed
+Improve error message if a non-existing subtask is invoked ([#6375](https://github.com/NomicFoundation/hardhat/issues/6375))

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -431,7 +431,7 @@ Please double check your arguments.`,
       messageTemplate:
         'Invalid subtask "{invalidSubtask}" for the task "{task}"',
       websiteTitle: "Invalid subtask value",
-      websiteDescription: `The subtasks for your task is invalid.
+      websiteDescription: `The subtask for the task you provided is invalid.
 
 Please double check your subtask.,`,
     },

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -429,11 +429,11 @@ Please double check your arguments.`,
     UNRECOGNIZED_SUBTASK: {
       number: 416,
       messageTemplate:
-        'Invalid subtask "{invalidSubtask}" for the task "{task}"',
-      websiteTitle: "Invalid subtask value",
-      websiteDescription: `The subtask for the task you provided is invalid.
+        'Unrecognized subtask "{invalidSubtask}" for the task "{task}"',
+      websiteTitle: "Unrecognized subtask",
+      websiteDescription: `The subtask for the task you provided is not recognized.
 
-Please double check your subtask.,`,
+Please check you have the correct subtask.`,
     },
   },
   ARGUMENTS: {

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -426,6 +426,15 @@ Please double check your task arguments.`,
 
 Please double check your arguments.`,
     },
+    UNRECOGNIZED_SUBTASK: {
+      number: 416,
+      messageTemplate:
+        'Invalid subtask "{invalidSubtask}" for the task "{task}"',
+      websiteTitle: "Invalid subtask value",
+      websiteDescription: `The subtasks for your task is invalid.
+
+Please double check your subtask.,`,
+    },
   },
   ARGUMENTS: {
     INVALID_VALUE_FOR_TYPE: {

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -168,6 +168,18 @@ export async function main(
 
     const task = taskOrId;
 
+    if (task.isEmpty && usedCliArguments.includes(false)) {
+      const invalidSubtask = cliArguments[usedCliArguments.indexOf(false)];
+
+      throw new HardhatError(
+        HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_SUBTASK,
+        {
+          task: task.id.join(" "),
+          invalidSubtask,
+        },
+      );
+    }
+
     if (builtinGlobalOptions.help || task.isEmpty) {
       const taskHelp = await getHelpString(task);
 

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/tasks-and-subtasks/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/tasks-and-subtasks/hardhat.config.ts
@@ -1,6 +1,6 @@
 import type { HardhatUserConfig } from "../../../../../src/config.js";
 
-import { task } from "../../../../../src/config.js";
+import { emptyTask, task } from "../../../../../src/config.js";
 
 export const tasksResults = {
   wasArg1Used: false,
@@ -42,6 +42,8 @@ const customTask2 = task("task-default")
   })
   .build();
 
+const customTask3 = emptyTask("task-default-3", "description").build();
+
 const customSubtask = task(["task", "subtask"])
   .addOption({ name: "arg1", defaultValue: "<default-value1>" })
   .addPositionalArgument({ name: "arg2" })
@@ -70,8 +72,19 @@ const customSubtask2 = task(["task-default", "subtask-default"])
   })
   .build();
 
+const customSubtask3 = task(["task-default-3", "subtask-default-3"])
+  .setAction(() => {})
+  .build();
+
 const config: HardhatUserConfig = {
-  tasks: [customTask, customTask2, customSubtask, customSubtask2],
+  tasks: [
+    customTask,
+    customTask2,
+    customTask3,
+    customSubtask,
+    customSubtask2,
+    customSubtask3,
+  ],
 };
 
 export default config;

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -210,6 +210,23 @@ describe("main", function () {
       });
     });
 
+    describe("task wit non existing subtask", function () {
+      useFixtureProject("cli/parsing/tasks-and-subtasks");
+
+      it("should throw because the subtask does not exist", async function () {
+        const command = "npx hardhat task-default-3 nonExistingTask";
+
+        await assertRejectsWithHardhatError(
+          () => runMain(command),
+          HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_SUBTASK,
+          {
+            task: "task-default-3",
+            invalidSubtask: "nonExistingTask",
+          },
+        );
+      });
+    });
+
     describe("global help", function () {
       useFixtureProject("cli/parsing/base-project");
 
@@ -269,6 +286,23 @@ Usage: hardhat [GLOBAL OPTIONS] empty-task <SUBTASK> [SUBTASK OPTIONS] [--] [SUB
 `;
 
           assert.equal(lines.join(""), expected);
+        });
+      });
+
+      describe("subtask does not exist", () => {
+        useFixtureProject("cli/parsing/tasks-and-subtasks");
+
+        it("should throw because the help option cannot be used on a non-existent subtask", async function () {
+          const command = "npx hardhat task-default-3 nonExistingTask --help";
+
+          await assertRejectsWithHardhatError(
+            () => runMain(command),
+            HardhatError.ERRORS.TASK_DEFINITIONS.UNRECOGNIZED_SUBTASK,
+            {
+              task: "task-default-3",
+              invalidSubtask: "nonExistingTask",
+            },
+          );
         });
       });
 

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -210,7 +210,7 @@ describe("main", function () {
       });
     });
 
-    describe("task wit non existing subtask", function () {
+    describe("task with non existing subtask", function () {
       useFixtureProject("cli/parsing/tasks-and-subtasks");
 
       it("should throw because the subtask does not exist", async function () {


### PR DESCRIPTION
Now if you run 

- `npx hardhat task nonExistingTask`
- `npx hardhat task nonExistingTask --help`

An error will thrown:

`Invalid subtask "nonExistingTask" for the task "task"`