### PR TITLE
Enable multichain testing support in Solidity test runner

### DIFF
--- a/.changeset/fluffy-glasses-beam.md
+++ b/.changeset/fluffy-glasses-beam.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/config": patch
+"hardhat": patch
+---
+
+Enable multichain testing support in Solidity test runner

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
   v-next/hardhat:
     dependencies:
       '@ignored/edr-optimism':
-        specifier: 0.13.0-alpha.5
-        version: 0.13.0-alpha.5
+        specifier: 0.13.0-alpha.6
+        version: 0.13.0-alpha.6
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.0-next.20
         version: link:../hardhat-errors
@@ -2306,36 +2306,36 @@ packages:
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
 
-  '@ignored/edr-optimism-darwin-arm64@0.13.0-alpha.5':
-    resolution: {integrity: sha512-J1ooV4FwBsSZmP1SdafzKDuudKQActy2UxMIl2qXlv8zg25oxqUwsS5SixbLjBfyZYIWxp5Ney7dc8GReqMy/Q==}
+  '@ignored/edr-optimism-darwin-arm64@0.13.0-alpha.6':
+    resolution: {integrity: sha512-axmysWxVDvvppIfHdWATWFeUGs0o17pD3skvAMS1yNJwnDm53C4b2UftQqbGDvLuMWVLypmTY9oEC8vyD4QCQA==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-darwin-x64@0.13.0-alpha.5':
-    resolution: {integrity: sha512-jIcouElAPl4LqeRqer/OPwIPnqJ5jtaZlRtCJNKzN/aUeGf/ZQSmZZc4Mw8xRb4f/0kD7tdEx+QW5ofMIrP/uA==}
+  '@ignored/edr-optimism-darwin-x64@0.13.0-alpha.6':
+    resolution: {integrity: sha512-Mh5ZzNdP2NPuMY/7srzZH/UQCYTSZUu/erPeaWvCIEDIpGP6D8IRs+/7Uj/CBdR+IJwV5i+DcaKEirAcH5T44w==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-arm64-gnu@0.13.0-alpha.5':
-    resolution: {integrity: sha512-W1WuixRgWAcsVFY6uO+WwUee+iqd3tUgmqXwN+u58y2+pHMFZrGdDRd/yaTlIpdH3z/XzCgFd+/eBNERYcef9Q==}
+  '@ignored/edr-optimism-linux-arm64-gnu@0.13.0-alpha.6':
+    resolution: {integrity: sha512-REu57Vz8ldAV7ck8JDRLEoN7+sOTmmZ+Ujx2oxqXYn5oEd1ZWXEd5zF36mqGlNHRqTPNwWhZmvFgObFWmfg92g==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-arm64-musl@0.13.0-alpha.5':
-    resolution: {integrity: sha512-2k8C6uu93AWz+pcLvU5OCQSnI+D8bnr1jhUChbFjHgpRdsKu6WWaUAWjsLSJtloBNsUIXLXiaCbUZVHflrzqTg==}
+  '@ignored/edr-optimism-linux-arm64-musl@0.13.0-alpha.6':
+    resolution: {integrity: sha512-fJxv6A2NwDj4YsjPvB0W343z+eoJ+RVZLCCANCCPpy84OeqZDFkFVaKdvVUJv9yuI3BBOnIIGFdlc/zkavyl6A==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-x64-gnu@0.13.0-alpha.5':
-    resolution: {integrity: sha512-XjiRZpgIqkypOF6lCpgn7UdZMRGAlD53xWDzsEy2oYd1LsU2R1y8lBDwf0RfZQOCpIEeuYQR55vdwtmrNldayg==}
+  '@ignored/edr-optimism-linux-x64-gnu@0.13.0-alpha.6':
+    resolution: {integrity: sha512-4+iLjlCNb8uk8n/i51FWK4t/pJZRxJN7/sxPZkz2uSkg6OL82jjQQqbyn0bNgfKKJObRn0++QAZ+Iz052DR7bw==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-linux-x64-musl@0.13.0-alpha.5':
-    resolution: {integrity: sha512-yazP0bVhYX0TLECwG+B3Hw0o+NIgEOfr5FWELjDOc8xx4U275j4K/dZHSOBOIxHHYDB7hyM6NLnB+spCEBmUhQ==}
+  '@ignored/edr-optimism-linux-x64-musl@0.13.0-alpha.6':
+    resolution: {integrity: sha512-YCnPHemYur1CqV4aLOFRY79n6hEiKZgHywg8OmRSrfItAQlmZq2NGpVwyEz7WKYMhmIpDCb/+BSJpOVcG+O1qA==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism-win32-x64-msvc@0.13.0-alpha.5':
-    resolution: {integrity: sha512-3ThTAlzyZQ29PAe/MyVec5M6OA1PyG2igMZcb3r7RtOwoFPx3WNWlKwEmpT1xgkFKLShMjsFdVEmXS0dTEezZQ==}
+  '@ignored/edr-optimism-win32-x64-msvc@0.13.0-alpha.6':
+    resolution: {integrity: sha512-iSM5QJnFKpenzhqk5OcqJsiNhajGG2eiq//axNjkmKmxlQ+BlTMNDYvfHxacGaZUoiJMb479fRx7sWeMHnrZlw==}
     engines: {node: '>= 18'}
 
-  '@ignored/edr-optimism@0.13.0-alpha.5':
-    resolution: {integrity: sha512-TzoEnMX5gBXcbDyFs8Ozbtv57nJ0Fw8Kpqd2iE+wTj5NAIBXZvscKXj/5FxA6fF/3JJcxm8DPnvfQUo5lgmzHg==}
+  '@ignored/edr-optimism@0.13.0-alpha.6':
+    resolution: {integrity: sha512-n13L9UUp+8sD3HtYOBsd40M2RdJ7amHfaXi+LRjpi4BGD4zjMGKxINYf1cZxYm2vsB5hZHkpdtaRKHfVdPwCrA==}
     engines: {node: '>= 18'}
 
   '@isaacs/cliui@8.0.2':
@@ -6198,36 +6198,36 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
-  '@ignored/edr-optimism-darwin-arm64@0.13.0-alpha.5':
+  '@ignored/edr-optimism-darwin-arm64@0.13.0-alpha.6':
     optional: true
 
-  '@ignored/edr-optimism-darwin-x64@0.13.0-alpha.5':
+  '@ignored/edr-optimism-darwin-x64@0.13.0-alpha.6':
     optional: true
 
-  '@ignored/edr-optimism-linux-arm64-gnu@0.13.0-alpha.5':
+  '@ignored/edr-optimism-linux-arm64-gnu@0.13.0-alpha.6':
     optional: true
 
-  '@ignored/edr-optimism-linux-arm64-musl@0.13.0-alpha.5':
+  '@ignored/edr-optimism-linux-arm64-musl@0.13.0-alpha.6':
     optional: true
 
-  '@ignored/edr-optimism-linux-x64-gnu@0.13.0-alpha.5':
+  '@ignored/edr-optimism-linux-x64-gnu@0.13.0-alpha.6':
     optional: true
 
-  '@ignored/edr-optimism-linux-x64-musl@0.13.0-alpha.5':
+  '@ignored/edr-optimism-linux-x64-musl@0.13.0-alpha.6':
     optional: true
 
-  '@ignored/edr-optimism-win32-x64-msvc@0.13.0-alpha.5':
+  '@ignored/edr-optimism-win32-x64-msvc@0.13.0-alpha.6':
     optional: true
 
-  '@ignored/edr-optimism@0.13.0-alpha.5':
+  '@ignored/edr-optimism@0.13.0-alpha.6':
     optionalDependencies:
-      '@ignored/edr-optimism-darwin-arm64': 0.13.0-alpha.5
-      '@ignored/edr-optimism-darwin-x64': 0.13.0-alpha.5
-      '@ignored/edr-optimism-linux-arm64-gnu': 0.13.0-alpha.5
-      '@ignored/edr-optimism-linux-arm64-musl': 0.13.0-alpha.5
-      '@ignored/edr-optimism-linux-x64-gnu': 0.13.0-alpha.5
-      '@ignored/edr-optimism-linux-x64-musl': 0.13.0-alpha.5
-      '@ignored/edr-optimism-win32-x64-msvc': 0.13.0-alpha.5
+      '@ignored/edr-optimism-darwin-arm64': 0.13.0-alpha.6
+      '@ignored/edr-optimism-darwin-x64': 0.13.0-alpha.6
+      '@ignored/edr-optimism-linux-arm64-gnu': 0.13.0-alpha.6
+      '@ignored/edr-optimism-linux-arm64-musl': 0.13.0-alpha.6
+      '@ignored/edr-optimism-linux-x64-gnu': 0.13.0-alpha.6
+      '@ignored/edr-optimism-linux-x64-musl': 0.13.0-alpha.6
+      '@ignored/edr-optimism-win32-x64-msvc': 0.13.0-alpha.6
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/v-next/config/eslint.config.js
+++ b/v-next/config/eslint.config.js
@@ -296,6 +296,7 @@ export function createConfig(
           "type",
           "builtin",
           "external",
+          "internal",
           "parent",
           "sibling",
           "index",

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -85,7 +85,7 @@
     "typescript": "~5.8.0"
   },
   "dependencies": {
-    "@ignored/edr-optimism": "0.13.0-alpha.5",
+    "@ignored/edr-optimism": "0.13.0-alpha.6",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0-next.20",
     "@nomicfoundation/hardhat-utils": "workspace:^3.0.0-next.20",
     "@nomicfoundation/hardhat-zod-utils": "workspace:^3.0.0-next.20",

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -44,7 +44,10 @@ import debug from "debug";
 import { hexToBytes } from "ethereum-cryptography/utils";
 import { addr } from "micro-eth-signer";
 
-import { EDR_NETWORK_REVERT_SNAPSHOT_EVENT } from "../../../constants.js";
+import {
+  EDR_NETWORK_REVERT_SNAPSHOT_EVENT,
+  OPTIMISM_CHAIN_TYPE,
+} from "../../../constants.js";
 import { getGlobalEdrContext } from "../../../edr/context.js";
 import { DEFAULT_HD_ACCOUNTS_CONFIG_PARAMS } from "../accounts/constants.js";
 import { BaseProvider } from "../base-provider.js";
@@ -431,7 +434,7 @@ async function getProviderConfig(
   const chainGenesisState =
     networkConfig.forking !== undefined
       ? [] // TODO: Add support for overriding remote fork state when the local fork is different
-      : networkConfig.chainType === "optimism"
+      : networkConfig.chainType === OPTIMISM_CHAIN_TYPE
         ? opGenesisState(opHardforkFromString(specId))
         : l1GenesisState(l1HardforkFromString(specId));
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -48,6 +48,7 @@ import {
   EDR_NETWORK_REVERT_SNAPSHOT_EVENT,
   OPTIMISM_CHAIN_TYPE,
 } from "../../../constants.js";
+import { hardhatChainTypeToEdrChainType } from "../../../edr/chain-type.js";
 import { getGlobalEdrContext } from "../../../edr/context.js";
 import { DEFAULT_HD_ACCOUNTS_CONFIG_PARAMS } from "../accounts/constants.js";
 import { BaseProvider } from "../base-provider.js";
@@ -72,7 +73,6 @@ import {
   hardhatHardforkToEdrSpecId,
   hardhatAccountsToEdrOwnedAccounts,
   hardhatForkingConfigToEdrForkConfig,
-  hardhatChainTypeToEdrChainType,
 } from "./utils/convert-to-edr.js";
 import { printLine, replaceLastLine } from "./utils/logger.js";
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -36,9 +36,6 @@ import {
   SHANGHAI,
   CANCUN,
   PRAGUE,
-  OP_CHAIN_TYPE as EDR_OP_CHAIN_TYPE,
-  L1_CHAIN_TYPE as EDR_L1_CHAIN_TYPE,
-  GENERIC_CHAIN_TYPE as EDR_GENERIC_CHAIN_TYPE,
   BEDROCK,
   REGOLITH,
   CANYON,
@@ -342,16 +339,4 @@ export async function hardhatForkingConfigToEdrForkConfig(
   }
 
   return fork;
-}
-
-export function hardhatChainTypeToEdrChainType(chainType: ChainType): string {
-  if (chainType === OPTIMISM_CHAIN_TYPE) {
-    return EDR_OP_CHAIN_TYPE;
-  }
-
-  if (chainType === L1_CHAIN_TYPE) {
-    return EDR_L1_CHAIN_TYPE;
-  }
-
-  return EDR_GENERIC_CHAIN_TYPE;
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -25,10 +25,10 @@ import { readBinaryFile } from "@nomicfoundation/hardhat-utils/fs";
 import { deepMerge } from "@nomicfoundation/hardhat-utils/lang";
 
 import { resolveConfigurationVariable } from "../../core/configuration-variables.js";
+import { isEdrSupportedChainType } from "../../edr/chain-type.js";
 
 import { resolveEdrNetwork, resolveHttpNetwork } from "./config-resolution.js";
 import { EdrProvider } from "./edr/edr-provider.js";
-import { isEdrSupportedChainType } from "./edr/utils/chain-type.js";
 import { HttpProvider } from "./http-provider.js";
 import { NetworkConnectionImplementation } from "./network-connection.js";
 import { validateNetworkConfigOverride } from "./type-validation.js";

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -25,7 +25,7 @@ import { readBinaryFile } from "@nomicfoundation/hardhat-utils/fs";
 import { deepMerge } from "@nomicfoundation/hardhat-utils/lang";
 
 import { resolveConfigurationVariable } from "../../core/configuration-variables.js";
-import { isEdrSupportedChainType } from "../../edr/chain-type.js";
+import { isSupportedChainType } from "../../edr/chain-type.js";
 
 import { resolveEdrNetwork, resolveHttpNetwork } from "./config-resolution.js";
 import { EdrProvider } from "./edr/edr-provider.js";
@@ -210,7 +210,7 @@ export class NetworkManagerImplementation implements NetworkManager {
         );
 
       if (resolvedNetworkConfig.type === "edr") {
-        if (!isEdrSupportedChainType(resolvedChainType)) {
+        if (!isSupportedChainType(resolvedChainType)) {
           throw new HardhatError(
             HardhatError.ERRORS.CORE.GENERAL.UNSUPPORTED_OPERATION,
             { operation: `Simulating chain type ${resolvedChainType}` },

--- a/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
@@ -8,7 +8,7 @@ import {
 import { exists } from "@nomicfoundation/hardhat-utils/fs";
 import chalk from "chalk";
 
-import { isEdrSupportedChainType } from "../../edr/chain-type.js";
+import { isSupportedChainType } from "../../edr/chain-type.js";
 
 import { formatEdrNetworkConfigAccounts } from "./helpers.js";
 import { JsonRpcServerImplementation } from "./json-rpc/server.js";
@@ -50,7 +50,7 @@ const nodeAction: NewTaskActionFunction<NodeActionArguments> = async (
   const networkConfigOverride: EdrNetworkConfigOverride = {};
 
   if (args.chainType !== undefined) {
-    if (!isEdrSupportedChainType(args.chainType)) {
+    if (!isSupportedChainType(args.chainType)) {
       // NOTE: We could make the error more specific here.
       throw new HardhatError(
         HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,

--- a/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
@@ -51,7 +51,6 @@ const nodeAction: NewTaskActionFunction<NodeActionArguments> = async (
 
   if (args.chainType !== undefined) {
     if (!isSupportedChainType(args.chainType)) {
-      // NOTE: We could make the error more specific here.
       throw new HardhatError(
         HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
         {

--- a/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
@@ -8,7 +8,7 @@ import {
 import { exists } from "@nomicfoundation/hardhat-utils/fs";
 import chalk from "chalk";
 
-import { isEdrSupportedChainType } from "../network-manager/edr/utils/chain-type.js";
+import { isEdrSupportedChainType } from "../../edr/chain-type.js";
 
 import { formatEdrNetworkConfigAccounts } from "./helpers.js";
 import { JsonRpcServerImplementation } from "./json-rpc/server.js";

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -1,6 +1,7 @@
 import type { RunOptions } from "./runner.js";
 import type { Abi } from "../../../types/artifacts.js";
 import type { SolidityTestConfig } from "../../../types/config.js";
+import type { ChainType } from "../../../types/network.js";
 import type {
   SolidityTestRunnerConfigArgs,
   CachedChains,
@@ -11,7 +12,15 @@ import type {
   Artifact,
 } from "@ignored/edr-optimism";
 
+import {
+  opGenesisState,
+  opLatestHardfork,
+  l1GenesisState,
+  l1HardforkLatest,
+} from "@ignored/edr-optimism";
 import { hexStringToBytes } from "@nomicfoundation/hardhat-utils/hex";
+
+import { OPTIMISM_CHAIN_TYPE } from "../../constants.js";
 
 function hexStringToBuffer(hexString: string): Buffer {
   return Buffer.from(hexStringToBytes(hexString));
@@ -24,6 +33,7 @@ export function solidityTestConfigToRunOptions(
 }
 
 export function solidityTestConfigToSolidityTestRunnerConfigArgs(
+  chainType: ChainType,
   projectRoot: string,
   config: SolidityTestConfig,
   testPattern?: string,
@@ -90,11 +100,17 @@ export function solidityTestConfigToSolidityTestRunnerConfigArgs(
       ? undefined
       : hexStringToBuffer(config.blockCoinbase);
 
+  const localPredeploys =
+    chainType === OPTIMISM_CHAIN_TYPE
+      ? opGenesisState(opLatestHardfork())
+      : l1GenesisState(l1HardforkLatest());
+
   return {
     projectRoot,
     ...config,
     fsPermissions,
     labels,
+    localPredeploys,
     sender,
     txOrigin,
     blockCoinbase,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -1,8 +1,8 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
-import { task } from "../../core/config.js";
-
 import { ArgumentType } from "hardhat/types/arguments";
+
+import { task } from "../../core/config.js";
 
 import "./type-extensions.js";
 
@@ -21,7 +21,7 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .addOption({
         name: "chainType",
-        description: "Not implemented yet - The chain type to use",
+        description: "The chain type to use",
         defaultValue: "l1",
       })
       .addOption({

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/runner.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/runner.ts
@@ -1,4 +1,5 @@
 import type { TestEvent, TestsStream } from "./types.js";
+import type { ChainType } from "../../../types/network.js";
 import type {
   ArtifactId,
   Artifact,
@@ -8,7 +9,6 @@ import type {
 
 import { Readable } from "node:stream";
 
-import { L1_CHAIN_TYPE } from "@ignored/edr-optimism";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
@@ -40,6 +40,7 @@ export interface RunOptions {
  * TODO: Once the signature is finalised, give feedback to the EDR team.
  */
 export function run(
+  chainType: ChainType,
   artifacts: Artifact[],
   testSuiteIds: ArtifactId[],
   configArgs: SolidityTestRunnerConfigArgs,
@@ -80,7 +81,7 @@ export function run(
         const edrContext = await getGlobalEdrContext();
 
         await edrContext.runSolidityTests(
-          L1_CHAIN_TYPE,
+          chainType,
           artifacts,
           testSuiteIds,
           configArgs,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/runner.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/runner.ts
@@ -12,6 +12,7 @@ import { Readable } from "node:stream";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
+import { hardhatChainTypeToEdrChainType } from "../../edr/chain-type.js";
 import { getGlobalEdrContext } from "../../edr/context.js";
 
 import { formatArtifactId } from "./formatters.js";
@@ -79,9 +80,8 @@ export function run(
       // TODO: Add support for predeploys once EDR supports them.
       try {
         const edrContext = await getGlobalEdrContext();
-
         await edrContext.runSolidityTests(
-          chainType,
+          hardhatChainTypeToEdrChainType(chainType),
           artifacts,
           testSuiteIds,
           configArgs,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -14,7 +14,7 @@ import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
 import { resolveFromRoot } from "@nomicfoundation/hardhat-utils/path";
 import { createNonClosingWriter } from "@nomicfoundation/hardhat-utils/stream";
 
-import { isEdrSupportedChainType } from "../../edr/chain-type.js";
+import { isSupportedChainType } from "../../edr/chain-type.js";
 import { throwIfSolidityBuildFailed } from "../solidity/build-results.js";
 
 import { getEdrArtifacts, getBuildInfos } from "./edr-artifacts.js";
@@ -39,7 +39,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
 ) => {
   let rootFilePaths: string[];
 
-  if (!isEdrSupportedChainType(chainType)) {
+  if (!isSupportedChainType(chainType)) {
     // NOTE: We could make the error more specific here.
     throw new HardhatError(
       HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -113,6 +113,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
 
   const config: SolidityTestRunnerConfigArgs =
     solidityTestConfigToSolidityTestRunnerConfigArgs(
+      chainType,
       hre.config.paths.root,
       solidityTestConfig,
       grep,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -9,11 +9,12 @@ import type {
 
 import { finished } from "node:stream/promises";
 
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
 import { resolveFromRoot } from "@nomicfoundation/hardhat-utils/path";
 import { createNonClosingWriter } from "@nomicfoundation/hardhat-utils/stream";
-import chalk from "chalk";
 
+import { isEdrSupportedChainType } from "../../edr/chain-type.js";
 import { throwIfSolidityBuildFailed } from "../solidity/build-results.js";
 
 import { getEdrArtifacts, getBuildInfos } from "./edr-artifacts.js";
@@ -38,14 +39,16 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
 ) => {
   let rootFilePaths: string[];
 
-  if (chainType !== "l1") {
-    console.log(
-      chalk.yellow(
-        `Chain type selection for tests will be implemented soon. Please check our communication channels for updates. For now, please run the task without the --chain-type option.`,
-      ),
+  if (!isEdrSupportedChainType(chainType)) {
+    // NOTE: We could make the error more specific here.
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+      {
+        value: chainType,
+        type: "ChainType",
+        name: "chainType",
+      },
     );
-    process.exitCode = 1;
-    return;
   }
 
   // NOTE: We run the compile task first to ensure all the artifacts for them are generated
@@ -129,6 +132,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   );
 
   const runStream = run(
+    chainType,
     edrArtifacts.map(({ edrAtifact }) => edrAtifact),
     testSuiteIds,
     config,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -40,7 +40,6 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   let rootFilePaths: string[];
 
   if (!isSupportedChainType(chainType)) {
-    // NOTE: We could make the error more specific here.
     throw new HardhatError(
       HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
       {

--- a/v-next/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -9,9 +9,15 @@ const hardhatPlugin: HardhatPlugin = {
   id: "builtin:test",
   tasks: [
     task("test", "Runs all your tests")
-      .addFlag({
-        name: "noCompile",
-        description: "Don't compile the project before running the tests",
+      .addVariadicArgument({
+        name: "testFiles",
+        description: "List of specific files to run tests on",
+        defaultValue: [],
+      })
+      .addOption({
+        name: "chainType",
+        description: "The chain type to use by the solidity test runner",
+        defaultValue: "l1",
       })
       .addOption({
         name: "grep",
@@ -19,10 +25,9 @@ const hardhatPlugin: HardhatPlugin = {
         type: ArgumentType.STRING_WITHOUT_DEFAULT,
         defaultValue: undefined,
       })
-      .addVariadicArgument({
-        name: "testFiles",
-        description: "List of specific files to run tests on",
-        defaultValue: [],
+      .addFlag({
+        name: "noCompile",
+        description: "Don't compile the project before running the tests",
       })
       .setAction(import.meta.resolve("./task-action.js"))
       .build(),

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -1,5 +1,9 @@
 import type { HookManager } from "../../../types/hooks.js";
-import type { NewTaskActionFunction, Task } from "../../../types/tasks.js";
+import type {
+  NewTaskActionFunction,
+  Task,
+  TaskArguments,
+} from "../../../types/tasks.js";
 
 import {
   assertHardhatInvariant,
@@ -10,12 +14,13 @@ import { HardhatRuntimeEnvironmentImplementation } from "../../core/hre.js";
 
 interface TestActionArguments {
   testFiles: string[];
-  noCompile: boolean;
+  chainType: string;
   grep: string | undefined;
+  noCompile: boolean;
 }
 
 const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
-  { testFiles, noCompile, grep },
+  { testFiles, chainType, grep, noCompile },
   hre,
 ) => {
   // If this code is executed, it means the user has not specified a test runner.
@@ -50,14 +55,14 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
       continue;
     }
 
-    const args = {
+    const args: TaskArguments = {
       testFiles: files,
-      noCompile: false,
       grep,
+      noCompile: subtask.options.has("noCompile"),
     };
 
-    if (subtask.options.has("noCompile")) {
-      args.noCompile = true;
+    if (subtask.options.has("chainType")) {
+      args.chainType = chainType;
     }
 
     await subtask.run(args);

--- a/v-next/hardhat/src/internal/edr/chain-type.ts
+++ b/v-next/hardhat/src/internal/edr/chain-type.ts
@@ -1,12 +1,18 @@
 import type { ChainType } from "../../types/network.js";
 
 import {
+  OP_CHAIN_TYPE as EDR_OP_CHAIN_TYPE,
+  L1_CHAIN_TYPE as EDR_L1_CHAIN_TYPE,
+  GENERIC_CHAIN_TYPE as EDR_GENERIC_CHAIN_TYPE,
+} from "@ignored/edr-optimism";
+
+import {
   GENERIC_CHAIN_TYPE,
   L1_CHAIN_TYPE,
   OPTIMISM_CHAIN_TYPE,
 } from "../constants.js";
 
-export function isEdrSupportedChainType(
+export function isSupportedChainType(
   chainType: unknown,
 ): chainType is ChainType {
   return (
@@ -14,4 +20,16 @@ export function isEdrSupportedChainType(
     chainType === L1_CHAIN_TYPE ||
     chainType === OPTIMISM_CHAIN_TYPE
   );
+}
+
+export function hardhatChainTypeToEdrChainType(chainType: ChainType): string {
+  if (chainType === OPTIMISM_CHAIN_TYPE) {
+    return EDR_OP_CHAIN_TYPE;
+  }
+
+  if (chainType === L1_CHAIN_TYPE) {
+    return EDR_L1_CHAIN_TYPE;
+  }
+
+  return EDR_GENERIC_CHAIN_TYPE;
 }

--- a/v-next/hardhat/src/internal/edr/chain-type.ts
+++ b/v-next/hardhat/src/internal/edr/chain-type.ts
@@ -1,10 +1,10 @@
-import type { ChainType } from "../../../../../types/network.js";
+import type { ChainType } from "../../types/network.js";
 
 import {
   GENERIC_CHAIN_TYPE,
   L1_CHAIN_TYPE,
   OPTIMISM_CHAIN_TYPE,
-} from "../../../../constants.js";
+} from "../constants.js";
 
 export function isEdrSupportedChainType(
   chainType: unknown,

--- a/v-next/hardhat/test/fixture-projects/solidity-test/contracts/Predeploy.sol
+++ b/v-next/hardhat/test/fixture-projects/solidity-test/contracts/Predeploy.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Predeploy {
+  // This function checks the size of the L1Block predeploy contract.
+  // The L1Block predeploy is only available in OP chain types, so this function
+  // will return a zero size in L1 or other non-OP chains.
+  function getPredeploySize() external view returns (uint256) {
+    address l1BlockPredeployAddress = 0x4200000000000000000000000000000000000015;
+    uint256 predeploySize;
+
+    assembly {
+      predeploySize := extcodesize(l1BlockPredeployAddress)
+    }
+
+    return predeploySize;
+  }
+}

--- a/v-next/hardhat/test/fixture-projects/solidity-test/test/contracts/failing/Failing.t.sol
+++ b/v-next/hardhat/test/fixture-projects/solidity-test/test/contracts/failing/Failing.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 contract FailingTest {
-  function testFailing() public view {
+  function testFailing() public pure {
     revert("Failing");
   }
 }

--- a/v-next/hardhat/test/fixture-projects/solidity-test/test/contracts/op/Predeploy.t.sol
+++ b/v-next/hardhat/test/fixture-projects/solidity-test/test/contracts/op/Predeploy.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../../contracts/Predeploy.sol";
+
+contract PredeployTest {
+  Predeploy predeploy;
+
+  function setUp() public {
+    predeploy = new Predeploy();
+  }
+
+  function testGetPredeploySize() public view {
+    require(
+      predeploy.getPredeploySize() > 0,
+      "Predeploy size should be greater than 0"
+    );
+  }
+}

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -37,6 +37,11 @@ const hardhatConfigFailingTests = {
   paths: { tests: { solidity: "test/contracts/failing" } },
 };
 
+const hardhatConfigOpTests = {
+  ...hardhatConfig,
+  paths: { tests: { solidity: "test/contracts/op" } },
+};
+
 describe("solidity-test/task-action", function () {
   let hre: HardhatRuntimeEnvironment;
 
@@ -128,6 +133,32 @@ describe("solidity-test/task-action", function () {
       } finally {
         process.exitCode = exitCode;
       }
+    });
+
+    describe("when the contracts are in the optimism chain type", () => {
+      it("should run all the solidity tests when the optimism chain type is specified", async () => {
+        hre = await createHardhatRuntimeEnvironment(hardhatConfigOpTests);
+
+        await hre.tasks.getTask(["test", "solidity"]).run({
+          noCompile: true,
+          chainType: "optimism",
+        });
+      });
+
+      it("should throw because the test is not compatible with the l1 chain type", async () => {
+        hre = await createHardhatRuntimeEnvironment(hardhatConfigOpTests);
+
+        const exitCode = process.exitCode;
+        try {
+          // default chain type is l1
+          await hre.tasks.getTask(["test", "solidity"]).run({
+            noCompile: true,
+          });
+          assert.equal(process.exitCode, 1);
+        } finally {
+          process.exitCode = exitCode;
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
This PR introduces support for multichain testing in the Solidity test runner.

#### Functional changes
- Configure predeploys for the solidity test runner.
- Allow passing `--chain-type` as an option to the `test solidity` task and validate it.
- Allow passing `--chain-type` as an option to the `test` task and forward it to `test solidity`.
- Add tests to ensure the `chainType` parameter is passed and predeploy contracts are working as expected.

#### Non-functional changes
- Refactor utilities: moved logic from `network-manager` to `internal/edr` and renamed.
- Fix ESLint `import/order` rule by adding the `"internal"` group so absolute imports from local packages are correctly ordered between external and relative imports.

Closes https://github.com/NomicFoundation/hardhat/issues/6866