### PR TITLE
Update development branch link to the correct GitHub organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The linter is always run in the CI, so make sure it passes before pushing code. 
 
 ## Branching
 
-We work on two branches, [`main`](https://github.com/nomiclabs/hardhat/tree/main) and [`development`](https://github.com/nomiclabs/hardhat/tree/development).
+We work on two branches, [`main`](https://github.com/nomiclabs/hardhat/tree/main) and [`development`](https://github.com/NomicFoundation/hardhat/tree/development).
 
 The `main` branch is meant to be kept in sync with the latest released version of each package. Most pull requests are based on `main`, so when in doubt use this branch.
 


### PR DESCRIPTION
Replaced the outdated link to the development branch from https://github.com/nomiclabs/hardhat/tree/development to the correct https://github.com/NomicFoundation/hardhat/tree/development in CONTRIBUTING.md. This ensures contributors are directed to the current repository and branch structure.