### PR TITLE
chore: update pnpm lock file in release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
         uses: changesets/action@v1
         with:
           title: Version Packages (v3)
+          version: |
+            pnpm changeset version
+            pnpm -w install --lockfile-only
 
       - name: Build All Packages
         if: steps.pr.outputs.hasChangesets == 'false'


### PR DESCRIPTION
The release PR created by changeset should update the Hardhat lockfile.


