### PR TITLE
chore: set maximum parallelism for package CI jobs

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -192,6 +192,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         package: ${{ fromJson(needs.list-packages.outputs.packages) }}
 
@@ -237,6 +238,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         package: ${{ fromJson(needs.list-packages.outputs.packages) }}
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]


### PR DESCRIPTION
We are seeing npm rate limiting on installing for each of our package jobs (and linting). This may be an issue with out github action caching, but for the moment I am limiting the number of jobs starting at once.

Next steps are an investigation into caching, bearing in mind we moved to `actions/checkout@v5` with its support for newer runners in GitHub Actions (changing the IP range as seen from NPM).
