### PR TITLE
chore: add testFail to supported solidity test config options

### DIFF
--- a/.changeset/dirty-experts-march.md
+++ b/.changeset/dirty-experts-march.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added `testFail` to supported solidity test config options

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -27,6 +27,7 @@ const solidityTestUserConfigType = z.object({
   isolate: z.boolean().optional(),
   ffi: z.boolean().optional(),
   allowInternalExpectRevert: z.boolean().optional(),
+  testFail: z.boolean().optional(),
   from: z.string().startsWith("0x").optional(),
   txOrigin: z.string().startsWith("0x").optional(),
   initialBalance: z.bigint().optional(),

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -24,6 +24,7 @@ declare module "../../../types/test.js" {
     isolate?: boolean;
     ffi?: boolean;
     allowInternalExpectRevert?: boolean;
+    testFail?: boolean;
     from?: string; // 0x-prefixed hex string
     txOrigin?: string; // 0x-prefixed hex string
     initialBalance?: bigint;


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

The projects currently tested in the regression test suite require `testFail` option.