### PR TITLE
fix grammatical mistakes and improve clarity in docs .md

### DIFF
--- a/docs/src/content/hardhat-chai-matchers/docs/overview.md
+++ b/docs/src/content/hardhat-chai-matchers/docs/overview.md
@@ -207,7 +207,7 @@ await expect(token.transfer(account, 1)).to.changeTokenBalance(
 );
 ```
 
-Further, you can also check these conditions for multiple addresses at the same time:
+Additionally, you can check these conditions for multiple addresses simultaneously:
 
 ```js
 await expect(() =>

--- a/docs/src/content/hardhat-chai-matchers/docs/reference.md
+++ b/docs/src/content/hardhat-chai-matchers/docs/reference.md
@@ -14,7 +14,7 @@ will work. These assertions don't normally work because the value returned by `t
 
 The supported types are:
 
-- Plain javascript numbers
+- Plain JavaScript numbers
 - [BigInts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)
 - [`bn.js`](https://github.com/indutny/bn.js/) instances
 - [`bignumber.js`](https://github.com/MikeMcl/bignumber.js/) instances

--- a/docs/src/content/hardhat-runner/docs/advanced/artifacts.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/artifacts.md
@@ -2,7 +2,7 @@
 
 Compiling with Hardhat generates two files per compiled contract (not each `.sol` file): an artifact and a debug file.
 
-An **artifact** has all the information that is necessary to deploy and interact with the contract. These are compatible with most tools, including Truffle's artifact format. Each artifact consists of a json with the following properties:
+An **artifact** has all the information that is necessary to deploy and interact with the contract. These are compatible with most tools, including Truffle's artifact format. Each artifact consists of a JSON with the following properties:
 
 - `contractName`: A string with the contract's name.
 

--- a/docs/src/content/hardhat-runner/docs/advanced/building-plugins.md
+++ b/docs/src/content/hardhat-runner/docs/advanced/building-plugins.md
@@ -1,6 +1,6 @@
 # Building plugins
 
-In this section, we will explore the creation of plugins for Hardhat, which are the key component for integrating other tools and extending the built-in functionality.
+In this section, we will explore the creation of plugins for Hardhat, which are the key components for integrating other tools and extending the built-in functionality.
 
 ## What exactly are plugins in Hardhat?
 


### PR DESCRIPTION
This PR improves the documentation by fixing grammatical mistakes and improving clarity.

#### **Changes**
- **`docs/src/content/hardhat-chai-matchers/docs/overview.md`**
   Reworded a sentence for better readability.

- **`docs/src/content/hardhat-chai-matchers/docs/reference.md`**
   Standardized capitalization of "JavaScript."

- **`docs/src/content/hardhat-runner/docs/advanced/artifacts.md`**
   Corrected "json" to "JSON" for consistency.

- **`docs/src/content/hardhat-runner/docs/advanced/building-plugins.md`**
   Corrected "key component" to "key components" for singular/plural agreement in a sentence.

PR Checklist
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.
