### PR TITLE
Do not throw HHE201 for optional peer dependencies

### DIFF
--- a/v-next/hardhat-utils/src/package.ts
+++ b/v-next/hardhat-utils/src/package.ts
@@ -52,6 +52,7 @@ export interface PackageJson {
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional: boolean }>;
 }
 
 /**

--- a/v-next/hardhat/src/internal/core/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/hardhat/src/internal/core/plugins/detect-plugin-npm-dependency-problems.ts
@@ -19,7 +19,7 @@ import {
  * - {@link HardhatError.ERRORS.CORE.PLUGINS.PLUGIN_NOT_INSTALLED} if the plugin is
  * not installed as an npm package
  * - {@link HardhatError.ERRORS.CORE.PLUGINS.PLUGIN_MISSING_DEPENDENCY} if the
- * plugin package's peer dependency is not installed
+ * plugin package's non-optional peer dependency is not installed
  * - {@link HardhatError.ERRORS.CORE.PLUGINS.DEPENDENCY_VERSION_MISMATCH} if the
  * plugin package's peer dependency is installed but has the wrong version
  */
@@ -65,6 +65,12 @@ export async function detectPluginNpmDependencyProblems(
     );
 
     if (dependencyPackageJsonPath === undefined) {
+      const optional =
+        pluginPackageJson?.peerDependenciesMeta?.[dependencyName]?.optional ??
+        false;
+
+      if (optional) return;
+
       throw new HardhatError(
         HardhatError.ERRORS.CORE.PLUGINS.PLUGIN_MISSING_DEPENDENCY,
         {

--- a/v-next/hardhat/src/internal/core/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/v-next/hardhat/src/internal/core/plugins/detect-plugin-npm-dependency-problems.ts
@@ -19,9 +19,9 @@ import {
  * - {@link HardhatError.ERRORS.CORE.PLUGINS.PLUGIN_NOT_INSTALLED} if the plugin is
  * not installed as an npm package
  * - {@link HardhatError.ERRORS.CORE.PLUGINS.PLUGIN_MISSING_DEPENDENCY} if the
- * plugin's package peer dependency is not installed
+ * plugin package's peer dependency is not installed
  * - {@link HardhatError.ERRORS.CORE.PLUGINS.DEPENDENCY_VERSION_MISMATCH} if the
- * plugin's package peer dependency is installed but has the wrong version
+ * plugin package's peer dependency is installed but has the wrong version
  */
 export async function detectPluginNpmDependencyProblems(
   basePathForNpmResolution: string,


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This plugin specifies `ethers` and `viem` as optional peer dependencies using the `peerDependenciesMeta` field: https://github.com/solidstate-network/hardhat-accounts/blob/hh3/package.json

Running Hardhat in a repository with the plugin installed threw this error: 

```
Error HHE201: Plugin "@solidstate/hardhat-accounts" is missing a peer dependency "viem".
```

This shouldn't happen because `viem` is optional.  I believe using `peerDependenciesMeta` is the correct way to specify optional dependencies (at least with pnpm), though I also noticed the `optionalDependencies` field in the `PackageJson` interface.  Maybe both should be supported?