### PR TITLE
ci: test on Linux ARM and deprecate Intel MacOS

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -290,7 +290,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         # We run the tests for `hardhat-node-test-reporter` with the latest
         # versions of Node (the testing output relying on recent changes)
         node: [22, 24]

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -239,7 +239,7 @@ jobs:
       fail-fast: false
       matrix:
         package: ${{ fromJson(needs.list-packages.outputs.packages) }}
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         node: [22.0.0, 24.0.0]
         exclude:
           - package: hardhat-node-test-reporter
@@ -290,7 +290,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         # We run the tests for `hardhat-node-test-reporter` with the latest
         # versions of Node (the testing output relying on recent changes)
         node: [22, 24]

--- a/v-next/hardhat-ignition-core/test/helpers/execution-result-fixtures.ts
+++ b/v-next/hardhat-ignition-core/test/helpers/execution-result-fixtures.ts
@@ -4,9 +4,19 @@
  * @file
  */
 
+import os from "node:os";
+
 import { Artifact } from "../../src/types/artifact.js";
 
 import { RawStaticCallResult } from "../../src/internal/execution/types/jsonrpc.js";
+
+// NOTE: Compiler's long version string is an input to the build info ID calculation.
+// Linux ARM64 is a special case because the mirror we use doesn't advertise long
+// version information and we fall back to the short version string.
+const buildInfoId =
+  os.platform() === "linux" && os.arch() === "arm64"
+    ? "solc-0_8_19-212d1ae643d27f15734ceaa4108859c2f104c4ca"
+    : "solc-0_8_19-2fe1cba8ef218c727cd1ce3da3aaa170f8016338";
 
 export const staticCallResultFixtures: {
   [contractName: string]: { [functionName: string]: RawStaticCallResult };
@@ -405,7 +415,7 @@ export const staticCallResultFixturesArtifacts: {
     deployedLinkReferences: {},
     immutableReferences: {},
     inputSourceName: "project/contracts/C.sol",
-    buildInfoId: "solc-0_8_19-2fe1cba8ef218c727cd1ce3da3aaa170f8016338",
+    buildInfoId,
   },
 };
 
@@ -442,7 +452,7 @@ export const deploymentFixturesArtifacts: { [contractName: string]: Artifact } =
       deployedLinkReferences: {},
       immutableReferences: {},
       inputSourceName: "project/contracts/C.sol",
-      buildInfoId: "solc-0_8_19-2fe1cba8ef218c727cd1ce3da3aaa170f8016338",
+      buildInfoId,
     },
     WithLibrary: {
       _format: "hh3-artifact-1",
@@ -471,7 +481,7 @@ export const deploymentFixturesArtifacts: { [contractName: string]: Artifact } =
       deployedLinkReferences: {},
       immutableReferences: {},
       inputSourceName: "project/contracts/C.sol",
-      buildInfoId: "solc-0_8_19-2fe1cba8ef218c727cd1ce3da3aaa170f8016338",
+      buildInfoId,
     },
     WithAmbiguousLibraryName: {
       _format: "hh3-artifact-1",
@@ -508,7 +518,7 @@ export const deploymentFixturesArtifacts: { [contractName: string]: Artifact } =
       deployedLinkReferences: {},
       immutableReferences: {},
       inputSourceName: "project/contracts/C.sol",
-      buildInfoId: "solc-0_8_19-2fe1cba8ef218c727cd1ce3da3aaa170f8016338",
+      buildInfoId,
     },
   };
 
