### PR TITLE
add readme for viem matchers

### DIFF
--- a/.changeset/sixty-beans-pretend.md
+++ b/.changeset/sixty-beans-pretend.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/hardhat-viem-matchers": patch
+"@nomicfoundation/hardhat-toolbox-viem": patch
+"hardhat": patch
+---
+
+Add a new Hardhat assertion plugin for `viem` ([#6574](https://github.com/NomicFoundation/hardhat/pull/6574))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1185,6 +1185,9 @@ importers:
       '@nomicfoundation/hardhat-viem':
         specifier: workspace:^3.0.0-next.11
         version: link:../hardhat-viem
+      '@nomicfoundation/hardhat-viem-matchers':
+        specifier: workspace:^3.0.0-next.11
+        version: link:../hardhat-viem-matchers
       '@nomicfoundation/ignition-core':
         specifier: workspace:^3.0.0-next.11
         version: link:../hardhat-ignition-core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@nomicfoundation/hardhat-viem':
         specifier: workspace:^3.0.0-next.11
         version: link:../hardhat-viem
+      '@nomicfoundation/hardhat-viem-matchers':
+        specifier: workspace:^3.0.0-next.11
+        version: link:../hardhat-viem-matchers
       '@nomicfoundation/ignition-core':
         specifier: workspace:^3.0.0-next.11
         version: link:../hardhat-ignition-core

--- a/v-next/example-project/contracts/FailingContract.sol
+++ b/v-next/example-project/contracts/FailingContract.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+pragma solidity *;
+
+contract FailingContract {
+  error CustomError();
+  error CustomErrorWithUintAndString(uint, string);
+
+  function fail() public pure {
+    innerRevert();
+  }
+
+  function innerRevert() internal pure {
+    revert("Revert Message");
+  }
+
+  function failByRevertWithCustomError() external pure {
+    revert CustomError();
+  }
+
+  function failByRevertWithCustomErrorWithUintAndString(
+    uint n,
+    string memory s
+  ) external pure {
+    revert CustomErrorWithUintAndString(n, s);
+  }
+}

--- a/v-next/example-project/contracts/Rocket.sol
+++ b/v-next/example-project/contracts/Rocket.sol
@@ -5,6 +5,9 @@ contract Rocket {
   string public name;
   string public status;
 
+  event LaunchWithoutArgs();
+  event LaunchWithTwoStringArgs(string u, string v);
+
   constructor(string memory _name) {
     name = _name;
     status = "ignition";
@@ -12,5 +15,8 @@ contract Rocket {
 
   function launch() public {
     status = "lift-off";
+
+    emit LaunchWithoutArgs();
+    emit LaunchWithTwoStringArgs(name, status);
   }
 }

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -8,6 +8,7 @@ import HardhatNodeTestRunner from "@nomicfoundation/hardhat-node-test-runner";
 import HardhatMochaTestRunner from "@nomicfoundation/hardhat-mocha";
 import HardhatKeystore from "@nomicfoundation/hardhat-keystore";
 import HardhatViem from "@nomicfoundation/hardhat-viem";
+import HardhatViemMatchers from "@nomicfoundation/hardhat-viem-matchers";
 import hardhatNetworkHelpersPlugin from "@nomicfoundation/hardhat-network-helpers";
 import hardhatEthersPlugin from "@nomicfoundation/hardhat-ethers";
 import hardhatChaiMatchersPlugin from "@nomicfoundation/hardhat-ethers-chai-matchers";
@@ -156,6 +157,7 @@ const config: HardhatUserConfig = {
     hardhatNetworkHelpersPlugin,
     HardhatNodeTestRunner,
     HardhatViem,
+    HardhatViemMatchers,
     hardhatChaiMatchersPlugin,
     hardhatTypechain,
     hardhatIgnitionViem,

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -36,6 +36,7 @@
     "@nomicfoundation/hardhat-node-test-runner": "workspace:^3.0.0-next.11",
     "@nomicfoundation/hardhat-typechain": "workspace:^3.0.0-next.11",
     "@nomicfoundation/hardhat-viem": "workspace:^3.0.0-next.11",
+    "@nomicfoundation/hardhat-viem-matchers": "workspace:^3.0.0-next.11",
     "@openzeppelin/contracts": "5.1.0",
     "@types/chai": "^4.2.0",
     "@types/mocha": ">=10.0.10",

--- a/v-next/example-project/test/node/example-test-of-assertions.ts
+++ b/v-next/example-project/test/node/example-test-of-assertions.ts
@@ -1,0 +1,82 @@
+import { describe, it, before } from "node:test";
+import hre from "hardhat";
+import { ContractReturnType } from "@nomicfoundation/hardhat-viem/types";
+
+const { viem } = await hre.network.connect();
+
+describe("Example EDR based test", () => {
+  describe("revert", () => {
+    let failingContract: ContractReturnType<"FailingContract">;
+
+    before(async () => {
+      failingContract = await viem.deployContract("FailingContract");
+    });
+
+    it("should support checking that a transaction reverts", async () => {
+      await viem.assertions.revert(failingContract.read.fail());
+    });
+
+    it("should support checking that a transaction reverts with a specific message", async () => {
+      await viem.assertions.revertWith(
+        failingContract.read.fail(),
+        "Revert Message",
+      );
+    });
+
+    it("should support checking that a transaction reverts with a custom error and specific arguments", async () => {
+      await viem.assertions.revertWithCustomErrorWithArgs(
+        failingContract.read.failByRevertWithCustomErrorWithUintAndString([
+          10n,
+          "example",
+        ]),
+        failingContract,
+        "CustomErrorWithUintAndString",
+        [10n, "example"],
+      );
+    });
+  });
+
+  describe("Events", () => {
+    it("should support detecting an emitted event", async () => {
+      const rocketContract = await viem.deployContract("Rocket", ["Apollo"]);
+
+      await viem.assertions.emit(
+        rocketContract.write.launch(),
+        rocketContract,
+        "LaunchWithoutArgs",
+      );
+    });
+
+    it("should support detecting an emitted events arguments", async () => {
+      const rocketContract = await viem.deployContract("Rocket", ["Apollo"]);
+
+      await viem.assertions.emitWithArgs(
+        rocketContract.write.launch(),
+        rocketContract,
+        "LaunchWithTwoStringArgs",
+        ["Apollo", "lift-off"],
+      );
+    });
+  });
+
+  it("should support detecting a change of balance", async () => {
+    const [bobWalletClient, aliceWalletClient] = await viem.getWalletClients();
+
+    await viem.assertions.balancesHaveChanged(
+      bobWalletClient.sendTransaction({
+        to: aliceWalletClient.account.address,
+        value: 3333333333333333n,
+      }),
+      [
+        {
+          address: aliceWalletClient.account.address,
+          amount: 3333333333333333n,
+        },
+        {
+          address: bobWalletClient.account.address,
+          amount: -3333333333333333n,
+        },
+      ],
+    );
+  });
+});

--- a/v-next/example-project/tsconfig.json
+++ b/v-next/example-project/tsconfig.json
@@ -26,6 +26,9 @@
       "path": "../hardhat-viem"
     },
     {
+      "path": "../hardhat-viem-matchers"
+    },
+    {
       "path": "../hardhat-ethers-chai-matchers"
     },
     {

--- a/v-next/hardhat-toolbox-viem/package.json
+++ b/v-next/hardhat-toolbox-viem/package.json
@@ -53,6 +53,7 @@
     "@nomicfoundation/hardhat-node-test-runner": "workspace:^3.0.0-next.11",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@nomicfoundation/hardhat-viem": "workspace:^3.0.0-next.11",
+    "@nomicfoundation/hardhat-viem-matchers": "workspace:^3.0.0-next.11",
     "@nomicfoundation/ignition-core": "workspace:^3.0.0-next.11",
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
@@ -71,6 +72,7 @@
     "@nomicfoundation/hardhat-network-helpers": "workspace:^3.0.0-next.11",
     "@nomicfoundation/hardhat-node-test-runner": "workspace:^3.0.0-next.11",
     "@nomicfoundation/hardhat-viem": "workspace:^3.0.0-next.11",
+    "@nomicfoundation/hardhat-viem-matchers": "workspace:^3.0.0-next.11",
     "@nomicfoundation/ignition-core": "workspace:^3.0.0-next.11",
     "hardhat": "workspace:^3.0.0-next.11",
     "viem": "^2.30.0"

--- a/v-next/hardhat-toolbox-viem/src/index.ts
+++ b/v-next/hardhat-toolbox-viem/src/index.ts
@@ -35,6 +35,12 @@ const hardhatToolboxViemPlugin: HardhatPlugin = {
       );
       return hardhatViemPlugin;
     },
+    async () => {
+      const { default: hardhatViemMatchers } = await import(
+        "@nomicfoundation/hardhat-viem-matchers"
+      );
+      return hardhatViemMatchers;
+    },
   ],
   npmPackage: "@nomicfoundation/hardhat-toolbox-viem",
 };

--- a/v-next/hardhat-toolbox-viem/src/type-extensions.ts
+++ b/v-next/hardhat-toolbox-viem/src/type-extensions.ts
@@ -3,3 +3,4 @@ export type * from "@nomicfoundation/hardhat-keystore";
 export type * from "@nomicfoundation/hardhat-network-helpers";
 export type * from "@nomicfoundation/hardhat-node-test-runner";
 export type * from "@nomicfoundation/hardhat-viem";
+export type * from "@nomicfoundation/hardhat-viem-matchers";

--- a/v-next/hardhat-toolbox-viem/tsconfig.json
+++ b/v-next/hardhat-toolbox-viem/tsconfig.json
@@ -27,6 +27,9 @@
     },
     {
       "path": "../hardhat-viem"
+    },
+    {
+      "path": "../hardhat-viem-matchers"
     }
   ]
 }

