### PR TITLE
build(deps): bump slackapi/slack-github-action to v1.27.1

### DIFF
--- a/.github/workflows/LATEST_DEPENDENCY_VERSIONS.yml
+++ b/.github/workflows/LATEST_DEPENDENCY_VERSIONS.yml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm test || (echo "===== Retry =====" && pnpm test)
       - name: Notify failures
         if: failure()
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
         with:
           payload: |
             {


### PR DESCRIPTION
  Update slackapi/slack-github-action from commit 70cd7be8e40a46e8b0eced40b0de447bdb42f68e
  to fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 (v1.27.1).

[ Release notes](https://github.com/slackapi/slack-github-action/releases/tag/v1.27.1)






