### PR TITLE
Add temporary fix for incorrect error message

### DIFF
--- a/.changeset/shy-lies-camp.md
+++ b/.changeset/shy-lies-camp.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add temporary fix for incorrect error message ([#7168](https://github.com/NomicFoundation/hardhat/issues/7168))

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -265,7 +265,11 @@ export async function* testReporter(
           );
         }
         if (reason === undefined || reason === "") {
-          reason = failure.reason ?? "Unknown error";
+          reason =
+            failure.reason ===
+            "FFI is disabled; add the `--ffi` flag to allow tests to call external commands"
+              ? "FFI is disabled; set `test.solidity.ffi` to `true` in your Hardhat config to allow tests to call external commands"
+              : failure.reason ?? "Unknown error";
         }
         yield indenter.t`${colorizer.red(`Error: ${reason}`)}\n`;
         // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- Ignore Cases not matched: undefined


### PR DESCRIPTION
fixes https://github.com/NomicFoundation/hardhat/issues/7168 temporarily

This error message actually comes from [EDR](https://github.com/NomicFoundation/edr/blob/ce3c978db8fa678e9231860e5311dfd313a8a7b4/crates/foundry/cheatcodes/src/fs.rs#L1195), and it should ideally be changed on their end. For the time being, however, this PR is a temp fix until then.