### PR TITLE
Fix typechain factories for abstract contracts

### DIFF
--- a/.changeset/nervous-cherries-switch.md
+++ b/.changeset/nervous-cherries-switch.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-typechain": patch
+---
+
+Fix an issue with abstract contracts' factories

--- a/v-next/hardhat-typechain/src/internal/generate-types.ts
+++ b/v-next/hardhat-typechain/src/internal/generate-types.ts
@@ -154,7 +154,7 @@ export function addJsExtensionsIfNeeded(content: string): string {
 function addSupportForAttachMethod(modifiedContent: string): string {
   // Pattern to find the contract name in factory files
   // Factories of abstract contracts don't extend ContractFactory, so we skip
-  // them by adding "extends" in the
+  // them by adding "extends"
   const pattern = /class\s+(\w+)__factory extends/;
   const match = modifiedContent.match(pattern);
 

--- a/v-next/hardhat-typechain/src/internal/generate-types.ts
+++ b/v-next/hardhat-typechain/src/internal/generate-types.ts
@@ -152,7 +152,10 @@ export function addJsExtensionsIfNeeded(content: string): string {
 //   ...
 // }
 function addSupportForAttachMethod(modifiedContent: string): string {
-  const pattern = /class\s+(\w+)__factory/; // Pattern to find the contract name in factory files
+  // Pattern to find the contract name in factory files
+  // Factories of abstract contracts don't extend ContractFactory, so we skip
+  // them by adding "extends" in the
+  const pattern = /class\s+(\w+)__factory extends/;
   const match = modifiedContent.match(pattern);
 
   if (match === null) {

--- a/v-next/hardhat-typechain/test/fixture-projects/custom-out-dir/contracts/A.sol
+++ b/v-next/hardhat-typechain/test/fixture-projects/custom-out-dir/contracts/A.sol
@@ -6,3 +6,9 @@ contract A {
     return "Hello from A contract!";
   }
 }
+
+abstract contract B {
+  function getMessage() external pure returns (string memory) {
+    return "Hello from A contract!";
+  }
+}

--- a/v-next/hardhat-typechain/test/index.ts
+++ b/v-next/hardhat-typechain/test/index.ts
@@ -64,7 +64,7 @@ describe("hardhat-typechain", () => {
       assert.equal(content.includes(`import { ethers } from 'ethers'`), true);
     });
 
-    it("should generated types for the contracts and add the support for the `attach` method", async () => {
+    it("should generated types for the contracts and add the support for the `attach` method for concrete contracts", async () => {
       const content = await readUtf8File(
         path.join(
           process.cwd(),
@@ -85,6 +85,30 @@ describe("hardhat-typechain", () => {
       assert.equal(
         content.includes(`override attach(address: string | Addressable): A {`),
         true,
+      );
+    });
+
+    it("should notgenerated types for the contracts and do not add the support for the `attach` method for abstract contracts", async () => {
+      const content = await readUtf8File(
+        path.join(
+          process.cwd(),
+          "types",
+          "ethers-contracts",
+          "factories",
+          "A__factory.ts",
+        ),
+      );
+
+      // The "Addressable" type should be imported
+      assert.equal(
+        content.includes(`import type { Addressable } from "ethers";`),
+        true,
+      );
+
+      // The "attach" method should not be added to the factory of an abstract contract
+      assert.equal(
+        content.includes(`override attach(address: string | Addressable): B {`),
+        false,
       );
     });
   });


### PR DESCRIPTION
This PR fixes the issue that was leading to errors when running `pnpm build` in the `example-project` after compiling the contracts.

The root of the problem is that typechain generates contract factories for abstract contracts, but they don't extend `ContractFactory`. That made the `attach` fix to generate invalid code.

This PR restricts where we implement the attach fix, skipping abstract contracts.