### PR TITLE
fix: change deployment folder rule for ignition

### DIFF
--- a/.changeset/sour-pandas-attend.md
+++ b/.changeset/sour-pandas-attend.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/hardhat-ignition-ethers": patch
+"@nomicfoundation/hardhat-ignition-viem": patch
+"@nomicfoundation/hardhat-ignition": patch
+---
+
+Fix rule for determining whether local files are written for an Ignition deployment ([#6999](https://github.com/NomicFoundation/hardhat/issues/6999))

--- a/v-next/hardhat-ignition-ethers/src/internal/ethers-ignition-helper.ts
+++ b/v-next/hardhat-ignition-ethers/src/internal/ethers-ignition-helper.ts
@@ -143,7 +143,7 @@ export class EthersIgnitionHelperImpl<ChainTypeT extends ChainType | string>
     const deploymentId = resolveDeploymentId(givenDeploymentId, chainId);
 
     const deploymentDir =
-      this.#connection.networkName === "default"
+      this.#connection.networkConfig.type === "edr"
         ? undefined
         : path.join(
             this.#hardhatConfig.paths.ignition,

--- a/v-next/hardhat-ignition-viem/src/internal/viem-ignition-helper.ts
+++ b/v-next/hardhat-ignition-viem/src/internal/viem-ignition-helper.ts
@@ -146,7 +146,7 @@ export class ViemIgnitionHelperImpl<ChainTypeT extends ChainType | string>
     const deploymentId = resolveDeploymentId(givenDeploymentId, chainId);
 
     const deploymentDir =
-      this.#connection.networkName === "default"
+      this.#connection.networkConfig.type === "edr"
         ? undefined
         : path.join(
             this.#hardhatConfig.paths.ignition,

--- a/v-next/hardhat-ignition/src/internal/tasks/deploy.ts
+++ b/v-next/hardhat-ignition/src/internal/tasks/deploy.ts
@@ -86,9 +86,10 @@ const taskDeploy: NewTaskActionFunction<TaskDeployArguments> = async (
   );
 
   const deploymentDir =
-    connection.networkName === "hardhat" && !writeLocalhostDeployment
+    connection.networkConfig.type === "edr" && !writeLocalhostDeployment
       ? undefined
       : path.join(hre.config.paths.ignition, "deployments", deploymentId);
+
   if (chainId !== 31337) {
     if (process.env.HARDHAT_IGNITION_CONFIRM_DEPLOYMENT === undefined) {
       const prompt = await Prompt({

--- a/v-next/hardhat-ignition/test/deploy/reset.ts
+++ b/v-next/hardhat-ignition/test/deploy/reset.ts
@@ -1,29 +1,53 @@
+import path, { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import { remove } from "@nomicfoundation/hardhat-utils/fs";
 import { status } from "@nomicfoundation/ignition-core";
 import { assert } from "chai";
 
 import { HardhatArtifactResolver } from "../../src/helpers/hardhat-artifact-resolver.js";
 import { useFileIgnitionProject } from "../test-helpers/use-ignition-project.js";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const deploymentId = "custom-reset-id";
+const deploymentDir = path.join(
+  path.resolve(__dirname, `../fixture-projects/${deploymentId}/ignition`),
+  "deployments",
+  "chain-31337",
+);
+
 describe("reset flag", function () {
-  useFileIgnitionProject("reset-flag", "custom-reset-id");
+  useFileIgnitionProject("reset-flag", deploymentId);
+
+  beforeEach("clean filesystem", async function () {
+    // make sure nothing is left over from a previous test
+    await remove(deploymentDir);
+  });
+
+  afterEach("clean filesystem", async function () {
+    // cleanup
+    await remove(deploymentDir);
+  });
 
   before(async function () {
     process.env.HARDHAT_IGNITION_CONFIRM_DEPLOYMENT = "false";
     process.env.HARDHAT_IGNITION_CONFIRM_RESET = "false";
   });
 
-  // TODO: Re-enable once the logic for creating the deploymentDir based on the ephemeral network is fixed
-  it.skip("should reset a deployment", async function () {
+  it("should reset a deployment", async function () {
     await this.hre.tasks.getTask(["ignition", "deploy"]).run({
       modulePath: "./ignition/modules/FirstPass.js",
-      deploymentId: "custom-reset-id",
-      reset: true,
+      deploymentId,
+      writeLocalhostDeployment: true,
+      reset: false,
     });
 
     await this.hre.tasks.getTask(["ignition", "deploy"]).run({
       modulePath: "./ignition/modules/SecondPass.js",
-      deploymentId: "custom-reset-id",
+      deploymentId,
+      writeLocalhostDeployment: true,
       reset: true,
     });
 

--- a/v-next/hardhat-ignition/test/deploy/writeLocalhost.ts
+++ b/v-next/hardhat-ignition/test/deploy/writeLocalhost.ts
@@ -37,8 +37,7 @@ describe("localhost deployment flag", function () {
     assert(await exists(deploymentDir), "Deployment was not written to disk");
   });
 
-  // TODO: Re-enable once the logic for creating the deploymentDir based on the ephemeral network is fixed
-  it.skip("false should not write deployment to disk", async function () {
+  it("false should not write deployment to disk", async function () {
     await this.hre.tasks.getTask(["ignition", "deploy"]).run({
       modulePath: "./ignition/modules/OwnModule.js",
       writeLocalhostDeployment: false,

--- a/v-next/hardhat-ignition/test/plan/index.ts
+++ b/v-next/hardhat-ignition/test/plan/index.ts
@@ -8,8 +8,7 @@ import { useEphemeralIgnitionProject } from "../test-helpers/use-ignition-projec
 describe("visualize", () => {
   useEphemeralIgnitionProject("minimal");
 
-  // TODO: HH3 bring back visualization
-  it.skip("should create a visualization", async function () {
+  it("should create a visualization", async function () {
     const visualizationPath = path.resolve("../minimal/cache/visualization");
     await emptyDir(visualizationPath);
 


### PR DESCRIPTION
In Hardhat 2, the deployment folder is not generated if running against an in-memory network or `writeLocalhostDeployment` is enabled. The rule for in-memory network is detected was based on the name (i.e. "hardhat").

The rule is now changing to be based on whether the network running against is of type `edr`, which indicates that the network is running in-memory in Hardhat 3.

The rule is updated in the `deploy` task, as well of the helper objects in the viem and ethers Ignition plugins.

Resolves #6999.
