### PR TITLE
rename path.tests.nodeTest to path.tests.nodejs

### DIFF
--- a/.changeset/friendly-cameras-notice.md
+++ b/.changeset/friendly-cameras-notice.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-runner": patch
+---
+
+Change the config test path property from `nodeTest` to `nodejs` ([#7100](https://github.com/NomicFoundation/hardhat/pull/7100))

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -167,7 +167,7 @@ const config: HardhatUserConfig = {
   paths: {
     tests: {
       mocha: "test/mocha",
-      nodeTest: "test/node",
+      nodejs: "test/node",
       solidity: "test/contracts",
     },
   },

--- a/v-next/hardhat-node-test-runner/src/hookHandlers/config.ts
+++ b/v-next/hardhat-node-test-runner/src/hookHandlers/config.ts
@@ -13,10 +13,10 @@ const userConfigType = z.object({
     .object({
       test: conditionalUnionType(
         [
-          [isObject, z.object({ nodeTest: z.string().optional() })],
+          [isObject, z.object({ nodejs: z.string().optional() })],
           [(data) => typeof data === "string", z.string()],
         ],
-        "Expected a string or an object with an optional 'nodeTest' property",
+        "Expected a string or an object with an optional 'nodejs' property",
       ).optional(),
     })
     .optional(),
@@ -40,8 +40,7 @@ export default async (): Promise<Partial<ConfigHooks>> => {
       let testsPath = userConfig.paths?.tests;
 
       // TODO: use isObject when the type narrowing issue is fixed
-      testsPath =
-        typeof testsPath === "object" ? testsPath.nodeTest : testsPath;
+      testsPath = typeof testsPath === "object" ? testsPath.nodejs : testsPath;
       testsPath ??= "test";
 
       return {
@@ -50,7 +49,7 @@ export default async (): Promise<Partial<ConfigHooks>> => {
           ...resolvedConfig.paths,
           tests: {
             ...resolvedConfig.paths.tests,
-            nodeTest: resolveFromRoot(resolvedConfig.paths.root, testsPath),
+            nodejs: resolveFromRoot(resolvedConfig.paths.root, testsPath),
           },
         },
       };

--- a/v-next/hardhat-node-test-runner/src/hookHandlers/test.ts
+++ b/v-next/hardhat-node-test-runner/src/hookHandlers/test.ts
@@ -10,7 +10,7 @@ export default async (): Promise<Partial<TestHooks>> => {
       const allRunnersDirectories = Object.values(context.config.paths.tests);
 
       const inThisRunnersDirectory = absoluteFilePath.startsWith(
-        context.config.paths.tests.nodeTest,
+        context.config.paths.tests.nodejs,
       );
 
       const notInOtherRunnersDirectory = allRunnersDirectories.every(

--- a/v-next/hardhat-node-test-runner/src/task-action.ts
+++ b/v-next/hardhat-node-test-runner/src/task-action.ts
@@ -44,7 +44,7 @@ async function getTestFiles(
   }
 
   return getAllFilesMatching(
-    config.paths.tests.nodeTest,
+    config.paths.tests.nodejs,
     (f) => isJavascriptFile(f) || isTypescriptFile(f),
   );
 }

--- a/v-next/hardhat-node-test-runner/src/type-extensions.ts
+++ b/v-next/hardhat-node-test-runner/src/type-extensions.ts
@@ -2,10 +2,10 @@ import "hardhat/types/config";
 
 declare module "hardhat/types/config" {
   export interface TestPathsUserConfig {
-    nodeTest?: string;
+    nodejs?: string;
   }
 
   export interface TestPathsConfig {
-    nodeTest: string;
+    nodejs: string;
   }
 }

--- a/v-next/hardhat-node-test-runner/test/registerFileForTestRunner.ts
+++ b/v-next/hardhat-node-test-runner/test/registerFileForTestRunner.ts
@@ -23,7 +23,7 @@ describe("registerFileForTestRunner hook", function () {
   it("is not nodejs when the file ends with .sol", async () => {
     hre = await createHardhatRuntimeEnvironment({
       ...baseHhConfig,
-      paths: { tests: { nodeTest: "test" } },
+      paths: { tests: { nodejs: "test" } },
     });
 
     const result = await hre.hooks.runHandlerChain(
@@ -39,7 +39,7 @@ describe("registerFileForTestRunner hook", function () {
   it("is nodejs when the file is inside the node test folder", async () => {
     hre = await createHardhatRuntimeEnvironment({
       ...baseHhConfig,
-      paths: { tests: { nodeTest: "test" } },
+      paths: { tests: { nodejs: "test" } },
     });
 
     const result = await hre.hooks.runHandlerChain(
@@ -55,7 +55,7 @@ describe("registerFileForTestRunner hook", function () {
   it("is nodejs when the file is not inside other runners directories", async () => {
     hre = await createHardhatRuntimeEnvironment({
       ...baseHhConfig,
-      paths: { tests: { nodeTest: "test" } },
+      paths: { tests: { nodejs: "test" } },
     });
 
     const result = await hre.hooks.runHandlerChain(
@@ -71,7 +71,7 @@ describe("registerFileForTestRunner hook", function () {
   it("is not nodejs when the file is inside other runners directories", async () => {
     hre = await createHardhatRuntimeEnvironment({
       ...baseHhConfig,
-      paths: { tests: { nodeTest: "test", solidity: "contracts" } },
+      paths: { tests: { nodejs: "test", solidity: "contracts" } },
     });
 
     const result = await hre.hooks.runHandlerChain(


### PR DESCRIPTION
In Hardhat config rename `path.tests.nodeTest` to `path.tests.nodejs`. We renamed the Node Test Runner task from `node` to `nodejs`, this small change to the config name brings the path inline with the task name:

```js
  // ...
  paths: {
    tests: {
      mocha: "test/mocha",
      nodejs: "test/node",
      solidity: "test/contracts",
    },
  },
```