### PR TITLE
chore: fix typos

### DIFF
--- a/archive/hardhat-verify/test/integration/index.ts
+++ b/archive/hardhat-verify/test/integration/index.ts
@@ -164,7 +164,7 @@ https://hardhat.etherscan.io/address/${address}#code
       );
     });
 
-    describe("with overriden config", () => {
+    describe("with overridden config", () => {
       let originalCompilers: SolcConfig[];
 
       it("should throw if the deployed contract version does not match the configured version", async function () {

--- a/v-next/hardhat-ignition-core/src/internal/execution/utils/address.ts
+++ b/v-next/hardhat-ignition-core/src/internal/execution/utils/address.ts
@@ -10,10 +10,10 @@ export function isAddress(address: any): address is string {
 }
 
 /**
- * Returns a normalized and checksumed address for the given address.
+ * Returns a normalized and checksummed address for the given address.
  *
  * @param address - the address to reformat
- * @returns checksumed address
+ * @returns checksummed address
  */
 export function toChecksumFormat(address: string): string {
   assertIgnitionInvariant(

--- a/v-next/hardhat-keystore/test/keystores/encryption.ts
+++ b/v-next/hardhat-keystore/test/keystores/encryption.ts
@@ -467,7 +467,7 @@ describe("Keystore primitives", () => {
   });
 
   describe("Adding secrets to keystore", () => {
-    it("Should add multiple secrets to a keystore, modifying only the secrets and hmac, allowing to overwrite secrets by key, and generating different cyphertext and ivs for the same secret values", () => {
+    it("Should add multiple secrets to a keystore, modifying only the secrets and hmac, allowing to overwrite secrets by key, and generating different ciphertext and ivs for the same secret values", () => {
       const { emptyKeystore, masterKey } = testEmptyKeystore;
 
       let previousKeystore = emptyKeystore;


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `overriden` → `overridden`
  - `checksumed` → `checksummed`
  - `cyphertext` → `ciphertext`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.