### PR TITLE
fix: pass buildProfile to getCompilationJobs

### DIFF
--- a/v-next/hardhat-verify/src/internal/artifacts.ts
+++ b/v-next/hardhat-verify/src/internal/artifacts.ts
@@ -62,10 +62,12 @@ export async function getCompilerInput(
   solidity: SolidityBuildSystem,
   rootFilePath: string,
   sourceName: string,
+  buildProfile: string,
 ): Promise<CompilerInput> {
   const compilationJob = await solidity.getCompilationJobs(
     [path.join(rootFilePath, sourceName)],
     {
+      buildProfile,
       quiet: true,
     },
   );

--- a/v-next/hardhat-verify/src/internal/verification.ts
+++ b/v-next/hardhat-verify/src/internal/verification.ts
@@ -199,6 +199,7 @@ Explorer: ${etherscan.getContractUrl(address)}
     solidity,
     config.paths.root,
     contractInformation.sourceName,
+    buildProfileName,
   );
 
   const { success: minimalInputVerificationSuccess } =


### PR DESCRIPTION
The build profile was not being passed to the `getCompilerInput`, making the results invalid.