### PR TITLE
correct parameter name and fix comment wording

### DIFF
--- a/v-next/hardhat-keystore/src/internal/loaders/keystore-file-loader.ts
+++ b/v-next/hardhat-keystore/src/internal/loaders/keystore-file-loader.ts
@@ -14,11 +14,11 @@ export class KeystoreFileLoader implements KeystoreLoader {
   constructor(
     keystoreFilePath: string,
     keystoreDevPasswordFilePath: string,
-    fileManger: FileManager,
+    fileManager: FileManager,
   ) {
     this.#keystoreFilePath = keystoreFilePath;
     this.#keystoreDevPasswordFilePath = keystoreDevPasswordFilePath;
-    this.#fileManager = fileManger;
+    this.#fileManager = fileManager;
 
     this.#keystoreCache = null;
   }

--- a/v-next/hardhat-keystore/src/internal/types.ts
+++ b/v-next/hardhat-keystore/src/internal/types.ts
@@ -14,7 +14,7 @@ export interface Keystore {
  * The KeystoreLoader is responsible for loading and saving the in-memory
  * keystore from and to the on-disk keystore file.
  *
- * As part of those tasks, it has responsilibty for:
+ * As part of those tasks, it has responsibility for:
  * - validating that the on-disk keystore file meets the expected structure
  *   during loading
  * - caching the in-memory keystore to reduce IO during loads

--- a/v-next/hardhat-utils/test/ci.ts
+++ b/v-next/hardhat-utils/test/ci.ts
@@ -3,7 +3,7 @@ import { after, beforeEach, describe, it } from "node:test";
 
 import { isCi } from "../src/ci.js";
 
-// Get the original ENV variables so they can be restored at the end of teh tests
+// Get the original ENV variables so they can be restored at the end of the tests
 const ORIGINAL_ENV_VARS = process.env;
 
 describe("ci", () => {


### PR DESCRIPTION


- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

### What I did
- Renamed constructor parameter `fileManger` → `fileManager` in `keystore-file-loader.ts`.
- Fixed comment wording/typos in keystore types (`responsilibty` → `responsibility`).
- Fixed a small typo in a test comment (`teh` → `the`) in `hardhat-utils/test/ci.ts`.

### Why
- The misspelled parameter name is confusing during review and autocomplete.  
- Comment typos reduce readability of the codebase and docs.

### How I did it
- Updated the constructor signature and assignment:
  - `fileManger: FileManager` → `fileManager: FileManager`
  - `this.#fileManager = fileManger;` → `this.#fileManager = fileManager;`
- Updated comments in:
  - `v-next/hardhat-keystore/src/internal/types.ts`
  - `v-next/hardhat-utils/test/ci.ts`


### Cute Animal
<img width="222" height="148" alt="image" src="https://github.com/user-attachments/assets/6878194f-0ae9-44ff-a76e-3086a1168b21" />

