### PR TITLE
fix: the error message produced by the errorenous regex matches

### DIFF
--- a/.changeset/short-hornets-end.md
+++ b/.changeset/short-hornets-end.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-reporter": patch
+---
+
+Improve the error message produced by hardhat node test reporter for failing regex match assertions

--- a/v-next/hardhat-node-test-reporter/integration-tests/README.md
+++ b/v-next/hardhat-node-test-reporter/integration-tests/README.md
@@ -10,7 +10,7 @@ You can run all the tests by running `npm run test:integration`.
 
 ## Running a single test
 
-You can run a single test by running `npm run test:integration --test-only example-test`.
+You can run a single test by running `npm run test:integration -- --test-only example-test`.
 
 ## Running each test manually
 
@@ -22,4 +22,10 @@ If you want to re-generate all the expected results, you can run the following s
 
 ```bash
 bash scripts/regenerate-fixtures.sh
+```
+
+To re-generate only a single fixture, you can run the following script from the package root:
+
+```bash
+bash scripts/regenerate-fixture.sh <fixture-name>
 ```

--- a/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/no-match-test/result.svg
+++ b/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/no-match-test/result.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="361.244mm" height="99.1306mm"
+ viewBox="0 0 1024 281"
+ xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"  version="1.2" baseProfile="tiny">
+<title>Qt Svg Document</title>
+<desc>Generated with Qt</desc>
+<defs>
+</defs>
+<g fill="none" stroke="black" stroke-width="1" fill-rule="evenodd" stroke-linecap="square" stroke-linejoin="bevel" >
+
+<g fill="#ffffff" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,281 L0,281 L0,0"/>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,281 L0,281 L0,0"/>
+</g>
+
+<g fill="#000000" fill-opacity="1" stroke="none" transform="matrix(1,0,0,1,0,0)"
+font-family="Helvetica" font-size="12" font-weight="400" font-style="normal" 
+>
+<path vector-effect="non-scaling-stroke" fill-rule="evenodd" d="M0,0 L1024,0 L1024,281 L0,281 L0,0"/>
+</g>
+
+<g fill="#ffffff" fill-opacity="1" stroke="#ffffff" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="39" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >  </text>
+</g>
+
+<g fill="#00ff00" fill-opacity="1" stroke="#00ff00" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#00ff00" fill-opacity="1" stroke="none" xml:space="preserve" x="24" y="39" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >✔</text>
+</g>
+
+<g fill="#696969" fill-opacity="1" stroke="#696969" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#696969" fill-opacity="1" stroke="none" xml:space="preserve" x="32" y="39" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ > match</text>
+</g>
+
+<g fill="#ffffff" fill-opacity="1" stroke="#ffffff" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="69" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >  </text>
+</g>
+
+<g fill="#ff0000" fill-opacity="1" stroke="#ff0000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ff0000" fill-opacity="1" stroke="none" xml:space="preserve" x="24" y="69" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >1) no match</text>
+</g>
+
+<g fill="#00ff00" fill-opacity="1" stroke="#00ff00" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#00ff00" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="114" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >1 passing</text>
+</g>
+
+<g fill="#696969" fill-opacity="1" stroke="#696969" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#696969" fill-opacity="1" stroke="none" xml:space="preserve" x="78" y="114" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ > (128ms)</text>
+</g>
+
+<g fill="#ff0000" fill-opacity="1" stroke="#ff0000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ff0000" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="129" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >1 failing</text>
+</g>
+
+<g fill="#ffffff" fill-opacity="1" stroke="#ffffff" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="159" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >  1) no match:</text>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="189" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >   </text>
+</g>
+
+<g fill="#ff0000" fill-opacity="1" stroke="#ff0000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ff0000" fill-opacity="1" stroke="none" xml:space="preserve" x="31" y="189" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >AssertionError: The input did not match the regular expression /^bar$/. Input:</text>
+</g>
+
+<g fill="#ffffff" fill-opacity="1" stroke="#ffffff" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="204" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >   </text>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="219" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >   </text>
+</g>
+
+<g fill="#ff0000" fill-opacity="1" stroke="#ff0000" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ff0000" fill-opacity="1" stroke="none" xml:space="preserve" x="31" y="219" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >'foo'</text>
+</g>
+
+<g fill="#ffffff" fill-opacity="1" stroke="#ffffff" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="234" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >   </text>
+<text fill="#ffffff" fill-opacity="1" stroke="none" xml:space="preserve" x="8" y="249" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >   </text>
+</g>
+
+<g fill="#696969" fill-opacity="1" stroke="#696969" stroke-opacity="1" stroke-width="1" stroke-linecap="square" stroke-linejoin="bevel" transform="matrix(1,0,0,1,0,0)"
+font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+>
+<text fill="#696969" fill-opacity="1" stroke="none" xml:space="preserve" x="31" y="249" font-family="Courier New" font-size="13" font-weight="400" font-style="normal" 
+ >    at TestContext.&lt;anonymous&gt; (integration-tests/fixture-tests/no-match-test/test.ts:9:10)</text>
+</g>
+</g>
+</svg>

--- a/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/no-match-test/result.txt
+++ b/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/no-match-test/result.txt
@@ -1,0 +1,17 @@
+
+  [90m[32m✔[39m[90m match[39m
+
+  [31m1) no match[39m
+
+
+[32m1 passing[39m[90m (128ms)[39m[31m[39m
+[31m1 failing[39m
+
+  1) no match:
+
+   [31mAssertionError: The input did not match the regular expression /^bar$/. Input:[39m
+   [31m[39m
+   [31m'foo'[39m
+   [31m[39m
+   [90m    at TestContext.<anonymous> (integration-tests/fixture-tests/no-match-test/test.ts:9:10)[39m
+

--- a/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/no-match-test/test.ts
+++ b/v-next/hardhat-node-test-reporter/integration-tests/fixture-tests/no-match-test/test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("match", () => {
+  assert.match("foo", /^foo$/);
+});
+
+test("no match", () => {
+  assert.match("foo", /^bar$/);
+});

--- a/v-next/hardhat-node-test-reporter/src/error-formatting.ts
+++ b/v-next/hardhat-node-test-reporter/src/error-formatting.ts
@@ -243,6 +243,10 @@ function getErrorDiff(error: Error): string | undefined {
     return undefined;
   }
 
+  if (typeof error.expected !== typeof error.actual) {
+    return undefined;
+  }
+
   return getDiff(error.expected, error.actual) ?? undefined;
 }
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This resolves one of the issues reported in https://github.com/NomicFoundation/hardhat/issues/6608

Issue nr. 1 - `assert.match` 
The issue was that we were comparing unrelated types when trying to extract a full diff out of the error and it was showing up to the users as an error message related to their code.

