### PR TITLE
Update build info ids to include compiler and version

### DIFF
--- a/.changeset/calm-taxis-film.md
+++ b/.changeset/calm-taxis-film.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Update build info ids ([#7049](https://github.com/NomicFoundation/hardhat/issues/7049))

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job.ts
@@ -220,7 +220,9 @@ export class CompilationJobImplementation implements CompilationJob {
       solcConfig: this.solcConfig,
     });
 
-    return createNonCryptographicHashId(preimage);
+    const jobHash = await createNonCryptographicHashId(preimage);
+
+    return `solc-${this.solcConfig.version.replaceAll(".", "_")}-${jobHash}`;
   }
 
   #getSourceContentHash(sourceName: string, text: string): any {


### PR DESCRIPTION
Closes #7049 

This PR only changes the build info ids to include the compiler (only solc for now) and the version in the build id. This directly affects the file names for both the build infos and the build info outputs.