### PR TITLE
build: upgrade EDR to v0.11.2

### DIFF
--- a/.changeset/common-dodos-invent.md
+++ b/.changeset/common-dodos-invent.md
@@ -1,0 +1,7 @@
+---
+"hardhat": patch
+---
+
+Upgraded EDR to [v0.11.2](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.11.2):
+
+- Removed copying of account code for provider accounts in forked networks. Code was previously ignored for default accounts only, now also for user accounts.

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -99,7 +99,7 @@
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",
     "@ethersproject/abi": "^5.1.2",
-    "@nomicfoundation/edr": "^0.11.1",
+    "@nomicfoundation/edr": "^0.11.2",
     "@nomicfoundation/solidity-analyzer": "^0.1.0",
     "@sentry/node": "^5.18.1",
     "@types/bn.js": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,8 +201,8 @@ importers:
         specifier: ^5.1.2
         version: 5.8.0
       '@nomicfoundation/edr':
-        specifier: ^0.11.1
-        version: 0.11.1
+        specifier: ^0.11.2
+        version: 0.11.2
       '@nomicfoundation/solidity-analyzer':
         specifier: ^0.1.0
         version: 0.1.2
@@ -3070,36 +3070,36 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.11.1':
-    resolution: {integrity: sha512-vjca7gkl1o0yYqMjwxQpMEtdsb20nWHBnnxDO8ZBCTD5IwfYT5LiMxFaJo8NUJ7ODIRkF/zuEtAF3W7+ZlC5RA==}
+  '@nomicfoundation/edr-darwin-arm64@0.11.2':
+    resolution: {integrity: sha512-/QU0GHeoLFOJp28qK46kkTG849NN/5Qgq9ifKzhqBas1MCqwcdjrUI3raGkvE9SWJevljWd1HdW16fFpxUrzbA==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-darwin-x64@0.11.1':
-    resolution: {integrity: sha512-0aGStHq9XePXX9UqdU1w60HGO9AfYCgkNEir5sBpntU5E0TvZEK6jwyYr667+s90n2mihdeP97QSA0O/6PT6PA==}
+  '@nomicfoundation/edr-darwin-x64@0.11.2':
+    resolution: {integrity: sha512-Dam+k00vyYNXCkM7JZGQBm0McNaL6ilbfY8BuIdHU2mpIVO5hpAFk8IQnMnG3FRuXuPJ0JoSTkn1R495T8AKqw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.11.1':
-    resolution: {integrity: sha512-OWhCETc03PVdtzatW/c2tpOPx+GxlBfBaLmMuGRD1soAr1nMOmg2WZAlo4i6Up9fkQYl+paiYMMFVat1meaMvQ==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.11.2':
+    resolution: {integrity: sha512-6Z+hZ61c0v5EPVhCAc/rV36eN20GbPRfcmUeFJ3t+RjdY20EiUQzP85YU0q3AgCuwr410W27pazoBoL73cCPbg==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.11.1':
-    resolution: {integrity: sha512-p0qvtIvDA2eZ8pQ5XUKnWdW1IrwFzSrjyrO88oYx6Lkw8nYwf2JEeETo5o5W84DDfimfoBGP7RWPTPcTBKCaLQ==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.11.2':
+    resolution: {integrity: sha512-AqC4AI3pR4vSsEcFyW/6rI1q16wEjIRYIR25IJO/EdBmXdsuVZgxsf/kMUCWQhhTuy89RTgIGTbMAQA0+DfSvA==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.11.1':
-    resolution: {integrity: sha512-V4Us7Q0E8kng3O/czd5GRcxmZxWX+USgqz9yQ3o7DVq7FP96idaKvtcbMQp64tjHf2zNtX2y77sGzgbVau7Bww==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.11.2':
+    resolution: {integrity: sha512-vz1uiof1ZIi6RnXfHZiAXRgkloLciuYGD1rNDrqm1Pp7Nf0pbxw+e4TBQLoMYKzZn0MYS4u4Fa0AV2S7NjfptQ==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.11.1':
-    resolution: {integrity: sha512-lCSXsF10Kjjvs5duGbM6pi1WciWHXFNWkMgDAY4pg6ZRIy4gh+uGC6CONMfP4BDZwfrALo2p6+LwyotrJEqpyg==}
+  '@nomicfoundation/edr-linux-x64-musl@0.11.2':
+    resolution: {integrity: sha512-ArAbcrWwn+8Ze8JAaA9349N2E7hfs9PYvxDgfhujEH9iVC9XI6L+OhMATPsS3wkOST/+ykxELAF1KT4YjSxcrA==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.11.1':
-    resolution: {integrity: sha512-sNSmmRTURAd1sdKuyO5tqrFiJvHHVPZLM4HB53F21makGoyInFGhejdo3qZrkoinM8k0ewEJDbUp0YuMEgMOhQ==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.11.2':
+    resolution: {integrity: sha512-GDXBhxy5wlmZYQrTXu9Oh9OPTsi4tCdmHy1z8O9XqdH9wsP674Frh6Fb43yjVoS2Ek1F9yX11nexIrFXSuNyJQ==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr@0.11.1':
-    resolution: {integrity: sha512-P97XwcD9DdMMZm9aqw89+mzqzlKmqzSPM3feBES2WVRm5/LOiBYorhpeAX+ANj0X8532SKgxoZK/CN5OWv9vZA==}
+  '@nomicfoundation/edr@0.11.2':
+    resolution: {integrity: sha512-JEFMTs5Tju+YiCsv6EO+657O/fvPaQ7bkUCkWqHFYFFbCKH1yh0PeRIaqj5h4z4O16ckxbVpAM676ZFTmvFUGQ==}
     engines: {node: '>= 18'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -9884,29 +9884,29 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@nomicfoundation/edr-darwin-arm64@0.11.1': {}
+  '@nomicfoundation/edr-darwin-arm64@0.11.2': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.11.1': {}
+  '@nomicfoundation/edr-darwin-x64@0.11.2': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.11.1': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.11.2': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.11.1': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.11.2': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.11.1': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.11.2': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.11.1': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.11.2': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.11.1': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.11.2': {}
 
-  '@nomicfoundation/edr@0.11.1':
+  '@nomicfoundation/edr@0.11.2':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.11.1
-      '@nomicfoundation/edr-darwin-x64': 0.11.1
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.11.1
-      '@nomicfoundation/edr-linux-arm64-musl': 0.11.1
-      '@nomicfoundation/edr-linux-x64-gnu': 0.11.1
-      '@nomicfoundation/edr-linux-x64-musl': 0.11.1
-      '@nomicfoundation/edr-win32-x64-msvc': 0.11.1
+      '@nomicfoundation/edr-darwin-arm64': 0.11.2
+      '@nomicfoundation/edr-darwin-x64': 0.11.2
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.11.2
+      '@nomicfoundation/edr-linux-arm64-musl': 0.11.2
+      '@nomicfoundation/edr-linux-x64-gnu': 0.11.2
+      '@nomicfoundation/edr-linux-x64-musl': 0.11.2
+      '@nomicfoundation/edr-win32-x64-msvc': 0.11.2
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true


### PR DESCRIPTION
Upgraded EDR to [v0.11.2](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.11.2):

- Removed copying of account code for provider accounts in forked networks. Code was previously ignored for default accounts only, now also for user accounts.

Follow up to https://github.com/NomicFoundation/hardhat/pull/6842#discussion_r2142794489.