### PR TITLE
fix: update the validation to reflect the new property

### DIFF
--- a/.changeset/dirty-pens-tell.md
+++ b/.changeset/dirty-pens-tell.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Update validation for solidity test config ([#7205](https://github.com/NomicFoundation/hardhat/pull/7205))

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -82,7 +82,7 @@ const userConfigType = z.object({
     .optional(),
   test: z
     .object({
-      solidityTest: solidityTestUserConfigType.optional(),
+      solidity: solidityTestUserConfigType.optional(),
     })
     .optional(),
 });

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -1,0 +1,81 @@
+import type { HardhatUserConfig } from "../../../../src/types/config.js";
+import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
+import type { HardhatPlugin } from "../../../../src/types/plugins.js";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
+
+import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+
+import solidityTestPlugin from "../../../../src/internal/builtin-plugins/solidity-test/index.js";
+import { resolveProjectRoot } from "../../../../src/internal/core/hre.js";
+import { resolvePluginList } from "../../../../src/internal/core/plugins/resolve-plugin-list.js";
+
+describe("config validation", () => {
+  it("should validate an acceptable `test.solidity` config", async () => {
+    const hre = await _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
+      {
+        test: {
+          solidity: {
+            timeout: 5000,
+          },
+        },
+      },
+      solidityTestPlugin,
+    );
+
+    assert.equal(hre.config.test.solidity.timeout, 5000);
+  });
+
+  it("should not throw when the `test.solidity` config is not set by the user", async () => {
+    await _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
+      {
+        test: {},
+      },
+      solidityTestPlugin,
+    );
+  });
+
+  it("should throw when the `test.solidity` properties are invalid", async () => {
+    const userConfig: HardhatUserConfig = {
+      test: {
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          -- intentionally violating the types for the test */
+        solidity: {
+          timeout: "not a number",
+        } as any,
+      },
+    };
+
+    await assertRejectsWithHardhatError(
+      _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
+        userConfig,
+        solidityTestPlugin,
+      ),
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
+      {
+        errors:
+          "\t* Config error in config.test.solidity.timeout: Expected number, received string",
+      },
+    );
+  });
+});
+
+async function _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
+  config: HardhatUserConfig,
+  builtinPlugin: HardhatPlugin,
+): Promise<HardhatRuntimeEnvironment> {
+  const projectRoot = undefined;
+  const resolvedProjectRoot = await resolveProjectRoot(projectRoot);
+
+  const resolvedPlugins = await resolvePluginList(resolvedProjectRoot, [
+    builtinPlugin,
+  ]);
+
+  return createHardhatRuntimeEnvironment(config, {}, resolvedProjectRoot, {
+    resolvedPlugins,
+  });
+}


### PR DESCRIPTION
This property was renamed from `solidityTest` to `test`, but this change was missed.

See https://github.com/NomicFoundation/hardhat/pull/7101 for context.
