### PR TITLE
HH3 plugin migration guide

### DIFF
--- a/docs/src/content/hardhat3-alpha/learn-more/_dirinfo.yaml
+++ b/docs/src/content/hardhat3-alpha/learn-more/_dirinfo.yaml
@@ -7,3 +7,5 @@ order:
     href: /alpha-limitations
   # - title: Solidity Tests
   #   href: /solidity-tests
+  # - title: Plugin Migration
+  #   href: /plugin-migration

--- a/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
+++ b/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
@@ -159,6 +159,24 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
 });
 ```
 
+Like tasks, hooks must be registeredon your `HardhatPlugin` object:
+
+```typescript
+// index.ts
+import type { HardhatPlugin } from "hardhat/types/plugins";
+import newTask from "./tasks/new-task.js";
+
+const plugin: HardhatPlugin = {
+  id: "plugin-name",
+  tasks: [newTask],
+  hookHandlers: {
+    solidity: import.meta.resolve("./hook_handlers/solidity.js"),
+  },
+};
+
+export default plugin;
+```
+
 ### Config Hooks
 
 The `extendConfig` function no longer exists in Hardhat 3. Instead, use one of the `ConfigHooks`:

--- a/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
+++ b/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
@@ -46,6 +46,12 @@ Update your dependencies to the new version of Hardhat. Make sure that Hardhat i
 }
 ```
 
+Some dependencies are no lnoger required and can be removed:
+
+```bash
+npm remove @types/mocha
+```
+
 ## `HardhatPlugin` export
 
 Plugins for Hardhat 2 were largely configured through import side effects. In Hardhat 3, this process is declarative. Your plugin will now need to export a `HardhatPlugin` object for users to register in their Hardhat coniguration files.

