### PR TITLE
Fix v3 yarn support

### DIFF
--- a/.changeset/metal-owls-itch.md
+++ b/.changeset/metal-owls-itch.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add Yarn support for Hardhat v3 ([#7192](https://github.com/NomicFoundation/hardhat/issues/7192))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1580,6 +1580,31 @@ importers:
         version: 3.24.1
 
   v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem:
+    dependencies:
+      '@nomicfoundation/hardhat-ignition-viem':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-ignition-viem
+      '@nomicfoundation/hardhat-keystore':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-keystore
+      '@nomicfoundation/hardhat-network-helpers':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-network-helpers
+      '@nomicfoundation/hardhat-node-test-runner':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-node-test-runner
+      '@nomicfoundation/hardhat-verify':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-verify
+      '@nomicfoundation/hardhat-viem':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-viem
+      '@nomicfoundation/hardhat-viem-assertions':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-viem-assertions
+      '@nomicfoundation/ignition-core':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-ignition-core
     devDependencies:
       '@nomicfoundation/hardhat-ignition':
         specifier: workspace:^3.0.0
@@ -1604,6 +1629,31 @@ importers:
         version: 2.30.0(typescript@5.8.3)(zod@3.24.1)
 
   v-next/hardhat/templates/hardhat-3/02-mocha-ethers:
+    dependencies:
+      '@nomicfoundation/hardhat-ethers-chai-matchers':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-ethers-chai-matchers
+      '@nomicfoundation/hardhat-ignition-ethers':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-ignition-ethers
+      '@nomicfoundation/hardhat-keystore':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-keystore
+      '@nomicfoundation/hardhat-mocha':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-mocha
+      '@nomicfoundation/hardhat-network-helpers':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-network-helpers
+      '@nomicfoundation/hardhat-typechain':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-typechain
+      '@nomicfoundation/hardhat-verify':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-verify
+      '@nomicfoundation/ignition-core':
+        specifier: workspace:^3.0.0
+        version: link:../../../../hardhat-ignition-core
     devDependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: workspace:^4.0.0

--- a/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/package.json
+++ b/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/package.json
@@ -12,5 +12,15 @@
     "forge-std": "foundry-rs/forge-std#v1.9.4",
     "typescript": "~5.8.0",
     "viem": "^2.30.0"
+  },
+  "peerDependencies": {
+    "@nomicfoundation/hardhat-ignition-viem": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-keystore": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-network-helpers": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-node-test-runner": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-viem": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-viem-assertions": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-verify": "workspace:^3.0.0",
+    "@nomicfoundation/ignition-core": "workspace:^3.0.0"
   }
 }

--- a/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/package.json
+++ b/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/package.json
@@ -18,5 +18,16 @@
     "forge-std": "foundry-rs/forge-std#v1.9.4",
     "mocha": "^11.0.0",
     "typescript": "~5.8.0"
+  },
+  "peerDependencies": {
+    "@nomicfoundation/hardhat-ethers-chai-matchers": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-ignition": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-ignition-ethers": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-keystore": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-mocha": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-network-helpers": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-typechain": "workspace:^3.0.0",
+    "@nomicfoundation/hardhat-verify": "workspace:^3.0.0",
+    "@nomicfoundation/ignition-core": "workspace:^3.0.0"
   }
 }


### PR DESCRIPTION
resolves https://github.com/NomicFoundation/hardhat/issues/7192

The logic for adding peer dependencies to the install command for appropriate package managers is already there, the peer dependencies just needed to be added to the template projects.