### PR TITLE
Collect and display gas statistics on JavaScript/TypeScript tests

### DIFF
--- a/v-next/hardhat-mocha/package.json
+++ b/v-next/hardhat-mocha/package.json
@@ -13,7 +13,8 @@
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js",
-    "./coverage": "./dist/src/coverage.js"
+    "./coverage": "./dist/src/coverage.js",
+    "./gas-stats": "./dist/src/gas-stats.js"
   },
   "keywords": [
     "ethereum",

--- a/v-next/hardhat-mocha/src/gas-stats.ts
+++ b/v-next/hardhat-mocha/src/gas-stats.ts
@@ -1,0 +1,7 @@
+import { markTestWorkerDone } from "hardhat/internal/gas-analytics";
+
+export const mochaHooks = {
+  async afterAll(): Promise<void> {
+    await markTestWorkerDone("mocha");
+  },
+};

--- a/v-next/hardhat-mocha/src/task-action.ts
+++ b/v-next/hardhat-mocha/src/task-action.ts
@@ -8,10 +8,15 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { setGlobalOptionsAsEnvVariables } from "@nomicfoundation/hardhat-utils/env";
 import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
 import {
-  markTestRunDone,
-  markTestRunStart,
-  markTestWorkerDone,
+  markTestRunStart as initCoverage,
+  markTestWorkerDone as saveCoverageData,
+  markTestRunDone as reportCoverage,
 } from "hardhat/internal/coverage";
+import {
+  markTestRunStart as initGasStats,
+  markTestWorkerDone as saveGasStats,
+  markTestRunDone as reportGasStats,
+} from "hardhat/internal/gas-analytics";
 
 interface TestActionArguments {
   testFiles: string[];
@@ -82,6 +87,15 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
       hre.config.test.mocha.require.push(coverage.href);
     }
 
+    if (hre.globalOptions.gasStats === true) {
+      const gasStats = new URL(
+        import.meta.resolve("@nomicfoundation/hardhat-mocha/gas-stats"),
+      );
+
+      hre.config.test.mocha.require = hre.config.test.mocha.require ?? [];
+      hre.config.test.mocha.require.push(gasStats.href);
+    }
+
     process.env.NODE_OPTIONS = imports
       .map((href) => `--import "${href}"`)
       .join(" ");
@@ -120,7 +134,8 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   // which supports both ESM and CJS
   await mocha.loadFilesAsync();
 
-  await markTestRunStart("mocha");
+  await initCoverage("mocha");
+  await initGasStats("mocha");
 
   const testFailures = await new Promise<number>((resolve) => {
     mocha.run(resolve);
@@ -128,10 +143,12 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
   if (hre.config.test.mocha.parallel !== true) {
     // NOTE: We execute mocha tests in the main process.
-    await markTestWorkerDone("mocha");
+    await saveCoverageData("mocha");
+    await saveGasStats("mocha");
   }
   // NOTE: This might print a coverage report.
-  await markTestRunDone("mocha");
+  await reportCoverage("mocha");
+  await reportGasStats("mocha");
 
   if (testFailures > 0) {
     process.exitCode = 1;

--- a/v-next/hardhat-node-test-runner/package.json
+++ b/v-next/hardhat-node-test-runner/package.json
@@ -13,7 +13,8 @@
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js",
-    "./coverage": "./dist/src/coverage.js"
+    "./coverage": "./dist/src/coverage.js",
+    "./gas-stats": "./dist/src/gas-stats.js"
   },
   "keywords": [
     "ethereum",

--- a/v-next/hardhat-node-test-runner/src/gas-stats.ts
+++ b/v-next/hardhat-node-test-runner/src/gas-stats.ts
@@ -1,0 +1,7 @@
+import { after } from "node:test";
+
+import { markTestWorkerDone } from "hardhat/internal/gas-analytics";
+
+after(async () => {
+  await markTestWorkerDone("nodejs");
+});

--- a/v-next/hardhat-node-test-runner/src/task-action.ts
+++ b/v-next/hardhat-node-test-runner/src/task-action.ts
@@ -10,7 +10,14 @@ import { hardhatTestReporter } from "@nomicfoundation/hardhat-node-test-reporter
 import { setGlobalOptionsAsEnvVariables } from "@nomicfoundation/hardhat-utils/env";
 import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
 import { createNonClosingWriter } from "@nomicfoundation/hardhat-utils/stream";
-import { markTestRunStart, markTestRunDone } from "hardhat/internal/coverage";
+import {
+  markTestRunStart as initCoverage,
+  markTestRunDone as reportCoverage,
+} from "hardhat/internal/coverage";
+import {
+  markTestRunStart as initGasStats,
+  markTestRunDone as reportGasStats,
+} from "hardhat/internal/gas-analytics";
 
 interface TestActionArguments {
   testFiles: string[];
@@ -85,6 +92,15 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
     imports.push(coverage.href);
   }
 
+  if (hre.globalOptions.gasStats === true) {
+    const gasStats = new URL(
+      import.meta.resolve(
+        "@nomicfoundation/hardhat-node-test-runner/gas-stats",
+      ),
+    );
+    imports.push(gasStats.href);
+  }
+
   process.env.NODE_OPTIONS = imports
     .map((href) => `--import "${href}"`)
     .join(" ");
@@ -130,12 +146,14 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
     return failures;
   }
 
-  await markTestRunStart("nodejs");
+  await initCoverage("nodejs");
+  await initGasStats("nodejs");
 
   const testFailures = await runTests();
 
   // NOTE: This might print a coverage report.
-  await markTestRunDone("nodejs");
+  await reportCoverage("nodejs");
+  await reportGasStats("nodejs");
 
   if (testFailures > 0) {
     process.exitCode = 1;

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -23,6 +23,7 @@
     "./env": "./dist/src/env.js",
     "./error": "./dist/src/error.js",
     "./eth": "./dist/src/eth.js",
+    "./format": "./dist/src/format.js",
     "./fs": "./dist/src/fs.js",
     "./global-dir": "./dist/src/global-dir.js",
     "./hex": "./dist/src/hex.js",

--- a/v-next/hardhat-utils/src/format.ts
+++ b/v-next/hardhat-utils/src/format.ts
@@ -1,0 +1,89 @@
+import { getStringWidth } from "./internal/format.js";
+
+/**
+ * Formats a set of rows into a Markdown table string, with optional header and
+ * footer rows.
+ *
+ * @param headerRow An optional row of column headers. If provided, a Markdown
+ * divider row is inserted after it.
+ * @param rows The main body rows of the table. Each inner array represents one
+ * row.
+ * @param footerRow An optional row of column footers. If provided, a Markdown
+ * divider row is inserted before it.
+ * @returns The formatted Markdown table as a string, ready to be rendered.
+ *
+ * @example
+ * ```ts
+ * formatMarkdownTable(
+ *   ["Name", "Age"],
+ *   [["Alice", "30"], ["Bob", "25"]],
+ *   ["Average", "27.5"]
+ * );
+ *
+ * // =>
+ * // | Name   | Age |
+ * // | ------ | --- |
+ * // | Alice  | 30  |
+ * // | Bob    | 25  |
+ * // | ------ | --- |
+ * // | Average| 27.5|
+ * ```
+ */
+export function formatMarkdownTable(
+  headerRow: string[] | undefined,
+  rows: string[][],
+  footerRow: string[] | undefined,
+): string {
+  const widths: number[] = [];
+
+  const allRows: string[][] = [];
+  if (headerRow !== undefined) {
+    allRows.push([...headerRow]);
+  }
+
+  for (const row of rows) {
+    allRows.push([...row]);
+  }
+
+  if (footerRow !== undefined) {
+    allRows.push([...footerRow]);
+  }
+
+  // Calculate maximum width for each column
+  for (const row of allRows) {
+    for (let i = 0; i < row.length; i++) {
+      while (i >= widths.length) {
+        widths.push(0);
+      }
+      widths[i] = Math.max(widths[i], getStringWidth(row[i]));
+    }
+  }
+
+  // Ensure all rows have the same number of columns
+  for (const row of allRows) {
+    while (row.length < widths.length) {
+      row.push("");
+    }
+  }
+
+  const dividerRow = widths.map((width) => "-".repeat(width));
+
+  if (headerRow !== undefined) {
+    allRows.splice(1, 0, dividerRow);
+  }
+
+  if (footerRow !== undefined) {
+    allRows.splice(allRows.length - 1, 0, dividerRow);
+  }
+
+  allRows.forEach((row) => {
+    for (let i = 0; i < row.length; i++) {
+      const displayWidth = getStringWidth(row[i]);
+      const actualLength = row[i].length;
+      // Adjust padding to account for difference between display width and actual length
+      row[i] = row[i].padEnd(widths[i] + actualLength - displayWidth);
+    }
+  });
+
+  return allRows.map((row) => `| ${row.join(" | ")} |`).join("\n");
+}

--- a/v-next/hardhat-utils/src/format.ts
+++ b/v-next/hardhat-utils/src/format.ts
@@ -1,56 +1,52 @@
 import { getStringWidth } from "./internal/format.js";
 
+export type TableRow = string[];
+export interface TableDivider {
+  type: "divider";
+}
+export type TableItem = TableRow | TableDivider;
+
+export const divider: TableDivider = { type: "divider" };
+
 /**
- * Formats a set of rows into a Markdown table string, with optional header and
- * footer rows.
+ * Formats an array of rows and dividers into a table string.
  *
- * @param headerRow An optional row of column headers. If provided, a Markdown
- * divider row is inserted after it.
- * @param rows The main body rows of the table. Each inner array represents one
- * row.
- * @param footerRow An optional row of column footers. If provided, a Markdown
- * divider row is inserted before it.
- * @returns The formatted Markdown table as a string, ready to be rendered.
+ * @param items An array of table rows (string arrays) and dividers.
+ * Dividers are objects with type: "divider" and will be rendered as table dividers.
+ * @returns The formatted table as a string, ready to be rendered.
  *
  * @example
  * ```ts
- * formatMarkdownTable(
+ * formatTable([
  *   ["Name", "Age"],
- *   [["Alice", "30"], ["Bob", "25"]],
+ *   divider,
+ *   ["Alice", "30"],
+ *   ["Bob", "25"],
+ *   divider,
  *   ["Average", "27.5"]
- * );
+ * ]);
  *
  * // =>
- * // | Name   | Age |
- * // | ------ | --- |
- * // | Alice  | 30  |
- * // | Bob    | 25  |
- * // | ------ | --- |
- * // | Average| 27.5|
+ * // | Name    | Age  |
+ * // | ------- | ---- |
+ * // | Alice   | 30   |
+ * // | Bob     | 25   |
+ * // | ------- | ---- |
+ * // | Average | 27.5 |
  * ```
  */
-export function formatMarkdownTable(
-  headerRow: string[] | undefined,
-  rows: string[][],
-  footerRow: string[] | undefined,
-): string {
+export function formatTable(items: TableItem[]): string {
   const widths: number[] = [];
+  const dataRows: string[][] = [];
 
-  const allRows: string[][] = [];
-  if (headerRow !== undefined) {
-    allRows.push([...headerRow]);
-  }
-
-  for (const row of rows) {
-    allRows.push([...row]);
-  }
-
-  if (footerRow !== undefined) {
-    allRows.push([...footerRow]);
+  for (const item of items) {
+    if (Array.isArray(item)) {
+      dataRows.push([...item]);
+    }
   }
 
   // Calculate maximum width for each column
-  for (const row of allRows) {
+  for (const row of dataRows) {
     for (let i = 0; i < row.length; i++) {
       while (i >= widths.length) {
         widths.push(0);
@@ -59,24 +55,23 @@ export function formatMarkdownTable(
     }
   }
 
-  // Ensure all rows have the same number of columns
-  for (const row of allRows) {
-    while (row.length < widths.length) {
-      row.push("");
+  const dividerRow = widths.map((width) => "-".repeat(width));
+  const outputRows: string[][] = [];
+
+  for (const item of items) {
+    if (Array.isArray(item)) {
+      const row = [...item];
+      // Pad the row to match the number of columns
+      while (row.length < widths.length) {
+        row.push("");
+      }
+      outputRows.push(row);
+    } else {
+      outputRows.push([...dividerRow]);
     }
   }
 
-  const dividerRow = widths.map((width) => "-".repeat(width));
-
-  if (headerRow !== undefined) {
-    allRows.splice(1, 0, dividerRow);
-  }
-
-  if (footerRow !== undefined) {
-    allRows.splice(allRows.length - 1, 0, dividerRow);
-  }
-
-  allRows.forEach((row) => {
+  outputRows.forEach((row) => {
     for (let i = 0; i < row.length; i++) {
       const displayWidth = getStringWidth(row[i]);
       const actualLength = row[i].length;
@@ -85,5 +80,5 @@ export function formatMarkdownTable(
     }
   });
 
-  return allRows.map((row) => `| ${row.join(" | ")} |`).join("\n");
+  return outputRows.map((row) => `| ${row.join(" | ")} |`).join("\n");
 }

--- a/v-next/hardhat-utils/src/internal/format.ts
+++ b/v-next/hardhat-utils/src/internal/format.ts
@@ -1,0 +1,5 @@
+export function getStringWidth(str: string): number {
+  // Remove ANSI escape codes if present
+  const stripped = str.replace(/\u001b\[[0-9;]*m/g, "");
+  return stripped.length;
+}

--- a/v-next/hardhat-utils/src/internal/panic-errors.ts
+++ b/v-next/hardhat-utils/src/internal/panic-errors.ts
@@ -1,0 +1,23 @@
+export function panicErrorCodeToReason(errorCode: bigint): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- we are only covering some of the integer range
+  switch (errorCode) {
+    case 0x1n:
+      return "Assertion error";
+    case 0x11n:
+      return "Arithmetic operation overflowed outside of an unchecked block";
+    case 0x12n:
+      return "Division or modulo division by zero";
+    case 0x21n:
+      return "Tried to convert a value into an enum, but the value was too big or negative";
+    case 0x22n:
+      return "Incorrectly encoded storage byte array";
+    case 0x31n:
+      return ".pop() was called on an empty array";
+    case 0x32n:
+      return "Array accessed at an out-of-bounds or negative index";
+    case 0x41n:
+      return "Too much memory was allocated, or an array was created that is too large";
+    case 0x51n:
+      return "Called a zero-initialized variable of internal function type";
+  }
+}

--- a/v-next/hardhat-utils/src/panic-errors.ts
+++ b/v-next/hardhat-utils/src/panic-errors.ts
@@ -1,5 +1,19 @@
 import { numberToHexString } from "./hex.js";
+import { panicErrorCodeToReason } from "./internal/panic-errors.js";
 
+/**
+ * Converts a Solidity panic error code into a human-readable revert message.
+ *
+ * Solidity defines a set of standardized panic codes (0x01, 0x11, etc.)
+ * that represent specific runtime errors (e.g. arithmetic overflow).
+ * This function looks up the corresponding reason string and formats it
+ * into a message similar to what clients like Hardhat or ethers.js display.
+ *
+ * @param errorCode The panic error code returned by the EVM as a bigint.
+ * @returns A formatted message string:
+ * - `"reverted with panic code <hex> (<reason>)"` if the code is recognized.
+ * - `"reverted with unknown panic code <hex>"` if the code is not recognized.
+ */
 export function panicErrorCodeToMessage(errorCode: bigint): string {
   const reason = panicErrorCodeToReason(errorCode);
 
@@ -8,28 +22,4 @@ export function panicErrorCodeToMessage(errorCode: bigint): string {
   }
 
   return `reverted with unknown panic code ${numberToHexString(errorCode)}`;
-}
-
-function panicErrorCodeToReason(errorCode: bigint): string | undefined {
-  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- we are only covering some of the integer range
-  switch (errorCode) {
-    case 0x1n:
-      return "Assertion error";
-    case 0x11n:
-      return "Arithmetic operation overflowed outside of an unchecked block";
-    case 0x12n:
-      return "Division or modulo division by zero";
-    case 0x21n:
-      return "Tried to convert a value into an enum, but the value was too big or negative";
-    case 0x22n:
-      return "Incorrectly encoded storage byte array";
-    case 0x31n:
-      return ".pop() was called on an empty array";
-    case 0x32n:
-      return "Array accessed at an out-of-bounds or negative index";
-    case 0x41n:
-      return "Too much memory was allocated, or an array was created that is too large";
-    case 0x51n:
-      return "Called a zero-initialized variable of internal function type";
-  }
 }

--- a/v-next/hardhat-utils/test/format.ts
+++ b/v-next/hardhat-utils/test/format.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { formatMarkdownTable } from "../src/format.js";
+
+describe("format", () => {
+  describe("formatMarkdownTable", () => {
+    it("Should create a basic table with header and rows", () => {
+      const header = ["Name", "Age", "City"];
+      const rows = [
+        ["Alice", "25", "New York"],
+        ["Bob", "30", "London"],
+      ];
+      const result = formatMarkdownTable(header, rows, undefined);
+
+      assert.equal(
+        result,
+        `
+| Name  | Age | City     |
+| ----- | --- | -------- |
+| Alice | 25  | New York |
+| Bob   | 30  | London   |`.trim(),
+      );
+    });
+
+    it("Should create a table without header", () => {
+      const rows = [
+        ["Alice", "25", "New York"],
+        ["Bob", "30", "London"],
+      ];
+      const result = formatMarkdownTable(undefined, rows, undefined);
+
+      assert.equal(
+        result,
+        `
+| Alice | 25 | New York |
+| Bob   | 30 | London   |`.trim(),
+      );
+    });
+
+    it("Should create a table with header and footer", () => {
+      const header = ["Name", "Age"];
+      const rows = [
+        ["Alice", "25"],
+        ["Bob", "30"],
+      ];
+      const footer = ["Total", "55"];
+      const result = formatMarkdownTable(header, rows, footer);
+
+      assert.equal(
+        result,
+        `
+| Name  | Age |
+| ----- | --- |
+| Alice | 25  |
+| Bob   | 30  |
+| ----- | --- |
+| Total | 55  |`.trim(),
+      );
+    });
+
+    it("Should create a table with only footer", () => {
+      const rows = [
+        ["Alice", "25"],
+        ["Bob", "30"],
+      ];
+      const footer = ["Total", "55"];
+      const result = formatMarkdownTable(undefined, rows, footer);
+
+      assert.equal(
+        result,
+        `
+| Alice | 25 |
+| Bob   | 30 |
+| ----- | -- |
+| Total | 55 |`.trim(),
+      );
+    });
+
+    it("Should handle varying column widths", () => {
+      const header = ["A", "Very Long Header", "C"];
+      const rows = [
+        ["Short", "B", "Very Long Content"],
+        ["X", "Y", "Z"],
+      ];
+      const result = formatMarkdownTable(header, rows, undefined);
+
+      assert.equal(
+        result,
+        `
+| A     | Very Long Header | C                 |
+| ----- | ---------------- | ----------------- |
+| Short | B                | Very Long Content |
+| X     | Y                | Z                 |`.trim(),
+      );
+    });
+
+    it("Should handle empty rows", () => {
+      const header = ["A", "B", "C"];
+      const rows: string[][] = [];
+      const result = formatMarkdownTable(header, rows, undefined);
+
+      assert.equal(
+        result,
+        `
+| A | B | C |
+| - | - | - |`.trim(),
+      );
+    });
+
+    it("Should handle rows with different lengths", () => {
+      const header = ["A", "B", "C", "D"];
+      const rows = [
+        ["1", "2"],
+        ["3", "4", "5"],
+        ["6", "7", "8", "9"],
+      ];
+      const result = formatMarkdownTable(header, rows, undefined);
+
+      assert.equal(
+        result,
+        `
+| A | B | C | D |
+| - | - | - | - |
+| 1 | 2 |   |   |
+| 3 | 4 | 5 |   |
+| 6 | 7 | 8 | 9 |`.trim(),
+      );
+    });
+
+    it("Should handle single column table", () => {
+      const header = ["Items"];
+      const rows = [["Apple"], ["Banana"], ["Cherry"]];
+      const result = formatMarkdownTable(header, rows, undefined);
+
+      assert.equal(
+        result,
+        `
+| Items  |
+| ------ |
+| Apple  |
+| Banana |
+| Cherry |`.trim(),
+      );
+    });
+
+    it("Should handle empty strings in cells", () => {
+      const header = ["Name", "Value"];
+      const rows = [
+        ["", "123"],
+        ["Test", ""],
+        ["", ""],
+      ];
+      const result = formatMarkdownTable(header, rows, undefined);
+
+      assert.equal(
+        result,
+        `
+| Name | Value |
+| ---- | ----- |
+|      | 123   |
+| Test |       |
+|      |       |`.trim(),
+      );
+    });
+
+    it("Should handle ANSI escape codes in content", () => {
+      const header = ["Status", "Message"];
+      const rows = [
+        ["\u001b[32mPASS\u001b[0m", "Test passed"],
+        ["\u001b[31mFAIL\u001b[0m", "Test failed"],
+      ];
+      const result = formatMarkdownTable(header, rows, undefined);
+
+      assert.equal(
+        result,
+        `
+| Status | Message     |
+| ------ | ----------- |
+| \u001b[32mPASS\u001b[0m   | Test passed |
+| \u001b[31mFAIL\u001b[0m   | Test failed |`.trim(),
+      );
+    });
+
+    it("Should handle mixed ANSI and regular content", () => {
+      const rows = [
+        ["Normal", "\u001b[1mBold\u001b[0m", "Regular"],
+        ["\u001b[33mYellow\u001b[0m", "Plain", "\u001b[4mUnderline\u001b[0m"],
+      ];
+      const result = formatMarkdownTable(undefined, rows, undefined);
+
+      assert.equal(
+        result,
+        `
+| Normal | \u001b[1mBold\u001b[0m  | Regular   |
+| \u001b[33mYellow\u001b[0m | Plain | \u001b[4mUnderline\u001b[0m |`.trim(),
+      );
+    });
+  });
+});

--- a/v-next/hardhat-utils/test/format.ts
+++ b/v-next/hardhat-utils/test/format.ts
@@ -1,17 +1,18 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { formatMarkdownTable } from "../src/format.js";
+import { formatTable, divider } from "../src/format.js";
 
 describe("format", () => {
-  describe("formatMarkdownTable", () => {
-    it("Should create a basic table with header and rows", () => {
-      const header = ["Name", "Age", "City"];
+  describe("formatTable", () => {
+    it("Should create a basic table with a single divider", () => {
       const rows = [
+        ["Name", "Age", "City"],
+        divider,
         ["Alice", "25", "New York"],
         ["Bob", "30", "London"],
       ];
-      const result = formatMarkdownTable(header, rows, undefined);
+      const result = formatTable(rows);
 
       assert.equal(
         result,
@@ -23,12 +24,12 @@ describe("format", () => {
       );
     });
 
-    it("Should create a table without header", () => {
+    it("Should create a table without dividers", () => {
       const rows = [
         ["Alice", "25", "New York"],
         ["Bob", "30", "London"],
       ];
-      const result = formatMarkdownTable(undefined, rows, undefined);
+      const result = formatTable(rows);
 
       assert.equal(
         result,
@@ -38,14 +39,16 @@ describe("format", () => {
       );
     });
 
-    it("Should create a table with header and footer", () => {
-      const header = ["Name", "Age"];
+    it("Should create a table with multiple dividers", () => {
       const rows = [
+        ["Name", "Age"],
+        divider,
         ["Alice", "25"],
         ["Bob", "30"],
+        divider,
+        ["Total", "55"],
       ];
-      const footer = ["Total", "55"];
-      const result = formatMarkdownTable(header, rows, footer);
+      const result = formatTable(rows);
 
       assert.equal(
         result,
@@ -59,31 +62,14 @@ describe("format", () => {
       );
     });
 
-    it("Should create a table with only footer", () => {
-      const rows = [
-        ["Alice", "25"],
-        ["Bob", "30"],
-      ];
-      const footer = ["Total", "55"];
-      const result = formatMarkdownTable(undefined, rows, footer);
-
-      assert.equal(
-        result,
-        `
-| Alice | 25 |
-| Bob   | 30 |
-| ----- | -- |
-| Total | 55 |`.trim(),
-      );
-    });
-
     it("Should handle varying column widths", () => {
-      const header = ["A", "Very Long Header", "C"];
       const rows = [
+        ["A", "Very Long Header", "C"],
+        divider,
         ["Short", "B", "Very Long Content"],
         ["X", "Y", "Z"],
       ];
-      const result = formatMarkdownTable(header, rows, undefined);
+      const result = formatTable(rows);
 
       assert.equal(
         result,
@@ -95,27 +81,15 @@ describe("format", () => {
       );
     });
 
-    it("Should handle empty rows", () => {
-      const header = ["A", "B", "C"];
-      const rows: string[][] = [];
-      const result = formatMarkdownTable(header, rows, undefined);
-
-      assert.equal(
-        result,
-        `
-| A | B | C |
-| - | - | - |`.trim(),
-      );
-    });
-
     it("Should handle rows with different lengths", () => {
-      const header = ["A", "B", "C", "D"];
       const rows = [
+        ["A", "B", "C", "D"],
+        divider,
         ["1", "2"],
         ["3", "4", "5"],
         ["6", "7", "8", "9"],
       ];
-      const result = formatMarkdownTable(header, rows, undefined);
+      const result = formatTable(rows);
 
       assert.equal(
         result,
@@ -129,9 +103,8 @@ describe("format", () => {
     });
 
     it("Should handle single column table", () => {
-      const header = ["Items"];
-      const rows = [["Apple"], ["Banana"], ["Cherry"]];
-      const result = formatMarkdownTable(header, rows, undefined);
+      const rows = [["Items"], divider, ["Apple"], ["Banana"], ["Cherry"]];
+      const result = formatTable(rows);
 
       assert.equal(
         result,
@@ -145,13 +118,14 @@ describe("format", () => {
     });
 
     it("Should handle empty strings in cells", () => {
-      const header = ["Name", "Value"];
       const rows = [
+        ["Name", "Value"],
+        divider,
         ["", "123"],
         ["Test", ""],
         ["", ""],
       ];
-      const result = formatMarkdownTable(header, rows, undefined);
+      const result = formatTable(rows);
 
       assert.equal(
         result,
@@ -165,12 +139,13 @@ describe("format", () => {
     });
 
     it("Should handle ANSI escape codes in content", () => {
-      const header = ["Status", "Message"];
       const rows = [
+        ["Status", "Message"],
+        divider,
         ["\u001b[32mPASS\u001b[0m", "Test passed"],
         ["\u001b[31mFAIL\u001b[0m", "Test failed"],
       ];
-      const result = formatMarkdownTable(header, rows, undefined);
+      const result = formatTable(rows);
 
       assert.equal(
         result,
@@ -187,7 +162,7 @@ describe("format", () => {
         ["Normal", "\u001b[1mBold\u001b[0m", "Regular"],
         ["\u001b[33mYellow\u001b[0m", "Plain", "\u001b[4mUnderline\u001b[0m"],
       ];
-      const result = formatMarkdownTable(undefined, rows, undefined);
+      const result = formatTable(rows);
 
       assert.equal(
         result,

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -37,6 +37,7 @@
     "./types/solidity": "./dist/src/types/solidity.js",
     "./console.sol": "./console.sol",
     "./internal/coverage": "./dist/src/internal/builtin-plugins/coverage/exports.js",
+    "./internal/gas-analytics": "./dist/src/internal/builtin-plugins/gas-analytics/exports.js",
     "./utils/contract-names": "./dist/src/utils/contract-names.js"
   },
   "keywords": [

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/exports.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/exports.ts
@@ -1,0 +1,5 @@
+export {
+  markTestRunStart,
+  markTestRunDone,
+  markTestWorkerDone,
+} from "./helpers.js";

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -1,9 +1,61 @@
 import type { GasAnalyticsManager, GasMeasurement } from "./types.js";
 
+import crypto from "node:crypto";
+import path from "node:path";
+
+import {
+  ensureDir,
+  remove,
+  writeJsonFile,
+} from "@nomicfoundation/hardhat-utils/fs";
+import debug from "debug";
+
+const gasStatsLog = debug(
+  "hardhat:core:gas-analytics:gas-analytics-manager:gas-stats",
+);
+
 export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
-  public async addGasMeasurement(
-    _gasMeasurement: GasMeasurement,
-  ): Promise<void> {
+  public gasMeasurements: GasMeasurement[] = [];
+  readonly #gasStatsPath: string;
+
+  constructor(gasStatsPath: string) {
+    this.#gasStatsPath = gasStatsPath;
+  }
+
+  public addGasMeasurement(gasMeasurement: GasMeasurement): void {
+    this.gasMeasurements.push(gasMeasurement);
+
+    gasStatsLog(
+      "Added gas measurement",
+      JSON.stringify(
+        gasMeasurement,
+        (_, val) => (typeof val === "bigint" ? val.toString() : val),
+        2,
+      ),
+    );
+  }
+
+  public async clearGasStats(id: string): Promise<void> {
+    const dataPath = await this.#getGasStatsPath(id);
+    await remove(dataPath);
+    this.gasMeasurements = [];
+    gasStatsLog("Cleared gas stats from disk and memory");
+  }
+
+  public async saveGasStats(id: string): Promise<void> {
+    const dataPath = await this.#getGasStatsPath(id);
+    const filePath = path.join(dataPath, `${crypto.randomUUID()}.json`);
+    await writeJsonFile(filePath, this.gasMeasurements);
+    gasStatsLog("Saved gas stats", id, filePath);
+  }
+
+  public async reportGasStats(..._ids: string[]): Promise<void> {
     // TODO
+  }
+
+  async #getGasStatsPath(id: string): Promise<string> {
+    const dataPath = path.join(this.#gasStatsPath, "gas-stats", id);
+    await ensureDir(dataPath);
+    return dataPath;
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -93,9 +93,9 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
   }
 
   async #getGasMeasurementsPath(id: string): Promise<string> {
-    const dataPath = path.join(this.#gasStatsPath, "gas-stats", id);
-    await ensureDir(dataPath);
-    return dataPath;
+    const gasMeasurementsPath = path.join(this.#gasStatsPath, "gas-stats", id);
+    await ensureDir(gasMeasurementsPath);
+    return gasMeasurementsPath;
   }
 
   /**
@@ -104,8 +104,8 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
   public async _loadGasMeasurements(...ids: string[]): Promise<void> {
     this.gasMeasurements = [];
     for (const id of ids) {
-      const gasStatsPath = await this.#getGasMeasurementsPath(id);
-      const filePaths = await getAllFilesMatching(gasStatsPath);
+      const gasMeasurementsPath = await this.#getGasMeasurementsPath(id);
+      const filePaths = await getAllFilesMatching(gasMeasurementsPath);
       for (const filePath of filePaths) {
         const entries = await readJsonFile<GasMeasurement[]>(filePath);
         for (const entry of entries) {

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -1,0 +1,9 @@
+import type { GasAnalyticsManager, GasMeasurement } from "./types.js";
+
+export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
+  public async addGasMeasurement(
+    _gasMeasurement: GasMeasurement,
+  ): Promise<void> {
+    // TODO
+  }
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 
 import {
   ensureDir,
+  getAllFilesMatching,
+  readJsonFile,
   remove,
   writeJsonFile,
 } from "@nomicfoundation/hardhat-utils/fs";
@@ -14,9 +16,18 @@ const gasStatsLog = debug(
   "hardhat:core:gas-analytics:gas-analytics-manager:gas-stats",
 );
 
+interface GasStats {
+  min: number;
+  max: number;
+  avg: number;
+  median: number;
+  calls: number;
+}
+
 export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
   public gasMeasurements: GasMeasurement[] = [];
   readonly #gasStatsPath: string;
+  #gasStatsReportEnabled = true;
 
   constructor(gasStatsPath: string) {
     this.#gasStatsPath = gasStatsPath;
@@ -48,8 +59,24 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
     gasStatsLog("Saved gas measurements", id, filePath);
   }
 
-  public async reportGasStats(..._ids: string[]): Promise<void> {
-    // TODO
+  public async reportGasStats(...ids: string[]): Promise<void> {
+    if (!this.#gasStatsReportEnabled) {
+      return;
+    }
+
+    await this._loadGasMeasurements(...ids);
+
+    const _report = this._calculateGasStats();
+
+    // TODO size: only for deployments
+  }
+
+  public enableGasStatsReport(): void {
+    this.#gasStatsReportEnabled = true;
+  }
+
+  public disableGasStatsReport(): void {
+    this.#gasStatsReportEnabled = false;
   }
 
   async #getGasMeasurementsPath(id: string): Promise<string> {
@@ -57,4 +84,102 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
     await ensureDir(dataPath);
     return dataPath;
   }
+
+  /**
+   * @private exposed for testing purposes only
+   */
+  public async _loadGasMeasurements(...ids: string[]): Promise<void> {
+    this.gasMeasurements = [];
+    for (const id of ids) {
+      const gasStatsPath = await this.#getGasMeasurementsPath(id);
+      const filePaths = await getAllFilesMatching(gasStatsPath);
+      for (const filePath of filePaths) {
+        const entries = await readJsonFile<GasMeasurement[]>(filePath);
+        for (const entry of entries) {
+          this.gasMeasurements.push(entry);
+        }
+        gasStatsLog("Loaded gas measurements", id, filePath);
+      }
+    }
+  }
+
+  /**
+   * @private exposed for testing purposes only
+   */
+  public _calculateGasStats(): Map<string, Map<string, GasStats>> {
+    const report: Map<string, Map<string, GasStats>> = new Map();
+    const measurementsByContract = this._aggregateGasMeasurements();
+
+    for (const [contractFqn, functions] of measurementsByContract) {
+      const contractGasStats = new Map<string, GasStats>();
+
+      for (const [functionOrDeployment, gasValues] of functions) {
+        const stats: GasStats = {
+          min: Math.min(...gasValues),
+          max: Math.max(...gasValues),
+          avg: avg(gasValues),
+          median: median(gasValues),
+          calls: gasValues.length,
+          // TODO size: only for deployments
+        };
+
+        contractGasStats.set(functionOrDeployment, stats);
+      }
+
+      report.set(contractFqn, contractGasStats);
+    }
+
+    return report;
+  }
+
+  /**
+   * @private exposed for testing purposes only
+   */
+  public _aggregateGasMeasurements(): Map<string, Map<string, number[]>> {
+    const measurementsByContract = new Map<
+      string,
+      Map<string, number[]> // functionSig or "deployment"
+    >();
+
+    for (const currentMeasurement of this.gasMeasurements) {
+      let contractMeasurements = measurementsByContract.get(
+        currentMeasurement.contractFqn,
+      );
+      if (contractMeasurements === undefined) {
+        contractMeasurements = new Map<string, number[]>();
+        measurementsByContract.set(
+          currentMeasurement.contractFqn,
+          contractMeasurements,
+        );
+      }
+
+      const key =
+        currentMeasurement.type === "deployment"
+          ? "deployment"
+          : currentMeasurement.functionSig;
+
+      let measurements = contractMeasurements.get(key);
+      if (measurements === undefined) {
+        measurements = [];
+        contractMeasurements.set(key, measurements);
+      }
+
+      measurements.push(currentMeasurement.gas);
+    }
+
+    return measurementsByContract;
+  }
+}
+
+export function avg(values: number[]): number {
+  return values.reduce((a, c) => a + c, 0) / values.length;
+}
+
+export function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+
+  return sorted.length % 2 === 1
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -31,25 +31,28 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
     );
   }
 
-  public async clearGasStats(id: string): Promise<void> {
-    const dataPath = await this.#getGasStatsPath(id);
-    await remove(dataPath);
+  public async clearGasMeasurements(id: string): Promise<void> {
+    const gasMeasurementsPath = await this.#getGasMeasurementsPath(id);
+    await remove(gasMeasurementsPath);
     this.gasMeasurements = [];
-    gasStatsLog("Cleared gas stats from disk and memory");
+    gasStatsLog("Cleared gas measurements from disk and memory");
   }
 
-  public async saveGasStats(id: string): Promise<void> {
-    const dataPath = await this.#getGasStatsPath(id);
-    const filePath = path.join(dataPath, `${crypto.randomUUID()}.json`);
+  public async saveGasMeasurements(id: string): Promise<void> {
+    const gasMeasurementsPath = await this.#getGasMeasurementsPath(id);
+    const filePath = path.join(
+      gasMeasurementsPath,
+      `${crypto.randomUUID()}.json`,
+    );
     await writeJsonFile(filePath, this.gasMeasurements);
-    gasStatsLog("Saved gas stats", id, filePath);
+    gasStatsLog("Saved gas measurements", id, filePath);
   }
 
   public async reportGasStats(..._ids: string[]): Promise<void> {
     // TODO
   }
 
-  async #getGasStatsPath(id: string): Promise<string> {
+  async #getGasMeasurementsPath(id: string): Promise<string> {
     const dataPath = path.join(this.#gasStatsPath, "gas-stats", id);
     await ensureDir(dataPath);
     return dataPath;

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -27,11 +27,7 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
 
     gasStatsLog(
       "Added gas measurement",
-      JSON.stringify(
-        gasMeasurement,
-        (_, val) => (typeof val === "bigint" ? val.toString() : val),
-        2,
-      ),
+      JSON.stringify(gasMeasurement, null, 2),
     );
   }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -50,7 +50,6 @@ interface ContractGasMeasurements {
 export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
   public gasMeasurements: GasMeasurement[] = [];
   readonly #gasStatsPath: string;
-  #gasStatsReportEnabled = true;
 
   constructor(gasStatsPath: string) {
     this.#gasStatsPath = gasStatsPath;
@@ -83,10 +82,6 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
   }
 
   public async reportGasStats(...ids: string[]): Promise<void> {
-    if (!this.#gasStatsReportEnabled) {
-      return;
-    }
-
     await this._loadGasMeasurements(...ids);
 
     const gasStatsByContract = this._calculateGasStats();
@@ -95,14 +90,6 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
 
     console.log(report);
     gasStatsLog("Printed markdown report");
-  }
-
-  public enableGasStatsReport(): void {
-    this.#gasStatsReportEnabled = true;
-  }
-
-  public disableGasStatsReport(): void {
-    this.#gasStatsReportEnabled = false;
   }
 
   async #getGasMeasurementsPath(id: string): Promise<string> {

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -3,6 +3,7 @@ import type { GasAnalyticsManager, GasMeasurement } from "./types.js";
 import crypto from "node:crypto";
 import path from "node:path";
 
+import { formatMarkdownTable } from "@nomicfoundation/hardhat-utils/format";
 import {
   ensureDir,
   getAllFilesMatching,
@@ -66,9 +67,13 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
 
     await this._loadGasMeasurements(...ids);
 
-    const _report = this._calculateGasStats();
+    const gasStatsReport = this._calculateGasStats();
 
     // TODO size: only for deployments
+    const markdownReport = this._formatGasStatsMarkdownReport(gasStatsReport);
+
+    console.log(markdownReport);
+    gasStatsLog("Printed markdown report");
   }
 
   public enableGasStatsReport(): void {
@@ -110,10 +115,10 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
     const report: Map<string, Map<string, GasStats>> = new Map();
     const measurementsByContract = this._aggregateGasMeasurements();
 
-    for (const [contractFqn, functions] of measurementsByContract) {
+    for (const [contractFqn, measurements] of measurementsByContract) {
       const contractGasStats = new Map<string, GasStats>();
 
-      for (const [functionOrDeployment, gasValues] of functions) {
+      for (const [functionOrDeployment, gasValues] of measurements) {
         const stats: GasStats = {
           min: Math.min(...gasValues),
           max: Math.max(...gasValues),
@@ -168,6 +173,44 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
     }
 
     return measurementsByContract;
+  }
+
+  /**
+   * @private exposed for testing purposes only
+   */
+  public _formatGasStatsMarkdownReport(
+    gasStatsReport: Map<string, Map<string, GasStats>>,
+  ): string {
+    const rows: string[][] = [];
+    for (const [contractFqn, contractGasStats] of gasStatsReport) {
+      rows.push([contractFqn]);
+      for (const [functionOrDeployment, gasStats] of contractGasStats) {
+        if (functionOrDeployment === "deployment") {
+          rows.push(["Deployment Cost", "Deployment Size"]);
+          rows.push([`${gasStats.avg}`, ""]);
+          rows.push([
+            "Function name",
+            "Min",
+            "Average",
+            "Median",
+            "Max",
+            "#calls",
+          ]);
+        } else {
+          rows.push([
+            functionOrDeployment,
+            `${gasStats.min}`,
+            `${gasStats.avg}`,
+            `${gasStats.median}`,
+            `${gasStats.max}`,
+            `${gasStats.calls}`,
+          ]);
+        }
+      }
+      rows.push([]);
+    }
+
+    return formatMarkdownTable(undefined, rows, undefined);
   }
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -1,9 +1,10 @@
 import type { GasAnalyticsManager, GasMeasurement } from "./types.js";
+import type { TableItem } from "@nomicfoundation/hardhat-utils/format";
 
 import crypto from "node:crypto";
 import path from "node:path";
 
-import { formatMarkdownTable } from "@nomicfoundation/hardhat-utils/format";
+import { divider, formatTable } from "@nomicfoundation/hardhat-utils/format";
 import {
   ensureDir,
   getAllFilesMatching,
@@ -11,6 +12,7 @@ import {
   remove,
   writeJsonFile,
 } from "@nomicfoundation/hardhat-utils/fs";
+import chalk from "chalk";
 import debug from "debug";
 
 const gasStatsLog = debug(
@@ -181,17 +183,24 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
   public _formatGasStatsMarkdownReport(
     gasStatsReport: Map<string, Map<string, GasStats>>,
   ): string {
-    const rows: string[][] = [];
+    const rows: TableItem[] = [];
     for (const [contractFqn, contractGasStats] of gasStatsReport) {
-      rows.push([getUserFqn(contractFqn)]);
+      rows.push([chalk.cyan.bold(getUserFqn(contractFqn))]);
+      rows.push(divider);
 
       const deploymentGasStats = contractGasStats.get("deployment");
       if (deploymentGasStats !== undefined) {
-        rows.push(["Deployment Cost", "Deployment Size"]);
+        rows.push(
+          ["Deployment Cost", "Deployment Size"].map((s) => chalk.yellow(s)),
+        );
         rows.push([`${deploymentGasStats.avg}`, ""]);
       }
 
-      rows.push(["Function name", "Min", "Average", "Median", "Max", "#calls"]);
+      rows.push(
+        ["Function name", "Min", "Average", "Median", "Max", "#calls"].map(
+          (s) => chalk.yellow(s),
+        ),
+      );
 
       for (const [functionOrDeployment, gasStats] of contractGasStats) {
         if (functionOrDeployment !== "deployment") {
@@ -208,7 +217,7 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
       rows.push([]);
     }
 
-    return formatMarkdownTable(undefined, rows, undefined);
+    return formatTable(rows);
   }
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/helpers.ts
@@ -29,7 +29,7 @@ export async function markTestRunStart(id: string): Promise<void> {
 
 export async function markTestWorkerDone(id: string): Promise<void> {
   const { default: hre } = await import("../../../index.js");
-  if (hre.globalOptions.coverage === true) {
+  if (hre.globalOptions.gasStats === true) {
     assertHardhatInvariant(
       hre instanceof HardhatRuntimeEnvironmentImplementation,
       "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/helpers.ts
@@ -23,7 +23,7 @@ export async function markTestRunStart(id: string): Promise<void> {
       hre instanceof HardhatRuntimeEnvironmentImplementation,
       "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
     );
-    await hre._gasAnalytics.clearGasStats(id);
+    await hre._gasAnalytics.clearGasMeasurements(id);
   }
 }
 
@@ -34,7 +34,7 @@ export async function markTestWorkerDone(id: string): Promise<void> {
       hre instanceof HardhatRuntimeEnvironmentImplementation,
       "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
     );
-    await hre._gasAnalytics.saveGasStats(id);
+    await hre._gasAnalytics.saveGasMeasurements(id);
   }
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/helpers.ts
@@ -1,0 +1,50 @@
+import path from "node:path";
+
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+
+import { HardhatRuntimeEnvironmentImplementation } from "../../core/hre.js";
+
+/**
+ * NOTE: The following helpers interact with the global HRE instance only;
+ * This is OK because:
+ * - They are intended for the internal use only. They are exposed via the
+ *   internal public API only.
+ * - We know the HRE has been initialized by the time they are used.
+ */
+
+export function getGasStatsPath(rootPath: string): string {
+  return path.join(rootPath, "coverage");
+}
+
+export async function markTestRunStart(id: string): Promise<void> {
+  const { default: hre } = await import("../../../index.js");
+  if (hre.globalOptions.gasStats === true) {
+    assertHardhatInvariant(
+      hre instanceof HardhatRuntimeEnvironmentImplementation,
+      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+    );
+    await hre._gasAnalytics.clearGasStats(id);
+  }
+}
+
+export async function markTestWorkerDone(id: string): Promise<void> {
+  const { default: hre } = await import("../../../index.js");
+  if (hre.globalOptions.coverage === true) {
+    assertHardhatInvariant(
+      hre instanceof HardhatRuntimeEnvironmentImplementation,
+      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+    );
+    await hre._gasAnalytics.saveGasStats(id);
+  }
+}
+
+export async function markTestRunDone(id: string): Promise<void> {
+  const { default: hre } = await import("../../../index.js");
+  if (hre.globalOptions.gasStats === true) {
+    assertHardhatInvariant(
+      hre instanceof HardhatRuntimeEnvironmentImplementation,
+      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+    );
+    await hre._gasAnalytics.reportGasStats(id);
+  }
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/hre.ts
@@ -7,7 +7,7 @@ import { GasAnalyticsManagerImplementation } from "../gas-analytics-manager.js";
 
 export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
   created: async (context, hre) => {
-    if (context.globalOptions.coverage) {
+    if (context.globalOptions.gasStats) {
       const gasAnalyticsManager = new GasAnalyticsManagerImplementation();
 
       assertHardhatInvariant(

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/hre.ts
@@ -1,0 +1,31 @@
+import type { HardhatRuntimeEnvironmentHooks } from "../../../../types/hooks.js";
+
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+
+import { HardhatRuntimeEnvironmentImplementation } from "../../../core/hre.js";
+import { GasAnalyticsManagerImplementation } from "../gas-analytics-manager.js";
+
+export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
+  created: async (context, hre) => {
+    if (context.globalOptions.coverage) {
+      const gasAnalyticsManager = new GasAnalyticsManagerImplementation();
+
+      assertHardhatInvariant(
+        hre instanceof HardhatRuntimeEnvironmentImplementation,
+        "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+      );
+
+      hre._gasAnalytics = gasAnalyticsManager;
+
+      // NOTE: We register this hook dynamically to avoid a circular dependency
+      // between gas-analytics and network-manager plugins. The network-manager
+      // checks for the existence of onGasReported handlers to determine if gas
+      // analytics is enabled, rather than directly checking the global option.
+      hre.hooks.registerHandlers("network", {
+        onGasMeasurement: async (_context, gasMeasurement) => {
+          await gasAnalyticsManager.addGasMeasurement(gasMeasurement);
+        },
+      });
+    }
+  },
+});

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/hre.ts
@@ -4,11 +4,15 @@ import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 
 import { HardhatRuntimeEnvironmentImplementation } from "../../../core/hre.js";
 import { GasAnalyticsManagerImplementation } from "../gas-analytics-manager.js";
+import { getGasStatsPath } from "../helpers.js";
 
 export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
   created: async (context, hre) => {
     if (context.globalOptions.gasStats) {
-      const gasAnalyticsManager = new GasAnalyticsManagerImplementation();
+      const gasStatsPath = getGasStatsPath(hre.config.paths.root);
+      const gasAnalyticsManager = new GasAnalyticsManagerImplementation(
+        gasStatsPath,
+      );
 
       assertHardhatInvariant(
         hre instanceof HardhatRuntimeEnvironmentImplementation,
@@ -22,8 +26,8 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
       // checks for the existence of onGasReported handlers to determine if gas
       // analytics is enabled, rather than directly checking the global option.
       hre.hooks.registerHandlers("network", {
-        onGasMeasurement: async (_context, gasMeasurement) => {
-          await gasAnalyticsManager.addGasMeasurement(gasMeasurement);
+        onGasMeasurement: (_context, gasMeasurement) => {
+          gasAnalyticsManager.addGasMeasurement(gasMeasurement);
         },
       });
     }

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
@@ -1,0 +1,21 @@
+import type { HardhatPlugin } from "../../../types/plugins.js";
+
+import { globalFlag } from "../../core/config.js";
+
+import "./type-extensions.js";
+
+const hardhatPlugin: HardhatPlugin = {
+  id: "builtin:gas-analytics",
+  tasks: [],
+  globalOptions: [
+    globalFlag({
+      name: "gasStats",
+      description:
+        "Collects and displays gas usage statistics for all function calls during tests",
+    }),
+  ],
+  hookHandlers: {},
+  npmPackage: "hardhat",
+};
+
+export default hardhatPlugin;

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
@@ -14,7 +14,9 @@ const hardhatPlugin: HardhatPlugin = {
         "Collects and displays gas usage statistics for all function calls during tests",
     }),
   ],
-  hookHandlers: {},
+  hookHandlers: {
+    hre: () => import("./hook-handlers/hre.js"),
+  },
   npmPackage: "hardhat",
 };
 

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/type-extensions.ts
@@ -1,0 +1,6 @@
+import "../../../types/global-options.js";
+declare module "../../../types/global-options.js" {
+  export interface GlobalOptions {
+    gasStats: boolean;
+  }
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/types.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/types.ts
@@ -16,5 +16,9 @@ interface DeploymentGasMeasurement extends BaseGasMeasurement {
 export type GasMeasurement = FunctionGasMeasurement | DeploymentGasMeasurement;
 
 export interface GasAnalyticsManager {
-  addGasMeasurement(gasMeasurement: GasMeasurement): Promise<void>;
+  /* Gas Statistics */
+  addGasMeasurement(gasMeasurement: GasMeasurement): void;
+  clearGasStats(id: string): Promise<void>;
+  saveGasStats(id: string): Promise<void>;
+  reportGasStats(...ids: string[]): Promise<void>;
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/types.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/types.ts
@@ -1,0 +1,20 @@
+interface BaseGasMeasurement {
+  contractFqn: string;
+  gas: bigint;
+}
+
+interface FunctionGasMeasurement extends BaseGasMeasurement {
+  type: "function";
+  functionSig: string;
+}
+
+interface DeploymentGasMeasurement extends BaseGasMeasurement {
+  type: "deployment";
+  size: bigint;
+}
+
+export type GasMeasurement = FunctionGasMeasurement | DeploymentGasMeasurement;
+
+export interface GasAnalyticsManager {
+  addGasMeasurement(gasMeasurement: GasMeasurement): Promise<void>;
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/types.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/types.ts
@@ -18,7 +18,7 @@ export type GasMeasurement = FunctionGasMeasurement | DeploymentGasMeasurement;
 export interface GasAnalyticsManager {
   /* Gas Statistics */
   addGasMeasurement(gasMeasurement: GasMeasurement): void;
-  clearGasStats(id: string): Promise<void>;
-  saveGasStats(id: string): Promise<void>;
+  clearGasMeasurements(id: string): Promise<void>;
+  saveGasMeasurements(id: string): Promise<void>;
   reportGasStats(...ids: string[]): Promise<void>;
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/types.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/types.ts
@@ -1,6 +1,6 @@
 interface BaseGasMeasurement {
   contractFqn: string;
-  gas: bigint;
+  gas: number;
 }
 
 interface FunctionGasMeasurement extends BaseGasMeasurement {
@@ -10,7 +10,7 @@ interface FunctionGasMeasurement extends BaseGasMeasurement {
 
 interface DeploymentGasMeasurement extends BaseGasMeasurement {
   type: "deployment";
-  size: bigint;
+  size: number;
 }
 
 export type GasMeasurement = FunctionGasMeasurement | DeploymentGasMeasurement;

--- a/v-next/hardhat/src/internal/builtin-plugins/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/index.ts
@@ -5,6 +5,7 @@ import clean from "./clean/index.js";
 import console from "./console/index.js";
 import coverage from "./coverage/index.js";
 import flatten from "./flatten/index.js";
+import gasAnalytics from "./gas-analytics/index.js";
 import networkManager from "./network-manager/index.js";
 import node from "./node/index.js";
 import run from "./run/index.js";
@@ -19,6 +20,7 @@ export type * from "./artifacts/index.js";
 export type * from "./solidity/index.js";
 export type * from "./test/index.js";
 export type * from "./solidity-test/index.js";
+export type * from "./gas-analytics/index.js";
 export type * from "./network-manager/index.js";
 export type * from "./clean/index.js";
 export type * from "./console/index.js";
@@ -43,4 +45,5 @@ export const builtinPlugins: HardhatPlugin[] = [
   node,
   flatten,
   telemetry,
+  gasAnalytics,
 ];

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -174,7 +174,7 @@ export class EdrProvider extends BaseProvider {
       chainDescriptors,
     );
 
-    const contractDecoder = ContractDecoder.withContracts(tracingConfig)
+    const contractDecoder = ContractDecoder.withContracts(tracingConfig);
 
     let edrProvider: EdrProvider;
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -23,6 +23,7 @@ import type {
   ProviderConfig,
   TracingConfigWithBuffers,
   AccountOverride,
+  GasReportConfig,
 } from "@nomicfoundation/edr";
 
 import {
@@ -141,6 +142,7 @@ interface EdrProviderConfig {
   tracingConfig?: TracingConfigWithBuffers;
   jsonRpcRequestWrapper?: JsonRpcRequestWrapperFunction;
   coverageConfig?: CoverageConfig;
+  gasReportConfig?: GasReportConfig;
 }
 
 export class EdrProvider extends BaseProvider {
@@ -159,6 +161,7 @@ export class EdrProvider extends BaseProvider {
     tracingConfig = {},
     jsonRpcRequestWrapper,
     coverageConfig,
+    gasReportConfig,
   }: EdrProviderConfig): Promise<EdrProvider> {
     const printLineFn = loggerConfig.printLineFn ?? printLine;
     const replaceLastLineFn = loggerConfig.replaceLastLineFn ?? replaceLastLine;
@@ -166,6 +169,7 @@ export class EdrProvider extends BaseProvider {
     const providerConfig = await getProviderConfig(
       networkConfig,
       coverageConfig,
+      gasReportConfig,
       chainDescriptors,
     );
 
@@ -412,6 +416,7 @@ export class EdrProvider extends BaseProvider {
 export async function getProviderConfig(
   networkConfig: RequireField<EdrNetworkConfig, "chainType">,
   coverageConfig: CoverageConfig | undefined,
+  gasReportConfig: GasReportConfig | undefined,
   chainDescriptors: ChainDescriptorsConfig,
 ): Promise<ProviderConfig> {
   const specId = hardhatHardforkToEdrSpecId(
@@ -488,6 +493,7 @@ export async function getProviderConfig(
     networkId: BigInt(networkConfig.networkId),
     observability: {
       codeCoverage: coverageConfig,
+      gasReport: gasReportConfig,
     },
     ownedAccounts: ownedAccounts.map((account) => account.secretKey),
     precompileOverrides: [],

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -31,6 +31,7 @@ import {
   opHardforkFromString,
   l1GenesisState,
   l1HardforkFromString,
+  ContractDecoder,
 } from "@nomicfoundation/edr";
 import {
   assertHardhatInvariant,
@@ -173,6 +174,8 @@ export class EdrProvider extends BaseProvider {
       chainDescriptors,
     );
 
+    const contractDecoder = ContractDecoder.withContracts(tracingConfig)
+
     let edrProvider: EdrProvider;
 
     // We need to catch errors here, as the provider creation can panic unexpectedly,
@@ -204,7 +207,7 @@ export class EdrProvider extends BaseProvider {
             edrProvider.onSubscriptionEvent(event);
           },
         },
-        tracingConfig,
+        contractDecoder,
       );
 
       edrProvider = new EdrProvider(provider, jsonRpcRequestWrapper);

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -370,8 +370,8 @@ export function edrGasReportToHardhatGasMeasurements(
         gasMeasurements.push({
           contractFqn,
           type: "deployment",
-          gas: deployment.gas,
-          size: deployment.size,
+          gas: Number(deployment.gas),
+          size: Number(deployment.size),
         });
       }
     }
@@ -384,7 +384,7 @@ export function edrGasReportToHardhatGasMeasurements(
             contractFqn,
             type: "function",
             functionSig,
-            gas: call.gas,
+            gas: Number(call.gas),
           });
         }
       }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -377,7 +377,7 @@ export function edrGasReportToHardhatGasMeasurements(
     }
 
     // Process function calls
-    for (const [functionSig, { calls }] of Object.entries(data.functions)) {
+    for (const [functionSig, calls] of Object.entries(data.functions)) {
       for (const call of calls) {
         if (call.status === GasReportExecutionStatus.Success) {
           gasMeasurements.push({

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -8,12 +8,14 @@ import type {
   EdrNetworkMiningConfig,
 } from "../../../../../types/config.js";
 import type { ChainType } from "../../../../../types/network.js";
+import type { GasMeasurement } from "../../../gas-analytics/types.js";
 import type { RpcDebugTraceOutput, RpcStructLog } from "../types/output.js";
 import type {
   IntervalRange,
   DebugTraceResult,
   ChainOverride,
   ForkConfig,
+  GasReport,
 } from "@nomicfoundation/edr";
 
 import {
@@ -43,6 +45,7 @@ import {
   FJORD,
   GRANITE,
   HOLOCENE,
+  GasReportExecutionStatus,
 } from "@nomicfoundation/edr";
 import { getUnprefixedHexString } from "@nomicfoundation/hardhat-utils/hex";
 
@@ -349,4 +352,44 @@ export async function hardhatForkingConfigToEdrForkConfig(
   }
 
   return fork;
+}
+
+/**
+ * Converts EDR's nested GasReport structure into a flat array of gas entries.
+ * Filters out reverted transactions.
+ */
+export function edrGasReportToHardhatGasMeasurements(
+  gasReport: GasReport,
+): GasMeasurement[] {
+  const gasMeasurements: GasMeasurement[] = [];
+
+  for (const [contractFqn, data] of Object.entries(gasReport.contracts)) {
+    // Process deployments
+    for (const deployment of data.deployments) {
+      if (deployment.status === GasReportExecutionStatus.Success) {
+        gasMeasurements.push({
+          contractFqn,
+          type: "deployment",
+          gas: deployment.gas,
+          size: deployment.size,
+        });
+      }
+    }
+
+    // Process function calls
+    for (const [functionSig, { calls }] of Object.entries(data.functions)) {
+      for (const call of calls) {
+        if (call.status === GasReportExecutionStatus.Success) {
+          gasMeasurements.push({
+            contractFqn,
+            type: "function",
+            functionSig,
+            gas: call.gas,
+          });
+        }
+      }
+    }
+  }
+
+  return gasMeasurements;
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -19,6 +19,7 @@ import type {
   JsonRpcRequest,
   JsonRpcResponse,
 } from "../../../types/providers.js";
+import type { GasReportConfig } from "@nomicfoundation/edr";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { readBinaryFile } from "@nomicfoundation/hardhat-utils/fs";
@@ -29,6 +30,7 @@ import { isSupportedChainType } from "../../edr/chain-type.js";
 
 import { resolveEdrNetwork, resolveHttpNetwork } from "./config-resolution.js";
 import { EdrProvider } from "./edr/edr-provider.js";
+import { edrGasReportToHardhatGasMeasurements } from "./edr/utils/convert-to-edr.js";
 import { HttpProvider } from "./http-provider.js";
 import { NetworkConnectionImplementation } from "./network-connection.js";
 import { validateNetworkConfigOverride } from "./type-validation.js";
@@ -219,7 +221,6 @@ export class NetworkManagerImplementation implements NetworkManager {
         }
 
         let coverageConfig: CoverageConfig | undefined;
-
         const shouldEnableCoverage = await hookManager.hasHandlers(
           "network",
           "onCoverageData",
@@ -237,6 +238,28 @@ export class NetworkManagerImplementation implements NetworkManager {
                 "onCoverageData",
                 [tags],
               );
+            },
+          };
+        }
+
+        let gasReportConfig: GasReportConfig | undefined;
+        const shouldEnableGasStats = await hookManager.hasHandlers(
+          "network",
+          "onGasMeasurement",
+        );
+        if (shouldEnableGasStats) {
+          gasReportConfig = {
+            onCollectedGasReportCallback: async (gasReport) => {
+              const gasMeasurements =
+                edrGasReportToHardhatGasMeasurements(gasReport);
+
+              for (const measurement of gasMeasurements) {
+                await hookManager.runParallelHandlers(
+                  "network",
+                  "onGasMeasurement",
+                  [measurement],
+                );
+              }
             },
           };
         }
@@ -262,6 +285,7 @@ export class NetworkManagerImplementation implements NetworkManager {
             ignoreContracts: false,
           },
           coverageConfig,
+          gasReportConfig,
         });
       }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/hooks.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/hooks.ts
@@ -63,6 +63,6 @@ declare module "../../../../types/hooks.js" {
     onGasMeasurement(
       context: HookContext,
       gasMeasurement: GasMeasurement,
-    ): Promise<void>;
+    ): void;
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/hooks.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/hooks.ts
@@ -7,6 +7,7 @@ import type {
   JsonRpcResponse,
 } from "../../../../types/providers.js";
 import type { CoverageData } from "../../coverage/types.js";
+import type { GasMeasurement } from "../../gas-analytics/types.js";
 
 import "../../../../types/hooks.js";
 declare module "../../../../types/hooks.js" {
@@ -51,6 +52,17 @@ declare module "../../../../types/hooks.js" {
     onCoverageData(
       context: HookContext,
       coverageData: CoverageData,
+    ): Promise<void>;
+
+    /**
+     * Hook triggered when the gas data is received from EDR.
+     *
+     * @param context The hook context.
+     * @param gasMeasurement The gas measurement.
+     */
+    onGasMeasurement(
+      context: HookContext,
+      gasMeasurement: GasMeasurement,
     ): Promise<void>;
   }
 }

--- a/v-next/hardhat/src/internal/core/hre.ts
+++ b/v-next/hardhat/src/internal/core/hre.ts
@@ -20,6 +20,7 @@ import type { SolidityBuildSystem } from "../../types/solidity/build-system.js";
 import type { TaskManager } from "../../types/tasks.js";
 import type { UserInterruptionManager } from "../../types/user-interruptions.js";
 import type { CoverageManager } from "../builtin-plugins/coverage/types.js";
+import type { GasAnalyticsManager } from "../builtin-plugins/gas-analytics/types.js";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { findClosestPackageRoot } from "@nomicfoundation/hardhat-utils/package";
@@ -46,9 +47,13 @@ export class HardhatRuntimeEnvironmentImplementation
   public artifacts!: ArtifactManager;
   public solidity!: SolidityBuildSystem;
 
-  // NOTE: This is slight architectural violation, as this is intended for the
-  // internal use only. It is set up by the coverage plugin in the `created` hook.
+  // NOTE: These underscore-prefixed properties are architectural violations intended
+  // for internal use only. They are declared here rather than through module
+  // augmentation to hide them from TypeScript users (keeping them out of the public
+  // HardhatRuntimeEnvironment interface). They are initialized by their respective
+  // plugins in the `created` hook.
   public _coverage!: CoverageManager;
+  public _gasAnalytics!: GasAnalyticsManager;
 
   public static async create(
     inputUserConfig: HardhatUserConfig,

--- a/v-next/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  avg,
+  median,
+  getUserFqn,
+  getFunctionName,
+  findDuplicates,
+  roundTo,
+} from "../../../../src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.js";
+
+describe("gas-analytics-manager", () => {
+  describe("helpers", () => {
+    describe("avg", () => {
+      it("should calculate average of numbers", () => {
+        assert.equal(avg([1, 2, 3, 4, 5]), 3);
+        assert.equal(avg([10, 20, 30]), 20);
+        assert.equal(avg([1]), 1);
+        assert.equal(avg([0, 0, 0]), 0);
+        assert.equal(avg([5.5, 2.5]), 4);
+      });
+    });
+
+    describe("median", () => {
+      it("should calculate median for odd length arrays", () => {
+        assert.equal(median([1, 2, 3]), 2);
+        assert.equal(median([5, 1, 3]), 3);
+        assert.equal(median([1]), 1);
+      });
+
+      it("should calculate median for even length arrays", () => {
+        assert.equal(median([1, 2]), 1.5);
+        assert.equal(median([1, 2, 3, 4]), 2.5);
+        assert.equal(median([10, 20, 30, 40]), 25);
+      });
+
+      it("should handle unsorted arrays", () => {
+        assert.equal(median([3, 1, 2]), 2);
+        assert.equal(median([4, 1, 3, 2]), 2.5);
+      });
+    });
+
+    describe("getUserFqn", () => {
+      it("should remove project/ prefix", () => {
+        assert.equal(
+          getUserFqn("project/contracts/MyContract.sol"),
+          "contracts/MyContract.sol",
+        );
+        assert.equal(getUserFqn("project/test.sol"), "test.sol");
+      });
+
+      it("should handle npm packages", () => {
+        assert.equal(
+          getUserFqn("npm/package@1.0.0/Contract.sol"),
+          "package/Contract.sol",
+        );
+        assert.equal(
+          getUserFqn("npm/@scope/package@1.0.0/Contract.sol"),
+          "@scope/package/Contract.sol",
+        );
+      });
+
+      it("should handle npm packages without version match", () => {
+        assert.equal(getUserFqn("npm/invalid-format"), "invalid-format");
+      });
+
+      it("should return input as-is for other formats", () => {
+        assert.equal(getUserFqn("other/format"), "other/format");
+        assert.equal(getUserFqn("simple"), "simple");
+      });
+    });
+
+    describe("getFunctionName", () => {
+      it("should extract function name from signature", () => {
+        assert.equal(getFunctionName("transfer(address,uint256)"), "transfer");
+        assert.equal(getFunctionName("balanceOf(address)"), "balanceOf");
+        assert.equal(getFunctionName("approve(address,uint256)"), "approve");
+      });
+
+      it("should handle functions without parameters", () => {
+        assert.equal(getFunctionName("totalSupply()"), "totalSupply");
+      });
+
+      it("should handle simple names without parentheses", () => {
+        assert.equal(getFunctionName("simple"), "simple");
+      });
+    });
+
+    describe("findDuplicates", () => {
+      it("should find duplicate strings", () => {
+        const result = findDuplicates(["a", "b", "a", "c", "b"]);
+        assert.deepEqual(result.sort(), ["a", "b"]);
+      });
+
+      it("should find duplicate numbers", () => {
+        const result = findDuplicates([1, 2, 1, 3, 2]);
+        assert.deepEqual(result.sort(), [1, 2]);
+      });
+
+      it("should return empty array when no duplicates", () => {
+        assert.deepEqual(findDuplicates(["a", "b", "c"]), []);
+        assert.deepEqual(findDuplicates([1, 2, 3]), []);
+      });
+
+      it("should handle empty array", () => {
+        assert.deepEqual(findDuplicates([]), []);
+      });
+
+      it("should handle single element", () => {
+        assert.deepEqual(findDuplicates(["a"]), []);
+      });
+    });
+
+    describe("roundTo", () => {
+      it("should round to specified decimal places", () => {
+        assert.equal(roundTo(3.14159, 2), 3.14);
+        assert.equal(roundTo(3.14159, 3), 3.142);
+        assert.equal(roundTo(3.14159, 0), 3);
+      });
+
+      it("should handle rounding up", () => {
+        assert.equal(roundTo(3.156, 2), 3.16);
+        assert.equal(roundTo(3.999, 2), 4);
+      });
+
+      it("should handle negative numbers", () => {
+        assert.equal(roundTo(-3.14159, 2), -3.14);
+        assert.equal(roundTo(-3.156, 2), -3.16);
+      });
+
+      it("should handle zero", () => {
+        assert.equal(roundTo(0, 2), 0);
+      });
+    });
+  });
+});

--- a/v-next/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -1,5 +1,15 @@
+import type { GasMeasurement } from "../../../../src/internal/builtin-plugins/gas-analytics/types.js";
+
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import path from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  getAllFilesMatching,
+  readJsonFile,
+  remove,
+} from "@nomicfoundation/hardhat-utils/fs";
+import chalk from "chalk";
 
 import {
   avg,
@@ -8,9 +18,863 @@ import {
   getFunctionName,
   findDuplicates,
   roundTo,
+  GasAnalyticsManagerImplementation,
 } from "../../../../src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.js";
 
 describe("gas-analytics-manager", () => {
+  describe("GasAnalyticsManager", () => {
+    describe("constructor", () => {
+      it("should initialize with empty gasMeasurements array", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        assert.deepEqual(manager.gasMeasurements, []);
+      });
+    });
+
+    describe("addGasMeasurement", () => {
+      it("should add function gas measurement to the array", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        const functionMeasurement: GasMeasurement = {
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        };
+
+        manager.addGasMeasurement(functionMeasurement);
+
+        assert.equal(manager.gasMeasurements.length, 1);
+        assert.deepEqual(manager.gasMeasurements[0], functionMeasurement);
+      });
+
+      it("should add deployment gas measurement to the array", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        const deploymentMeasurement: GasMeasurement = {
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        };
+
+        manager.addGasMeasurement(deploymentMeasurement);
+
+        assert.equal(manager.gasMeasurements.length, 1);
+        assert.deepEqual(manager.gasMeasurements[0], deploymentMeasurement);
+      });
+    });
+
+    describe("saveGasMeasurements", () => {
+      afterEach(async () => {
+        await remove(path.join(process.cwd(), "gas-stats"));
+      });
+
+      it("should save gas measurements in memory", async () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        const measurement1: GasMeasurement = {
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        };
+        const measurement2: GasMeasurement = {
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        };
+
+        manager.addGasMeasurement(measurement1);
+        manager.addGasMeasurement(measurement2);
+
+        await manager.saveGasMeasurements("test-id");
+
+        assert.equal(manager.gasMeasurements.length, 2);
+        assert.deepEqual(manager.gasMeasurements[0], measurement1);
+        assert.deepEqual(manager.gasMeasurements[1], measurement2);
+      });
+
+      it("should save gas measurements in disk", async () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        const measurement1: GasMeasurement = {
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        };
+        const measurement2: GasMeasurement = {
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        };
+
+        manager.addGasMeasurement(measurement1);
+        manager.addGasMeasurement(measurement2);
+
+        await manager.saveGasMeasurements("test-id");
+
+        const gasMeasurementsPath = await getAllFilesMatching(
+          path.join(process.cwd(), "gas-stats", "test-id"),
+        );
+
+        assert.ok(
+          gasMeasurementsPath.length !== 0,
+          "The gas measurements should be saved to disk",
+        );
+
+        const gasMeasurements = await readJsonFile<GasMeasurement[]>(
+          gasMeasurementsPath[0],
+        );
+        assert.equal(gasMeasurements.length, 2);
+        assert.deepEqual(gasMeasurements[0], measurement1);
+        assert.deepEqual(gasMeasurements[1], measurement2);
+      });
+    });
+
+    describe("clearGasMeasurements", () => {
+      it("should clear gas measurements in memory", async () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        const measurement1: GasMeasurement = {
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        };
+        const measurement2: GasMeasurement = {
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        };
+
+        manager.addGasMeasurement(measurement1);
+        manager.addGasMeasurement(measurement2);
+
+        await manager.saveGasMeasurements("test-id");
+
+        await manager.clearGasMeasurements("test-id");
+
+        assert.equal(manager.gasMeasurements.length, 0);
+      });
+
+      it("should clear gas measurements in disk", async () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        const measurement1: GasMeasurement = {
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        };
+        const measurement2: GasMeasurement = {
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        };
+
+        manager.addGasMeasurement(measurement1);
+        manager.addGasMeasurement(measurement2);
+
+        await manager.saveGasMeasurements("test-id");
+
+        await manager.clearGasMeasurements("test-id");
+
+        const gasMeasurementsPath = await getAllFilesMatching(
+          path.join(process.cwd(), "gas-stats", "test-id"),
+        );
+
+        assert.ok(
+          gasMeasurementsPath.length === 0,
+          "The gas measurements should be cleared from disk",
+        );
+      });
+    });
+
+    describe("_loadGasMeasurements", () => {
+      afterEach(async () => {
+        await remove(path.join(process.cwd(), "gas-stats"));
+      });
+
+      it("should load gas measurements from disk", async () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        const measurement1: GasMeasurement = {
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        };
+        const measurement2: GasMeasurement = {
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        };
+        manager.addGasMeasurement(measurement1);
+        manager.addGasMeasurement(measurement2);
+
+        await manager.saveGasMeasurements("test-id");
+
+        const newManager = new GasAnalyticsManagerImplementation(process.cwd());
+        await newManager._loadGasMeasurements("test-id");
+
+        assert.equal(newManager.gasMeasurements.length, 2);
+        assert.deepEqual(newManager.gasMeasurements[0], measurement1);
+        assert.deepEqual(newManager.gasMeasurements[1], measurement2);
+      });
+
+      it("should load gas measurements from multiple files", async () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        const measurement1: GasMeasurement = {
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        };
+        const measurement2: GasMeasurement = {
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        };
+        manager.addGasMeasurement(measurement1);
+        manager.addGasMeasurement(measurement2);
+
+        await manager.saveGasMeasurements("test-id");
+        // Save again to create a second file
+        await manager.saveGasMeasurements("test-id");
+
+        const newManager = new GasAnalyticsManagerImplementation(process.cwd());
+        await newManager._loadGasMeasurements("test-id");
+
+        assert.equal(newManager.gasMeasurements.length, 4);
+        assert.deepEqual(newManager.gasMeasurements[0], measurement1);
+        assert.deepEqual(newManager.gasMeasurements[1], measurement2);
+        assert.deepEqual(newManager.gasMeasurements[2], measurement1);
+        assert.deepEqual(newManager.gasMeasurements[3], measurement2);
+      });
+    });
+
+    describe("_aggregateGasMeasurements", () => {
+      it("should return empty map for no measurements", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+
+        const result = manager._aggregateGasMeasurements();
+
+        assert.equal(result.size, 0);
+      });
+
+      it("should aggregate function measurements for single contract", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 30000,
+        });
+
+        const result = manager._aggregateGasMeasurements();
+
+        assert.equal(result.size, 1);
+        const contractMeasurements = result.get(
+          "project/contracts/MyContract.sol:MyContract",
+        );
+        assert.ok(
+          contractMeasurements !== undefined,
+          "Contract measurements should be defined",
+        );
+        assert.equal(contractMeasurements.deployment, undefined);
+        assert.equal(contractMeasurements.functions.size, 1);
+
+        const transferMeasurements = contractMeasurements.functions.get(
+          "transfer(address,uint256)",
+        );
+        assert.ok(
+          transferMeasurements !== undefined,
+          "Function measurements should be defined",
+        );
+        assert.deepEqual(transferMeasurements, [25000, 30000]);
+      });
+
+      it("should aggregate deployment measurement for single contract", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        });
+
+        const result = manager._aggregateGasMeasurements();
+
+        assert.equal(result.size, 1);
+        const contractMeasurements = result.get(
+          "project/contracts/MyContract.sol:MyContract",
+        );
+        assert.ok(
+          contractMeasurements !== undefined,
+          "Contract measurements should be defined",
+        );
+        assert.ok(
+          contractMeasurements.deployment !== undefined,
+          "Deployment should be defined",
+        );
+        assert.equal(contractMeasurements.deployment.gas, 500000);
+        assert.equal(contractMeasurements.deployment.size, 2048);
+        assert.equal(contractMeasurements.functions.size, 0);
+      });
+
+      it("should aggregate both deployment and function measurements", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "balanceOf(address)",
+          gas: 15000,
+        });
+
+        const result = manager._aggregateGasMeasurements();
+
+        assert.equal(result.size, 1);
+        const contractMeasurements = result.get(
+          "project/contracts/MyContract.sol:MyContract",
+        );
+        assert.ok(
+          contractMeasurements !== undefined,
+          "Contract measurements should be defined",
+        );
+
+        assert.ok(
+          contractMeasurements.deployment !== undefined,
+          "Deployment should be defined",
+        );
+        assert.equal(contractMeasurements.deployment.gas, 500000);
+        assert.equal(contractMeasurements.deployment.size, 2048);
+
+        assert.equal(contractMeasurements.functions.size, 2);
+        const transferMeasurements = contractMeasurements.functions.get(
+          "transfer(address,uint256)",
+        );
+        assert.ok(
+          transferMeasurements !== undefined,
+          "Transfer measurements should be defined",
+        );
+        assert.deepEqual(transferMeasurements, [25000]);
+
+        const balanceOfMeasurements =
+          contractMeasurements.functions.get("balanceOf(address)");
+        assert.ok(
+          balanceOfMeasurements !== undefined,
+          "BalanceOf measurements should be defined",
+        );
+        assert.deepEqual(balanceOfMeasurements, [15000]);
+      });
+
+      it("should aggregate measurements for multiple contracts", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/TokenA.sol:TokenA",
+          functionSig: "mint(uint256)",
+          gas: 50000,
+        });
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/TokenB.sol:TokenB",
+          gas: 600000,
+          size: 3072,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/TokenB.sol:TokenB",
+          functionSig: "burn(uint256)",
+          gas: 30000,
+        });
+
+        const result = manager._aggregateGasMeasurements();
+
+        assert.equal(result.size, 2);
+
+        const tokenAMeasurements = result.get(
+          "project/contracts/TokenA.sol:TokenA",
+        );
+        assert.ok(
+          tokenAMeasurements !== undefined,
+          "TokenA measurements should be defined",
+        );
+        assert.equal(tokenAMeasurements.deployment, undefined);
+        assert.equal(tokenAMeasurements.functions.size, 1);
+        const mintMeasurements =
+          tokenAMeasurements.functions.get("mint(uint256)");
+        assert.ok(
+          mintMeasurements !== undefined,
+          "Mint measurements should be defined",
+        );
+        assert.deepEqual(mintMeasurements, [50000]);
+
+        const tokenBMeasurements = result.get(
+          "project/contracts/TokenB.sol:TokenB",
+        );
+        assert.ok(
+          tokenBMeasurements !== undefined,
+          "TokenB measurements should be defined",
+        );
+        assert.ok(
+          tokenBMeasurements.deployment !== undefined,
+          "TokenB deployment should be defined",
+        );
+        assert.equal(tokenBMeasurements.deployment.gas, 600000);
+        assert.equal(tokenBMeasurements.deployment.size, 3072);
+        assert.equal(tokenBMeasurements.functions.size, 1);
+        const burnMeasurements =
+          tokenBMeasurements.functions.get("burn(uint256)");
+        assert.ok(
+          burnMeasurements !== undefined,
+          "Burn measurements should be defined",
+        );
+        assert.deepEqual(burnMeasurements, [30000]);
+      });
+
+      it("should aggregate multiple measurements for same function", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 30000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 20000,
+        });
+
+        const result = manager._aggregateGasMeasurements();
+
+        assert.equal(result.size, 1);
+        const contractMeasurements = result.get(
+          "project/contracts/MyContract.sol:MyContract",
+        );
+        assert.ok(
+          contractMeasurements !== undefined,
+          "Contract measurements should be defined",
+        );
+        assert.equal(contractMeasurements.functions.size, 1);
+
+        const transferMeasurements = contractMeasurements.functions.get(
+          "transfer(address,uint256)",
+        );
+        assert.ok(
+          transferMeasurements !== undefined,
+          "Function measurements should be defined",
+        );
+        assert.deepEqual(transferMeasurements, [25000, 30000, 20000]);
+      });
+
+      it("should handle overloaded function signatures", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256,bytes)",
+          gas: 35000,
+        });
+
+        const result = manager._aggregateGasMeasurements();
+
+        assert.equal(result.size, 1);
+        const contractMeasurements = result.get(
+          "project/contracts/MyContract.sol:MyContract",
+        );
+        assert.ok(
+          contractMeasurements !== undefined,
+          "Contract measurements should be defined",
+        );
+        assert.equal(contractMeasurements.functions.size, 2);
+
+        const transfer1Measurements = contractMeasurements.functions.get(
+          "transfer(address,uint256)",
+        );
+        assert.ok(
+          transfer1Measurements !== undefined,
+          "First transfer measurements should be defined",
+        );
+        assert.deepEqual(transfer1Measurements, [25000]);
+
+        const transfer2Measurements = contractMeasurements.functions.get(
+          "transfer(address,uint256,bytes)",
+        );
+        assert.ok(
+          transfer2Measurements !== undefined,
+          "Second transfer measurements should be defined",
+        );
+        assert.deepEqual(transfer2Measurements, [35000]);
+      });
+
+      it("should only keep latest deployment measurement per contract", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        });
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 600000,
+          size: 3072,
+        });
+
+        const result = manager._aggregateGasMeasurements();
+
+        assert.equal(result.size, 1);
+        const contractMeasurements = result.get(
+          "project/contracts/MyContract.sol:MyContract",
+        );
+        assert.ok(
+          contractMeasurements !== undefined,
+          "Contract measurements should be defined",
+        );
+        assert.ok(
+          contractMeasurements.deployment !== undefined,
+          "Deployment should be defined",
+        );
+        assert.equal(contractMeasurements.deployment.gas, 600000);
+        assert.equal(contractMeasurements.deployment.size, 3072);
+      });
+    });
+
+    describe("_calculateGasStats", () => {
+      it("should calculate stats for a single function with multiple gas measurements", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 30000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 20000,
+        });
+
+        const gasStats = manager._calculateGasStats();
+
+        assert.equal(gasStats.size, 1);
+        const contractStats = gasStats.get(
+          "project/contracts/MyContract.sol:MyContract",
+        );
+        assert.ok(
+          contractStats !== undefined,
+          "Contract stats should be defined",
+        );
+        assert.equal(contractStats.functions.size, 1);
+
+        const transferStats = contractStats.functions.get("transfer");
+        assert.ok(
+          transferStats !== undefined,
+          "transfer function stats should be defined",
+        );
+        assert.equal(transferStats.min, 20000);
+        assert.equal(transferStats.max, 30000);
+        assert.equal(transferStats.avg, 25000);
+        assert.equal(transferStats.median, 25000);
+        assert.equal(transferStats.calls, 3);
+      });
+
+      it("should calculate stats for deployment gas measurements", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        });
+
+        const gasStats = manager._calculateGasStats();
+
+        assert.equal(gasStats.size, 1);
+        const contractStats = gasStats.get(
+          "project/contracts/MyContract.sol:MyContract",
+        );
+        assert.ok(
+          contractStats !== undefined,
+          "Contract stats should be defined",
+        );
+        assert.ok(
+          contractStats.deployment !== undefined,
+          "Deployment stats should be defined",
+        );
+        assert.equal(contractStats.deployment.gas, 500000);
+        assert.equal(contractStats.deployment.size, 2048);
+      });
+
+      it("should calculate stats for multiple contracts", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/TokenA.sol:TokenA",
+          functionSig: "mint(uint256)",
+          gas: 50000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/TokenB.sol:TokenB",
+          functionSig: "burn(uint256)",
+          gas: 30000,
+        });
+
+        const gasStats = manager._calculateGasStats();
+
+        assert.equal(gasStats.size, 2);
+
+        const tokenAStats = gasStats.get("project/contracts/TokenA.sol:TokenA");
+        assert.ok(tokenAStats !== undefined, "TokenA stats should be defined");
+        assert.equal(tokenAStats.functions.size, 1);
+        assert.ok(
+          tokenAStats.functions.get("mint") !== undefined,
+          "mint function stats should be defined",
+        );
+
+        const tokenBStats = gasStats.get("project/contracts/TokenB.sol:TokenB");
+        assert.ok(tokenBStats !== undefined, "TokenB stats should be defined");
+        assert.equal(tokenBStats.functions.size, 1);
+        assert.ok(
+          tokenBStats.functions.get("burn") !== undefined,
+          "burn function stats should be defined",
+        );
+      });
+
+      it("should handle overloaded functions by using full signature", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256,bytes)",
+          gas: 35000,
+        });
+
+        const gasStats = manager._calculateGasStats();
+
+        assert.equal(gasStats.size, 1);
+        const contractStats = gasStats.get(
+          "project/contracts/MyContract.sol:MyContract",
+        );
+        assert.ok(
+          contractStats !== undefined,
+          "Contract stats should be defined",
+        );
+        assert.equal(contractStats.functions.size, 2);
+
+        const transferOverload1 = contractStats.functions.get(
+          "transfer(address,uint256)",
+        );
+        assert.ok(
+          transferOverload1 !== undefined,
+          "transfer(address,uint256) function stats should be defined",
+        );
+        assert.equal(transferOverload1.min, 25000);
+        assert.equal(transferOverload1.max, 25000);
+        assert.equal(transferOverload1.avg, 25000);
+        assert.equal(transferOverload1.median, 25000);
+        assert.equal(transferOverload1.calls, 1);
+
+        const transferOverload2 = contractStats.functions.get(
+          "transfer(address,uint256,bytes)",
+        );
+        assert.ok(
+          transferOverload2 !== undefined,
+          "transfer(address,uint256,bytes) function stats should be defined",
+        );
+        assert.equal(transferOverload2.min, 35000);
+        assert.equal(transferOverload2.max, 35000);
+        assert.equal(transferOverload2.avg, 35000);
+        assert.equal(transferOverload2.median, 35000);
+        assert.equal(transferOverload2.calls, 1);
+      });
+
+      it("should handle empty gas measurements", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+
+        const gasStats = manager._calculateGasStats();
+
+        assert.equal(gasStats.size, 0);
+      });
+
+      it("should round average and median to 2 decimal places", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 33330,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 33334,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 33335,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 33340,
+        });
+
+        const gasStats = manager._calculateGasStats();
+
+        const contractStats = gasStats.get(
+          "project/contracts/MyContract.sol:MyContract",
+        );
+        const transferStats = contractStats?.functions.get("transfer");
+
+        assert.ok(
+          transferStats !== undefined,
+          "transfer function stats should be defined",
+        );
+        assert.equal(transferStats.avg, 33334.75);
+        assert.equal(transferStats.median, 33334.5);
+      });
+    });
+
+    describe("_generateGasStatsReport", () => {
+      it("should generate an empty report for no gas stats", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+
+        const report = manager._generateGasStatsReport(new Map());
+
+        assert.equal(report, "");
+      });
+
+      it("should generate a report", () => {
+        const manager = new GasAnalyticsManagerImplementation(process.cwd());
+        const gasStats = new Map();
+        gasStats.set("project/contracts/MyContract.sol:MyContract", {
+          deployment: { gas: 500000, size: 2048 },
+          functions: new Map([
+            [
+              "transfer",
+              {
+                min: 20000,
+                max: 30000,
+                avg: 25000,
+                median: 25000,
+                calls: 3,
+              },
+            ],
+            [
+              "balanceOf",
+              {
+                min: 15000,
+                max: 15000,
+                avg: 15000,
+                median: 15000,
+                calls: 1,
+              },
+            ],
+          ]),
+        });
+
+        gasStats.set("project/contracts/TokenA.sol:TokenA", {
+          deployment: undefined,
+          functions: new Map([
+            [
+              "transfer(address,uint256)",
+              {
+                min: 22000,
+                max: 28000,
+                avg: 25000,
+                median: 25000,
+                calls: 2,
+              },
+            ],
+            [
+              "transfer(address,uint256,bytes)",
+              {
+                min: 32000,
+                max: 36000,
+                avg: 34000,
+                median: 34000,
+                calls: 2,
+              },
+            ],
+          ]),
+        });
+
+        const report = manager._generateGasStatsReport(gasStats);
+
+        const expectedReport = `
+| ${chalk.cyan.bold("contracts/MyContract.sol:MyContract")} |                 |         |        |       |        |
+| ----------------------------------- | --------------- | ------- | ------ | ----- | ------ |
+| ${chalk.yellow("Deployment Cost")}                     | ${chalk.yellow("Deployment Size")} |         |        |       |        |
+| 500000                              | 2048            |         |        |       |        |
+| ${chalk.yellow("Function name")}                       | ${chalk.yellow("Min")}             | ${chalk.yellow("Average")} | ${chalk.yellow("Median")} | ${chalk.yellow("Max")}   | ${chalk.yellow("#calls")} |
+| transfer                            | 20000           | 25000   | 25000  | 30000 | 3      |
+| balanceOf                           | 15000           | 15000   | 15000  | 15000 | 1      |
+|                                     |                 |         |        |       |        |
+| ${chalk.cyan.bold("contracts/TokenA.sol:TokenA")}         |                 |         |        |       |        |
+| ----------------------------------- | --------------- | ------- | ------ | ----- | ------ |
+| ${chalk.yellow("Function name")}                       | ${chalk.yellow("Min")}             | ${chalk.yellow("Average")} | ${chalk.yellow("Median")} | ${chalk.yellow("Max")}   | ${chalk.yellow("#calls")} |
+| transfer(address,uint256)           | 22000           | 25000   | 25000  | 28000 | 2      |
+| transfer(address,uint256,bytes)     | 32000           | 34000   | 34000  | 36000 | 2      |
+`.trim();
+
+        assert.equal(report, expectedReport);
+      });
+    });
+  });
+
   describe("helpers", () => {
     describe("avg", () => {
       it("should calculate average of numbers", () => {

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -395,6 +395,7 @@ describe("edr-provider", () => {
       const providerConfig = await getProviderConfig(
         networkConfigStub,
         undefined,
+        undefined,
         new Map([
           [1n, { name: "mainnet", chainType: "l1", blockExplorers: {} }],
           [

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -261,6 +261,7 @@ GLOBAL OPTIONS:
   --build-profile          The build profile to use
   --config                 A Hardhat config file
   --coverage               Enables code coverage
+  --gas-stats              Collects and displays gas usage statistics for all function calls during tests
   --help, -h               Show this message, or a task's help if its name is provided
   --init                   Initializes a Hardhat project
   --network                The network to connect to
@@ -333,6 +334,7 @@ GLOBAL OPTIONS:
   --build-profile          The build profile to use
   --config                 A Hardhat config file
   --coverage               Enables code coverage
+  --gas-stats              Collects and displays gas usage statistics for all function calls during tests
   --help, -h               Show this message, or a task's help if its name is provided
   --init                   Initializes a Hardhat project
   --network                The network to connect to
@@ -372,6 +374,7 @@ GLOBAL OPTIONS:
   --build-profile          The build profile to use
   --config                 A Hardhat config file
   --coverage               Enables code coverage
+  --gas-stats              Collects and displays gas usage statistics for all function calls during tests
   --help, -h               Show this message, or a task's help if its name is provided
   --init                   Initializes a Hardhat project
   --network                The network to connect to

--- a/v-next/hardhat/test/internal/hre-initialization.ts
+++ b/v-next/hardhat/test/internal/hre-initialization.ts
@@ -247,6 +247,7 @@ describe("HRE initialization", () => {
           buildProfile: undefined,
           config: configPath,
           coverage: false,
+          gasStats: false,
           help: false,
           init: false,
           showStackTraces: false,


### PR DESCRIPTION
Implements gas usage statistics collection and reporting during JavaScript/TypeScript test execution.

### Changes
 - Added `gas-analytics` built-in plugin with `--gas-stats` global flag.
 - Integrated gas data collection from EDR via `onCollectedGasReportCallback` callback.
 - Implemented statistics calculation (min, avg, median, max, call count) for contract functions.
 - Added formatted table output displayed after test completion. 
 - Supported JavaScript/TypeScript test runners.

### Technical Details

 - Gas measurements are collected via the `onGasMeasurement` hook in the `network-manager` plugin.
 - Statistics are aggregated by contract and function, with proper handling of overloaded functions. For deployments, only the last deployment is saved.

### Usage
```
hardhat test nodejs --gas-stats
```

### Output Example
```
// TODO
```

Closes https://github.com/NomicFoundation/hardhat/issues/7428