### PR TITLE
docs: clarify comment on chainId format in ProviderWrapper

### DIFF
--- a/packages/hardhat-core/src/internal/core/providers/chainId.ts
+++ b/packages/hardhat-core/src/internal/core/providers/chainId.ts
@@ -34,8 +34,9 @@ export abstract class ProviderWrapperWithChainId extends ProviderWrapper {
       method: "net_version",
     })) as string;
 
-    // There's a node returning this as decimal instead of QUANTITY.
-    // TODO: Document here which node does that
+    // Most Ethereum clients (including Geth, OpenEthereum, and others) return net_version
+    // as a decimal string (e.g., "1", "3", "8995") according to the JSON-RPC specification,
+    // while some may return it in QUANTITY format (hexadecimal with "0x" prefix).
     return id.startsWith("0x") ? rpcQuantityToNumber(id) : parseInt(id, 10);
   }
 }


### PR DESCRIPTION




- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Clarified the comment explaining how different Ethereum clients return net_version—either as a decimal string or as a hex QUANTITY