### PR TITLE
chore: fix spelling issues

### DIFF
--- a/packages/hardhat-ignition/test/deploy/nonce-checks/error-on-rerun-with-replaced-pending-user-transaction.ts
+++ b/packages/hardhat-ignition/test/deploy/nonce-checks/error-on-rerun-with-replaced-pending-user-transaction.ts
@@ -52,7 +52,7 @@ describe("execution - error on rerun with replaced pending user transaction", ()
 
     const FooArtifact = this.hre.artifacts.readArtifactSync("Foo");
 
-    // Send user interefering deploy transaction, between runs
+    // Send user interfering deploy transaction, between runs
     // so it is in mempool, overriding the existing nonce 2
     // transaction
     const [, , signer2] = (await this.hre.network.provider.request({

--- a/packages/hardhat-ignition/test/ui/helpers/test-format.ts
+++ b/packages/hardhat-ignition/test/ui/helpers/test-format.ts
@@ -9,7 +9,7 @@ export function testFormat(expected: string): string {
     .substring(1) // Remove the first newline
     .split("\n");
 
-  // calcualte the length of the whitespace prefix based on the first line
+  // calculate the length of the whitespace prefix based on the first line
   const whitespacePrefixLength = lines[0].search(/\S/);
 
   return lines


### PR DESCRIPTION
Hey devs! Found and fixed simple errors

packages/hardhat-ignition/test/deploy/nonce-checks/error-on-rerun-with-replaced-pending-user-transaction.ts
`interefering` - `interfering`

packages/hardhat-ignition/test/ui/helpers/test-format.ts
`calcualte` - `calculate`