### PR TITLE
feat: added a global verbosity flag

### DIFF
--- a/.changeset/lucky-elephants-play.md
+++ b/.changeset/lucky-elephants-play.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added a global verbosity flag

--- a/v-next/hardhat/src/internal/builtin-global-options.ts
+++ b/v-next/hardhat/src/internal/builtin-global-options.ts
@@ -1,6 +1,6 @@
 import type { GlobalOptionDefinitions } from "../types/global-options.js";
 
-import { globalFlag, globalOption } from "../config.js";
+import { globalFlag, globalLevel, globalOption } from "../config.js";
 import { ArgumentType } from "../types/arguments.js";
 
 export const BUILTIN_GLOBAL_OPTIONS_DEFINITIONS: GlobalOptionDefinitions =
@@ -55,6 +55,17 @@ export const BUILTIN_GLOBAL_OPTIONS_DEFINITIONS: GlobalOptionDefinitions =
         option: globalFlag({
           name: "verbose",
           description: "Enables Hardhat verbose logging.",
+        }),
+      },
+    ],
+    [
+      "verbosity",
+      {
+        pluginId: "builtin",
+        option: globalLevel({
+          name: "verbosity",
+          shortName: "v",
+          description: "Sets the verbosity level.",
         }),
       },
     ],

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -242,12 +242,16 @@ export async function parseBuiltinGlobalOptions(
   showStackTraces: boolean;
   help: boolean;
   version: boolean;
+  verbose: boolean;
+  verbosity: number;
 }> {
   let configPath: string | undefined;
   let showStackTraces: boolean = isCi();
   let help: boolean = false;
   let version: boolean = false;
   let init: boolean = false;
+  let verbose: boolean = false;
+  let verbosity: number = 0;
 
   const builtinGlobalOptions = await parseGlobalOptions(
     BUILTIN_GLOBAL_OPTIONS_DEFINITIONS,
@@ -275,11 +279,20 @@ export async function parseBuiltinGlobalOptions(
     version = builtinGlobalOptions.version;
   }
 
+  if (builtinGlobalOptions.verbose === true) {
+    verbose = true;
+    verbosity = 1;
+  }
+
   if (
-    builtinGlobalOptions.verbose === true ||
-    (builtinGlobalOptions.verbosity !== undefined &&
-      builtinGlobalOptions.verbosity !== 0)
+    builtinGlobalOptions.verbosity !== undefined &&
+    builtinGlobalOptions.verbosity !== 0
   ) {
+    verbose = true;
+    verbosity = builtinGlobalOptions.verbosity;
+  }
+
+  if (verbose) {
     debug.enable("hardhat*");
   }
 
@@ -289,7 +302,15 @@ export async function parseBuiltinGlobalOptions(
     );
   }
 
-  return { init, configPath, showStackTraces, help, version };
+  return {
+    init,
+    configPath,
+    showStackTraces,
+    help,
+    version,
+    verbose,
+    verbosity,
+  };
 }
 
 export async function parseGlobalOptions(

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -232,6 +232,7 @@ export async function main(
   }
 }
 
