### PR TITLE
fix: prevent production keystore access during tests in configuration-variables

### DIFF
--- a/v-next/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
+++ b/v-next/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
@@ -45,10 +45,12 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
 
       // Then, if the development keystore does not have the key and `fetchValue` is not called from a test,
       // attempt to retrieve the value from the production keystore.
-      value = await getValue(context, variable, false, onlyAllowDevKeystore);
+      if (!onlyAllowDevKeystore) {
+        value = await getValue(context, variable, false, onlyAllowDevKeystore);
 
-      if (value !== undefined) {
-        return value;
+        if (value !== undefined) {
+          return value;
+        }
       }
 
       return next(context, variable);
@@ -61,6 +63,11 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
     isDevKeystore: boolean,
     onlyAllowDevKeystore: boolean,
   ): Promise<string | undefined> {
+    // In test mode, never access the production keystore
+    if (onlyAllowDevKeystore && !isDevKeystore) {
+      return undefined;
+    }
+
     let keystoreLoader = isDevKeystore ? keystoreLoaderDev : keystoreLoaderProd;
     let masterKey = isDevKeystore ? masterKeyDev : masterKeyProd;
 


### PR DESCRIPTION
When running tests (HH_TEST === "true"), we must avoid any interaction with the production keystore to prevent password prompts. This change:
- Skips the production keystore fallback in fetchValue when in test mode.
- Adds an early return in getValue for the prod path when tests are running, preventing loader initialization and password requests.


This aligns behavior with the in-file comment (“only dev keystore to avoid prompting for the production keystore password”) and avoids unintended prompts. CI bypass remains intact; non-test behavior is unchanged.