### PR TITLE
Fix warning: passing args to `spawn` when shell is set to true

### DIFF
--- a/.changeset/stupid-cars-suffer.md
+++ b/.changeset/stupid-cars-suffer.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix a warning in Node 24 about passing args to `spawn` with shell: true. [#6896](https://github.com/NomicFoundation/hardhat/issues/6896)

--- a/v-next/hardhat/src/internal/cli/init/init.ts
+++ b/v-next/hardhat/src/internal/cli/init/init.ts
@@ -305,11 +305,15 @@ export async function validatePackageJson(
   // package managers support `<package manager> pkg set type=module`.
   const packageManagerToUse = packageManager === "pnpm" ? "pnpm" : "npm";
 
-  await spawn(packageManagerToUse, ["pkg", "set", "type=module"], {
-    cwd: workspace,
-    shell: true,
-    stdio: "inherit",
-  });
+  await spawn(
+    [packageManagerToUse, "pkg", "set", "type=module"].join(" "),
+    [],
+    {
+      cwd: workspace,
+      shell: true,
+      stdio: "inherit",
+    },
+  );
 }
 
 /**
@@ -469,7 +473,7 @@ export async function installProjectDependencies(
       console.log();
       console.log(commandString);
 
-      await spawn(command[0], command.slice(1), {
+      await spawn([command[0], ...command.slice(1)].join(" "), [], {
         cwd: workspace,
         // We need to run with `shell: true` for this to work on powershell, but
         // we already enclosed every dependency identifier in quotes, so this
@@ -513,7 +517,7 @@ export async function installProjectDependencies(
       console.log();
       console.log(commandString);
 
-      await spawn(command[0], command.slice(1), {
+      await spawn([command[0], ...command.slice(1)].join(" "), [], {
         cwd: workspace,
         // We need to run with `shell: true` for this to work on powershell, but
         // we already enclosed every dependency identifier in quotes, so this

--- a/v-next/hardhat/src/internal/cli/init/init.ts
+++ b/v-next/hardhat/src/internal/cli/init/init.ts
@@ -473,7 +473,7 @@ export async function installProjectDependencies(
       console.log();
       console.log(commandString);
 
-      await spawn([command[0], ...command.slice(1)].join(" "), [], {
+      await spawn(commandString, [], {
         cwd: workspace,
         // We need to run with `shell: true` for this to work on powershell, but
         // we already enclosed every dependency identifier in quotes, so this

--- a/v-next/hardhat/src/internal/cli/init/init.ts
+++ b/v-next/hardhat/src/internal/cli/init/init.ts
@@ -517,7 +517,7 @@ export async function installProjectDependencies(
       console.log();
       console.log(commandString);
 
-      await spawn([command[0], ...command.slice(1)].join(" "), [], {
+      await spawn(commandString, [], {
         cwd: workspace,
         // We need to run with `shell: true` for this to work on powershell, but
         // we already enclosed every dependency identifier in quotes, so this


### PR DESCRIPTION
Closes #6896 