--- a/v-next/hardhat-viem-matchers/README.md
+++ b/v-next/hardhat-viem-matchers/README.md
@@ -65,9 +65,7 @@ Several matchers are included to assert that a transaction reverted, and the rea
 Assert that a transaction reverted for any reason, without checking the cause of the revert:
 
 ```ts
-revert(
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
-): Promise<void>;
+await viem.assertions.revert(token.write.transfer([address, 0n]));
 ```
 
 #### `.revertWith`
@@ -75,16 +73,10 @@ revert(
 Assert that a transaction reverted with a specific reason string:
 
 ```ts
-revertWith(
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
-  expectedRevertReason: string,
-): Promise<void>;
-```
-
-You can also use regular expressions:
-
-```ts
-xxxx;
+await viem.assertions.revertWith(
+  token.write.transfer([address, 0n]),
+  "transfer value must be positive",
+);
 ```
 
 #### `.revertWithCustomError`
@@ -92,30 +84,26 @@ xxxx;
 Assert that a transaction reverted with a specific custom error:
 
 ```ts
-revertWithCustomError<ContractName extends CompiledContractName>(
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
-  contract: ContractReturnType<ContractName>,
-  customErrorName: string,
-): Promise<void>;
+await viem.assertions.revertWithCustomError(
+  token.write.transfer([address, 0n]),
+  token,
+  "InvalidTransferValue",
+);
 ```
 
-The first argument must be the contract that defines the error. The contract is used to determine the full signature of the expected error. The matcher does not check whether the error was emitted by the contract.
-
-If the error has arguments, the .withArgs matcher can be added:
-
-xxx
+The second argument must be the contract that defines the error. The contract is used to determine the full signature of the expected error. The matcher does not check whether the error was emitted by the contract.
 
 #### `.revertWithCustomErrorWithArgs`
 
 Assert that a transaction reverted with a custom error and specific arguments:
 
 ```ts
-revertWithCustomErrorWithArgs<ContractName extends CompiledContractName>(
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
-  contract: ContractReturnType<ContractName>,
-  customErrorName: string,
-  args: any[],
-): Promise<void>;
+await viem.assertions.revertWithCustomErrorWithArgs(
+  token.write.transfer([address, 0n]),
+  token,
+  "InvalidTransferValue",
+  [0n],
+);
 ```
 
 ### Events
@@ -125,16 +113,11 @@ revertWithCustomErrorWithArgs<ContractName extends CompiledContractName>(
 Assert that a transaction emits a specific event:
 
 ```ts
-emit<
-  ContractName extends CompiledContractName,
-  EventName extends ContractName extends keyof ContractAbis
-    ? ContractEventName<ContractAbis[ContractName]>
-    : string,
->(
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
-  contract: ContractReturnType<ContractName>,
-  eventName: EventName,
-): Promise<void>;
+await viem.assertions.emit(
+  rocketContract.write.launch(),
+  rocketContract,
+  "LaunchEvent",
+);
 ```
 
 #### `.emitWithArgs`
@@ -142,17 +125,12 @@ emit<
 Assert that a transaction emits an event with specific arguments:
 
 ```ts
-emitWithArgs<
-  ContractName extends CompiledContractName,
-  EventName extends ContractName extends keyof ContractAbis
-    ? ContractEventName<ContractAbis[ContractName]>
-    : string,
->(
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
-  contract: ContractReturnType<ContractName>,
-  eventName: EventName,
-  args: any[],
-): Promise<void>;
+await viem.assertions.emitWithArgs(
+  rocketContract.write.launch(),
+  rocketContract,
+  "LaunchEventWithArgs",
+  ["Apollo", "lift-off"],
+);
 ```
 
 ### Balance change
@@ -164,11 +142,20 @@ These matchers can be used to assert how a given transaction affects the ether b
 Assert that a transaction changes the balance of specific addresses:
 
 ```ts
-balancesHaveChanged: (
-  resolvedTxHash: Promise<Hash>,
-  changes: Array<{
-    address: Address;
-    amount: bigint;
-  }>,
-) => Promise<void>;
+await viem.assertions.balancesHaveChanged(
+  bobWalletClient.sendTransaction({
+    to: aliceWalletClient.account.address,
+    value: 3333333333333333n,
+  }),
+  [
+    {
+      address: aliceWalletClient.account.address,
+      amount: 3333333333333333n,
+    },
+    {
+      address: bobWalletClient.account.address,
+      amount: -3333333333333333n,
+    },
+  ],
+);
 ```

--- a/v-next/hardhat-viem-matchers/README.md
+++ b/v-next/hardhat-viem-matchers/README.md
@@ -1,1 +1,174 @@
-# TODO
+# Hardhat Viem Matchers plugin
+
+This plugin adds an Ethereum-specific matchers assertion library that integrate with [viem](https://viem.sh/), making your smart contract tests easy to write and read.
+
+## Installation
+
+To install this plugin, run the following command:
+
+```bash
+npm install --save-dev @nomicfoundation/hardhat-viem-matchers@next
+```
+
+and add the following statements to your `hardhat.config.ts` file:
+
+```typescript
+// ...
+import viemMatchersPlugin from "@nomicfoundation/hardhat-viem-matchers";
+
+// ...
+
+export default {
+  // ...
+  plugins: [
+    // ...
+    viemMatchersPlugin,
+  ],
+
+  // ...
+};
+```
+
+## Usage
+
+You don't need to do anything else to use this plugin. Whenever you run your tests with Hardhat, it will automatically add the matchers to the `viem` object.
+
+Here is an example of using the `balancesHaveChanged` matcher:
+
+```ts
+const { viem } = await hre.network.connect();
+
+const [bobWalletClient, aliceWalletClient] = await viem.getWalletClients();
+
+await viem.assertions.balancesHaveChanged(
+  bobWalletClient.sendTransaction({
+    to: aliceWalletClient.account.address,
+    value: 3333333333333333n,
+  }),
+  [
+    {
+      address: aliceWalletClient.account.address,
+      amount: 3333333333333333n,
+    },
+  ],
+);
+```
+
+## Reference
+
+### Reverted transactions
+
+Several matchers are included to assert that a transaction reverted, and the reason of the revert.
+
+#### `.revert`
+
+Assert that a transaction reverted for any reason, without checking the cause of the revert:
+
+```ts
+revert(
+  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+): Promise<void>;
+```
+
+#### `.revertWith`
+
+Assert that a transaction reverted with a specific reason string:
+
+```ts
+revertWith(
+  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+  expectedRevertReason: string,
+): Promise<void>;
+```
+
+You can also use regular expressions:
+
+```ts
+xxxx;
+```
+
+#### `.revertWithCustomError`
+
+Assert that a transaction reverted with a specific custom error:
+
+```ts
+revertWithCustomError<ContractName extends CompiledContractName>(
+  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+  contract: ContractReturnType<ContractName>,
+  customErrorName: string,
+): Promise<void>;
+```
+
+The first argument must be the contract that defines the error. The contract is used to determine the full signature of the expected error. The matcher does not check whether the error was emitted by the contract.
+
+If the error has arguments, the .withArgs matcher can be added:
+
+xxx
+
+#### `.revertWithCustomErrorWithArgs`
+
+Assert that a transaction reverted with a custom error and specific arguments:
+
+```ts
+revertWithCustomErrorWithArgs<ContractName extends CompiledContractName>(
+  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+  contract: ContractReturnType<ContractName>,
+  customErrorName: string,
+  args: any[],
+): Promise<void>;
+```
+
+### Events
+
+#### `.emit`
+
+Assert that a transaction emits a specific event:
+
+```ts
+emit<
+  ContractName extends CompiledContractName,
+  EventName extends ContractName extends keyof ContractAbis
+    ? ContractEventName<ContractAbis[ContractName]>
+    : string,
+>(
+  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+  contract: ContractReturnType<ContractName>,
+  eventName: EventName,
+): Promise<void>;
+```
+
+#### `.emitWithArgs`
+
+Assert that a transaction emits an event with specific arguments:
+
+```ts
+emitWithArgs<
+  ContractName extends CompiledContractName,
+  EventName extends ContractName extends keyof ContractAbis
+    ? ContractEventName<ContractAbis[ContractName]>
+    : string,
+>(
+  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+  contract: ContractReturnType<ContractName>,
+  eventName: EventName,
+  args: any[],
+): Promise<void>;
+```
+
+### Balance change
+
+These matchers can be used to assert how a given transaction affects the ether balance of a specific address.
+
+#### `.balancesHaveChanged`
+
+Assert that a transaction changes the balance of specific addresses:
+
+```ts
+balancesHaveChanged: (
+  resolvedTxHash: Promise<Hash>,
+  changes: Array<{
+    address: Address;
+    amount: bigint;
+  }>,
+) => Promise<void>;
+```


### PR DESCRIPTION
This PR adds a few elements to allow us to include the new `@nomicfoundation/hardhat-viem-matchers` plugin in the template projects:

1. It adds a basic README.md that shows basic usage of each assertion function.
2. It adds the plugin to the viem toolbox
3. It adds a changeset
4. It adds the plugin to the example project to ease manual testing

The `README.md` is roughly based on the chai matcher reference page of the docs: https://hardhat.org/hardhat-chai-matchers/docs/reference.

