### PR TITLE
build: upgrade to @nomicfoundation/edr v0.12.0-next.3

### DIFF
--- a/.changeset/proud-colts-itch.md
+++ b/.changeset/proud-colts-itch.md
@@ -1,0 +1,5 @@
+---
+"hardhat": minor
+---
+
+Upgraded EDR dependency to @nomicfoundation/edr v0.12.0-next.3

--- a/.changeset/spotty-pianos-confess.md
+++ b/.changeset/spotty-pianos-confess.md
@@ -1,0 +1,5 @@
+---
+"hardhat": minor
+---
+
+Removed deprecated JSON-RPC methods: `eth_mining`, `net_listening`, `net_peerCount`, `hardhat_addCompilationResult`, `hardhat_intervalMine`, and `hardhat_reset`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
   v-next/hardhat:
     dependencies:
       '@nomicfoundation/edr':
-        specifier: 0.12.0-next.2
-        version: 0.12.0-next.2
+        specifier: 0.12.0-next.3
+        version: 0.12.0-next.3
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.0-next.26
         version: link:../hardhat-errors
@@ -2428,36 +2428,36 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.2':
-    resolution: {integrity: sha512-JzVYNU+u3AQ0nlOorTA3fFyKxqvDGDS6NPQGQ7ZPuV3EAfrJ+runX8ae4McRXKl7HUOCfv2haQncRKdez04/Nw==}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.3':
+    resolution: {integrity: sha512-7IDinGMqSRSrDyVFX3wqkxEad/gIsZR/XfjtOU0Vxb153+r2ZxSLYhO+YDtVe82TPt6N1RGUSv5NEgEheKHPPQ==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.2':
-    resolution: {integrity: sha512-2zBP80o0ispaWhcEoAHPzKEsd2aw9iBa1U7njjCGJwyfDk336sETTpQmdwmCvAwt1OwjJILbRkercEyNMxkVNQ==}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.3':
+    resolution: {integrity: sha512-NmNLmYMNp7NyCA3C4AUM1iVoD8SFtJDkJpnSR64EKv4qpz3a3MacoWq47pNCgFt/+1WpdKM3fPVmCieSa8CuNg==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.2':
-    resolution: {integrity: sha512-Fu+Wz9HJ7ARiGzUyqPLqe57C/x+9eg/MUB1CB8PtaHlNznNDCsLQtuFPIQ92bGlkjTXdVrSCJK6qtqU1/2JQow==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.3':
+    resolution: {integrity: sha512-ZpD4PX1efgBGLrEZxYUuRgsUaEasjmNz4NWy1M4rX+/3OB8QRYG2qVvp93EVd4JQR8XL+RvzUU2TV7bc6UpUnA==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.2':
-    resolution: {integrity: sha512-hy26FL5vVyuGv2fgPJiy/CIwhL4noVQEleHUCHYtVdLWedbubBbFlE7O+MypCCPvUrlvTiTNUGGXnE2GLUitOQ==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.3':
+    resolution: {integrity: sha512-1Tcv+IoH5ovVbsOlQDm96z1FaG4MTkF67+cT1c5QvbXzSc9uI3iTomy49dHKa4s2Xy+fiGd8SVprzOjfu152cA==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.2':
-    resolution: {integrity: sha512-YlpI4PYpQv7BsHsDB9bAOQznS0N6SZ0l+cBJ1zWIkTb6E+Ksg5FY9HlFW4xJNTMLOfEGEJ3O8ktwUwpKQrZztQ==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.3':
+    resolution: {integrity: sha512-QcJ9/q+vYCCJp3Y7sp7nZC6d0P54/ukq0uOTHWQtypAIucHWT8bY3zASzTdGwl6BN6k09xBB7oAwhaWwceUz/w==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.2':
-    resolution: {integrity: sha512-VhGzsLwI3sTOpVTWO76Abuod2n6sFOHJGhGkj66Yh+/ARF86qY3O7RRnyKQZThOlmhxeTFukK2gz+L47HEidVQ==}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.3':
+    resolution: {integrity: sha512-ATaGBXhw3Or7aPEX+T9QRHrsXmyV5R0dauVZh6mSEkzpu5SoNIybbjZR+kfKP2QcEKX42NSc3tDEvwBIyG+EVw==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.2':
-    resolution: {integrity: sha512-5RiadF1ujRRVea/565cSkaObstrY8w/Bbq7qd44PO5kodcNKL6b+rHC9y0OER8vvFdsBzeiUKt4kU7SYgc6ppg==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.3':
+    resolution: {integrity: sha512-gUo4fUW8rq2oX4XuoQ5pQ8jyrkKWHRkiGicuP/ZTTx+lxlXvIFdFYu/k9yspC04odTHDibQ6Tsx7iGiR0wrVYQ==}
     engines: {node: '>= 18'}
 
-  '@nomicfoundation/edr@0.12.0-next.2':
-    resolution: {integrity: sha512-+N8e1CuDphNzti1bOHf12WATSsDPO6NufHE5p0GqWsz2gKK4sgAq5041uasAFJO9kCz4kGVemCec6WPXtRUNyA==}
+  '@nomicfoundation/edr@0.12.0-next.3':
+    resolution: {integrity: sha512-OQ72j5j8gDynE1GRjTWwBj+8XTmUFuMpYcwSxdV/p5uXoO+Ac0nB3gBQ6OmdgwDK2X12zFvss/gaOf2zTwDgPQ==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -6355,36 +6355,36 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.18.0
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.2':
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.3':
     optional: true
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.2':
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.3':
     optional: true
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.2':
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.3':
     optional: true
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.2':
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.3':
     optional: true
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.2':
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.3':
     optional: true
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.2':
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.3':
     optional: true
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.2':
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.3':
     optional: true
 
-  '@nomicfoundation/edr@0.12.0-next.2':
+  '@nomicfoundation/edr@0.12.0-next.3':
     optionalDependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.2
-      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.2
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.2
-      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.2
-      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.2
-      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.2
-      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.2
+      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.3
+      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.3
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.3
+      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.3
+      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.3
+      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.3
+      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.3
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true
@@ -7738,7 +7738,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4(eslint-plugin-import@2.31.0)(eslint@9.25.1))(eslint@9.25.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7760,7 +7760,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.25.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.25.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4(eslint-plugin-import@2.31.0)(eslint@9.25.1))(eslint@9.25.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -85,7 +85,7 @@
     "typescript": "~5.8.0"
   },
   "dependencies": {
-    "@nomicfoundation/edr": "0.12.0-next.2",
+    "@nomicfoundation/edr": "0.12.0-next.3",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0-next.26",
     "@nomicfoundation/hardhat-utils": "workspace:^3.0.0-next.26",
     "@nomicfoundation/hardhat-zod-utils": "workspace:^3.0.0-next.26",


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This PR builds on top of https://github.com/NomicFoundation/hardhat/pull/7102 and should be merged in order.

I upgrade the dependency for EDR to `@nomicfoundation/edr v0.12.0-next.3`, with the following changes:

### Minor Changes

- 6ea800c: Removed deprecated JSON-RPC methods: `eth_mining`, `net_listening`, `net_peerCount`, `hardhat_addCompilationResult`, `hardhat_intervalMine`, and `hardhat_reset`.
- a5cc346: Added cheatcode error stack trace entry. This fixes stack traces for errors from expect revert cheatcodes and improves stack traces for other cheatcode errors.
