### PR TITLE
chore: update the dependency check CI job to point at v2

### DIFF
--- a/.github/workflows/LATEST_DEPENDENCY_VERSIONS.yml
+++ b/.github/workflows/LATEST_DEPENDENCY_VERSIONS.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ${{ matrix.system }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: v2
       - uses: ./.github/actions/setup-env
       - name: Delete pnpm-lock.yaml
         run: "rm pnpm-lock.yaml"


### PR DESCRIPTION
This is a v2 CI check that has still to be ported to Hardhat 3. For the moment we point it back at the Hardhat 2 branch.

The same test fails currently on `main` due to issues with mocha tests in Ignition core. We should swap out the Ignition tests to use Node test runner.
