### PR TITLE
fix: treat `0x` as a valid value for `setCode`

### DIFF
--- a/.changeset/violet-laws-shout.md
+++ b/.changeset/violet-laws-shout.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Accept `0x` as a valid value for `setCode`, thanks @arr00 ([#6844](https://github.com/NomicFoundation/hardhat/pull/6844))

--- a/v-next/hardhat-network-helpers/src/internal/assertions.ts
+++ b/v-next/hardhat-network-helpers/src/internal/assertions.ts
@@ -5,7 +5,7 @@ import {
 } from "@nomicfoundation/hardhat-utils/eth";
 
 export function assertHexString(hexString: string): void {
-  if (typeof hexString !== "string" || !/^0x[0-9a-fA-F]+$/.test(hexString)) {
+  if (typeof hexString !== "string" || !/^0x[0-9a-fA-F]*$/.test(hexString)) {
     throw new HardhatError(
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_HEX_STRING,
       {

--- a/v-next/hardhat-network-helpers/test/network-helpers/set-code.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/set-code.ts
@@ -35,6 +35,12 @@ describe("network-helpers - setCode", () => {
     assert.equal(await getCode(provider, recipient), "0xa1a2a3");
   });
 
+  it("should allow setting the code of a given address to an empty string", async function () {
+    await networkHelpers.setCode(recipient, "0x");
+
+    assert.equal(await getCode(provider, recipient), "0x");
+  });
+
   describe("accepted parameter types for code", () => {
     it("should not accept strings that are not 0x-prefixed", async () => {
       await assertRejectsWithHardhatError(


### PR DESCRIPTION
This is based on a fix applied in main: https://github.com/NomicFoundation/hardhat/pull/6844
