### PR TITLE
Improve Grammar and Consistency in Hardhat Documentation

### DIFF
--- a/docs/src/content/tutorial/deploying-to-a-live-network.md
+++ b/docs/src/content/tutorial/deploying-to-a-live-network.md
@@ -4,7 +4,7 @@ Once you're ready to share your dApp with other people, you may want to deploy i
 
 The "mainnet" Ethereum network deals with real money, but there are separate "testnet" networks that do not. These testnets provide shared staging environments that do a good job of mimicking the real world scenario without putting real money at stake, and [Ethereum has several](https://ethereum.org/en/developers/docs/networks/#ethereum-testnets), like _Sepolia_ and _Goerli_. We recommend you deploy your contracts to the _Sepolia_ testnet.
 
-At the software level, deploying to a testnet is the same as deploying to mainnet. The only difference is which network you connect to. Let's look into what the code to deploy your contracts using [Hardhat Ignition](/ignition) would look like.
+At the software level, deploying to a testnet is the same as deploying to the mainnet. The only difference is which network you connect to. Let's look into what the code to deploy your contracts using [Hardhat Ignition](/ignition) would look like.
 
 In Hardhat Ignition, deployments are defined through Ignition Modules. These modules are abstractions to describe a deployment; that is, JavaScript functions that specify what you want to deploy.
 

--- a/docs/src/content/tutorial/testing-contracts.md
+++ b/docs/src/content/tutorial/testing-contracts.md
@@ -2,7 +2,7 @@
 
 Writing automated tests when building smart contracts is of crucial importance, as your user's money is what's at stake.
 
-To test our contract, we are going to use Hardhat Network, a local Ethereum network designed for development. It comes built-in with Hardhat, and it's used as the default network. You don't need to setup anything to use it.
+To test our contract, we are going to use Hardhat Network, a local Ethereum network designed for development. It comes built-in with Hardhat, and it's used as the default network. You don't need to set up anything to use it.
 
 In our tests we're going to use [ethers.js](https://docs.ethers.org/v6/) to interact with the Ethereum contract we built in the previous section, and we'll use [Mocha](https://mochajs.org/) as our test runner.
 

--- a/docs/src/content/tutorial/writing-and-compiling-contracts.md
+++ b/docs/src/content/tutorial/writing-and-compiling-contracts.md
@@ -84,7 +84,7 @@ contract Token {
     }
 
     /**
-     * Read only function to retrieve the token balance of a given account.
+     * Read-only function to retrieve the token balance of a given account.
      *
      * The `view` modifier indicates that it doesn't modify the contract's
      * state, which allows us to call it without executing a transaction.


### PR DESCRIPTION
File: [Deployment Guide]

Before: At the software level, deploying to a testnet is the same as deploying to mainnet.
After: At the software level, deploying to a testnet is the same as deploying to the mainnet.
Reason: Added the definite article "the" before "mainnet" for grammatical correctness, as "mainnet" is a specific entity.
File: [Testing Guide]

Before: You don't need to setup anything to use it.
After: You don't need to set up anything to use it.
Reason: "Set up" (verb) should be separated, as "setup" is a noun. This corrects verb usage.
File: [Smart Contract Guide]

Before: Read only function to retrieve the token balance of a given account.
After: Read-only function to retrieve the token balance of a given account.
Reason: "Read-only" should be hyphenated as it functions as a compound adjective.

