### PR TITLE
Rename `optimism` chaintype to `op`

### DIFF
--- a/.changeset/gorgeous-knives-yawn.md
+++ b/.changeset/gorgeous-knives-yawn.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+"hardhat": patch
+---
+
+Rename `optimism` chain type to `op` ([#7085](https://github.com/NomicFoundation/hardhat/issues/7085))

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -116,13 +116,13 @@ const config: HardhatUserConfig = {
   networks: {
     op: {
       type: "http",
-      chainType: "optimism",
+      chainType: "op",
       url: "https://mainnet.optimism.io/",
       accounts: [configVariable("OP_SENDER")],
     },
     edrOp: {
       type: "edr",
-      chainType: "optimism",
+      chainType: "op",
       chainId: 10,
       forking: {
         url: "https://mainnet.optimism.io",
@@ -130,13 +130,13 @@ const config: HardhatUserConfig = {
     },
     opSepolia: {
       type: "http",
-      chainType: "optimism",
+      chainType: "op",
       url: "https://sepolia.optimism.io",
       accounts: [configVariable("OP_SEPOLIA_SENDER")],
     },
     edrOpSepolia: {
       type: "edr",
-      chainType: "optimism",
+      chainType: "op",
       forking: {
         url: "https://sepolia.optimism.io",
       },

--- a/v-next/example-project/scripts/send-op-tx-viem.ts
+++ b/v-next/example-project/scripts/send-op-tx-viem.ts
@@ -5,7 +5,7 @@ async function sendL2Transaction(networkConfigName: string) {
 
   const { viem, networkConfig } = await network.connect({
     network: networkConfigName,
-    chainType: "optimism",
+    chainType: "op",
   });
 
   if (networkConfig.type === "edr") {

--- a/v-next/example-project/scripts/send-op-tx.ts
+++ b/v-next/example-project/scripts/send-op-tx.ts
@@ -2,7 +2,7 @@ import { network } from "hardhat";
 
 const { provider } = await network.connect({
   network: "op",
-  chainType: "optimism",
+  chainType: "op",
 });
 
 const accounts = (await provider.request({

--- a/v-next/example-project/scripts/viem-plugin-example.ts
+++ b/v-next/example-project/scripts/viem-plugin-example.ts
@@ -5,7 +5,7 @@ async function testL2Extensions() {
   // This network connection has access to an optimism-specific viem api
   const optimism = await hre.network.connect({
     network: "localhost",
-    chainType: "optimism",
+    chainType: "op",
   });
   const opPublicClient = await optimism.viem.getPublicClient();
   const l1BaseFee = await opPublicClient.getL1BaseFee();

--- a/v-next/hardhat-viem/src/internal/chains.ts
+++ b/v-next/hardhat-viem/src/internal/chains.ts
@@ -190,7 +190,7 @@ function createHardhatChain<ChainTypeT extends ChainType | string>(
     id: chainId,
   };
 
-  if (chainType === "optimism") {
+  if (chainType === "op") {
     // we add the optimism contracts to enable viem's L2 actions
     chain.contracts = {
       ...optimism.contracts,

--- a/v-next/hardhat-viem/src/internal/clients.ts
+++ b/v-next/hardhat-viem/src/internal/clients.ts
@@ -41,7 +41,7 @@ export async function getPublicClient<ChainTypeT extends ChainType | string>(
     ...publicClientConfig,
   });
 
-  if (chainType === "optimism") {
+  if (chainType === "op") {
     publicClient = publicClient.extend(publicActionsL2());
   }
 
@@ -71,7 +71,7 @@ export async function getWalletClients<ChainTypeT extends ChainType | string>(
     }),
   );
 
-  if (chainType === "optimism") {
+  if (chainType === "op") {
     walletClients = walletClients.map((walletClient) =>
       walletClient.extend(walletActionsL2()),
     );
@@ -101,7 +101,7 @@ export async function getWalletClient<ChainTypeT extends ChainType | string>(
     ...walletClientConfig,
   });
 
-  if (chainType === "optimism") {
+  if (chainType === "op") {
     walletClient = walletClient.extend(walletActionsL2());
   }
 

--- a/v-next/hardhat-viem/src/types.ts
+++ b/v-next/hardhat-viem/src/types.ts
@@ -35,7 +35,7 @@ export interface HardhatViemHelpers<
    * @param publicClientConfig A viem's PublicClientConfig object with the
    * desired configuration.
    * @returns The configured public client. If the connection's chainType is
-   * "optimism", the client will be extended with L2 actions.
+   * "op", the client will be extended with L2 actions.
    */
   getPublicClient: (
     publicClientConfig?: Partial<ViemPublicClientConfig>,
@@ -47,7 +47,7 @@ export interface HardhatViemHelpers<
    * @param walletClientConfig A viem's WalletClientConfig object with the
    * desired configuration.
    * @returns An array with the configured wallet clients. If the connection's
-   * chainType is "optimism", the clients will be extended with L2 actions.
+   * chainType is "op", the clients will be extended with L2 actions.
    */
   getWalletClients: (
     walletClientConfig?: Partial<ViemWalletClientConfig>,
@@ -60,7 +60,7 @@ export interface HardhatViemHelpers<
    * @param walletClientConfig A viem's WalletClientConfig object with the
    * desired configuration.
    * @returns The configured wallet client for the specified address. If the
-   * connection's chainType is "optimism", the client will be extended with L2
+   * connection's chainType is "op", the client will be extended with L2
    * actions.
    */
   getWalletClient: (
@@ -133,10 +133,10 @@ export interface HardhatViemHelpers<
 }
 
 export type GetPublicClientReturnType<ChainTypeT extends ChainType | string> =
-  ChainTypeT extends "optimism" ? OpPublicClient : PublicClient;
+  ChainTypeT extends "op" ? OpPublicClient : PublicClient;
 
 export type GetWalletClientReturnType<ChainTypeT extends ChainType | string> =
-  ChainTypeT extends "optimism" ? OpWalletClient : WalletClient;
+  ChainTypeT extends "op" ? OpWalletClient : WalletClient;
 
 export type PublicClient = ViemPublicClient<ViemTransport, ViemChain>;
 

--- a/v-next/hardhat-viem/test/clients.ts
+++ b/v-next/hardhat-viem/test/clients.ts
@@ -46,7 +46,7 @@ describe("clients", () => {
 
     it("should return a public client extended with L2 actions for Optimism", async () => {
       const provider = new MockEthereumProvider({ eth_chainId: "0xa" }); // optimism
-      const client = await getPublicClient(provider, "optimism");
+      const client = await getPublicClient(provider, "op");
 
       assert.equal(client.type, "publicClient");
       assert.equal(client.chain.id, 10);
@@ -126,7 +126,7 @@ describe("clients", () => {
         eth_chainId: "0xa", // optimism
         eth_accounts: ["0x123", "0x456"],
       });
-      const clients = await getWalletClients(provider, "optimism");
+      const clients = await getWalletClients(provider, "op");
 
       assert.ok(Array.isArray(clients), "should return an array of clients");
       assert.equal(
@@ -248,7 +248,7 @@ describe("clients", () => {
       const provider = new MockEthereumProvider({
         eth_chainId: "0xa", // optimism
       });
-      const client = await getWalletClient(provider, "optimism", "0x123");
+      const client = await getWalletClient(provider, "op", "0x123");
 
       assert.equal(client.type, "walletClient");
       assert.equal(client.chain.id, 10);
@@ -317,7 +317,7 @@ describe("clients", () => {
         eth_chainId: "0xa", // optimism
         eth_accounts: ["0x123", "0x456"],
       });
-      const client = await getDefaultWalletClient(provider, "optimism");
+      const client = await getDefaultWalletClient(provider, "op");
 
       assert.equal(client.type, "walletClient");
       assert.equal(client.chain.id, 10);
@@ -503,14 +503,14 @@ describe("clients", () => {
         networks: {
           edrOptimism: {
             type: "edr",
-            chainType: "optimism",
+            chainType: "op",
           },
         },
       });
 
       const { viem } = await hre.network.connect({
         network: "edrOptimism",
-        chainType: "optimism",
+        chainType: "op",
       });
       const publicClient = await viem.getPublicClient();
       const [senderClient] = await viem.getWalletClients();

--- a/v-next/hardhat-viem/test/contracts.ts
+++ b/v-next/hardhat-viem/test/contracts.ts
@@ -186,7 +186,7 @@ describe("contracts", () => {
             edrOptimism: {
               type: "edr",
               chainId: 10,
-              chainType: "optimism",
+              chainType: "op",
               forking: {
                 url: "https://mainnet.optimism.io",
               },
@@ -199,7 +199,7 @@ describe("contracts", () => {
 
         const networkConnection = await hre.network.connect({
           network: "edrOptimism",
-          chainType: "optimism",
+          chainType: "op",
         });
         const contract = await networkConnection.viem.deployContract(
           "WithoutConstructorArgs",

--- a/v-next/hardhat/src/internal/constants.ts
+++ b/v-next/hardhat/src/internal/constants.ts
@@ -6,6 +6,6 @@ export const EDR_NETWORK_REVERT_SNAPSHOT_EVENT = "hardhatNetworkRevertSnapshot";
 
 export const GENERIC_CHAIN_TYPE = "generic";
 export const L1_CHAIN_TYPE = "l1";
-export const OPTIMISM_CHAIN_TYPE = "optimism";
+export const OPTIMISM_CHAIN_TYPE = "op";
 
 export const DEFAULT_NETWORK_NAME = "default";

--- a/v-next/hardhat/src/types/network.ts
+++ b/v-next/hardhat/src/types/network.ts
@@ -5,9 +5,9 @@ import type { EthereumProvider } from "./providers.js";
  * Represents the possible chain types for the network. The options are:
  * - `GenericNetworkType`: Represents the most generic type of network.
  * - `"l1"`: Represents Layer 1 networks like Ethereum.
- * - `"optimism"`: Represents Layer 2 networks like Optimism.
+ * - `"op"`: Represents Layer 2 networks like Optimism.
  */
-export type ChainType = GenericChainType | "l1" | "optimism";
+export type ChainType = GenericChainType | "l1" | "op";
 
 /**
  * The most generic chanin type.

--- a/v-next/hardhat/templates/01-node-test-runner-viem/hardhat.config.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/hardhat.config.ts
@@ -52,7 +52,7 @@ const config: HardhatUserConfig = {
    *   allowing you to have multiple simulated networks.
    *
    * - You can set a `chainType` for each network, which is either `generic`,
-   *   `l1`, or `optimism`. This has two uses. It ensures that you always
+   *   `l1`, or `op`. This has two uses. It ensures that you always
    *   connect to the network with the right Chain Type. And, on `edr`
    *   networks, it makes sure that the simulated chain behaves exactly like the
    *   real one. More information about this can be found in the test files.
@@ -70,7 +70,7 @@ const config: HardhatUserConfig = {
     },
     hardhatOp: {
       type: "edr",
-      chainType: "optimism",
+      chainType: "op",
     },
     sepolia: {
       type: "http",

--- a/v-next/hardhat/templates/01-node-test-runner-viem/scripts/check-predeploy.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/scripts/check-predeploy.ts
@@ -23,7 +23,7 @@ async function mainnetExample() {
 async function opExample() {
   const { viem } = await network.connect({
     network: "hardhatOp",
-    chainType: "optimism",
+    chainType: "op",
   });
 
   const publicClient = await viem.getPublicClient();

--- a/v-next/hardhat/templates/01-node-test-runner-viem/scripts/send-op-tx.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/scripts/send-op-tx.ts
@@ -2,7 +2,7 @@ import { network } from "hardhat";
 
 const { viem } = await network.connect({
   network: "hardhatOp",
-  chainType: "optimism",
+  chainType: "op",
 });
 
 console.log("Sending transaction using the OP chain type");

--- a/v-next/hardhat/templates/01-node-test-runner-viem/test/Counter.ts
+++ b/v-next/hardhat/templates/01-node-test-runner-viem/test/Counter.ts
@@ -44,7 +44,7 @@ describe("Counter", async function () {
    *   to the `sepolia` network config, treating it as an "l1" network with the
    *   appropriate viem extensions.
    *
-   * - `await network.connect({network: "hardhatOp", chainType: "optimism"})`:
+   * - `await network.connect({network: "hardhatOp", chainType: "op"})`:
    *   Creates a new EDR instance in Optimism mode, using the `hardhatOp`
    *   network config.
    *

--- a/v-next/hardhat/templates/02-mocha-ethers/hardhat.config.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/hardhat.config.ts
@@ -52,7 +52,7 @@ const config: HardhatUserConfig = {
    *   allowing you to have multiple simulated networks.
    *
    * - You can set a `chainType` for each network, which is either `generic`,
-   *   `l1`, or `optimism`. This has two uses. It ensures that you always
+   *   `l1`, or `op`. This has two uses. It ensures that you always
    *   connect to the network with the right Chain Type. And, on `edr`
    *   networks, it makes sure that the simulated chain behaves exactly like the
    *   real one. More information about this can be found in the test files.
@@ -70,7 +70,7 @@ const config: HardhatUserConfig = {
     },
     hardhatOp: {
       type: "edr",
-      chainType: "optimism",
+      chainType: "op",
     },
     sepolia: {
       type: "http",

--- a/v-next/hardhat/templates/02-mocha-ethers/scripts/check-predeploy.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/scripts/check-predeploy.ts
@@ -20,7 +20,7 @@ async function mainnetExample() {
 async function opExample() {
   const { ethers } = await network.connect({
     network: "hardhatOp",
-    chainType: "optimism",
+    chainType: "op",
   });
 
   const gasPriceOracleCode = await ethers.provider.getCode(OP_GAS_PRICE_ORACLE);

--- a/v-next/hardhat/templates/02-mocha-ethers/scripts/send-op-tx.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/scripts/send-op-tx.ts
@@ -2,7 +2,7 @@ import { network } from "hardhat";
 
 const { ethers } = await network.connect({
   network: "hardhatOp",
-  chainType: "optimism",
+  chainType: "op",
 });
 
 console.log("Sending transaction using the OP chain type");

--- a/v-next/hardhat/templates/02-mocha-ethers/test/Counter.ts
+++ b/v-next/hardhat/templates/02-mocha-ethers/test/Counter.ts
@@ -31,7 +31,7 @@ import { network } from "hardhat";
  * - `await network.connect({network: "sepolia", chainType: "l1"})`: Connects
  *   to the `sepolia` network config, treating it as an "l1" network.
  *
- * - `await network.connect(network: "hardhatOp", chainType: "optimism"})`:
+ * - `await network.connect(network: "hardhatOp", chainType: "op"})`:
  *   Creates a new EDR instance in Optimism mode, using the `hardhatOp`
  *   network config.
  *

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -138,7 +138,7 @@ describe("network-manager/hook-handlers/config", () => {
       assertValidationErrors(validationErrors, [
         {
           path: ["defaultChainType"],
-          message: "Expected 'l1', 'optimism', or 'generic'",
+          message: "Expected 'l1', 'op', or 'generic'",
         },
       ]);
     });
@@ -241,7 +241,7 @@ describe("network-manager/hook-handlers/config", () => {
       assertValidationErrors(validationErrors, [
         {
           path: ["networks", "localhost", "chainType"],
-          message: "Expected 'l1', 'optimism', or 'generic'",
+          message: "Expected 'l1', 'op', or 'generic'",
         },
       ]);
     });

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -1273,7 +1273,7 @@ describe("NetworkManagerImplementation", () => {
           assertValidationErrors(validationErrors, []);
 
           validationErrors = await validateNetworkUserConfig(
-            httpConfig({ chainType: "optimism" }),
+            httpConfig({ chainType: "op" }),
           );
 
           assertValidationErrors(validationErrors, []);
@@ -1293,7 +1293,7 @@ describe("NetworkManagerImplementation", () => {
           assertValidationErrors(validationErrors, [
             {
               path: ["networks", "hardhat", "chainType"],
-              message: "Expected 'l1', 'optimism', or 'generic'",
+              message: "Expected 'l1', 'op', or 'generic'",
             },
           ]);
         });
@@ -1308,7 +1308,7 @@ describe("NetworkManagerImplementation", () => {
           assertValidationErrors(validationErrors, []);
 
           validationErrors = await validateNetworkUserConfig(
-            edrConfig({ chainType: "optimism" }),
+            edrConfig({ chainType: "op" }),
           );
 
           assertValidationErrors(validationErrors, []);
@@ -1328,7 +1328,7 @@ describe("NetworkManagerImplementation", () => {
           assertValidationErrors(validationErrors, [
             {
               path: ["networks", "hardhat", "chainType"],
-              message: "Expected 'l1', 'optimism', or 'generic'",
+              message: "Expected 'l1', 'op', or 'generic'",
             },
           ]);
         });
@@ -2004,7 +2004,7 @@ describe("NetworkManagerImplementation", () => {
             {
               path: ["networks", "hardhat", "hardfork"],
               message:
-                "Invalid hardfork name anything else for chainType optimism. Expected bedrock | regolith | canyon | ecotone | fjord | granite | holocene.",
+                "Invalid hardfork name anything else for chainType op. Expected bedrock | regolith | canyon | ecotone | fjord | granite | holocene.",
             },
           ]);
         });

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -141,7 +141,7 @@ describe("solidity-test/task-action", function () {
 
         await hre.tasks.getTask(["test", "solidity"]).run({
           noCompile: true,
-          chainType: "optimism",
+          chainType: "op",
         });
       });
 


### PR DESCRIPTION
Renames `optimism` to `op` for the network chaintype in Hardhat config e.g.

```ts
const config: HardhatUserConfig = {
  networks: {
    op: {
      type: "http",
      chainType: "op", // <-- previously "optimism"
      url: "https://mainnet.optimism.io/",
      accounts: [configVariable("OP_SENDER")],
    },
  },
}
```

This brings our naming inline with the Optimism docs.

## Naming consideration

The mainnet is called `op`, as evidenced by:

* https://explorer.optimism.io/
* https://docs.optimism.io/stack/getting-started
* https://chainlist.org/chain/10

It should be noted that `optimism` is the label for the chain in `viem` e.g.:

```ts
import { optimism } from "viem/chains";

console.log(optimism.name); // "OP Mainnet"
```

However, we are choosing to move closer to the official documentation.

Resolves #7085
