### PR TITLE
Warn on usage of verbose foundry flag for solidity tests

### DIFF
--- a/.changeset/wild-flowers-greet.md
+++ b/.changeset/wild-flowers-greet.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Message on usage of verbose foundry flag for solidity tests (#6444)

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -12,6 +12,7 @@ import {
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
 import { readClosestPackageJson } from "@nomicfoundation/hardhat-utils/package";
 import { kebabToCamelCase } from "@nomicfoundation/hardhat-utils/string";
+import chalk from "chalk";
 import debug from "debug";
 import { register } from "tsx/esm/api";
 
@@ -194,7 +195,26 @@ export async function main(
 
     await Promise.all([task.run(taskArguments), sendTaskAnalytics(task.id)]);
   } catch (error) {
-    printErrorMessages(error, builtinGlobalOptions?.showStackTraces);
+    // TODO: Remove after -v, -vv etc are implemented
+    if (
+      (HardhatError.isHardhatError(
+        error,
+        HardhatError.ERRORS.CORE.SOLIDITY.RESOLVING_NONEXISTENT_PROJECT_FILE,
+      ) ||
+        HardhatError.isHardhatError(
+          error,
+          HardhatError.ERRORS.CORE.TEST_PLUGIN.CANNOT_DETERMINE_TEST_RUNNER,
+        )) &&
+      /-v+/.test(error.message)
+    ) {
+      console.error(
+        chalk.red(
+          `\nSupport for verbose test output will be added soon. Please re-run this command without the flag.\n`,
+        ),
+      );
+    } else {
+      printErrorMessages(error, builtinGlobalOptions?.showStackTraces);
+    }
 
     if (error instanceof Error) {
       try {


### PR DESCRIPTION
Closes #6444

When -v, -vv, etc, flags are detected when passed to the `test` or `test solidity` task, we  fail and show a message