### PR TITLE
chore: add CI workflow for HH3 dependency checks

### DIFF
--- a/.github/workflows/check-v2-with-latest-dependencies.yml
+++ b/.github/workflows/check-v2-with-latest-dependencies.yml
@@ -1,4 +1,4 @@
-name: Run the entire test suite with the latest dependency versions
+name: Run the Hardhat 2 test suite with the latest dependency versions
 
 on:
   schedule:
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: v2
+          ref: v2 # Checkout the `v2` branch
       - uses: ./.github/actions/setup-env
       - name: Delete pnpm-lock.yaml
         run: "rm pnpm-lock.yaml"

--- a/.github/workflows/check-v3-with-latest-dependencies.yml
+++ b/.github/workflows/check-v3-with-latest-dependencies.yml
@@ -1,0 +1,36 @@
+name: Run the Hardhat 3 test suite with the latest dependency versions
+
+on:
+  schedule:
+    - cron: "0 0/8 * * *"
+  workflow_dispatch:
+
+jobs:
+  test-without-pnpm-lock-yaml:
+    name: Test without pnpm-lock.yaml
+    strategy:
+      matrix:
+        system: ["ubuntu-latest", "windows-latest"]
+    runs-on: ${{ matrix.system }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-env
+      - name: Delete pnpm-lock.yaml
+        run: "rm pnpm-lock.yaml"
+      - name: Install
+        run: pnpm install --no-frozen-lockfile
+      - name: List dependencies
+        run: pnpm list -r --depth 2
+      - name: Run tests
+        run: pnpm test || (echo "===== Retry =====" && pnpm test)
+      - name: Notify failures
+        if: failure()
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        with:
+          payload: |
+            {
+              "workflow_name": "${{ github.workflow }}",
+              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
We keep the Hardhat 2 dependency check flow against `v2` and add a new one to cover Hardhat 3 on `main`.

I have intentionally duplicated, but kept both broadly the same; we can iterate on the Hardhat 3 version to ensure it is deliverying value.

Part of #7332.
