### PR TITLE
chore: bump the version of the viem toolbox

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -17,7 +17,7 @@
     "@nomicfoundation/hardhat-node-test-reporter": "2.0.0",
     "@nomicfoundation/hardhat-node-test-runner": "2.0.0",
     "@nomicfoundation/hardhat-test-utils": "2.0.0",
-    "@nomicfoundation/hardhat-toolbox-viem": "3.0.0",
+    "@nomicfoundation/hardhat-toolbox-viem": "4.0.0",
     "@nomicfoundation/hardhat-typechain": "2.0.0",
     "@nomicfoundation/hardhat-utils": "2.0.0",
     "@nomicfoundation/hardhat-toolbox-mocha-ethers": "2.0.0",

--- a/.changeset/twelve-taxes-help.md
+++ b/.changeset/twelve-taxes-help.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-toolbox-viem": patch
+---
+
+Update the pre-release version number of the viem toolbox inline with the latest full release

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1567,7 +1567,7 @@ importers:
         specifier: workspace:^3.0.0-next.17
         version: link:../../../hardhat-ignition
       '@nomicfoundation/hardhat-toolbox-viem':
-        specifier: workspace:^4.0.0-next.17
+        specifier: workspace:^5.0.0-next.17
         version: link:../../../hardhat-toolbox-viem
       '@types/node':
         specifier: ^22.8.5

--- a/v-next/hardhat-toolbox-viem/package.json
+++ b/v-next/hardhat-toolbox-viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/hardhat-toolbox-viem",
-  "version": "4.0.0-next.17",
+  "version": "5.0.0-next.17",
   "description": "Nomic Foundation's recommended bundle of Hardhat plugins",
   "homepage": "https://github.com/nomicfoundation/hardhat/tree/v-next/v-next/hardhat-toolbox-viem",
   "repository": {

--- a/v-next/hardhat/templates/01-node-test-runner-viem/package.json
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "devDependencies": {
     "hardhat": "workspace:^3.0.0-next.17",
-    "@nomicfoundation/hardhat-toolbox-viem": "workspace:^4.0.0-next.17",
+    "@nomicfoundation/hardhat-toolbox-viem": "workspace:^5.0.0-next.17",
     "@nomicfoundation/hardhat-ignition": "workspace:^3.0.0-next.17",
     "@types/node": "^22.8.5",
     "forge-std": "foundry-rs/forge-std#v1.9.4",


### PR DESCRIPTION
We released a new major version of the viem toolbox. Hence the alpha version has to be incremented by a major version.

## Testing

I tested the version change manually using verdaccio, then installed both the viem and ethers toolbox template projects and ran through the standard compile/test/run/ignition smoke tests.
