### PR TITLE
[chore] Upgrade TS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "devDependencies": {
     "@changesets/cli": "^2.16.0",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "scripts": {
     "build": "pnpm run --recursive --if-present build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,8 +223,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -254,8 +254,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -309,8 +309,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -385,8 +385,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       mocha:
         specifier: ^11.0.0
         version: 11.1.0
@@ -846,8 +846,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -904,8 +904,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -947,8 +947,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -984,8 +984,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1036,8 +1036,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1070,8 +1070,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1149,8 +1149,8 @@ importers:
         specifier: ^6.14.0
         version: 6.14.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1213,8 +1213,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1283,8 +1283,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1344,8 +1344,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1411,8 +1411,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1454,8 +1454,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1503,8 +1503,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1543,8 +1543,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -1645,8 +1645,8 @@ importers:
         specifier: 9.25.1
         version: 9.25.1
       expect-type:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^1.2.1
+        version: 1.2.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5
@@ -3784,8 +3784,8 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
-  expect-type@0.19.0:
-    resolution: {integrity: sha512-piv9wz3IrAG4Wnk2A+n2VRCHieAyOSxrRLU872Xo6nyn39kYXKDALk4OcqnvLRnFvkz659CnWC8MWZLuuQnoqg==}
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
 
   extendable-error@0.1.7:
@@ -7898,7 +7898,7 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
-  expect-type@0.19.0: {}
+  expect-type@1.2.1: {}
 
   extendable-error@0.1.7: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.16.0
         version: 2.27.12
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/config:
     devDependencies:
@@ -34,7 +34,7 @@ importers:
         version: 4.3.4(eslint-plugin-import@2.31.0)(eslint@9.25.1)
       eslint-plugin-import:
         specifier: 2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.7.2))(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1)
+        version: 2.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1)
       eslint-plugin-no-only-tests:
         specifier: 3.3.0
         version: 3.3.0
@@ -49,7 +49,7 @@ importers:
         version: 5.0.10
       typescript-eslint:
         specifier: 8.31.0
-        version: 8.31.0(eslint@9.25.1)(typescript@5.7.2)
+        version: 8.31.0(eslint@9.25.1)(typescript@5.8.3)
 
   v-next/example-project:
     devDependencies:
@@ -129,11 +129,11 @@ importers:
         specifier: ^5.0.5
         version: 5.0.10
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
       viem:
         specifier: ^2.30.0
-        version: 2.30.0(typescript@5.5.4)(zod@3.24.1)
+        version: 2.30.0(typescript@5.8.3)(zod@3.24.1)
 
   v-next/hardhat:
     dependencies:
@@ -232,8 +232,8 @@ importers:
         specifier: ^5.0.5
         version: 5.0.10
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-errors:
     dependencies:
@@ -266,8 +266,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-ethers:
     dependencies:
@@ -321,8 +321,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-ethers-chai-matchers:
     dependencies:
@@ -400,8 +400,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-ignition:
     dependencies:
@@ -492,13 +492,13 @@ importers:
         version: 14.0.2
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.17.16)(typescript@5.5.4)
+        version: 10.9.2(@types/node@20.17.16)(typescript@5.8.3)
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
       viem:
         specifier: ^2.30.0
-        version: 2.30.0(typescript@5.5.4)(zod@3.24.1)
+        version: 2.30.0(typescript@5.8.3)(zod@3.24.1)
 
   v-next/hardhat-ignition-core:
     dependencies:
@@ -589,10 +589,10 @@ importers:
         version: 5.0.10
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.17.16)(typescript@5.5.4)
+        version: 10.9.2(@types/node@20.17.16)(typescript@5.8.3)
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-ignition-ethers:
     dependencies:
@@ -647,13 +647,13 @@ importers:
         version: 5.0.10
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.17.16)(typescript@5.5.4)
+        version: 10.9.2(@types/node@20.17.16)(typescript@5.8.3)
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-ignition-ui:
     devDependencies:
@@ -725,10 +725,10 @@ importers:
         version: 3.6.2
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@22.10.10)(typescript@5.5.4)
+        version: 10.9.2(@types/node@22.10.10)(typescript@5.8.3)
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
       vite:
         specifier: ^5.0.0
         version: 5.4.14(@types/node@22.10.10)
@@ -786,16 +786,16 @@ importers:
         version: 5.0.10
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.17.16)(typescript@5.5.4)
+        version: 10.9.2(@types/node@20.17.16)(typescript@5.8.3)
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
       viem:
         specifier: ^2.30.0
-        version: 2.30.0(typescript@5.5.4)(zod@3.24.1)
+        version: 2.30.0(typescript@5.8.3)(zod@3.24.1)
 
   v-next/hardhat-keystore:
     dependencies:
@@ -858,8 +858,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-mocha:
     dependencies:
@@ -913,8 +913,8 @@ importers:
         specifier: ^5.0.5
         version: 5.0.10
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-network-helpers:
     dependencies:
@@ -959,8 +959,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-node-test-reporter:
     dependencies:
@@ -996,8 +996,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-node-test-runner:
     dependencies:
@@ -1045,8 +1045,8 @@ importers:
         specifier: ^5.0.5
         version: 5.0.10
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-test-utils:
     dependencies:
@@ -1082,8 +1082,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-toolbox-mocha-ethers:
     dependencies:
@@ -1161,8 +1161,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-toolbox-viem:
     dependencies:
@@ -1225,11 +1225,11 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
       viem:
         specifier: ^2.30.0
-        version: 2.30.0(typescript@5.5.4)(zod@3.24.1)
+        version: 2.30.0(typescript@5.8.3)(zod@3.24.1)
 
   v-next/hardhat-typechain:
     dependencies:
@@ -1247,7 +1247,7 @@ importers:
         version: link:../hardhat-zod-utils
       '@typechain/ethers-v6':
         specifier: ^0.5.0
-        version: 0.5.1(ethers@6.14.1)(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4)
+        version: 0.5.1(ethers@6.14.1)(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)
       debug:
         specifier: ^4.3.2
         version: 4.4.0(supports-color@5.5.0)
@@ -1259,7 +1259,7 @@ importers:
         version: link:../hardhat
       typechain:
         specifier: ^8.3.1
-        version: 8.3.2(typescript@5.5.4)
+        version: 8.3.2(typescript@5.8.3)
       zod:
         specifier: ^3.23.8
         version: 3.24.1
@@ -1295,8 +1295,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-utils:
     dependencies:
@@ -1356,8 +1356,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-verify:
     dependencies:
@@ -1423,8 +1423,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/hardhat-viem:
     dependencies:
@@ -1466,11 +1466,11 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
       viem:
         specifier: ^2.30.0
-        version: 2.30.0(typescript@5.5.4)(zod@3.24.1)
+        version: 2.30.0(typescript@5.8.3)(zod@3.24.1)
 
   v-next/hardhat-viem-assertions:
     dependencies:
@@ -1515,11 +1515,11 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
       viem:
         specifier: ^2.30.0
-        version: 2.30.0(typescript@5.5.4)(zod@3.24.1)
+        version: 2.30.0(typescript@5.8.3)(zod@3.24.1)
 
   v-next/hardhat-zod-utils:
     dependencies:
@@ -1555,8 +1555,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
       zod:
         specifier: ^3.23.8
         version: 3.24.1
@@ -1579,11 +1579,11 @@ importers:
         specifier: workspace:^3.0.0-next.15
         version: link:../..
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
       viem:
         specifier: ^2.30.0
-        version: 2.30.0(typescript@5.5.4)(zod@3.24.1)
+        version: 2.30.0(typescript@5.8.3)(zod@3.24.1)
 
   v-next/hardhat/templates/02-mocha-ethers:
     devDependencies:
@@ -1624,8 +1624,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
   v-next/template-package:
     devDependencies:
@@ -1657,8 +1657,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ~5.5.0
-        version: 5.5.4
+        specifier: ~5.8.0
+        version: 5.8.3
 
 packages:
 
