### PR TITLE
fix/update v2 to work with latest type deps

### DIFF
--- a/.changeset/clear-guests-rhyme.md
+++ b/.changeset/clear-guests-rhyme.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix to be explicit that execFile should pass stdout/stderr as strings ([#7333](https://github.com/NomicFoundation/hardhat/pull/7333))

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "v2",
   "updateInternalDependencies": "minor",
   "ignore": ["@nomiclabs/common"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/packages/hardhat-ledger/src/errors.ts
+++ b/packages/hardhat-ledger/src/errors.ts
@@ -35,10 +35,13 @@ export class HardhatLedgerConnectionError extends HardhatLedgerError {
   private readonly _isConnectionError = true;
 
   constructor(error: Error) {
-    super(`There was an error trying to establish a connection to the Ledger wallet: "${error.message}".
+    super(
+      `There was an error trying to establish a connection to the Ledger wallet: "${error.message}".
 
 Make sure your Ledger is connected and unlocked, and that the Ethereum app is open.
-`, error);
+`,
+      error
+    );
 
     if (error.name === "TransportError") {
       const transportError = error as TransportError;


### PR DESCRIPTION
The update of the types, in the absence of an explicit encoding set stdout/stderr as not `string` anymore but `string | Buffer<ArrayLikeOrSomething>`.

I have updated options to enforce "utf8" as the encoding which then shows up at the type level. This forcing is ensured by omitting "encoding" from the options object, ensuring you can't accidentaly violate this assumption.

Part of #7332.

> [!Note]
> Review a commit at a time


