### PR TITLE
chore: restore testFail cases exclusion

### DIFF
--- a/.github/config/regression-tests.yml
+++ b/.github/config/regression-tests.yml
@@ -560,10 +560,13 @@ repositories:
         "test": {
           "solidity": {
             "allowInternalExpectRevert": true,
-            "testFail": true
           }
         }
       };
+    ignore: |
+      # Unsupported testFail: https://github.com/NomicFoundation/hardhat/issues/7253
+      test/Kali.t.sol
+      test/ReentrancyGuard.t.sol
     ref: 21213d34042b8a5a68afeb590f43018f08c81a58
   mds1/multicall:
     commands:
@@ -638,7 +641,6 @@ repositories:
         "test": {
           "solidity": {
             "allowInternalExpectRevert": true,
-            "testFail": true,
             "ffi": true,
             "fsPermissions": {
               "dangerouslyReadWriteDirectory": [
@@ -692,6 +694,9 @@ repositories:
       test/pool-cl/CLCustomCurveHook.t.sol
       test/pool-cl/CLMintBurnFeeHook.t.sol
       test/pool-cl/libraries/TickBitmap.t.sol
+
+      # Unsupported testFail: https://github.com/NomicFoundation/hardhat/issues/7253
+      test/VaultToken.t.sol
     ref: 9a050c44cdf801fd19753409e6a03a8026a1fd09
   pcaversaccio/createx:
     commands:
@@ -1000,10 +1005,25 @@ repositories:
         "test": {
           "solidity": {
             "allowInternalExpectRevert": true,
-            "testFail": true
           }
         }
       };
+    ignore: |
+      # Unsupported testFail: https://github.com/NomicFoundation/hardhat/issues/7253
+      src/test/Auth.t.sol
+      src/test/ERC6909.t.sol
+      src/test/CREATE3.t.sol
+      src/test/DSTestPlus.t.sol
+      src/test/ReentrancyGuard.t.sol
+      src/test/SSTORE2.t.sol
+      src/test/SafeCastLib.t.sol
+      src/test/ERC1155.t.sol
+      src/test/ERC721.t.sol
+      src/test/SafeTransferLib.t.sol
+      src/test/SignedWadMath.t.sol
+      src/test/ERC20.t.sol
+      src/test/ERC4626.t.sol
+      src/test/FixedPointMathLib.t.sol
     ref: c93f7716c9909175d45f6ef80a34a650e2d24e56
   OpenZeppelin/openzeppelin-contracts:
     commands:


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Excludes unsupported `testFail` test cases from the regression tests suite.