+// TODO: Replace calls to parseBuiltinGlobalOptions with parseGlobalOptions(BUILTIN_GLOBAL_OPTIONS_DEFINITIONS, ...)
 export async function parseBuiltinGlobalOptions(
   cliArguments: string[],
   usedCliArguments: boolean[],
@@ -248,66 +249,38 @@ export async function parseBuiltinGlobalOptions(
   let version: boolean = false;
   let init: boolean = false;
 
-  for (let i = 0; i < cliArguments.length; i++) {
-    const arg = cliArguments[i];
+  const builtinGlobalOptions = await parseGlobalOptions(
+    BUILTIN_GLOBAL_OPTIONS_DEFINITIONS,
+    cliArguments,
+    usedCliArguments,
+  );
 
-    if (arg === "--init") {
-      usedCliArguments[i] = true;
-      init = true;
-      continue;
-    }
+  if (builtinGlobalOptions.init !== undefined) {
+    init = builtinGlobalOptions.init;
+  }
 
-    if (arg === "--config") {
-      usedCliArguments[i] = true;
+  if (builtinGlobalOptions.config !== undefined) {
+    configPath = builtinGlobalOptions.config;
+  }
 
-      if (configPath !== undefined) {
-        throw new HardhatError(
-          HardhatError.ERRORS.CORE.ARGUMENTS.DUPLICATED_NAME,
-          {
-            name: "--config",
-          },
-        );
-      }
+  if (builtinGlobalOptions.showStackTraces !== undefined) {
+    showStackTraces = builtinGlobalOptions.showStackTraces;
+  }
 
-      if (
-        usedCliArguments[i + 1] === undefined ||
-        usedCliArguments[i + 1] === true
-      ) {
-        throw new HardhatError(
-          HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_CONFIG_FILE,
-        );
-      }
+  if (builtinGlobalOptions.help !== undefined) {
+    help = builtinGlobalOptions.help;
+  }
 
-      configPath = cliArguments[i + 1];
-      i++;
+  if (builtinGlobalOptions.version !== undefined) {
+    version = builtinGlobalOptions.version;
+  }
 
-      usedCliArguments[i] = true;
-      continue;
-    }
-
-    if (arg === "--show-stack-traces") {
-      usedCliArguments[i] = true;
-      showStackTraces = true;
-      continue;
-    }
-
-    if (arg === "--help") {
-      usedCliArguments[i] = true;
-      help = true;
-      continue;
-    }
-
-    if (arg === "--version") {
-      usedCliArguments[i] = true;
-      version = true;
-      continue;
-    }
-
-    if (arg === "--verbose") {
-      usedCliArguments[i] = true;
-      debug.enable("hardhat*");
-      continue;
-    }
+  if (
+    builtinGlobalOptions.verbose === true ||
+    (builtinGlobalOptions.verbosity !== undefined &&
+      builtinGlobalOptions.verbosity !== 0)
+  ) {
+    debug.enable("hardhat*");
   }
 
   if (init && configPath !== undefined) {

--- a/v-next/hardhat/src/types/global-options.ts
+++ b/v-next/hardhat/src/types/global-options.ts
@@ -21,6 +21,8 @@ export interface GlobalOptions {
   help: boolean;
   init: boolean;
   showStackTraces: boolean;
+  verbose: boolean;
+  verbosity: number;
   version: boolean;
 }
 

--- a/v-next/hardhat/test/internal/cli/help/get-global-help-string.ts
+++ b/v-next/hardhat/test/internal/cli/help/get-global-help-string.ts
@@ -201,6 +201,7 @@ GLOBAL OPTIONS:
   --user-option-1          userOption1 description.
   --user-option-2          userOption2 description.
   --verbose                Enables Hardhat verbose logging.
+  --verbosity              Sets the verbosity level.
   --version                Shows hardhat's version.
 
 To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
@@ -300,6 +301,7 @@ GLOBAL OPTIONS:
   --user-option-1          userOption1 description.
   --user-option-2          userOption2 description.
   --verbose                Enables Hardhat verbose logging.
+  --verbosity              Sets the verbosity level.
   --version                Shows hardhat's version.
 
 To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;

--- a/v-next/hardhat/test/internal/cli/help/get-global-help-string.ts
+++ b/v-next/hardhat/test/internal/cli/help/get-global-help-string.ts
@@ -201,7 +201,7 @@ GLOBAL OPTIONS:
   --user-option-1          userOption1 description.
   --user-option-2          userOption2 description.
   --verbose                Enables Hardhat verbose logging.
-  --verbosity              Sets the verbosity level.
+  --verbosity, -v          Sets the verbosity level.
   --version                Shows hardhat's version.
 
 To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
@@ -301,7 +301,7 @@ GLOBAL OPTIONS:
   --user-option-1          userOption1 description.
   --user-option-2          userOption2 description.
   --verbose                Enables Hardhat verbose logging.
-  --verbosity              Sets the verbosity level.
+  --verbosity, -v          Sets the verbosity level.
   --version                Shows hardhat's version.
 
 To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -392,7 +392,7 @@ For global options help run: hardhat --help`;
     it("should set all the builtin global options", async function () {
       // All the <value> and "task" should be ignored
       const command =
-        "npx hardhat --help <value> --version --show-stack-traces task --config ./path-to-config <value>";
+        "npx hardhat --help <value> --version --show-stack-traces task --config ./path-to-config --verbose --verbosity 2 <value>";
 
       const cliArguments = command.split(" ").slice(2);
       const usedCliArguments = new Array(cliArguments.length).fill(false);
@@ -410,6 +410,9 @@ For global options help run: hardhat --help`;
         false,
         true,
         true,
+        true,
+        true,
+        true,
         false,
       ]);
       assert.deepEqual(builtinGlobalOptions, {
@@ -418,6 +421,8 @@ For global options help run: hardhat --help`;
         showStackTraces: true,
         help: true,
         version: true,
+        verbose: true,
+        verbosity: 2,
       });
     });
 
@@ -446,6 +451,8 @@ For global options help run: hardhat --help`;
         showStackTraces: expected,
         help: false,
         version: false,
+        verbose: false,
+        verbosity: 0,
       });
     });
 
