### PR TITLE
Error when using a low interval mining value and mismatching timestamp

### DIFF
--- a/.changeset/tasty-deers-doubt.md
+++ b/.changeset/tasty-deers-doubt.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Warn when using a low interval mining value and mismatching timestamp

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -75,7 +75,6 @@ export async function resolveUserConfig(
 
   const resolvedNetworks: Record<string, NetworkConfig> = {};
 
-  // resolve edr and http networks
   for (const [networkName, networkConfig] of Object.entries(networks)) {
     if (networkConfig.type !== "http" && networkConfig.type !== "edr") {
       throw new HardhatError(HardhatError.ERRORS.NETWORK.INVALID_NETWORK_TYPE, {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -10,7 +10,6 @@ import type {
 import type { ConfigHooks } from "../../../../types/hooks.js";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import chalk from "chalk";
 
 import { GENERIC_CHAIN_TYPE } from "../../../constants.js";
 import { resolveEdrNetwork, resolveHttpNetwork } from "../config-resolution.js";
@@ -69,7 +68,6 @@ export async function resolveUserConfig(
     nextUserConfig: HardhatUserConfig,
     nextResolveConfigurationVariable: ConfigurationVariableResolver,
   ) => Promise<HardhatConfig>,
-  warn: typeof console.warn = console.warn,
 ): Promise<HardhatConfig> {
   const resolvedConfig = await next(userConfig, resolveConfigurationVariable);
 
@@ -95,23 +93,6 @@ export async function resolveUserConfig(
             resolvedConfig.paths.cache,
             resolveConfigurationVariable,
           );
-  }
-
-  // Validate mining config
-  for (const network of Object.values(networks)) {
-    if (network.type !== "edr" || network?.mining?.interval === undefined) {
-      continue;
-    }
-    const interval = network.mining.interval;
-    const minInterval =
-      typeof interval === "number" ? interval : Math.min(...interval);
-    if (minInterval < 1000 && network.allowBlocksWithSameTimestamp !== true) {
-      warn(
-        chalk.yellow(
-          "Mining interval is set to less than 1000 ms. To avoid the block timestamp diverging from clock time, please set allowBlocksWithSameTimestamp: true on the network config",
-        ),
-      );
-    }
   }
 
   return {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -10,6 +10,7 @@ import type {
 import type { ConfigHooks } from "../../../../types/hooks.js";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import chalk from "chalk";
 
 import { GENERIC_CHAIN_TYPE } from "../../../constants.js";
 import { resolveEdrNetwork, resolveHttpNetwork } from "../config-resolution.js";
@@ -68,6 +69,7 @@ export async function resolveUserConfig(
     nextUserConfig: HardhatUserConfig,
     nextResolveConfigurationVariable: ConfigurationVariableResolver,
   ) => Promise<HardhatConfig>,
+  warn: typeof console.warn = console.warn,
 ): Promise<HardhatConfig> {
   const resolvedConfig = await next(userConfig, resolveConfigurationVariable);
 
@@ -75,6 +77,7 @@ export async function resolveUserConfig(
 
   const resolvedNetworks: Record<string, NetworkConfig> = {};
 
+  // resolve edr and http networks
   for (const [networkName, networkConfig] of Object.entries(networks)) {
     if (networkConfig.type !== "http" && networkConfig.type !== "edr") {
       throw new HardhatError(HardhatError.ERRORS.NETWORK.INVALID_NETWORK_TYPE, {
@@ -92,6 +95,23 @@ export async function resolveUserConfig(
             resolvedConfig.paths.cache,
             resolveConfigurationVariable,
           );
+  }
+
+  // Validate mining config
+  for (const network of Object.values(networks)) {
+    if (network.type !== "edr" || network?.mining?.interval === undefined) {
+      continue;
+    }
+    const interval = network.mining.interval;
+    const minInterval =
+      typeof interval === "number" ? interval : Math.min(...interval);
+    if (minInterval < 1000 && network.allowBlocksWithSameTimestamp !== true) {
+      warn(
+        chalk.yellow(
+          "Mining interval is set to less than 1000 ms. To avoid the block timestamp diverging from clock time, please set allowBlocksWithSameTimestamp: true on the network config",
+        ),
+      );
+    }
   }
 
   return {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -23,7 +23,6 @@ import {
   unionType,
   validateUserConfigZodType,
 } from "@nomicfoundation/hardhat-zod-utils";
-import chalk from "chalk";
 import { z } from "zod";
 
 import {
@@ -269,6 +268,24 @@ function refineEdrNetworkUserConfig(
         message: `'enableTransientStorage' must be enabled for hardforks 'cancun' or later. To disable this feature, use a hardfork before 'cancun'.`,
       });
     }
+
+    if (
+      typeof networkConfig.mining?.interval === "number" ||
+      Array.isArray(networkConfig.mining?.interval)
+    ) {
+      const interval = networkConfig.mining.interval;
+      const minInterval =
+        typeof interval === "number" ? interval : Math.min(...interval);
+      if (
+        minInterval < 1000 &&
+        networkConfig.allowBlocksWithSameTimestamp !== true
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `mining.interval is set to less than 1000 ms. To avoid the block timestamp diverging from clock time, please set allowBlocksWithSameTimestamp: true on the network config`,
+        });
+      }
+    }
   }
 }
 
@@ -297,25 +314,7 @@ const networkConfigOverrideSchema = z
 
 export async function validateNetworkUserConfig(
   userConfig: HardhatUserConfig,
-  warn: typeof console.warn = console.warn,
 ): Promise<HardhatUserConfigValidationError[]> {
-  // Validate mining config
-  for (const network of Object.values(userConfig.networks ?? {})) {
-    if (network.type !== "edr" || network?.mining?.interval === undefined) {
-      continue;
-    }
-    const interval = network.mining.interval;
-    const minInterval =
-      typeof interval === "number" ? interval : Math.min(...interval);
-    if (minInterval < 1000 && network.allowBlocksWithSameTimestamp !== true) {
-      warn(
-        chalk.yellow(
-          "Mining interval is set to less than 1000 ms. To avoid the block timestamp diverging from clock time, please set allowBlocksWithSameTimestamp: true on the network config",
-        ),
-      );
-    }
-  }
-
   return validateUserConfigZodType(userConfig, userConfigSchema);
 }
 

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -2124,7 +2124,7 @@ describe("NetworkManagerImplementation", () => {
             edrConfig({
               mining: {
                 auto: true,
-                interval: 123,
+                interval: 1234,
                 mempool: {
                   order: "fifo",
                 },
@@ -2138,7 +2138,7 @@ describe("NetworkManagerImplementation", () => {
             edrConfig({
               mining: {
                 auto: true,
-                interval: [123, 456],
+                interval: [1234, 4567],
                 mempool: {
                   order: "priority",
                 },
@@ -2168,7 +2168,7 @@ describe("NetworkManagerImplementation", () => {
           validationErrors = await validateNetworkUserConfig(
             edrConfig({
               mining: {
-                interval: "123",
+                interval: "1234",
               },
             }),
           );


### PR DESCRIPTION
Closes #6012 

I put this logic inside the `resolveUserConfig` hook since by that point it was already zod-checked. I also considered the `validateUserConfig` hook but if the config had wrong type, it would show both the warning and the zod error (also it could attempt to compare two non-number values).

Let me know if there's a better place to move the warning logic.