### PR TITLE
fix: correctly await unsubscribe requests when WebSocket closes

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/handler.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/jsonrpc/handler.ts
@@ -109,12 +109,12 @@ export class JsonRpcHandler {
 
       // Clear any active subscriptions for the closed websocket connection.
       isClosed = true;
-      subscriptions.forEach(async (subscriptionId) => {
-        await this._provider.request({
+      await Promise.all(subscriptions.map(async (subscriptionId) => {
+        return this._provider.request({
           method: "eth_unsubscribe",
           params: [subscriptionId],
         });
-      });
+      }));
     });
   };
 


### PR DESCRIPTION
Replace forEach with Promise.all + map pattern when unsubscribing from subscriptions on WebSocket close. This ensures that all unsubscribe operations are properly awaited before the event handler completes, preventing potential race conditions and resource leaks

Using forEach with an async callback doesn't properly wait for the promises to resolve, which could lead to incomplete cleanup of WebSocket subscriptions