### PR TITLE
fix: use production build profile by default

### DIFF
--- a/v-next/hardhat-verify/src/internal/artifacts.ts
+++ b/v-next/hardhat-verify/src/internal/artifacts.ts
@@ -62,12 +62,12 @@ export async function getCompilerInput(
   solidity: SolidityBuildSystem,
   rootFilePath: string,
   sourceName: string,
-  buildProfile: string,
+  buildProfileName: string,
 ): Promise<CompilerInput> {
   const compilationJob = await solidity.getCompilationJobs(
     [path.join(rootFilePath, sourceName)],
     {
-      buildProfile,
+      buildProfile: buildProfileName,
       quiet: true,
     },
   );

--- a/v-next/hardhat-verify/src/internal/verification.ts
+++ b/v-next/hardhat-verify/src/internal/verification.ts
@@ -66,7 +66,7 @@ export async function verifyContract(
   const {
     artifacts,
     config,
-    globalOptions: { buildProfile: buildProfileName },
+    globalOptions: { buildProfile: buildProfileName = "production" },
     network,
     solidity,
   } = hre;
@@ -88,7 +88,9 @@ export async function verifyContract(
     // provider
   } = verifyContractArgs;
 
-  const buildProfile = config.solidity.profiles[buildProfileName ?? "default"];
+  const buildProfile = config.solidity.profiles[buildProfileName];
+  // The "production" build profile is always present by default.
+  // This check only fails if the user specifies a non-existent build profile name.
   if (buildProfile === undefined) {
     throw new HardhatError(
       HardhatError.ERRORS.CORE.SOLIDITY.BUILD_PROFILE_NOT_FOUND,


### PR DESCRIPTION
Set "production" as the default build profile if `--build-profile` isn't specified.