### PR TITLE
refactor(network-helpers): make toBigInt synchronous and update call sites

### DIFF
--- a/v-next/hardhat-network-helpers/src/internal/conversion.ts
+++ b/v-next/hardhat-network-helpers/src/internal/conversion.ts
@@ -7,7 +7,7 @@ export function toNumber(x: NumberLike): number {
   return Number(toRpcQuantity(x));
 }
 
-export async function toBigInt(x: NumberLike): Promise<bigint> {
+export function toBigInt(x: NumberLike): bigint {
   return toBigIntUtil(toRpcQuantity(x));
 }
 

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/helpers/mine-up-to.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/helpers/mine-up-to.ts
@@ -10,8 +10,8 @@ export async function mineUpTo(
   blockNumber: NumberLike,
   time: Time,
 ): Promise<void> {
-  const normalizedBlockNumber = await toBigInt(blockNumber);
-  const latestHeight = await toBigInt(await time.latestBlock());
+  const normalizedBlockNumber = toBigInt(blockNumber);
+  const latestHeight = toBigInt(await time.latestBlock());
 
   assertLargerThan(normalizedBlockNumber, latestHeight);
 

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase-to.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase-to.ts
@@ -13,7 +13,7 @@ export async function increaseTo(
   timestamp: NumberLike | Date,
   duration: Duration,
 ): Promise<void> {
-  const normalizedTimestamp = await toBigInt(
+  const normalizedTimestamp = toBigInt(
     timestamp instanceof Date
       ? duration.millis(timestamp.valueOf())
       : timestamp,

--- a/v-next/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase.ts
+++ b/v-next/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase.ts
@@ -8,8 +8,8 @@ export async function increase(
   networkHelpers: NetworkHelpers,
   amountInSeconds: NumberLike,
 ): Promise<number> {
-  const normalizedAmount = await toBigInt(amountInSeconds);
-  const latestTimestamp = await toBigInt(await networkHelpers.time.latest());
+  const normalizedAmount = toBigInt(amountInSeconds);
+  const latestTimestamp = toBigInt(await networkHelpers.time.latest());
   const targetTimestamp = latestTimestamp + normalizedAmount;
 
   await provider.request({

--- a/v-next/hardhat-network-helpers/test/network-helpers/mine-up-to.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/mine-up-to.ts
@@ -35,8 +35,8 @@ describe("network-helpers - mineUpTo", () => {
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .BLOCK_NUMBER_SMALLER_THAN_CURRENT,
       {
-        newValue: await toBigInt(initialHeight),
-        currentValue: await toBigInt(initialHeight),
+        newValue: toBigInt(initialHeight),
+        currentValue: toBigInt(initialHeight),
       },
     );
   });
@@ -55,7 +55,7 @@ describe("network-helpers - mineUpTo", () => {
     it("should accept an argument of type ethers's bignumber", async () => {
       const initialHeight = await networkHelpers.time.latestBlock();
 
-      await networkHelpers.mineUpTo((await toBigInt(initialHeight)) + 3n);
+      await networkHelpers.mineUpTo(toBigInt(initialHeight) + 3n);
 
       const endHeight = await networkHelpers.time.latestBlock();
 
@@ -64,7 +64,7 @@ describe("network-helpers - mineUpTo", () => {
 
     it("should accept an argument of type hex string", async () => {
       const initialHeight = await networkHelpers.time.latestBlock();
-      const targetHeight = (await toBigInt(initialHeight)) + 3n;
+      const targetHeight = toBigInt(initialHeight) + 3n;
 
       await networkHelpers.mineUpTo(numberToHexString(targetHeight));
 

--- a/v-next/hardhat-network-helpers/test/time/increase-to.ts
+++ b/v-next/hardhat-network-helpers/test/time/increase-to.ts
@@ -62,7 +62,7 @@ describe("time - increaseTo", () => {
       const initialTimestamp = await time.latest();
       const newTimestamp = initialTimestamp + 3600;
 
-      await time.increaseTo(numberToHexString(await toBigInt(newTimestamp)));
+      await time.increaseTo(numberToHexString(toBigInt(newTimestamp)));
       const endTimestamp = await time.latest();
 
       assert.equal(newTimestamp, endTimestamp);


### PR DESCRIPTION
- Convert internal toBigInt(NumberLike) to a synchronous function and remove unnecessary awaits at all call sites and tests.
- This change eliminates a misleading async signature with no awaits, reduces overhead, and aligns toBigInt with other conversion helpers (toNumber, toRpcQuantity) and with @nomicfoundation/hardhat-utils/bigint which is synchronous.
- Impact: internal-only API change; updated all internal usages and tests accordingly. No external breaking change.