### PR TITLE
fix: check the --no-commit flag is supported on installed forge version

### DIFF
--- a/.changeset/fruity-brooms-stare.md
+++ b/.changeset/fruity-brooms-stare.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-foundry": patch
+---
+
+When running forge install, check the --no-commit flag is supported on installed forge version

--- a/.changeset/fruity-brooms-stare.md
+++ b/.changeset/fruity-brooms-stare.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-foundry": patch
 ---
 
-When running forge install, check the --no-commit flag is supported on installed forge version
+Fixed a bug in the `init-foundry` task that prevented it from being used with the latest versions of `forge`

--- a/packages/hardhat-foundry/src/foundry.ts
+++ b/packages/hardhat-foundry/src/foundry.ts
@@ -74,7 +74,14 @@ export async function getRemappings() {
 }
 
 export async function installDependency(dependency: string) {
-  const cmd = `forge install --no-commit ${dependency}`;
+  // Check if --no-commit flag is supported. Best way is checking the help text
+  const helpText = await runCmd("forge install --help");
+  const useNoCommitFlag = helpText.includes("--no-commit");
+
+  const cmd = `forge install ${
+    useNoCommitFlag ? "--no-commit" : ""
+  } ${dependency}`;
+
   console.log(`Running '${picocolors.blue(cmd)}'`);
 
   try {


### PR DESCRIPTION
Closes #6824 

Up to version 1.0.0 of foundry, the `--no-commit` flag is mandatory on our usage of `forge install`. From `1.1.0` onwards, it's mandatory to not use it. The simplest way to detect this for me is to just run `forge install --help` and see if the `--no-commit` flag is there.