### PR TITLE
improve exception filtering before sending to Sentry

### DIFF
--- a/.changeset/three-rats-share.md
+++ b/.changeset/three-rats-share.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Improved exception filtering for Sentry telemetry ([#7246](https://github.com/NomicFoundation/hardhat/issues/7246))

--- a/v-next/hardhat/src/internal/cli/telemetry/sentry/anonymizer.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/sentry/anonymizer.ts
@@ -37,7 +37,6 @@ export type AnonymizeEventResult =
   | { success: true; event: Event }
   | { success: false; error: string };
 
-const ANONYMIZED_FILE = ANONYMIZED_PATH;
 const ANONYMIZED_MNEMONIC = "<mnemonic>";
 const MNEMONIC_PHRASE_LENGTH_THRESHOLD = 7;
 const MINIMUM_AMOUNT_OF_WORDS_TO_ANONYMIZE = 4;
@@ -57,7 +56,7 @@ export class Anonymizer {
   ): Promise<AnonymizeEnvelopeResult> {
     for (const item of envelope[1]) {
       if (item[0].type === "event") {
-        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions 
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           -- We know that the item is an event item */
         const eventItem = item as EventItem;
 
@@ -136,12 +135,42 @@ export class Anonymizer {
   public anonymizeErrorMessage(errorMessage: string): string {
     errorMessage = this.#anonymizeMnemonic(errorMessage);
 
+    // We intentionally replace the config path with its own
+    // anonymized token, to help differentiate the config
+    // file in exception reports while keeping it anonymized.
+    if (this.#configPath !== undefined) {
+      errorMessage = errorMessage.replaceAll(
+        this.#configPath,
+        "<hardhat-config-file>",
+      );
+    }
+
     // hide hex strings of 20 chars or more
     const hexRegex = /(0x)?[0-9A-Fa-f]{20,}/g;
 
     return anonymizeUserPaths(errorMessage).replace(hexRegex, (match) =>
       match.replace(/./g, "x"),
     );
+  }
+
+  public filterOutEventsWithExceptionsNotRaisedByHardhat(
+    envelope: Envelope,
+  ): Envelope {
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+      We are just filtering events in place, not changing any type */
+    envelope[1] = envelope[1].filter((item) => {
+      if (item[0].type !== "event") {
+        return true;
+      }
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          -- We know that the item is an event item */
+      const eventItem = item as EventItem;
+
+      return this.raisedByHardhat(eventItem[1]);
+    }) as any;
+
+    return envelope;
   }
 
   public raisedByHardhat(event: Event): boolean {
@@ -155,6 +184,10 @@ export class Anonymizer {
 
     const originalException = exceptions[exceptions.length - 1];
 
+    if (!this.#isErrorMessageAllowed(originalException)) {
+      return false;
+    }
+
     const frames = originalException?.stacktrace?.frames;
 
     if (frames === undefined) {
@@ -166,38 +199,94 @@ export class Anonymizer {
         continue;
       }
 
-      if (this.#errorRaisedByPackageToIgnore(frame.filename)) {
-        return false;
-      }
-
-      // we stop after finding either a hardhat file or a file from the user's
-      // project
-      if (this.#isHardhatFile(frame.filename)) {
-        return true;
-      }
-
-      if (frame.filename === ANONYMIZED_FILE) {
-        return false;
-      }
-
+      // We don't report errors from the Hardhat.config file
       if (
         this.#configPath !== undefined &&
         this.#configPath.includes(frame.filename)
       ) {
         return false;
       }
+
+      if (this.#isPackageFile(frame.filename)) {
+        // We don't report errors from the ignored package list e.g. `ethers`
+        // even when buried as a subpackage of a hardhat package
+        if (this.#errorRaisedByPackageToIgnore(frame.filename)) {
+          return false;
+        }
+
+        // We report errors from Hardhat packages, we exclude
+        // those from non-hardhat packages
+        return this.#isHardhatFile(frame.filename);
+      }
+
+      // Error originating not in packages, but in the user project
+      // should be filtered.
+      if (this.#isUserProjectFile(frame.filename)) {
+        return false;
+      }
+
+      // Otherwise look at the next frame up
     }
 
     // if we didn't find any hardhat frame, we don't report the error
     return false;
   }
 
+  #isErrorMessageAllowed(originalException: Exception): boolean {
+    const exceptionType = originalException.type;
+    const exceptionMessage = originalException.value;
+
+    // Without an exception message, we can't filter so allow it
+    if (exceptionMessage === undefined) {
+      return true;
+    }
+
+    // Filter out required not defined in ES Modules errors
+    if (
+      exceptionType === "ReferenceError" &&
+      exceptionMessage ===
+        "require is not defined in ES module scope, you can use import instead"
+    ) {
+      return false;
+    }
+
+    // Filter out cannot find package when importing errors
+    if (
+      exceptionType === "Error" &&
+      /^Cannot find package '([^']+)' imported from .+$/.test(exceptionMessage)
+    ) {
+      return false;
+    }
+
+    // Filter out cannot find module errors
+    if (
+      exceptionType === "Error" &&
+      /^Cannot find module '([^']+)'/.test(exceptionMessage)
+    ) {
+      return false;
+    }
+
+    // Filter out "require() cannot be sued on an ESM graph"
+    if (
+      exceptionType === "Error" &&
+      exceptionMessage.startsWith(
+        "require() cannot be used on an ESM graph with top-level await. Use import() instead.",
+      )
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
   #errorRaisedByPackageToIgnore(filename: string): boolean {
+    // List of external packages that we don't want to report errors from
     const pkgsToIgnore: string[] = [
-      path.join("node_modules", "@ethersproject"), // List of external packages that we don't want to report errors from
+      path.join("node_modules", "@ethersproject"),
     ];
 
-    const pkgs = filename.match(/node_modules[\/\\][^\/\\]+/g); // Match path separators both for Windows and Unix
+    // Match path separators both for Windows and Unix
+    const pkgs = filename.match(/node_modules[\/\\][^\/\\]+/g);
 
     if (pkgs === null) {
       return false;
@@ -212,13 +301,24 @@ export class Anonymizer {
     const nomicFoundationPath = path.join("node_modules", "@nomicfoundation");
     const ignoredOrgPath = path.join("node_modules", "@ignored");
     const hardhatPath = path.join("node_modules", "hardhat");
+
     filename = filename.toLowerCase();
 
     return (
-      filename.startsWith(nomicFoundationPath) ||
-      filename.startsWith(ignoredOrgPath) ||
-      filename.startsWith(hardhatPath)
+      filename.includes(nomicFoundationPath) ||
+      filename.includes(ignoredOrgPath) ||
+      filename.includes(hardhatPath)
     );
+  }
+
+  #isPackageFile(filename: string): boolean {
+    return filename.includes("node_modules");
+  }
+
+  #isUserProjectFile(filename: string): boolean {
+    const anonymizedUserPath = anonymizeUserPaths(filename);
+
+    return anonymizedUserPath === ANONYMIZED_PATH;
   }
 
   async #anonymizeExceptions(exceptions: Exception[]): Promise<Exception[]> {

--- a/v-next/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
@@ -89,7 +89,7 @@ class Reporter {
         SENTRY_DSN,
         release,
         environment,
-        this.#hardhatConfigPath,
+        () => this.#hardhatConfigPath,
       ),
       release,
       environment,

--- a/v-next/hardhat/src/internal/cli/telemetry/sentry/transport.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/sentry/transport.ts
@@ -32,7 +32,7 @@ export function createDetachedProcessTransport(
   dsn: string,
   release: string,
   environment: string,
-  configPath?: string,
+  getConfigPath: () => string | undefined,
 ): Transport {
   return {
     send: (envelope) => {
@@ -52,7 +52,7 @@ export function createDetachedProcessTransport(
       let args = [
         subprocessPath,
         serializedEnvelope,
-        configPath ?? "",
+        getConfigPath() ?? "",
         dsn,
         release,
         environment,


### PR DESCRIPTION
Our Sentry exception reporting is including exceptions coming from within user scripts and tests. We need to improve our filtering to reduce the number of exceptions being reported that are really user land issues rather than Hardhat issues.

We intend to do this over a serious of tightening iterations. At the first pass we re-enable a filter and explicitly exclude:

* require in ESM exceptions
* cannot find package exceptions
* cannot find modules exceptions

We also broadly exclude exceptions originating in a `hardhat.config.{js,ts}` or that originate in a `node_modules` package that is not a hardhat package.

We attempt to exclude errors originating in user project files e.g. `./scripts/run.js` or `./ignition/modules/my-module.ts`.

Once we have established this baseline we will tighten up the definition until Sentry is only getting exceptions that are a strong signal that something unexpected has happened in Hardhat code.

Resolves #7246.

## Reviewer Note

> [!IMPORTANT]
> This PR is easier to review commit at a time

## TODO

- [x] Fix bug with fetching hardhat config lazily
- [x] Provide a custom replace for config path to help debugging
- [x] Add back in exception filter, but do it before anonymization
- [x] Review other heuristics
- [x] Add filter for require in ESM exceptions
- [x] Add filter for "Cannot find package" errors
- [x] Exemption for error messages starting with “Cannot find module” based on the examples enough
- [x] Re-introduce an equivalent of frame.filename === ANONYMIZED
