### PR TITLE
Cleanup text of changesets before release

### DIFF
--- a/.changeset/dull-frogs-wait.md
+++ b/.changeset/dull-frogs-wait.md
@@ -5,4 +5,4 @@
 "hardhat": patch
 ---
 
-Implemented a mechanism to automatically run tests using the appropriate test runner when none is explicitly specified
+Delegate from `npx hardhat test` to appropriate test runner when file test path provided ([#6616](https://github.com/NomicFoundation/hardhat/issues/6616))

--- a/.changeset/gorgeous-eyes-allow.md
+++ b/.changeset/gorgeous-eyes-allow.md
@@ -1,5 +1,0 @@
----
-"hardhat": patch
----
-
-Bump @ignored/edr to 0.10.0-alpha.3 which adds the ability to filter Solidity tests.

--- a/.changeset/mean-avocados-matter.md
+++ b/.changeset/mean-avocados-matter.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Add the ability to filter Solidity tests with `--grep`.
+Add the ability to filter Solidity tests with `--grep` ([#6690](https://github.com/NomicFoundation/hardhat/pull/6690))

--- a/.changeset/nervous-cherries-switch.md
+++ b/.changeset/nervous-cherries-switch.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-typechain": patch
 ---
 
-Fix an issue with abstract contracts' factories
+Fix an issue with abstract contracts' factories ([#6703](https://github.com/NomicFoundation/hardhat/pull/6703))

--- a/.changeset/olive-suits-deny.md
+++ b/.changeset/olive-suits-deny.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Ignore top-level `.json` files the `artifacts` folder, as those are never actual artifacts.
+Fix to ignore top-level `.json` files in the `artifacts` folder, as those are never actual artifacts ([#6613](https://github.com/NomicFoundation/hardhat/issues/6613))

--- a/.changeset/sixty-socks-roll.md
+++ b/.changeset/sixty-socks-roll.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/hardhat-utils": patch
----
-
-Add a `directoryFilter` param to `getAllFilesMatching`

--- a/.changeset/yellow-dolls-behave.md
+++ b/.changeset/yellow-dolls-behave.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Fixed an issue that prevented the creation of multiple duplicate accounts
+Fixed unintended deduplication of accounts ([#6707](https://github.com/NomicFoundation/hardhat/issues/6707))


### PR DESCRIPTION
Updating the text of the next release within the changesets (and adding references to issues):


## 3.0.0-next.9

### Patch Changes

- 458cc89: Delegate from `npx hardhat test` to appropriate test runner when file test path provided ([#6616](https://github.com/NomicFoundation/hardhat/issues/6616))
- d460644: Add the ability to filter Solidity tests with `--grep` ([#6690](https://github.com/NomicFoundation/hardhat/pull/6690))
- 918df12: Fix an issue with abstract contracts' factories ([#6703](https://github.com/NomicFoundation/hardhat/pull/6703))
- ad1d08b: Fix to ignore top-level `.json` files in the `artifacts` folder, as those are never actual artifacts ([#6613](https://github.com/NomicFoundation/hardhat/issues/6613))
- 624ba10: Fixed unintended deduplication of accounts ([#6707](https://github.com/NomicFoundation/hardhat/issues/6707))