--- a/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
+++ b/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
@@ -240,3 +240,18 @@ const plugin: HardhatPlugin = {
 
 export default plugin;
 ```
+
+## Readme
+
+The installation process for plugins has changed in Hardhat 3.  Users must now register them in their Hardhat configuration files.  Update any installation instructions to reflect this:
+
+```typescript
+import MyPlugin from 'hardhat-my-plugin';
+import type { HardhatUserConfig } from 'hardhat/config';
+
+const config: HardhatUserConfig = {
+  plugins: [MyPlugin],
+};
+
+export default config;
+```

--- a/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
+++ b/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
@@ -129,7 +129,7 @@ export default action;
 Reference it in your task builder:
 
 ```typescript
-// index.ts
+// tasks/new-task.ts
 import { task } from "hardhat/config";
 import { NewTaskDefinition } from "hardhat/types/tasks";
 

--- a/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
+++ b/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
@@ -1,0 +1,199 @@
+# Plugin Migration
+
+Hardhat 3 introduces many new features available to plugin developers, as well as API requirements for them to work. This guide explains the necessary and optional steps to migrate Hardhat 2 plugins to Hardhat 3.
+
+## ES Modules
+
+Hardhat 3 supports ESM. To make use of this, update your `package.json` to declare that your package is a module:
+
+```json
+{
+    "type": "module",
+    ...
+}
+```
+
+If you're using TypeScript, make sure that your `tsconfig` is set to support ESM:
+
+```json
+{
+  "compilerOptions": {
+    "module": "node16",
+    ...
+  },
+  ...
+}
+```
+
+## Dependencies
+
+Update your dependencies to the new version of Hardhat. Make sure that Hardhat is a peer dependency:
+
+```json
+{
+    "peerDependencies": {
+        "hardhat": "3.0.0-next.3",
+        ...
+    },
+    "devDependencies": {
+        "hardhat": "3.0.0-next.3",
+        ...
+    },
+    ...
+}
+```
+
+## `HardhatPlugin` export
+
+Plugins for Hardhat 2 were largely configured through import side effects. In Hardhat 3, this process is declarative. Your plugin will now need to export a `HardhatPlugin` object for users to register in their Hardhat coniguration files.
+
+```typescript
+import type { HardhatPlugin } from 'hardhat/types/plugins';
+
+const plugin: HardhatPlugin = {
+    id: 'plugin-name',
+    ...
+};
+
+export default plugin;
+```
+
+## Tasks
+
+Tasks have changed significantly in Hardhat 3. While still central to Hardhat, in some situations they are no longer appropriate.
+
+### Start with subtasks
+
+Hardhat 3 no longer includes subtasks. Existing subtasks should be converted to regular functions.
+
+### Build your tasks
+
+Tasks still exist, but are now defined using a builder pattern rather than declared as a side effect of the `task` function. Take note of the API changes to some of the builder functions, and finalize your task with `.build()`. If it's not declared in the same file as your `HardhatPlugin`, export it.
+
+```typescript
+import { task } from "hardhat/config";
+import { NewTaskDefinition } from "hardhat/types/tasks";
+
+const newTask: NewTaskDefinition = task("task-name")
+  .setDescription("A Hardhat 3 task")
+  .setAction(async () => {
+    // task logic
+  })
+  .addFlag({ name: "taskOption", description: "a boolean CLI flag" })
+  .build();
+
+export default newTask;
+```
+
+Register your task with your `HardhatPlugin` object:
+
+```typescript
+import type { HardhatPlugin } from 'hardhat/types/plugins';
+import newTask from './tasks/new-task.js';
+
+const plugin: HardhatPlugin = {
+    id: 'plugin-name',
+    tasks: [newTask],
+    ...
+};
+
+export default plugin;
+```
+
+### Task Actions
+
+Inline task action declaration is supported only for development purposes. For production, move your action to a separate file:
+
+```typescript
+export interface TaskActionArguments {
+  taskOption: boolean;
+}
+
+const action = (NewTaskActionFunction<TaskActionArguments> = async (
+  args,
+  hre,
+) => {
+  // task logic
+});
+
+export default action;
+```
+
+Reference it in your task builder:
+
+```typescript
+import { task } from "hardhat/config";
+import { NewTaskDefinition } from "hardhat/types/tasks";
+
+const newTask: NewTaskDefinition = task("task-name")
+  .setDescription("A Hardhat 3 task")
+  .setAction(import.meta.resolve("./actions/task.js"))
+  .addFlag({ name: "taskOption", description: "a boolean CLI flag" })
+  .build();
+
+export default newTask;
+```
+
+## Hooks
+
+Some processes that were previously handled exclusively by tasks might be better served by hooks. Generally task overrides will still work, but here's an example of a post-compilation action which uses a hook instead:
+
+```typescript
+import type { SolidityHooks } from "hardhat/types/hooks";
+
+export default async (): Promise<Partial<SolidityHooks>> => ({
+  onCleanUpArtifacts: async (context, artifactPaths, next) => {
+    // post-compilation script
+
+    return next(context, artifactPaths);
+  },
+});
+```
+
+### Config Hooks
+
+The `extendConfig` function no longer exists in Hardhat 3. Instead, use one of the `ConfigHooks`:
+
+```typescript
+import type { ConfigHooks } from "hardhat/types/hooks";
+
+export default async (): Promise<Partial<ConfigHooks>> => ({
+  resolveUserConfig: async (userConfig, resolveConfigurationariable, next) => {
+    const resolvedConfig = await next(userConfig, resolveConfigurationVariable);
+
+    const myUserConfig = {
+      ...defaultConfig,
+      ...userConfig.myUserConfig,
+    };
+
+    return {
+      ...resolvedConfig,
+      myUserConfig,
+    };
+  },
+});
+```
+
+## See Also
+
+### Global Options
+
+```typescript
+import { globalOption } from 'hardhat/config';
+import { ArgumentType } from 'hardhat/types/arguments';
+import type { HardhatPlugin } from 'hardhat/types/plugins';
+
+const plugin: HardhatPlugin = {
+    globalOptions: [
+        globalOption({
+            name: 'globalOption',
+            description: "A global option available for all tasks on the CLI",
+            defaultValue: false,
+            type: ArgumentType.BOOLEAN,
+        }),
+    ],
+    ...
+};
+
+export default plugin;
+```

--- a/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
+++ b/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
@@ -159,6 +159,8 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
 });
 ```
 
+Note that the `context` parameter is a subset of the `hre`. Th task runner is excluded, to discourage tight coupling of tasks.
+
 Like tasks, hooks must be registeredon your `HardhatPlugin` object:
 
 ```typescript

