### PR TITLE
chore(ignition-core): return artifact id in docs and simplify verify yield

### DIFF
--- a/v-next/hardhat-ignition-core/src/verify.ts
+++ b/v-next/hardhat-ignition-core/src/verify.ts
@@ -58,11 +58,6 @@ export async function* getVerificationInformation(
       deploymentLoader,
     );
 
-    if (typeof verifyInfo === "string") {
-      yield verifyInfo;
-      continue;
-    }
-
     yield verifyInfo;
   }
 }
@@ -84,7 +79,7 @@ async function convertExStateToVerifyInfo(
     );
 
     // if the artifact cannot be found, we cannot verify the contract
-    // we return the contract name so the recipient can know which contract could not be verified
+    // we return the artifact id so the recipient can know which contract could not be verified
     return exState.artifactId;
   }
 


### PR DESCRIPTION
- Align docs/comments with tested behavior by clarifying that the fallback string from getVerificationInformation is the artifact id (e.g., Module#Name), not the contract name. This matches tests and avoids ambiguity when multiple contracts share a name.
- Simplify generator loop in verify.ts by removing the redundant conditional yield/continue; now a single yield handles both VerifyInfo and string cases without behavior change.

Tests depend on artifact id being returned. Single-yield refactor is no-op behaviorally and aligns with project style of minimal branching when union types suffice.