### PR TITLE
chore: update header image link to absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](/img/hardhat-header.png)
+![](https://raw.githubusercontent.com/NomicFoundation/hardhat/main/img/hardhat-header.png)
 
 Hardhat is an Ethereum development environment for professionals. It facilitates performing frequent tasks, such as running tests, automatically checking code for mistakes or interacting with smart contracts.
 


### PR DESCRIPTION
For the image to appear properly on `npm` we need a full link.


