### PR TITLE
7114 global options arent displayed in the help message of a task

### DIFF
--- a/.changeset/neat-apes-beam.md
+++ b/.changeset/neat-apes-beam.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Display **GLOBAL OPTIONS** in help messages of all tasks that support them ([#7114](https://github.com/NomicFoundation/hardhat/issues/7114))

--- a/v-next/hardhat/src/internal/cli/help/get-global-help-string.ts
+++ b/v-next/hardhat/src/internal/cli/help/get-global-help-string.ts
@@ -7,8 +7,8 @@ import {
   GLOBAL_NAME_PADDING,
   getLongestNameLength,
   getSection,
-  parseGlobalOptions,
   parseTasks,
+  parseGlobalOptions,
 } from "./utils.js";
 
 export async function getGlobalHelpString(

--- a/v-next/hardhat/src/internal/cli/help/get-help-string.ts
+++ b/v-next/hardhat/src/internal/cli/help/get-help-string.ts
@@ -1,3 +1,4 @@
+import type { GlobalOptionDefinitions } from "../../../types/global-options.js";
 import type { Task } from "../../../types/tasks.js";
 
 import {
@@ -7,18 +8,28 @@ import {
   getSection,
   parseSubtasks,
   getUsageString,
+  parseGlobalOptions,
 } from "./utils.js";
 
-export async function getHelpString(task: Task): Promise<string> {
+export async function getHelpString(
+  task: Task,
+  globalOptionDefinitions: GlobalOptionDefinitions,
+): Promise<string> {
   const { default: chalk } = await import("chalk");
 
   const { options, positionalArguments } = parseOptions(task);
 
   const subtasks = parseSubtasks(task);
 
+  const globalOptions = parseGlobalOptions(globalOptionDefinitions);
+
   const namePadding =
-    getLongestNameLength([...options, ...positionalArguments, ...subtasks]) +
-    GLOBAL_NAME_PADDING;
+    getLongestNameLength([
+      ...options,
+      ...positionalArguments,
+      ...subtasks,
+      ...globalOptions,
+    ]) + GLOBAL_NAME_PADDING;
 
   let output = `${chalk.bold(task.description)}`;
 
@@ -27,6 +38,8 @@ export async function getHelpString(task: Task): Promise<string> {
 
     if (subtasks.length > 0) {
       output += getSection("AVAILABLE SUBTASKS", subtasks, namePadding);
+
+      output += getSection("GLOBAL OPTIONS", globalOptions, namePadding);
 
       output += `\nTo get help for a specific task run: npx hardhat ${task.id.join(" ")} <SUBTASK> --help`;
     }
@@ -54,7 +67,7 @@ export async function getHelpString(task: Task): Promise<string> {
     output += getSection("AVAILABLE SUBTASKS", subtasks, namePadding);
   }
 
-  output += `\nFor global options help run: hardhat --help`;
+  output += getSection("GLOBAL OPTIONS", globalOptions, namePadding);
 
   return output;
 }

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -178,7 +178,7 @@ export async function main(
     }
 
     if (builtinGlobalOptions.help || task.isEmpty) {
-      const taskHelp = await getHelpString(task);
+      const taskHelp = await getHelpString(task, globalOptionDefinitions);
 
       print(taskHelp);
       return;

--- a/v-next/hardhat/test/internal/cli/help/get-global-help-string.ts
+++ b/v-next/hardhat/test/internal/cli/help/get-global-help-string.ts
@@ -66,7 +66,34 @@ To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
           },
         ],
       ]);
-      const globalOptionDefinitions = new Map();
+
+      const globalOptionDefinitions = new Map([
+        [
+          "userOption1",
+          {
+            pluginId: "builtin",
+            option: globalOption({
+              name: "userOption1",
+              description: "userOption1 description.",
+              type: ArgumentType.STRING,
+              defaultValue: "default",
+            }),
+          },
+        ],
+        [
+          "userOption2",
+          {
+            pluginId: "builtin",
+            option: globalOption({
+              name: "userOption2",
+              shortName: "o",
+              description: "userOption2 description.",
+              type: ArgumentType.STRING,
+              defaultValue: "default",
+            }),
+          },
+        ],
+      ]);
 
       const help = await getGlobalHelpString(tasks, globalOptionDefinitions);
 
@@ -76,12 +103,13 @@ Usage: hardhat [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUM
 
 AVAILABLE TASKS:
 
-  task1      task1 description
-  task2      task2 description
+  task1                    task1 description
+  task2                    task2 description
 
 GLOBAL OPTIONS:
 
-
+  --user-option-1          userOption1 description.
+  --user-option-2, -o      userOption2 description.
 
 To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
 

--- a/v-next/hardhat/test/internal/cli/help/get-help-string.ts
+++ b/v-next/hardhat/test/internal/cli/help/get-help-string.ts
@@ -5,6 +5,7 @@ import { describe, it } from "node:test";
 
 import chalk from "chalk";
 
+import { globalOption } from "../../../../src/config.js";
 import { getHelpString } from "../../../../src/internal/cli/help/get-help-string.js";
 import { ArgumentType } from "../../../../src/types/arguments.js";
 
@@ -28,7 +29,35 @@ describe("getHelpString", function () {
         run: async () => {},
       };
 
-      const help = await getHelpString(task);
+      const globalOptionDefinitions = new Map([
+        [
+          "userOption1",
+          {
+            pluginId: "builtin",
+            option: globalOption({
+              name: "userOption1",
+              description: "userOption1 description.",
+              type: ArgumentType.STRING,
+              defaultValue: "default",
+            }),
+          },
+        ],
+        [
+          "userOption2",
+          {
+            pluginId: "builtin",
+            option: globalOption({
+              name: "userOption2",
+              shortName: "o",
+              description: "userOption2 description.",
+              type: ArgumentType.STRING,
+              defaultValue: "default",
+            }),
+          },
+        ],
+      ]);
+
+      const help = await getHelpString(task, globalOptionDefinitions);
 
       const expected = `${chalk.bold("task description")}
 
@@ -36,7 +65,12 @@ Usage: hardhat [GLOBAL OPTIONS] task <SUBTASK> [SUBTASK OPTIONS] [--] [SUBTASK P
 
 AVAILABLE SUBTASKS:
 
-  task subtask      An example empty subtask task
+  task subtask             An example empty subtask task
+
+GLOBAL OPTIONS:
+
+  --user-option-1          userOption1 description.
+  --user-option-2, -o      userOption2 description.
 
 To get help for a specific task run: npx hardhat task <SUBTASK> --help`;
 
@@ -69,7 +103,9 @@ To get help for a specific task run: npx hardhat task <SUBTASK> --help`;
           run: async () => {},
         };
 
-        const help = await getHelpString(task);
+        const globalOptionDefinitions = new Map();
+
+        const help = await getHelpString(task, globalOptionDefinitions);
 
         const expected = `${chalk.bold("task description")}
 
@@ -80,7 +116,10 @@ OPTIONS:
   --another-option      Another example option
   --option              An example option
 
-For global options help run: hardhat --help`;
+GLOBAL OPTIONS:
+
+
+`;
 
         assert.equal(help, expected);
       });
@@ -123,7 +162,9 @@ For global options help run: hardhat --help`;
           run: async () => {},
         };
 
-        const help = await getHelpString(task);
+        const globalOptionDefinitions = new Map();
+
+        const help = await getHelpString(task, globalOptionDefinitions);
 
         const expected = `${chalk.bold("task description")}
 
@@ -139,7 +180,10 @@ POSITIONAL ARGUMENTS:
   anotherPositionalArgument      Another example positional argument
   positionalArgument             An example positional argument
 
-For global options help run: hardhat --help`;
+GLOBAL OPTIONS:
+
+
+`;
 
         assert.equal(help, expected);
       });
@@ -184,7 +228,9 @@ For global options help run: hardhat --help`;
           run: async () => {},
         };
 
-        const help = await getHelpString(task);
+        const globalOptionDefinitions = new Map();
+
+        const help = await getHelpString(task, globalOptionDefinitions);
 
         const expected = `${chalk.bold("task description")}
 
@@ -204,7 +250,10 @@ AVAILABLE SUBTASKS:
   task another-subtask      Another example subtask
   task subtask              An example subtask
 
-For global options help run: hardhat --help`;
+GLOBAL OPTIONS:
+
+
+`;
 
         assert.equal(help, expected);
       });

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -307,15 +307,25 @@ Usage: hardhat [GLOBAL OPTIONS] test-task [--opt <STRING>] [--] pos1 [pos2] [var
 
 OPTIONS:
 
-  --opt      opt description (default: opt default value)
+  --opt                    opt description (default: opt default value)
 
 POSITIONAL ARGUMENTS:
 
-  pos1       pos1 description
-  pos2       pos2 description (default: pos2 default value)
-  var1       var1 description (default: var1 default value 1, var1 default value 2)
+  pos1                     pos1 description
+  pos2                     pos2 description (default: pos2 default value)
+  var1                     var1 description (default: var1 default value 1, var1 default value 2)
 
-For global options help run: hardhat --help`;
+GLOBAL OPTIONS:
+
+  --build-profile          The build profile to use
+  --config                 A Hardhat config file.
+  --coverage               Enables code coverage
+  --help, -h               Shows this message, or a task's help if its name is provided.
+  --init                   Initializes a Hardhat project.
+  --network                The network to connect to
+  --show-stack-traces      Show stack traces (always enabled on CI servers).
+  --version                Shows hardhat's version.
+`;
 
           assert.equal(lines.join(""), expected);
         });
