### PR TITLE
Fix REPORT_GAS envvar in toolboxes

### DIFF
--- a/.changeset/wild-wombats-compare.md
+++ b/.changeset/wild-wombats-compare.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-toolbox-viem": patch
+"@nomicfoundation/hardhat-toolbox": patch
+---
+
+Fix `REPORT_GAS` envvar in toolboxes (https://github.com/NomicFoundation/hardhat/pull/7367)

--- a/packages/hardhat-toolbox-viem/src/index.ts
+++ b/packages/hardhat-toolbox-viem/src/index.ts
@@ -20,6 +20,7 @@ extendConfig((config, userConfig) => {
   const configAsAny = config as any;
 
   if (userConfig.gasReporter?.enabled === undefined) {
-    configAsAny.gasReporter.enabled = process.env.REPORT_GAS ? true : false;
+    configAsAny.gasReporter.enabled =
+      process.env.REPORT_GAS === "true" ? true : false;
   }
 });

--- a/packages/hardhat-toolbox-viem/src/index.ts
+++ b/packages/hardhat-toolbox-viem/src/index.ts
@@ -19,21 +19,7 @@ import { extendConfig } from "hardhat/config";
 extendConfig((config, userConfig) => {
   const configAsAny = config as any;
 
-  // hardhat-gas-reporter doesn't use extendConfig, so
-  // the values of config.gasReporter and userConfig.gasReporter
-  // are the same. The userConfigVersion is frozen though, so we
-  // shouldn't use it.
-  const gasReporterConfig =
-    configAsAny.gasReporter as typeof userConfig.gasReporter;
-
-  configAsAny.gasReporter = gasReporterConfig ?? {};
-
-  if (gasReporterConfig?.enabled === undefined) {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+  if (userConfig.gasReporter?.enabled === undefined) {
     configAsAny.gasReporter.enabled = process.env.REPORT_GAS ? true : false;
-  }
-
-  if (gasReporterConfig?.currency === undefined) {
-    configAsAny.gasReporter.currency = "USD";
   }
 });

--- a/packages/hardhat-toolbox/src/index.ts
+++ b/packages/hardhat-toolbox/src/index.ts
@@ -21,7 +21,8 @@ extendConfig((config, userConfig) => {
   const configAsAny = config as any;
 
   if (userConfig.gasReporter?.enabled === undefined) {
-    configAsAny.gasReporter.enabled = process.env.REPORT_GAS ? true : false;
+    configAsAny.gasReporter.enabled =
+      process.env.REPORT_GAS === "true" ? true : false;
   }
 
   // We don't generate types for js projects

--- a/packages/hardhat-toolbox/src/index.ts
+++ b/packages/hardhat-toolbox/src/index.ts
@@ -20,22 +20,8 @@ import { extendConfig } from "hardhat/config";
 extendConfig((config, userConfig) => {
   const configAsAny = config as any;
 
-  // hardhat-gas-reporter doesn't use extendConfig, so
-  // the values of config.gasReporter and userConfig.gasReporter
-  // are the same. The userConfigVersion is frozen though, so we
-  // shouldn't use it.
-  const gasReporterConfig =
-    configAsAny.gasReporter as typeof userConfig.gasReporter;
-
-  configAsAny.gasReporter = gasReporterConfig ?? {};
-
-  if (gasReporterConfig?.enabled === undefined) {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+  if (userConfig.gasReporter?.enabled === undefined) {
     configAsAny.gasReporter.enabled = process.env.REPORT_GAS ? true : false;
-  }
-
-  if (gasReporterConfig?.currency === undefined) {
-    configAsAny.gasReporter.currency = "USD";
   }
 
   // We don't generate types for js projects


### PR DESCRIPTION
When we [upgraded](https://github.com/NomicFoundation/hardhat/pull/6886) `hardhat-gas-reporter` to v2, the `REPORT_GAS` variable stopped working.

The toolboxes READMEs have this snippet:

```
REPORT_GAS=true npx hardhat test
```

But now gas is reported whether you set the variable or not. The reason is that v2 of `hardhat-gas-reporter` now uses `extendConfig` and sets its options to some default values. `gasReport.enabled` defaults to true, so our code never changes it.

I changed the code so that `enabled` is set using the `REPORT_GAS` envvar only if the **user** config of gas reporter doesn't have an `enabled` field. This also means that gas is **not** reported by default, unlike what happens if you install the plugin manually. This was a conscious decision, both to have the same behavior we used to have, and because I don't think it makes sense to show gas usage by default.

I manually tested this locally with verdaccio and confirmed it works fine.