### PR TITLE
test: investigate slow request handler imports

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers-array.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers-array.ts
@@ -106,10 +106,12 @@ export async function createHandlersArray<
       const resolvedAccounts = await Promise.all(
         accounts.map((acc) => acc.getHexString()),
       );
-
-      requestHandlers.push(
-        new LocalAccountsHandler(networkConnection.provider, resolvedAccounts),
+      const localAccountsHandler = new LocalAccountsHandler(
+        networkConnection.provider,
       );
+      await localAccountsHandler.initializePrivateKeys(resolvedAccounts);
+
+      requestHandlers.push(localAccountsHandler);
     } else if (isHttpNetworkHdAccountsConfig(accounts)) {
       const { HDWalletHandler } = await import(
         "./handlers/accounts/hd-wallet-handler.js"

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/hd-wallet-handler.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/hd-wallet-handler.ts
@@ -21,9 +21,12 @@ export class HDWalletHandler extends LocalAccountsHandler {
       passphrase,
     );
 
-    return new HDWalletHandler(provider, privateKeys);
+    const hdWalletHandler = new HDWalletHandler(provider);
+    await hdWalletHandler.initializePrivateKeys(privateKeys);
+
+    return hdWalletHandler;
   }
-  private constructor(provider: EthereumProvider, privateKeys: string[]) {
-    super(provider, privateKeys);
+  private constructor(provider: EthereumProvider) {
+    super(provider);
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -58,10 +58,14 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     // directory or a file with a `.t.sol` extension in the `sources.solidity` directory
     rootFilePaths = (
       await Promise.all([
-        getAllFilesMatching(hre.config.paths.tests.solidity, (f) =>
-          f.endsWith(".sol"),
+        getAllFilesMatching(
+          hre.config.paths.tests.solidity,
+          (
+            f, // /tests/solidity
+          ) => f.endsWith(".sol"),
         ),
         ...hre.config.paths.sources.solidity.map(async (dir) => {
+          // /contracts
           return getAllFilesMatching(dir, (f) => f.endsWith(".t.sol"));
         }),
       ])

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers-array.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers-array.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
+import debug from "debug";
+
+const log = debug(
+  "hardhat:test:network-manager:request-handlers:request-array",
+);
+
+/**
+ * Example debug output:
+ * 2025-03-18T10:54:37.575Z hardhat:test:network-manager:request-handlers:request-array importing hd-wallet-handler.ts took 37ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing local-accounts.ts took 36ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing fixed-sender-handler.ts took 11ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing chain-id-handler.ts took 11ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing chain-id.ts took 11ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing automatic-gas-handler.ts took 11ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing automatic-gas-price-handler.ts took 11ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing fixed-gas-handler.ts took 11ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing automatic-sender-handler.ts took 10ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing sender.ts took 10ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing fixed-gas-price-handler.ts took 10ms
+ * 2025-03-18T10:54:37.576Z hardhat:test:network-manager:request-handlers:request-array importing multiplied-gas-estimation.ts took 10ms
+ */
+
+describe(
+  "HandlersArray",
+  {
+    skip: process.env.HARDHAT_DISABLE_SLOW_TESTS === "true",
+  },
+  async () => {
+    it(`should load all the handlers in a reasonable amount of time`, async () => {
+      const handlersDir = path.resolve(
+        "src/internal/builtin-plugins/network-manager/request-handlers/handlers",
+      );
+      const handlers = await getAllFilesMatching(handlersDir);
+      const handlerImports = [];
+
+      const nodeOptions: any = {
+        cwd: process.cwd(),
+        stdio: "pipe",
+        env: {
+          ...process.env,
+          FORCE_COLOR: "0",
+          NO_COLOR: "1",
+        },
+      };
+
+      // NOTE: First, we run a dummy command to warm up node. The number of runs
+      // is arbitrary, but it seems to be enough to get reasonable stability.
+      for (let i = 0; i < 20; i++) {
+        execSync("node --import tsx/esm -e ''", nodeOptions);
+      }
+
+      for (const handler of handlers) {
+        const output = execSync(
+          `node --import tsx/esm -e "const start = Date.now(); await import('${handler}'); console.log(Date.now() - start);"`,
+          {
+            cwd: process.cwd(),
+            stdio: "pipe",
+            env: {
+              ...process.env,
+              FORCE_COLOR: "0",
+              NO_COLOR: "1",
+            },
+          },
+        );
+        const duration = parseInt(output.toString().trim(), 10);
+        handlerImports.push({
+          handler: path.basename(handler),
+          duration,
+        });
+      }
+
+      handlerImports.sort((a, b) => b.duration - a.duration);
+
+      for (const { handler, duration } of handlerImports) {
+        log(`importing ${handler} took ${duration}ms`);
+      }
+
+      // NOTE: The maximum import duration is arbitrary, but it seems to reasonably detect the outliers.
+      const maxImportDuration = 20;
+      const longestHandlerImport = handlerImports[0];
+
+      assert.ok(
+        longestHandlerImport.duration < maxImportDuration,
+        `The maximum import duration of ${longestHandlerImport.duration}ms (${longestHandlerImport.handler}) exceeds the ${maxImportDuration}ms limit`,
+      );
+    });
+  },
+);

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
@@ -73,7 +73,7 @@ describe("LocalAccountsHandler", () => {
     "0xec02c2b7019e75378a05018adc30a0252ba705670acb383a1d332e57b0b792d2",
   ];
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockedProvider = new EthereumMockedProvider();
 
     mockedProvider.setReturnValue(
@@ -86,7 +86,8 @@ describe("LocalAccountsHandler", () => {
     );
     mockedProvider.setReturnValue("eth_accounts", []);
 
-    localAccountsHandler = new LocalAccountsHandler(mockedProvider, accounts);
+    localAccountsHandler = new LocalAccountsHandler(mockedProvider);
+    await localAccountsHandler.initializePrivateKeys(accounts);
   });
 
   describe("resolveRequest", () => {
@@ -141,7 +142,8 @@ describe("LocalAccountsHandler", () => {
       it("should be compatible with parity's implementation", async () => {
         // This test was created by using Parity Ethereum
         // v2.2.5-beta-7fbcdfeed-20181213 and calling eth_sign
-        localAccountsHandler = new LocalAccountsHandler(mockedProvider, [
+        localAccountsHandler = new LocalAccountsHandler(mockedProvider);
+        await localAccountsHandler.initializePrivateKeys([
           "0x6e59a6617c48d76d3b21d722eaba867e16ecf54ab3da7a93724f51812bc6d1aa",
         ]);
 
@@ -163,7 +165,8 @@ describe("LocalAccountsHandler", () => {
 
       it("should be compatible with ganache-cli's implementation", async () => {
         // This test was created by using Ganache CLI v6.1.6 (ganache-core: 2.1.5)
-        localAccountsHandler = new LocalAccountsHandler(mockedProvider, [
+        localAccountsHandler = new LocalAccountsHandler(mockedProvider);
+        await localAccountsHandler.initializePrivateKeys([
           "0xf159c85082f4dd4ee472583a37a1b5683c727ec99708f3d94ff05faa7a7a70ce",
         ]);
 
@@ -194,7 +197,8 @@ describe("LocalAccountsHandler", () => {
 
       it("should be compatible with geth's implementation", async () => {
         // This test was created by using Geth 1.8.20-stable
-        localAccountsHandler = new LocalAccountsHandler(mockedProvider, [
+        localAccountsHandler = new LocalAccountsHandler(mockedProvider);
+        await localAccountsHandler.initializePrivateKeys([
           "0xf2d19e944851ea0faa9440e24a22ddab850210cae46b306a3fde4c98b22a0dcb",
         ]);
 
@@ -251,7 +255,8 @@ describe("LocalAccountsHandler", () => {
         // This test was taken from the `eth_signTypedData` example from the
         // EIP-712 specification.
         // <https://eips.ethereum.org/EIPS/eip-712#eth_signtypeddata>
-        localAccountsHandler = new LocalAccountsHandler(mockedProvider, [
+        localAccountsHandler = new LocalAccountsHandler(mockedProvider);
+        await localAccountsHandler.initializePrivateKeys([
           // keccak256("cow")
           "0xc85ef7d79691fe79573b1a7064c19c1a9819ebdbd1faaab1a8ec92344438aaf4",
         ]);
@@ -309,7 +314,8 @@ describe("LocalAccountsHandler", () => {
       });
 
       it("should be compatible with stringified JSON input", async () => {
-        localAccountsHandler = new LocalAccountsHandler(mockedProvider, [
+        localAccountsHandler = new LocalAccountsHandler(mockedProvider);
+        await localAccountsHandler.initializePrivateKeys([
           // keccak256("cow")
           "0xc85ef7d79691fe79573b1a7064c19c1a9819ebdbd1faaab1a8ec92344438aaf4",
         ]);
@@ -406,7 +412,8 @@ describe("LocalAccountsHandler", () => {
     describe("personal_sign", () => {
       it("should be compatible with geth's implementation", async () => {
         // This test was created by using Geth 1.10.12-unstable and calling personal_sign
-        localAccountsHandler = new LocalAccountsHandler(mockedProvider, [
+        localAccountsHandler = new LocalAccountsHandler(mockedProvider);
+        await localAccountsHandler.initializePrivateKeys([
           "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         ]);
 
@@ -428,7 +435,8 @@ describe("LocalAccountsHandler", () => {
 
       it("should be compatible with metamask's implementation", async () => {
         // This test was created by using Metamask 10.3.0
-        localAccountsHandler = new LocalAccountsHandler(mockedProvider, [
+        localAccountsHandler = new LocalAccountsHandler(mockedProvider);
+        await localAccountsHandler.initializePrivateKeys([
           "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
         ]);
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Related to https://github.com/NomicFoundation/hardhat/issues/6211

In https://github.com/NomicFoundation/hardhat/commit/92ceb85fb18e438d49ebbcd080f05d9722a6a438, I set up a test which measures the import times of request handlers. It is not ideal but good enough to give us some data to work with.

By analyzing the results, it is clear that the [Local Accounts Handler](https://github.com/NomicFoundation/hardhat/blob/4d429a19c3731009435a6d1399c0753c42234f0f/v-next/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts) is the main culprit of the slow imports (the HD Wallet Accounts Handler imports the Local Accounts Handler which makes it slow by association).

As an exercise, I was able to shave off 1/3 of the loading time from the Local Accounts Handler by making the micro-eth-signer imports dynamic in https://github.com/NomicFoundation/hardhat/commit/4d429a19c3731009435a6d1399c0753c42234f0f. It shows that it is possible (and we could definitely do that for some other import paths there), but I'm not entirely sure we should go down that route.

I think we might be better off with the original solution to this, which is to use dynamic imports for handlers in the handlers array.

Here are the raw results of the handler import time analysis: https://github.com/NomicFoundation/hardhat/blob/92ceb85fb18e438d49ebbcd080f05d9722a6a438/v-next/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers-array.ts#L13-L27

I'm leaving this PR in draft as it was useful to me during the investigation. I don't necesarilly want to merge it as I think it would be a pretty flaky addition. We can discuss the next steps either here or in the original issue.


