### PR TITLE
Support predicates on viem-assertions

### DIFF
--- a/.changeset/lovely-dodos-tell.md
+++ b/.changeset/lovely-dodos-tell.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+Support predicates on viem-assertions ([#7038](https://github.com/NomicFoundation/hardhat/issues/7038))

--- a/v-next/hardhat-viem-assertions/package.json
+++ b/v-next/hardhat-viem-assertions/package.json
@@ -14,7 +14,8 @@
   "types": "dist/src/index.d.ts",
   "exports": {
     ".": "./dist/src/index.js",
-    "./types": "./dist/src/types.js"
+    "./types": "./dist/src/types.js",
+    "./predicates": "./dist/src/predicates.js"
   },
   "keywords": [
     "ethereum",

--- a/v-next/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
+++ b/v-next/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
@@ -91,9 +91,15 @@ export async function emitWithArgs<
 
       if (expectedArgs.some((arg) => typeof arg === "function")) {
         // If there are predicate matchers, we can't use the built-in deepEqual with diff
-        const displayExpectedArgs = expectedArgs.map((expectedArg) =>
-          typeof expectedArg === "function" ? "<predicate>" : expectedArg,
-        );
+        const displayExpectedArgs = expectedArgs.map((expectedArg) => {
+          if (typeof expectedArg === "function") {
+            const hasName =
+              expectedArg.name !== undefined && expectedArg.name !== "";
+            return `<${hasName ? expectedArg.name : "predicate"}>`;
+          } else {
+            return expectedArg;
+          }
+        });
 
         assert.fail(
           `The event arguments do not match the expected ones:\nExpected: ${stringifyArgs(displayExpectedArgs)}\nEmitted: ${stringifyArgs(emittedArgs)}`,

--- a/v-next/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
+++ b/v-next/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
@@ -14,7 +14,9 @@ import type {
 import assert from "node:assert/strict";
 
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
-import { deepEqual } from "@nomicfoundation/hardhat-utils/lang";
+
+import { stringifyArgs } from "../../helpers.js";
+import { isArgumentMatch } from "../../predicates.js";
 
 import { handleEmit } from "./core.js";
 
@@ -51,7 +53,7 @@ export async function emitWithArgs<
   const parsedLogs = await handleEmit(viem, contractFn, contract, eventName);
 
   for (const { args: logArgs } of parsedLogs) {
-    let emittedArgs: unknown[] = [];
+    let emittedArgs: any[] = [];
 
     if (logArgs === undefined) {
       if (expectedArgs.length === 0) {
@@ -80,17 +82,30 @@ export async function emitWithArgs<
       }
     }
 
-    if ((await deepEqual(emittedArgs, expectedArgs)) === true) {
+    if (await isArgumentMatch(emittedArgs, expectedArgs)) {
       return;
     }
 
     if (parsedLogs.length === 1) {
       // Provide additional error details only if a single event was emitted
-      assert.deepEqual(
-        emittedArgs,
-        expectedArgs,
-        "The event arguments do not match the expected ones.",
-      );
+
+      if (expectedArgs.some((arg) => typeof arg === "function")) {
+        // If there are predicate matchers, we can't use the built-in deepEqual with diff
+        const displayExpectedArgs = expectedArgs.map((expectedArg) =>
+          typeof expectedArg === "function" ? "<predicate>" : expectedArg,
+        );
+
+        assert.fail(
+          `The event arguments do not match the expected ones:\nExpected: ${stringifyArgs(displayExpectedArgs)}\nEmitted: ${stringifyArgs(emittedArgs)}`,
+        );
+      } else {
+        // Otherwise, we can use it
+        assert.deepEqual(
+          emittedArgs,
+          expectedArgs,
+          "The event arguments do not match the expected ones.",
+        );
+      }
     }
   }
 

--- a/v-next/hardhat-viem-assertions/src/internal/assertions/revert/revert-with-custom-error-with-args.ts
+++ b/v-next/hardhat-viem-assertions/src/internal/assertions/revert/revert-with-custom-error-with-args.ts
@@ -6,6 +6,9 @@ import type { ReadContractReturnType, WriteContractReturnType } from "viem";
 
 import assert from "node:assert/strict";
 
+import { stringifyArgs } from "../../helpers.js";
+import { isArgumentMatch } from "../../predicates.js";
+
 import { handleRevertWithCustomError } from "./handle-revert-with-custom-error.js";
 
 export async function revertWithCustomErrorWithArgs<
@@ -14,7 +17,7 @@ export async function revertWithCustomErrorWithArgs<
   contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
   contract: ContractReturnType<ContractName>,
   customErrorName: string,
-  args: any[],
+  expectedArgs: any[],
 ): Promise<void> {
   const errorArgs = await handleRevertWithCustomError(
     contractFn,
@@ -22,9 +25,26 @@ export async function revertWithCustomErrorWithArgs<
     customErrorName,
   );
 
-  assert.deepEqual(
-    errorArgs,
-    args,
-    `The function was expected to revert with arguments "${args.join(", ")}", but it reverted with arguments "${errorArgs.join(", ")}".`,
-  );
+  if (await isArgumentMatch(errorArgs, expectedArgs)) {
+    return;
+  }
+
+  // No match, then show error
+  if (expectedArgs.some((arg) => typeof arg === "function")) {
+    // If there are predicate matchers, we can't use the built-in deepEqual with diff
+    const displayExpectedArgs = expectedArgs.map((expectedArg) =>
+      typeof expectedArg === "function" ? "<predicate>" : expectedArg,
+    );
+
+    assert.fail(
+      `The error arguments do not match the expected ones:\nExpected: ${stringifyArgs(displayExpectedArgs)}\nRaised: ${stringifyArgs(errorArgs)}`,
+    );
+  } else {
+    // Otherwise, we can use it
+    assert.deepEqual(
+      errorArgs,
+      expectedArgs,
+      `The function was expected to revert with arguments "${expectedArgs.join(", ")}", but it reverted with arguments "${errorArgs.join(", ")}".`,
+    );
+  }
 }

--- a/v-next/hardhat-viem-assertions/src/internal/helpers.ts
+++ b/v-next/hardhat-viem-assertions/src/internal/helpers.ts
@@ -1,0 +1,8 @@
+/**
+ * This is a JSON.stringify function with a custom replacer that stringifies bigints as strings.
+ */
+export function stringifyArgs(obj: any): string {
+  return JSON.stringify(obj, (key, value) =>
+    typeof value === "bigint" ? value.toString() : value,
+  );
+}

--- a/v-next/hardhat-viem-assertions/src/internal/predicates.ts
+++ b/v-next/hardhat-viem-assertions/src/internal/predicates.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
+import { deepEqual } from "@nomicfoundation/hardhat-utils/lang";
+
+export function anyValue() {
+  return true;
+}
+
+export async function isArgumentMatch(
+  actualArgs: any[],
+  expectedArgs: any[],
+): Promise<boolean> {
+  assert.ok(
+    actualArgs.length === expectedArgs.length,
+    `${actualArgs.length} arguments emitted, but ${expectedArgs.length} expected`,
+  );
+
+  for (let index = 0; index < actualArgs.length; index++) {
+    const emittedArg = actualArgs[index];
+    const expectedArg = expectedArgs[index];
+
+    if (typeof expectedArg === "function") {
+      try {
+        if (expectedArg(emittedArg) !== true) {
+          return false;
+        }
+      } catch (e) {
+        ensureError(e);
+        assert.fail(
+          `The predicate of index ${index} threw when called: ${e.message}`,
+        );
+      }
+    } else {
+      if (!(await deepEqual(emittedArg, expectedArg))) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}

--- a/v-next/hardhat-viem-assertions/src/predicates.ts
+++ b/v-next/hardhat-viem-assertions/src/predicates.ts
@@ -1,0 +1,1 @@
+export { anyValue } from "./internal/predicates.js";

--- a/v-next/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Events.sol
+++ b/v-next/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Events.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+struct TestStruct {
+  uint a;
+  uint b;
+}
+
 contract Events {
   event WithoutArgs();
   event WithIntArg(int i);
@@ -11,6 +16,9 @@ contract Events {
   event SameEventDifferentArgs(uint u, uint v);
   event SameEventDifferentArgs(uint u, string s);
   event SameEventDifferentArgs(uint u, uint v, string s);
+  event WithString(string s);
+  event WithArray(uint[] a);
+  event WithStruct(TestStruct a);
 
   constructor() {}
 
@@ -46,5 +54,17 @@ contract Events {
 
   function emitSameEventDifferentArgs3(uint u, uint v, string memory s) public {
     emit SameEventDifferentArgs(u, v, s);
+  }
+
+  function emitString(string memory s) public {
+    emit WithString(s);
+  }
+
+  function emitArray(uint[] memory a) public {
+    emit WithArray(a);
+  }
+
+  function emitStruct(TestStruct memory a) public {
+    emit WithStruct(a);
   }
 }

--- a/v-next/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Revert.sol
+++ b/v-next/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Revert.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+struct TestStruct {
+  uint a;
+  uint b;
+}
+
 contract Revert {
   //
   // Custom errors
@@ -9,6 +14,8 @@ contract Revert {
   error CustomErrorWithInt(int);
   error CustomErrorWithUintAndString(uint, string);
   error CustomErrorWithUintAndStringNamedParam(uint u, uint v, string s);
+  error CustomErrorWithArray(uint[]);
+  error CustomErrorWithStruct(TestStruct);
 
   function alwaysRevert() external pure {
     revert("Intentional revert for testing purposes");
@@ -37,6 +44,14 @@ contract Revert {
     string memory s
   ) external pure {
     revert CustomErrorWithUintAndStringNamedParam(u, v, s);
+  }
+
+  function revertWithCustomErrorWithArray(uint[] memory a) external pure {
+    revert CustomErrorWithArray(a);
+  }
+
+  function revertWithCustomErrorWithStruct(TestStruct memory a) external pure {
+    revert CustomErrorWithStruct(a);
   }
 }
 

--- a/v-next/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
+++ b/v-next/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
@@ -241,6 +241,36 @@ describe("emitWithArgs", () => {
       );
     });
 
+    it("should print the predicate name if it has one", async () => {
+      const contract = await viem.deployContract("Events");
+
+      const isOdd = (x: bigint) => x % 2n === 1n;
+
+      await assertRejects(
+        viem.assertions.emitWithArgs(
+          contract.write.emitTwoUints([1n, 2n]),
+          contract,
+          "WithTwoUintArgs",
+          [anyValue, isOdd],
+        ),
+        (error) => error.message.includes(`["<anyValue>","<isOdd>"]`),
+      );
+    });
+
+    it("should use a placeholder name if the predicate is anonymous", async () => {
+      const contract = await viem.deployContract("Events");
+
+      await assertRejects(
+        viem.assertions.emitWithArgs(
+          contract.write.emitTwoUints([1n, 2n]),
+          contract,
+          "WithTwoUintArgs",
+          [anyValue, (x: bigint) => x % 2n === 1n],
+        ),
+        (error) => error.message.includes(`["<anyValue>","<predicate>"]`),
+      );
+    });
+
     it("should allow using a predicate for some of the arguments", async () => {
       const contract = await viem.deployContract("Events");
 

--- a/v-next/hardhat-viem-assertions/test/internal/assertions/revert/revert-with-custom-error-with-args.ts
+++ b/v-next/hardhat-viem-assertions/test/internal/assertions/revert/revert-with-custom-error-with-args.ts
@@ -11,6 +11,7 @@ import hardhatViem from "@nomicfoundation/hardhat-viem";
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 
 import hardhatViemAssertions from "../../../../src/index.js";
+import { anyValue } from "../../../../src/predicates.js";
 
 describe("revertWithCustomErrorWithArgs", () => {
   let hre: HardhatRuntimeEnvironment;
@@ -31,7 +32,7 @@ describe("revertWithCustomErrorWithArgs", () => {
     ({ viem } = await hre.network.connect());
   });
 
-  it("should check that the function reverts", async () => {
+  it("should check that the function reverts with uint", async () => {
     const contract = await viem.deployContract("Revert");
 
     await viem.assertions.revertWithCustomErrorWithArgs(
@@ -39,6 +40,28 @@ describe("revertWithCustomErrorWithArgs", () => {
       contract,
       "CustomErrorWithInt",
       [1n],
+    );
+  });
+
+  it("should check that the function reverts with array", async () => {
+    const contract = await viem.deployContract("Revert");
+
+    await viem.assertions.revertWithCustomErrorWithArgs(
+      contract.read.revertWithCustomErrorWithArray([[1, 2, 3]]),
+      contract,
+      "CustomErrorWithArray",
+      [[1n, 2n, 3n]],
+    );
+  });
+
+  it("should check that the function reverts with struct", async () => {
+    const contract = await viem.deployContract("Revert");
+
+    await viem.assertions.revertWithCustomErrorWithArgs(
+      contract.read.revertWithCustomErrorWithStruct([{ a: 1, b: 2 }]),
+      contract,
+      "CustomErrorWithStruct",
+      [{ a: 1n, b: 2n }],
     );
   });
 
@@ -94,5 +117,120 @@ describe("revertWithCustomErrorWithArgs", () => {
         error.message ===
         `The function was expected to revert with "CustomErrorWithInt", but it did not.`,
     );
+  });
+
+  describe("using predicates", function () {
+    it("supports predicates on all of the arguments", async () => {
+      const contract = await viem.deployContract("Revert");
+
+      await viem.assertions.revertWithCustomErrorWithArgs(
+        contract.read.revertWithCustomErrorWithUintAndString([1n, "test"]),
+        contract,
+        "CustomErrorWithUintAndString",
+        [anyValue, anyValue],
+      );
+    });
+
+    it("supports predicates on some of the arguments", async () => {
+      const contract = await viem.deployContract("Revert");
+
+      await viem.assertions.revertWithCustomErrorWithArgs(
+        contract.read.revertWithCustomErrorWithUintAndString([1n, "test"]),
+        contract,
+        "CustomErrorWithUintAndString",
+        [(arg: bigint) => arg === 1n, "test"],
+      );
+    });
+
+    it("supports predicates on strings", async () => {
+      const contract = await viem.deployContract("Revert");
+
+      await viem.assertions.revertWithCustomErrorWithArgs(
+        contract.read.revertWithCustomErrorWithUintAndString([1n, "test"]),
+        contract,
+        "CustomErrorWithUintAndString",
+        [1n, (arg: string) => arg.length === 4],
+      );
+
+      await assertRejects(
+        viem.assertions.revertWithCustomErrorWithArgs(
+          contract.read.revertWithCustomErrorWithUintAndString([1n, "test"]),
+          contract,
+          "CustomErrorWithUintAndString",
+          [1n, (arg: string) => arg.length === 5],
+        ),
+        (error) =>
+          error.message.includes(
+            `The error arguments do not match the expected ones`,
+          ),
+      );
+    });
+
+    it("supports predicates on arrays", async () => {
+      const contract = await viem.deployContract("Revert");
+
+      await viem.assertions.revertWithCustomErrorWithArgs(
+        contract.read.revertWithCustomErrorWithArray([[1, 2, 3]]),
+        contract,
+        "CustomErrorWithArray",
+        [(arg: bigint[]) => arg.length === 3],
+      );
+
+      await assertRejects(
+        viem.assertions.revertWithCustomErrorWithArgs(
+          contract.read.revertWithCustomErrorWithArray([[1, 2, 3]]),
+          contract,
+          "CustomErrorWithArray",
+          [(arg: bigint[]) => arg.length === 4],
+        ),
+        (error) =>
+          error.message.includes(
+            `The error arguments do not match the expected ones`,
+          ),
+      );
+    });
+
+    it("supports predicates on structs", async () => {
+      const contract = await viem.deployContract("Revert");
+
+      await viem.assertions.revertWithCustomErrorWithArgs(
+        contract.read.revertWithCustomErrorWithStruct([{ a: 1, b: 2 }]),
+        contract,
+        "CustomErrorWithStruct",
+        [(arg: { a: bigint; b: bigint }) => arg.a === 1n && arg.b === 2n],
+      );
+
+      await assertRejects(
+        viem.assertions.revertWithCustomErrorWithArgs(
+          contract.read.revertWithCustomErrorWithStruct([{ a: 1, b: 2 }]),
+          contract,
+          "CustomErrorWithStruct",
+          [(arg: { a: bigint; b: bigint }) => arg.a === 1n && arg.b === 3n],
+        ),
+        (error) =>
+          error.message.includes(
+            `The error arguments do not match the expected ones`,
+          ),
+      );
+    });
+
+    it("fails when predicate returns false", async () => {
+      const contract = await viem.deployContract("Revert");
+
+      await assertRejects(
+        viem.assertions.revertWithCustomErrorWithArgs(
+          contract.read.revertWithCustomErrorWithUintAndString([1n, "test"]),
+          contract,
+          "CustomErrorWithUintAndString",
+          [(arg: bigint) => arg === 2n, "test"],
+        ),
+        (error) =>
+          [
+            "The error arguments do not match the expected ones",
+            'Expected: ["<predicate>","test"]',
+            'Raised: ["1","test"]',
+          ].every((msg) => error.message.includes(msg)),
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #7038 

Predicates support has been added to `emitWithArgs` and `revertWithCustomErrorWithArgs`.

The assertion failures when using predicates to match are not displayed the same way as when passing primitive values. This is because for the latter we leverage assert.deepEqual, which shows the diff in the following way:
```
   AssertionError: The event arguments do not match the expected ones.
   - Expected
   + Received
   
     Array [
   -   2n,
   +   1n,
     ]
```

When using predicates and the assertion fails, we have to build a custom message and it looks like this:
```
   AssertionError: The event arguments do not match the expected ones:
   Expected: ["<predicate>"]
   Emitted: ["1"]
```

