### PR TITLE
add configVariable support for test.solidity.forking config

### DIFF
--- a/.changeset/red-readers-switch.md
+++ b/.changeset/red-readers-switch.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add configVariable support for test.solidity.forking config

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -1,6 +1,14 @@
 import type { HardhatUserConfig } from "../../../config.js";
-import type { HardhatConfig } from "../../../types/config.js";
+import type {
+  ConfigurationVariableResolver,
+  HardhatConfig,
+  ResolvedConfigurationVariable,
+} from "../../../types/config.js";
 import type { HardhatUserConfigValidationError } from "../../../types/hooks.js";
+import type {
+  SolidityTestForkingConfig,
+  SolidityTestUserConfig,
+} from "../../../types/test.js";
 
 import path from "node:path";
 
@@ -8,6 +16,8 @@ import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 import { resolveFromRoot } from "@nomicfoundation/hardhat-utils/path";
 import {
   conditionalUnionType,
+  sensitiveStringSchema,
+  sensitiveUrlSchema,
   validateUserConfigZodType,
 } from "@nomicfoundation/hardhat-zod-utils";
 import { z } from "zod";
@@ -49,9 +59,9 @@ const solidityTestUserConfigType = z.object({
     .optional(),
   forking: z
     .object({
-      url: z.string().optional(),
+      url: z.optional(sensitiveUrlSchema),
       blockNumber: z.bigint().optional(),
-      rpcEndpoints: z.record(z.string()).optional(),
+      rpcEndpoints: z.record(sensitiveStringSchema).optional(),
     })
     .optional(),
   invariant: z
@@ -88,6 +98,32 @@ const userConfigType = z.object({
     .optional(),
 });
 
+export function resolveSolidityTestForkingConfig(
+  forkingUserConfig: SolidityTestUserConfig["forking"],
+  resolveConfigurationVariable: ConfigurationVariableResolver,
+): SolidityTestForkingConfig | undefined {
+  if (forkingUserConfig === undefined) {
+    return undefined;
+  }
+
+  const resolvedRpcEndpoints: Record<string, ResolvedConfigurationVariable> =
+    {};
+  if (forkingUserConfig.rpcEndpoints !== undefined) {
+    for (const [name, url] of Object.entries(forkingUserConfig.rpcEndpoints)) {
+      resolvedRpcEndpoints[name] = resolveConfigurationVariable(url);
+    }
+  }
+
+  return {
+    ...forkingUserConfig,
+    url:
+      forkingUserConfig.url !== undefined
+        ? resolveConfigurationVariable(forkingUserConfig.url)
+        : undefined,
+    rpcEndpoints: resolvedRpcEndpoints,
+  };
+}
+
 export function validateSolidityTestUserConfig(
   userConfig: unknown,
 ): HardhatUserConfigValidationError[] {
@@ -97,6 +133,7 @@ export function validateSolidityTestUserConfig(
 export async function resolveSolidityTestUserConfig(
   userConfig: HardhatUserConfig,
   resolvedConfig: HardhatConfig,
+  resolveConfigurationVariable: ConfigurationVariableResolver,
 ): Promise<HardhatConfig> {
   let testsPath = userConfig.paths?.tests;
 
@@ -106,9 +143,15 @@ export async function resolveSolidityTestUserConfig(
 
   const defaultRpcCachePath = path.join(resolvedConfig.paths.cache, "edr");
 
+  const resolvedForking = resolveSolidityTestForkingConfig(
+    userConfig.test?.solidity?.forking,
+    resolveConfigurationVariable,
+  );
+
   const solidityTest = {
     rpcCachePath: defaultRpcCachePath,
     ...userConfig.test?.solidity,
+    forking: resolvedForking,
   };
 
   return {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -29,19 +29,19 @@ function hexStringToBuffer(hexString: string): Buffer {
 }
 
 export function solidityTestConfigToRunOptions(
-  config: SolidityTestConfig,
+  config: SolidityTestConfig
 ): RunOptions {
   return config;
 }
 
-export function solidityTestConfigToSolidityTestRunnerConfigArgs(
+export async function solidityTestConfigToSolidityTestRunnerConfigArgs(
   chainType: ChainType,
   projectRoot: string,
   config: SolidityTestConfig,
   verbosity: number,
   observability?: ObservabilityConfig,
-  testPattern?: string,
-): SolidityTestRunnerConfigArgs {
+  testPattern?: string
+): Promise<SolidityTestRunnerConfigArgs> {
   const fsPermissions: PathPermission[] | undefined = [
     config.fsPermissions?.readWriteFile?.map((p) => ({
       access: FsAccessPermission.ReadWriteFile,
@@ -98,9 +98,22 @@ export function solidityTestConfigToSolidityTestRunnerConfigArgs(
 
   const blockDifficulty = config.prevRandao;
 
-  const ethRpcUrl = config.forking?.url;
+  let ethRpcUrl: string | undefined;
+  if (config.forking?.url !== undefined) {
+    ethRpcUrl = await config.forking.url.get();
+  }
+
   const forkBlockNumber = config.forking?.blockNumber;
-  const rpcEndpoints = config.forking?.rpcEndpoints;
+
+  let rpcEndpoints: Record<string, string> | undefined;
+  if (config.forking?.rpcEndpoints !== undefined) {
+    rpcEndpoints = {};
+    for (const [name, configValue] of Object.entries(
+      config.forking.rpcEndpoints
+    )) {
+      rpcEndpoints[name] = await configValue.get();
+    }
+  }
 
   return {
     projectRoot,
@@ -135,7 +148,7 @@ export function isTestSuiteArtifact(artifact: Artifact): boolean {
 export function warnDeprecatedTestFail(
   artifact: Artifact,
   sourceNameToUserSourceName: Map<string, string>,
-  colorizer: Colorizer = chalk,
+  colorizer: Colorizer = chalk
 ): void {
   const abi: Abi = JSON.parse(artifact.contract.abi);
 
@@ -147,7 +160,7 @@ export function warnDeprecatedTestFail(
     ) {
       const formattedLocation = formatArtifactId(
         artifact.id,
-        sourceNameToUserSourceName,
+        sourceNameToUserSourceName
       );
       const warningMessage = `${colorizer.yellow("Warning")}: ${name} The support for the prefix \`testFail*\` has been removed. Consider using \`vm.expectRevert()\` for testing reverts in ${formattedLocation}\n`;
 

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/hook-handlers/config.ts
@@ -19,7 +19,11 @@ export default async (): Promise<Partial<ConfigHooks>> => {
         resolveConfigurationVariable,
       );
 
-      return resolveSolidityTestUserConfig(userConfig, resolvedConfig);
+      return resolveSolidityTestUserConfig(
+        userConfig,
+        resolvedConfig,
+        resolveConfigurationVariable,
+      );
     },
   };
 

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -133,7 +133,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   }
 
   const config: SolidityTestRunnerConfigArgs =
-    solidityTestConfigToSolidityTestRunnerConfigArgs(
+    await solidityTestConfigToSolidityTestRunnerConfigArgs(
       chainType,
       hre.config.paths.root,
       solidityTestConfig,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -1,4 +1,8 @@
 import "../../../types/config.js";
+import type {
+  SensitiveString,
+  ResolvedConfigurationVariable,
+} from "../../../types/config.js";
 
 declare module "../../../types/config.js" {
   export interface TestPathsUserConfig {
@@ -34,9 +38,9 @@ declare module "../../../types/test.js" {
     blockGasLimit?: bigint | false;
 
     forking?: {
-      url?: string;
+      url?: SensitiveString;
       blockNumber?: bigint;
-      rpcEndpoints?: Record<string, string>;
+      rpcEndpoints?: Record<string, SensitiveString>;
     };
 
     fuzz?: {
@@ -66,9 +70,16 @@ declare module "../../../types/test.js" {
     solidity?: SolidityTestUserConfig;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface -- This could be an extension point
-  export interface SolidityTestConfig extends SolidityTestUserConfig {}
+  export interface SolidityTestForkingConfig {
+    url?: ResolvedConfigurationVariable;
+    blockNumber?: bigint;
+    rpcEndpoints?: Record<string, ResolvedConfigurationVariable>;
+  }
 
+  export interface SolidityTestConfig
+    extends Omit<SolidityTestUserConfig, "forking"> {
+    forking?: SolidityTestForkingConfig;
+  }
   export interface HardhatTestConfig {
     solidity: SolidityTestConfig;
   }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

#7403 
This PR adds support for `configVariable` to the `test.solidity.forking` configuration.

Key changes:
- Updated the forking configuration types:
  - `url?: string;` is now `url?: SensitiveString;`
  - `rpcEndpoints?: Record<string, string>;` is now `rpcEndpoints?: Record<string, SensitiveString>;`
  
- Updated the Zod validation to support the new `SensitiveString` type.
- Change the `solidityTestConfigToSolidityTestRunnerConfigArgs` function to `async` to support resolving `configVariable` values inside it.