### PR TITLE
Feature: Add support for optional dependencies

### DIFF
--- a/v-next/hardhat/src/internal/core/plugins/resolve-plugin-list.ts
+++ b/v-next/hardhat/src/internal/core/plugins/resolve-plugin-list.ts
@@ -50,7 +50,9 @@ async function reverseTopologicalSort(
       let dependencyModules: Array<{ default: HardhatPlugin }>;
 
       try {
-        dependencyModules = await Promise.all(plugin.dependencies());
+        dependencyModules = (await Promise.all(plugin.dependencies())).filter(
+          (module) => module !== undefined,
+        );
       } catch (error) {
         ensureError(error);
         await detectPluginNpmDependencyProblems(projectRoot, plugin);

--- a/v-next/hardhat/src/types/plugins.ts
+++ b/v-next/hardhat/src/types/plugins.ts
@@ -37,7 +37,7 @@ export interface HardhatPlugin {
   /**
    * An array of plugins that this plugin depends on.
    */
-  dependencies?: () => Array<Promise<{ default: HardhatPlugin }>>;
+  dependencies?: () => Array<Promise<{ default: HardhatPlugin } | undefined>>;
 
   /**
    * An object with the different hook handlers that this plugin defines.


### PR DESCRIPTION
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.

---

Some plugins may want to provide additional (optional) features if another plugin is available. For example, a plugin that affect the connection may also perform additional actions on the `connection.ethers` or `connection.viem` objects if the corresponding plugins are installed. If either plugin is not installed, then it should not cause an error.

This PR changes the type of `HardhatPlugin['dependencies']` from
```typescript
Array<Promise<{ default: HardhatPlugin }>>
```
to
```typescript
Array<Promise<{ default: HardhatPlugin } | undefined>>
```

This allows the plugin to make a dependency optional by doing
```typescript
import("optional-dependency").catch(() => undefined);
```

This change is backward compatible: all existing `dependencies` arrays remain valid, and are not treated as optional.