### PR TITLE
[WIP] Drop node 22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:bullseye",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "22"
+      "version": "24"
     }
   },
   "postCreateCommand": "scripts/setup.sh",

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -329,7 +329,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - name: Download Hardhat
         if: (startsWith(matrix.command, 'hardhat ') && needs.inputs.outputs.hardhat-ref != 'next' && !startsWith(needs.inputs.outputs.hardhat-ref, '3'))
         uses: actions/download-artifact@v4

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -241,7 +241,7 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.list-packages.outputs.packages) }}
         os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
-        node: [22, 24]
+        node: [24]
 
     name: "[${{ matrix.package }}] ci on ${{ matrix.os }} (Node ${{ matrix.node }})"
     runs-on: ${{ matrix.os }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,9 @@ importers:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.5.0
         version: 4.5.0(eslint@9.25.1)
-      '@tsconfig/node22':
-        specifier: ^22.0.2
-        version: 22.0.2
+      '@tsconfig/node24':
+        specifier: ^24.0.1
+        version: 24.0.1
       '@types/eslint':
         specifier: 9.6.1
         version: 9.6.1
@@ -105,8 +105,8 @@ importers:
         specifier: '>=10.0.10'
         version: 10.0.10
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       chai:
         specifier: ^5.1.2
         version: 5.1.2
@@ -208,8 +208,8 @@ importers:
         specifier: ^4.1.7
         version: 4.1.12
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
@@ -245,8 +245,8 @@ importers:
         specifier: workspace:^3.0.0-next.16
         version: link:../hardhat-node-test-reporter
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -300,8 +300,8 @@ importers:
         specifier: ^4.1.7
         version: 4.1.12
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -376,8 +376,8 @@ importers:
         specifier: '>=10.0.10'
         version: 10.0.10
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -452,8 +452,8 @@ importers:
         specifier: '>=10.0.10'
         version: 10.0.10
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       '@types/prompts':
         specifier: ^2.4.2
         version: 2.4.9
@@ -492,7 +492,7 @@ importers:
         version: 14.0.2
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.17.16)(typescript@5.8.3)
+        version: 10.9.2(@types/node@24.0.3)(typescript@5.8.3)
       typescript:
         specifier: ~5.8.0
         version: 5.8.3
@@ -538,7 +538,7 @@ importers:
         version: 1.0.2(nyc@15.1.0)
       '@microsoft/api-extractor':
         specifier: 7.49.1
-        version: 7.49.1(@types/node@20.17.16)
+        version: 7.49.1(@types/node@24.0.3)
       '@nomicfoundation/hardhat-test-utils':
         specifier: workspace:^
         version: link:../hardhat-test-utils
@@ -561,8 +561,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       chai:
         specifier: ^5.1.2
         version: 5.1.2
@@ -589,7 +589,7 @@ importers:
         version: 5.0.10
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.17.16)(typescript@5.8.3)
+        version: 10.9.2(@types/node@24.0.3)(typescript@5.8.3)
       typescript:
         specifier: ~5.8.0
         version: 5.8.3
@@ -619,8 +619,8 @@ importers:
         specifier: workspace:^3.0.0-next.16
         version: link:../hardhat-ignition-core
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -647,7 +647,7 @@ importers:
         version: 5.0.10
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.17.16)(typescript@5.8.3)
+        version: 10.9.2(@types/node@24.0.3)(typescript@5.8.3)
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
@@ -683,7 +683,7 @@ importers:
         version: 5.1.26
       '@vitejs/plugin-react':
         specifier: ^4.0.0
-        version: 4.3.4(vite@5.4.14(@types/node@22.10.10))
+        version: 4.3.4(vite@5.4.14(@types/node@24.0.3))
       chai:
         specifier: ^5.1.2
         version: 5.1.2
@@ -725,16 +725,16 @@ importers:
         version: 3.6.2
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@22.10.10)(typescript@5.8.3)
+        version: 10.9.2(@types/node@24.0.3)(typescript@5.8.3)
       typescript:
         specifier: ~5.8.0
         version: 5.8.3
       vite:
         specifier: ^5.0.0
-        version: 5.4.14(@types/node@22.10.10)
+        version: 5.4.14(@types/node@24.0.3)
       vite-plugin-singlefile:
         specifier: ^2.0.1
-        version: 2.1.0(rollup@4.34.1)(vite@5.4.14(@types/node@22.10.10))
+        version: 2.1.0(rollup@4.34.1)(vite@5.4.14(@types/node@24.0.3))
 
   v-next/hardhat-ignition-viem:
     dependencies:
