### PR TITLE
ci: run the changeset check in the merge queue

### DIFF
--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -4,6 +4,7 @@
 name: Check that the PR has a changeset
 
 on:
+  merge_group:
   pull_request:
     branches:
       - main

--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -26,6 +26,15 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
+            const isMergeGroup = context.eventName === "merge_group";
+
+            // Merge group context
+            if (isMergeGroup) {
+              console.log("Ignore changeset check for merge group.");
+              return;
+            }
+
+            // Single PR context
             const pullNumber = context.issue.number;
 
             const { data: files } = await github.rest.pulls.listFiles({


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This should unblock the merge queue.