### PR TITLE
chore: disable the HH3 dep check job

### DIFF
--- a/.github/workflows/check-v3-with-latest-dependencies.yml
+++ b/.github/workflows/check-v3-with-latest-dependencies.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test-without-pnpm-lock-yaml:
+    if: false # disable the job
     name: Test without pnpm-lock.yaml
     strategy:
       matrix:


### PR DESCRIPTION
Until we have a working job we are disabling it.
