### PR TITLE
Replace deprecated `development` branch reference with `v-next `

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The linter is always run in the CI, so make sure it passes before pushing code. 
 
 ## Branching
 
-We work on two branches, [`main`](https://github.com/nomiclabs/hardhat/tree/main) and [`development`](https://github.com/nomiclabs/hardhat/tree/development).
+We work on two branches, [`main`](https://github.com/nomiclabs/hardhat/tree/main) and [`development`](https://github.com/NomicFoundation/hardhat/tree/v-next).
 
 The `main` branch is meant to be kept in sync with the latest released version of each package. Most pull requests are based on `main`, so when in doubt use this branch.
 


### PR DESCRIPTION
Updated outdated branch reference from `development` to `v-next` based on current repository structure. The `development` branch no longer exists, and `v-next ` is now used for major or in-progress changes.