### PR TITLE
Fix broken link

### DIFF
--- a/packages/hardhat-ignition-examples/ens/README.md
+++ b/packages/hardhat-ignition-examples/ens/README.md
@@ -1,6 +1,6 @@
 # ENS Example for Hardhat Ignition
 
-This Hardhat project is an example of using ignition to deploy the ENS system of contracts, based on the [Deploying ens on a private chain](https://docs.ens.domains/deploying-ens-on-a-private-chain#migration-file-example) from the ens docs.
+This Hardhat project is an example of using ignition to deploy the ENS system of contracts, based on the [Deploying ens on a private chain](https://docs.ens.domains/contracts) from the ens docs.
 
 ## Deploying
 


### PR DESCRIPTION
Replaced a broken ENS docs link with a working one that points to the ENS smart contracts page:

 Old: https://docs.ens.domains/deploying-ens-on-a-private-chain#migration-file-example

 New: https://docs.ens.domains/contracts

The previous link returned a 404. The new one still gives useful context for the ENS contracts used in this Hardhat example.

I recommend this replacement, but if there's a more specific or updated link, feel free to suggest it — happy to update the PR!
