### PR TITLE
Remove comments from template projects

### DIFF
--- a/.changeset/curly-shrimps-speak.md
+++ b/.changeset/curly-shrimps-speak.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Update comments and readme on template projects ([#7149](https://github.com/NomicFoundation/hardhat/issues/7149))

--- a/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/README.md
+++ b/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/README.md
@@ -1,10 +1,4 @@
-# Hardhat 3 Alpha: `node:test` and `viem` example project
-
-> **WARNING**: This example project uses Hardhat 3, which is still in development. Hardhat 3 is not yet intended for production use.
-
-Welcome to the Hardhat 3 alpha version! This project showcases some of the changes and new features coming in Hardhat 3.
-
-To learn more about the Hardhat 3 Alpha, please visit [its tutorial](https://hardhat.org/hardhat3-alpha). To share your feedback, join our [Hardhat 3 Alpha](https://hardhat.org/hardhat3-alpha-telegram-group) Telegram group or [open an issue](https://github.com/NomicFoundation/hardhat/issues/new?template=hardhat-3-alpha.yml) in our GitHub issue tracker.
+# Hardhat 3: `node:test` and `viem` example project
 
 ## Project Overview
 
@@ -19,11 +13,9 @@ This example project includes:
 
 To get the most out of this example project, we recommend exploring the files in the following order:
 
-1. Read the `hardhat.config.ts` file, which contains the project configuration and explains multiple changes.
+1. Read the `hardhat.config.ts` file, which contains the project configuration.
 2. Review the "Running Tests" section and explore the files in the `contracts/` and `test/` directories.
 3. Read the "Make a deployment to Sepolia" section and follow the instructions.
-
-Each file includes inline explanations of its purpose and highlights the changes and new features introduced in Hardhat 3.
 
 ## Usage
 
@@ -69,5 +61,3 @@ npx hardhat ignition deploy --network sepolia ignition/modules/Counter.ts
 ```
 
 ---
-
-Feel free to explore the project and provide feedback on your experience with Hardhat 3 Alpha!

--- a/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/hardhat.config.ts
+++ b/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/hardhat.config.ts
@@ -4,35 +4,12 @@ import hardhatToolboxViemPlugin from "@nomicfoundation/hardhat-toolbox-viem";
 import { configVariable } from "hardhat/config";
 
 const config: HardhatUserConfig = {
-  /*
-   * In Hardhat 3, plugins are defined as part of the Hardhat config instead of
-   * being based on the side-effect of imports.
-   *
-   * Note: A `hardhat-toolbox` like plugin for Hardhat 3 hasn't been defined yet,
-   * so this list is larger than what you would normally have.
-   */
   plugins: [hardhatToolboxViemPlugin],
   solidity: {
-    /*
-     * Hardhat 3 supports different build profiles, allowing you to configure
-     * different versions of `solc` and its settings for various use cases.
-     *
-     * Note: Using profiles is optional, and any Hardhat 2 `solidity` config
-     * is still valid in Hardhat 3.
-     */
     profiles: {
-      /*
-       * The default profile is used when no profile is defined or specified
-       * in the CLI or by the tasks you are running.
-       */
       default: {
         version: "0.8.28",
       },
-      /*
-       * The production profile is meant to be used for deployments, providing
-       * more control over settings for production builds and taking some extra
-       * steps to simplify the process of verifying your contracts.
-       */
       production: {
         version: "0.8.28",
         settings: {
@@ -44,25 +21,6 @@ const config: HardhatUserConfig = {
       },
     },
   },
-  /*
-   * The `networks` configuration is mostly compatible with Hardhat 2.
-   * The key differences right now are:
-   *
-   * - You must set a `type` for each network, which is either `edr` or `http`,
-   *   allowing you to have multiple simulated networks.
-   *
-   * - You can set a `chainType` for each network, which is either `generic`,
-   *   `l1`, or `op`. This has two uses. It ensures that you always
-   *   connect to the network with the right Chain Type. And, on `edr`
-   *   networks, it makes sure that the simulated chain behaves exactly like the
-   *   real one. More information about this can be found in the test files.
-   *
-   * - The `accounts` field of `http` networks can also receive Configuration
-   *   Variables, which are values that only get loaded when needed. This allows
-   *   Hardhat to still run despite some of its config not being available
-   *   (e.g., a missing private key or API key). More info about this can be
-   *   found in the "Sending a Transaction to Optimism Sepolia" of the README.
-   */
   networks: {
     hardhatMainnet: {
       type: "edr-simulated",

--- a/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/test/Counter.ts
+++ b/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/test/Counter.ts
@@ -4,64 +4,13 @@ import { describe, it } from "node:test";
 
 import { network } from "hardhat";
 
-/*
- * `node:test` uses `describe` and `it` to define tests, similar to Mocha.
- * `describe` blocks support async functions, simplifying the setup of tests.
- */
 describe("Counter", async function () {
-  /*
-   * In Hardhat 3, there isn't a single global connection to a network. Instead,
-   * you have a `network` object that allows you to connect to different
-   * networks.
-   *
-   * You can create multiple network connections using `network.connect`.
-   * It takes two optional parameters and returns a `NetworkConnection` object.
-   *
-   * Its parameters are:
-   *
-   * 1. The name of the network configuration to use (from `config.networks`).
-   *
-   * 2. The `ChainType` to use.
-   *
-   * Providing a `ChainType` ensures the connection is aware of the kind of
-   * chain it's using, potentially affecting RPC interactions for HTTP
-   * connections, and changing the simulation behavior for EDR networks.
-   * It also ensures the network connection has the correct TypeScript type and
-   * viem extensions (e.g. Optimism L2 actions).
-   *
-   * If you don't provide a `ChainType`, it will be inferred from the network
-   * config, and default to `generic` if not specified in the config. In either
-   * case, the connection will have a generic TypeScript type and no viem
-   * extensions.
-   *
-   * Every time you call `network.connect` with an EDR network config name, a
-   * new instance of EDR will be created. Each of these instances has its own
-   * state and blockchain, and they have no communication with each other.
-   *
-   * Examples:
-   *
-   * - `await network.connect({network: "sepolia", chainType: "l1"})`: Connects
-   *   to the `sepolia` network config, treating it as an "l1" network with the
-   *   appropriate viem extensions.
-   *
-   * - `await network.connect({network: "hardhatOp", chainType: "op"})`:
-   *   Creates a new EDR instance in Optimism mode, using the `hardhatOp`
-   *   network config.
-   *
-   * - `await network.connect()`: Creates a new EDR instance with the default
-   *    network config (i.e. `hardhat`), the `generic` chain type, and no
-   *    viem extensions.
-   *
-   * Each network connection object has a `provider` property and other
-   * network-related fields added by plugins, like `viem` and `networkHelpers`.
-   */
   const { viem } = await network.connect();
   const publicClient = await viem.getPublicClient();
 
   it("Should emit the Increment event when calling the inc() function", async function () {
     const counter = await viem.deployContract("Counter");
 
-    // Hardhat 3 comes with assertions to work with viem
     await viem.assertions.emitWithArgs(
       counter.write.inc(),
       counter,

--- a/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/README.md
+++ b/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/README.md
@@ -1,11 +1,5 @@
 # Hardhat 3 Alpha: `mocha` and `ethers` example project
 
-> **WARNING**: This example project uses Hardhat 3, which is still in development. Hardhat 3 is not yet intended for production use.
-
-Welcome to the Hardhat 3 alpha version! This project showcases some of the changes and new features coming in Hardhat 3.
-
-To learn more about the Hardhat 3 Alpha, please visit [its tutorial](https://hardhat.org/hardhat3-alpha). To share your feedback, join our [Hardhat 3 Alpha](https://hardhat.org/hardhat3-alpha-telegram-group) Telegram group or [open an issue](https://github.com/NomicFoundation/hardhat/issues/new?template=hardhat-3-alpha.yml) in our GitHub issue tracker.
-
 ## Project Overview
 
 This example project includes:
@@ -19,7 +13,7 @@ This example project includes:
 
 To get the most out of this example project, we recommend exploring the files in the following order:
 
-1. Read the `hardhat.config.ts` file, which contains the project configuration and explains multiple changes.
+1. Read the `hardhat.config.ts` file, which contains the project configuration.
 2. Review the "Running Tests" section and explore the files in the `contracts/` and `test/` directories.
 3. Read the "Make a deployment to Sepolia" section and follow the instructions.
 
@@ -69,5 +63,3 @@ npx hardhat ignition deploy --network sepolia ignition/modules/Counter.ts
 ```
 
 ---
-
-Feel free to explore the project and provide feedback on your experience with Hardhat 3 Alpha!

--- a/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/hardhat.config.ts
+++ b/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/hardhat.config.ts
@@ -4,35 +4,12 @@ import hardhatToolboxMochaEthersPlugin from "@nomicfoundation/hardhat-toolbox-mo
 import { configVariable } from "hardhat/config";
 
 const config: HardhatUserConfig = {
-  /*
-   * In Hardhat 3, plugins are defined as part of the Hardhat config instead of
-   * being based on the side-effect of imports.
-   *
-   * Note: A `hardhat-toolbox` like plugin for Hardhat 3 hasn't been defined yet,
-   * so this list is larger than what you would normally have.
-   */
   plugins: [hardhatToolboxMochaEthersPlugin],
   solidity: {
-    /*
-     * Hardhat 3 supports different build profiles, allowing you to configure
-     * different versions of `solc` and its settings for various use cases.
-     *
-     * Note: Using profiles is optional, and any Hardhat 2 `solidity` config
-     * is still valid in Hardhat 3.
-     */
     profiles: {
-      /*
-       * The default profile is used when no profile is defined or specified
-       * in the CLI or by the tasks you are running.
-       */
       default: {
         version: "0.8.28",
       },
-      /*
-       * The production profile is meant to be used for deployments, providing
-       * more control over settings for production builds and taking some extra
-       * steps to simplify the process of verifying your contracts.
-       */
       production: {
         version: "0.8.28",
         settings: {
@@ -44,25 +21,6 @@ const config: HardhatUserConfig = {
       },
     },
   },
-  /*
-   * The `networks` configuration is mostly compatible with Hardhat 2.
-   * The key differences right now are:
-   *
-   * - You must set a `type` for each network, which is either `http` or `edr`,
-   *   allowing you to have multiple simulated networks.
-   *
-   * - You can set a `chainType` for each network, which is either `generic`,
-   *   `l1`, or `op`. This has two uses. It ensures that you always
-   *   connect to the network with the right Chain Type. And, on `edr`
-   *   networks, it makes sure that the simulated chain behaves exactly like the
-   *   real one. More information about this can be found in the test files.
-   *
-   * - The `accounts` field of `http` networks can also receive Configuration
-   *   Variables, which are values that only get loaded when needed. This allows
-   *   Hardhat to still run despite some of its config not being available
-   *   (e.g., a missing private key or API key). More info about this can be
-   *   found in the "Sending a Transaction to Optimism Sepolia" of the README.
-   */
   networks: {
     hardhatMainnet: {
       type: "edr-simulated",

--- a/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/test/Counter.ts
+++ b/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/test/Counter.ts
@@ -1,46 +1,6 @@
 import { expect } from "chai";
 import { network } from "hardhat";
 
-/*
- * In Hardhat 3, there isn't a single global connection to a network. Instead,
- * you have a `network` object that allows you to connect to different
- * networks.
- *
- * You can create multiple network connections using `network.connect`.
- * It takes two optional parameters and returns a `NetworkConnection` object.
- *
- * Its parameters are:
- *
- * 1. The name of the network configuration to use (from `config.networks`).
- *
- * 2. The `ChainType` to use.
- *
- * Providing a `ChainType` ensures the connection is aware of the kind of
- * chain it's using, potentially affecting RPC interactions for HTTP
- * connections, and changing the simulation behavior for EDR networks.
- *
- * If you don't provide a `ChainType`, it will be inferred from the network
- * config, and default to `generic` if not specified in the config.
- *
- * Every time you call `network.connect` with an EDR network config name, a
- * new instance of EDR will be created. Each of these instances has its own
- * state and blockchain, and they have no communication with each other.
- *
- * Examples:
- *
- * - `await network.connect({network: "sepolia", chainType: "l1"})`: Connects
- *   to the `sepolia` network config, treating it as an "l1" network.
- *
- * - `await network.connect(network: "hardhatOp", chainType: "op"})`:
- *   Creates a new EDR instance in Optimism mode, using the `hardhatOp`
- *   network config.
- *
- * - `await network.connect()`: Creates a new EDR instance with the default
- *    network config (i.e. `hardhat`) and the `generic` chain type.
- *
- * Each network connection object has a `provider` property and other
- * network-related fields added by plugins, like `ethers` and `networkHelpers`.
- */
 const { ethers } = await network.connect();
 
 describe("Counter", function () {


### PR DESCRIPTION
This PR removes comments from template project files that now are meant to be included in the docs.

These are the points I think are currently missing from the docs, that were removed from the files:
- Config docs in general (plugins, network and build profiles). Looks like they are WiP in the docs site
- Examples for mocha-ethers stack (the ts testing section only has node+viem example)

Additionally I removed references to hardhat being alpha in the template projects' readmes. I think this wasn't in scope but thought it might be useful.

Closes #7149 