--- a/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
+++ b/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
@@ -7,6 +7,7 @@ Hardhat 3 introduces many new features available to plugin developers, as well a
 Hardhat 3 supports ESM. To make use of this, update your `package.json` to declare that your package is a module:
 
 ```json
+// package.json
 {
     "type": "module",
     ...
@@ -16,6 +17,7 @@ Hardhat 3 supports ESM. To make use of this, update your `package.json` to decla
 If you're using TypeScript, make sure that your `tsconfig` is set to support ESM:
 
 ```json
+// tsconfig.json
 {
   "compilerOptions": {
     "module": "node16",
@@ -30,6 +32,7 @@ If you're using TypeScript, make sure that your `tsconfig` is set to support ESM
 Update your dependencies to the new version of Hardhat. Make sure that Hardhat is a peer dependency:
 
 ```json
+// package.json
 {
     "peerDependencies": {
         "hardhat": "3.0.0-next.3",
@@ -48,6 +51,7 @@ Update your dependencies to the new version of Hardhat. Make sure that Hardhat i
 Plugins for Hardhat 2 were largely configured through import side effects. In Hardhat 3, this process is declarative. Your plugin will now need to export a `HardhatPlugin` object for users to register in their Hardhat coniguration files.
 
 ```typescript
+// index.ts
 import type { HardhatPlugin } from 'hardhat/types/plugins';
 
 const plugin: HardhatPlugin = {
@@ -71,6 +75,7 @@ Hardhat 3 no longer includes subtasks. Existing subtasks should be converted to 
 Tasks still exist, but are now defined using a builder pattern rather than declared as a side effect of the `task` function. Take note of the API changes to some of the builder functions, and finalize your task with `.build()`. If it's not declared in the same file as your `HardhatPlugin`, export it.
 
 ```typescript
+// tasks/new-task.ts
 import { task } from "hardhat/config";
 import { NewTaskDefinition } from "hardhat/types/tasks";
 
@@ -88,6 +93,7 @@ export default newTask;
 Register your task with your `HardhatPlugin` object:
 
 ```typescript
+// index.ts
 import type { HardhatPlugin } from 'hardhat/types/plugins';
 import newTask from './tasks/new-task.js';
 
@@ -105,6 +111,7 @@ export default plugin;
 Inline task action declaration is supported only for development purposes. For production, move your action to a separate file:
 
 ```typescript
+// actions/new-task.ts
 export interface TaskActionArguments {
   taskOption: boolean;
 }
@@ -122,12 +129,13 @@ export default action;
 Reference it in your task builder:
 
 ```typescript
+// index.ts
 import { task } from "hardhat/config";
 import { NewTaskDefinition } from "hardhat/types/tasks";
 
 const newTask: NewTaskDefinition = task("task-name")
   .setDescription("A Hardhat 3 task")
-  .setAction(import.meta.resolve("./actions/task.js"))
+  .setAction(import.meta.resolve("./actions/new-task.js"))
   .addFlag({ name: "taskOption", description: "a boolean CLI flag" })
   .build();
 
@@ -139,6 +147,7 @@ export default newTask;
 Some processes that were previously handled exclusively by tasks might be better served by hooks. Generally task overrides will still work, but here's an example of a post-compilation action which uses a hook instead:
 
 ```typescript
+// hook-handlers/solidity.ts
 import type { SolidityHooks } from "hardhat/types/hooks";
 
 export default async (): Promise<Partial<SolidityHooks>> => ({
@@ -155,6 +164,7 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
 The `extendConfig` function no longer exists in Hardhat 3. Instead, use one of the `ConfigHooks`:
 
 ```typescript
+// hook-handlers/config.ts
 import type { ConfigHooks } from "hardhat/types/hooks";
 
 export default async (): Promise<Partial<ConfigHooks>> => ({
@@ -179,6 +189,7 @@ export default async (): Promise<Partial<ConfigHooks>> => ({
 ### Global Options
 
 ```typescript
+// index.ts
 import { globalOption } from 'hardhat/config';
 import { ArgumentType } from 'hardhat/types/arguments';
 import type { HardhatPlugin } from 'hardhat/types/plugins';

--- a/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
+++ b/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
@@ -214,6 +214,12 @@ import { globalOption } from 'hardhat/config';
 import { ArgumentType } from 'hardhat/types/arguments';
 import type { HardhatPlugin } from 'hardhat/types/plugins';
 
+declare module 'hardhat/types/global-options' {
+  interface GlobalOptions {
+    globalOption: boolean;
+  }
+}
+
 const plugin: HardhatPlugin = {
     globalOptions: [
         globalOption({

--- a/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
+++ b/docs/src/content/hardhat3-alpha/learn-more/plugin-migration.md
@@ -9,8 +9,8 @@ Hardhat 3 supports ESM. To make use of this, update your `package.json` to decla
 ```json
 // package.json
 {
-    "type": "module",
-    ...
+  "type": "module"
+  // ...
 }
 ```
 
@@ -20,10 +20,10 @@ If you're using TypeScript, make sure that your `tsconfig` is set to support ESM
 // tsconfig.json
 {
   "compilerOptions": {
-    "module": "node16",
-    ...
-  },
-  ...
+    "module": "node16"
+    // ...
+  }
+  // ...
 }
 ```
 
@@ -34,15 +34,15 @@ Update your dependencies to the new version of Hardhat. Make sure that Hardhat i
 ```json
 // package.json
 {
-    "peerDependencies": {
-        "hardhat": "3.0.0-next.3",
-        ...
-    },
-    "devDependencies": {
-        "hardhat": "3.0.0-next.3",
-        ...
-    },
-    ...
+  "peerDependencies": {
+    "hardhat": "3.0.0-next.3"
+    // ...
+  },
+  "devDependencies": {
+    "hardhat": "3.0.0-next.3"
+    // ...
+  }
+  // ...
 }
 ```
 
@@ -52,11 +52,11 @@ Plugins for Hardhat 2 were largely configured through import side effects. In Ha
 
 ```typescript
 // index.ts
-import type { HardhatPlugin } from 'hardhat/types/plugins';
+import type { HardhatPlugin } from "hardhat/types/plugins";
 
 const plugin: HardhatPlugin = {
-    id: 'plugin-name',
-    ...
+  id: "plugin-name",
+  // ...
 };
 
 export default plugin;
@@ -94,13 +94,13 @@ Register your task with your `HardhatPlugin` object:
 
 ```typescript
 // index.ts
-import type { HardhatPlugin } from 'hardhat/types/plugins';
-import newTask from './tasks/new-task.js';
+import type { HardhatPlugin } from "hardhat/types/plugins";
+import newTask from "./tasks/new-task.js";
 
 const plugin: HardhatPlugin = {
-    id: 'plugin-name',
-    tasks: [newTask],
-    ...
+  id: "plugin-name",
+  tasks: [newTask],
+  // ...
 };
 
 export default plugin;
@@ -210,26 +210,26 @@ export default async (): Promise<Partial<ConfigHooks>> => ({
 
 ```typescript
 // index.ts
-import { globalOption } from 'hardhat/config';
-import { ArgumentType } from 'hardhat/types/arguments';
-import type { HardhatPlugin } from 'hardhat/types/plugins';
+import { globalOption } from "hardhat/config";
+import { ArgumentType } from "hardhat/types/arguments";
+import type { HardhatPlugin } from "hardhat/types/plugins";
 
-declare module 'hardhat/types/global-options' {
+declare module "hardhat/types/global-options" {
   interface GlobalOptions {
     globalOption: boolean;
   }
 }
 
 const plugin: HardhatPlugin = {
-    globalOptions: [
-        globalOption({
-            name: 'globalOption',
-            description: "A global option available for all tasks on the CLI",
-            defaultValue: false,
-            type: ArgumentType.BOOLEAN,
-        }),
-    ],
-    ...
+  globalOptions: [
+    globalOption({
+      name: "globalOption",
+      description: "A global option available for all tasks on the CLI",
+      defaultValue: false,
+      type: ArgumentType.BOOLEAN,
+    }),
+  ],
+  // ...
 };
 
 export default plugin;


### PR DESCRIPTION
This is a draft.  I will edit as I better understand HH3.

Some particular issues:
* It's not absolutely clear how to choose between tasks and hooks.  Most people migrating plugins will probably not bother with hooks if they're not convinced, because tasks still work.
* I don't fully understand the boundaries and interactions between ESM and Typescript.  Is `tsconfig.json` outside of the scope of this guide?  Are there any other required configuration options that I happened to already have set?