### PR TITLE
add ensureNodeErrnoExceptionError function to assert the error

### DIFF
--- a/.changeset/eleven-lies-sin.md
+++ b/.changeset/eleven-lies-sin.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+"hardhat": patch
+---
+
+Add ensureNodeErrnoExceptionError function to assert nodejs errors

--- a/v-next/hardhat-utils/src/error.ts
+++ b/v-next/hardhat-utils/src/error.ts
@@ -79,6 +79,31 @@ export function ensureError<ErrorT extends Error>(
 }
 
 /**
+ * Ensures that the provided value is a NodeJS.ErrnoException with a string 'code'.
+ * @param thrown The value to check.
+ * @throws The value if its not an error or if it doesn't have a code property.
+ * @example
+ * ```ts
+ * try {
+ *   await fs.promises.readFile("non-existing-file.txt");
+ * } catch (error) {
+ *   ensureNodeErrnoExceptionError(error);
+ *   console.error(error.code);
+ * }
+ * ```
+ */
+
+export function ensureNodeErrnoExceptionError(
+  thrown: unknown,
+): asserts thrown is NodeJS.ErrnoException & Error & { code: string } {
+  ensureError(thrown);
+
+  if (!("code" in thrown) || typeof thrown.code !== "string") {
+    throw thrown;
+  }
+}
+
+/**
  * Throws an error for an unreachable code path. This function is typically
  * used in a default case of a switch statement where all possible values of
  * the switched variable should be handled in other cases. If the default case

--- a/v-next/hardhat-utils/src/error.ts
+++ b/v-next/hardhat-utils/src/error.ts
@@ -92,7 +92,6 @@ export function ensureError<ErrorT extends Error>(
  * }
  * ```
  */
