### PR TITLE
chore: add Zoey and Armando to issue assigner

### DIFF
--- a/.github/workflows/autoassign-issues.yml
+++ b/.github/workflows/autoassign-issues.yml
@@ -15,9 +15,11 @@ jobs:
           script: |
             // each user has a chance of (p - (previousP ?? 0)) to be assigned
             const potentialAssignees = [
-              ["kanej", 1/4],
-              ["schaable", 2/4],
-              ["galargh", 3/4],
+              ["kanej", 1/6],
+              ["schaable", 2/6],
+              ["galargh", 3/6],
+              ["zoeyTM", 4/6],
+              ["antico5", 5/6],
               ["ChristopherDedominici", 1.0],
             ];
 


### PR DESCRIPTION
As Ignition has been folded into the Hardhat repo most new Ignition issues are coming from Hardhat.

