### PR TITLE
Use proxy

### DIFF
--- a/v-next/hardhat-utils/src/request.ts
+++ b/v-next/hardhat-utils/src/request.ts
@@ -347,6 +347,37 @@ export function isValidUrl(url: string): boolean {
   }
 }
 
+/**
+ * Returns the proxy URL from environment variables based on the target URL.
+ * For HTTPS URLs, checks `https_proxy` then `HTTPS_PROXY`.
+ * For HTTP URLs, checks `http_proxy` then `HTTP_PROXY`.
+ * Falls back to the other protocol's proxy if none found.
+ *
+ * @param url The target URL to determine proxy for.
+ * @returns The proxy URL, or `undefined` if none are set.
+ */
+export function getProxyUrl(url: string): string | undefined {
+  const { protocol } = new URL(url);
+
+  if (protocol === "https:") {
+    return (
+      process.env.https_proxy ??
+      process.env.HTTPS_PROXY ??
+      process.env.http_proxy ??
+      process.env.HTTP_PROXY
+    );
+  } else if (protocol === "http:") {
+    return (
+      process.env.http_proxy ??
+      process.env.HTTP_PROXY ??
+      process.env.https_proxy ??
+      process.env.HTTPS_PROXY
+    );
+  }
+
+  return undefined;
+}
+
 export {
   ConnectionRefusedError,
   DispatcherError,

--- a/v-next/hardhat-verify/src/internal/blockscout.ts
+++ b/v-next/hardhat-verify/src/internal/blockscout.ts
@@ -27,12 +27,11 @@ export const BLOCKSCOUT_PROVIDER_NAME: keyof VerificationProvidersConfig =
 const VERIFICATION_STATUS_POLLING_SECONDS = 3;
 
 export class Blockscout implements VerificationProvider {
-  public name: string;
-  public url: string;
-  public apiUrl: string;
-
-  readonly #dispatcher?: Dispatcher;
-  readonly #pollingIntervalMs: number;
+  public readonly name: string;
+  public readonly url: string;
+  public readonly apiUrl: string;
+  public readonly dispatcher?: Dispatcher;
+  public readonly pollingIntervalMs: number;
 
   constructor(blockscoutConfig: {
     name?: string;
@@ -43,8 +42,8 @@ export class Blockscout implements VerificationProvider {
     this.name = blockscoutConfig.name ?? "Blockscout";
     this.url = blockscoutConfig.url;
     this.apiUrl = blockscoutConfig.apiUrl;
-    this.#dispatcher = blockscoutConfig.dispatcher;
-    this.#pollingIntervalMs =
+    this.dispatcher = blockscoutConfig.dispatcher;
+    this.pollingIntervalMs =
       blockscoutConfig.dispatcher !== undefined
         ? 0
         : VERIFICATION_STATUS_POLLING_SECONDS;
@@ -67,7 +66,7 @@ export class Blockscout implements VerificationProvider {
             address,
           },
         },
-        this.#dispatcher,
+        this.dispatcher,
       );
       responseBody =
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -138,7 +137,7 @@ export class Blockscout implements VerificationProvider {
             action: "verifysourcecode",
           },
         },
-        this.#dispatcher,
+        this.dispatcher,
       );
       responseBody =
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -236,7 +235,7 @@ export class Blockscout implements VerificationProvider {
             guid,
           },
         },
-        this.#dispatcher,
+        this.dispatcher,
       );
       responseBody =
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -277,7 +276,7 @@ export class Blockscout implements VerificationProvider {
     );
 
     if (blockscoutResponse.isPending()) {
-      await sleep(this.#pollingIntervalMs);
+      await sleep(this.pollingIntervalMs);
 
       return this.pollVerificationStatus(guid, contractAddress, contractName);
     }

--- a/v-next/hardhat-verify/src/internal/etherscan.ts
+++ b/v-next/hardhat-verify/src/internal/etherscan.ts
@@ -33,14 +33,13 @@ const VERIFICATION_STATUS_POLLING_SECONDS = 3;
 export const ETHERSCAN_API_URL = "https://api.etherscan.io/v2/api";
 
 export class Etherscan implements VerificationProvider {
-  public chainId: string;
-  public name: string;
-  public url: string;
-  public apiUrl: string;
-  public apiKey: string;
-
-  readonly #dispatcher?: Dispatcher;
-  readonly #pollingIntervalMs: number;
+  public readonly chainId: string;
+  public readonly name: string;
+  public readonly url: string;
+  public readonly apiUrl: string;
+  public readonly apiKey: string;
+  public readonly dispatcher?: Dispatcher;
+  public readonly pollingIntervalMs: number;
 
   constructor(etherscanConfig: {
     chainId: number;
@@ -53,8 +52,8 @@ export class Etherscan implements VerificationProvider {
     this.name = etherscanConfig.name ?? "Etherscan";
     this.url = etherscanConfig.url;
     this.apiUrl = ETHERSCAN_API_URL;
-    this.#dispatcher = etherscanConfig.dispatcher;
-    this.#pollingIntervalMs =
+    this.dispatcher = etherscanConfig.dispatcher;
+    this.pollingIntervalMs =
       etherscanConfig.dispatcher !== undefined
         ? 0
         : VERIFICATION_STATUS_POLLING_SECONDS;
@@ -89,7 +88,7 @@ export class Etherscan implements VerificationProvider {
             address,
           },
         },
-        this.#dispatcher,
+        this.dispatcher,
       );
       responseBody =
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -162,7 +161,7 @@ export class Etherscan implements VerificationProvider {
             apikey: this.apiKey,
           },
         },
-        this.#dispatcher,
+        this.dispatcher,
       );
       responseBody =
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -252,7 +251,7 @@ export class Etherscan implements VerificationProvider {
             guid,
           },
         },
