### PR TITLE
Fix sample projects and add tests to avoid them breaking again

### DIFF
--- a/.changeset/bright-planes-talk.md
+++ b/.changeset/bright-planes-talk.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix sample projects

--- a/.changeset/bright-planes-talk.md
+++ b/.changeset/bright-planes-talk.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Fix sample projects
+Fix to the template project scripts to match the new signature of `network.connect(...)` ([#6691](https://github.com/NomicFoundation/hardhat/issues/6691))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1432,6 +1432,9 @@ importers:
 
   v-next/hardhat/templates/01-node-test-runner-viem:
     devDependencies:
+      '@nomicfoundation/hardhat-ignition':
+        specifier: workspace:^3.0.0-next.7
+        version: link:../../../hardhat-ignition
       '@nomicfoundation/hardhat-toolbox-viem':
         specifier: workspace:^4.0.0-next.7
         version: link:../../../hardhat-toolbox-viem
@@ -1453,6 +1456,12 @@ importers:
 
   v-next/hardhat/templates/02-mocha-ethers:
     devDependencies:
+      '@nomicfoundation/hardhat-ethers':
+        specifier: workspace:^4.0.0-next.7
+        version: link:../../../hardhat-ethers
+      '@nomicfoundation/hardhat-ignition':
+        specifier: workspace:^3.0.0-next.7
+        version: link:../../../hardhat-ignition
       '@nomicfoundation/hardhat-toolbox-mocha-ethers':
         specifier: workspace:^3.0.0-next.7
         version: link:../../../hardhat-toolbox-mocha-ethers

--- a/v-next/hardhat/templates/01-node-test-runner-viem/package.json
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "hardhat": "workspace:^3.0.0-next.7",
     "@nomicfoundation/hardhat-toolbox-viem": "workspace:^4.0.0-next.7",
+    "@nomicfoundation/hardhat-ignition": "workspace:^3.0.0-next.7",
     "@types/node": "^22.8.5",
     "forge-std": "foundry-rs/forge-std#v1.9.4",
     "typescript": "~5.5.0",

--- a/v-next/hardhat/templates/01-node-test-runner-viem/scripts/check-predeploy.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/scripts/check-predeploy.ts
@@ -4,7 +4,10 @@ import { network } from "hardhat";
 const OP_GAS_PRICE_ORACLE = "0x420000000000000000000000000000000000000F";
 
 async function mainnetExample() {
-  const { viem } = await network.connect("hardhatMainnet", "l1");
+  const { viem } = await network.connect({
+    network: "hardhatMainnet",
+    chainType: "l1",
+  });
 
   const publicClient = await viem.getPublicClient();
   const gasPriceOracleCode = await publicClient.getCode({
@@ -18,7 +21,10 @@ async function mainnetExample() {
 }
 
 async function opExample() {
-  const { viem } = await network.connect("hardhatOp", "optimism");
+  const { viem } = await network.connect({
+    network: "hardhatOp",
+    chainType: "optimism",
+  });
 
   const publicClient = await viem.getPublicClient();
   const gasPriceOracleCode = await publicClient.getCode({

--- a/v-next/hardhat/templates/01-node-test-runner-viem/scripts/send-op-tx.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/scripts/send-op-tx.ts
@@ -1,8 +1,9 @@
 import { network } from "hardhat";
 
-const chainType = "optimism";
-
-const { viem } = await network.connect("hardhatOp", chainType);
+const { viem } = await network.connect({
+  network: "hardhatOp",
+  chainType: "optimism",
+});
 
 console.log("Sending transaction using the OP chain type");
 

--- a/v-next/hardhat/templates/01-node-test-runner-viem/test/Counter.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/test/Counter.ts
@@ -39,12 +39,13 @@ describe("Counter", async function () {
    *
    * Examples:
    *
-   * - `await network.connect("sepolia", "l1")`: Connects to the
-   *   `sepolia` network config, treating it as an "l1" network with the
+   * - `await network.connect({network: "sepolia", chainType: "l1"})`: Connects
+   *   to the `sepolia` network config, treating it as an "l1" network with the
    *   appropriate viem extensions.
    *
-   * - `await network.connect("hardhatOp", "optimism")`: Creates a new EDR
-   *   instance in Optimism mode, using the `hardhatOp` network config.
+   * - `await network.connect({network: "hardhatOp", chainType: "optimism"})`:
+   *   Creates a new EDR instance in Optimism mode, using the `hardhatOp`
+   *   network config.
    *
    * - `await network.connect()`: Creates a new EDR instance with the default
    *    network config (i.e. `hardhat`), the `generic` chain type, and no

--- a/v-next/hardhat/templates/02-mocha-ethers/package.json
+++ b/v-next/hardhat/templates/02-mocha-ethers/package.json
@@ -7,6 +7,8 @@
   "devDependencies": {
     "hardhat": "workspace:^3.0.0-next.7",
     "@nomicfoundation/hardhat-toolbox-mocha-ethers": "workspace:^3.0.0-next.7",
+    "@nomicfoundation/hardhat-ignition": "workspace:^3.0.0-next.7",
+    "@nomicfoundation/hardhat-ethers": "workspace:^4.0.0-next.7",
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^8.0.1",
     "@types/mocha": ">=10.0.10",

--- a/v-next/hardhat/templates/02-mocha-ethers/scripts/check-predeploy.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/scripts/check-predeploy.ts
@@ -4,7 +4,10 @@ import { network } from "hardhat";
 const OP_GAS_PRICE_ORACLE = "0x420000000000000000000000000000000000000F";
 
 async function mainnetExample() {
-  const { ethers } = await network.connect("hardhatMainnet", "l1");
+  const { ethers } = await network.connect({
+    network: "hardhatMainnet",
+    chainType: "l1",
+  });
 
   const gasPriceOracleCode = await ethers.provider.getCode(OP_GAS_PRICE_ORACLE);
 
@@ -15,7 +18,10 @@ async function mainnetExample() {
 }
 
 async function opExample() {
-  const { ethers } = await network.connect("hardhatOp", "optimism");
+  const { ethers } = await network.connect({
+    network: "hardhatOp",
+    chainType: "optimism",
+  });
 
   const gasPriceOracleCode = await ethers.provider.getCode(OP_GAS_PRICE_ORACLE);
 

--- a/v-next/hardhat/templates/02-mocha-ethers/scripts/send-op-tx.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/scripts/send-op-tx.ts
@@ -1,6 +1,9 @@
 import { network } from "hardhat";
 
-const { ethers } = await network.connect("hardhatOp", "optimism");
+const { ethers } = await network.connect({
+  network: "hardhatOp",
+  chainType: "optimism",
+});
 
 console.log("Sending transaction using the OP chain type");
 

--- a/v-next/hardhat/templates/02-mocha-ethers/test/Counter.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/test/Counter.ts
@@ -30,11 +30,12 @@ describe("Counter", function () {
    *
    * Examples:
    *
-   * - `await network.connect("sepolia", "l1")`: Connects to the
-   *   `sepolia` network config, treating it as an "l1" network.
+   * - `await network.connect({network: "sepolia", chainType: "l1"})`: Connects
+   *   to the `sepolia` network config, treating it as an "l1" network.
    *
-   * - `await network.connect("hardhatOp", "optimism")`: Creates a new EDR
-   *   instance in Optimism mode, using the `hardhatOp` network config.
+   * - `await network.connect(network: "hardhatOp", chainType: "optimism"})`:
+   *   Creates a new EDR instance in Optimism mode, using the `hardhatOp`
+   *   network config.
    *
    * - `await network.connect()`: Creates a new EDR instance with the default
    *    network config (i.e. `hardhat`) and the `generic` chain type.

--- a/v-next/hardhat/templates/02-mocha-ethers/test/Counter.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/test/Counter.ts
@@ -1,6 +1,7 @@
 import { network } from "hardhat";
-import { HardhatEthers } from "@nomicfoundation/hardhat-ethers/types";
 import { expect } from "chai";
+
+const { ethers } = await network.connect();
 
 describe("Counter", function () {
   /*
@@ -43,11 +44,6 @@ describe("Counter", function () {
    * Each network connection object has a `provider` property and other
    * network-related fields added by plugins, like `ethers` and `networkHelpers`.
    */
-  let ethers: HardhatEthers;
-  beforeEach(async function () {
-    const connection = await network.connect();
-    ethers = connection.ethers;
-  });
 
   it("The sum of the Increment events should match the current value", async function () {
     const counter = await ethers.deployContract("Counter");

--- a/v-next/hardhat/test/internal/cli/init/template.ts
+++ b/v-next/hardhat/test/internal/cli/init/template.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import { describe, it } from "node:test";
+import { spawnSync } from "node:child_process";
 
 import { exists } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -29,6 +30,31 @@ describe("getTemplates", () => {
           `Template file ${file} does not exist`,
         );
       }
+    }
+  });
+});
+
+describe.only("template contents", () => {
+  describe("templates should have valid typescript", async () => {
+    const templates = await getTemplates();
+
+    for (const template of templates) {
+      it(`template ${template.name} should compile with tsc`, async () => {
+        const previousCwd = process.cwd();
+        try {
+          process.chdir(template.path);
+
+          // We run tsc --noEmit in the template, which will throw it it fails
+          const result = spawnSync("pnpm tsc --noEmit", {
+            stdio: "inherit",
+            shell: true,
+          });
+
+          assert.equal(result.status, 0, "Template failed to compile");
+        } finally {
+          process.chdir(previousCwd);
+        }
+      });
     }
   });
 });

--- a/v-next/hardhat/test/internal/cli/init/template.ts
+++ b/v-next/hardhat/test/internal/cli/init/template.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { describe, it } from "node:test";
-import { spawnSync } from "node:child_process";
 
 import { exists } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -34,7 +34,7 @@ describe("getTemplates", () => {
   });
 });
 
-describe.only("template contents", () => {
+describe("template contents", () => {
   describe("templates should have valid typescript", async () => {
     const templates = await getTemplates();
 
@@ -44,13 +44,28 @@ describe.only("template contents", () => {
         try {
           process.chdir(template.path);
 
-          // We run tsc --noEmit in the template, which will throw it it fails
-          const result = spawnSync("pnpm tsc --noEmit", {
+          const resultHardhatBuild = spawnSync("pnpm hardhat compile", {
             stdio: "inherit",
             shell: true,
           });
 
-          assert.equal(result.status, 0, "Template failed to compile");
+          assert.equal(
+            resultHardhatBuild.status,
+            0,
+            "Template failed to compile contracts",
+          );
+
+          // We run tsc --noEmit in the template, which will throw it it fails
+          const resultTscBuild = spawnSync("pnpm tsc --noEmit", {
+            stdio: "inherit",
+            shell: true,
+          });
+
+          assert.equal(
+            resultTscBuild.status,
+            0,
+            "Template failed to compile its TypeScript",
+          );
         } finally {
           process.chdir(previousCwd);
         }


### PR DESCRIPTION
This PR introduces a few changes:

- It adds tests that compile the sample projects, and fail if they fail to compile
- It fixes all the compilation failures (which were related to the change in the network.connect API)
- It improves the ethers template a bit, so that it looks nicer
- It fixes the dependencies in the templates. `hardhat-ignition` and `hardhat-ethers` need to be installed explicitly.