### PR TITLE
Fix compilation error with bignumber.js latest types

### DIFF
--- a/packages/hardhat-chai-matchers/test/bigNumber.ts
+++ b/packages/hardhat-chai-matchers/test/bigNumber.ts
@@ -1,5 +1,5 @@
 import { expect, AssertionError } from "chai";
-import { BigNumber as BigNumberJs } from "bignumber.js";
+import { default as BigNumberJs } from "bignumber.js";
 import BN from "bn.js";
 
 import { HardhatError } from "hardhat/internal/core/errors";


### PR DESCRIPTION
Same as https://github.com/NomicFoundation/hardhat/pull/6541 but after fixing that I only re-compiled in `hardhat-core` and didn't realize this was also happening in another package.