### PR TITLE
chore: tweak PR creation to use `pnpm version-for-release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: changesets/action@v1
         with:
           title: Version Packages (v3)
-          version: pnpm changeset version && pnpm -w install --lockfile-only
+          version: pnpm version-for-release
 
       - name: Build All Packages
         if: steps.pr.outputs.hasChangesets == 'false'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prelint": "pnpm build",
     "lint": "pnpm run --recursive --if-present lint",
     "prelint:fix": "pnpm build",
-    "lint:fix": "pnpm run --recursive --if-present lint:fix"
+    "lint:fix": "pnpm run --recursive --if-present lint:fix",
+    "version-for-release": "pnpm changeset version && pnpm -w install --lockfile-only"
   }
 }


### PR DESCRIPTION
Combine changeset version with an update of the pnpm-lock file.

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
