### PR TITLE
test: disable test due to infura bug

### DIFF
--- a/packages/hardhat-core/test/internal/hardhat-network/jsonrpc/client.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/jsonrpc/client.ts
@@ -349,7 +349,10 @@ describe("JsonRpcClient", () => {
             );
           });
 
-          it("returns null for non-existent block", async function () {
+          // TODO: re-enable this test once infura fixes the rpc response
+          // of eth_getBlockByNumber to return null instead of returning
+          // an `service temporarily unavailable` error
+          it.skip("returns null for non-existent block", async function () {
             const block = await client.getBlockByNumber(
               forkNumber + 1000n,
               true


### PR DESCRIPTION
Disable the test that `eth_getBlockByNumber` returns null for nonexistant blocks for both infura and alchemy.

We will re-enable it once Infura fixes their bug where they are currently returning an error `service temporarily unavailable` for this case.


