### PR TITLE
Fix compilation error with bignumber.js latest types

### DIFF
--- a/packages/hardhat-core/src/common/bigInt.ts
+++ b/packages/hardhat-core/src/common/bigInt.ts
@@ -1,6 +1,6 @@
 import type { BigNumber as EthersBigNumberType } from "ethers-v5";
 // eslint-disable-next-line import/no-extraneous-dependencies
-import type { BigNumber as BigNumberJsType } from "bignumber.js";
+import type { default as BigNumberJsType } from "bignumber.js";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { default as BNType } from "bn.js";
 


### PR DESCRIPTION
The latest version of bignumber.js has breaking changes in its types, even if it's a minor bump. This change works both with the currently installed version and with the latest. This is just a dev dependency anyway, so it's not a big deal.