### PR TITLE
Resolve all dependencies when using submodules in `after`

### DIFF
--- a/.changeset/many-falcons-relate.md
+++ b/.changeset/many-falcons-relate.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/ignition-core": patch
+"@nomicfoundation/hardhat-ignition": patch
+---
+
+Resolve all dependencies when using submodules in `after`

--- a/packages/hardhat-ignition-core/src/internal/batcher.ts
+++ b/packages/hardhat-ignition-core/src/internal/batcher.ts
@@ -130,29 +130,7 @@ export class Batcher {
   ): boolean {
     const dependencies = batchState.adjacencyList.getDependenciesFor(futureId);
 
-    return [...dependencies].every((depId) => {
-      // We distinguish between module and future ids here, as the future's always have `#` and the modules don't.
-      if (/#/.test(depId)) {
-        return batchState.visitState[depId] === VisitStatus.VISITED;
-      }
-
-      return this._checkModuleDependencyIsComplete(depId, batchState);
-    });
-  }
-
-  /**
-   * This is needed because moduleIds are not present in the visit state
-   * causing an infinite loop when checking whether a depenedency is visited if that dependency is a module.
-   */
-  private static _checkModuleDependencyIsComplete(
-    moduleId: string,
-    batchState: BatchState
-  ) {
-    const dependencies = Object.keys(batchState.visitState).filter((futureId) =>
-      futureId.startsWith(moduleId)
-    );
-
-    return dependencies.every(
+    return [...dependencies].every(
       (depId) => batchState.visitState[depId] === VisitStatus.VISITED
     );
   }

--- a/packages/hardhat-ignition-core/src/internal/utils/adjacency-list-converter.ts
+++ b/packages/hardhat-ignition-core/src/internal/utils/adjacency-list-converter.ts
@@ -16,7 +16,11 @@ export class AdjacencyListConverter {
 
     for (const future of futures) {
       for (const dependency of future.dependencies) {
-        dependencyGraph.addDependency({ from: future.id, to: dependency.id });
+        if (isFuture(dependency)) {
+          // We only add Futures to the dependency graph, modules are handled
+          // in the method call below, by adding their futures to the graph.
+          dependencyGraph.addDependency({ from: future.id, to: dependency.id });
+        }
 
         this._optionallyAddDependenciesFromSubmodules(
           dependencyGraph,

--- a/packages/hardhat-ignition-core/src/internal/utils/adjacency-list-converter.ts
+++ b/packages/hardhat-ignition-core/src/internal/utils/adjacency-list-converter.ts
@@ -2,6 +2,7 @@ import { isFuture } from "../../type-guards";
 import { Future } from "../../types/module";
 
 import { AdjacencyList } from "./adjacency-list";
+import { getFuturesFromModule } from "./get-futures-from-module";
 
 export class AdjacencyListConverter {
   public static buildAdjacencyListFromFutures(
@@ -19,6 +20,15 @@ export class AdjacencyListConverter {
             future,
             dependency
           );
+        } else {
+          const futures = getFuturesFromModule(dependency);
+
+          for (const moduleDep of futures) {
+            dependencyGraph.addDependency({
+              from: future.id,
+              to: moduleDep.id,
+            });
+          }
         }
       }
     }

--- a/packages/hardhat-ignition-core/src/internal/utils/adjacency-list.ts
+++ b/packages/hardhat-ignition-core/src/internal/utils/adjacency-list.ts
@@ -32,6 +32,16 @@ export class AdjacencyList {
     this._list.set(from, toSet);
   }
 
+  public hasDependency({ from, to }: { from: string; to: string }): boolean {
+    const toSet = this._list.get(from);
+
+    if (toSet === undefined) {
+      return false;
+    }
+
+    return toSet.has(to);
+  }
+
   public deleteDependency({ from, to }: { from: string; to: string }) {
     const toSet = this._list.get(from) ?? new Set<string>();
 

--- a/packages/hardhat-ignition-core/src/internal/utils/adjacency-list.ts
+++ b/packages/hardhat-ignition-core/src/internal/utils/adjacency-list.ts
@@ -32,16 +32,6 @@ export class AdjacencyList {
     this._list.set(from, toSet);
   }
 
-  public hasDependency({ from, to }: { from: string; to: string }): boolean {
-    const toSet = this._list.get(from);
-
-    if (toSet === undefined) {
-      return false;
-    }
-
-    return toSet.has(to);
-  }
-
   public deleteDependency({ from, to }: { from: string; to: string }) {
     const toSet = this._list.get(from) ?? new Set<string>();
 

--- a/packages/hardhat-ignition/test/deploy/module-patterns/index-pattern.ts
+++ b/packages/hardhat-ignition/test/deploy/module-patterns/index-pattern.ts
@@ -1,0 +1,45 @@
+/* eslint-disable import/no-unused-modules */
+import { buildModule } from "@nomicfoundation/ignition-core";
+import { assert } from "chai";
+
+import { useEphemeralIgnitionProject } from "../../test-helpers/use-ignition-project";
+
+describe("index pattern deployments", function () {
+  useEphemeralIgnitionProject("index-pattern-success");
+
+  it("should succeed for a standard case", async function () {
+    const Mod1 = buildModule("Mod1", (m) => {
+      const F1 = m.contract("F1");
+
+      m.call(F1, "first");
+
+      return { F1 };
+    });
+
+    const Mod2 = buildModule("Mod2", (m) => {
+      const { F1 } = m.useModule(Mod1);
+
+      const F2 = m.contract("F2", [F1]);
+
+      m.call(F2, "second");
+
+      return { F2 };
+    });
+
+    const IndexMod = buildModule("IndexMod", (m) => {
+      const { F2 } = m.useModule(Mod2);
+
+      return { F2 };
+    });
+
+    const moduleDefinition = buildModule("DeployModule", (m) => {
+      const { F1 } = m.useModule(Mod1);
+
+      m.call(F1, "third", [], { after: [Mod1, IndexMod] });
+
+      return { F1 };
+    });
+
+    await assert.isFulfilled(this.hre.ignition.deploy(moduleDefinition));
+  });
+});

--- a/packages/hardhat-ignition/test/deploy/module-patterns/index-pattern.ts
+++ b/packages/hardhat-ignition/test/deploy/module-patterns/index-pattern.ts
@@ -42,4 +42,63 @@ describe("index pattern deployments", function () {
 
     await assert.isFulfilled(this.hre.ignition.deploy(moduleDefinition));
   });
+
+  it("should succeed for a malaga case", async function () {
+    const Mod1 = buildModule("Mod1", (m) => {
+      const F1 = m.contract("F1");
+
+      return { F1 };
+    });
+
+    const Mod2 = buildModule("Mod2", (m) => {
+      const { F1 } = m.useModule(Mod1);
+
+      const F2 = m.contract("F2", [F1]);
+
+      const firstCall = m.call(F2, "unrelatedFunc");
+      const secondCall = m.call(F2, "unrelatedFunc", [], {
+        after: [firstCall],
+        id: "secondCall",
+      });
+      const lastCall = m.call(F2, "unrelatedFunc", [], {
+        after: [secondCall],
+        id: "lastCall",
+      });
+
+      m.call(F2, "mustBeCalledByTwoSeparateContracts", [], {
+        after: [lastCall],
+      });
+
+      return { F2 };
+    });
+
+    const Mod3 = buildModule("Mod3", (m) => {
+      const { F1 } = m.useModule(Mod1);
+
+      const F3 = m.contract("F2", [F1], { id: "F3" });
+
+      return { F3 };
+    });
+
+    const IndexMod = buildModule("IndexMod", (m) => {
+      const { F1 } = m.useModule(Mod1);
+      const { F2 } = m.useModule(Mod2);
+      const { F3 } = m.useModule(Mod3);
+
+      const lastCall = m.call(F3, "mustBeCalledByTwoSeparateContracts");
+      const NewF1 = m.contractAt("F1", F1, { after: [lastCall], id: "NewF1" });
+
+      return { NewF1, F2, F3 };
+    });
+
+    const moduleDefinition = buildModule("DeployModule", (m) => {
+      const { NewF1 } = m.useModule(IndexMod);
+
+      m.call(NewF1, "throwsIfNotCalledTwice");
+
+      return {};
+    });
+
+    await assert.isFulfilled(this.hre.ignition.deploy(moduleDefinition));
+  });
 });

--- a/packages/hardhat-ignition/test/fixture-projects/index-pattern-success/contracts/Test.sol
+++ b/packages/hardhat-ignition/test/fixture-projects/index-pattern-success/contracts/Test.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+contract F1 {
+  bool public firstCalled;
+  bool public secondCalled;
+  bool public thirdCalled;
+
+  function first() public {
+    firstCalled = true;
+  }
+
+  function second() public {
+    require(firstCalled, "first() was not called");
+    require(!thirdCalled, "third() was called");
+
+    secondCalled = true;
+  }
+
+  function third() public {
+    require(firstCalled, "first() was not called");
+    require(secondCalled, "second() was not called");
+
+    thirdCalled = true;
+  }
+}
+
+contract F2 {
+
+  F1 public f1;
+
+  constructor(F1 _f1) {
+    f1 = _f1;
+  }
+
+  function second() public {
+    f1.second();
+  }
+}

--- a/packages/hardhat-ignition/test/fixture-projects/index-pattern-success/contracts/Test.sol
+++ b/packages/hardhat-ignition/test/fixture-projects/index-pattern-success/contracts/Test.sol
@@ -6,6 +6,9 @@ contract F1 {
   bool public secondCalled;
   bool public thirdCalled;
 
+  address public caller1;
+  address public caller2;
+
   function first() public {
     firstCalled = true;
   }
@@ -23,11 +26,25 @@ contract F1 {
 
     thirdCalled = true;
   }
+
+  function mustBeCalledByTwoSeparateContracts() public {
+    if (caller1 == address(0)) {
+      caller1 = msg.sender;
+    } else {
+      caller2 = msg.sender;
+    }
+  }
+
+  function throwsIfNotCalledTwice() public view {
+    require(caller1 != address(0) && caller2 != address(0) && caller1 != caller2, "was not called by two separate contracts");
+  }
 }
 
 contract F2 {
 
   F1 public f1;
+
+  uint public counter;
 
   constructor(F1 _f1) {
     f1 = _f1;
@@ -35,5 +52,13 @@ contract F2 {
 
   function second() public {
     f1.second();
+  }
+
+  function mustBeCalledByTwoSeparateContracts() public {
+    f1.mustBeCalledByTwoSeparateContracts();
+  }
+
+  function unrelatedFunc() public {
+    counter++;
   }
 }

--- a/packages/hardhat-ignition/test/fixture-projects/index-pattern-success/hardhat.config.js
+++ b/packages/hardhat-ignition/test/fixture-projects/index-pattern-success/hardhat.config.js
@@ -1,0 +1,14 @@
+require("@nomicfoundation/hardhat-ignition");
+
+/** @type import('hardhat/config').HardhatUserConfig */
+module.exports = {
+  solidity: {
+    version: "0.8.19",
+    settings: {
+      metadata: {
+        // We disable the metadata to keep the fixtures more stables
+        appendCBOR: false,
+      },
+    },
+  },
+};

--- a/packages/hardhat-ignition/test/fixture-projects/index-pattern-success/ignition/modules/MyModule.js
+++ b/packages/hardhat-ignition/test/fixture-projects/index-pattern-success/ignition/modules/MyModule.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line import/no-unused-modules
+const { buildModule } = require("@nomicfoundation/ignition-core");
+
+module.exports = buildModule("MyModule", (m) => {
+  const foo = m.contract("Foo");
+
+  return { foo };
+});


### PR DESCRIPTION
This issue has two commits:

1. The first commit resolves the original issue (https://github.com/NomicFoundation/hardhat-ignition/issues/857) by recursively collecting all futures from all submodules of a module given as a dependency in an `after` option of a future.
2. The second commit extends the above logic to apply to futures passed as dependencies in an `after` option as well. The reason for this change is to cover what I'm calling a combined "malaga-index" case:

```typescript
const IndexMod = buildModule("IndexMod", (m) => {
  const { F1 } = m.useModule(Mod1);
  const { F2 } = m.useModule(Mod2);
  const { F3 } = m.useModule(Mod3);

  const lastCall = m.call(F3, "mustBeCalledByTwoSeparateContracts");
  const NewF1 = m.contractAt("F1", F1, { after: [lastCall], id: "NewF1" });

  return { NewF1, F2, F3 };
});

const moduleDefinition = buildModule("DeployModule", (m) => {
  const { NewF1 } = m.useModule(IndexMod);

  const failingCall = m.call(NewF1, "throwsIfNotCalledTwice");

  return {};
});
```

In the above example, before the fix in the second commit, the final future calling the function `throwsIfNotCalledTwice` would fail because the second call to `mustBeCalledByTwoSeparateContracts` inside `Mod2` had not completed yet as there was no direct dependency link between that call and `failingCall`. It's a similar problem to the original issue, however this one would still occur with the original fix if the failing call was depending on a future inside the index module instead of the index module itself (the malaga rule). 

This fix essentially applies the malaga rule logic to the new index module assumption that any submodule included in a module that is used as a dependency should have all of its futures and submodules futures and so on added to the original futures dependencies. 