### PR TITLE
fix: correct typos

### DIFF
--- a/v-next/hardhat-node-test-reporter/src/error-formatting.ts
+++ b/v-next/hardhat-node-test-reporter/src/error-formatting.ts
@@ -339,7 +339,7 @@ export function formatStackLine({ line, reference }: StackLine): string {
 }
 
 /**
- * This functions normlizes a location string by:
+ * This functions normalizes a location string by:
  * - Turning file URLs into file paths
  * - Turning absolute paths into relative paths if they are inside the current
  *   working directory

--- a/v-next/hardhat/test/internal/hre-initialization.ts
+++ b/v-next/hardhat/test/internal/hre-initialization.ts
@@ -139,7 +139,7 @@ describe("HRE initialization", () => {
           }
         });
 
-        it("should noramlize and return the provided path", async () => {
+        it("should normalize and return the provided path", async () => {
           assert.equal(
             await resolveHardhatConfigPath("other.config.js"),
             await getRealPath("other.config.js"),


### PR DESCRIPTION
`normlizes` → `normalizes`
`noramlize` → `normalize`