@@ -590,7 +600,7 @@ export const callEncodingFixtures: { [contractName: string]: Artifact } = {
     deployedLinkReferences: {},
     immutableReferences: {},
     inputSourceName: "project/contracts/C.sol",
-    buildInfoId: "solc-0_8_19-2fe1cba8ef218c727cd1ce3da3aaa170f8016338",
+    buildInfoId,
   },
   ToTestEthersEncodingConversion: {
     _format: "hh3-artifact-1",
@@ -949,7 +959,7 @@ export const callEncodingFixtures: { [contractName: string]: Artifact } = {
     deployedLinkReferences: {},
     immutableReferences: {},
     inputSourceName: "project/contracts/C.sol",
-    buildInfoId: "solc-0_8_19-2fe1cba8ef218c727cd1ce3da3aaa170f8016338",
+    buildInfoId,
   },
   FunctionNameValidation: {
     _format: "hh3-artifact-1",
@@ -1069,6 +1079,6 @@ export const callEncodingFixtures: { [contractName: string]: Artifact } = {
     deployedLinkReferences: {},
     immutableReferences: {},
     inputSourceName: "project/contracts/C.sol",
-    buildInfoId: "solc-0_8_19-2fe1cba8ef218c727cd1ce3da3aaa170f8016338",
+    buildInfoId,
   },
 };

--- a/v-next/hardhat-ignition-core/test/helpers/execution-result-fixtures.ts
+++ b/v-next/hardhat-ignition-core/test/helpers/execution-result-fixtures.ts
@@ -10,9 +10,8 @@ import { Artifact } from "../../src/types/artifact.js";
 
 import { RawStaticCallResult } from "../../src/internal/execution/types/jsonrpc.js";
 
-// NOTE: Compiler's long version string is an input to the build info ID calculation.
-// Linux ARM64 is a special case because the mirror we use doesn't advertise long
-// version information and we fall back to the short version string.
+// NOTE: We are testing against a known build info id. As input to the build info // ID calculation we use the Compiler's long version string if available, and the // short version string if it is not.
+// On Linux ARM64 we download from a mirror that does not provide the long version, hence the known build info id has to change when running the test suite on that platform.
 const buildInfoId =
   os.platform() === "linux" && os.arch() === "arm64"
     ? "solc-0_8_19-212d1ae643d27f15734ceaa4108859c2f104c4ca"

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -39,29 +39,29 @@ describe(
 
       it("should throw when version is bad", async function () {
         await assertRejectsWithHardhatError(
-          () => wasmDownloader.isCompilerDownloaded("0.4.12a"),
+          () => wasmDownloader.isCompilerDownloaded("0.5.0a"),
           HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
           {
-            version: "0.4.12a",
+            version: "0.5.0a",
           },
         );
       });
 
       it("should return false when the compiler isn't downloaded yet", async function () {
         assert.ok(
-          !(await wasmDownloader.isCompilerDownloaded("0.4.12")),
+          !(await wasmDownloader.isCompilerDownloaded("0.5.0")),
           "Compiler should not be downloaded",
         );
       });
 
       it("should return true when the compiler is already downloaded", async function () {
-        await wasmDownloader.updateCompilerListIfNeeded(new Set(["0.4.12"]));
+        await wasmDownloader.updateCompilerListIfNeeded(new Set(["0.5.0"]));
         assert.ok(
-          await wasmDownloader.downloadCompiler("0.4.12"),
+          await wasmDownloader.downloadCompiler("0.5.0"),
           "Downloading compiler should succeed",
         );
         assert.ok(
-          await wasmDownloader.isCompilerDownloaded("0.4.12"),
+          await wasmDownloader.isCompilerDownloaded("0.5.0"),
           "Compiler should be downloaded",
         );
       });
@@ -79,29 +79,29 @@ describe(
 
       it("should throw when version is bad", async function () {
         await assertRejectsWithHardhatError(
-          () => downloader.isCompilerDownloaded("0.4.12a"),
+          () => downloader.isCompilerDownloaded("0.5.0a"),
           HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
           {
-            version: "0.4.12a",
+            version: "0.5.0a",
           },
         );
       });
 
       it("should return false when the compiler isn't downloaded yet", async function () {
         assert.ok(
-          !(await downloader.isCompilerDownloaded("0.4.12")),
+          !(await downloader.isCompilerDownloaded("0.5.0")),
           "Compiler should not be downloaded",
         );
       });
 
       it("should return true when the compiler is already downloaded", async function () {
-        await downloader.updateCompilerListIfNeeded(new Set(["0.4.12"]));
+        await downloader.updateCompilerListIfNeeded(new Set(["0.5.0"]));
         assert.ok(
-          await downloader.downloadCompiler("0.4.12"),
+          await downloader.downloadCompiler("0.5.0"),
           "Downloading compiler should succeed",
         );
         assert.ok(
-          await downloader.isCompilerDownloaded("0.4.12"),
+          await downloader.isCompilerDownloaded("0.5.0"),
           "Compiler should be downloaded",
         );
       });
@@ -149,7 +149,7 @@ describe(
         );
 
         await assertRejectsWithHardhatError(
-          () => mockDownloader.updateCompilerListIfNeeded(new Set(["0.4.12"])),
+          () => mockDownloader.updateCompilerListIfNeeded(new Set(["0.5.0"])),
           HardhatError.ERRORS.CORE.SOLIDITY.VERSION_LIST_DOWNLOAD_FAILED,
           {},
         );
@@ -174,13 +174,13 @@ describe(
           },
         );
 
-        await mockDownloader.updateCompilerListIfNeeded(new Set(["0.4.12"]));
+        await mockDownloader.updateCompilerListIfNeeded(new Set(["0.5.0"]));
 
         await assertRejectsWithHardhatError(
-          () => mockDownloader.downloadCompiler("0.4.12"),
+          () => mockDownloader.downloadCompiler("0.5.0"),
           HardhatError.ERRORS.CORE.SOLIDITY.DOWNLOAD_FAILED,
           {
-            remoteVersion: "0.4.12+commit.194ff033",
+            remoteVersion: "0.5.0+commit.1d4f565a",
           },
         );
       });
