### PR TITLE
ci: do not attempt to comment on PRs from forks

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -180,7 +180,7 @@ jobs:
             echo '' | tee -a $GITHUB_OUTPUT
           done
           echo 'EOF' >> $GITHUB_OUTPUT
-      - if: github.event_name == 'pull_request' && steps.download.outputs.count != '0'
+      - if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name && steps.download.outputs.count != '0'
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
           header: bundle


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

The PAT created in PRs originating from forks do not have permission to comment on said PRs. In this PR I ensure we skip the comment step on PRs originating from forks. 