### PR TITLE
Fix hh-viem l2 actions when using the optimism chain type

### DIFF
--- a/.changeset/chilled-mails-call.md
+++ b/.changeset/chilled-mails-call.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Fixed hardhat-viem support for L2 actions when using the optimism chain type

--- a/v-next/hardhat-viem/src/internal/clients.ts
+++ b/v-next/hardhat-viem/src/internal/clients.ts
@@ -29,7 +29,8 @@ export async function getPublicClient<ChainTypeT extends ChainType | string>(
   chainType: ChainTypeT,
   publicClientConfig?: Partial<ViemPublicClientConfig>,
 ): Promise<GetPublicClientReturnType<ChainTypeT>> {
-  const chain = publicClientConfig?.chain ?? (await getChain(provider));
+  const chain =
+    publicClientConfig?.chain ?? (await getChain(provider, chainType));
   const { defaultClientParams, defaultTransportParams } =
     await getDefaultParams(provider);
 
@@ -54,7 +55,8 @@ export async function getWalletClients<ChainTypeT extends ChainType | string>(
   chainType: ChainTypeT,
   walletClientConfig?: Partial<ViemWalletClientConfig>,
 ): Promise<Array<GetWalletClientReturnType<ChainTypeT>>> {
-  const chain = walletClientConfig?.chain ?? (await getChain(provider));
+  const chain =
+    walletClientConfig?.chain ?? (await getChain(provider, chainType));
   const accounts = await getAccounts(provider);
   const { defaultClientParams, defaultTransportParams } =
     await getDefaultParams(provider);
@@ -86,7 +88,8 @@ export async function getWalletClient<ChainTypeT extends ChainType | string>(
   address: ViemAddress,
   walletClientConfig?: Partial<ViemWalletClientConfig>,
 ): Promise<GetWalletClientReturnType<ChainTypeT>> {
-  const chain = walletClientConfig?.chain ?? (await getChain(provider));
+  const chain =
+    walletClientConfig?.chain ?? (await getChain(provider, chainType));
   const { defaultClientParams, defaultTransportParams } =
     await getDefaultParams(provider);
 
@@ -114,7 +117,8 @@ export async function getDefaultWalletClient<
   chainType: ChainTypeT,
   walletClientConfig?: Partial<ViemWalletClientConfig>,
 ): Promise<GetWalletClientReturnType<ChainTypeT>> {
-  const chain = walletClientConfig?.chain ?? (await getChain(provider));
+  const chain =
+    walletClientConfig?.chain ?? (await getChain(provider, chainType));
   const [defaultAccount] = await getAccounts(provider);
 
   if (defaultAccount === undefined) {
@@ -139,7 +143,8 @@ export async function getTestClient<ChainTypeT extends ChainType | string>(
   chainType: ChainTypeT,
   testClientConfig?: Partial<ViemTestClientConfig>,
 ): Promise<TestClient> {
-  const chain = testClientConfig?.chain ?? (await getChain(provider));
+  const chain =
+    testClientConfig?.chain ?? (await getChain(provider, chainType));
   const mode = await getMode(provider);
 
   const testClient = createTestClient({

--- a/v-next/hardhat-viem/test/chains.ts
+++ b/v-next/hardhat-viem/test/chains.ts
@@ -21,7 +21,7 @@ describe("chains", () => {
     it("should return the chain corresponding to the chain id", async () => {
       const provider = new MockEthereumProvider({ eth_chainId: "0x1" }); // mainnet chain id
 
-      const chain = await getChain(provider);
+      const chain = await getChain(provider, "generic");
 
       assert.deepEqual(chain, chains.mainnet);
       assert.equal(provider.callCount, 1);
@@ -33,7 +33,7 @@ describe("chains", () => {
         hardhat_metadata: {},
       });
 
-      const chain = await getChain(provider);
+      const chain = await getChain(provider, "generic");
 
       assert.deepEqual(chain, chains.hardhat);
       assert.equal(provider.callCount, 2);
@@ -49,7 +49,7 @@ describe("chains", () => {
         },
       });
 
-      const chain = await getChain(provider);
+      const chain = await getChain(provider, "generic");
 
       assert.deepEqual(chain, {
         ...chains.mainnet,
@@ -69,7 +69,7 @@ describe("chains", () => {
         },
       });
 
-      const chain = await getChain(provider);
+      const chain = await getChain(provider, "generic");
 
       assert.deepEqual(chain, {
         ...chains.hardhat,
@@ -84,7 +84,7 @@ describe("chains", () => {
         anvil_nodeInfo: {},
       });
 
-      const chain = await getChain(provider);
+      const chain = await getChain(provider, "generic");
 
       assert.deepEqual(chain, chains.anvil);
       assert.equal(provider.callCount, 2);
@@ -94,7 +94,7 @@ describe("chains", () => {
       const provider = new MockEthereumProvider({ eth_chainId: "0x0" }); // fake chain id 0
 
       await assertRejectsWithHardhatError(
-        getChain(provider),
+        getChain(provider, "generic"),
         HardhatError.ERRORS.HARDHAT_VIEM.GENERAL.NETWORK_NOT_FOUND,
         { chainId: 0 },
       );
@@ -104,7 +104,7 @@ describe("chains", () => {
       // chain id 999 corresponds to wanchainTestnet but also zoraTestnet
       const provider = new MockEthereumProvider({ eth_chainId: "0x3e7" }); // 999 in hex
 
-      const chainId = await getChain(provider);
+      const chainId = await getChain(provider, "generic");
       assert.equal(chainId, chains.wanchainTestnet);
     });
 
@@ -114,7 +114,7 @@ describe("chains", () => {
         hardhat_metadata: {},
       });
 
-      const chain = await getChain(provider);
+      const chain = await getChain(provider, "generic");
 
       assert.deepEqual(chain, {
         ...chains.hardhat,
@@ -128,7 +128,7 @@ describe("chains", () => {
         anvil_nodeInfo: {},
       });
 
-      const chain = await getChain(provider);
+      const chain = await getChain(provider, "generic");
 
       assert.deepEqual(chain, {
         ...chains.anvil,

--- a/v-next/hardhat-viem/test/clients.ts
+++ b/v-next/hardhat-viem/test/clients.ts
@@ -497,38 +497,28 @@ describe("clients", () => {
       assert.equal(blockNumber, 1000000n);
     });
 
-    // TODO: this test is skipped because it forks optimism mainnet, which is slow
-    it.skip("should be able to query the blockchain with the extended L2 actions", async () => {
+    it("should have access to L2 actions", async () => {
       hre = await createHardhatRuntimeEnvironment({
         plugins: [HardhatViem],
         networks: {
           edrOptimism: {
             type: "edr",
-            chainId: 10,
             chainType: "optimism",
-            forking: {
-              url: "https://mainnet.optimism.io",
-            },
-            gas: "auto",
-            gasMultiplier: 1,
-            gasPrice: "auto",
           },
         },
       });
 
-      const networkConnection = await hre.network.connect({
+      const { viem } = await hre.network.connect({
         network: "edrOptimism",
         chainType: "optimism",
       });
-      const publicClient = await networkConnection.viem.getPublicClient();
-      const l1BaseFee = await publicClient.getL1BaseFee();
-      const latestBlock = await publicClient.getBlock(); // should still have access to L1 actions
-
-      assert.ok(l1BaseFee > 0n, "L1 base fee should be greater than 0");
-      assert.ok(
-        latestBlock.number > 0n,
-        "Latest block number should be greater than 0",
-      );
+      const publicClient = await viem.getPublicClient();
+      const [senderClient] = await viem.getWalletClients();
+      await publicClient.estimateL1Gas({
+        account: senderClient.account.address,
+        to: senderClient.account.address,
+        value: 1n,
+      });
     });
   });
 });


### PR DESCRIPTION
Fixed viem L2 actions, which @schaable broke by making the mistake of trusting my judgement.

Notice that I'm only adding the contracts. Even this is conceptually wrong because EDR doesn't add all the contracts in viem's `optimism` chain, but I think this is a good middle ground.

I also removed a skipped test that didn't make sense anyway.