@@ -466,6 +473,77 @@ For global options help run: hardhat --help`;
         showStackTraces: true,
         help: false,
         version: false,
+        verbose: false,
+        verbosity: 0,
+      });
+    });
+
+    it("should set the verbose flag if the verbosity flag is used", async function () {
+      const command = "npx hardhat --verbosity 2";
+
+      const cliArguments = command.split(" ").slice(2);
+      const usedCliArguments = new Array(cliArguments.length).fill(false);
+
+      const builtinGlobalOptions = await parseBuiltinGlobalOptions(
+        cliArguments,
+        usedCliArguments,
+      );
+
+      assert.deepEqual(usedCliArguments, [true, true]);
+      assert.deepEqual(builtinGlobalOptions, {
+        init: false,
+        configPath: undefined,
+        showStackTraces: false,
+        help: false,
+        version: false,
+        verbose: true,
+        verbosity: 2,
+      });
+    });
+
+    it("should set the verbosity flag if the verbose flag is used", async function () {
+      const command = "npx hardhat --verbose";
+
+      const cliArguments = command.split(" ").slice(2);
+      const usedCliArguments = new Array(cliArguments.length).fill(false);
+
+      const builtinGlobalOptions = await parseBuiltinGlobalOptions(
+        cliArguments,
+        usedCliArguments,
+      );
+
+      assert.deepEqual(usedCliArguments, [true]);
+      assert.deepEqual(builtinGlobalOptions, {
+        init: false,
+        configPath: undefined,
+        showStackTraces: false,
+        help: false,
+        version: false,
+        verbose: true,
+        verbosity: 1,
+      });
+    });
+
+    it("should set the verbosity flag through grouped repetition", async function () {
+      const command = "npx hardhat -vvvv";
+
+      const cliArguments = command.split(" ").slice(2);
+      const usedCliArguments = new Array(cliArguments.length).fill(false);
+
+      const builtinGlobalOptions = await parseBuiltinGlobalOptions(
+        cliArguments,
+        usedCliArguments,
+      );
+
+      assert.deepEqual(usedCliArguments, [true]);
+      assert.deepEqual(builtinGlobalOptions, {
+        init: false,
+        configPath: undefined,
+        showStackTraces: false,
+        help: false,
+        version: false,
+        verbose: true,
+        verbosity: 4,
       });
     });
 

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -288,7 +288,7 @@ GLOBAL OPTIONS:
   --network                The network to connect to
   --show-stack-traces      Show stack traces (always enabled on CI servers).
   --verbose                Enables Hardhat verbose logging.
-  --verbosity              Sets the verbosity level.
+  --verbosity, -v          Sets the verbosity level.
   --version                Shows hardhat's version.
 
 To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -389,6 +389,13 @@ For global options help run: hardhat --help`;
   });
 
   describe("parseBuiltinGlobalOptions", function () {
+    let showStackTraces: boolean;
+
+    before(function () {
+      // In the GitHub CI this value is true, but in the local environment it is false
+      showStackTraces = isCi();
+    });
+
     it("should set all the builtin global options", async function () {
       // All the <value> and "task" should be ignored
       const command =
@@ -442,13 +449,10 @@ For global options help run: hardhat --help`;
         new Array(cliArguments.length).fill(false),
       );
 
-      // In the GitHub CI this value is true, but in the local environment it is false
-      const expected = isCi();
-
       assert.deepEqual(builtinGlobalOptions, {
         init: false,
         configPath: undefined,
-        showStackTraces: expected,
+        showStackTraces,
         help: false,
         version: false,
         verbose: false,
@@ -493,7 +497,7 @@ For global options help run: hardhat --help`;
       assert.deepEqual(builtinGlobalOptions, {
         init: false,
         configPath: undefined,
-        showStackTraces: false,
+        showStackTraces,
         help: false,
         version: false,
         verbose: true,
@@ -516,7 +520,7 @@ For global options help run: hardhat --help`;
       assert.deepEqual(builtinGlobalOptions, {
         init: false,
         configPath: undefined,
-        showStackTraces: false,
+        showStackTraces,
         help: false,
         version: false,
         verbose: true,
@@ -539,7 +543,7 @@ For global options help run: hardhat --help`;
       assert.deepEqual(builtinGlobalOptions, {
         init: false,
         configPath: undefined,
-        showStackTraces: false,
+        showStackTraces,
         help: false,
         version: false,
         verbose: true,

--- a/v-next/hardhat/test/internal/hre-initialization.ts
+++ b/v-next/hardhat/test/internal/hre-initialization.ts
@@ -251,6 +251,7 @@ describe("HRE initialization", () => {
           init: false,
           showStackTraces: false,
           verbose: false,
+          verbosity: 0,
           version: false,
           myGlobalOption: "default",
           network: undefined,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This PR builds on top of https://github.com/NomicFoundation/hardhat/pull/6942 which added support for level argument types. It adds a global option - `verbosity` - of type level. It can be used to set the verbosity level of debug logging.

After the changes, hardhat debug logging will be enabled when either the `verbose` or `verbosity` flag is provided.

I also added `verbose` and `verbosity` to the global options interface, and simplified the logic of parsing builtin global options (now it uses the same parser all the other options go through).