### PR TITLE
Prevent losing typechain types when compiling a subset of contracts

### DIFF
--- a/.changeset/sour-mayflies-speak.md
+++ b/.changeset/sour-mayflies-speak.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-typechain": patch
+---
+
+Fix typechain overwrite when compiling a subset of contracts

--- a/v-next/hardhat-typechain/src/internal/hook-handlers/solidity.ts
+++ b/v-next/hardhat-typechain/src/internal/hook-handlers/solidity.ts
@@ -13,8 +13,18 @@ export default async (): Promise<Partial<SolidityHooks>> => {
         artifacts: Map<CompilationJob, ReadonlyMap<string, string[]>>,
       ) => Promise<void>,
     ) {
-      const artifactsPaths = Array.from(artifacts.values()).flatMap(
+      const currentArtifactsPaths = Array.from(artifacts.values()).flatMap(
         (innerMap) => Array.from(innerMap.values()).flat(),
+      );
+
+      const existingArtifactsPaths = await Promise.all(
+        Array.from(await context.artifacts.getAllFullyQualifiedNames()).map(
+          (name) => context.artifacts.getArtifactPath(name),
+        ),
+      );
+
+      const artifactsPaths = Array.from(
+        new Set([...currentArtifactsPaths, ...existingArtifactsPaths]),
       );
 
       await generateTypes(

--- a/v-next/hardhat-typechain/test/fixture-projects/generate-types/contracts/B.sol
+++ b/v-next/hardhat-typechain/test/fixture-projects/generate-types/contracts/B.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract B {
+  function getMessage() external pure returns (string memory) {
+    return "Hello from B contract!";
+  }
+}


### PR DESCRIPTION
When compiling a subset of contracts, only the generated artifacts were being passed to typechain, losing the types of any previously generated artifacts.

This PR changes that, so besides passing the current generated artifacts, it passes all available artifacts in the project.

I had to adapt the test cases a bit since apparently on windows the generated files have a different directory structure than in linux/mac when having multiple contracts.

Closes #6311 