### PR TITLE
chore: update CI now v-next is main

### DIFF
--- a/.github/config/regression-tests.yml
+++ b/.github/config/regression-tests.yml
@@ -996,13 +996,13 @@ commands:
     template: 'Compiled ${0} file(s)'
 presets:
   default:
-    hardhat-ref: v-next
+    hardhat-ref: main
     edr-ref: ''
     repositories: []
     runners: []
     commands: []
   solidity-test:
-    hardhat-ref: v-next
+    hardhat-ref: main
     edr-ref: ''
     repositories:
       - Elytro-eth/soul-wallet-contract
@@ -1028,7 +1028,7 @@ presets:
       - forge test
       - hardhat test solidity
   solidity-compile:
-    hardhat-ref: v-next
+    hardhat-ref: main
     edr-ref: ''
     repositories:
       - OpenZeppelin/openzeppelin-contracts

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -6,7 +6,7 @@ on:
       - main
       - pre-release-testing-branch
       - changeset-release/main
-      - v-next
+      - v2
     paths:
       - ".github/workflows/cache.yml"
       - "**/pnpm-lock.yaml"

--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - main
-      - v-next
+      - v2
     types:
       - opened
       - synchronize

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - v-next
+      - main
 
 defaults:
   run:
@@ -41,6 +41,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: node scripts/version-alpha.mjs
+          title: Version Packages (v3)
 
       - name: Check if release needs to be published
         id: before

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - v-next
+      - v2
   pull_request:
   workflow_dispatch:
 
@@ -14,9 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # TODO: Replace with https://github.com/streetsidesoftware/cspell-action
-      # once it supports the `report` input
-      - uses: galargh/cspell-action@report
+      - uses: streetsidesoftware/cspell-action@v7
         with:
           incremental_files_only: ${{ github.event_name == 'pull_request' }}
           config: cspell.yaml

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -4,7 +4,7 @@ on:
   merge_group:
   push:
     branches:
-      - v-next
+      - main
   pull_request:
   workflow_dispatch:
 
@@ -96,7 +96,6 @@ jobs:
         with:
           list-files: json
           filters: ${{ steps.generate.outputs.filters }}
-          base: v-next # TODO: Remove once v-next becomes the default branch
 
   bundle:
     # Depending on list-packages only to check whether pnpm-lock.yaml has changed


### PR DESCRIPTION
Update the CI jobs, though note that the `./v-next` folder structure remains. We will clean this up with a later change.
