### PR TITLE
Fix Typos and Improve Comment Clarity

### DIFF
--- a/packages/hardhat-ignition/test/ui/helpers/test-format.ts
+++ b/packages/hardhat-ignition/test/ui/helpers/test-format.ts
@@ -9,7 +9,7 @@ export function testFormat(expected: string): string {
     .substring(1) // Remove the first newline
     .split("\n");
 
-  // calcualte the length of the whitespace prefix based on the first line
+  // calculate the length of the whitespace prefix based on the first line
   const whitespacePrefixLength = lines[0].search(/\S/);
 
   return lines

--- a/packages/hardhat-truffle4/test/tests.ts
+++ b/packages/hardhat-truffle4/test/tests.ts
@@ -93,7 +93,7 @@ function testArtifactsFunctionality() {
     assert.equal(await greeterWithNew.greet(), "Hi!!!");
   });
 
-  it("Should provison cloned contracts", async function () {
+  it("Should provision cloned contracts", async function () {
     const Greeter = this.env.artifacts.require("Greeter");
     const ClonedGreeter = Greeter.clone();
     const greeter = await ClonedGreeter.new();

--- a/packages/hardhat-truffle5/test/tests.ts
+++ b/packages/hardhat-truffle5/test/tests.ts
@@ -86,7 +86,7 @@ function testArtifactsFunctionality() {
     assert.equal(await greeterWithNew.greet(), "Hi!!!");
   });
 
-  it("Should provison cloned contracts", async function () {
+  it("Should provision cloned contracts", async function () {
     const Greeter = this.env.artifacts.require("Greeter");
     const ClonedGreeter = Greeter.clone();
     const greeter = await ClonedGreeter.new();


### PR DESCRIPTION


---

**Description:**  
- Corrected typos in test descriptions (`provison` → `provision`) in Truffle4 and Truffle5 test files.
- Improved comment clarity in `testFormat` helper by fixing a minor typo.


---