### PR TITLE
fix: correct package manager selection in CLI install

### DIFF
--- a/.changeset/hot-birds-cover.md
+++ b/.changeset/hot-birds-cover.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Use `npm_config_user_agent` to determine what package manager to use for project creation

--- a/packages/hardhat-core/src/internal/cli/project-creation.ts
+++ b/packages/hardhat-core/src/internal/cli/project-creation.ts
@@ -554,12 +554,24 @@ function isInstalled(dep: string) {
   return dep in allDependencies;
 }
 
+function getProjectTypeFromUserAgent() {
+  const userAgent = process.env.npm_config_user_agent;
+  // Get first part of user agent string
+  const [projectType] = userAgent?.split("/") ?? [];
+  return projectType;
+}
+
 async function isYarnProject() {
-  return fsExtra.pathExists("yarn.lock");
+  return (
+    getProjectTypeFromUserAgent() === "yarn" || fsExtra.pathExists("yarn.lock")
+  );
 }
 
 async function isPnpmProject() {
-  return fsExtra.pathExists("pnpm-lock.yaml");
+  return (
+    getProjectTypeFromUserAgent() === "pnpm" ||
+    fsExtra.pathExists("pnpm-lock.yaml")
+  );
 }
 
 async function getProjectPackageManager(): Promise<PackageManager> {


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
(It seems there are no existing tests for the CLI installation yet, so I have kept the same level of testing for now and added my manual test below).
- [x] The change was previously discussed on an Issue or with someone from the team.

**Description:**
* (issue #6111) Franco noticed that the install script defaults to using `npm` in some cases, noting that its probably to do with checking the directories package manager related files.
* Confirmed that the checks in `project-creation.ts` are checking for related .lock files, and therefore if the project isn't set up correctly then the CLI could use the wrong package manager.
* Added a new function `getProjectTypeFromUserAgent` which extracts the first part of `process.env.npm_config_user_agent`, this is then added as the first check in the `isYarnProject` and `isPnpmProject` functions. 
* **Note:** This also removes the need to make a file system check in most cases.
* **Note:** `process.env.npm_config_user_agent` might not be available on all OS, and we still default back to initial behaviour for now.
* Rebuilt, packaged, and tested the change by printing the results of `getProjectTypeFromUserAgent` at start of CLI code.

Manual CLI test output:
```
howardtang hardhat-test % pnpm dlx $(pwd)/hardhat-2.22.19.tgz init
 WARN  3 deprecated subdependencies found: ethereumjs-abi@0.6.8, glob@8.1.0, inflight@1.0.6
Packages: +243
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 243, reused 242, downloaded 1, added 243, done
aychtang/hardhat
userAgent pnpm/8.8.0 npm/? node/v20.8.0 darwin arm64
projectType pnpm
```