### PR TITLE
fix: add safe optional chaining for contract access in verify module

### DIFF
--- a/.changeset/popular-bats-doubt.md
+++ b/.changeset/popular-bats-doubt.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Fix `ContractInformationResolver` to use optional chaining when accessing compiler output contracts to prevent potential `TypeError` ([#7291](https://github.com/NomicFoundation/hardhat/pull/7291))

--- a/v-next/hardhat-verify/src/internal/contract.ts
+++ b/v-next/hardhat-verify/src/internal/contract.ts
@@ -228,7 +228,7 @@ export class ContractInformationResolver {
     const inputSourceName = buildInfo.userSourceNameMap[sourceName];
 
     const compilerOutputContract =
-      buildInfoOutput.output.contracts?.[inputSourceName][contractName];
+      buildInfoOutput.output.contracts?.[inputSourceName]?.[contractName];
 
     // TODO: can this happen after validating the artifact and build info? should we throw an error?
     assertHardhatInvariant(


### PR DESCRIPTION
Add missing optional chaining operator when accessing compiler output contracts
to prevent potential runtime TypeError in ContractInformationResolver.

The fix ensures that accessing buildInfoOutput.output.contracts[inputSourceName][contractName]
is safe by using optional chaining for both array accesses, preventing crashes
when either the contracts object or the specific source contracts array is undefined.

This change maintains the existing error handling through assertHardhatInvariant
while making the code more robust against unexpected data structure states.