### PR TITLE
feat: set prague as the default hardfork

### DIFF
--- a/.changeset/large-papayas-enjoy.md
+++ b/.changeset/large-papayas-enjoy.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Set prague as the default hardfork in Hardhat network

--- a/.changeset/large-papayas-enjoy.md
+++ b/.changeset/large-papayas-enjoy.md
@@ -1,5 +1,5 @@
 ---
-"hardhat": patch
+"hardhat": minor
 ---
 
 Set prague as the default hardfork in Hardhat network

--- a/packages/hardhat-core/src/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/src/internal/core/config/config-resolution.ts
@@ -238,19 +238,6 @@ function resolveHardhatNetworkConfig(
     delete config.initialBaseFeePerGas;
   }
 
-  if (
-    hardhatNetworkConfig.enableTransientStorage === true &&
-    hardhatNetworkConfig.hardfork === undefined
-  ) {
-    config.hardfork = "cancun";
-  }
-  if (
-    hardhatNetworkConfig.enableTransientStorage === false &&
-    hardhatNetworkConfig.hardfork === undefined
-  ) {
-    config.hardfork = "shanghai";
-  }
-
   return config;
 }
 

--- a/packages/hardhat-core/src/internal/core/config/default-config.ts
+++ b/packages/hardhat-core/src/internal/core/config/default-config.ts
@@ -36,7 +36,7 @@ export const defaultHardhatNetworkParams: Omit<
   HardhatNetworkConfig,
   "gas" | "initialDate"
 > = {
-  hardfork: HardforkName.CANCUN,
+  hardfork: HardforkName.PRAGUE,
   blockGasLimit: 30_000_000,
   gasPrice: HARDHAT_NETWORK_DEFAULT_GAS_PRICE,
   chainId: 31337,
@@ -83,7 +83,7 @@ export const defaultHardhatNetworkParams: Omit<
           [HardforkName.MERGE, 15_537_394],
           [HardforkName.SHANGHAI, 17_034_870],
           [HardforkName.CANCUN, 19_426_589],
-          [HardforkName.PRAGUE, 30_000_000], // TODO: replace with actual block number
+          [HardforkName.PRAGUE, 22_431_084],
         ]),
       },
     ],

--- a/packages/hardhat-core/test/internal/core/config/config-resolution.ts
+++ b/packages/hardhat-core/test/internal/core/config/config-resolution.ts
@@ -762,28 +762,17 @@ describe("Config resolution", () => {
         });
       });
 
-      it("should use cancun as the hardfork when enableTransientStorage is set", async function () {
+      it("should default to the latest hardfork", async function () {
         const config = resolveConfig(__filename, {
           networks: {
-            hardhat: {
-              enableTransientStorage: true,
-            },
+            hardhat: {},
           },
         });
 
-        assert.equal(config.networks.hardhat.hardfork, "cancun");
-      });
-
-      it("should use shanghai as the hardfork when enableTransientStorage is disabled", async function () {
-        const config = resolveConfig(__filename, {
-          networks: {
-            hardhat: {
-              enableTransientStorage: false,
-            },
-          },
-        });
-
-        assert.equal(config.networks.hardhat.hardfork, "shanghai");
+        assert.equal(
+          config.networks.hardhat.hardfork,
+          Object.values(HardforkName).pop()
+        );
       });
     });
 

--- a/packages/hardhat-ethers/test/error-messages.ts
+++ b/packages/hardhat-ethers/test/error-messages.ts
@@ -49,7 +49,7 @@ function runTests() {
 
     await assert.isRejected(
       contract.succeeds({
-        gasLimit: 21_064,
+        gasLimit: 21_175,
       }),
       "ran out of gas"
     );


### PR DESCRIPTION
Set Prague as the default hardfork and add the activation block to the hardfork history of mainnet.

Slot: https://beaconcha.in/slot/11649024
Block: https://beaconcha.in/block/22431084

Docs: https://github.com/NomicFoundation/hardhat-website/pull/6