### PR TITLE
Increase default http request timeout from 30s to 300s

### DIFF
--- a/.changeset/eleven-bees-serve.md
+++ b/.changeset/eleven-bees-serve.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Increase http timeout

--- a/v-next/hardhat-utils/src/request.ts
+++ b/v-next/hardhat-utils/src/request.ts
@@ -23,7 +23,7 @@ import {
   handleError,
 } from "./internal/request.js";
 
-export const DEFAULT_TIMEOUT_IN_MILLISECONDS = 30_000;
+export const DEFAULT_TIMEOUT_IN_MILLISECONDS = 300_000; // Aligned with unidici
 export const DEFAULT_MAX_REDIRECTS = 10;
 export const DEFAULT_POOL_MAX_CONNECTIONS = 128;
 export const DEFAULT_USER_AGENT = "Hardhat";

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts
@@ -54,7 +54,7 @@ export function resolveHttpNetwork(
     gasMultiplier: networkConfig.gasMultiplier ?? 1,
     gasPrice: resolveGasConfig(networkConfig.gasPrice),
     url: resolveConfigurationVariable(networkConfig.url),
-    timeout: networkConfig.timeout ?? 20_000,
+    timeout: networkConfig.timeout ?? 300_000,
     httpHeaders: networkConfig.httpHeaders ?? {},
   };
 }

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/config-resolution.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/config-resolution.ts
@@ -101,7 +101,7 @@ describe("config-resolution", () => {
       assert.equal(httpNetworkConfig.chainType, undefined);
       assert.equal(httpNetworkConfig.from, undefined);
       assert.equal(httpNetworkConfig.gasMultiplier, 1);
-      assert.equal(httpNetworkConfig.timeout, 20_000);
+      assert.equal(httpNetworkConfig.timeout, 300_000);
       assert.deepEqual(httpNetworkConfig.httpHeaders, {});
     });
   });

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -1227,7 +1227,7 @@ describe("network-manager/hook-handlers/config", () => {
           gasPrice: "auto",
           accounts: "remote",
           url: new FixedValueConfigurationVariable("http://localhost:8545"),
-          timeout: 20_000,
+          timeout: 300_000,
           httpHeaders: {},
         },
       });


### PR DESCRIPTION
Closes #6439 

Scanned the v3 codebase for all potential outgoing http requests. Since they all go through utils/request, it all cleanly resolves to a single default value for timeouts (which we use for connection, headers and body timeout). Increased it to match unidici's defaults.