### PR TITLE
fix/node 24 module status 3

### DIFF
--- a/.changeset/tiny-feet-promise.md
+++ b/.changeset/tiny-feet-promise.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add support for running under Node 24 ([#6792](https://github.com/NomicFoundation/hardhat/issues/6792))

--- a/v-next/hardhat-utils/src/subprocess.ts
+++ b/v-next/hardhat-utils/src/subprocess.ts
@@ -33,7 +33,7 @@ export async function spawnDetachedSubProcess(
   const subprocessArgs = [absolutePathToSubProcessFile, ...args];
 
   if (absolutePathToSubProcessFile.endsWith(".ts")) {
-    subprocessArgs.unshift("--import", "tsx/esm");
+    subprocessArgs.unshift("--import", import.meta.resolve("tsx/esm"));
   }
 
   const subprocess = spawn(process.execPath, subprocessArgs, {


### PR DESCRIPTION
Apply the `import.meta.resolve` fix to another instance of `tsx/esm` import.

This issue was discovered in manual testing of Node 24 against the release. I applied this fix and retested against Verdaccio. I then retested with a fresh install into verdaccio:

* viem stack
  * `npx hardhat compile`
  * `npx hardhat test`
  * `npx hardhat test node`
  * `npx hardhat test node --coverage`
  * `npx hardhat test node --grep inc`
  * `npx hardhat keystore list`
  * `npx hardhat keystore get MY_KEY`
  * `npx hardhat run scripts/check-predeploy.ts`
  * `npx hardhat run scripts/send-op-tx.ts`
  * `npx hardhat ignition deploy ./ignition/modules/Counter.ts`
  * `npx hardhat node` in other terminal `npx hardhat ignition deploy ./ignition/modules/Counter.ts --network localhost`
  * `npx hardhat clean`
  * `npx hardhat console`
* ethers stack
  * `npx hardhat compile`
  * `npx hardhat test`
  * `npx hardhat test mocha`
  * `npx hardhat test mocha --coverage`
  * `npx hardhat test mocha --grep inc`
  * `npx hardhat keystore list`
  * `npx hardhat keystore get MY_KEY`
  * `npx hardhat run scripts/check-predeploy.ts`
  * `npx hardhat run scripts/send-op-tx.ts`
  * `npx hardhat ignition deploy ./ignition/modules/Counter.ts`
  * `npx hardhat node` in other terminal `npx hardhat ignition deploy ./ignition/modules/Counter.ts --network localhost`
  * `npx hardhat clean`
  * `npx hardhat console`