-        this.#dispatcher,
+        this.dispatcher,
       );
       responseBody =
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -293,7 +292,7 @@ export class Etherscan implements VerificationProvider {
     );
 
     if (etherscanResponse.isPending()) {
-      await sleep(this.#pollingIntervalMs);
+      await sleep(this.pollingIntervalMs);
 
       return this.pollVerificationStatus(guid, contractAddress, contractName);
     }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -16,6 +16,7 @@ import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { sleep, isObject } from "@nomicfoundation/hardhat-utils/lang";
 import {
   getDispatcher,
+  getProxyUrl,
   isValidUrl,
   postJsonRequest,
   shouldUseProxy,
@@ -273,7 +274,7 @@ export class HttpProvider extends BaseProvider {
 
 /**
  * Gets either a pool or proxy dispatcher depending on the URL and the
- * environment variable `http_proxy`. This function is used internally by
+ * proxy configuration. This function is used internally by
  * `HttpProvider.create` and should not be used directly.
  */
 export async function getHttpDispatcher(
@@ -282,9 +283,11 @@ export async function getHttpDispatcher(
 ): Promise<Dispatcher> {
   let dispatcher: Dispatcher;
 
-  if (process.env.http_proxy !== undefined && shouldUseProxy(url)) {
+  const proxyUrl = shouldUseProxy(url) ? getProxyUrl(url) : undefined;
+
+  if (proxyUrl !== undefined) {
     dispatcher = await getDispatcher(url, {
-      proxy: process.env.http_proxy,
+      proxy: proxyUrl,
       timeout,
     });
   } else {

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
@@ -518,23 +518,44 @@ describe("http-provider", () => {
   describe("getHttpDispatcher", () => {
     const { setEnvVar } = createTestEnvManager();
 
-    it("should return a pool dispatcher if process.env.http_proxy is not set", async () => {
+    it("should return a pool dispatcher when getProxyUrl returns undefined", async () => {
       const dispatcher = await getHttpDispatcher("http://example.com");
 
       assert.equal(dispatcher.constructor.name, "Pool");
     });
 
-    it("should return a pool dispatcher if shouldUseProxy is false", async () => {
+    it("should return a pool dispatcher when shouldUseProxy returns false", async () => {
       setEnvVar("http_proxy", "http://proxy.com");
-      // shouldUseProxy is false for localhost
+      // shouldUseProxy returns false for localhost, so getProxyUrl should return undefined
       const dispatcher = await getHttpDispatcher("http://localhost");
 
       assert.equal(dispatcher.constructor.name, "Pool");
     });
 
-    it("should return a proxy dispatcher if process.env.http_proxy is set and shouldUseProxy is true", async () => {
+    it("should return a proxy dispatcher when http_proxy env var is set", async () => {
       setEnvVar("http_proxy", "http://proxy.com");
       const dispatcher = await getHttpDispatcher("http://example.com");
+
+      assert.equal(dispatcher.constructor.name, "ProxyAgent");
+    });
+
+    it("should return a proxy dispatcher when HTTP_PROXY env var is set", async () => {
+      setEnvVar("HTTP_PROXY", "http://proxy.com");
+      const dispatcher = await getHttpDispatcher("http://example.com");
+
+      assert.equal(dispatcher.constructor.name, "ProxyAgent");
+    });
+
+    it("should return a proxy dispatcher when https_proxy env var is set", async () => {
+      setEnvVar("https_proxy", "http://proxy.com");
+      const dispatcher = await getHttpDispatcher("https://example.com");
+
+      assert.equal(dispatcher.constructor.name, "ProxyAgent");
+    });
+
+    it("should return a proxy dispatcher when HTTPS_PROXY env var is set", async () => {
+      setEnvVar("HTTPS_PROXY", "http://proxy.com");
+      const dispatcher = await getHttpDispatcher("https://example.com");
 
       assert.equal(dispatcher.constructor.name, "ProxyAgent");
     });


### PR DESCRIPTION
Improves proxy support in `hardhat-verify` by adding automatic proxy detection from environment variables and fixing `getHttpDispatcher` to properly handle both lowercase and uppercase proxy environment variables.

Based on https://github.com/NomicFoundation/hardhat/pull/7390.