### PR TITLE
fix: update Hardhat peer dependencies

### DIFF
--- a/.changeset/grumpy-geckos-fold.md
+++ b/.changeset/grumpy-geckos-fold.md
@@ -1,0 +1,7 @@
+---
+"hardhat": patch
+"@nomicfoundation/hardhat-utils": patch
+"@nomicfoundation/hardhat-zod-utils": patch
+---
+
+Fixed peer dependencies for Hardhat so `rpc` utils can be loaded ([#7415](https://github.com/NomicFoundation/hardhat/issues/7415))


### PR DESCRIPTION
The refactor for moving rpc utils to zod utils intentionally did not have a changeset, this was a mistake.

This commit adds a changeset, that when merged will bump up and release new versions of `hardhat-utils` and `hardhat-zod-utils`. The release can then set the peer dependencies of Hardhat to require those changed APIs.

Resolves #7415.