### PR TITLE
Fix #6613

### DIFF
--- a/.changeset/olive-suits-deny.md
+++ b/.changeset/olive-suits-deny.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Ignore top-level `.json` files the `artifacts` folder, as those are never actual artifacts.

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -279,7 +279,12 @@ Please replace "${contractNameOrFullyQualifiedName}" with the correct ${contract
 
     const allArtifactPaths = await getAllFilesMatching(
       this.#artifactsPath,
-      (p) => !p.startsWith(buildInfosDir) && p.endsWith(".json"),
+      (p) =>
+        p.endsWith(".json") && // Only consider json files
+        // Ignore top level json files
+        p.indexOf(path.sep, this.#artifactsPath.length + path.sep.length) !==
+          -1,
+      (dir) => dir !== buildInfosDir, // Ignore build infos directory
     );
 
     const allFullyQualifiedNames = new Set<string>();

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -598,11 +598,19 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       }
     }
 
+    const buildInfosDir = path.join(this.#options.artifactsPath, `build-info`);
+
+    // TODO: This logic is duplicated with respect to the artifacts manager
     const artifactPaths = await getAllFilesMatching(
       this.#options.artifactsPath,
-      (f) =>
-        !f.startsWith(path.join(this.#options.artifactsPath, "build-info")) &&
-        f.endsWith(".json"),
+      (p) =>
+        p.endsWith(".json") && // Only consider json files
+        // Ignore top level json files
+        p.indexOf(
+          path.sep,
+          this.#options.artifactsPath.length + path.sep.length,
+        ) !== -1,
+      (dir) => dir !== buildInfosDir,
     );
 
     const reachableBuildInfoIds = await Promise.all(
@@ -617,9 +625,8 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     );
 
     // Get all the reachable build info files
-    const buildInfoFiles = await getAllFilesMatching(
-      this.#options.artifactsPath,
-      (f) => f.startsWith(path.join(this.#options.artifactsPath, "build-info")),
+    const buildInfoFiles = await getAllFilesMatching(buildInfosDir, (f) =>
+      f.startsWith(buildInfosDir),
     );
 
     for (const buildInfoFile of buildInfoFiles) {


### PR DESCRIPTION
This PR fixes #6613 by ignoring all the top-level json files in the artifacts folder.

We need better tests for this part of the code. I'm sending this as a quickfix now though.