### PR TITLE
fix: remove contract reverted without a reason string message from solidity tests

### DIFF
--- a/.changeset/chatty-rocks-reply.md
+++ b/.changeset/chatty-rocks-reply.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Replace "Contract reverted without a reason string" message with a more detailed failure reason in solidity tests

--- a/.changeset/chatty-rocks-reply.md
+++ b/.changeset/chatty-rocks-reply.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Replace "Contract reverted without a reason string" message with a more detailed failure reason in solidity tests
+Replace "Contract reverted without a reason string" message with a more detailed failure reason in solidity tests ([#6647](https://github.com/NomicFoundation/hardhat/issues/6647))

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
@@ -46,13 +46,15 @@ export function getMessageFromLastStackTraceEntry(
     case StackTraceEntryType.DIRECT_LIBRARY_CALL_ERROR:
       return `Library was called directly`;
 
+    /* These types are not associate with a more detailed error message */
     case StackTraceEntryType.UNRECOGNIZED_CREATE_ERROR:
     case StackTraceEntryType.UNRECOGNIZED_CONTRACT_ERROR: {
-      return "Contract reverted without a reason string";
+      return undefined;
     }
 
+    /* These types are not associate with a more detailed error message */
     case StackTraceEntryType.REVERT_ERROR: {
-      return "Contract reverted without a reason string";
+      return undefined;
     }
 
     case StackTraceEntryType.PANIC_ERROR:


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This fixes the issue reported in #6647.

As a follow-up, we should review the logic of extracting a more detailed error message from stack trace (https://github.com/NomicFoundation/hardhat/blob/999a8153bdedde5435432a28cd7cafd30fac8a90/v-next/hardhat/src/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts#L6) than the failure reason we get here (https://github.com/NomicFoundation/hardhat/blob/999a8153bdedde5435432a28cd7cafd30fac8a90/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts#L132). cc @kanej @agostbiro 

#### Testing

I tested this on the reproduction repo provided here - https://github.com/agostbiro/hh3-repro

Before:
```
Failure (1): test_IncByZero()
Reason: Contract reverted without a reason string
  at Counter.incBy (contracts/Counter.sol:15)
  at CounterTest.test_IncByZero (contracts/Counter.t.sol:18)
```

After:
```
Failure (1): test_IncByZero()
Reason: revert: incBy: increment should be positive
  at Counter.incBy (contracts/Counter.sol:15)
  at CounterTest.test_IncByZero (contracts/Counter.t.sol:18)
```