### PR TITLE
test: re-enable toolbox test

### DIFF
--- a/v-next/hardhat-toolbox-mocha-ethers/test/index.ts
+++ b/v-next/hardhat-toolbox-mocha-ethers/test/index.ts
@@ -11,8 +11,7 @@ describe("hardhat-toolbox-mocha-ethers", function () {
   describe("all the expected plugins are available", function () {
     useFixtureProject("toolbox");
 
-    // TODO: This test should be brought back once an intermittent bug in EDR is resolved
-    it.skip("should not throw because all the plugins should exist", async function () {
+    it("should not throw because all the plugins should exist", async function () {
       const hardhatConfig = await import(
         pathToFileURL(path.join(process.cwd(), "hardhat.config.js")).href
       );


### PR DESCRIPTION
A change in EDR lets us run this test consistently in our CI.

Resolves #6627.
