### PR TITLE
Don't use `undici`'s global dispatcher

### DIFF
--- a/.changeset/pink-schools-exercise.md
+++ b/.changeset/pink-schools-exercise.md
@@ -1,0 +1,6 @@
+---
+"hardhat": patch
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Don't use `undici`'s global dispatcher, making Hardhat more stable across Node.js versions

--- a/packages/hardhat-core/src/internal/util/download.ts
+++ b/packages/hardhat-core/src/internal/util/download.ts
@@ -24,13 +24,13 @@ export async function download(
   timeoutMillis = 10000,
   extraHeaders: { [name: string]: string } = {}
 ) {
-  const { getGlobalDispatcher, ProxyAgent, request } = await import("undici");
+  const { Agent, ProxyAgent, request } = await import("undici");
 
   let dispatcher: Dispatcher;
   if (process.env.http_proxy !== undefined && shouldUseProxy(url)) {
     dispatcher = new ProxyAgent(process.env.http_proxy);
   } else {
-    dispatcher = getGlobalDispatcher();
+    dispatcher = new Agent();
   }
 
   const hardhatVersion = getHardhatVersion();

--- a/packages/hardhat-verify/src/internal/undici.ts
+++ b/packages/hardhat-verify/src/internal/undici.ts
@@ -29,13 +29,12 @@ export async function sendPostRequest(
 }
 
 function getDispatcher(): Undici.Dispatcher {
-  const { ProxyAgent, getGlobalDispatcher } =
-    require("undici") as typeof Undici;
+  const { ProxyAgent, Agent } = require("undici") as typeof Undici;
   if (process.env.http_proxy !== undefined) {
     return new ProxyAgent(process.env.http_proxy);
   }
 
-  return getGlobalDispatcher();
+  return new Agent();
 }
 
 export function isSuccessStatusCode(statusCode: number): boolean {

--- a/packages/hardhat-verify/src/internal/undici.ts
+++ b/packages/hardhat-verify/src/internal/undici.ts
@@ -28,13 +28,25 @@ export async function sendPostRequest(
   });
 }
 
+let mockDispatcher: Undici.Dispatcher | undefined;
+
 function getDispatcher(): Undici.Dispatcher {
+  if (mockDispatcher !== undefined) {
+    return mockDispatcher;
+  }
+
   const { ProxyAgent, Agent } = require("undici") as typeof Undici;
   if (process.env.http_proxy !== undefined) {
     return new ProxyAgent(process.env.http_proxy);
   }
 
   return new Agent();
+}
+
+export function setMockDispatcher(
+  dispatcher: Undici.Dispatcher | undefined
+): void {
+  mockDispatcher = dispatcher;
 }
 
 export function isSuccessStatusCode(statusCode: number): boolean {

--- a/packages/hardhat-verify/test/integration/mocks/etherscan.ts
+++ b/packages/hardhat-verify/test/integration/mocks/etherscan.ts
@@ -1,9 +1,5 @@
-import {
-  Dispatcher,
-  getGlobalDispatcher,
-  MockAgent,
-  setGlobalDispatcher,
-} from "undici";
+import { MockAgent } from "undici";
+import { setMockDispatcher } from "../../../src/internal/undici";
 
 const mockAgent = new MockAgent({
   keepAliveTimeout: 10,
@@ -13,17 +9,15 @@ const mockAgent = new MockAgent({
 const client = mockAgent.get("https://api-hardhat.etherscan.io");
 
 export const mockEnvironment = () => {
-  let globalDispatcher: Dispatcher;
   // enable network connections for everything but etherscan API
   mockAgent.enableNetConnect(/^(?!https:\/\/api-hardhat\.etherscan\.io)/);
 
   before(() => {
-    globalDispatcher = getGlobalDispatcher();
-    setGlobalDispatcher(mockAgent);
+    setMockDispatcher(mockAgent);
   });
 
   after(() => {
-    setGlobalDispatcher(globalDispatcher);
+    setMockDispatcher(undefined);
   });
 };
 

--- a/packages/hardhat-verify/test/integration/mocks/sourcify.ts
+++ b/packages/hardhat-verify/test/integration/mocks/sourcify.ts
@@ -1,9 +1,5 @@
-import {
-  Dispatcher,
-  getGlobalDispatcher,
-  MockAgent,
-  setGlobalDispatcher,
-} from "undici";
+import { MockAgent } from "undici";
+import { setMockDispatcher } from "../../../src/internal/undici";
 
 const mockAgent = new MockAgent({
   keepAliveTimeout: 10,
@@ -13,17 +9,15 @@ const mockAgent = new MockAgent({
 const client = mockAgent.get("https://sourcify.dev");
 
 export const mockEnvironmentSourcify = () => {
-  let globalDispatcher: Dispatcher;
   // enable network connections for everything but etherscan API
   mockAgent.enableNetConnect(/^(?!https:\/\/sourcify\.dev)/);
 
   before(() => {
-    globalDispatcher = getGlobalDispatcher();
-    setGlobalDispatcher(mockAgent);
+    setMockDispatcher(mockAgent);
   });
 
   after(() => {
-    setGlobalDispatcher(globalDispatcher);
+    setMockDispatcher(undefined);
   });
 };
 


### PR DESCRIPTION
This PR switches user user of `undici`'s `getGlobalDispatcher` to initializing our own `Agent`.

The reason to do it is that `getGlobalDispatcher` can return `Node.js`'s internal dispatcher, which can have different APIs depending on the version that the user is running 🤯. This PR makes things more stable.

@schaable I think we also want to implement this in v3.

fixes #7118
