### PR TITLE
Triage label is added for external issues regardless of other status

### DIFF
--- a/.github/workflows/add-label-to-new-issue.yml
+++ b/.github/workflows/add-label-to-new-issue.yml
@@ -22,21 +22,13 @@ jobs:
               issue_number: context.issue.number
             });
 
-            const statusLabel = issue.data.labels.find(({ name }) =>
-              name.startsWith("status:")
-            );
-
-            if (statusLabel === undefined) {
-              console.log("Author association:", issue.data.author_association);
-              const isCollaborator = ["OWNER", "MEMBER", "COLLABORATOR"].includes(issue.data.author_association)
-              if (!isCollaborator) {
-                await github.rest.issues.addLabels({
-                  owner: context.issue.owner,
-                  repo: context.issue.repo,
-                  issue_number: context.issue.number,
-                  labels: ["status:triaging"]
-                });
-              }
-            } else {
-              console.log(`Issue already has a status: ${statusLabel.name}`);
+            console.log("Author association:", issue.data.author_association);
+            const isCollaborator = ["OWNER", "MEMBER", "COLLABORATOR"].includes(issue.data.author_association)
+            if (!isCollaborator) {
+              await github.rest.issues.addLabels({
+                owner: context.issue.owner,
+                repo: context.issue.repo,
+                issue_number: context.issue.number,
+                labels: ["status:triaging"]
+              });
             }


### PR DESCRIPTION
Updated issue template for features automatically adds label `status:needs-priority` to mark the features for planning
This prevents external features to get the triage label as well
This PR removes the check for existing status labels and assigns triaging to all external issues.