### PR TITLE
chore: include release info in Sentry

### DIFF
--- a/v-next/hardhat/src/internal/cli/telemetry/sentry/anonymizer.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/sentry/anonymizer.ts
@@ -55,6 +55,7 @@ export class Anonymizer {
     const result: Event = {
       event_id: event.event_id,
       platform: event.platform,
+      release: event.release,
       timestamp: event.timestamp,
       extra: event.extra,
     };

--- a/v-next/hardhat/src/internal/cli/telemetry/sentry/init.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/sentry/init.ts
@@ -30,6 +30,7 @@ import { createGetModuleFromFilename } from "./vendor/utils/module.js";
 interface InitOptions {
   dsn: string;
   transport: (transportOptions: BaseTransportOptions) => Transport;
+  release?: string;
   serverName?: string;
   integrations?: (integrations: Integration[]) => Integration[];
 }

--- a/v-next/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
@@ -68,6 +68,7 @@ class Reporter {
       "./vendor/integrations/contextlines.js"
     );
 
+    const hardhatVersion = await getHardhatVersion();
     const { init } = await import("./init.js");
 
     const linkedErrorsIntegrationInstance = linkedErrorsIntegration({
@@ -79,6 +80,7 @@ class Reporter {
     await init({
       dsn: SENTRY_DSN,
       transport: makeSubprocessTransport,
+      release: `hardhat@${hardhatVersion}`,
       integrations: () => [
         linkedErrorsIntegrationInstance,
         contextLinesIntegrationInstance,
@@ -86,7 +88,7 @@ class Reporter {
     });
 
     setExtra("nodeVersion", process.version);
-    setExtra("hardhatVersion", await getHardhatVersion());
+    setExtra("hardhatVersion", hardhatVersion);
 
     return this.#instance;
   }

--- a/v-next/hardhat/test/internal/cli/telemetry/sentry/anonymizer.ts
+++ b/v-next/hardhat/test/internal/cli/telemetry/sentry/anonymizer.ts
@@ -1,3 +1,5 @@
+import type { Event } from "@sentry/core";
+
 import assert from "node:assert/strict";
 import path from "node:path";
 import { describe, it } from "node:test";
@@ -17,6 +19,29 @@ class MockedAnonymizer extends Anonymizer {
 }
 
 describe("Anonymizer", () => {
+  it("should clone key information from an anonymized event", async () => {
+    const originalEvent: Event = {
+      event_id: "my-event",
+      platform: "platform1",
+      release: "release1",
+      timestamp: 1754398906,
+      extra: {
+        another: "example",
+      },
+    };
+
+    const anonymizer = new Anonymizer();
+
+    const result = await anonymizer.anonymize(originalEvent);
+
+    if (!result.success) {
+      assert.fail("The event should anonymize without issue");
+      return;
+    }
+
+    assert.deepEqual(result.event, originalEvent);
+  });
+
   it("should anonymize paths of the user's project", async () => {
     const anonymizer = new Anonymizer();
     const anonymizationResult = await anonymizer.anonymizeFilename(


### PR DESCRIPTION
We include the hardhat version already, but by passing it as a release we leverage Sentries release tracking.

Resolves #7011

## Manual Testing

I manually tested this by forcing an error within the example project. This generated a new release under `hardhat3` in Sentry.
