### PR TITLE
Add summary outputs when multiple test runners are invoked

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
         specifier: foundry-rs/forge-std#v1.9.4
         version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262
       hardhat:
-        specifier: workspace:^3.0.6
+        specifier: workspace:^3.0.0
         version: link:../hardhat
       mocha:
         specifier: ^11.0.0

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -23,7 +23,7 @@
     "test": "hardhat test nodejs && hardhat test mocha"
   },
   "devDependencies": {
-    "hardhat": "workspace:^3.0.6",
+    "hardhat": "workspace:^3.0.0",
     "@nomicfoundation/hardhat-ethers-chai-matchers": "workspace:^3.0.0",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.0",
     "@nomicfoundation/hardhat-ethers": "workspace:^4.0.0",

--- a/v-next/hardhat-mocha/src/task-action.ts
+++ b/v-next/hardhat-mocha/src/task-action.ts
@@ -122,8 +122,9 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
   await markTestRunStart("mocha");
 
+  let total = 0;
   const testFailures = await new Promise<number>((resolve) => {
-    mocha.run(resolve);
+    total = mocha.run(resolve).total;
   });
 
   if (hre.config.test.mocha.parallel !== true) {
@@ -139,7 +140,7 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
   console.log();
 
-  return testFailures;
+  return `passed: ${total - testFailures}\nfailed: ${testFailures}`;
 };
 
 export default testWithHardhat;

--- a/v-next/hardhat-node-test-runner/src/index.ts
+++ b/v-next/hardhat-node-test-runner/src/index.ts
@@ -28,6 +28,11 @@ const hardhatPlugin: HardhatPlugin = {
         name: "noCompile",
         description: "Don't compile the project before running the tests",
       })
+      .addFlag({
+        name: "summaryEnabled",
+        description: "Print a summary of all test runners",
+        // hidden: true
+      })
       .setAction(() => import("./task-action.js"))
       .build(),
   ],

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -40,6 +40,11 @@ const hardhatPlugin: HardhatPlugin = {
         description: "Verbosity level of the test output",
         defaultValue: 2,
       })
+      .addFlag({
+        name: "summaryEnabled",
+        description: "Print a summary of all test runners",
+        // hidden: true
+      })
       .setAction(async () => import("./task-action.js"))
       .build(),
   ],

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -47,6 +47,8 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
     hre._coverage.disableReport();
   }
 
+  const testSummaries: Record<string, string> = {};
+
   for (const subtask of thisTask.subtasks.values()) {
     const files = getTestFilesForSubtask(subtask, testFiles, subtasksToFiles);
 
@@ -70,7 +72,18 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
       args.verbosity = verbosity;
     }
 
-    await subtask.run(args);
+    if (subtask.options.has("summaryEnabled")) {
+      args.summaryEnabled = true;
+    }
+
+    testSummaries[subtask.id.join("-")] = await subtask.run(args);
+  }
+
+  for (const [subtaskName, summary] of Object.entries(testSummaries)) {
+    console.log(`=== Summary for ${subtaskName} ===`);
+    console.log();
+    console.log(summary);
+    console.log();
   }
 
   if (hre.globalOptions.coverage === true) {


### PR DESCRIPTION
closes https://github.com/NomicFoundation/hardhat/issues/7053

I'm not entirely sure this is exactly what we want. In my opinion, it looks a bit sloppier than just the runners on their own, but i'm happy to workshop the output if we decide to.