### PR TITLE
fix: distribute coverage.sol inside hardhat package

### DIFF
--- a/.changeset/kind-bags-yawn.md
+++ b/.changeset/kind-bags-yawn.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Distribute coverage.sol as a part of the hardhat package

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -61,6 +61,7 @@
     "src/",
     "templates/",
     "console.sol",
+    "coverage.sol",
     "CHANGELOG.md",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

We need to include `coverage.sol` in the files included in the hardhat bundle.

If we don't include it in the bundle, then when hardhat is installed properly, then we don't have access to it.