-
 export function ensureNodeErrnoExceptionError(
   thrown: unknown,
 ): asserts thrown is NodeJS.ErrnoException & Error & { code: string } {

--- a/v-next/hardhat-utils/src/fs.ts
+++ b/v-next/hardhat-utils/src/fs.ts
@@ -8,7 +8,7 @@ import { pipeline } from "node:stream/promises";
 import { JSONParser } from "@streamparser/json-node";
 import { JsonStreamStringify } from "json-stream-stringify";
 
-import { ensureError } from "./error.js";
+import { ensureNodeErrnoExceptionError } from "./error.js";
 import {
   FileNotFoundError,
   FileSystemAccessError,
@@ -31,7 +31,7 @@ export async function getRealPath(absolutePath: string): Promise<string> {
   try {
     return await fsPromises.realpath(path.normalize(absolutePath));
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     if (e.code === "ENOENT") {
       throw new FileNotFoundError(absolutePath, e);
     }
@@ -165,7 +165,7 @@ export async function isDirectory(absolutePath: string): Promise<boolean> {
   try {
     return (await fsPromises.lstat(absolutePath)).isDirectory();
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     if (e.code === "ENOENT") {
       throw new FileNotFoundError(absolutePath, e);
     }
@@ -189,7 +189,7 @@ export async function readJsonFile<T>(absolutePathToFile: string): Promise<T> {
   try {
     return JSON.parse(content.toString());
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     throw new InvalidFileFormatError(absolutePathToFile, e);
   }
 }
@@ -241,7 +241,7 @@ export async function readJsonFileAsStream<T>(
 
     return result;
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
 
     if (e.code === "ENOENT") {
       throw new FileNotFoundError(absolutePathToFile, e);
@@ -281,7 +281,7 @@ export async function writeJsonFile<T>(
   try {
     content = JSON.stringify(object, null, 2);
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     throw new JsonSerializationError(absolutePathToFile, e);
   }
 
@@ -318,7 +318,7 @@ export async function writeJsonFileAsStream<T>(
 
     await pipeline(jsonStream, fileWriteStream);
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     // if the directory was created, we should remove it
     if (dirExists === false) {
       try {
@@ -356,7 +356,7 @@ export async function readUtf8File(
   try {
     return await fsPromises.readFile(absolutePathToFile, { encoding: "utf8" });
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
 
     if (e.code === "ENOENT") {
       throw new FileNotFoundError(absolutePathToFile, e);
@@ -398,7 +398,7 @@ export async function writeUtf8File(
       flag,
     });
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     // if the directory was created, we should remove it
     if (dirExists === false) {
       try {
@@ -436,7 +436,7 @@ export async function readBinaryFile(
     const buffer = await fsPromises.readFile(absolutePathToFile);
     return new Uint8Array(buffer);
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
 
     if (e.code === "ENOENT") {
       throw new FileNotFoundError(absolutePathToFile, e);
@@ -463,7 +463,7 @@ export async function readdir(absolutePathToDir: string): Promise<string[]> {
   try {
     return await fsPromises.readdir(absolutePathToDir);
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     if (e.code === "ENOENT") {
       throw new FileNotFoundError(absolutePathToDir, e);
     }
@@ -503,7 +503,7 @@ export async function mkdir(absolutePath: string): Promise<void> {
   try {
     await fsPromises.mkdir(absolutePath, { recursive: true });
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     throw new FileSystemAccessError(e.message, e);
   }
 }
@@ -528,7 +528,7 @@ export async function getChangeTime(absolutePath: string): Promise<Date> {
     const stats = await fsPromises.stat(absolutePath);
     return stats.ctime;
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     if (e.code === "ENOENT") {
       throw new FileNotFoundError(absolutePath, e);
     }
@@ -550,7 +550,7 @@ export async function getAccessTime(absolutePath: string): Promise<Date> {
     const stats = await fsPromises.stat(absolutePath);
     return stats.atime;
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     if (e.code === "ENOENT") {
       throw new FileNotFoundError(absolutePath, e);
     }
@@ -572,7 +572,7 @@ export async function getFileSize(absolutePath: string): Promise<number> {
     const stats = await fsPromises.stat(absolutePath);
     return stats.size;
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     if (e.code === "ENOENT") {
       throw new FileNotFoundError(absolutePath, e);
     }
@@ -610,7 +610,7 @@ export async function copy(source: string, destination: string): Promise<void> {
   try {
     await fsPromises.copyFile(source, destination);
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     if (e.code === "ENOENT") {
       if (!(await exists(source))) {
         throw new FileNotFoundError(source, e);
@@ -654,7 +654,7 @@ export async function move(source: string, destination: string): Promise<void> {
   try {
     await fsPromises.rename(source, destination);
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     if (e.code === "ENOENT") {
       if (!(await exists(source))) {
         throw new FileNotFoundError(source, e);
@@ -692,7 +692,7 @@ export async function remove(absolutePath: string): Promise<void> {
       retryDelay: 300,
     });
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     throw new FileSystemAccessError(e.message, e);
   }
 }
@@ -712,7 +712,7 @@ export async function chmod(
   try {
     await fsPromises.chmod(absolutePath, mode);
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     if (e.code === "ENOENT") {
       throw new FileNotFoundError(absolutePath, e);
     }
@@ -749,7 +749,7 @@ export async function emptyDir(absolutePath: string): Promise<void> {
     isDir = stats.isDirectory();
     mode = stats.mode;
   } catch (e) {
-    ensureError<NodeJS.ErrnoException>(e);
+    ensureNodeErrnoExceptionError(e);
     if (e.code === "ENOENT") {
       await mkdir(absolutePath);
       return;

--- a/v-next/hardhat-utils/src/synchronization.ts
+++ b/v-next/hardhat-utils/src/synchronization.ts
@@ -13,7 +13,7 @@ import path from "node:path";
 
 import debug from "debug";
 
-import { ensureError } from "./error.js";
+import { ensureNodeErrnoExceptionError } from "./error.js";
 import { FileSystemAccessError } from "./errors/fs.js";
 import { sleep } from "./lang.js";
 
@@ -62,7 +62,7 @@ export class MultiProcessMutex {
       fs.writeFileSync(this.#mutexFilePath, "", { flag: "wx+" });
       return true;
     } catch (e) {
-      ensureError<NodeJS.ErrnoException>(e);
+      ensureNodeErrnoExceptionError(e);
 
       if (e.code === "EEXIST") {
         // File already exists, so the mutex is already acquired
@@ -91,7 +91,7 @@ export class MultiProcessMutex {
     try {
       fileStat = fs.statSync(this.#mutexFilePath);
     } catch (e) {
-      ensureError<NodeJS.ErrnoException>(e);
+      ensureNodeErrnoExceptionError(e);
 
       if (e.code === "ENOENT") {
         // The file might have been deleted by another process while this function was trying to access it.
@@ -113,7 +113,7 @@ export class MultiProcessMutex {
       log(`Deleting mutex file at path '${this.#mutexFilePath}'`);
       fs.unlinkSync(this.#mutexFilePath);
     } catch (e) {
-      ensureError<NodeJS.ErrnoException>(e);
+      ensureNodeErrnoExceptionError(e);
 
       if (e.code === "ENOENT") {
         // The file might have been deleted by another process while this function was trying to access it.

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/base-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/base-provider.ts
@@ -9,7 +9,7 @@ import type {
 import EventEmitter from "node:events";
 import util from "node:util";
 
-import { ensureError } from "@nomicfoundation/hardhat-utils/error";
+import { ensureNodeErrnoExceptionError } from "@nomicfoundation/hardhat-utils/error";
 
 export abstract class BaseProvider
   extends EventEmitter
@@ -44,12 +44,7 @@ export abstract class BaseProvider
           result,
         };
       } catch (error) {
-        ensureError(error);
-
-        if (!("code" in error) || error.code === undefined) {
-          throw error;
-        }
-
+        ensureNodeErrnoExceptionError(error);
         /* eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         -- Allow string interpolation of unknown `error.code`. It will be converted
         to a number, and we will handle NaN cases appropriately afterwards. */


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

resolve #5605 

Add ensureNodeJSError function to replace unsafe  ensureError<T>