@@ -761,8 +761,8 @@ importers:
         specifier: workspace:^3.0.0-next.16
         version: link:../hardhat-ignition-core
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -786,7 +786,7 @@ importers:
         version: 5.0.10
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@20.17.16)(typescript@5.8.3)
+        version: 10.9.2(@types/node@24.0.3)(typescript@5.8.3)
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
@@ -837,8 +837,8 @@ importers:
         specifier: ^4.1.7
         version: 4.1.12
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -895,8 +895,8 @@ importers:
         specifier: '>=10.0.10'
         version: 10.0.10
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -938,8 +938,8 @@ importers:
         specifier: ^4.1.7
         version: 4.1.12
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -975,8 +975,8 @@ importers:
         version: 29.7.0
     devDependencies:
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1027,8 +1027,8 @@ importers:
         specifier: workspace:^
         version: link:../hardhat-test-utils
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1061,8 +1061,8 @@ importers:
         specifier: workspace:^3.0.0-next.16
         version: link:../hardhat-node-test-reporter
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1134,8 +1134,8 @@ importers:
         specifier: ^4.2.0
         version: 4.3.20
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1204,8 +1204,8 @@ importers:
         specifier: workspace:^3.0.0-next.16
         version: link:../hardhat-ignition-core
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1274,8 +1274,8 @@ importers:
         specifier: ^4.1.7
         version: 4.1.12
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1335,8 +1335,8 @@ importers:
         specifier: ^4.1.7
         version: 4.1.12
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1399,8 +1399,8 @@ importers:
         specifier: ^4.1.7
         version: 4.1.12
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
@@ -1445,8 +1445,8 @@ importers:
         specifier: workspace:^
         version: link:../hardhat-test-utils
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1494,8 +1494,8 @@ importers:
         specifier: workspace:^3.0.0-next.16
         version: link:../hardhat-viem
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1534,8 +1534,8 @@ importers:
         specifier: workspace:^
         version: link:../hardhat-test-utils
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1636,8 +1636,8 @@ importers:
         specifier: workspace:^
         version: link:../hardhat-test-utils
       '@types/node':
