### PR TITLE
Agostbiro/fix soltest config options

### DIFF
--- a/.changeset/wicked-cycles-watch.md
+++ b/.changeset/wicked-cycles-watch.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added missing Solidity test config option `allowInternalExpectRevert` and fixed `timeout` config option not being passed in.

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -26,6 +26,7 @@ const solidityTestUserConfigType = z.object({
     .optional(),
   isolate: z.boolean().optional(),
   ffi: z.boolean().optional(),
+  allowInternalExpectRevert: z.boolean().optional(),
   from: z.string().startsWith("0x").optional(),
   txOrigin: z.string().startsWith("0x").optional(),
   initialBalance: z.bigint().optional(),

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -98,6 +98,7 @@ export function solidityTestConfigToSolidityTestRunnerConfigArgs(
   const ethRpcUrl = config.forking?.url;
   const forkBlockNumber = config.forking?.blockNumber;
   const rpcEndpoints = config.forking?.rpcEndpoints;
+  const promptTimeout = config.timeout;
 
   return {
     projectRoot,
@@ -116,6 +117,7 @@ export function solidityTestConfigToSolidityTestRunnerConfigArgs(
     ethRpcUrl,
     forkBlockNumber,
     rpcEndpoints,
+    promptTimeout
   };
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -23,7 +23,7 @@ declare module "../../../types/test.js" {
     };
     isolate?: boolean;
     ffi?: boolean;
-
+    allowInternalExpectRevert?: boolean
     from?: string; // 0x-prefixed hex string
     txOrigin?: string; // 0x-prefixed hex string
     initialBalance?: bigint;


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

Added missing Solidity test config option `allowInternalExpectRevert` and fixed `timeout` config option not being passed in to EDR. 

Note that EDR supports the following config options that are not exposed by Hardhat, but I'm not sure if these are omitted on purpose, so I didn't add them:

1. `blockNumber` - The value of block.number in tests. Defaults to 1.
1. `chainId` - The value of the chainid opcode in tests. Defaults to 31337.
1. `gasLimit` - The gas limit for each test case. Defaults to 9_223_372_036_854_775_807 (i64::MAX). (The docs have blockGasLimit but it's described differently)
1. `gasPrice` - The price of gas (in wei) in tests. Defaults to 0.
1. `blockDifficulty` - The value of block.difficulty in tests. Defaults to 0.
1. `memoryLimit` - The memory limit of the EVM in bytes. Defaults to 33_554_432 (2^25 = 32MiB).
