### PR TITLE
Avoid cleaning up solidity test artifacts on compile task

### DIFF
--- a/.changeset/forty-steaks-live.md
+++ b/.changeset/forty-steaks-live.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Stop solidity tests being recompiled unnecessarily ([#7116](https://github.com/NomicFoundation/hardhat/issues/7116))

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
@@ -120,6 +120,7 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => {
         soliditySourcesPaths: hre.config.paths.sources.solidity,
         artifactsPath: hre.config.paths.artifacts,
         cachePath: hre.config.paths.cache,
+        solidityTestsPath: hre.config.paths.tests.solidity,
       });
     },
   };

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -107,6 +107,7 @@ describe(
         soliditySourcesPaths: [path.join(process.cwd(), "contracts")],
         artifactsPath: expectedArtifactsPath,
         cachePath: expectedCachePath,
+        solidityTestsPath: path.join(process.cwd(), "tests"),
       });
       const rootFilePaths = await solidity.getRootFilePaths();
       await solidity.build(rootFilePaths, {
@@ -129,6 +130,7 @@ describe(
         soliditySourcesPaths: [path.join(process.cwd(), "contracts")],
         artifactsPath: actualArtifactsPath,
         cachePath: actualCachePath,
+        solidityTestsPath: path.join(process.cwd(), "tests"),
       });
     });
 


### PR DESCRIPTION
I found the issue with solidity tests being recompiled. The test task runs compile 2 times, one for the contracts and one for the tests. The first run, which compiles all contracts (empty files list), triggers the cleanup. Then this cleanup would remove the test artifacts, since they won't match any file from the full compilation (because full compilation doesn't compile test files).

The proposed fix is skipping test artifacts from cleanup, that would mean their source files end with `.t.sol` or they are `.sol` but inside the solidity tests folder. The only downside is that some artifact folders won't be automatically cleaned up if e.g. a test file is deleted or renamed. Build infos are still cleaned up correctly.

Closes #7116 