### PR TITLE
Move pluginId to the error category from the error descriptors

### DIFF
--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -8,11 +8,6 @@ export interface ErrorDescriptor {
   number: number;
 
   /**
-   * The id of the plugin that throws this error.
-   */
-  pluginId?: string;
-
-  /**
    * A tempalte of the message of the error.
    *
    * This should be a short description. If possible, it should tell the user
@@ -44,6 +39,7 @@ export const ERROR_CATEGORIES: {
   [packageName: string]: {
     min: number;
     max: number;
+    pluginId: string | undefined;
     websiteTitle: string;
     CATEGORIES: {
       [categoryName: string]: {
@@ -57,6 +53,7 @@ export const ERROR_CATEGORIES: {
   CORE: {
     min: 1,
     max: 9999,
+    pluginId: undefined,
     websiteTitle: "Hardhat Core",
     CATEGORIES: {
       GENERAL: {
@@ -124,6 +121,7 @@ export const ERROR_CATEGORIES: {
   IGNITION: {
     min: 10000,
     max: 19999,
+    pluginId: "hardhat-ignition",
     websiteTitle: "Hardhat Ignition",
     CATEGORIES: {
       GENERAL: {
@@ -196,6 +194,7 @@ export const ERROR_CATEGORIES: {
   HARDHAT_ETHERS: {
     min: 20000,
     max: 29999,
+    pluginId: "hardhat-ethers",
     websiteTitle: "Hardhat Ethers",
     CATEGORIES: {
       GENERAL: {
@@ -208,6 +207,7 @@ export const ERROR_CATEGORIES: {
   HARDHAT_MOCHA: {
     min: 30000,
     max: 39999,
+    pluginId: "hardhat-mocha",
     websiteTitle: "Hardhat Mocha",
     CATEGORIES: {
       GENERAL: {
@@ -220,6 +220,7 @@ export const ERROR_CATEGORIES: {
   HARDHAT_VIEM: {
     min: 40000,
     max: 49999,
+    pluginId: "hardhat-viem",
     websiteTitle: "Hardhat Viem",
     CATEGORIES: {
       GENERAL: {
@@ -232,6 +233,7 @@ export const ERROR_CATEGORIES: {
   HARDHAT_KEYSTORE: {
     min: 50000,
     max: 59999,
+    pluginId: "hardhat-keystore",
     websiteTitle: "Hardhat Keystore",
     CATEGORIES: {
       GENERAL: {
@@ -244,6 +246,7 @@ export const ERROR_CATEGORIES: {
   NETWORK_HELPERS: {
     min: 60000,
     max: 69999,
+    pluginId: "hardhat-network-helpers",
     websiteTitle: "Hardhat Network Helpers",
     CATEGORIES: {
       GENERAL: {
@@ -256,6 +259,7 @@ export const ERROR_CATEGORIES: {
   CHAI_MATCHERS: {
     min: 70000,
     max: 79999,
+    pluginId: "hardhat-ethers-chai-matchers",
     websiteTitle: "Hardhat Chai Matchers",
     CATEGORIES: {
       GENERAL: {

--- a/v-next/hardhat-errors/src/errors.ts
+++ b/v-next/hardhat-errors/src/errors.ts
@@ -3,7 +3,7 @@ import type { ErrorDescriptor } from "./descriptors.js";
 import { CustomError } from "@nomicfoundation/hardhat-utils/error";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { ERRORS } from "./descriptors.js";
+import { ERRORS, ERROR_CATEGORIES } from "./descriptors.js";
 
 export type ErrorMessageTemplateValue =
   | string
@@ -154,7 +154,17 @@ export class HardhatError<
   }
 
   public get pluginId(): string | undefined {
-    return this.#descriptor.pluginId;
+    for (const category of Object.values(ERROR_CATEGORIES)) {
+      const isWithinCategoryRange =
+        this.#descriptor.number >= category.min &&
+        this.#descriptor.number <= category.max;
+
+      if (isWithinCategoryRange) {
+        return category.pluginId;
+      }
+    }
+
+    return undefined;
   }
 
   public get descriptor(): ErrorDescriptor {

--- a/v-next/hardhat-errors/test/errors.ts
+++ b/v-next/hardhat-errors/test/errors.ts
@@ -154,6 +154,17 @@ describe("HardhatError", () => {
       assert.equal(error.message, "HHE12: a b 123");
     });
   });
+
+  describe("pluginId", () => {
+    it("Should return the plugin id if its dscriptor is in a category that uses one", () => {
+      assert.equal(
+        new HardhatError(
+          HardhatError.ERRORS.HARDHAT_KEYSTORE.GENERAL.INVALID_PASSWORD_OR_CORRUPTED_KEYSTORE,
+        ).pluginId,
+        ERROR_CATEGORIES.HARDHAT_KEYSTORE.pluginId,
+      );
+    });
+  });
 });
 
 describe("HardhatPluginError", () => {

--- a/v-next/hardhat-errors/test/errors.ts
+++ b/v-next/hardhat-errors/test/errors.ts
@@ -156,7 +156,7 @@ describe("HardhatError", () => {
   });
 
   describe("pluginId", () => {
-    it("Should return the plugin id if its dscriptor is in a category that uses one", () => {
+    it("Should return the plugin id if its descriptor is in a category that uses one", () => {
       assert.equal(
         new HardhatError(
           HardhatError.ERRORS.HARDHAT_KEYSTORE.GENERAL.INVALID_PASSWORD_OR_CORRUPTED_KEYSTORE,

--- a/v-next/hardhat/test/internal/cli/error-handler.ts
+++ b/v-next/hardhat/test/internal/cli/error-handler.ts
@@ -14,11 +14,18 @@ import {
   HARDHAT_WEBSITE_URL,
 } from "../../../src/internal/constants.js";
 
-const mockErrorDescriptor = {
+const mockCoreErrorDescriptor = {
   number: 123,
   messageTemplate: "error message",
   websiteTitle: "Mock error",
   websiteDescription: "This is a mock error",
+} as const;
+
+const mockPluginErrorDescriptor = {
+  number: 50000,
+  messageTemplate: "plugin error message",
+  websiteTitle: "Mock error",
+  websiteDescription: "This is a mock error in the range of a plugin",
 } as const;
 
 describe("error-handler", () => {
@@ -26,7 +33,7 @@ describe("error-handler", () => {
     describe("with a Hardhat error", () => {
       it("should print the error message", () => {
         const lines: string[] = [];
-        const error = new HardhatError(mockErrorDescriptor);
+        const error = new HardhatError(mockCoreErrorDescriptor);
 
         printErrorMessages(error, false, (msg: string) => {
           lines.push(msg);
@@ -47,7 +54,7 @@ describe("error-handler", () => {
 
       it("should print the stack trace", () => {
         const lines: string[] = [];
-        const error = new HardhatError(mockErrorDescriptor);
+        const error = new HardhatError(mockCoreErrorDescriptor);
 
         printErrorMessages(error, true, (msg: string) => {
           lines.push(msg);
@@ -66,10 +73,7 @@ describe("error-handler", () => {
     describe("with a Hardhat plugin error", () => {
       it("should print the error message", () => {
         const lines: string[] = [];
-        const error = new HardhatError({
-          pluginId: "example-plugin",
-          ...mockErrorDescriptor,
-        });
+        const error = new HardhatError(mockPluginErrorDescriptor);
 
         printErrorMessages(error, false, (msg: string) => {
           lines.push(msg);
@@ -90,10 +94,7 @@ describe("error-handler", () => {
 
       it("should print the stack trace", () => {
         const lines: string[] = [];
-        const error = new HardhatError({
-          pluginId: "example-plugin",
-          ...mockErrorDescriptor,
-        });
+        const error = new HardhatError(mockPluginErrorDescriptor);
 
         printErrorMessages(error, true, (msg: string) => {
           lines.push(msg);


### PR DESCRIPTION
This is a small improvement on top of #6552.

I moved the `pluginId` definition from each error descriptor (where it's easy to forget it), to the error categories object.

I didn't add any changeset because it can be seen as covered by #6552's changeset.