@@ -202,11 +202,11 @@ describe(
         );
 
         await mockDownloader.updateCompilerListIfNeeded(
-          new Set(["0.4.12", "0.4.13"]),
+          new Set(["0.5.0", "0.5.1"]),
         );
 
-        await mockDownloader.downloadCompiler("0.4.12");
-        await mockDownloader.downloadCompiler("0.4.13");
+        await mockDownloader.downloadCompiler("0.5.0");
+        await mockDownloader.downloadCompiler("0.5.1");
 
         // NOTE: 1 download is done for the list, and 2 downloads are done for
         // the compilers.
@@ -245,13 +245,13 @@ describe(
           },
         );
 
-        await mockDownloader.updateCompilerListIfNeeded(new Set(["0.4.12"]));
+        await mockDownloader.updateCompilerListIfNeeded(new Set(["0.5.0"]));
 
         await assertRejectsWithHardhatError(
-          () => mockDownloader.downloadCompiler("0.4.12"),
+          () => mockDownloader.downloadCompiler("0.5.0"),
           HardhatError.ERRORS.CORE.SOLIDITY.INVALID_DOWNLOAD,
           {
-            remoteVersion: "0.4.12+commit.194ff033",
+            remoteVersion: "0.5.0+commit.1d4f565a",
           },
         );
 
@@ -266,9 +266,9 @@ describe(
 
         // it should work with the normal download now
         stopMocking = true;
-        await mockDownloader.downloadCompiler("0.4.12");
+        await mockDownloader.downloadCompiler("0.5.0");
         assert.ok(
-          await mockDownloader.isCompilerDownloaded("0.4.12"),
+          await mockDownloader.isCompilerDownloaded("0.5.0"),
           "Compiler should be downloaded",
         );
       });
