### PR TITLE
fix: pass all artifacts to edr when executing solidity tests

### DIFF
--- a/.changeset/wet-students-act.md
+++ b/.changeset/wet-students-act.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Compile all sources and pass all generated artifacts to EDR when executing solidity tests

--- a/v-next/hardhat-mocha/src/index.ts
+++ b/v-next/hardhat-mocha/src/index.ts
@@ -24,7 +24,7 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .addFlag({
         name: "noCompile",
-        description: "Don't compile the project before running the test",
+        description: "Don't compile the project before running the tests",
       })
       .setAction(import.meta.resolve("./task-action.js"))
       .build(),

--- a/v-next/hardhat-node-test-runner/src/index.ts
+++ b/v-next/hardhat-node-test-runner/src/index.ts
@@ -24,7 +24,7 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .addFlag({
         name: "noCompile",
-        description: "Don't compile the project before running the test",
+        description: "Don't compile the project before running the tests",
       })
       .setAction(import.meta.resolve("./task-action.js"))
       .build(),

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -21,6 +21,10 @@ const hardhatPlugin: HardhatPlugin = {
         description: "Not implemented yet - The chain type to use",
         defaultValue: "l1",
       })
+      .addFlag({
+        name: "noCompile",
+        description: "Don't compile the project before running the tests",
+      })
       .setAction(import.meta.resolve("./task-action.js"))
       .build(),
   ],

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -49,6 +49,9 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     return;
   }
 
+  // NOTE: We run the compile task first to ensure all the artifacts for them are generated
+  // Then, we compile just the test sources. We don't do it in one go because the user
+  // is likely to use different compilation options for the tests and the sources.
   await hre.tasks.getTask("compile").run();
 
   if (testFiles.length > 0) {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -79,17 +79,16 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   // the tests.solidity paths and the sources paths
   rootFilePaths = Array.from(new Set(rootFilePaths));
 
-  if (noCompile === false) {
-    const buildOptions: BuildOptions = {
-      force: false,
-      buildProfile: hre.globalOptions.buildProfile,
-      quiet: true,
-    };
-
-    const results = await hre.solidity.build(rootFilePaths, buildOptions);
-
-    throwIfSolidityBuildFailed(results);
-  }
+  // NOTE: We are not skipping the test compilation even if the noCompile flag is set
+  // because the user cannot run test compilation outside of the test task yet.
+  // TODO: Allow users to run test compilation outside of the test task.
+  const buildOptions: BuildOptions = {
+    force: false,
+    buildProfile: hre.globalOptions.buildProfile,
+    quiet: true,
+  };
+  const results = await hre.solidity.build(rootFilePaths, buildOptions);
+  throwIfSolidityBuildFailed(results);
 
   const buildInfos = await getBuildInfos(hre.artifacts);
   const artifacts = await getArtifacts(hre.artifacts);

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -49,6 +49,8 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     return;
   }
 
