### PR TITLE
feat: disable strict mode in Transaction.prepare

### DIFF
--- a/.changeset/gold-months-try.md
+++ b/.changeset/gold-months-try.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Relax validations for transaction signing introduced in the previous version by disabling strict mode in `Transaction.prepare`.

--- a/packages/hardhat-core/src/internal/core/providers/accounts.ts
+++ b/packages/hardhat-core/src/internal/core/providers/accounts.ts
@@ -295,6 +295,8 @@ export class LocalAccountsProvider extends ProviderWrapperWithChainId {
     );
 
     let transaction;
+    // strict mode is not meant to be used in the context of hardhat
+    const strictMode = false;
     const baseTxParams = {
       to: checksummedAddress,
       nonce: txData.nonce,
@@ -303,16 +305,6 @@ export class LocalAccountsProvider extends ProviderWrapperWithChainId {
       data: bytesToHex(txData.data ?? new Uint8Array()),
       gasLimit: txData.gasLimit,
     };
-
-    // Disable strict mode for chainIds > 2 ** 32 - 1.
-    //
-    // micro-eth-signer throws if strict mode is enabled with a chainId above 2 ** 32 - 1
-    // (see: https://github.com/paulmillr/micro-eth-signer/blob/baa4b8c922c3253b125e3f46b1fce6dee7c33853/src/tx.ts#L500).
-    //
-    // As a workaround we disable strict mode for larger chains. This also bypasses
-    // other internal checks enforced by the library, which is not ideal.
-    const strictMode =
-      txData.chainId === undefined || txData.chainId <= BigInt(2 ** 32 - 1);
 
     if (authorizationList !== undefined) {
       assertHardhatInvariant(


### PR DESCRIPTION
Disable strict mode in `Transaction.prepare`, as it's intended for direct user usage and isn't useful in the context of Hardhat.

Closes https://github.com/NomicFoundation/hardhat/issues/6614