### PR TITLE
[v-next] feat: disable strict mode in Transaction.prepare

### DIFF
--- a/.changeset/wet-walls-jog.md
+++ b/.changeset/wet-walls-jog.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Relax validations for transaction signing introduced in the previous version by disabling strict mode in `Transaction.prepare`.

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
@@ -313,17 +313,9 @@ export class LocalAccountsHandler extends ChainId implements RequestHandler {
       "nonce should be defined",
     );
 
-    // Disable strict mode for chainIds > 2 ** 32 - 1.
-    //
-    // micro-eth-signer throws if strict mode is enabled with a chainId above 2 ** 32 - 1
-    // (see: https://github.com/paulmillr/micro-eth-signer/blob/baa4b8c922c3253b125e3f46b1fce6dee7c33853/src/tx.ts#L500).
-    //
-    // As a workaround we disable strict mode for larger chains. This also bypasses
-    // other internal checks enforced by the library, which is not ideal.
-    const strictMode =
-      txData.chainId === undefined || txData.chainId <= BigInt(2 ** 32 - 1);
-
     let transaction;
+    // strict mode is not meant to be used in the context of hardhat
+    const strictMode = false;
     if (txData.maxFeePerGas !== undefined) {
       transaction = Transaction.prepare(
         {


### PR DESCRIPTION
Disable strict mode in `Transaction.prepare`, as it's intended for direct user usage and isn't useful in the context of Hardhat.

This PR is the v3 equivalent of [nomicfoundation/hardhat#6643](https://github.com/NomicFoundation/hardhat/pull/6643).