### PR TITLE
feat: support stack trace warnings and infer error messages from stack trace

### DIFF
--- a/.changeset/pretty-lizards-roll.md
+++ b/.changeset/pretty-lizards-roll.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Display solidity stack trace generation warnings to the users and try to infer better error messages from said stack traces

--- a/.changeset/pretty-lizards-roll.md
+++ b/.changeset/pretty-lizards-roll.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Display solidity stack trace generation warnings to the users and try to infer better error messages from said stack traces
+Infer and display better error messages from stack traces ([#6505](https://github.com/NomicFoundation/hardhat/issues/6505))

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -181,7 +181,7 @@ function sourceReferenceToSolidityCallsite(
   );
 }
 
-function getMessageFromLastStackTraceEntry(
+export function getMessageFromLastStackTraceEntry(
   stackTraceEntry: SolidityStackTraceEntry,
 ): string | undefined {
   switch (stackTraceEntry.type) {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -181,7 +181,7 @@ function sourceReferenceToSolidityCallsite(
   );
 }
 
-export function getMessageFromLastStackTraceEntry(
+function getMessageFromLastStackTraceEntry(
   stackTraceEntry: SolidityStackTraceEntry,
 ): string | undefined {
   switch (stackTraceEntry.type) {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -126,7 +126,7 @@ export async function* testReporter(
 
       let reason: string | undefined;
       if (stackTrace?.kind === "StackTrace") {
-        reason = getMessageFromLastStackTraceEntry(stackTrace.entries[0]);
+        reason = getMessageFromLastStackTraceEntry(stackTrace.entries[stackTrace.entries.length - 1]);
       }
       if (reason === undefined || reason === "") {
         reason = failure.reason ?? "Unknown error";

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -126,7 +126,9 @@ export async function* testReporter(
 
       let reason: string | undefined;
       if (stackTrace?.kind === "StackTrace") {
-        reason = getMessageFromLastStackTraceEntry(stackTrace.entries[stackTrace.entries.length - 1]);
+        reason = getMessageFromLastStackTraceEntry(
+          stackTrace.entries[stackTrace.entries.length - 1],
+        );
       }
       if (reason === undefined || reason === "") {
         reason = failure.reason ?? "Unknown error";

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -8,12 +8,10 @@ import type { TestResult } from "@ignored/edr";
 import { bytesToHexString } from "@nomicfoundation/hardhat-utils/hex";
 import chalk from "chalk";
 
-import {
-  encodeStackTraceEntry,
-  getMessageFromLastStackTraceEntry,
-} from "../network-manager/edr/stack-traces/stack-trace-solidity-errors.js";
+import { encodeStackTraceEntry } from "../network-manager/edr/stack-traces/stack-trace-solidity-errors.js";
 
 import { formatArtifactId } from "./formatters.js";
+import { getMessageFromLastStackTraceEntry } from "./stack-trace-solidity-errors.js";
 
 /**
  * This is a solidity test reporter. It is intended to be composed with the

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -8,7 +8,10 @@ import type { TestResult } from "@ignored/edr";
 import { bytesToHexString } from "@nomicfoundation/hardhat-utils/hex";
 import chalk from "chalk";
 
-import { encodeStackTraceEntry } from "../network-manager/edr/stack-traces/stack-trace-solidity-errors.js";
+import {
+  encodeStackTraceEntry,
+  getMessageFromLastStackTraceEntry,
+} from "../network-manager/edr/stack-traces/stack-trace-solidity-errors.js";
 
 import { formatArtifactId } from "./formatters.js";
 
@@ -119,33 +122,46 @@ export async function* testReporter(
     for (const [index, failure] of failures.entries()) {
       yield `\n${chalk.bold(chalk.red(`Failure (${index + 1})`))}: ${failure.name}\n`;
 
-      if (
-        failure.reason !== undefined &&
-        failure.reason !== null &&
-        failure.reason !== ""
-      ) {
-        yield `Reason: ${chalk.grey(failure.reason)}\n`;
+      const stackTrace = failure.stackTrace();
+
+      let reason: string | undefined;
+      if (stackTrace?.kind === "StackTrace") {
+        reason = getMessageFromLastStackTraceEntry(stackTrace.entries[0]);
+      }
+      if (reason === undefined || reason === "") {
+        reason = failure.reason ?? "Unknown error";
       }
 
-      const stackTrace = failure.stackTrace();
-      // TODO handle `UnexpectedError` and `UnsafeToReplay` variants
-      if (
-        stackTrace !== undefined &&
-        stackTrace !== null &&
-        stackTrace.kind === "StackTrace" &&
-        stackTrace.entries.length > 0
-      ) {
-        const stackTraceStack: string[] = [];
-        for (const entry of stackTrace.entries.reverse()) {
-          const callsite = encodeStackTraceEntry(entry);
-          if (callsite !== undefined) {
-            stackTraceStack.push(`  at ${callsite.toString()}`);
-          }
-        }
+      yield `Reason: ${chalk.grey(reason)}\n`;
 
-        if (stackTraceStack.length > 0) {
-          yield `${chalk.grey(stackTraceStack.join("\n"))}\n`;
-        }
+      switch (stackTrace?.kind) {
+        case "StackTrace":
+          const stackTraceStack: string[] = [];
+          for (const entry of stackTrace.entries.reverse()) {
+            const callsite = encodeStackTraceEntry(entry);
+            if (callsite !== undefined) {
+              stackTraceStack.push(`  at ${callsite.toString()}`);
+            }
+          }
+
+          if (stackTraceStack.length > 0) {
+            yield `${chalk.grey(stackTraceStack.join("\n"))}\n`;
+          }
+          break;
+        case "UnexpectedError":
+          yield `Stack Trace Warning: ${chalk.grey(stackTrace.errorMessage)}\n`;
+          break;
+        case "UnsafeToReplay":
+          if (stackTrace.globalForkLatest === true) {
+            yield `Stack Trace Warning: ${chalk.grey("The test is not safe to replay because a fork url without a fork block number was provided.")}\n`;
+          }
+          if (stackTrace.impureCheatcodes.length > 0) {
+            yield `Stack Trace Warning: ${chalk.grey(`The test is not safe to replay because it uses impure cheatcodes: ${stackTrace.impureCheatcodes.join(", ")}`)}\n`;
+          }
+          break;
+        case "HeuristicFailed":
+        default:
+          break;
       }
 
       if (

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
@@ -1,0 +1,83 @@
+import type { SolidityStackTraceEntry } from "../network-manager/edr/stack-traces/solidity-stack-trace.js";
+
+import { panicErrorCodeToMessage } from "../network-manager/edr/stack-traces/panic-errors.js";
+import { StackTraceEntryType } from "../network-manager/edr/stack-traces/solidity-stack-trace.js";
+
+export function getMessageFromLastStackTraceEntry(
+  stackTraceEntry: SolidityStackTraceEntry,
+): string | undefined {
+  switch (stackTraceEntry.type) {
+    case StackTraceEntryType.PRECOMPILE_ERROR:
+      return `Call to precompile ${stackTraceEntry.precompile} failed`;
+
+    case StackTraceEntryType.FUNCTION_NOT_PAYABLE_ERROR:
+      return `Non-payable function was called with value ${stackTraceEntry.value.toString(
+        10,
+      )}`;
+
+    case StackTraceEntryType.INVALID_PARAMS_ERROR:
+      return `Function was called with incorrect parameters`;
+
+    case StackTraceEntryType.FALLBACK_NOT_PAYABLE_ERROR:
+      return `Fallback function is not payable and was called with value ${stackTraceEntry.value.toString(
+        10,
+      )}`;
+
+    case StackTraceEntryType.FALLBACK_NOT_PAYABLE_AND_NO_RECEIVE_ERROR:
+      return `There's no receive function, fallback function is not payable and was called with value ${stackTraceEntry.value.toString(
+        10,
+      )}`;
+
+    case StackTraceEntryType.UNRECOGNIZED_FUNCTION_WITHOUT_FALLBACK_ERROR:
+      return `Function selector was not recognized and there's no fallback function`;
+
+    case StackTraceEntryType.MISSING_FALLBACK_OR_RECEIVE_ERROR:
+      return `Function selector was not recognized and there's no fallback nor receive function`;
+
+    case StackTraceEntryType.RETURNDATA_SIZE_ERROR:
+      return `Function returned an unexpected amount of data`;
+
+    case StackTraceEntryType.NONCONTRACT_ACCOUNT_CALLED_ERROR:
+      return `Function call to a non-contract account`;
+
+    case StackTraceEntryType.CALL_FAILED_ERROR:
+      return `Function call failed to execute`;
+
+    case StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR:
+      return `Library was called directly`;
+
+    case StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR:
+    case StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR: {
+      return "Contract reverted without a reason string";
+    }
+
+    case StackTraceEntryType.REVERT_ERROR: {
+      return "Contract reverted without a reason string";
+    }
+
+    case StackTraceEntryType.PANIC_ERROR:
+      return panicErrorCodeToMessage(stackTraceEntry.errorCode);
+
+    case StackTraceEntryType.CUSTOM_ERROR:
+      return stackTraceEntry.message;
+
+    case StackTraceEntryType.CONTRACT_TOO_LARGE_ERROR:
+      return "Trying to deploy a contract whose code is too large";
+
+    case StackTraceEntryType.CONTRACT_CALL_RUN_OUT_OF_GAS_ERROR:
+      return "Contract call run out of gas";
+
+    /* These types are not associate with a more detailed error message */
+    case StackTraceEntryType.UNMAPPED_SOLC_0_6_3_REVERT_ERROR:
+    case StackTraceEntryType.OTHER_EXECUTION_ERROR:
+      return undefined;
+
+    /* These types are not expected to be the last entry in the stack trace, as
+    their presence indicates that another frame should follow in the call stack. */
+    case StackTraceEntryType.CALLSTACK_ENTRY:
+    case StackTraceEntryType.UNRECOGNIZED_CREATE_CALLSTACK_ENTRY:
+    case StackTraceEntryType.UNRECOGNIZED_CONTRACT_CALLSTACK_ENTRY:
+    case StackTraceEntryType.INTERNAL_FUNCTION_CALLSTACK_ENTRY:
+      return undefined;
+  }
+}


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This is a follow-up to https://nomicfoundation.slack.com/archives/C03P6B72ZHU/p1742980461593939

It resolved https://github.com/NomicFoundation/hardhat/issues/6505 and https://github.com/NomicFoundation/hardhat/issues/6475

Here's an example run which showcases both error messages inferred from stack trace and new stack trace warnings - https://github.com/galargh/hardhat/actions/runs/14082082256/job/39437613164

Please note that the notes are not part of the actual output.

```
...
✘ Run Failed: 443 tests, 440 passed, 3 failed, 0 skipped (duration: 12062 ms)

Failure (1): setUp()
# 💁 NOTE: This message would have been previously EvmError: Revert
Reason: Transaction reverted without a reason string
  at TokenLocker.constructor (test/vault/VaultReentrancy.t.sol:22)
  at TokenLocker.<unknown> (test/vault/VaultReentrancy.t.sol:18)

Failure (2): test_getTickAtSqrtRatio_matchesJavascriptImplWithin1()
Reason: EvmError: Revert
# 💁 NOTE: This is a new entry in the test failure details
Stack Trace Warning: The test is not safe to replay because it uses impure cheatcodes: function ffi(string[] calldata commandInput) external returns (bytes memory result);

Failure (3): test_getSqrtRatioAtTick_matchesJavaScriptImplByOneHundrethOfABip()
Reason: EvmError: Revert
Stack Trace Warning: The test is not safe to replay because it uses impure cheatcodes: function ffi(string[] calldata commandInput) external returns (bytes memory result);
```
