### PR TITLE
test: remove timeouts from the object cache test

### DIFF
--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/cache.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/cache.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, it } from "node:test";
 
 import { useTmpDir } from "@nomicfoundation/hardhat-test-utils";
 import {
+  getAccessTime,
   getAllFilesMatching,
   getFileSize,
 } from "@nomicfoundation/hardhat-utils/fs";
@@ -69,42 +70,44 @@ describe("ObjectCache", () => {
       assert.deepEqual(filesAfter, filesBefore);
     });
 
-    it("should remove everything with the max age set to 0", async () => {
+    it("should remove everything with the max age set to -1", async () => {
       const filesBefore = await getAllFilesMatching(cachePath);
       assert.notDeepEqual(filesBefore, []);
-      // NOTE: We're waiting a little so that the file's atime is different
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      await cache.clean(0);
+      // NOTE: -1 is not enough on Windows for some reason. Maybe there is some
+      // delay in how the access time is set on files on creation?
+      await cache.clean(-100);
       const filesAfter = await getAllFilesMatching(cachePath);
       assert.deepEqual(filesAfter, []);
     });
 
-    it("should remove everything with the max size set to 0", async () => {
+    it("should remove everything with the max size set to -1", async () => {
       const filesBefore = await getAllFilesMatching(cachePath);
       assert.notDeepEqual(filesBefore, []);
-      await cache.clean(undefined, 0);
+      await cache.clean(undefined, -1);
       const filesAfter = await getAllFilesMatching(cachePath);
       assert.deepEqual(filesAfter, []);
     });
 
     it("should remove something with the max age set to some value", async () => {
+      await cache.set(randomUUID(), testValue);
       const filesBefore = await getAllFilesMatching(cachePath);
       assert.notDeepEqual(filesBefore, []);
-      // NOTE: We're waiting a little so that the file's atime is different
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      await cache.set(randomUUID(), testValue);
-      await cache.clean(10);
+      await cache.clean(
+        new Date().getTime() -
+          (await getAccessTime(filesBefore[0])).getTime() -
+          1,
+      );
       const filesAfter = await getAllFilesMatching(cachePath);
-      assert.notDeepEqual(filesAfter, []);
+      // NOTE: It would be nice to check whether we removed some but not all files,
+      // but that check has proven to be flaky, especially on Intel macOS, due to
+      // its heavy reliance on timing of the operations.
       assert.notDeepEqual(filesAfter, filesBefore);
     });
 
     it("should remove something with the max size set to some value", async () => {
+      await cache.set(randomUUID(), testValue);
       const filesBefore = await getAllFilesMatching(cachePath);
       assert.notDeepEqual(filesBefore, []);
-      // NOTE: We're waiting a little so that the file's atime is different
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      await cache.set(randomUUID(), testValue);
       await cache.clean(undefined, (await getFileSize(filesBefore[0])) * 1.5);
       const filesAfter = await getAllFilesMatching(cachePath);
       assert.notDeepEqual(filesAfter, []);


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This resolves https://github.com/NomicFoundation/hardhat/issues/6503

I ran the test after changes a 100 times on each runner:
- https://github.com/NomicFoundation/hardhat/actions/runs/14118656535
- https://github.com/NomicFoundation/hardhat/actions/runs/14118548054


