### PR TITLE
fix(type-guards): exclude ENCODE_FUNCTION_CALL from isFutureThatSubmitsOnchainTransaction

### DIFF
--- a/.changeset/orange-experts-try.md
+++ b/.changeset/orange-experts-try.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/ignition-core": patch
+---
+
+Fix the type guard to include `m.encodeFunctionCall` in those that do not submit transactions, thanks @radik878 ([#7264](https://github.com/NomicFoundation/hardhat/pull/7264))

--- a/v-next/hardhat-ignition-core/src/type-guards.ts
+++ b/v-next/hardhat-ignition-core/src/type-guards.ts
@@ -298,18 +298,22 @@ export function isFutureThatSubmitsOnchainTransaction(
 ): f is Exclude<
   Exclude<
     Exclude<
-      Exclude<Future, StaticCallFuture<string, string>>,
-      ReadEventArgumentFuture
+      Exclude<
+        Exclude<Future, StaticCallFuture<string, string>>,
+        ReadEventArgumentFuture
+      >,
+      NamedArtifactContractAtFuture<string>
     >,
-    NamedArtifactContractAtFuture<string>
+    ContractAtFuture
   >,
-  ContractAtFuture
+  EncodeFunctionCallFuture<string, string>
 > {
   return (
     !isNamedStaticCallFuture(f) &&
     !isReadEventArgumentFuture(f) &&
     !isNamedContractAtFuture(f) &&
-    !isArtifactContractAtFuture(f)
+    !isArtifactContractAtFuture(f) &&
+    !isEncodeFunctionCallFuture(f)
   );
 }
 


### PR DESCRIPTION
ENCODE_FUNCTION_CALL doesn’t submit transactions (initialized and marked SUCCESS without networkInteractions) and is excluded by pending-onchain selectors. The guard wrongly included it, causing inconsistency. Updated guard to exclude it at type and runtime.