### PR TITLE
Update pnpm/action-setup from v3 to v4

### DIFF
--- a/.github/workflows/hardhat-ci.yml
+++ b/.github/workflows/hardhat-ci.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
       - uses: actions/setup-node@v4


### PR DESCRIPTION
This PR updates the pnpm/action-setup GitHub Action from version 3 to version 4 in the CI workflow configuration.

Changes:
- Updated `pnpm/action-setup@v3` to `pnpm/action-setup@v4` in the hardhat-ci.yml workflow file