-        specifier: ^20.14.9
-        version: 20.17.16
+        specifier: ^24.0.3
+        version: 24.0.3
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -2701,8 +2701,8 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@tsconfig/node22@22.0.2':
-    resolution: {integrity: sha512-Kmwj4u8sDRDrMYRoN9FDEcXD8UpBSaPQQ24Gz+Gamqfm7xxn+GBR7ge/Z7pK8OXNGyUzbSwJj+TH6B+DS/epyA==}
+  '@tsconfig/node24@24.0.1':
+    resolution: {integrity: sha512-3+IXshza3bIrT0tbHBr9CixQDVf4iBf0HTR0hCYowhpLqkzJjswu3UY8aZWjRXZep31kYB+o2SQeD8KwIoUHYw==}
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
@@ -2795,14 +2795,14 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@20.17.16':
-    resolution: {integrity: sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==}
-
   '@types/node@22.10.10':
     resolution: {integrity: sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
+  '@types/node@24.0.3':
+    resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
 
   '@types/prettier@2.7.3':
     resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
@@ -5268,6 +5268,9 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
   undici@5.28.5:
     resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
     engines: {node: '>=14.0'}
@@ -6341,23 +6344,23 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@microsoft/api-extractor-model@7.30.2(@types/node@20.17.16)':
+  '@microsoft/api-extractor-model@7.30.2(@types/node@24.0.3)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.2(@types/node@20.17.16)
+      '@rushstack/node-core-library': 5.10.2(@types/node@24.0.3)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.49.1(@types/node@20.17.16)':
+  '@microsoft/api-extractor@7.49.1(@types/node@24.0.3)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.2(@types/node@20.17.16)
+      '@microsoft/api-extractor-model': 7.30.2(@types/node@24.0.3)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.2(@types/node@20.17.16)
+      '@rushstack/node-core-library': 5.10.2(@types/node@24.0.3)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.5(@types/node@20.17.16)
-      '@rushstack/ts-command-line': 4.23.3(@types/node@20.17.16)
+      '@rushstack/terminal': 0.14.5(@types/node@24.0.3)
+      '@rushstack/ts-command-line': 4.23.3(@types/node@24.0.3)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -6514,7 +6517,7 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@rushstack/node-core-library@5.10.2(@types/node@20.17.16)':
+  '@rushstack/node-core-library@5.10.2(@types/node@24.0.3)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -6525,23 +6528,23 @@ snapshots:
       resolve: 1.22.10
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 20.17.16
+      '@types/node': 24.0.3
 
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.14.5(@types/node@20.17.16)':
+  '@rushstack/terminal@0.14.5(@types/node@24.0.3)':
     dependencies:
-      '@rushstack/node-core-library': 5.10.2(@types/node@20.17.16)
+      '@rushstack/node-core-library': 5.10.2(@types/node@24.0.3)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 20.17.16
+      '@types/node': 24.0.3
 
-  '@rushstack/ts-command-line@4.23.3(@types/node@20.17.16)':
+  '@rushstack/ts-command-line@4.23.3(@types/node@24.0.3)':
     dependencies:
-      '@rushstack/terminal': 0.14.5(@types/node@20.17.16)
+      '@rushstack/terminal': 0.14.5(@types/node@24.0.3)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -6620,7 +6623,7 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@tsconfig/node22@22.0.2': {}
+  '@tsconfig/node24@24.0.1': {}
 
   '@tybys/wasm-util@0.9.0':
     dependencies:
@@ -6637,7 +6640,7 @@ snapshots:
 
   '@types/adm-zip@0.5.7':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 24.0.3
 
   '@types/argparse@1.0.38': {}
 
@@ -6664,7 +6667,7 @@ snapshots:
 
   '@types/bn.js@5.1.6':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 24.0.3
 
   '@types/chai-as-promised@8.0.1':
     dependencies:
@@ -6720,14 +6723,10 @@ snapshots:
 
   '@types/ndjson@2.0.1':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 24.0.3
       '@types/through': 0.0.33
 
   '@types/node@12.20.55': {}
-
-  '@types/node@20.17.16':
-    dependencies:
-      undici-types: 6.19.8
 
   '@types/node@22.10.10':
     dependencies:
@@ -6737,11 +6736,15 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/node@24.0.3':
+    dependencies:
+      undici-types: 7.8.0
+
   '@types/prettier@2.7.3': {}
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 24.0.3
       kleur: 3.0.3
 
   '@types/prop-types@15.7.14': {}
@@ -6771,13 +6774,13 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 24.0.3
 
   '@types/unist@2.0.11': {}
 
   '@types/ws@8.5.14':
     dependencies:
-      '@types/node': 22.10.10
+      '@types/node': 24.0.3
 
   '@typescript-eslint/eslint-plugin@8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint@9.25.1)(typescript@5.8.3)':
     dependencies:
@@ -6909,14 +6912,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.7.0':
     optional: true
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.14(@types/node@22.10.10))':
+  '@vitejs/plugin-react@4.3.4(vite@5.4.14(@types/node@24.0.3))':
     dependencies:
       '@babel/core': 7.26.7
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.7)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.14(@types/node@22.10.10)
+      vite: 5.4.14(@types/node@24.0.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -9447,32 +9450,14 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  ts-node@10.9.2(@types/node@20.17.16)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@24.0.3)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.17.16
-      acorn: 8.14.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.8.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
-  ts-node@10.9.2(@types/node@22.10.10)(typescript@5.8.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.10.10
+      '@types/node': 24.0.3
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -9593,6 +9578,8 @@ snapshots:
 
   undici-types@6.20.0: {}
 
+  undici-types@7.8.0: {}
+
   undici@5.28.5:
     dependencies:
       '@fastify/busboy': 2.1.1
@@ -9675,19 +9662,19 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-plugin-singlefile@2.1.0(rollup@4.34.1)(vite@5.4.14(@types/node@22.10.10)):
+  vite-plugin-singlefile@2.1.0(rollup@4.34.1)(vite@5.4.14(@types/node@24.0.3)):
     dependencies:
       micromatch: 4.0.8
       rollup: 4.34.1
-      vite: 5.4.14(@types/node@22.10.10)
+      vite: 5.4.14(@types/node@24.0.3)
 
-  vite@5.4.14(@types/node@22.10.10):
+  vite@5.4.14(@types/node@24.0.3):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
       rollup: 4.34.1
     optionalDependencies:
-      '@types/node': 22.10.10
+      '@types/node': 24.0.3
       fsevents: 2.3.3
 
   web-worker@1.5.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1570,8 +1570,8 @@ importers:
         specifier: workspace:^4.0.0-next.16
         version: link:../../../hardhat-toolbox-viem
       '@types/node':
-        specifier: ^22.8.5
-        version: 22.10.10
+        specifier: ^24.0.3
+        version: 24.0.3
       forge-std:
         specifier: foundry-rs/forge-std#v1.9.4
         version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262
@@ -1606,8 +1606,8 @@ importers:
         specifier: '>=10.0.10'
         version: 10.0.10
       '@types/node':
-        specifier: ^22.8.5
-        version: 22.10.10
+        specifier: ^24.0.3
+        version: 24.0.3
       chai:
         specifier: ^5.1.2
         version: 5.1.2
@@ -2794,9 +2794,6 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
-  '@types/node@22.10.10':
-    resolution: {integrity: sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
@@ -5265,9 +5262,6 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
-
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
@@ -6727,10 +6721,6 @@ snapshots:
       '@types/through': 0.0.33
 
   '@types/node@12.20.55': {}
-
-  '@types/node@22.10.10':
-    dependencies:
-      undici-types: 6.20.0
 
   '@types/node@22.7.5':
     dependencies:
@@ -9575,8 +9565,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.19.8: {}
-
-  undici-types@6.20.0: {}
 
   undici-types@7.8.0: {}
 

--- a/v-next/config/eslint.config.js
+++ b/v-next/config/eslint.config.js
@@ -436,8 +436,6 @@ export function createConfig(
           devDependencies: true,
         },
       ],
-      // Disabled until this gets resolved https://github.com/nodejs/node/issues/51292
-      "@typescript-eslint/no-floating-promises": "off",
     },
   };
 

