### PR TITLE
ove extraneous dependency to peer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1630,6 +1630,9 @@ importers:
 
   v-next/hardhat/templates/hardhat-3/02-mocha-ethers:
     dependencies:
+      '@nomicfoundation/hardhat-ethers':
+        specifier: workspace:^4.0.0
+        version: link:../../../../hardhat-ethers
       '@nomicfoundation/hardhat-ethers-chai-matchers':
         specifier: workspace:^3.0.0
         version: link:../../../../hardhat-ethers-chai-matchers
@@ -1655,9 +1658,6 @@ importers:
         specifier: workspace:^3.0.0
         version: link:../../../../hardhat-ignition-core
     devDependencies:
-      '@nomicfoundation/hardhat-ethers':
-        specifier: workspace:^4.0.0
-        version: link:../../../../hardhat-ethers
       '@nomicfoundation/hardhat-ignition':
         specifier: workspace:^3.0.0
         version: link:../../../../hardhat-ignition

--- a/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/package.json
+++ b/v-next/hardhat/templates/hardhat-3/02-mocha-ethers/package.json
@@ -8,7 +8,6 @@
     "hardhat": "workspace:^3.0.0",
     "@nomicfoundation/hardhat-toolbox-mocha-ethers": "workspace:^3.0.0",
     "@nomicfoundation/hardhat-ignition": "workspace:^3.0.0",
-    "@nomicfoundation/hardhat-ethers": "workspace:^4.0.0",
     "@types/chai": "^4.2.0",
     "@types/chai-as-promised": "^8.0.1",
     "@types/mocha": ">=10.0.10",
@@ -20,6 +19,7 @@
     "typescript": "~5.8.0"
   },
   "peerDependencies": {
+    "@nomicfoundation/hardhat-ethers": "workspace:^4.0.0",
     "@nomicfoundation/hardhat-ethers-chai-matchers": "workspace:^3.0.0",
     "@nomicfoundation/hardhat-ignition": "workspace:^3.0.0",
     "@nomicfoundation/hardhat-ignition-ethers": "workspace:^3.0.0",


### PR DESCRIPTION
resolves https://github.com/NomicFoundation/hardhat/issues/7231

There was only `hardhat-ethers` that I could tell as being extraneous and needing to be moved into peer according to the cases that Pato laid out in his comment. 