### PR TITLE
docs: update reamde to include note on branches

### DIFF
--- a/packages/hardhat-core/README.md
+++ b/packages/hardhat-core/README.md
@@ -42,8 +42,8 @@ On [Hardhat's website](https://hardhat.org) you will find:
 
 Within the [Hardhat repo](https://github.com/nomicFoundation/hardhat):
 
-* Hardhat 2 development is on the `v2` branch
-* Hardhat 3 development is on the `main` branch
+- Hardhat 2 development is on the `v2` branch
+- Hardhat 3 development is on the `main` branch
 
 ## Contributing
 

--- a/packages/hardhat-core/README.md
+++ b/packages/hardhat-core/README.md
@@ -38,6 +38,13 @@ On [Hardhat's website](https://hardhat.org) you will find:
 - [Hardhat Network](https://hardhat.org/hardhat-network/)
 - [Plugin list](https://hardhat.org/plugins/)
 
+## Branches
+
+Within the [Hardhat repo](https://github.com/nomicFoundation/hardhat):
+
+* Hardhat 2 development is on the `v2` branch
+* Hardhat 3 development is on the `main` branch
+
 ## Contributing
 
 Contributions are always welcome! Feel free to open any issue or send a pull request.


### PR DESCRIPTION
Add a note explaining development for Hardhat 2 is on the `v2` branch.