@@ -335,16 +345,26 @@ Usage: hardhat [GLOBAL OPTIONS] task [--arg-1 <STRING>] [--arg-4] [--arg-5 <LEVE
 
 OPTIONS:
 
-  --arg-1, -o       (default: <default-value1>)
-  --arg-4, -f       (default: false)
-  --arg-5, -l       (default: 0)
+  --arg-1, -o               (default: <default-value1>)
+  --arg-4, -f               (default: false)
+  --arg-5, -l               (default: 0)
 
 POSITIONAL ARGUMENTS:
 
   arg2
   arg3
 
-For global options help run: hardhat --help`;
+GLOBAL OPTIONS:
+
+  --build-profile          The build profile to use
+  --config                 A Hardhat config file.
+  --coverage               Enables code coverage
+  --help, -h               Shows this message, or a task's help if its name is provided.
+  --init                   Initializes a Hardhat project.
+  --network                The network to connect to
+  --show-stack-traces      Show stack traces (always enabled on CI servers).
+  --version                Shows hardhat's version.
+`;
 
         assert.equal(lines.join(""), expected);
       });


### PR DESCRIPTION
`GLOBAL OPTIONS:` section is displayed in the help message in all cases where the help message specifies that global options can be used (message contains `GLOBAL OPTIONS`)
For example: `Usage: hardhat [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUMENTS]`

This applies to all tasks, subtasks and global help
[Design doc](https://www.notion.so/nomicfoundation/Hardhat-CLI-help-247578cdeaf580b59adedc18f1d21af4?source=copy_link)
