### PR TITLE
Add 'test solidity' test verifying a failure

### DIFF
--- a/v-next/hardhat/test/fixture-projects/solidity-test/test/contracts/failing/Failing.t.sol
+++ b/v-next/hardhat/test/fixture-projects/solidity-test/test/contracts/failing/Failing.t.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract FailingTest {
+  function testFailing() public view {
+    revert("Failing");
+  }
+}

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -1,5 +1,6 @@
 import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
 
+import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
@@ -15,6 +16,7 @@ import hardhatConfig from "../../../fixture-projects/solidity-test/hardhat.confi
  * The fixture project for this test has two folders:
  *   - all: runs all tests — verifies that all test files are executed
  *   - partial: runs selected tests — verifies that only specific files are executed
+ *   - failing: test that fails — used to verify that tests actually run
  *
  * The `partial` folder includes a test that fails if run, ensuring the task-action runs only the intended files.
  * If it fails, unintended files were executed.
@@ -28,6 +30,11 @@ const hardhatConfigAllTests = {
 const hardhatConfigPartialTests = {
   ...hardhatConfig,
   paths: { tests: { solidity: "test/contracts/partial" } },
+};
+
+const hardhatConfigFailingTests = {
+  ...hardhatConfig,
+  paths: { tests: { solidity: "test/contracts/failing" } },
 };
 
 describe("solidity-test/task-action", function () {
@@ -107,6 +114,20 @@ describe("solidity-test/task-action", function () {
           files: "./test/not-in-test-path.ts",
         },
       );
+    });
+  });
+
+  describe("running the tests", () => {
+    it("should run all the tests and throw if any of them fail", async () => {
+      hre = await createHardhatRuntimeEnvironment(hardhatConfigFailingTests);
+
+      const exitCode = process.exitCode;
+      try {
+        await hre.tasks.getTask(["test", "solidity"]).run({ noCompile: true });
+        assert.equal(process.exitCode, 1);
+      } finally {
+        process.exitCode = exitCode;
+      }
     });
   });
 });


### PR DESCRIPTION
This PR adds a test to the `test solidity` task, verifying that the tests are actually run. This is done by introducing a failing test and asserting its failure.