### PR TITLE
Better default `package.json` on `--init`

### DIFF
--- a/v-next/hardhat/src/internal/cli/init/init.ts
+++ b/v-next/hardhat/src/internal/cli/init/init.ts
@@ -272,10 +272,13 @@ export async function validatePackageJson(
 
   // Create the package.json file if it does not exist
   if (!(await exists(absolutePathToPackageJson))) {
-    await writeJsonFile(absolutePathToPackageJson, {
-      name: "hardhat-project",
+    const packageJson: PackageJson = {
+      name: path.basename(workspace),
       type: "module",
-    });
+      version: "1.0.0",
+    };
+
+    await writeJsonFile(absolutePathToPackageJson, packageJson);
   }
 
   const pkg: PackageJson = await readJsonFile(absolutePathToPackageJson);

--- a/v-next/hardhat/test/internal/cli/init/template.ts
+++ b/v-next/hardhat/test/internal/cli/init/template.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { describe, it } from "node:test";
 
-import { exists } from "@nomicfoundation/hardhat-utils/fs";
+import { exists, remove } from "@nomicfoundation/hardhat-utils/fs";
 
 import { getTemplates } from "../../../../src/internal/cli/init/template.js";
 
@@ -41,9 +41,9 @@ describe("template contents", () => {
     for (const template of templates) {
       it(`template ${template.name} should compile with tsc`, async () => {
         const previousCwd = process.cwd();
-        try {
-          process.chdir(template.path);
+        process.chdir(template.path);
 
+        try {
           const resultHardhatBuild = spawnSync("pnpm hardhat compile", {
             stdio: "inherit",
             shell: true,
@@ -67,6 +67,11 @@ describe("template contents", () => {
             "Template failed to compile its TypeScript",
           );
         } finally {
+          // Remove all the files that `hardhat compile` may have created
+          await remove(path.join(template.path, "artifacts"));
+          await remove(path.join(template.path, "cache"));
+          await remove(path.join(template.path, "types"));
+
           process.chdir(previousCwd);
         }
       });


### PR DESCRIPTION
This PR improves the default `package.json` that we create on `--init` in two ways:

1) It's name is based on the folder name, just like npm does.
2) We set a default version (i.e. `1.0.0`)

These two changes allow us to tell people to directly use `npx hardhat@next --init` to initialize a project.

This PR also fixes an unrelated test.