### PR TITLE
fix: broken links in plugin READMEs

### DIFF
--- a/v-next/hardhat-keystore/README.md
+++ b/v-next/hardhat-keystore/README.md
@@ -24,4 +24,4 @@ export default {
 
 ## Usage
 
-Check [our guide to configuration variables](https://hardhat.org/hardhat3-alpha/learn-more/configuration-variables) to learn how to use the keystore in your Hardhat configuration.
+Check [our guide to configuration variables](https://hardhat.org/docs/learn-more/configuration-variables) to learn how to use the keystore in your Hardhat configuration.

--- a/v-next/hardhat-verify/README.md
+++ b/v-next/hardhat-verify/README.md
@@ -40,7 +40,7 @@ export default {
 };
 ```
 
-We recommend using a [configuration variable](https://hardhat.org/hardhat3-alpha/learn-more/configuration-variables) to set sensitive information like API keys.
+We recommend using a [configuration variable](https://hardhat.org/docs/learn-more/configuration-variables) to set sensitive information like API keys.
 
 ```typescript
 import { configVariable } from "hardhat/config";

--- a/v-next/hardhat-viem/README.md
+++ b/v-next/hardhat-viem/README.md
@@ -39,4 +39,4 @@ await counter.write.inc();
 console.log(await counter.read.x());
 ```
 
-To learn more about using viem with Hardhat, read [our guide](https://hardhat.org/hardhat3-alpha/learn-more/using-viem).
+To learn more about using viem with Hardhat, read [our guide](https://hardhat.org/docs/learn-more/using-viem).


### PR DESCRIPTION
Hi! While reading through the docs for hardhat-verify, hardhat-viem and hardhat-keystore I noticed that some links still point to the old hardhat3-alpha pages. Those URLs are no longer valid and give 404s.