### PR TITLE
fix: code coverage max callstack on load

### DIFF
--- a/.changeset/clever-days-remain.md
+++ b/.changeset/clever-days-remain.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed coverage report when loading data from large test suites ([#7385](https://github.com/NomicFoundation/hardhat/issues/7385))

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -62,14 +62,20 @@ export class CoverageManagerImplementation implements CoverageManager {
   }
 
   public async addData(data: CoverageData): Promise<void> {
-    this.data.push(...data);
+    for (const entry of data) {
+      this.data.push(entry);
+    }
+
     log("Added data", JSON.stringify(data, null, 2));
   }
 
   public async addMetadata(metadata: CoverageMetadata): Promise<void> {
     // NOTE: The received metadata might contain duplicates. We deduplicate it
     // when we generate the report.
-    this.metadata.push(...metadata);
+    for (const entry of metadata) {
+      this.metadata.push(entry);
+    }
+
     log("Added metadata", JSON.stringify(metadata, null, 2));
   }
 
@@ -121,13 +127,13 @@ export class CoverageManagerImplementation implements CoverageManager {
     for (const id of ids) {
       const dataPath = await this.#getDataPath(id);
       const filePaths = await getAllFilesMatching(dataPath);
-      const data = [];
       for (const filePath of filePaths) {
-        const partialData = await readJsonFile<CoverageData>(filePath);
-        data.push(...partialData);
+        const entries = await readJsonFile<CoverageData>(filePath);
+        for (const entry of entries) {
+          this.data.push(entry);
+        }
         log("Loaded data", id, filePath);
       }
-      this.data.push(...data);
     }
   }
 

--- a/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -144,6 +144,43 @@ describe("CoverageManagerImplementation", () => {
     }
   });
 
+  /**
+   * This test was introduced in response to:
+   * https://github.com/NomicFoundation/hardhat/issues/7385
+   *
+   * This test should be monitored for performance in our CI.
+   */
+  it("should load large save data files", async () => {
+    const data1: CoverageData = Array.from({ length: 150_000 }, (_, i) =>
+      (i + 1).toString(),
+    );
+
+    const allMetadata: CoverageMetadata = [];
+
+    for (const item of [...data1]) {
+      allMetadata.push({
+        relativePath: "contracts/test.sol",
+        tag: item,
+        startLine: 1,
+        endLine: 1,
+      });
+    }
+
+    const coverageManager1 = new CoverageManagerImplementation(process.cwd());
+    await coverageManager1.addData(data1);
+    await coverageManager1.saveData(id);
+
+    await coverageManager.loadData(id);
+    const allData = coverageManager.data;
+
+    for (const item of [...data1]) {
+      assert.ok(
+        allData.includes(item),
+        `The loaded data should include ${item}`,
+      );
+    }
+  });
+
   it("should store all the metadata", async () => {
     const metadata1: CoverageMetadata = [
       {

--- a/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -148,6 +148,10 @@ describe("CoverageManagerImplementation", () => {
    * This test was introduced in response to:
    * https://github.com/NomicFoundation/hardhat/issues/7385
    *
+   * The underlying issue was that with enough coverage entries
+   * we were getting issues with conversion to function params,
+   * hence the large array size: `150_000`.
+   *
    * This test should be monitored for performance in our CI.
    */
   it("should load large save data files", async () => {


### PR DESCRIPTION
Replace the splatting conversion of arrays into arguments with for loops.

This allows us to load larger coverage data files.

Resolves https://github.com/NomicFoundation/hardhat/issues/7385.
