### PR TITLE
chore: allow ignition ui test from clean

### DIFF
--- a/v-next/hardhat-ignition-ui/package.json
+++ b/v-next/hardhat-ignition-ui/package.json
@@ -11,6 +11,7 @@
     "predev": "pnpm regenerate-deployment-example",
     "dev": "vite --force",
     "build": "tsc --build .",
+    "pretest": "pnpm build",
     "test": "mocha --loader=ts-node/esm --recursive \"test/**/*.ts\"",
     "test:coverage": "nyc mocha --loader=ts-node/esm --recursive \"test/**/*.ts\"",
     "regenerate-deployment-example": "node ./scripts/generate-example-deployment-json.js",


### PR DESCRIPTION
When running in a clean repo, to allow for testing just of ignition ui, we add a `pretest` step to build both ignition ui and its project ref dependencies.

Part of https://github.com/NomicFoundation/hardhat/issues/7332