@@ -5240,13 +5240,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -6627,13 +6627,13 @@ snapshots:
       tslib: 2.7.0
     optional: true
 
-  '@typechain/ethers-v6@0.5.1(ethers@6.14.1)(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4)':
+  '@typechain/ethers-v6@0.5.1(ethers@6.14.1)(typechain@8.3.2(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
       ethers: 6.14.1
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.5.4)
-      typechain: 8.3.2(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-essentials: 7.0.3(typescript@5.8.3)
+      typechain: 8.3.2(typescript@5.8.3)
+      typescript: 5.8.3
 
   '@types/adm-zip@0.5.7':
     dependencies:
@@ -6779,32 +6779,32 @@ snapshots:
     dependencies:
       '@types/node': 22.10.10
 
-  '@typescript-eslint/eslint-plugin@8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.7.2))(eslint@9.25.1)(typescript@5.7.2)':
+  '@typescript-eslint/eslint-plugin@8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint@9.25.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1)(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.31.0
-      '@typescript-eslint/type-utils': 8.31.0(eslint@9.25.1)(typescript@5.7.2)
-      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1)(typescript@5.7.2)
+      '@typescript-eslint/type-utils': 8.31.0(eslint@9.25.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.31.0
       eslint: 9.25.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.7.2)
-      typescript: 5.7.2
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.7.2)':
+  '@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.31.0
       '@typescript-eslint/types': 8.31.0
-      '@typescript-eslint/typescript-estree': 8.31.0(typescript@5.7.2)
+      '@typescript-eslint/typescript-estree': 8.31.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.31.0
       debug: 4.4.0
       eslint: 9.25.1
-      typescript: 5.7.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6813,20 +6813,20 @@ snapshots:
       '@typescript-eslint/types': 8.31.0
       '@typescript-eslint/visitor-keys': 8.31.0
 
-  '@typescript-eslint/type-utils@8.31.0(eslint@9.25.1)(typescript@5.7.2)':
+  '@typescript-eslint/type-utils@8.31.0(eslint@9.25.1)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.31.0(typescript@5.7.2)
-      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1)(typescript@5.7.2)
+      '@typescript-eslint/typescript-estree': 8.31.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1)(typescript@5.8.3)
       debug: 4.4.0
       eslint: 9.25.1
-      ts-api-utils: 2.1.0(typescript@5.7.2)
-      typescript: 5.7.2
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.31.0': {}
 
-  '@typescript-eslint/typescript-estree@8.31.0(typescript@5.7.2)':
+  '@typescript-eslint/typescript-estree@8.31.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.31.0
       '@typescript-eslint/visitor-keys': 8.31.0
@@ -6835,19 +6835,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 2.1.0(typescript@5.7.2)
-      typescript: 5.7.2
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.31.0(eslint@9.25.1)(typescript@5.7.2)':
+  '@typescript-eslint/utils@8.31.0(eslint@9.25.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.25.1)
       '@typescript-eslint/scope-manager': 8.31.0
       '@typescript-eslint/types': 8.31.0
-      '@typescript-eslint/typescript-estree': 8.31.0(typescript@5.7.2)
+      '@typescript-eslint/typescript-estree': 8.31.0(typescript@5.8.3)
       eslint: 9.25.1
-      typescript: 5.7.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6920,9 +6920,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  abitype@1.0.8(typescript@5.5.4)(zod@3.24.1):
+  abitype@1.0.8(typescript@5.8.3)(zod@3.24.1):
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
       zod: 3.24.1
 
   acorn-jsx@5.3.2(acorn@8.14.0):
@@ -7761,22 +7761,22 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.0
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.7.2))(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1)(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1)(typescript@5.8.3)
       eslint: 9.25.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.3.4(eslint-plugin-import@2.31.0)(eslint@9.25.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.7.2))(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -7787,7 +7787,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.25.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7799,7 +7799,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1)(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -8883,17 +8883,17 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.6.9(typescript@5.5.4)(zod@3.24.1):
+  ox@0.6.9(typescript@5.8.3)(zod@3.24.1):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.8.2
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.5.4)(zod@3.24.1)
+      abitype: 1.0.8(typescript@5.8.3)(zod@3.24.1)
       eventemitter3: 5.0.1
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - zod
 
