### PR TITLE
Communication via socket for test child processes' user interruptions

### DIFF
--- a/.changeset/strong-adults-knock.md
+++ b/.changeset/strong-adults-knock.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-runner": patch
+---
+
+Allow user input on test child processes via socket communication with runner process

--- a/v-next/hardhat-node-test-runner/src/hookHandlers/user-interruptions.ts
+++ b/v-next/hardhat-node-test-runner/src/hookHandlers/user-interruptions.ts
@@ -1,0 +1,28 @@
+import type { HookContext, UserInterruptionHooks } from "hardhat/types/hooks";
+
+import { isChildTestProcess, TestProtocolClient } from "../protocol.js";
+
+export default async (): Promise<Partial<UserInterruptionHooks>> => {
+  const handlers: Partial<UserInterruptionHooks> = {
+    requestSecretInput: async (
+      context: HookContext,
+      interruptor: string,
+      inputDescription: string,
+      next: (
+        nextContext: HookContext,
+        nextInterruptor: string,
+        nextInputDescription: string,
+      ) => Promise<string>,
+    ) => {
+      // Test child processes cannot deal with user input, so we request the main runner process via sockets
+      if (isChildTestProcess()) {
+        const client = new TestProtocolClient();
+        return client.requestSecretInput(interruptor, inputDescription);
+      } else {
+        return next(context, interruptor, inputDescription);
+      }
+    },
+  };
+
+  return handlers;
+};

--- a/v-next/hardhat-node-test-runner/src/index.ts
+++ b/v-next/hardhat-node-test-runner/src/index.ts
@@ -34,6 +34,9 @@ const hardhatPlugin: HardhatPlugin = {
   hookHandlers: {
     config: import.meta.resolve("./hookHandlers/config.js"),
     test: import.meta.resolve("./hookHandlers/test.js"),
+    userInterruptions: import.meta.resolve(
+      "./hookHandlers/user-interruptions.js",
+    ),
   },
   npmPackage: "@nomicfoundation/hardhat-node-test-runner",
 };

--- a/v-next/hardhat-node-test-runner/src/protocol.ts
+++ b/v-next/hardhat-node-test-runner/src/protocol.ts
@@ -1,0 +1,148 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
+
+import fs from "node:fs";
+import net from "node:net";
+import * as os from "node:os";
+
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+
+function getSocketPath(): string {
+  if (os.platform() === "win32") {
+    return "\\\\.\\pipe\\hardhat_node_test";
+  } else {
+    return "/tmp/hardhat_node_test.sock";
+  }
+}
+
+export function isChildTestProcess(): boolean {
+  return process.env.NODE_TEST_CONTEXT !== undefined;
+}
+
+export class TestProtocolClient {
+  readonly #socketPath: string;
+
+  constructor() {
+    this.#socketPath = getSocketPath();
+  }
+
+  public async requestSecretInput(
+    interruptor: string,
+    inputDescription: string,
+  ): Promise<string> {
+    const response = await this.#request({
+      type: "requestSecretInput",
+      params: { interruptor, inputDescription },
+    });
+
+    assertHardhatInvariant(
+      response.type === "secretInputResponse",
+      "Expected response to be a secretInputResponse",
+    );
+
+    const { secretInput } = response.params;
+
+    return secretInput;
+  }
+
+  async #request(msg: Message): Promise<Message> {
+    return new Promise((resolve) => {
+      const socket = net.createConnection(this.#socketPath, () => {
+        socket.write(JSON.stringify(msg));
+      });
+
+      socket.on("data", (data) => {
+        const message = JSON.parse(data.toString());
+        socket.end();
+        resolve(message);
+      });
+    });
+  }
+}
+
+export class TestProtocolServer {
+  readonly #socketPath: string;
+  #server?: net.Server;
+  readonly #secretInputCache: Map<string, string> = new Map();
+  readonly #hre: HardhatRuntimeEnvironment;
+
+  constructor(hre: HardhatRuntimeEnvironment) {
+    this.#hre = hre;
+    this.#socketPath = getSocketPath();
+  }
+
+  public start(): void {
+    if (process.platform !== "win32" && fs.existsSync(this.#socketPath)) {
+      fs.unlinkSync(this.#socketPath); // remove stale socket
+    }
+
+    this.#server = net.createServer((socket) => {
+      socket.on("data", async (data) => {
+        await this.#handleData(socket, data);
+      });
+    });
+
+    this.#server.listen(this.#socketPath);
+  }
+
+  public end(): void {
+    this.#server?.close();
+  }
+
+  async #handleData(socket: net.Socket, data: Buffer): Promise<void> {
+    const message = this.#parseMessage(data);
+
+    if (message.type === "requestSecretInput") {
+      await this.#handleRequestSecretInput(socket, message);
+    }
+  }
+
+  async #handleRequestSecretInput(
+    socket: net.Socket,
+    message: RequestSecretInputMessage,
+  ): Promise<void> {
+    const { interruptor, inputDescription } = message.params;
+    const cacheKey = [interruptor, inputDescription].join();
+
+    let secretInput: string;
+
+    if (this.#secretInputCache.has(cacheKey)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- already checked presence
+      secretInput = this.#secretInputCache.get(cacheKey)!;
+    } else {
+      secretInput = await this.#hre.interruptions.requestSecretInput(
+        interruptor,
+        inputDescription,
+      );
+      this.#secretInputCache.set(cacheKey, secretInput);
+    }
+
+    await this.#send(socket, {
+      type: "secretInputResponse",
+      params: { secretInput },
+    });
+  }
+
+  async #send(socket: net.Socket, msg: Message): Promise<void> {
+    socket.write(JSON.stringify(msg));
+  }
+  #parseMessage(data: Buffer): Message {
+    return JSON.parse(data.toString());
+  }
+}
+
+export type Message = SecretInputResponseMessage | RequestSecretInputMessage;
+
+export interface SecretInputResponseMessage {
+  type: "secretInputResponse";
+  params: {
+    secretInput: string;
+  };
+}
+
+export interface RequestSecretInputMessage {
+  type: "requestSecretInput";
+  params: {
+    interruptor: string;
+    inputDescription: string;
+  };
+}


### PR DESCRIPTION
This is a WIP/exploration PR. Some feedback/polishing may be needed.

This addresses the issue where node test child processes can't deal with user input, which e.g. prevents users from typing the keystore master password.

This proposed solution uses a file socket to communicate between child test processes and the main process runner, so when they need user input (`requestSecretInput` hook for now), it gets forwarded to the main process and the response is sent back. 

This implementation is somewhat naive but has room for extension if it's approved. For now I added caching based on interrupter plugin and prompt, so the master password isn't requested once for each child process.