### PR TITLE
fix: update template project scripts to match new network.connect api

### DIFF
--- a/.changeset/chatty-chairs-deliver.md
+++ b/.changeset/chatty-chairs-deliver.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix to the template project scripts to match the new signature of `network.connect(...)` ([#6691](https://github.com/NomicFoundation/hardhat/issues/6691))

--- a/v-next/hardhat/templates/01-node-test-runner-viem/scripts/check-predeploy.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/scripts/check-predeploy.ts
@@ -4,7 +4,10 @@ import { network } from "hardhat";
 const OP_GAS_PRICE_ORACLE = "0x420000000000000000000000000000000000000F";
 
 async function mainnetExample() {
-  const { viem } = await network.connect("hardhatMainnet", "l1");
+  const { viem } = await network.connect({
+    network: "hardhatMainnet",
+    chainType: "l1",
+  });
 
   const publicClient = await viem.getPublicClient();
   const gasPriceOracleCode = await publicClient.getCode({
@@ -18,7 +21,10 @@ async function mainnetExample() {
 }
 
 async function opExample() {
-  const { viem } = await network.connect("hardhatOp", "optimism");
+  const { viem } = await network.connect({
+    network: "hardhatOp",
+    chainType: "optimism",
+  });
 
   const publicClient = await viem.getPublicClient();
   const gasPriceOracleCode = await publicClient.getCode({

--- a/v-next/hardhat/templates/01-node-test-runner-viem/scripts/send-op-tx.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/scripts/send-op-tx.ts
@@ -2,7 +2,10 @@ import { network } from "hardhat";
 
 const chainType = "optimism";
 
-const { viem } = await network.connect("hardhatOp", chainType);
+const { viem } = await network.connect({
+  network: "hardhatOp",
+  chainType,
+});
 
 console.log("Sending transaction using the OP chain type");
 

--- a/v-next/hardhat/templates/02-mocha-ethers/scripts/check-predeploy.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/scripts/check-predeploy.ts
@@ -4,7 +4,10 @@ import { network } from "hardhat";
 const OP_GAS_PRICE_ORACLE = "0x420000000000000000000000000000000000000F";
 
 async function mainnetExample() {
-  const { ethers } = await network.connect("hardhatMainnet", "l1");
+  const { ethers } = await network.connect({
+    network: "hardhatMainnet",
+    chainType: "l1",
+  });
 
   const gasPriceOracleCode = await ethers.provider.getCode(OP_GAS_PRICE_ORACLE);
 
@@ -15,7 +18,10 @@ async function mainnetExample() {
 }
 
 async function opExample() {
-  const { ethers } = await network.connect("hardhatOp", "optimism");
+  const { ethers } = await network.connect({
+    network: "hardhatOp",
+    chainType: "optimism",
+  });
 
   const gasPriceOracleCode = await ethers.provider.getCode(OP_GAS_PRICE_ORACLE);
 

--- a/v-next/hardhat/templates/02-mocha-ethers/scripts/send-op-tx.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/scripts/send-op-tx.ts
@@ -1,6 +1,9 @@
 import { network } from "hardhat";
 
-const { ethers } = await network.connect("hardhatOp", "optimism");
+const { ethers } = await network.connect({
+  network: "hardhatOp",
+  chainType: "optimism",
+});
 
 console.log("Sending transaction using the OP chain type");
 


### PR DESCRIPTION
The signature of `network.connect(...)` was changed to a single options object. However the `./scripts` of the template projects where not updated at the same time.

This is a gap in our CI. For the moment I have updated the usages.

Resolves #6691.

See https://github.com/NomicFoundation/hardhat/pull/6674 for the signature change.

## TODO

- [x] Manual test of templates with Verdaccio