### PR TITLE
refactor: make coverage table consistent with gas statistics table

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -5,10 +5,12 @@ import type {
   Statement,
   Tag,
 } from "./types.js";
+import type { TableItem } from "@nomicfoundation/hardhat-utils/format";
 
 import path from "node:path";
 
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import { divider, formatTable } from "@nomicfoundation/hardhat-utils/format";
 import {
   ensureDir,
   getAllFilesMatching,
@@ -17,6 +19,7 @@ import {
   writeJsonFile,
   writeUtf8File,
 } from "@nomicfoundation/hardhat-utils/fs";
+import chalk from "chalk";
 import debug from "debug";
 
 const log = debug("hardhat:core:coverage:coverage-manager");
@@ -26,7 +29,9 @@ const MAX_COLUMN_WIDTH = 80;
 type Line = number;
 type Branch = [Line, Tag];
 
-// NOTE: This is exposed for testing only
+/**
+ * @private exposed for testing purposes only
+ */
 export interface Report {
   [relativePath: string]: {
     tagExecutionCounts: Map<Tag, number>;
@@ -43,8 +48,13 @@ export interface Report {
 }
 
 export class CoverageManagerImplementation implements CoverageManager {
-  // NOTE: These are exposed for testing only
+  /**
+   * @private exposed for testing purposes only
+   */
   public metadata: CoverageMetadata = [];
+  /**
+   * @private exposed for testing purposes only
+   */
   public data: CoverageData = [];
 
   readonly #coveragePath: string;
@@ -122,7 +132,9 @@ export class CoverageManagerImplementation implements CoverageManager {
     this.#reportEnabled = false;
   }
 
-  // NOTE: This is exposed for testing only
+  /**
+   * @private exposed for testing purposes only
+   */
   public async loadData(...ids: string[]): Promise<void> {
     this.data = [];
     for (const id of ids) {
@@ -138,7 +150,9 @@ export class CoverageManagerImplementation implements CoverageManager {
     }
   }
 
-  // NOTE: This is exposed for testing only
+  /**
+   * @private exposed for testing purposes only
+   */
   public getReport(): Report {
     const report: Report = {};
 
@@ -278,7 +292,9 @@ export class CoverageManagerImplementation implements CoverageManager {
     return report;
   }
 
-  // NOTE: This is exposed for testing only
+  /**
+   * @private exposed for testing purposes only
+   */
   public formatLcovReport(report: Report): string {
     // NOTE: Format follows the guidelines set out in:
     // https://github.com/linux-test-project/lcov/blob/df03ba434eee724bfc2b27716f794d0122951404/man/geninfo.1#L1409
@@ -349,7 +365,9 @@ export class CoverageManagerImplementation implements CoverageManager {
     return lcov;
   }
 
-  // NOTE: This is exposed for testing only
+  /**
+   * @private exposed for testing purposes only
+   */
   public formatRelativePath(relativePath: string): string {
     if (relativePath.length <= MAX_COLUMN_WIDTH) {
       return relativePath;
@@ -383,12 +401,16 @@ export class CoverageManagerImplementation implements CoverageManager {
     return parts.reverse().join(path.sep);
   }
 
-  // NOTE: This is exposed for testing only
+  /**
+   * @private exposed for testing purposes only
+   */
   public formatCoverage(coverage: number): string {
     return coverage.toFixed(2).toString();
   }
 
-  // NOTE: This is exposed for testing only
+  /**
+   * @private exposed for testing purposes only
+   */
   public formatLines(lines: Set<number>): string {
     if (lines.size === 0) {
       return "-";
@@ -449,7 +471,9 @@ export class CoverageManagerImplementation implements CoverageManager {
     return [intervals.join(sep), suffix].join(suffixSep);
   }
 
-  // NOTE: This is exposed for testing only
+  /**
+   * @private exposed for testing purposes only
+   */
   public formatMarkdownReport(report: Report): string {
     let totalExecutedLines = 0;
     let totalExecutableLines = 0;
@@ -457,15 +481,22 @@ export class CoverageManagerImplementation implements CoverageManager {
     let totalExecutedStatements = 0;
     let totalExecutableStatements = 0;
 
-    const headerRow = [
-      "File Path 📦",
-      "Line % 📈",
-      "Statement % 📈",
-      "Uncovered Lines 🔍",
-      "Partially Covered Lines 🔍",
-    ];
+    const rows: TableItem[] = [];
 
-    const rows = Object.entries(report).map(
+    rows.push([chalk.bold("Coverage Report")]);
+    rows.push(divider);
+
+    rows.push(
+      [
+        "File Path",
+        "Line %",
+        "Statement %",
+        "Uncovered Lines",
+        "Partially Covered Lines",
+      ].map((s) => chalk.yellow(s)),
+    );
+
+    const bodyRows = Object.entries(report).map(
       ([
         relativePath,
         {
@@ -504,6 +535,8 @@ export class CoverageManagerImplementation implements CoverageManager {
       },
     );
 
+    rows.push(...bodyRows);
+
     const totalLineCoverage =
       totalExecutableLines === 0
         ? 0
@@ -513,40 +546,15 @@ export class CoverageManagerImplementation implements CoverageManager {
         ? 0
         : (totalExecutedStatements * 100.0) / totalExecutableStatements;
 
-    const footerRow = [
-      "Total",
+    rows.push(divider);
+    rows.push([
+      chalk.yellow("Total"),
       this.formatCoverage(totalLineCoverage),
       this.formatCoverage(totalStatementCoverage),
       "",
       "",
-    ];
+    ]);
 
-    const widths = headerRow.map((header) => header.length);
-
-    for (const row of rows) {
-      for (let i = 0; i < row.length; i++) {
-        widths[i] = Math.max(widths[i], row[i].length);
-      }
-    }
-
-    for (let i = 0; i < footerRow.length; i++) {
-      widths[i] = Math.max(widths[i], footerRow[i].length);
-    }
-
-    const dividerRow = widths.map((width) => "-".repeat(width));
-
-    rows.unshift(dividerRow);
-    rows.unshift(headerRow);
-
-    rows.push(dividerRow);
-    rows.push(footerRow);
-
-    rows.forEach((row) => {
-      for (let i = 0; i < row.length; i++) {
-        row[i] = row[i].padEnd(widths[i]);
-      }
-    });
-
-    return rows.map((row) => `| ${row.join(" | ")} |`).join("\n");
+    return formatTable(rows);
   }
 }

--- a/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, it } from "node:test";
 
 import { disableConsole, useTmpDir } from "@nomicfoundation/hardhat-test-utils";
 import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
+import chalk from "chalk";
 
 import { CoverageManagerImplementation } from "../../../../src/internal/builtin-plugins/coverage/coverage-manager.js";
 
@@ -315,12 +316,13 @@ describe("CoverageManagerImplementation", () => {
   it("should format the markdown report", async () => {
     const actual = coverageManager.formatMarkdownReport(report);
     const expected = [
-      "| File Path 📦        | Line % 📈 | Statement % 📈 | Uncovered Lines 🔍 | Partially Covered Lines 🔍 |",
-      "| ------------------- | --------- | -------------- | ------------------ | -------------------------- |",
-      "| contracts/test.sol  | 80.00     | 75.00          | 6                  | 5                          |",
-      "| contracts/other.sol | 0.00      | 0.00           | 1-2                | -                          |",
-      "| ------------------- | --------- | -------------- | ------------------ | -------------------------- |",
-      "| Total               | 57.14     | 60.00          |                    |                            |",
+      `| ${chalk.bold("Coverage Report")}     |        |             |                 |                         |`,
+      "| ------------------- | ------ | ----------- | --------------- | ----------------------- |",
+      `| ${chalk.yellow("File Path")}           | ${chalk.yellow("Line %")} | ${chalk.yellow("Statement %")} | ${chalk.yellow("Uncovered Lines")} | ${chalk.yellow("Partially Covered Lines")} |`,
+      "| contracts/test.sol  | 80.00  | 75.00       | 6               | 5                       |",
+      "| contracts/other.sol | 0.00   | 0.00        | 1-2             | -                       |",
+      "| ------------------- | ------ | ----------- | --------------- | ----------------------- |",
+      `| ${chalk.yellow("Total")}               | 57.14  | 60.00       |                 |                         |`,
     ].join("\n");
     assert.equal(actual, expected);
   });


### PR DESCRIPTION
Before:
<img width="1695" height="285" alt="image" src="https://github.com/user-attachments/assets/476d3d0e-9b83-4d74-9678-15c41fa874b6" />

After:
<img width="1511" height="316" alt="image" src="https://github.com/user-attachments/assets/c178f263-e16d-4aec-aa08-71269020f0e0" />

Gas Statistics Table for reference:
<img width="1552" height="607" alt="image" src="https://github.com/user-attachments/assets/3a818f33-cbb4-4127-a5f2-87ba3a22ac4d" />
