### PR TITLE
fix(provider): correct index check in clearEventListeners to avoid negative index access

### DIFF
--- a/v-next/hardhat-ethers/src/internal/hardhat-ethers-provider/hardhat-ethers-provider.ts
+++ b/v-next/hardhat-ethers/src/internal/hardhat-ethers-provider/hardhat-ethers-provider.ts
@@ -1283,7 +1283,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
     } else {
       const index = await this.#findEventListenerIndex(event);
 
-      if (index === -1) {
+      if (index !== -1) {
         const { listenersMap } = this.#eventListeners[index];
         this.#eventListeners.splice(index, 1);
         for (const blockListener of listenersMap.values()) {


### PR DESCRIPTION
Ensure #clearEventListeners only removes when a matching event is found by changing the condition to index !== -1, aligning behavior with #removeEventListener and preventing erroneous access to this.#eventListeners[-1].