### PR TITLE
Support grep on the npx hardhat test task

### DIFF
--- a/.changeset/spicy-grapes-crash.md
+++ b/.changeset/spicy-grapes-crash.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add support for `grep` in the Hardhat `test` task.

--- a/v-next/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -1,5 +1,6 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { ArgumentType } from "../../../types/arguments.js";
 import { task } from "../../core/config.js";
 
 import "./type-extensions.js";
@@ -11,6 +12,12 @@ const hardhatPlugin: HardhatPlugin = {
       .addFlag({
         name: "noCompile",
         description: "Don't compile the project before running the tests",
+      })
+      .addOption({
+        name: "grep",
+        description: "Only run tests matching the given string or regexp",
+        type: ArgumentType.STRING_WITHOUT_DEFAULT,
+        defaultValue: undefined,
       })
       .addVariadicArgument({
         name: "testFiles",

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -11,7 +11,7 @@ import { HardhatRuntimeEnvironmentImplementation } from "../../core/hre.js";
 interface TestActionArguments {
   testFiles: string[];
   noCompile: boolean;
-  grep: string;
+  grep: string | undefined;
 }
 
 const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
@@ -50,11 +50,17 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
       continue;
     }
 
+    const args = {
+      testFiles: files,
+      noCompile: false,
+      grep,
+    };
+
     if (subtask.options.has("noCompile")) {
-      await subtask.run({ testFiles: files, noCompile: true, grep });
-    } else {
-      await subtask.run({ testFiles: files, grep });
+      args.noCompile = true;
     }
+
+    await subtask.run(args);
   }
 
   if (hre.globalOptions.coverage === true) {

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -11,10 +11,11 @@ import { HardhatRuntimeEnvironmentImplementation } from "../../core/hre.js";
 interface TestActionArguments {
   testFiles: string[];
   noCompile: boolean;
+  grep: string;
 }
 
 const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
-  { testFiles, noCompile },
+  { testFiles, noCompile, grep },
   hre,
 ) => {
   // If this code is executed, it means the user has not specified a test runner.
@@ -50,9 +51,9 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
     }
 
     if (subtask.options.has("noCompile")) {
-      await subtask.run({ testFiles: files, noCompile: true });
+      await subtask.run({ testFiles: files, noCompile: true, grep });
     } else {
-      await subtask.run({ testFiles: files });
+      await subtask.run({ testFiles: files, grep });
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/hardhat/issues/6726

Usage examples:
```
// no test runner specified, no file paths specified
pnpm hardhat test --grep "Other example"

// no test runner specified, file paths specified
pnpm hardhat test --grep "Other example"  test/node/*

// test runner specified, no file paths specified
pnpm hardhat test node --grep "Other example" 
```