### PR TITLE
rename `edr` label in network config `edr-simulated`

### DIFF
--- a/.changeset/long-rules-glow.md
+++ b/.changeset/long-rules-glow.md
@@ -1,0 +1,14 @@
+---
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+"@nomicfoundation/hardhat-ignition-ethers": patch
+"@nomicfoundation/ignition-core": patch
+"@nomicfoundation/hardhat-ignition-viem": patch
+"@nomicfoundation/hardhat-ignition": patch
+"@nomicfoundation/hardhat-errors": patch
+"@nomicfoundation/hardhat-ethers": patch
+"@nomicfoundation/hardhat-verify": patch
+"@nomicfoundation/hardhat-viem": patch
+"hardhat": patch
+---
+
+Rename `edr` label to `edr-simulated` in network config ([#7051](https://github.com/NomicFoundation/hardhat/issues/7051))

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -121,7 +121,7 @@ const config: HardhatUserConfig = {
       accounts: [configVariable("OP_SENDER")],
     },
     edrOp: {
-      type: "edr",
+      type: "edr-simulated",
       chainType: "op",
       chainId: 10,
       forking: {
@@ -135,7 +135,7 @@ const config: HardhatUserConfig = {
       accounts: [configVariable("OP_SEPOLIA_SENDER")],
     },
     edrOpSepolia: {
-      type: "edr",
+      type: "edr-simulated",
       chainType: "op",
       forking: {
         url: "https://sepolia.optimism.io",

--- a/v-next/example-project/scripts/send-op-tx-viem.ts
+++ b/v-next/example-project/scripts/send-op-tx-viem.ts
@@ -8,7 +8,7 @@ async function sendL2Transaction(networkConfigName: string) {
     chainType: "op",
   });
 
-  if (networkConfig.type === "edr") {
+  if (networkConfig.type === "edr-simulated") {
     console.log("Using an EDR network simulating Optimism, forking it");
   } else {
     console.log("Using an HTTP connection to Optimism");

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -945,7 +945,7 @@ Try using another mnemonic or deriving less keys.`,
         messageTemplate:
           'The provided network type "{networkType}" for network "{networkName}" is not recognized, only `http` and `edr` are supported.',
         websiteTitle: "Invalid network type",
-        websiteDescription: `The network manager only supports the network types 'http' and 'edr'.`,
+        websiteDescription: `The network manager only supports the network types 'http' and 'edr-simulated'.`,
       },
       DATA_FIELD_CANNOT_BE_NULL_WITH_NULL_ADDRESS: {
         number: 721,
@@ -1154,9 +1154,9 @@ Please use the fully qualified name of the contract to disambiguate it.`,
     NODE: {
       INVALID_NETWORK_TYPE: {
         number: 1100,
-        messageTemplate: `The provided node network type "{networkType}" for network "{networkName}" is not recognized, only 'edr' is supported.`,
+        messageTemplate: `The provided node network type "{networkType}" for network "{networkName}" is not recognized, only 'edr-simulated' is supported.`,
         websiteTitle: "Invalid node network type",
-        websiteDescription: `The node only supports the 'edr' network type.`,
+        websiteDescription: `The node only supports the 'edr-simulated' network type.`,
       },
     },
     TEST_PLUGIN: {
@@ -2448,7 +2448,7 @@ Possible causes:
 Specify the exact contract using the \`--contract\` flag.`,
         websiteTitle: "Multiple contract matches",
         websiteDescription: `The deployed bytecode matches multiple compiled contracts. Specify the exact contract using the \`--contract\` flag. For example:
-        
+
 \`\`\`sh
 npx hardhat verify --contract contracts/Example.sol:ExampleContract <other args>
 \`\`\`

--- a/v-next/hardhat-ethers-chai-matchers/test/multi-network-connections.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/multi-network-connections.ts
@@ -31,11 +31,11 @@ describe("handle multiple connections", () => {
       plugins: [hardhatChaiMatchersPlugin, hardhatEthersPlugin],
       networks: {
         test1: {
-          type: "edr",
+          type: "edr-simulated",
           chainId: 1,
         },
         test2: {
-          type: "edr",
+          type: "edr-simulated",
           chainId: 2,
         },
       },

--- a/v-next/hardhat-ethers/src/internal/signers/signers.ts
+++ b/v-next/hardhat-ethers/src/internal/signers/signers.ts
@@ -37,7 +37,7 @@ type SignerAccounts =
       accounts: HttpNetworkAccountsConfig;
     }
   | {
-      type: "edr";
+      type: "edr-simulated";
       accounts: EdrNetworkAccountsConfig;
     };
 
@@ -69,7 +69,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
     const signerAccounts: SignerAccounts =
       networkConfig.type === "http"
         ? { type: "http", accounts: networkConfig.accounts }
-        : { type: "edr", accounts: networkConfig.accounts };
+        : { type: "edr-simulated", accounts: networkConfig.accounts };
 
     return new HardhatEthersSigner(address, provider, signerAccounts, gasLimit);
   }
@@ -349,7 +349,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
       }
     }
 
-    if (type === "edr") {
+    if (type === "edr-simulated") {
       if (Array.isArray(accounts)) {
         return Promise.all(accounts.map((acc) => acc.privateKey.get()));
       }

--- a/v-next/hardhat-ethers/test/hardhat-ethers-signer.ts
+++ b/v-next/hardhat-ethers/test/hardhat-ethers-signer.ts
@@ -144,7 +144,7 @@ describe("hardhat ethers signer", () => {
         const { ethers: hhEthers } = await initializeTestEthers([], {
           networks: {
             default: {
-              type: "edr",
+              type: "edr-simulated",
               accounts: [
                 { balance: "1000000000000000000", privateKey: TEST_P_KEY_1 },
                 { balance: "1000000000000000000", privateKey: TEST_P_KEY_2 },
@@ -160,7 +160,7 @@ describe("hardhat ethers signer", () => {
         const { ethers: hhEthers } = await initializeTestEthers([], {
           networks: {
             default: {
-              type: "edr",
+              type: "edr-simulated",
               accounts: HD_ACCOUNTS,
             },
           },

--- a/v-next/hardhat-ignition-core/test-integrations/fixture-projects/dont-throw-on-reverts/hardhat.config.js
+++ b/v-next/hardhat-ignition-core/test-integrations/fixture-projects/dont-throw-on-reverts/hardhat.config.js
@@ -15,7 +15,7 @@ export default {
   },
   networks: {
     hardhat: {
-      type: "edr",
+      type: "edr-simulated",
       throwOnTransactionFailures: false,
     },
   },

--- a/v-next/hardhat-ignition-ethers/src/internal/ethers-ignition-helper.ts
+++ b/v-next/hardhat-ignition-ethers/src/internal/ethers-ignition-helper.ts
@@ -143,7 +143,7 @@ export class EthersIgnitionHelperImpl<ChainTypeT extends ChainType | string>
     const deploymentId = resolveDeploymentId(givenDeploymentId, chainId);
 
     const deploymentDir =
-      this.#connection.networkConfig.type === "edr"
+      this.#connection.networkConfig.type === "edr-simulated"
         ? undefined
         : path.join(
             this.#hardhatConfig.paths.ignition,

--- a/v-next/hardhat-ignition-viem/src/internal/viem-ignition-helper.ts
+++ b/v-next/hardhat-ignition-viem/src/internal/viem-ignition-helper.ts
@@ -146,7 +146,7 @@ export class ViemIgnitionHelperImpl<ChainTypeT extends ChainType | string>
     const deploymentId = resolveDeploymentId(givenDeploymentId, chainId);
 
     const deploymentDir =
-      this.#connection.networkConfig.type === "edr"
+      this.#connection.networkConfig.type === "edr-simulated"
         ? undefined
         : path.join(
             this.#hardhatConfig.paths.ignition,

--- a/v-next/hardhat-ignition/src/internal/tasks/deploy.ts
+++ b/v-next/hardhat-ignition/src/internal/tasks/deploy.ts
@@ -66,7 +66,8 @@ const taskDeploy: NewTaskActionFunction<TaskDeployArguments> = async (
   );
 
   const deploymentDir =
-    connection.networkConfig.type === "edr" && !writeLocalhostDeployment
+    connection.networkConfig.type === "edr-simulated" &&
+    !writeLocalhostDeployment
       ? undefined
       : path.join(hre.config.paths.ignition, "deployments", deploymentId);
 

--- a/v-next/hardhat-ignition/test/config.ts
+++ b/v-next/hardhat-ignition/test/config.ts
@@ -21,7 +21,7 @@ describe("config", () => {
         plugins: [hardhatIgnition],
         networks: {
           default: {
-            type: "edr",
+            type: "edr-simulated",
             mining: {
               auto: false,
             },

--- a/v-next/hardhat-ignition/test/fixture-projects/default-with-new-chain-id/hardhat.config.js
+++ b/v-next/hardhat-ignition/test/fixture-projects/default-with-new-chain-id/hardhat.config.js
@@ -17,7 +17,7 @@ export default {
     default: {
       // We use a different chain id to avoid triggering the auto-wipe for fixtures
       chainId: 1337,
-      type: "edr",
+      type: "edr-simulated",
     },
   },
 };

--- a/v-next/hardhat-ignition/test/fixture-projects/reset-flag/hardhat.config.js
+++ b/v-next/hardhat-ignition/test/fixture-projects/reset-flag/hardhat.config.js
@@ -17,7 +17,7 @@ export default {
   },
   networks: {
     nothardhat: {
-      type: "edr",
+      type: "edr-simulated",
       chainId: 99999,
       gas: "auto",
       gasMultiplier: 1,

--- a/v-next/hardhat-verify/test/fixture-projects/integration/hardhat.config.ts
+++ b/v-next/hardhat-verify/test/fixture-projects/integration/hardhat.config.ts
@@ -5,7 +5,7 @@ import hardhatVerify from "../../../src/index.js";
 const config: HardhatUserConfig = {
   networks: {
     default: {
-      type: "edr",
+      type: "edr-simulated",
       chainId: 11155111, // Sepolia
     },
   },

--- a/v-next/hardhat-viem/test/clients.ts
+++ b/v-next/hardhat-viem/test/clients.ts
@@ -502,7 +502,7 @@ describe("clients", () => {
         plugins: [HardhatViem],
         networks: {
           edrOptimism: {
-            type: "edr",
+            type: "edr-simulated",
             chainType: "op",
           },
         },

--- a/v-next/hardhat-viem/test/contracts.ts
+++ b/v-next/hardhat-viem/test/contracts.ts
@@ -184,7 +184,7 @@ describe("contracts", () => {
           plugins: [HardhatViem],
           networks: {
             edrOptimism: {
-              type: "edr",
+              type: "edr-simulated",
               chainId: 10,
               chainType: "op",
               forking: {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-override.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-override.ts
@@ -48,7 +48,7 @@ export async function normalizeNetworkConfigOverride(
 
     networkConfigOverrideWithType = {
       ...networkConfigOverrideAsEdr,
-      type: "edr",
+      type: "edr-simulated",
     };
   }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts
@@ -68,7 +68,7 @@ export function resolveEdrNetwork(
   resolveConfigurationVariable: ConfigurationVariableResolver,
 ): EdrNetworkConfig {
   return {
-    type: "edr",
+    type: "edr-simulated",
     accounts: resolveEdrNetworkAccounts(
       networkConfig.accounts,
       resolveConfigurationVariable,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -62,7 +62,7 @@ export async function extendUserConfig(
         gasMultiplier: 1,
         gasPrice: "auto",
         ...defaultConfig,
-        type: "edr",
+        type: "edr-simulated",
       },
     },
   };
@@ -83,7 +83,10 @@ export async function resolveUserConfig(
   const resolvedNetworks: Record<string, NetworkConfig> = {};
 
   for (const [networkName, networkConfig] of Object.entries(networks)) {
-    if (networkConfig.type !== "http" && networkConfig.type !== "edr") {
+    if (
+      networkConfig.type !== "http" &&
+      networkConfig.type !== "edr-simulated"
+    ) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.NETWORK.INVALID_NETWORK_TYPE,
         {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -210,7 +210,7 @@ export class NetworkManagerImplementation implements NetworkManager {
           async (_context, _connection, req) => defaultBehavior(req),
         );
 
-      if (resolvedNetworkConfig.type === "edr") {
+      if (resolvedNetworkConfig.type === "edr-simulated") {
         if (!isSupportedChainType(resolvedChainType)) {
           throw new HardhatError(
             HardhatError.ERRORS.CORE.GENERAL.UNSUPPORTED_OPERATION,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/config.ts
@@ -94,7 +94,7 @@ declare module "../../../../types/config.js" {
   export type GasUserConfig = "auto" | number | bigint;
 
   export interface EdrNetworkUserConfig {
-    type: "edr";
+    type: "edr-simulated";
     accounts?: EdrNetworkAccountsUserConfig;
     chainId?: number;
     chainType?: ChainType;
@@ -233,7 +233,7 @@ declare module "../../../../types/config.js" {
   export type GasConfig = "auto" | bigint;
 
   export interface EdrNetworkConfig {
-    type: "edr";
+    type: "edr-simulated";
     accounts: EdrNetworkAccountsConfig;
     chainId: number;
     chainType?: ChainType;

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -290,7 +290,7 @@ const edrNetworkMiningUserConfigSchema = z.object({
 });
 
 const edrNetworkUserConfigSchema = z.object({
-  type: z.literal("edr"),
+  type: z.literal("edr-simulated"),
   accounts: z.optional(edrNetworkAccountsUserConfigSchema),
   chainId: z.optional(chainIdSchema),
   chainType: z.optional(chainTypeUserConfigSchema),
@@ -327,7 +327,7 @@ function refineEdrNetworkUserConfig(
   networkConfig: NetworkUserConfig,
   ctx: RefinementCtx,
 ): void {
-  if (networkConfig.type === "edr") {
+  if (networkConfig.type === "edr-simulated") {
     const {
       chainType = GENERIC_CHAIN_TYPE,
       hardfork,

--- a/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
@@ -38,7 +38,7 @@ const nodeAction: NewTaskActionFunction<NodeActionArguments> = async (
     });
   }
 
-  if (hre.config.networks[network].type !== "edr") {
+  if (hre.config.networks[network].type !== "edr-simulated") {
     throw new HardhatError(HardhatError.ERRORS.CORE.NODE.INVALID_NETWORK_TYPE, {
       networkType: hre.config.networks[network].type,
       networkName: network,
@@ -133,7 +133,7 @@ const nodeAction: NewTaskActionFunction<NodeActionArguments> = async (
   // NOTE: Before creating the node, we check if the input network config is of type edr.
   // We only proceed if it is. Hence, we can assume that the output network config is of type edr as well.
   assertHardhatInvariant(
-    networkConfig.type === "edr",
+    networkConfig.type === "edr-simulated",
     "Network config type should be edr",
   );
 

--- a/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/hardhat.config.ts
+++ b/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/hardhat.config.ts
@@ -65,11 +65,11 @@ const config: HardhatUserConfig = {
    */
   networks: {
     hardhatMainnet: {
-      type: "edr",
+      type: "edr-simulated",
       chainType: "l1",
     },
     hardhatOp: {
-      type: "edr",
+      type: "edr-simulated",
       chainType: "op",
     },
     sepolia: {

--- a/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/hardhat.config.ts
+++ b/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/hardhat.config.ts
@@ -65,11 +65,11 @@ const config: HardhatUserConfig = {
    */
   networks: {
     hardhatMainnet: {
-      type: "edr",
+      type: "edr-simulated",
       chainType: "l1",
     },
     hardhatOp: {
-      type: "edr",
+      type: "edr-simulated",
       chainType: "op",
     },
     sepolia: {

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/config-resolution.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/config-resolution.ts
@@ -115,7 +115,7 @@ describe("config-resolution", () => {
   describe("resolveEdrNetwork", () => {
     it("should return the edr network config if it is provided", () => {
       const userConfig: EdrNetworkUserConfig = {
-        type: "edr",
+        type: "edr-simulated",
         chainId: 1,
         chainType: L1_CHAIN_TYPE,
         from: "0x1234",
@@ -176,7 +176,7 @@ describe("config-resolution", () => {
 
     it("should use the default values for the optional fields if they are not provided", () => {
       const userConfig: EdrNetworkUserConfig = {
-        type: "edr",
+        type: "edr-simulated",
       };
       const now = new Date();
       const edrNetworkConfig = resolveEdrNetwork(
@@ -187,7 +187,7 @@ describe("config-resolution", () => {
 
       // Only check the fields that are resolved by the function itself
       // Other fields are checked in the following describe blocks
-      assert.equal(edrNetworkConfig.type, "edr");
+      assert.equal(edrNetworkConfig.type, "edr-simulated");
       assert.equal(edrNetworkConfig.chainId, 31337);
       assert.equal(edrNetworkConfig.chainType, undefined);
       assert.equal(edrNetworkConfig.from, undefined);
@@ -209,7 +209,7 @@ describe("config-resolution", () => {
 
     it("should use the provided chainId for the networkId if it is not provided", () => {
       const userConfig: EdrNetworkUserConfig = {
-        type: "edr",
+        type: "edr-simulated",
         chainId: 1,
       };
       const edrNetworkConfig = resolveEdrNetwork(

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -176,7 +176,8 @@ describe("network-manager/hook-handlers/config", () => {
       assertValidationErrors(validationErrors, [
         {
           path: ["networks", "localhost", "type"],
-          message: "Invalid discriminator value. Expected 'http' | 'edr'",
+          message:
+            "Invalid discriminator value. Expected 'http' | 'edr-simulated'",
         },
       ]);
     });
@@ -195,7 +196,8 @@ describe("network-manager/hook-handlers/config", () => {
       assertValidationErrors(validationErrors, [
         {
           path: ["networks", "localhost", "type"],
-          message: "Invalid discriminator value. Expected 'http' | 'edr'",
+          message:
+            "Invalid discriminator value. Expected 'http' | 'edr-simulated'",
         },
       ]);
     });
@@ -441,7 +443,7 @@ describe("network-manager/hook-handlers/config", () => {
       ): HardhatUserConfig => ({
         networks: {
           test: {
-            type: "edr",
+            type: "edr-simulated",
             chainType: "l1",
             allowBlocksWithSameTimestamp,
             mining: {
@@ -875,7 +877,7 @@ describe("network-manager/hook-handlers/config", () => {
                 gas: "auto",
                 gasMultiplier: 1,
                 gasPrice: "auto",
-                type: "edr",
+                type: "edr-simulated",
                 accounts: "", // Modified in the tests
                 url: "http://localhost:8545",
               },

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -76,7 +76,7 @@ describe("NetworkManagerImplementation", () => {
         url: "http://node.myNetwork.com",
       },
       edrNetwork: {
-        type: "edr",
+        type: "edr-simulated",
         chainType: OPTIMISM_CHAIN_TYPE,
         initialDate,
         mining: {
@@ -113,7 +113,7 @@ describe("NetworkManagerImplementation", () => {
       ),
       edrNetwork: resolveEdrNetwork(
         {
-          type: "edr",
+          type: "edr-simulated",
           chainType: OPTIMISM_CHAIN_TYPE,
           initialDate,
           mining: {
@@ -227,7 +227,7 @@ describe("NetworkManagerImplementation", () => {
 
       assert.equal(networkConnection.networkName, "edrNetwork");
       assert.equal(networkConnection.chainType, OPTIMISM_CHAIN_TYPE);
-      assert.equal(networks.edrNetwork.type, "edr"); // this is for the type assertion
+      assert.equal(networks.edrNetwork.type, "edr-simulated"); // this is for the type assertion
       assert.deepEqual(networkConnection.networkConfig, {
         ...networks.edrNetwork,
         ...edrConfigOverride,
@@ -258,7 +258,7 @@ describe("NetworkManagerImplementation", () => {
           /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           -- Cast to test validation error */
           override: {
-            type: "edr",
+            type: "edr-simulated",
           } as any,
         }),
         HardhatError.ERRORS.CORE.NETWORK.INVALID_CONFIG_OVERRIDE,
@@ -454,7 +454,7 @@ describe("NetworkManagerImplementation", () => {
       return {
         networks: {
           hardhat: {
-            type: "edr",
+            type: "edr-simulated",
             ...partial,
           },
         },


### PR DESCRIPTION
This rename gives a clearer indication that the network config is for a local in-memory simulation via EDR.

Resolves #7051
