### PR TITLE
Enable concurrency in node test runner

### DIFF
--- a/.changeset/hungry-news-rhyme.md
+++ b/.changeset/hungry-news-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-runner": patch
+---
+
+Updated the node.js test runner to run tests in parallel by default

--- a/v-next/hardhat-node-test-runner/src/task-action.ts
+++ b/v-next/hardhat-node-test-runner/src/task-action.ts
@@ -97,7 +97,11 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   async function runTests(): Promise<number> {
     let failures = 0;
 
-    const nodeTestOptions: LastParameter<typeof run> = { files, only };
+    const nodeTestOptions: LastParameter<typeof run> = {
+      files,
+      only,
+      concurrency: true, // uses `os.availableParallelism() - 1`
+    };
 
     if (grep !== undefined && grep !== "") {
       nodeTestOptions.testNamePatterns = grep;


### PR DESCRIPTION
Closes https://github.com/NomicFoundation/hardhat/issues/7311

I tried to add a test for this, but I couldn't think of a reliable way do it. Some things I considered:

- Checking in the test itself if it's being run with concurrency -> From skimming the node test runner docs, this doesn't seem to be possible.
- Writing a pair of intertwined tests that only pass if they are run in parallel (e.g., both write a file and wait until the other one wrote its file) -> This could work, but only if concurrency is > 1, which might not be the case in CI environments.
- Writing a pair of tests that sleep for 1 second and assert that it takes less than 1.5 seconds to run them -> Ugly, unreliable, and it has the same issue as the previous item.