### PR TITLE
Print error cause when showing stack traces

### DIFF
--- a/.changeset/breezy-feet-impress.md
+++ b/.changeset/breezy-feet-impress.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Print error's `cause` when showing stack traces

--- a/v-next/hardhat/src/internal/cli/error-handler.ts
+++ b/v-next/hardhat/src/internal/cli/error-handler.ts
@@ -1,5 +1,3 @@
-import util from "node:util";
-
 import {
   HardhatError,
   HardhatPluginError,
@@ -69,7 +67,7 @@ interface ErrorMessages {
 export function printErrorMessages(
   error: unknown,
   shouldShowStackTraces: boolean = false,
-  print: (message: string) => void = console.error,
+  print: (message: any) => void = console.error,
 ): void {
   const showStackTraces =
     shouldShowStackTraces ||
@@ -85,7 +83,7 @@ export function printErrorMessages(
   print("");
 
   if (showStackTraces) {
-    print(error instanceof Error ? `${error.stack}` : `${util.inspect(error)}`);
+    print(error);
     if (postErrorStackTraceMessage !== undefined) {
       print("");
       print(postErrorStackTraceMessage);

--- a/v-next/hardhat/src/internal/cli/error-handler.ts
+++ b/v-next/hardhat/src/internal/cli/error-handler.ts
@@ -65,9 +65,9 @@ interface ErrorMessages {
  * `console.error`. Useful for testing to capture error messages.
  */
 export function printErrorMessages(
-  error: unknown,
+  error: Error,
   shouldShowStackTraces: boolean = false,
-  print: (message: any) => void = console.error,
+  print: (message: string | Error) => void = console.error,
 ): void {
   const showStackTraces =
     shouldShowStackTraces ||
@@ -93,7 +93,7 @@ export function printErrorMessages(
   }
 }
 
-function getErrorWithCategory(error: unknown): ErrorWithCategory {
+function getErrorWithCategory(error: Error): ErrorWithCategory {
   if (HardhatError.isHardhatError(error)) {
     if (error.pluginId === undefined) {
       return {
@@ -121,7 +121,7 @@ function getErrorWithCategory(error: unknown): ErrorWithCategory {
   };
 }
 
-function getErrorMessages(error: unknown): ErrorMessages {
+function getErrorMessages(error: Error): ErrorMessages {
   const { category, categorizedError } = getErrorWithCategory(error);
   switch (category) {
     case ErrorCategory.HARDHAT:

--- a/v-next/hardhat/src/internal/cli/main.ts
+++ b/v-next/hardhat/src/internal/cli/main.ts
@@ -10,6 +10,7 @@ import {
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { readClosestPackageJson } from "@nomicfoundation/hardhat-utils/package";
 import { kebabToCamelCase } from "@nomicfoundation/hardhat-utils/string";
 import debug from "debug";
@@ -201,14 +202,13 @@ export async function main(
 
     await Promise.all([task.run(taskArguments), sendTaskAnalytics(task.id)]);
   } catch (error) {
+    ensureError(error);
     printErrorMessages(error, builtinGlobalOptions?.showStackTraces);
 
-    if (error instanceof Error) {
-      try {
-        await sendErrorTelemetry(error);
-      } catch (e) {
-        log("Couldn't report error to sentry: %O", e);
-      }
+    try {
+      await sendErrorTelemetry(error);
+    } catch (e) {
+      log("Couldn't report error to sentry: %O", e);
     }
 
     if (options.rethrowErrors) {

--- a/v-next/hardhat/test/internal/cli/error-handler.ts
+++ b/v-next/hardhat/test/internal/cli/error-handler.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import util from "node:util";
 
 import {
   HardhatError,
@@ -32,10 +31,10 @@ describe("error-handler", () => {
   describe("printErrorMessages", () => {
     describe("with a Hardhat error", () => {
       it("should print the error message", () => {
-        const lines: string[] = [];
+        const lines: Array<string | Error> = [];
         const error = new HardhatError(mockCoreErrorDescriptor);
 
-        printErrorMessages(error, false, (msg: string) => {
+        printErrorMessages(error, false, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -53,10 +52,10 @@ describe("error-handler", () => {
       });
 
       it("should print the stack trace", () => {
-        const lines: string[] = [];
+        const lines: Array<string | Error> = [];
         const error = new HardhatError(mockCoreErrorDescriptor);
 
-        printErrorMessages(error, true, (msg: string) => {
+        printErrorMessages(error, true, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -66,16 +65,16 @@ describe("error-handler", () => {
           `${chalk.red.bold(`Error ${error.errorCode}:`)} ${error.formattedMessage}`,
         );
         assert.equal(lines[1], "");
-        assert.equal(lines[2], `${error.stack}`);
+        assert.equal(lines[2], error);
       });
     });
 
     describe("with a Hardhat plugin error", () => {
       it("should print the error message", () => {
-        const lines: string[] = [];
+        const lines: Array<string | Error> = [];
         const error = new HardhatError(mockPluginErrorDescriptor);
 
-        printErrorMessages(error, false, (msg: string) => {
+        printErrorMessages(error, false, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -93,10 +92,10 @@ describe("error-handler", () => {
       });
 
       it("should print the stack trace", () => {
-        const lines: string[] = [];
+        const lines: Array<string | Error> = [];
         const error = new HardhatError(mockPluginErrorDescriptor);
 
-        printErrorMessages(error, true, (msg: string) => {
+        printErrorMessages(error, true, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -106,19 +105,19 @@ describe("error-handler", () => {
           `${chalk.red.bold(`Error ${error.errorCode} in plugin ${error.pluginId}:`)} ${error.formattedMessage}`,
         );
         assert.equal(lines[1], "");
-        assert.equal(lines[2], `${error.stack}`);
+        assert.equal(lines[2], error);
       });
     });
 
     describe("with a Hardhat community plugin error", () => {
       it("should print the error message", () => {
-        const lines: string[] = [];
+        const lines: Array<string | Error> = [];
         const error = new HardhatPluginError(
           "community-plugin",
           "error message",
         );
 
-        printErrorMessages(error, false, (msg: string) => {
+        printErrorMessages(error, false, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -135,13 +134,13 @@ describe("error-handler", () => {
       });
 
       it("should print the stack trace", () => {
-        const lines: string[] = [];
+        const lines: Array<string | Error> = [];
         const error = new HardhatPluginError(
           "community-plugin",
           "error message",
         );
 
-        printErrorMessages(error, true, (msg: string) => {
+        printErrorMessages(error, true, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -151,42 +150,23 @@ describe("error-handler", () => {
           `${chalk.red.bold(`Error in community plugin ${error.pluginId}:`)} ${error.message}`,
         );
         assert.equal(lines[1], "");
-        assert.equal(lines[2], `${error.stack}`);
+        assert.equal(lines[2], error);
       });
     });
 
     describe("with an unknown error", () => {
       it("should print the error message with the stack traces for an instance of Error", () => {
-        const lines: string[] = [];
+        const lines: Array<string | Error> = [];
         const error = new Error("error message");
 
-        printErrorMessages(error, false, (msg: string) => {
+        printErrorMessages(error, false, (msg: string | Error) => {
           lines.push(msg);
         });
 
         assert.equal(lines.length, 5);
         assert.equal(lines[0], chalk.red.bold(`An unexpected error occurred:`));
         assert.equal(lines[1], "");
-        assert.equal(lines[2], `${error.stack}`);
-        assert.equal(lines[3], "");
-        assert.equal(
-          lines[4],
-          `If you think this is a bug in Hardhat, please report it here: ${HARDHAT_WEBSITE_URL}report-bug`,
-        );
-      });
-
-      it("should print the error message with the error for an unknown error", () => {
-        const lines: string[] = [];
-        const error = { message: "error message" };
-
-        printErrorMessages(error, false, (msg: string) => {
-          lines.push(msg);
-        });
-
-        assert.equal(lines.length, 5);
-        assert.equal(lines[0], chalk.red.bold(`An unexpected error occurred:`));
-        assert.equal(lines[1], "");
-        assert.equal(lines[2], `${util.inspect(error)}`);
+        assert.equal(lines[2], error);
         assert.equal(lines[3], "");
         assert.equal(
           lines[4],


### PR DESCRIPTION
This fixes how we print errors. The previous version was skipping the error causes.

I also tried calling `inspect` on the error, but that doesn't work the same as just `console.error()` them. `console` methods are smarter with respect to coloring and the like.