### PR TITLE
Invariant error when running chai matchers and load fixture

### DIFF
--- a/.changeset/early-wolves-move.md
+++ b/.changeset/early-wolves-move.md
@@ -2,6 +2,4 @@
 "@nomicfoundation/hardhat-network-helpers": patch
 ---
 
-Network helpers - fixture error
-
-Fixed an error in `hardhat-network-helpers` where the blockchain `snapshot` was being shared across different connections. Now, each connection has its own `snapshot`.
+Fix for `hardhat-network-helpers` where the blockchain `snapshot` was being shared across different network connections ([#6377](https://github.com/NomicFoundation/hardhat/issues/6377))

--- a/.changeset/early-wolves-move.md
+++ b/.changeset/early-wolves-move.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Network helpers - fixture error
+
+Fixed an error in `hardhat-network-helpers` where the blockchain `snapshot` was being shared across different connections. Now, each connection has its own `snapshot`.

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/helpers/load-fixture.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/helpers/load-fixture.ts
@@ -2,11 +2,10 @@ import type { Fixture, NetworkHelpers, Snapshot } from "../../../types.js";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 
-let snapshots: Array<Snapshot<any>> = [];
-
 export async function loadFixture<T>(
   networkHelpers: NetworkHelpers,
   fixture: Fixture<T>,
+  snapshots: Array<Snapshot<any>>,
 ): Promise<T> {
   if (fixture.name === "") {
     throw new HardhatError(
@@ -20,10 +19,14 @@ export async function loadFixture<T>(
     try {
       await snapshot.restorer.restore();
 
-      snapshots = snapshots.filter(
+      const filteredSnapshots = snapshots.filter(
         (s) =>
           Number(s.restorer.snapshotId) <= Number(snapshot.restorer.snapshotId),
       );
+
+      // Modify the array by reference
+      snapshots.length = 0;
+      snapshots.push(...filteredSnapshots);
     } catch (e) {
       if (
         HardhatError.isHardhatError(e) &&
@@ -52,6 +55,7 @@ export async function loadFixture<T>(
   }
 }
 
-export function clearSnapshots(): void {
-  snapshots = [];
+export function clearSnapshots(snapshots: Array<Snapshot<any>>): void {
+  // Modify the array by reference
+  snapshots.length = 0;
 }

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
@@ -16,7 +16,7 @@ import {
 import { dropTransaction } from "./helpers/drop-transaction.js";
 import { getStorageAt } from "./helpers/get-storage-at.js";
 import { impersonateAccount } from "./helpers/impersonate-account.js";
-import { clearSnapshots, loadFixture } from "./helpers/load-fixture.js";
+import { loadFixture } from "./helpers/load-fixture.js";
 import { mineUpTo } from "./helpers/mine-up-to.js";
 import { mine } from "./helpers/mine.js";
 import { reset } from "./helpers/reset.js";
@@ -37,7 +37,7 @@ const SUPPORTED_TEST_NETWORKS = ["hardhat", "zksync", "anvil"];
 export class NetworkHelpers implements NetworkHelpersI {
   readonly #provider: EthereumProvider;
   readonly #networkName: string;
-  readonly #snapshots: Array<Snapshot<any>> = [];
+  #snapshots: Array<Snapshot<any>> = [];
 
   #isDevelopmentNetwork: boolean | undefined;
   #version: string | undefined;
@@ -52,7 +52,7 @@ export class NetworkHelpers implements NetworkHelpersI {
   }
 
   public clearSnapshots(): void {
-    clearSnapshots(this.#snapshots);
+    this.#snapshots = [];
   }
 
   public async dropTransaction(txHash: string): Promise<boolean> {

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
@@ -3,6 +3,7 @@ import type {
   Fixture,
   NetworkHelpers as NetworkHelpersI,
   NumberLike,
+  Snapshot,
   SnapshotRestorer,
 } from "../../types.js";
 import type { EthereumProvider } from "hardhat/types/providers";
@@ -36,6 +37,7 @@ const SUPPORTED_TEST_NETWORKS = ["hardhat", "zksync", "anvil"];
 export class NetworkHelpers implements NetworkHelpersI {
   readonly #provider: EthereumProvider;
   readonly #networkName: string;
+  readonly #snapshots: Array<Snapshot<any>> = [];
 
   #isDevelopmentNetwork: boolean | undefined;
   #version: string | undefined;
@@ -50,7 +52,7 @@ export class NetworkHelpers implements NetworkHelpersI {
   }
 
   public clearSnapshots(): void {
-    clearSnapshots();
+    clearSnapshots(this.#snapshots);
   }
 
   public async dropTransaction(txHash: string): Promise<boolean> {
@@ -74,7 +76,7 @@ export class NetworkHelpers implements NetworkHelpersI {
 
   public async loadFixture<T>(fixture: Fixture<T>): Promise<T> {
     await this.throwIfNotDevelopmentNetwork();
-    return loadFixture(this, fixture);
+    return loadFixture(this, fixture, this.#snapshots);
   }
 
   public async mine(

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
@@ -76,7 +76,16 @@ export class NetworkHelpers implements NetworkHelpersI {
 
   public async loadFixture<T>(fixture: Fixture<T>): Promise<T> {
     await this.throwIfNotDevelopmentNetwork();
-    return loadFixture(this, fixture, this.#snapshots);
+
+    const { snapshots, snapshotData } = await loadFixture(
+      this,
+      fixture,
+      this.#snapshots,
+    );
+
+    this.#snapshots = snapshots;
+
+    return snapshotData;
   }
 
   public async mine(


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/hardhat/issues/6377

Fix explanation: Hardhat now supports multiple connections. The `snapshots` array used in the `loadFixture` function was declared globally, which meant it was shared across multiple connections, leading to the failure described in the issue.
To fix this problem, I moved the `snapshots` array to the `network-helpers` class declaration. Since a new class is created for every connection, the `snapshots` array will now be unique for each connection.
