### PR TITLE
Revert "chore(regression-tests): unignore testBumpSlot"

### DIFF
--- a/.github/config/regression-tests.yml
+++ b/.github/config/regression-tests.yml
@@ -439,6 +439,10 @@ repositories:
       test/WebAuthn.t.sol
 
       # https://github.com/NomicFoundation/hardhat/issues/6509
+      # testBumpSlot(bytes32,uint256): Unknown error
+      test/LibStorage.t.sol
+
+      # https://github.com/NomicFoundation/hardhat/issues/6509
       # testTargetGenerate(): Transaction reverted: contract call run out of gas and made the transaction revert
       test/DeploylessPredeployQueryer.t.sol
     ref: c9e079c0ca836dcc52777a1fa7227ef28e3537b3

--- a/.github/config/regression-tests.yml
+++ b/.github/config/regression-tests.yml
@@ -438,7 +438,7 @@ repositories:
       test/P256.t.sol
       test/WebAuthn.t.sol
 
-      # https://github.com/NomicFoundation/hardhat/issues/6509
+      # This test is flaky - no action required 
       # testBumpSlot(bytes32,uint256): Unknown error
       test/LibStorage.t.sol
 


### PR DESCRIPTION
Reverts NomicFoundation/hardhat#6800

It turns out that the test is just flaky. See this run for example: https://github.com/NomicFoundation/hardhat/actions/runs/15506491633

It passed on macos but failed on linux and windows.