--- a/v-next/config/package.json
+++ b/v-next/config/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "4.5.0",
-    "@tsconfig/node22": "^22.0.2",
+    "@tsconfig/node24": "^24.0.1",
     "@types/eslint": "9.6.1",
     "eslint": "9.25.1",
     "eslint-import-resolver-typescript": "4.3.4",

--- a/v-next/config/tsconfig.base.json
+++ b/v-next/config/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node22/tsconfig.json",
+  "extends": "@tsconfig/node24/tsconfig.json",
   "compilerOptions": {
     "outDir": "${configDir}/dist",
     "declaration": true,

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -41,7 +41,7 @@
     "@openzeppelin/contracts": "5.1.0",
     "@types/chai": "^4.2.0",
     "@types/mocha": ">=10.0.10",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "chai": "^5.1.2",
     "ethers": "^6.14.0",
     "forge-std": "foundry-rs/forge-std#v1.9.4",

--- a/v-next/hardhat-errors/package.json
+++ b/v-next/hardhat-errors/package.json
@@ -43,7 +43,7 @@
   ],
   "devDependencies": {
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-ethers-chai-matchers/package.json
+++ b/v-next/hardhat-ethers-chai-matchers/package.json
@@ -52,7 +52,7 @@
     "@types/debug": "^4.1.7",
     "@types/deep-eql": "^4.0.2",
     "@types/mocha": ">=10.0.10",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-ethers/package.json
+++ b/v-next/hardhat-ethers/package.json
@@ -46,7 +46,7 @@
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/debug": "^4.1.7",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-ignition-core/package.json
+++ b/v-next/hardhat-ignition-core/package.json
@@ -60,7 +60,7 @@
     "@types/lodash-es": "^4.17.12",
     "@types/mocha": ">=10.0.10",
     "@types/ndjson": "2.0.1",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "chai": "^5.1.2",
     "chai-as-promised": "^8.0.0",
     "cross-env": "7.0.3",

--- a/v-next/hardhat-ignition-ethers/package.json
+++ b/v-next/hardhat-ignition-ethers/package.json
@@ -46,7 +46,7 @@
     "@nomicfoundation/ignition-core": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "cross-env": "7.0.3",
     "eslint": "9.25.1",

--- a/v-next/hardhat-ignition-viem/package.json
+++ b/v-next/hardhat-ignition-viem/package.json
@@ -47,7 +47,7 @@
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-viem": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "cross-env": "7.0.3",
     "eslint": "9.25.1",

--- a/v-next/hardhat-ignition/package.json
+++ b/v-next/hardhat-ignition/package.json
@@ -60,7 +60,7 @@
     "@types/chai-as-promised": "^8.0.1",
     "@types/debug": "^4.1.7",
     "@types/mocha": ">=10.0.10",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "@types/prompts": "^2.4.2",
     "@types/sinon": "^10.0.13",
     "chai": "^5.1.2",

--- a/v-next/hardhat-keystore/package.json
+++ b/v-next/hardhat-keystore/package.json
@@ -44,7 +44,7 @@
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/debug": "^4.1.7",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-mocha/package.json
+++ b/v-next/hardhat-mocha/package.json
@@ -44,7 +44,7 @@
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/mocha": ">=10.0.10",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-network-helpers/package.json
+++ b/v-next/hardhat-network-helpers/package.json
@@ -47,7 +47,7 @@
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/debug": "^4.1.7",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-node-test-reporter/package.json
+++ b/v-next/hardhat-node-test-reporter/package.json
@@ -44,7 +44,7 @@
     "README.md"
   ],
   "devDependencies": {
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-node-test-runner/package.json
+++ b/v-next/hardhat-node-test-runner/package.json
@@ -43,7 +43,7 @@
   ],
   "devDependencies": {
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-test-utils/package.json
+++ b/v-next/hardhat-test-utils/package.json
@@ -38,7 +38,7 @@
   ],
   "devDependencies": {
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-toolbox-mocha-ethers/package.json
+++ b/v-next/hardhat-toolbox-mocha-ethers/package.json
@@ -58,7 +58,7 @@
     "@nomicfoundation/hardhat-verify": "workspace:^3.0.0-next.16",
     "@nomicfoundation/ignition-core": "workspace:^3.0.0-next.16",
     "@types/chai": "^4.2.0",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "chai": "^5.1.2",
     "eslint": "9.25.1",

--- a/v-next/hardhat-toolbox-viem/package.json
+++ b/v-next/hardhat-toolbox-viem/package.json
@@ -56,7 +56,7 @@
     "@nomicfoundation/hardhat-viem-assertions": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-verify": "workspace:^3.0.0-next.16",
     "@nomicfoundation/ignition-core": "workspace:^3.0.0-next.16",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-typechain/package.json
+++ b/v-next/hardhat-typechain/package.json
@@ -48,7 +48,7 @@
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/debug": "^4.1.7",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -65,7 +65,7 @@
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@types/bn.js": "^5.1.5",
     "@types/debug": "^4.1.7",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-verify/package.json
+++ b/v-next/hardhat-verify/package.json
@@ -50,7 +50,7 @@
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/debug": "^4.1.7",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "@types/semver": "^7.5.8",
     "c8": "^9.1.0",
     "eslint": "9.25.1",

--- a/v-next/hardhat-viem-assertions/package.json
+++ b/v-next/hardhat-viem-assertions/package.json
@@ -49,7 +49,7 @@
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@nomicfoundation/hardhat-viem": "workspace:^3.0.0-next.16",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-viem/package.json
+++ b/v-next/hardhat-viem/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat-zod-utils/package.json
+++ b/v-next/hardhat-zod-utils/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -74,7 +74,7 @@
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/adm-zip": "^0.5.5",
     "@types/debug": "^4.1.7",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "@types/semver": "^7.5.8",
     "@types/ws": "^8.5.13",
     "c8": "^9.1.0",

--- a/v-next/hardhat/src/internal/cli/node-version.ts
+++ b/v-next/hardhat/src/internal/cli/node-version.ts
@@ -3,7 +3,7 @@
 
 import chalk from "chalk";
 
-export const MIN_SUPPORTED_NODE_VERSION: number[] = [22, 10, 0];
+export const MIN_SUPPORTED_NODE_VERSION: number[] = [24, 0, 0];
 
 export function isNodeVersionSupported(): boolean {
   try {

--- a/v-next/hardhat/templates/01-node-test-runner-viem/package.json
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/package.json
@@ -8,7 +8,7 @@
     "hardhat": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-toolbox-viem": "workspace:^4.0.0-next.16",
     "@nomicfoundation/hardhat-ignition": "workspace:^3.0.0-next.16",
-    "@types/node": "^22.8.5",
+    "@types/node": "^24.0.3",
     "forge-std": "foundry-rs/forge-std#v1.9.4",
     "typescript": "~5.8.0",
     "viem": "^2.30.0"

--- a/v-next/hardhat/templates/02-mocha-ethers/package.json
+++ b/v-next/hardhat/templates/02-mocha-ethers/package.json
@@ -12,7 +12,7 @@
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^8.0.1",
     "@types/mocha": ">=10.0.10",
-    "@types/node": "^22.8.5",
+    "@types/node": "^24.0.3",
     "chai": "^5.1.2",
     "ethers": "^6.14.0",
     "forge-std": "foundry-rs/forge-std#v1.9.4",

--- a/v-next/template-package/package.json
+++ b/v-next/template-package/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.0-next.16",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.3",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",


### PR DESCRIPTION
A PR to drop support for Node 22. Currently in WIP, as I'm waiting to see if I can get this https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73062 in, so that we can enable `no-floating-promises` in our tests.