@@ -279,7 +279,7 @@ describe(
           // Without a mutex, the value would be 10 because the compiler would be downloaded multiple times.
           // However, the check is implemented to ensure that the value remains 1.
 
-          const VERSION = "0.4.12";
+          const VERSION = "0.5.0";
 
           let downloads = 0;
           const mockDownloader = new CompilerDownloader(
@@ -369,26 +369,26 @@ describe(
         await downloader.updateCompilerListIfNeeded(new Set([]));
 
         await assertRejectsWithHardhatError(
-          () => downloader.getCompiler("0.4.12"),
+          () => downloader.getCompiler("0.5.0"),
           HardhatError.ERRORS.CORE.INTERNAL.ASSERTION_ERROR,
           {
-            message: "Trying to get a compiler 0.4.12 before it was downloaded",
+            message: "Trying to get a compiler 0.5.0 before it was downloaded",
           },
         );
       });
 
       it("should throw when trying to get a compiler that's in the compiler list but hasn't been downloaded yet", async function () {
         await downloader.updateCompilerListIfNeeded(
-          new Set(["0.4.12", "0.4.13"]),
+          new Set(["0.5.0", "0.5.1"]),
         );
 
-        await downloader.downloadCompiler("0.4.12");
+        await downloader.downloadCompiler("0.5.0");
 
         await assertRejectsWithHardhatError(
-          () => downloader.getCompiler("0.4.13"),
+          () => downloader.getCompiler("0.5.1"),
           HardhatError.ERRORS.CORE.INTERNAL.ASSERTION_ERROR,
           {
-            message: "Trying to get a compiler 0.4.13 before it was downloaded",
+            message: "Trying to get a compiler 0.5.1 before it was downloaded",
           },
         );
       });
@@ -402,7 +402,7 @@ describe(
           async (_url, destination, _requestOptions, _dispatcherOptions) => {
             if (!hasDownloadedOnce) {
               hasDownloadedOnce = true;
-              const longVersion = "0.4.12+mock";
+              const longVersion = "0.5.0+mock";
               const compilersList = {
                 builds: [
                   {
@@ -410,7 +410,7 @@ describe(
                       platform === CompilerPlatform.WINDOWS
                         ? "solc.exe"
                         : "solc",
-                    version: "0.4.12",
+                    version: "0.5.0",
                     longVersion,
                     build: "build",
                     keccak256:
@@ -420,9 +420,9 @@ describe(
                   },
                 ],
                 releases: {
-                  "0.4.12": "0.4.12+mock",
+                  "0.5.0": "0.5.0+mock",
                 },
-                latestRelease: "0.4.12",
+                latestRelease: "0.5.0",
               };
 
               await fs.ensureDir(path.dirname(destination));
@@ -435,31 +435,35 @@ describe(
           },
         );
 
-        await mockDownloader.updateCompilerListIfNeeded(new Set(["0.4.12"]));
+        await mockDownloader.updateCompilerListIfNeeded(new Set(["0.5.0"]));
 
+        const remoteVersion =
+          platform === CompilerPlatform.LINUX_ARM64
+            ? "0.5.0"
+            : "0.5.0+commit.1d4f565a";
         await assertRejectsWithHardhatError(
-          () => mockDownloader.downloadCompiler("0.4.12"),
+          () => mockDownloader.downloadCompiler("0.5.0"),
           HardhatError.ERRORS.CORE.SOLIDITY.INVALID_DOWNLOAD,
           {
-            remoteVersion: "0.4.12+commit.194ff033",
+            remoteVersion,
           },
         );
       });
 
       it("should work for downloaded compilers", async function () {
         await downloader.updateCompilerListIfNeeded(
-          new Set(["0.4.12", "0.4.13"]),
+          new Set(["0.5.0", "0.5.1"]),
         );
 
-        await downloader.downloadCompiler("0.4.12");
+        await downloader.downloadCompiler("0.5.0");
         assert.ok(
-          downloader.getCompiler("0.4.12") !== undefined,
+          downloader.getCompiler("0.5.0") !== undefined,
           "Compiler should be defined",
         );
 
-        await downloader.downloadCompiler("0.4.13");
+        await downloader.downloadCompiler("0.5.1");
         assert.ok(
-          downloader.getCompiler("0.4.13") !== undefined,
+          downloader.getCompiler("0.5.1") !== undefined,
           "Compiler should be defined",
         );
       });


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Resolves https://github.com/NomicFoundation/hardhat/issues/7232#event-19198518774

Linux ARM machines are now free for public repos - https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

While Intel MacOS machines are getting deprecated in September - https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/