### PR TITLE
Fix command injection vulnerability in file opening utility

### DIFF
--- a/v-next/hardhat-ignition/src/internal/utils/open.ts
+++ b/v-next/hardhat-ignition/src/internal/utils/open.ts
@@ -1,21 +1,18 @@
-import { execSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import os from "node:os";
 
 export function open(filePath: string): void {
-  let command: string;
-  switch (os.platform()) {
-    case "win32":
-      command = "start";
-      break;
-    case "darwin":
-      command = "open";
-      break;
-    default:
-      command = "xdg-open";
-  }
-
   try {
-    execSync(`${command} ${filePath}`, { stdio: "ignore" });
+    switch (os.platform()) {
+      case "win32":
+        spawnSync("cmd", ["/c", "start", "", filePath], { stdio: "ignore", windowsHide: true });
+        break;
+      case "darwin":
+        execFileSync("open", [filePath], { stdio: "ignore" });
+        break;
+      default:
+        execFileSync("xdg-open", [filePath], { stdio: "ignore" });
+    }
   } catch {
     // do nothing
   }


### PR DESCRIPTION


**Security Fix**: Replaced unsafe `execSync` with shell command concatenation with secure `execFileSync`/`spawnSync` calls using argument arrays.

### What Changed

- **Before**: `execSync(\`${command} ${filePath}\`)` - vulnerable to command injection via `filePath` parameter
- **After**: Platform-specific secure execution:
  - **Windows**: `spawnSync("cmd", ["/c", "start", "", filePath])`
  - **macOS**: `execFileSync("open", [filePath])`  
  - **Linux**: `execFileSync("xdg-open", [filePath])`

### Why This Matters

The previous implementation concatenated the file path directly into a shell command string, allowing potential command injection if the `filePath` parameter contained shell metacharacters (`;`, `&&`, `|`, `$()`, etc.).

