### PR TITLE
docs: add JSDoc for assertions API to improve IntelliSense discoverability

### DIFF
--- a/.changeset/honest-queens-perform.md
+++ b/.changeset/honest-queens-perform.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-viem-assertions": patch
 ---
 
-Added JSDocs for viem assertions to help with intellisense discoverability, thanks GarmashAlex ([#6758](https://github.com/NomicFoundation/hardhat/issues/6758))
+Added JSDocs for viem assertions to help with intellisense discoverability, thanks @GarmashAlex ([#6758](https://github.com/NomicFoundation/hardhat/issues/6758))

--- a/.changeset/honest-queens-perform.md
+++ b/.changeset/honest-queens-perform.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+Added JSDocs for viem assertions to help with intellisense discoverability, thanks GarmashAlex ([#6758](https://github.com/NomicFoundation/hardhat/issues/6758))

--- a/v-next/hardhat-viem-assertions/src/predicates.ts
+++ b/v-next/hardhat-viem-assertions/src/predicates.ts
@@ -2,7 +2,6 @@
  * Predicate that matches any value.
  *
  * Use this helper in assertions that accept predicate arguments, such as
- * `emitWithArgs` and `revertWithCustomErrorWithArgs`, when any value is acceptable
- * at a given position.
+ * `emitWithArgs` and `revertWithCustomErrorWithArgs`, when any value is acceptable.
  */
 export { anyValue } from "./internal/predicates.js";

--- a/v-next/hardhat-viem-assertions/src/predicates.ts
+++ b/v-next/hardhat-viem-assertions/src/predicates.ts
@@ -1,1 +1,8 @@
+/**
+ * Predicate that matches any value.
+ *
+ * Use this helper in assertions that accept predicate arguments, such as
+ * `emitWithArgs` and `revertWithCustomErrorWithArgs`, when any value is acceptable
+ * at a given position.
+ */
 export { anyValue } from "./internal/predicates.js";

--- a/v-next/hardhat-viem-assertions/src/type-extensions.ts
+++ b/v-next/hardhat-viem-assertions/src/type-extensions.ts
@@ -2,10 +2,10 @@ import "@nomicfoundation/hardhat-viem";
 import type { HardhatViemAssertions } from "./types.js";
 
 declare module "@nomicfoundation/hardhat-viem/types" {
-	interface HardhatViemHelpers {
-		/**
-		 * Ethereum-specific assertions integrated with viem. Accessible via `viem.assertions`.
-		 */
-		assertions: HardhatViemAssertions;
-	}
+  interface HardhatViemHelpers {
+    /**
+     * Ethereum-specific assertions integrated with viem. Accessible via `viem.assertions`.
+     */
+    assertions: HardhatViemAssertions;
+  }
 }

--- a/v-next/hardhat-viem-assertions/src/type-extensions.ts
+++ b/v-next/hardhat-viem-assertions/src/type-extensions.ts
@@ -2,7 +2,10 @@ import "@nomicfoundation/hardhat-viem";
 import type { HardhatViemAssertions } from "./types.js";
 
 declare module "@nomicfoundation/hardhat-viem/types" {
-  interface HardhatViemHelpers {
-    assertions: HardhatViemAssertions;
-  }
+	interface HardhatViemHelpers {
+		/**
+		 * Ethereum-specific assertions integrated with viem. Accessible via `viem.assertions`.
+		 */
+		assertions: HardhatViemAssertions;
+	}
 }

--- a/v-next/hardhat-viem-assertions/src/type-extensions.ts
+++ b/v-next/hardhat-viem-assertions/src/type-extensions.ts
@@ -4,7 +4,7 @@ import type { HardhatViemAssertions } from "./types.js";
 declare module "@nomicfoundation/hardhat-viem/types" {
   interface HardhatViemHelpers {
     /**
-     * Ethereum-specific assertions integrated with viem. Accessible via `viem.assertions`.
+     * Ethereum-specific test assertions integrated with viem.
      */
     assertions: HardhatViemAssertions;
   }

--- a/v-next/hardhat-viem-assertions/src/types.ts
+++ b/v-next/hardhat-viem-assertions/src/types.ts
@@ -11,11 +11,10 @@ import type {
 } from "viem";
 
 /**
- * Ethereum-specific assertions that integrate with viem and Hardhat.
+ * Ethereum-specific test assertions that integrate with viem.
  *
- * These assertions help validate reverted transactions, emitted events, and
- * ether balance changes in a clear, test-friendly way. They are available at
- * `viem.assertions` after connecting to a Hardhat network.
+ * These assertions help validate: reverted transactions, emitted events, and
+ * ether balance changes in a test-friendly way.
  */
 export interface HardhatViemAssertions {
   /**
@@ -64,7 +63,7 @@ export interface HardhatViemAssertions {
    * Assert that executing a contract function emits a specific event with the given arguments.
    *
    * Arguments are matched positionally in the same order as defined in the event's ABI. You can pass
-   * predicate functions in the `args` array to perform flexible checks, or use the `anyValue` predicate
+   * predicate functions in the `args` array to perform specific checks, or use the `anyValue` predicate
    * to match any value.
    *
    * @typeParam ContractName - The contract name associated with the `contract` instance.
@@ -87,7 +86,7 @@ export interface HardhatViemAssertions {
   ): Promise<void>;
 
   /**
-   * Assert that executing a contract function reverts for any reason.
+   * Assert that executing a contract function reverts for any reason, without checking the cause of the revert
    *
    * @param contractFn - A promise returned by a viem read or write contract call expected to revert.
    */
@@ -126,7 +125,7 @@ export interface HardhatViemAssertions {
    * Assert that executing a contract function reverts with a specific custom error and arguments.
    *
    * Arguments are matched positionally in the same order as defined in the error's ABI. Each expected argument
-   * can be a concrete value or a predicate function to perform flexible checks. You can also use the `anyValue`
+   * can be a concrete value or a predicate function to perform specific checks. You can also use the `anyValue`
    * predicate to match any value.
    *
    * @typeParam ContractName - The contract name associated with the `contract` instance.

--- a/v-next/hardhat-viem-assertions/src/types.ts
+++ b/v-next/hardhat-viem-assertions/src/types.ts
@@ -86,7 +86,7 @@ export interface HardhatViemAssertions {
   ): Promise<void>;
 
   /**
-   * Assert that executing a contract function reverts for any reason, without checking the cause of the revert
+   * Assert that executing a contract function reverts for any reason, without checking the cause of the revert.
    *
    * @param contractFn - A promise returned by a viem read or write contract call expected to revert.
    */

--- a/v-next/hardhat-viem-assertions/src/types.ts
+++ b/v-next/hardhat-viem-assertions/src/types.ts
@@ -10,7 +10,24 @@ import type {
   WriteContractReturnType,
 } from "viem";
 
+/**
+ * Ethereum-specific assertions that integrate with viem and Hardhat.
+ *
+ * These assertions help validate reverted transactions, emitted events, and
+ * ether balance changes in a clear, test-friendly way. They are available at
+ * `viem.assertions` after connecting to a Hardhat network.
+ */
 export interface HardhatViemAssertions {
+  /**
+   * Assert that a transaction changes the ether balance of the given addresses by the specified amounts.
+   *
+   * The comparison is made between the block immediately before the transaction and the transaction's block.
+   * For the transaction sender, the effective gas fee is accounted for so the expected amount reflects the
+   * pure value transfer effect.
+   *
+   * @param resolvedTxHash - A promise that resolves to the transaction hash returned by `sendTransaction`.
+   * @param changes - The expected balance deltas, in wei, for each address. Negative values are allowed.
+   */
   balancesHaveChanged: (
     resolvedTxHash: Promise<Hash>,
     changes: Array<{
@@ -19,6 +36,19 @@ export interface HardhatViemAssertions {
     }>,
   ) => Promise<void>;
 
+  /**
+   * Assert that executing a contract function emits a specific event.
+   *
+   * The function is awaited, then logs are fetched for the contract address and parsed
+   * against the contract ABI for the given event name. The assertion passes if at least one
+   * matching event is found.
+   *
+   * @typeParam ContractName - The contract name associated with the `contract` instance.
+   * @typeParam EventName - The name of the event to check.
+   * @param contractFn - A promise returned by a viem read or write contract call.
+   * @param contract - The viem contract instance whose ABI is used to parse logs.
+   * @param eventName - The event name to assert.
+   */
   emit<
     ContractName extends CompiledContractName,
     EventName extends ContractName extends keyof ContractAbis
@@ -30,6 +60,20 @@ export interface HardhatViemAssertions {
     eventName: EventName,
   ): Promise<void>;
 
+  /**
+   * Assert that executing a contract function emits a specific event with the given arguments.
+   *
+   * Arguments are matched positionally in the same order as defined in the event's ABI. You can pass
+   * predicate functions in the `args` array to perform flexible checks, or use the `anyValue` predicate
+   * to match any value.
+   *
+   * @typeParam ContractName - The contract name associated with the `contract` instance.
+   * @typeParam EventName - The name of the event to check.
+   * @param contractFn - A promise returned by a viem read or write contract call.
+   * @param contract - The viem contract instance whose ABI is used to parse logs.
+   * @param eventName - The event name to assert.
+   * @param args - Expected event arguments. Each item can be a concrete value or a predicate function `(value) => boolean`.
+   */
   emitWithArgs<
     ContractName extends CompiledContractName,
     EventName extends ContractName extends keyof ContractAbis
@@ -42,21 +86,55 @@ export interface HardhatViemAssertions {
     args: any[],
   ): Promise<void>;
 
+  /**
+   * Assert that executing a contract function reverts for any reason.
+   *
+   * @param contractFn - A promise returned by a viem read or write contract call expected to revert.
+   */
   revert(
     contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
   ): Promise<void>;
 
+  /**
+   * Assert that executing a contract function reverts with the specified reason string.
+   *
+   * @param contractFn - A promise returned by a viem read or write contract call expected to revert.
+   * @param expectedRevertReason - The expected revert reason string.
+   */
   revertWith(
     contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
     expectedRevertReason: string,
   ): Promise<void>;
 
+  /**
+   * Assert that executing a contract function reverts with a specific custom error defined in the given contract.
+   *
+   * The contract's ABI is used to decode the revert data and validate the error name.
+   *
+   * @typeParam ContractName - The contract name associated with the `contract` instance.
+   * @param contractFn - A promise returned by a viem read or write contract call expected to revert.
+   * @param contract - The viem contract instance whose ABI defines the expected custom error.
+   * @param customErrorName - The expected custom error name.
+   */
   revertWithCustomError<ContractName extends CompiledContractName>(
     contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
     contract: ContractReturnType<ContractName>,
     customErrorName: string,
   ): Promise<void>;
 
+  /**
+   * Assert that executing a contract function reverts with a specific custom error and arguments.
+   *
+   * Arguments are matched positionally in the same order as defined in the error's ABI. Each expected argument
+   * can be a concrete value or a predicate function to perform flexible checks. You can also use the `anyValue`
+   * predicate to match any value.
+   *
+   * @typeParam ContractName - The contract name associated with the `contract` instance.
+   * @param contractFn - A promise returned by a viem read or write contract call expected to revert.
+   * @param contract - The viem contract instance whose ABI defines the expected custom error.
+   * @param customErrorName - The expected custom error name.
+   * @param args - Expected custom error arguments. Each item can be a concrete value or a predicate function `(value) => boolean`.
+   */
   revertWithCustomErrorWithArgs<ContractName extends CompiledContractName>(
     contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
     contract: ContractReturnType<ContractName>,


### PR DESCRIPTION
Add detailed JSDoc to the HardhatViemAssertions interface and all public methods:
- balancesHaveChanged
- emit
- emitWithArgs
- revert
- revertWith
- revertWithCustomError
- revertWithCustomErrorWithArgs


Document anyValue predicate export for use in argument/predicate-based assertions.


Document viem.assertions property in Hardhat viem helpers module augmentation.

Fix #6758 