### PR TITLE
[WIP] feat: enable code coverage for solidity tests

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -10,6 +10,7 @@ import type {
   StorageCachingConfig,
   AddressLabel,
   Artifact,
+  ObservabilityConfig,
 } from "@ignored/edr-optimism";
 
 import {
@@ -36,6 +37,7 @@ export function solidityTestConfigToSolidityTestRunnerConfigArgs(
   chainType: ChainType,
   projectRoot: string,
   config: SolidityTestConfig,
+  observability?: ObservabilityConfig,
   testPattern?: string,
 ): SolidityTestRunnerConfigArgs {
   const fsPermissions: PathPermission[] | undefined = [
@@ -115,6 +117,7 @@ export function solidityTestConfigToSolidityTestRunnerConfigArgs(
     txOrigin,
     blockCoinbase,
     rpcStorageCaching,
+    observability,
     testPattern,
   };
 }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Should providing the `onCollectedCoverageData` callback through the observability config be enough to enable code coverage for solidity tests? The callback doesn't seem to be called in the current state of this branch.

```
{
  ...,
  observability: {
    codeCoverage: {
      onCollectedCoverageCallback: [AsyncFunction: onCollectedCoverageCallback]
    }
  },
  ...
}
```
