### PR TITLE
Rename dependencies to compile and build task

### DIFF
--- a/.changeset/cold-oranges-guess.md
+++ b/.changeset/cold-oranges-guess.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Rename dependenciesToCompile to npmFilesToBuild. Add `build` task that is an alias to `compile`

--- a/.changeset/cold-oranges-guess.md
+++ b/.changeset/cold-oranges-guess.md
@@ -2,4 +2,5 @@
 "hardhat": patch
 ---
 
-Rename dependenciesToCompile to npmFilesToBuild. Add `build` task that is an alias to `compile`
+Rename `dependenciesToCompile` to `npmFilesToBuild` in Hardhat config ([#6877](https://github.com/NomicFoundation/hardhat/issues/6877))
+Add `build` task that replaces `compile`, but keep the `compile` task as an alias to `build` ([#6877](https://github.com/NomicFoundation/hardhat/issues/6877))

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -199,7 +199,7 @@ const config: HardhatUserConfig = {
         version: "0.8.2",
       },
     },
-    dependenciesToCompile: [
+    npmFilesToBuild: [
       "@openzeppelin/contracts/token/ERC20/ERC20.sol",
       "forge-std/Test.sol",
     ],

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -111,12 +111,11 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       )
     ).flat(1);
 
-    const dependenciesToCompile =
-      this.#options.solidityConfig.dependenciesToCompile.map(
-        npmModuleToNpmRootPath,
-      );
+    const npmFilesToBuild = this.#options.solidityConfig.npmFilesToBuild.map(
+      npmModuleToNpmRootPath,
+    );
 
-    return [...localFilesToCompile, ...dependenciesToCompile];
+    return [...localFilesToCompile, ...npmFilesToBuild];
   }
 
   public async build(

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/config.ts
@@ -47,7 +47,7 @@ const multiVersionSolcUserConfigType = z.object({
 });
 
 const commonSolidityUserConfigType = z.object({
-  dependenciesToCompile: z.array(z.string()).optional(),
+  npmFilesToBuild: z.array(z.string()).optional(),
 });
 
 const singleVersionSolidityUserConfigType = singleVersionSolcUserConfigType
@@ -215,7 +215,7 @@ function resolveSolidityConfig(
           overrides: {},
         },
       },
-      dependenciesToCompile: [],
+      npmFilesToBuild: [],
     };
   }
 
@@ -232,7 +232,7 @@ function resolveSolidityConfig(
           overrides: {},
         },
       },
-      dependenciesToCompile: solidityConfig.dependenciesToCompile ?? [],
+      npmFilesToBuild: solidityConfig.npmFilesToBuild ?? [],
     };
   }
 
@@ -259,7 +259,7 @@ function resolveSolidityConfig(
           ),
         },
       },
-      dependenciesToCompile: solidityConfig.dependenciesToCompile ?? [],
+      npmFilesToBuild: solidityConfig.npmFilesToBuild ?? [],
     };
   }
 
