### PR TITLE
chore: update changesets before release

### DIFF
--- a/.changeset/neat-buckets-admire.md
+++ b/.changeset/neat-buckets-admire.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Replaced solidity tests output with a mocha/jest-inspired reporter
+Improved solidity tests output with a mocha/jest-inspired reporter ([#6909](https://github.com/NomicFoundation/hardhat/issues/6909))

--- a/.changeset/nervous-bobcats-think.md
+++ b/.changeset/nervous-bobcats-think.md
@@ -1,5 +1,0 @@
----
-"hardhat": patch
----
-
-Upgraded EDR dependency to @nomicfoundation/edr v0.12.0-next.1


### PR DESCRIPTION
Remove the note on the EDR upgrade and dd a link to the Solidity Test changes.
