### PR TITLE
feat: support chainId values above 2^32 - 1 for local account transac…

### DIFF
--- a/.changeset/weak-frogs-care.md
+++ b/.changeset/weak-frogs-care.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Support chainId values above 2^32 - 1 for local account transactions

--- a/packages/hardhat-core/src/internal/core/providers/accounts.ts
+++ b/packages/hardhat-core/src/internal/core/providers/accounts.ts
@@ -304,16 +304,15 @@ export class LocalAccountsProvider extends ProviderWrapperWithChainId {
       gasLimit: txData.gasLimit,
     };
 
-    let strictMode = true;
-
-    // If the chainId is greater than 2^32 - 1, we need to disable strict mode
-    // See: https://github.com/paulmillr/micro-eth-signer/issues/34
-    if (
-      baseTxParams.chainId !== undefined &&
-      baseTxParams.chainId > BigInt(2 ** 32 - 1)
-    ) {
-      strictMode = false;
-    }
+    // Disable strict mode for chainIds > 2 ** 32 - 1.
+    //
+    // micro-eth-signer throws if strict mode is enabled with a chainId above 2 ** 32 - 1
+    // (see: https://github.com/paulmillr/micro-eth-signer/blob/baa4b8c922c3253b125e3f46b1fce6dee7c33853/src/tx.ts#L500).
+    //
+    // As a workaround we disable strict mode for larger chains. This also bypasses
+    // other internal checks enforced by the library, which is not ideal.
+    const strictMode =
+      txData.chainId === undefined || txData.chainId <= BigInt(2 ** 32 - 1);
 
     if (authorizationList !== undefined) {
       assertHardhatInvariant(

--- a/packages/hardhat-core/test/internal/core/providers/accounts.ts
+++ b/packages/hardhat-core/test/internal/core/providers/accounts.ts
@@ -399,6 +399,34 @@ describe("Local accounts provider", () => {
     assert.equal(rawTransaction, expectedRaw);
   });
 
+  it("should allow 'chainId' to be larger than 2^32 - 1 ", async () => {
+    const tx = {
+      from: "0xb5bc06d4548a3ac17d72b372ae1e416bf65b8ead",
+      to: "0xb5bc06d4548a3ac17d72b372ae1e416bf65b8ead",
+      gas: numberToRpcQuantity(100000),
+      nonce: numberToRpcQuantity(0),
+      value: numberToRpcQuantity(1),
+      chainId: numberToRpcQuantity(BigInt(2 ** 32)),
+      maxFeePerGas: numberToRpcQuantity(12),
+      maxPriorityFeePerGas: numberToRpcQuantity(2),
+    };
+    await wrapper.request({
+      method: "eth_sendTransaction",
+      params: [tx],
+    });
+
+    const rawTransaction = mock.getLatestParams("eth_sendRawTransaction")[0];
+
+    // BigInt(2 ** 32) is 0x + 100000000
+    const expectedRaw =
+      "0x02f86885010000000080020c830186a094b5bc06d4548a3ac17d72b372" +
+      "ae1e416bf65b8ead0180c001a0d2dc2ca1503a8e440849a4c87bd971d3f9" +
+      "9060fc0d12c7557cce964ec465f3faa017b976a4ec68cc1e03a4f14b342b" +
+      "e7666a76318a802cc1197a3bb88a36549bc8";
+
+    assert.equal(rawTransaction, expectedRaw);
+  });
+
   it("should throw if both 'to' and 'data' are undefined", async () => {
     await expectHardhatErrorAsync(
       () =>

--- a/packages/hardhat-core/test/internal/core/providers/accounts.ts
+++ b/packages/hardhat-core/test/internal/core/providers/accounts.ts
@@ -399,7 +399,7 @@ describe("Local accounts provider", () => {
     assert.equal(rawTransaction, expectedRaw);
   });
 
-  it("should allow 'chainId' to be larger than 2^32 - 1 ", async () => {
+  it("should allow 'chainId' to be larger than 2^32 - 1", async () => {
     const tx = {
       from: "0xb5bc06d4548a3ac17d72b372ae1e416bf65b8ead",
       to: "0xb5bc06d4548a3ac17d72b372ae1e416bf65b8ead",


### PR DESCRIPTION
…tions

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

#6603 

This PR add chainId check. When chainId larger than 2^32 - 1， set `strict=false` and pass this to Transaction.prepare function
