### PR TITLE
docs: replace dead Truffle testing link

### DIFF
--- a/packages/hardhat-truffle4/README.md
+++ b/packages/hardhat-truffle4/README.md
@@ -6,7 +6,7 @@
 
 ## What
 
-This plugin brings to Hardhat TruffleContracts from Truffle 4. With it you can call [`contract()` and `artifacts.require()`](https://truffleframework.com/docs/truffle/testing/writing-tests-in-javascript) like you normally would with Truffle. Interact with your contracts with a familiar API from tasks, scripts and tests.
+This plugin brings to Hardhat TruffleContracts from Truffle 4. With it you can call [`contract()` and `artifacts.require()`](https://archive.trufflesuite.com/docs/truffle/how-to/debug-test/write-tests-in-javascript/) like you normally would with Truffle. Interact with your contracts with a familiar API from tasks, scripts and tests.
 
 Additionally, you can **migrate your contracts to Solidity 5 without needing to migrate your tests to Truffle 5**.
 

--- a/packages/hardhat-truffle5/README.md
+++ b/packages/hardhat-truffle5/README.md
@@ -6,7 +6,7 @@
 
 ## What
 
-This plugin brings to Hardhat TruffleContracts from Truffle 5. With it you can call [`contract()` and `artifacts.require()`](https://truffleframework.com/docs/truffle/testing/writing-tests-in-javascript) like you normally would with Truffle. Interact with your contracts with a familiar API from tasks, scripts and tests.
+This plugin brings to Hardhat TruffleContracts from Truffle 5. With it you can call [`contract()` and `artifacts.require()`](https://archive.trufflesuite.com/docs/truffle/how-to/debug-test/write-tests-in-javascript/) like you normally would with Truffle. Interact with your contracts with a familiar API from tasks, scripts and tests.
 
 ## Required plugins
 


### PR DESCRIPTION
Replaced `https://truffleframework.com/docs/truffle/testing/writing-tests-in-javascript`
with `https://archive.trufflesuite.com/docs/truffle/how-to/debug-test/write-tests-in-javascript/`
because the original domain is no longer active.
