### PR TITLE
docs: fix dead link to Sourcify

### DIFF
--- a/packages/hardhat-verify/README.md
+++ b/packages/hardhat-verify/README.md
@@ -6,7 +6,7 @@
 
 ## What
 
-This plugin helps you verify the source code for your Solidity contracts. At the moment, it supports [Etherscan](https://etherscan.io)-based explorers, explorers compatible with its API like [Blockscout](https://www.blockscout.com/) and [Sourcify](https://sourcify.dev/).
+This plugin helps you verify the source code for your Solidity contracts. At the moment, it supports [Etherscan](https://etherscan.io)-based explorers, explorers compatible with its API like [Blockscout](https://www.blockscout.com/) and [Sourcify](https://github.com/sourcifyeth/sourcify).
 
 It's smart and it tries to do as much as possible to facilitate the process:
 


### PR DESCRIPTION
This update replaces the outdated Sourcify link (https://sourcify.dev/) with their official GitHub repository (https://github.com/sourcifyeth/sourcify).

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
