### PR TITLE
docs: add a warning to Hardhat utils indicating it is internal

### DIFF
--- a/v-next/hardhat-utils/README.md
+++ b/v-next/hardhat-utils/README.md
@@ -1,5 +1,7 @@
 # Hardhat utils
 
+> **Warning:** This package is **internal** to Hardhat, its **API is considered internal** and may change without notice i.e. we may push breaking changes in a `hardhat-utils` major version bump to support a patch change in Hardhat.
+
 This package contains utilities used by Hardhat 3 and its plugins.
 
 This package is internal to Hardhat and should not be used directly.


### PR DESCRIPTION
The `hardhat-utils` package is internal to Hardhat. It can be used from external plugins, but we do not commit to keeping major versions of utils inline with Hardhat.

Put another way, if we need to make breaking changes to the util APIs for a patch update of Hardhat, we will.
