### PR TITLE
Remove duplicate @types/bn.js dependency

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -102,7 +102,6 @@
     "@nomicfoundation/edr": "^0.11.2",
     "@nomicfoundation/solidity-analyzer": "^0.1.0",
     "@sentry/node": "^5.18.1",
-    "@types/bn.js": "^5.1.0",
     "@types/lru-cache": "^5.1.0",
     "adm-zip": "^0.4.16",
     "aggregate-error": "^3.0.0",


### PR DESCRIPTION
Removes the duplicate @types/bn.js dependency from the dependencies section, as it's already present in devDependencies. Type definitions should only be in devDependencies since they're only used during development and not at runtime. This change reduces package size and follows npm best practices.