### PR TITLE
clarify telemetry status message

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/telemetry/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/telemetry/task-action.ts
@@ -33,11 +33,11 @@ const configureTelemetry: NewTaskActionFunction<
 
   if (consent) {
     console.log(
-      "Telemetry is now enabled, to disable it run `npx hardhat telemetry --disable`",
+      "Telemetry is enabled, to disable it run `npx hardhat telemetry --disable`",
     );
   } else {
     console.log(
-      "Telemetry is now disabled, to enable it run `npx hardhat telemetry --enable`",
+      "Telemetry is disabled, to enable it run `npx hardhat telemetry --enable`",
     );
   }
 };


### PR DESCRIPTION
I ran the `telemetry` task without any options, and, based on the output message, I thought it had toggled the consent status.  The word "now" in this context implies that the state is not the same as the previous state.