### PR TITLE
chore: ignore type stripping in dep check

### DIFF
--- a/.github/workflows/check-v3-with-latest-dependencies.yml
+++ b/.github/workflows/check-v3-with-latest-dependencies.yml
@@ -23,6 +23,8 @@ jobs:
         run: pnpm list -r --depth 2
       - name: Run tests
         run: pnpm test || (echo "===== Retry =====" && pnpm test)
+        env:
+          NODE_OPTIONS: --no-experimental-strip-types
       - name: Notify failures
         if: failure()
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0


### PR DESCRIPTION
We run the dep check under Node 24, which in later versions enable type stripping by default. This interacts poorly with our tsx usage.

I have disabled in this test run, though we may want a global disabling across our CI jobs running Node 24.

Part of #7332.
