### PR TITLE
fix: add proper custom error handling in Foo.sol

### DIFF
--- a/e2e/fixture-projects/compile-fail/contracts/Foo.sol
+++ b/e2e/fixture-projects/compile-fail/contracts/Foo.sol
@@ -3,9 +3,13 @@ pragma solidity ^0.8.0;
 
 contract Foo {
   uint public x;
+  
+  error ValueTooHigh(uint currentValue);
 
   function inc() public {
     x++;
-    error
+    if (x > 100) {
+      revert ValueTooHigh(x);
+    }
   }
 }


### PR DESCRIPTION
Replace invalid 'error' statement with properly defined custom error
'ValueTooHigh' and add validation logic to prevent overflow.