### PR TITLE
Use input source names in the link references

### DIFF
--- a/.changeset/tough-rice-jam.md
+++ b/.changeset/tough-rice-jam.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Use input source names in the link references, fixing a bug in the solidity test runner

--- a/v-next/hardhat-utils/src/internal/bytecode.ts
+++ b/v-next/hardhat-utils/src/internal/bytecode.ts
@@ -12,7 +12,7 @@ import { isAddress } from "../eth.js";
 export interface Artifact {
   bytecode: string;
   linkReferences: {
-    [sourceName: string]: {
+    [inputSourceName: string]: {
       [libraryName: string]: Array<{ start: number; length: number }>;
     };
   };

--- a/v-next/hardhat-viem/test/contracts.ts
+++ b/v-next/hardhat-viem/test/contracts.ts
@@ -383,7 +383,7 @@ describe("contracts", () => {
             contractName: "OnlyNormalLib",
             error:
               "The following libraries are missing:\n" +
-              '\t* "contracts/WithLibs.sol:NormalLib"\n' +
+              '\t* "project/contracts/WithLibs.sol:NormalLib"\n' +
               "\n" +
               "Please provide all the required libraries.",
           },
@@ -461,8 +461,8 @@ describe("contracts", () => {
             error:
               "The following libraries may resolve to multiple libraries:\n" +
               '\t* "ConstructorLib":\n' +
-              '\t\t* "contracts/ConstructorLib.sol:ConstructorLib"\n' +
-              '\t\t* "contracts/WithLibs.sol:ConstructorLib"\n' +
+              '\t\t* "project/contracts/ConstructorLib.sol:ConstructorLib"\n' +
+              '\t\t* "project/contracts/WithLibs.sol:ConstructorLib"\n' +
               "\n" +
               "Please provide the fully qualified name for these libraries.",
           },
@@ -484,8 +484,8 @@ describe("contracts", () => {
             error:
               "The following libraries may resolve to multiple libraries:\n" +
               '\t* "ConstructorLib":\n' +
-              '\t\t* "contracts/ConstructorLib.sol:ConstructorLib"\n' +
-              '\t\t* "contracts/WithLibs.sol:ConstructorLib"\n' +
+              '\t\t* "project/contracts/ConstructorLib.sol:ConstructorLib"\n' +
+              '\t\t* "project/contracts/WithLibs.sol:ConstructorLib"\n' +
               "\n" +
               "Please provide the fully qualified name for these libraries.",
           },
@@ -498,9 +498,9 @@ describe("contracts", () => {
           [2n],
           {
             libraries: {
-              "contracts/ConstructorLib.sol:ConstructorLib":
+              "project/contracts/ConstructorLib.sol:ConstructorLib":
                 constructorLibConstructorLibContract.address,
-              "contracts/WithLibs.sol:ConstructorLib":
+              "project/contracts/WithLibs.sol:ConstructorLib":
                 withLibsConstructorLibContract.address,
             },
           },
@@ -523,7 +523,7 @@ describe("contracts", () => {
           networkConnection.viem.deployContract("OnlyConstructorLib", [1n], {
             libraries: {
               ConstructorLib: constructorLibContract.address,
-              "contracts/WithLibs.sol:ConstructorLib":
+              "project/contracts/WithLibs.sol:ConstructorLib":
                 constructorLibContract.address,
             },
           }),
@@ -532,7 +532,7 @@ describe("contracts", () => {
             contractName: "OnlyConstructorLib",
             error:
               "The following libraries are provided more than once:\n" +
-              '\t* "contracts/WithLibs.sol:ConstructorLib"\n' +
+              '\t* "project/contracts/WithLibs.sol:ConstructorLib"\n' +
               "\n" +
               "Please ensure that each library is provided only once, either by its name or its fully qualified name.",
           },

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/artifacts.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/artifacts.ts
@@ -1,8 +1,4 @@
-import type {
-  Artifact,
-  BuildInfo,
-  LinkReferences,
-} from "../../../../types/artifacts.js";
+import type { Artifact, BuildInfo } from "../../../../types/artifacts.js";
 import type { CompilationJob } from "../../../../types/solidity/compilation-job.js";
 import type {
   CompilerOutput,
@@ -21,7 +17,6 @@ export function getContractArtifact(
   inputSourceName: string,
   contractName: string,
   contract: CompilerOutputContract,
-  userSourceNameMap: Record<string, string>,
 ): Artifact {
   const evmBytecode = contract.evm?.bytecode;
   const bytecode: string =
@@ -47,32 +42,14 @@ export function getContractArtifact(
     abi: contract.abi,
     bytecode,
     deployedBytecode,
-    linkReferences: applyUserSourceNamesToLinkReferences(
-      linkReferences,
-      userSourceNameMap,
-    ),
-    deployedLinkReferences: applyUserSourceNamesToLinkReferences(
-      deployedLinkReferences,
-      userSourceNameMap,
-    ),
+    linkReferences,
+    deployedLinkReferences,
     immutableReferences,
     inputSourceName,
     buildInfoId,
   };
 
   return artifact;
-}
-
-function applyUserSourceNamesToLinkReferences(
-  linkReferences: LinkReferences,
-  userSourceNameMap: Record<string, string>,
-): LinkReferences {
-  return Object.fromEntries(
-    Object.entries(linkReferences).map(([sourceName, references]) => [
-      userSourceNameMap[sourceName] ?? sourceName,
-      references,
-    ]),
-  );
 }
 
 export function getArtifactsDeclarationFile(artifacts: Artifact[]): string {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -471,16 +471,6 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     const result = new Map<string, string[]>();
     const buildId = await compilationJob.getBuildId();
 
-    const userSourceNameMap = Object.fromEntries(
-      compilationJob.dependencyGraph
-        .getRoots()
-        .entries()
-        .map(([userSourceName, root]) => [
-          root.inputSourceName,
-          userSourceName,
-        ]),
-    );
-
     // We emit the artifacts for each root file, first emitting one artifact
     // for each contract, and then one declaration file for the entire file,
     // which defines their types and augments the ArtifactMap type.
@@ -511,7 +501,6 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
             root.inputSourceName,
             contractName,
             contract,
-            userSourceNameMap,
           );
 
           await writeUtf8File(

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -218,7 +218,7 @@ export interface Artifact<AbiT extends Abi = Abi> {
  * The link references of a contract, which need to be resolved before using it.
  */
 export interface LinkReferences {
-  [librarySourceName: string]: {
+  [libraryInputSourceName: string]: {
     [libraryName: string]: Array<{ length: number; start: number }>;
   };
 }


### PR DESCRIPTION
This PR changes how we store the link references in artifacts, which fixes a bug that prevented solidity tests from using libraries