### PR TITLE
build: upgrade to EDR v0.9.0

### DIFF
--- a/.changeset/ninety-beans-warn.md
+++ b/.changeset/ninety-beans-warn.md
@@ -1,0 +1,6 @@
+---
+"hardhat": patch
+---
+
+Upgraded EDR to [v0.9.0](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.9.0):
+- Added support for the Prague hardfork

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.1.2",
     "@metamask/eth-sig-util": "^4.0.0",
-    "@nomicfoundation/edr": "^0.8.0",
+    "@nomicfoundation/edr": "^0.9.0",
     "@nomicfoundation/ethereumjs-common": "4.0.4",
     "@nomicfoundation/ethereumjs-tx": "5.0.4",
     "@nomicfoundation/ethereumjs-util": "9.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,8 +201,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
       '@nomicfoundation/edr':
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.9.0
+        version: 0.9.0
       '@nomicfoundation/ethereumjs-common':
         specifier: 4.0.4
         version: 4.0.4
@@ -3086,36 +3086,36 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.8.0':
-    resolution: {integrity: sha512-sKTmOu/P5YYhxT0ThN2Pe3hmCE/5Ag6K/eYoiavjLWbR7HEb5ZwPu2rC3DpuUk1H+UKJqt7o4/xIgJxqw9wu6A==}
+  '@nomicfoundation/edr-darwin-arm64@0.9.0':
+    resolution: {integrity: sha512-px47bTRzCJ0b5WqVIxr0c9hTkg8Lm+wtjE3mnKWvti/7hM4ZXrZE+DlYUzKZem/tb+C3LV2fuhJ8Yd0v4/n9Ag==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-darwin-x64@0.8.0':
-    resolution: {integrity: sha512-8ymEtWw1xf1Id1cc42XIeE+9wyo3Dpn9OD/X8GiaMz9R70Ebmj2g+FrbETu8o6UM+aL28sBZQCiCzjlft2yWAg==}
+  '@nomicfoundation/edr-darwin-x64@0.9.0':
+    resolution: {integrity: sha512-gHCZVsBqtKk2Jrvpis6NhPnOoe1WRoY4aoXbRmThSXqrK1xaZ4d1qfDQSvBB921R0+NdhgKrxd3Hfg9lRTUbdg==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.8.0':
-    resolution: {integrity: sha512-h/wWzS2EyQuycz+x/SjMRbyA+QMCCVmotRsgM1WycPARvVZWIVfwRRsKoXKdCftsb3S8NTprqBdJlOmsFyETFA==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.9.0':
+    resolution: {integrity: sha512-T5zIar+Agt5uQKvcSPG1xEQZw5SuvQtG980fug9rtz1w+RKs3xSieF9Cl4yIcEz9XxeWI2DBTPlqslsWwlBtTw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.8.0':
-    resolution: {integrity: sha512-gnWxDgdkka0O9GpPX/gZT3REeKYV28Guyg13+Vj/bbLpmK1HmGh6Kx+fMhWv+Ht/wEmGDBGMCW1wdyT/CftJaQ==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.9.0':
+    resolution: {integrity: sha512-B5WOTvz36I01E71gy5ldj6MqvldHIujW81+V9Rykc9xg4WpxA+wpwbcT26ou09hK+6NRVET6qk/kc4EoFMD/JQ==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.8.0':
-    resolution: {integrity: sha512-DTMiAkgAx+nyxcxKyxFZk1HPakXXUCgrmei7r5G7kngiggiGp/AUuBBWFHi8xvl2y04GYhro5Wp+KprnLVoAPA==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.9.0':
+    resolution: {integrity: sha512-DAouwbPvCiqZ+wVsj1vskI3zCZAydbAmoXii3Zxj9XZwwL+CVZdHTGGS+FSArvKnueTn0yN0SJoKJypcEDfCgQ==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.8.0':
-    resolution: {integrity: sha512-iTITWe0Zj8cNqS0xTblmxPbHVWwEtMiDC+Yxwr64d7QBn/1W0ilFQ16J8gB6RVVFU3GpfNyoeg3tUoMpSnrm6Q==}
+  '@nomicfoundation/edr-linux-x64-musl@0.9.0':
+    resolution: {integrity: sha512-2aqQc7vuoSDKtGH+fNKiMKBEO7lII+WgVsI3bMMG53xw5YDTVoCyG7efwUsRX6X7zkIN6zUH98UDRbzj3ch3ug==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.8.0':
-    resolution: {integrity: sha512-mNRDyd/C3j7RMcwapifzv2K57sfA5xOw8g2U84ZDvgSrXVXLC99ZPxn9kmolb+dz8VMm9FONTZz9ESS6v8DTnA==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.9.0':
+    resolution: {integrity: sha512-iHOe8v+sTSneukg5yHRd5S97bvwxUd+XN6X0cQy9lSKi/CtPUEimKTjoONZO1m4e7jWVXlcRfiVxZDCmSwdMSw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr@0.8.0':
-    resolution: {integrity: sha512-dwWRrghSVBQDpt0wP+6RXD8BMz2i/9TI34TcmZqeEAZuCLei3U9KZRgGTKVAM1rMRvrpf5ROfPqrWNetKVUTag==}
+  '@nomicfoundation/edr@0.9.0':
+    resolution: {integrity: sha512-pjZtppf7+sCE2js07qed1vrnUrwUP4VCPuzYm/B+tKac26Xov1bwHefNsn5EUo0x9VaQ4L7iKEQX/u5jj4DHTQ==}
     engines: {node: '>= 18'}
 
   '@nomicfoundation/ethereumjs-block@5.0.4':
@@ -9843,29 +9843,29 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@nomicfoundation/edr-darwin-arm64@0.8.0': {}
+  '@nomicfoundation/edr-darwin-arm64@0.9.0': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.8.0': {}
+  '@nomicfoundation/edr-darwin-x64@0.9.0': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.8.0': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.9.0': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.8.0': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.9.0': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.8.0': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.9.0': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.8.0': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.9.0': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.8.0': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.9.0': {}
 
-  '@nomicfoundation/edr@0.8.0':
+  '@nomicfoundation/edr@0.9.0':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.8.0
-      '@nomicfoundation/edr-darwin-x64': 0.8.0
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.8.0
-      '@nomicfoundation/edr-linux-arm64-musl': 0.8.0
-      '@nomicfoundation/edr-linux-x64-gnu': 0.8.0
-      '@nomicfoundation/edr-linux-x64-musl': 0.8.0
-      '@nomicfoundation/edr-win32-x64-msvc': 0.8.0
+      '@nomicfoundation/edr-darwin-arm64': 0.9.0
+      '@nomicfoundation/edr-darwin-x64': 0.9.0
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.9.0
+      '@nomicfoundation/edr-linux-arm64-musl': 0.9.0
+      '@nomicfoundation/edr-linux-x64-gnu': 0.9.0
+      '@nomicfoundation/edr-linux-x64-musl': 0.9.0
+      '@nomicfoundation/edr-win32-x64-msvc': 0.9.0
 
   '@nomicfoundation/ethereumjs-block@5.0.4':
     dependencies:


### PR DESCRIPTION
Upgrades EDR to [v0.9.0](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.9.0), introducing support for the Prague hardfork.

This contains no changes in the code's API. However, it does contain breaking changes in the JSON-RPC. Namely:
- all call request & transaction request types now contain optional [EIP-7702-specifc fields](https://github.com/NomicFoundation/edr/pull/814)
- all transaction getters can now return (optional) [EIP-7702-specific fields](https://github.com/NomicFoundation/edr/pull/814)
- all block getters can now return (optional) [EIP-7685-specific fields](https://github.com/NomicFoundation/edr/pull/814)

All Prague EIPs are extensively tested inside EDR. However, it might be desirable to add some smoke tests to validate end-to-end functionality. Additionally, the Hardhat team might need to do some work to expose configuration of the Prague hardfork to the end user.