@@ -311,6 +311,6 @@ function resolveSolidityConfig(
 
   return {
     profiles,
-    dependenciesToCompile: solidityConfig.dependenciesToCompile ?? [],
+    npmFilesToBuild: solidityConfig.npmFilesToBuild ?? [],
   };
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/index.ts
@@ -37,13 +37,13 @@ const hardhatPlugin: HardhatPlugin = {
   tasks: [
     {
       ...buildTask,
-      id: ["compile"],
-      description: "Builds your project (alias for build)",
+      id: ["build"],
+      description: "Builds your project",
     },
     {
       ...buildTask,
-      id: ["build"],
-      description: "Builds your project",
+      id: ["compile"],
+      description: "Builds your project (alias for build)",
     },
   ],
   globalOptions: [

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/index.ts
@@ -5,6 +5,28 @@ import { globalOption, task } from "../../core/config.js";
 
 import "./type-extensions.js";
 
+const buildTask = task("build", "Builds your project")
+  .addFlag({
+    name: "force",
+    description: "Force compilation even if no files have changed",
+  })
+  .addFlag({
+    name: "quiet",
+    description: "Makes the compilation process less verbose",
+  })
+  .addOption({
+    name: "defaultBuildProfile",
+    description: "The default build profile to use",
+    defaultValue: "default",
+  })
+  .addVariadicArgument({
+    name: "files",
+    description: "An optional list of files to compile",
+    defaultValue: [],
+  })
+  .setAction(import.meta.resolve("./tasks/compile.js"))
+  .build();
+
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:solidity",
   dependencies: [async () => (await import("../artifacts/index.js")).default],
@@ -13,27 +35,16 @@ const hardhatPlugin: HardhatPlugin = {
     hre: import.meta.resolve("./hook-handlers/hre.js"),
   },
   tasks: [
-    task("compile", "Compiles your project")
-      .addFlag({
-        name: "force",
-        description: "Force compilation even if no files have changed",
-      })
-      .addFlag({
-        name: "quiet",
-        description: "Makes the compilation process less verbose",
-      })
-      .addOption({
-        name: "defaultBuildProfile",
-        description: "The default build profile to use",
-        defaultValue: "default",
-      })
-      .addVariadicArgument({
-        name: "files",
-        description: "An optional list of files to compile",
-        defaultValue: [],
-      })
-      .setAction(import.meta.resolve("./tasks/compile.js"))
-      .build(),
+    {
+      ...buildTask,
+      id: ["compile"],
+      description: "Builds your project (alias for build)",
+    },
+    {
+      ...buildTask,
+      id: ["build"],
+      description: "Builds your project",
+    },
   ],
   globalOptions: [
     globalOption({

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/index.ts
@@ -24,7 +24,7 @@ const buildTask = task("build", "Builds your project")
     description: "An optional list of files to compile",
     defaultValue: [],
   })
-  .setAction(import.meta.resolve("./tasks/compile.js"))
+  .setAction(import.meta.resolve("./tasks/build.js"))
   .build();
 
 const hardhatPlugin: HardhatPlugin = {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
@@ -12,7 +12,7 @@ interface CompileActionArguments {
   defaultBuildProfile: string | undefined;
 }
 
-const compileAction: NewTaskActionFunction<CompileActionArguments> = async (
+const buildAction: NewTaskActionFunction<CompileActionArguments> = async (
   { force, files, quiet, defaultBuildProfile },
   { solidity, globalOptions },
 ) => {
@@ -43,4 +43,4 @@ const compileAction: NewTaskActionFunction<CompileActionArguments> = async (
   }
 };
 
-export default compileAction;
+export default buildAction;

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
@@ -24,7 +24,7 @@ declare module "../../../types/config.js" {
   }
 
   export interface CommonSolidityUserConfig {
-    dependenciesToCompile?: string[];
+    npmFilesToBuild?: string[];
   }
 
   export interface SingleVersionSolidityUserConfig
@@ -59,7 +59,7 @@ declare module "../../../types/config.js" {
 
   export interface SolidityConfig {
     profiles: Record<string, SolidityBuildProfileConfig>;
-    dependenciesToCompile: string[];
+    npmFilesToBuild: string[];
   }
 
   export interface HardhatConfig {

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -80,7 +80,7 @@ describe(
           overrides: {},
         },
       },
-      dependenciesToCompile: [],
+      npmFilesToBuild: [],
     };
 
     before(async () => {

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -242,8 +242,9 @@ Usage: hardhat [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUM
 
 AVAILABLE TASKS:
 
+  build                    Builds your project
   clean                    Clears the cache and deletes all artifacts
-  compile                  Compiles your project
+  compile                  Builds your project (alias for build)
   console                  Opens a hardhat console
   flatten                  Flattens and prints contracts and their dependencies
   node                     Starts a JSON-RPC server on top of Hardhat Network


### PR DESCRIPTION
This PR renames the `dependenciesToCompile` config property to `npmFilesToBuild`.

Also it introduces a new task, `build`, that is just an alias for `compile`. It uses the same arguments and task action as `compile`

Closes #6877 