### PR TITLE
fix: global flag option parsing

### DIFF
--- a/.changeset/spicy-ravens-type.md
+++ b/.changeset/spicy-ravens-type.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Fixed global flag option parsing
+Fixed global flag option parsing ([#7028](https://github.com/NomicFoundation/hardhat/issues/7028))

--- a/.changeset/spicy-ravens-type.md
+++ b/.changeset/spicy-ravens-type.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed global flag option parsing

--- a/v-next/hardhat/src/internal/core/arguments.ts
+++ b/v-next/hardhat/src/internal/core/arguments.ts
@@ -185,12 +185,7 @@ export function parseArgumentValue(
     case ArgumentType.BOOLEAN:
       return validateAndParseBoolean(name, value);
     case ArgumentType.FLAG:
-      throw new HardhatError(
-        HardhatError.ERRORS.CORE.INTERNAL.ASSERTION_ERROR,
-        {
-          message: "Flags should never accept values",
-        },
-      );
+      return validateAndParseFlag(name, value);
   }
 }
 
@@ -275,6 +270,23 @@ function validateAndParseBoolean(name: string, value: string): boolean {
         value,
         name,
         type: ArgumentType.BOOLEAN,
+      },
+    );
+  }
+
+  return normalizedValue === "true";
+}
+
+function validateAndParseFlag(name: string, value: string): boolean {
+  const normalizedValue = value.toLowerCase();
+
+  if (normalizedValue !== "true" && normalizedValue !== "false") {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+      {
+        value,
+        name,
+        type: ArgumentType.FLAG,
       },
     );
   }

--- a/v-next/hardhat/test/internal/core/arguments.ts
+++ b/v-next/hardhat/test/internal/core/arguments.ts
@@ -183,16 +183,8 @@ describe("Arguments", () => {
       );
     });
 
-    it("should throw when parsing flag arguments values", () => {
-      assertThrowsHardhatError(
-        () => {
-          parseArgumentValue("true", ArgumentType.FLAG, "name");
-        },
-        HardhatError.ERRORS.CORE.INTERNAL.ASSERTION_ERROR,
-        {
-          message: "Flags should never accept values",
-        },
-      );
+    it("should parse flag arguments", () => {
+      assert.equal(parseArgumentValue("true", ArgumentType.FLAG, "name"), true);
     });
 
     it("should parse level arguments", () => {
@@ -245,9 +237,11 @@ describe("Arguments", () => {
           () => {
             parseArgumentValue("foo", ArgumentType.FLAG, "name");
           },
-          HardhatError.ERRORS.CORE.INTERNAL.ASSERTION_ERROR,
+          HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
           {
-            message: "Flags should never accept values",
+            value: "foo",
+            name: "name",
+            type: ArgumentType.FLAG,
           },
         );
       });

--- a/v-next/hardhat/test/internal/core/global-options.ts
+++ b/v-next/hardhat/test/internal/core/global-options.ts
@@ -10,7 +10,11 @@ import {
   RESERVED_ARGUMENT_NAMES,
   RESERVED_ARGUMENT_SHORT_NAMES,
 } from "../../../src/internal/core/arguments.js";
-import { globalOption } from "../../../src/internal/core/config.js";
+import {
+  globalFlag,
+  globalLevel,
+  globalOption,
+} from "../../../src/internal/core/config.js";
 import {
   buildGlobalOptionDefinition,
   buildGlobalOptionDefinitions,
@@ -457,11 +461,29 @@ describe("Global Options", () => {
               type: ArgumentType.BIGINT,
               defaultValue: 0n,
             }),
+            globalFlag({
+              name: "globalOption4",
+              description: "globalOption4 description",
+            }),
+            globalFlag({
+              name: "globalOption5",
+              description: "globalOption5 description",
+            }),
+            globalLevel({
+              name: "globalOption6",
+              description: "globalOption6 description",
+            }),
+            globalLevel({
+              name: "globalOption7",
+              description: "globalOption7 description",
+            }),
           ],
         },
       ]);
 
       setEnvVar("HARDHAT_GLOBAL_OPTION_3", "5n");
+      setEnvVar("HARDHAT_GLOBAL_OPTION_5", "true");
+      setEnvVar("HARDHAT_GLOBAL_OPTION_7", "2");
 
       const globalOptions = resolveGlobalOptions(
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions  --
@@ -470,6 +492,8 @@ describe("Global Options", () => {
         {
           globalOption1: false,
           globalOption2: "user",
+          globalOption4: true,
+          globalOption6: 2,
         } as Partial<GlobalOptions>,
         globalOptionDefinitions,
       );
@@ -478,6 +502,10 @@ describe("Global Options", () => {
         globalOption1: false,
         globalOption2: "user",
         globalOption3: 5n,
+        globalOption4: true,
+        globalOption5: true,
+        globalOption6: 2,
+        globalOption7: 2,
       });
     });
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This is the most straighforward fix for https://github.com/NomicFoundation/hardhat/issues/7028

In an usual case, we do not expect flag options to be associated with values. However, that's not always the case in our codebase. In particular, we're parsing global options differently to task options. This is because global option values can be also provided via the environmental variables. In particular, `--coverage` global flag option can be provided via `HARDHAT_COVERAGE` environmental variable. When that happens, we should know how to parse its' value (exactly the same as we do for boolean options). This is why we have to remove the invariant of never expecting flags to be associated with values from the `parseArgumentValue` function.