@@ -9430,9 +9430,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@2.1.0(typescript@5.7.2):
+  ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
-      typescript: 5.7.2
+      typescript: 5.8.3
 
   ts-command-line-args@2.5.1:
     dependencies:
@@ -9443,11 +9443,11 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-essentials@7.0.3(typescript@5.5.4):
+  ts-essentials@7.0.3(typescript@5.8.3):
     dependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
 
-  ts-node@10.9.2(@types/node@20.17.16)(typescript@5.5.4):
+  ts-node@10.9.2(@types/node@20.17.16)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -9461,11 +9461,11 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.5.4
+      typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4):
+  ts-node@10.9.2(@types/node@22.10.10)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -9479,7 +9479,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.5.4
+      typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -9511,7 +9511,7 @@ snapshots:
 
   type-fest@0.8.1: {}
 
-  typechain@8.3.2(typescript@5.5.4):
+  typechain@8.3.2(typescript@5.8.3):
     dependencies:
       '@types/prettier': 2.7.3
       debug: 4.4.0
@@ -9522,8 +9522,8 @@ snapshots:
       mkdirp: 1.0.4
       prettier: 2.8.8
       ts-command-line-args: 2.5.1
-      ts-essentials: 7.0.3(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-essentials: 7.0.3(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9564,19 +9564,19 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.31.0(eslint@9.25.1)(typescript@5.7.2):
+  typescript-eslint@8.31.0(eslint@9.25.1)(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.7.2))(eslint@9.25.1)(typescript@5.7.2)
-      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1)(typescript@5.7.2)
-      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint@9.25.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.31.0(eslint@9.25.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.31.0(eslint@9.25.1)(typescript@5.8.3)
       eslint: 9.25.1
-      typescript: 5.7.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.5.4: {}
-
   typescript@5.7.2: {}
+
+  typescript@5.8.3: {}
 
   typical@4.0.0: {}
 
@@ -9658,18 +9658,18 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  viem@2.30.0(typescript@5.5.4)(zod@3.24.1):
+  viem@2.30.0(typescript@5.8.3)(zod@3.24.1):
     dependencies:
       '@noble/curves': 1.8.2
       '@noble/hashes': 1.7.2
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.5.4)(zod@3.24.1)
+      abitype: 1.0.8(typescript@5.8.3)(zod@3.24.1)
       isows: 1.0.7(ws@8.18.1)
-      ox: 0.6.9(typescript@5.5.4)(zod@3.24.1)
+      ox: 0.6.9(typescript@5.8.3)(zod@3.24.1)
       ws: 8.18.1
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -48,7 +48,7 @@
     "mocha": "^11.0.0",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "viem": "^2.30.0"
   }
 }

--- a/v-next/hardhat-errors/package.json
+++ b/v-next/hardhat-errors/package.json
@@ -50,7 +50,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-utils": "workspace:^3.0.0-next.15"

--- a/v-next/hardhat-errors/package.json
+++ b/v-next/hardhat-errors/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-ethers-chai-matchers/package.json
+++ b/v-next/hardhat-ethers-chai-matchers/package.json
@@ -55,7 +55,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "mocha": "^11.0.0",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",

--- a/v-next/hardhat-ethers-chai-matchers/package.json
+++ b/v-next/hardhat-ethers-chai-matchers/package.json
@@ -60,7 +60,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0-next.15",

--- a/v-next/hardhat-ethers/package.json
+++ b/v-next/hardhat-ethers/package.json
@@ -49,7 +49,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-ethers/package.json
+++ b/v-next/hardhat-ethers/package.json
@@ -53,7 +53,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0-next.15",

--- a/v-next/hardhat-ignition-core/package.json
+++ b/v-next/hardhat-ignition-core/package.json
@@ -70,7 +70,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "ts-node": "10.9.2",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@ethersproject/address": "5.6.1",