+  await hre.tasks.getTask("compile").run();
+
   if (testFiles.length > 0) {
     rootFilePaths = testFiles.map((f) =>
       resolveFromRoot(hre.config.paths.root, f),
@@ -81,9 +83,14 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
 
   throwIfSolidityBuildFailed(results);
 
-  const buildInfos = await getBuildInfos(results, hre.artifacts);
-  const artifacts = await getArtifacts(results);
+  const buildInfos = await getBuildInfos(hre.artifacts);
+  const artifacts = await getArtifacts(hre.artifacts);
   const testSuiteIds = artifacts
+    .filter((artifact) =>
+      rootFilePaths.includes(
+        resolveFromRoot(hre.config.paths.root, artifact.id.source),
+      ),
+    )
     .filter(isTestSuiteArtifact)
     .map((artifact) => artifact.id);
 

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-results.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-results.ts
@@ -155,7 +155,7 @@ export async function getArtifacts(
     const id = {
       name: artifact.contractName,
       solcVersion,
-      source: artifact.sourceName,
+      source: artifact.inputSourceName ?? artifact.sourceName,
     };
 
     const contract = {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-results.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-results.ts
@@ -161,7 +161,9 @@ export async function getArtifacts(
     const contract = {
       abi: JSON.stringify(artifact.abi),
       bytecode: artifact.bytecode,
+      linkReferences: artifact.linkReferences,
       deployedBytecode: artifact.deployedBytecode,
+      deployedLinkReferences: artifact.deployedLinkReferences,
     };
 
     return {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-results.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-results.ts
@@ -1,7 +1,4 @@
-import type {
-  Artifact as HardhatArtifact,
-  ArtifactManager,
-} from "../../../types/artifacts.js";
+import type { ArtifactManager, BuildInfo } from "../../../types/artifacts.js";
 import type {
   CompilationJobCreationError,
   FailedFileBuildResult,
@@ -59,26 +56,18 @@ export function throwIfSolidityBuildFailed(
 }
 
 /**
- * This function returns the build infos and outputs associated with the given
- * Solidity build results.
+ * This function returns all the build infos and associated outputs.
  *
- * @param results The successful Solidity build results.
  * @param artifactManager The artifact manager.
  * @returns The build infos in the Hardhat v3 format as expected by the EDR.
  */
 export async function getBuildInfos(
-  results: SuccessfulSolidityBuildResults,
   artifactManager: ArtifactManager,
 ): Promise<BuildInfoAndOutput[]> {
-  const buildIds = await Promise.all(
-    Array.from(new Set(results.values())).map(async ({ compilationJob }) =>
-      compilationJob.getBuildId(),
-    ),
-  );
-  const uniqueBuildIds = Array.from(new Set(buildIds));
+  const buildIds = await artifactManager.getAllBuildInfoIds();
 
   return Promise.all(
-    uniqueBuildIds.map(async (buildId) => {
+    Array.from(buildIds).map(async (buildId) => {
       const buildInfoPath = await artifactManager.getBuildInfoPath(buildId);
       const buildInfoOutputPath =
         await artifactManager.getBuildInfoOutputPath(buildId);
@@ -109,46 +98,75 @@ export async function getBuildInfos(
 }
 
 /**
- * This function returns the artifacts generated during the compilation associated
- * with the given Solidity build results. It relies on the fact that each successful
- * build result has a corresponding artifact generated property.
+ * This function returns the artifacts generated during the compilation.
  *
- * @param results The successful Solidity build results.
+ * @param artifactManager The artifact manager.
  * @returns The artifacts in the format expected by the EDR.
  */
 export async function getArtifacts(
-  results: SuccessfulSolidityBuildResults,
+  artifactManager: ArtifactManager,
 ): Promise<EdrArtifact[]> {
-  const contractArtifacts = Array.from(results.entries())
-    .map(([source, result]) => {
-      return result.contractArtifactsGenerated.map((artifactPath) => ({
-        source,
-        solcVersion: result.compilationJob.solcConfig.version,
-        artifactPath,
-      }));
-    })
-    .flat();
+  const fullyQualifiedNames = await artifactManager.getAllFullyQualifiedNames();
 
-  return Promise.all(
-    contractArtifacts.map(async ({ source, artifactPath, solcVersion }) => {
-      const artifact: HardhatArtifact = await readJsonFile(artifactPath);
-
-      const id = {
-        name: artifact.contractName,
-        solcVersion,
-        source,
-      };
-
-      const contract = {
-        abi: JSON.stringify(artifact.abi),
-        bytecode: artifact.bytecode,
-        deployedBytecode: artifact.deployedBytecode,
-      };
-
-      return {
-        id,
-        contract,
-      };
+  const artifacts = await Promise.all(
+    Array.from(fullyQualifiedNames).map(async (fullyQualifiedName) => {
+      return artifactManager.readArtifact(fullyQualifiedName);
     }),
   );
+
+  const buildInfoIds = Array.from(
+    new Set(artifacts.map((artifact) => artifact.buildInfoId)),
+  );
+
+  const solcVersionsArray: Array<[string, string]> = await Promise.all(
+    buildInfoIds.map(async (buildInfoId) => {
+      assertHardhatInvariant(
+        buildInfoId !== undefined,
+        "artifactBuildInfoId should not be undefined",
+      );
+
+      const buildInfoPath = await artifactManager.getBuildInfoPath(buildInfoId);
+
+      assertHardhatInvariant(
+        buildInfoPath !== undefined,
+        "buildInfoPath should not be undefined",
+      );
+
+      const buildInfo: BuildInfo = await readJsonFile(buildInfoPath);
+
+      return [buildInfoId, buildInfo.solcVersion];
+    }),
+  );
+  const solcVersions = new Map(solcVersionsArray);
+
+  return artifacts.map((artifact) => {
+    assertHardhatInvariant(
+      artifact.buildInfoId !== undefined,
+      "solcVersion should not be undefined",
+    );
+
+    const solcVersion = solcVersions.get(artifact.buildInfoId);
+
+    assertHardhatInvariant(
+      solcVersion !== undefined,
+      "solcVersion should not be undefined",
+    );
+
+    const id = {
+      name: artifact.contractName,
+      solcVersion,
+      source: artifact.sourceName,
+    };
+
+    const contract = {
+      abi: JSON.stringify(artifact.abi),
+      bytecode: artifact.bytecode,
+      deployedBytecode: artifact.deployedBytecode,
+    };
+
+    return {
+      id,
+      contract,
+    };
+  });
 }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Resolves #6522

In this PR, I ensure the `compile` task is executed before the test sources compilation in the `test solidity` task. I also ensure that all the artifacts present in the artifacts folder after these two compilations are passed over to EDR for the solidity tests execution.

Context: https://nomicfoundation.slack.com/archives/C03P6B72ZHU/p1743408250467489