### PR TITLE
regroup test configs under a test object

### DIFF
--- a/.changeset/khaki-seahorses-develop.md
+++ b/.changeset/khaki-seahorses-develop.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Group `mocha` and `solidityTest` config under `test` property ([#7101](https://github.com/NomicFoundation/hardhat/pull/7101))

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -211,7 +211,7 @@ const config: HardhatUserConfig = {
     mocha: {
       color: true,
     },
-    solidityTests: {
+    solidity: {
       timeout: 1000,
     },
   },

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -211,7 +211,7 @@ const config: HardhatUserConfig = {
     mocha: {
       color: true,
     },
-    solidityTest: {
+    solidityTests: {
       timeout: 1000,
     },
   },

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -207,6 +207,14 @@ const config: HardhatUserConfig = {
   typechain: {
     tsNocheck: false,
   },
+  test: {
+    mocha: {
+      color: true,
+    },
+    solidityTest: {
+      timeout: 1000,
+    },
+  },
 };
 
 export default config;

--- a/v-next/hardhat-mocha/src/hookHandlers/config.ts
+++ b/v-next/hardhat-mocha/src/hookHandlers/config.ts
@@ -73,7 +73,11 @@ const mochaConfigType = z.object({
 });
 
 const userConfigType = z.object({
-  mocha: z.optional(mochaConfigType),
+  test: z
+    .object({
+      mocha: z.optional(mochaConfigType),
+    })
+    .optional(),
   paths: z
     .object({
       test: conditionalUnionType(
@@ -110,10 +114,13 @@ export default async (): Promise<Partial<ConfigHooks>> => {
 
       return {
         ...resolvedConfig,
-        mocha: {
-          timeout: 40000,
-          ...resolvedConfig.mocha,
-          ...userConfig.mocha,
+        test: {
+          ...resolvedConfig.test,
+          mocha: {
+            timeout: 40000,
+            ...resolvedConfig.test.mocha,
+            ...userConfig.test?.mocha,
+          },
         },
         paths: {
           ...resolvedConfig.paths,

--- a/v-next/hardhat-mocha/src/task-action.ts
+++ b/v-next/hardhat-mocha/src/task-action.ts
@@ -67,7 +67,7 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
   const { default: Mocha } = await import("mocha");
 
-  const mochaConfig: MochaOptions = { ...hre.config.mocha };
+  const mochaConfig: MochaOptions = { ...hre.config.test.mocha };
 
   if (grep !== "") {
     mochaConfig.grep = grep;

--- a/v-next/hardhat-mocha/src/type-extensions.ts
+++ b/v-next/hardhat-mocha/src/type-extensions.ts
@@ -3,19 +3,22 @@ import "hardhat/types/config";
 import type { MochaOptions } from "mocha";
 
 declare module "hardhat/types/config" {
-  export interface HardhatUserConfig {
-    mocha?: MochaOptions;
-  }
-
   export interface TestPathsUserConfig {
     mocha?: string;
   }
 
-  export interface HardhatConfig {
-    mocha: MochaOptions;
-  }
-
   export interface TestPathsConfig {
     mocha: string;
+  }
+}
+
+import "hardhat/types/test";
+declare module "hardhat/types/test" {
+  export interface HardhatTestUserConfig {
+    mocha?: MochaOptions;
+  }
+
+  export interface HardhatTestConfig {
+    mocha: MochaOptions;
   }
 }

--- a/v-next/hardhat-mocha/test/fixture-projects/invalid-mocha-config/hardhat.config.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/invalid-mocha-config/hardhat.config.ts
@@ -4,9 +4,11 @@ import HardhatMochaPlugin from "../../../src/index.js";
 
 const config: HardhatUserConfig = {
   plugins: [HardhatMochaPlugin],
-  mocha: {
-    // @ts-expect-error -- testing config validation
-    delay: 123,
+  test: {
+    mocha: {
+      // @ts-expect-error -- testing config validation
+      delay: 123,
+    },
   },
 };
 

--- a/v-next/hardhat-mocha/test/index.ts
+++ b/v-next/hardhat-mocha/test/index.ts
@@ -33,7 +33,7 @@ describe("Hardhat Mocha plugin", () => {
       const { createHardhatRuntimeEnvironment } = await import("hardhat/hre");
 
       const errors =
-        "\t* Config error in config.mocha.delay: Expected boolean, received number";
+        "\t* Config error in config.test.mocha.delay: Expected boolean, received number";
 
       const hardhatConfig = await import(
         "./fixture-projects/invalid-mocha-config/hardhat.config.js"

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -31,6 +31,7 @@
     "./types/plugins": "./dist/src/types/plugins.js",
     "./types/providers": "./dist/src/types/providers.js",
     "./types/tasks": "./dist/src/types/tasks.js",
+    "./types/test": "./dist/src/types/test.js",
     "./types/user-interruptions": "./dist/src/types/user-interruptions.js",
     "./types/utils": "./dist/src/types/utils.js",
     "./types/solidity": "./dist/src/types/solidity.js",

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -104,7 +104,7 @@ export async function resolveSolidityTestUserConfig(
 
   const solidityTest = {
     rpcCachePath: defaultRpcCachePath,
-    ...userConfig.test?.solidityTest,
+    ...userConfig.test?.solidityTests,
   };
 
   return {
@@ -118,7 +118,7 @@ export async function resolveSolidityTestUserConfig(
     },
     test: {
       ...resolvedConfig.test,
-      solidityTest,
+      solidityTests: solidityTest,
     },
   };
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -104,7 +104,7 @@ export async function resolveSolidityTestUserConfig(
 
   const solidityTest = {
     rpcCachePath: defaultRpcCachePath,
-    ...userConfig.test?.solidityTests,
+    ...userConfig.test?.solidity,
   };
 
   return {
@@ -118,7 +118,7 @@ export async function resolveSolidityTestUserConfig(
     },
     test: {
       ...resolvedConfig.test,
-      solidityTests: solidityTest,
+      solidity: solidityTest,
     },
   };
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -77,7 +77,11 @@ const userConfigType = z.object({
       ).optional(),
     })
     .optional(),
-  solidityTest: solidityTestUserConfigType.optional(),
+  test: z
+    .object({
+      solidityTest: solidityTestUserConfigType.optional(),
+    })
+    .optional(),
 });
 
 export function validateSolidityTestUserConfig(
@@ -100,7 +104,7 @@ export async function resolveSolidityTestUserConfig(
 
   const solidityTest = {
     rpcCachePath: defaultRpcCachePath,
-    ...userConfig.solidityTest,
+    ...userConfig.test?.solidityTest,
   };
 
   return {
@@ -112,6 +116,9 @@ export async function resolveSolidityTestUserConfig(
         solidity: resolveFromRoot(resolvedConfig.paths.root, testsPath),
       },
     },
-    solidityTest,
+    test: {
+      ...resolvedConfig.test,
+      solidityTest,
+    },
   };
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -1,7 +1,7 @@
 import type { RunOptions } from "./runner.js";
 import type { Abi } from "../../../types/artifacts.js";
-import type { SolidityTestConfig } from "../../../types/config.js";
 import type { ChainType } from "../../../types/network.js";
+import type { SolidityTestConfig } from "../../../types/test.js";
 import type {
   SolidityTestRunnerConfigArgs,
   PathPermission,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -119,7 +119,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   let includesFailures = false;
   let includesErrors = false;
 
-  const solidityTestConfig = hre.config.test.solidityTest;
+  const solidityTestConfig = hre.config.test.solidityTests;
   let observabilityConfig: ObservabilityConfig | undefined;
   if (hre.globalOptions.coverage) {
     assertHardhatInvariant(

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -119,7 +119,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   let includesFailures = false;
   let includesErrors = false;
 
-  const solidityTestConfig = hre.config.solidityTest;
+  const solidityTestConfig = hre.config.test.solidityTest;
   let observabilityConfig: ObservabilityConfig | undefined;
   if (hre.globalOptions.coverage) {
     assertHardhatInvariant(

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -119,7 +119,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   let includesFailures = false;
   let includesErrors = false;
 
-  const solidityTestConfig = hre.config.test.solidityTests;
+  const solidityTestConfig = hre.config.test.solidity;
   let observabilityConfig: ObservabilityConfig | undefined;
   if (hre.globalOptions.coverage) {
     assertHardhatInvariant(

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -60,13 +60,13 @@ declare module "../../../types/test.js" {
   }
 
   export interface HardhatTestUserConfig {
-    solidityTest?: SolidityTestUserConfig;
+    solidityTests?: SolidityTestUserConfig;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface -- This could be an extension point
   export interface SolidityTestConfig extends SolidityTestUserConfig {}
 
   export interface HardhatTestConfig {
-    solidityTest: SolidityTestConfig;
+    solidityTests: SolidityTestConfig;
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -60,13 +60,13 @@ declare module "../../../types/test.js" {
   }
 
   export interface HardhatTestUserConfig {
-    solidityTests?: SolidityTestUserConfig;
+    solidity?: SolidityTestUserConfig;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface -- This could be an extension point
   export interface SolidityTestConfig extends SolidityTestUserConfig {}
 
   export interface HardhatTestConfig {
-    solidityTests: SolidityTestConfig;
+    solidity: SolidityTestConfig;
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -8,7 +8,9 @@ declare module "../../../types/config.js" {
   export interface TestPathsConfig {
     solidity: string;
   }
+}
 
+declare module "../../../types/test.js" {
   export interface SolidityTestUserConfig {
     timeout?: number;
     fsPermissions?: {
@@ -57,14 +59,14 @@ declare module "../../../types/config.js" {
     };
   }
 
-  export interface HardhatUserConfig {
+  export interface HardhatTestUserConfig {
     solidityTest?: SolidityTestUserConfig;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface -- This could be an extension point
   export interface SolidityTestConfig extends SolidityTestUserConfig {}
 
-  export interface HardhatConfig {
+  export interface HardhatTestConfig {
     solidityTest: SolidityTestConfig;
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/test/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/config.ts
@@ -1,0 +1,17 @@
+import type {
+  HardhatConfig,
+  HardhatUserConfig,
+} from "../../../types/config.js";
+
+export async function resolveTestUserConfig(
+  userConfig: HardhatUserConfig,
+  resolvedConfig: HardhatConfig,
+): Promise<HardhatConfig> {
+  return {
+    ...resolvedConfig,
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the
+    empty object is typed correctly by core type, but not when the solidity test
+    plugins extensions are included  */
+    test: userConfig.test ?? ({} as any),
+  };
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/test/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/hook-handlers/config.ts
@@ -1,0 +1,22 @@
+import type { ConfigHooks } from "../../../../types/hooks.js";
+
+import { resolveTestUserConfig } from "../config.js";
+
+export default async (): Promise<Partial<ConfigHooks>> => {
+  const handlers: Partial<ConfigHooks> = {
+    resolveUserConfig: async (
+      userConfig,
+      resolveConfigurationVariable,
+      next,
+    ) => {
+      const resolvedConfig = await next(
+        userConfig,
+        resolveConfigurationVariable,
+      );
+
+      return resolveTestUserConfig(userConfig, resolvedConfig);
+    },
+  };
+
+  return handlers;
+};

--- a/v-next/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -7,6 +7,9 @@ import "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:test",
+  hookHandlers: {
+    config: import.meta.resolve("./hook-handlers/config.js"),
+  },
   tasks: [
     task("test", "Runs all your tests")
       .addVariadicArgument({

--- a/v-next/hardhat/src/internal/builtin-plugins/test/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/type-extensions.ts
@@ -1,4 +1,19 @@
 import "../../../types/hooks.js";
+import type {
+  HardhatTestConfig,
+  HardhatTestUserConfig,
+} from "../../../types/test.js";
+
+declare module "../../../types/config.js" {
+  export interface HardhatUserConfig {
+    test?: HardhatTestUserConfig;
+  }
+
+  export interface HardhatConfig {
+    test: HardhatTestConfig;
+  }
+}
+
 declare module "../../../types/hooks.js" {
   export interface HardhatHooks {
     test: TestHooks;

--- a/v-next/hardhat/src/types/test.ts
+++ b/v-next/hardhat/src/types/test.ts
@@ -1,0 +1,7 @@
+/* eslint-disable-next-line @typescript-eslint/no-empty-interface -- Empty
+interface allow plugins to extend the Test user configuration for Hardhat. */
+export interface HardhatTestUserConfig {}
+
+/* eslint-disable-next-line @typescript-eslint/no-empty-interface -- Empty
+interface allow plugins to extend the Test configuration for Hardhat. */
+export interface HardhatTestConfig {}

--- a/v-next/hardhat/test/internal/builtin-plugins/test/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/test/config.ts
@@ -18,7 +18,7 @@ describe("test/config", function () {
 
   it("should keep the existing `test` config  provided", async () => {
     const existingTestConfig = {
-      solidityTest: {
+      solidityTests: {
         timeout: 123,
       },
     };
@@ -29,8 +29,8 @@ describe("test/config", function () {
     });
 
     assert.equal(
-      hre.config.test.solidityTest.timeout,
-      existingTestConfig.solidityTest.timeout,
+      hre.config.test.solidityTests.timeout,
+      existingTestConfig.solidityTests.timeout,
     );
   });
 });

--- a/v-next/hardhat/test/internal/builtin-plugins/test/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/test/config.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import HardhatTestPlugin from "../../../../src/internal/builtin-plugins/test/index.js";
+import { createHardhatRuntimeEnvironment } from "../../../../src/internal/hre-initialization.js";
+
+describe("test/config", function () {
+  it("should initialize the `test` object if none is provided provided", async () => {
+    const hre = await createHardhatRuntimeEnvironment({
+      plugins: [HardhatTestPlugin],
+    });
+
+    assert.ok(
+      hre.config.test !== null && typeof hre.config.test === "object",
+      "hre.config.test should be an object, to allow plugins to extend",
+    );
+  });
+
+  it("should keep the existing `test` config  provided", async () => {
+    const existingTestConfig = {
+      solidityTest: {
+        timeout: 123,
+      },
+    };
+
+    const hre = await createHardhatRuntimeEnvironment({
+      plugins: [HardhatTestPlugin],
+      test: existingTestConfig,
+    });
+
+    assert.equal(
+      hre.config.test.solidityTest.timeout,
+      existingTestConfig.solidityTest.timeout,
+    );
+  });
+});

--- a/v-next/hardhat/test/internal/builtin-plugins/test/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/test/config.ts
@@ -18,7 +18,7 @@ describe("test/config", function () {
 
   it("should keep the existing `test` config  provided", async () => {
     const existingTestConfig = {
-      solidityTests: {
+      solidity: {
         timeout: 123,
       },
     };
@@ -29,8 +29,8 @@ describe("test/config", function () {
     });
 
     assert.equal(
-      hre.config.test.solidityTests.timeout,
-      existingTestConfig.solidityTests.timeout,
+      hre.config.test.solidity.timeout,
+      existingTestConfig.solidity.timeout,
     );
   });
 });


### PR DESCRIPTION
Move the Mocha and Solidity test configurations under a `test` property of the Hardhat config.

Also rename `solidityTest` to just `solidity`.

So from top level properties:

```js
mocha: {
  color: true,
},
solidityTest: {
  timeout: 1000,
},
```

They are now grouped under a `test` property:

```js
test: {
    mocha: {
      color: true,
    },
    solidity: {
      timeout: 1000,
    },
}
```

# Approach

1. In `test` built-in plugin extend `HardhatConfig` and `HardhatUserConfig` with `HardhatTestConfig` and `HardhatTestUserConfig`
2. Export `HardhatTestConfig` and `HardhatTestUserConfig` as types under `types/test`
  - should this be under `types/config`?
4. Add config hook to `test` built-in plugin that adds an empty object for `test` in the returned `HardhatConfig` instance
  - Note: no validation was added for this empty config object
5. Rewire the `mocha` plugin and the `solidity-test` built-in plugin to read and write from the new `test` grouping property