--- a/v-next/hardhat-ignition-ethers/package.json
+++ b/v-next/hardhat-ignition-ethers/package.json
@@ -56,7 +56,7 @@
     "rimraf": "^5.0.5",
     "ts-node": "10.9.2",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0-next.15"

--- a/v-next/hardhat-ignition-ui/package.json
+++ b/v-next/hardhat-ignition-ui/package.json
@@ -46,7 +46,7 @@
     "styled-components": "5.3.10",
     "svg-pan-zoom": "^3.6.1",
     "ts-node": "10.9.2",
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "vite": "^5.0.0",
     "vite-plugin-singlefile": "^2.0.1"
   }

--- a/v-next/hardhat-ignition-viem/package.json
+++ b/v-next/hardhat-ignition-viem/package.json
@@ -56,7 +56,7 @@
     "rimraf": "^5.0.5",
     "ts-node": "10.9.2",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "viem": "^2.30.0"
   },
   "dependencies": {

--- a/v-next/hardhat-ignition/package.json
+++ b/v-next/hardhat-ignition/package.json
@@ -73,7 +73,7 @@
     "rimraf": "^5.0.5",
     "sinon": "^14.0.0",
     "ts-node": "10.9.2",
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "viem": "^2.30.0"
   },
   "dependencies": {

--- a/v-next/hardhat-keystore/package.json
+++ b/v-next/hardhat-keystore/package.json
@@ -51,7 +51,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0-next.15",

--- a/v-next/hardhat-keystore/package.json
+++ b/v-next/hardhat-keystore/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-mocha/package.json
+++ b/v-next/hardhat-mocha/package.json
@@ -50,7 +50,7 @@
     "expect-type": "^0.19.0",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "hardhat": "workspace:^3.0.0-next.15",

--- a/v-next/hardhat-mocha/package.json
+++ b/v-next/hardhat-mocha/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "typescript": "~5.8.0"

--- a/v-next/hardhat-network-helpers/package.json
+++ b/v-next/hardhat-network-helpers/package.json
@@ -50,7 +50,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-network-helpers/package.json
+++ b/v-next/hardhat-network-helpers/package.json
@@ -54,7 +54,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0-next.15",

--- a/v-next/hardhat-node-test-reporter/package.json
+++ b/v-next/hardhat-node-test-reporter/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-node-test-reporter/package.json
+++ b/v-next/hardhat-node-test-reporter/package.json
@@ -51,7 +51,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@actions/core": "^1.10.1",

--- a/v-next/hardhat-node-test-runner/package.json
+++ b/v-next/hardhat-node-test-runner/package.json
@@ -49,7 +49,7 @@
     "expect-type": "^0.19.0",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0-next.15",

--- a/v-next/hardhat-node-test-runner/package.json
+++ b/v-next/hardhat-node-test-runner/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "typescript": "~5.8.0"

--- a/v-next/hardhat-test-utils/package.json
+++ b/v-next/hardhat-test-utils/package.json
@@ -45,7 +45,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0-next.15",

--- a/v-next/hardhat-test-utils/package.json
+++ b/v-next/hardhat-test-utils/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-toolbox-mocha-ethers/package.json
+++ b/v-next/hardhat-toolbox-mocha-ethers/package.json
@@ -63,7 +63,7 @@
     "chai": "^5.1.2",
     "eslint": "9.25.1",
     "ethers": "^6.14.0",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-toolbox-mocha-ethers/package.json
+++ b/v-next/hardhat-toolbox-mocha-ethers/package.json
@@ -67,7 +67,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "peerDependencies": {
     "@nomicfoundation/hardhat-ethers": "workspace:^4.0.0-next.15",

--- a/v-next/hardhat-toolbox-viem/package.json
+++ b/v-next/hardhat-toolbox-viem/package.json
@@ -63,7 +63,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "viem": "^2.30.0"
   },
   "peerDependencies": {

--- a/v-next/hardhat-toolbox-viem/package.json
+++ b/v-next/hardhat-toolbox-viem/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-typechain/package.json
+++ b/v-next/hardhat-typechain/package.json
@@ -55,7 +55,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0-next.15",

--- a/v-next/hardhat-typechain/package.json
+++ b/v-next/hardhat-typechain/package.json
@@ -51,7 +51,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -68,7 +68,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -72,7 +72,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@streamparser/json-node": "^0.0.22",

--- a/v-next/hardhat-utils/test/lang.ts
+++ b/v-next/hardhat-utils/test/lang.ts
@@ -114,7 +114,7 @@ describe("lang", () => {
 
       assert.deepEqual(clonedBuffer, expected);
       assert.notEqual(clonedBuffer, expected);
-      expectTypeOf(clonedBuffer).toEqualTypeOf<Buffer>();
+      expectTypeOf(clonedBuffer).toEqualTypeOf<Buffer<ArrayBuffer>>();
     });
 
     it("Should clone arguments to a normal object", async () => {

--- a/v-next/hardhat-verify/package.json
+++ b/v-next/hardhat-verify/package.json
@@ -58,7 +58,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.8.0",

--- a/v-next/hardhat-verify/package.json
+++ b/v-next/hardhat-verify/package.json
@@ -54,7 +54,7 @@
     "@types/semver": "^7.5.8",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-viem-assertions/package.json
+++ b/v-next/hardhat-viem-assertions/package.json
@@ -56,7 +56,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "viem": "^2.30.0"
   },
   "dependencies": {

--- a/v-next/hardhat-viem-assertions/package.json
+++ b/v-next/hardhat-viem-assertions/package.json
@@ -52,7 +52,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-viem/package.json
+++ b/v-next/hardhat-viem/package.json
@@ -54,7 +54,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "viem": "^2.30.0"
   },
   "dependencies": {

--- a/v-next/hardhat-viem/package.json
+++ b/v-next/hardhat-viem/package.json
@@ -50,7 +50,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat-zod-utils/package.json
+++ b/v-next/hardhat-zod-utils/package.json
@@ -51,7 +51,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "zod": "^3.23.8"
   },
   "dependencies": {

--- a/v-next/hardhat-zod-utils/package.json
+++ b/v-next/hardhat-zod-utils/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -79,7 +79,7 @@
     "@types/ws": "^8.5.13",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "typescript": "~5.8.0"

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -82,7 +82,7 @@
     "expect-type": "^0.19.0",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@ignored/edr": "0.10.0-alpha.5",

--- a/v-next/hardhat/templates/01-node-test-runner-viem/package.json
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/package.json
@@ -10,7 +10,7 @@
     "@nomicfoundation/hardhat-ignition": "workspace:^3.0.0-next.15",
     "@types/node": "^22.8.5",
     "forge-std": "foundry-rs/forge-std#v1.9.4",
-    "typescript": "~5.5.0",
+    "typescript": "~5.8.0",
     "viem": "^2.30.0"
   }
 }

--- a/v-next/hardhat/templates/02-mocha-ethers/package.json
+++ b/v-next/hardhat/templates/02-mocha-ethers/package.json
@@ -17,6 +17,6 @@
     "ethers": "^6.14.0",
     "forge-std": "foundry-rs/forge-std#v1.9.4",
     "mocha": "^11.0.0",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   }
 }

--- a/v-next/template-package/package.json
+++ b/v-next/template-package/package.json
@@ -53,6 +53,6 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",
-    "typescript": "~5.5.0"
+    "typescript": "~5.8.0"
   }
 }

--- a/v-next/template-package/package.json
+++ b/v-next/template-package/package.json
@@ -49,7 +49,7 @@
     "@types/node": "^20.14.9",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
-    "expect-type": "^0.19.0",
+    "expect-type": "^1.2.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "tsx": "^4.19.3",


### PR DESCRIPTION
A small PR upgrading TS so that we can use the new additions.

The most interesting changes from these upgrades are:

* [Iterator Helper Methods](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#iterator-helper-methods): Which let's you do things like `object.entries().map().filter().toArray()`.
* [Granular Checks for Branches in Return Expressions](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/#granular-checks-for-branches-in-return-expressions)

There was a single new type error after the upgrade, which I fixed.