### PR TITLE
Fix broken Abitopic link in docs

### DIFF
--- a/packages/hardhat-core/test/internal/hardhat-network/helpers/contracts.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/helpers/contracts.ts
@@ -190,7 +190,7 @@ contract Example {
       type: "event",
     },
   ],
-  // Computed with https://abitopic.now.sh/
+  // Computed with https://abitopic.io/
   selectors: {
     i: "0xe5aa3d58",
     j: "0xb582ec5f",


### PR DESCRIPTION
Hey! This PR updates all documentation references from `https://abitopic.now.sh/` to the active URL `https://abitopic.io`, ensuring users reach the correct live site.






