### PR TITLE
test: fix integration test for deps install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 hoist-pattern[]=!@types/*
 minimum-release-age=10080
+minimum-release-age-exclude[]="hardhat"
+minimum-release-age-exclude[]="@nomicfoundation/*"

--- a/v-next/hardhat/test/internal/cli/init/init.ts
+++ b/v-next/hardhat/test/internal/cli/init/init.ts
@@ -377,6 +377,16 @@ describe("installProjectDependencies", async () => {
       },
       async () => {
         await writeUtf8File("package.json", JSON.stringify({ type: "module" }));
+        // NOTE: Because we run tests under `pnpm`, the config setting in
+        // the root `./npmrc` file make it to the subprocesses.
+        // Unfortunately the `minimum-release-age-exclude` because it is an
+        // array can get lost.
+        // We explicitly add the `minimum-release-age-exclude` in as a
+        // `.npmrc` file in the temporary folder to re-introduce this exclude.
+        await writeUtf8File(
+          ".npmrc",
+          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
+        );
         await installProjectDependencies(process.cwd(), template, true, false);
         assert.ok(await exists("node_modules"), "node_modules should exist");
         const dependencies = Object.keys(
@@ -420,6 +430,11 @@ describe("installProjectDependencies", async () => {
           type: "module",
           devDependencies: { hardhat: "0.0.0" },
         }),
+      );
+      // NOTE: See related explanation in the `should install all the ${template.name} ...` test
+      await writeUtf8File(
+        ".npmrc",
+        'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
       );
       await installProjectDependencies(process.cwd(), template, false, true);
       assert.ok(await exists("node_modules"), "node_modules should exist");


### PR DESCRIPTION
The integration test that tests the install of the template projects was failing after we introduced the `maxReleaseAge` config option in the root `.npmrc` file.
The failure was because the latest version of hardhat (i.e. "3.0.7"), had only just been released so the install constraints could not be met until it had been released for a week.
This commit resolves the issue with two moves:

1. Add `hardhat` and the `@nomicfoundation` packages as excludes from this rule in the root `.npmrc` file
2. Further add a temporary `.npmrc` file in the tmp directory used for testing the installs with pnpm

The second step was necessary as our tests are run with pnpm, which populates the env of the running process with `npm_config_*` entries. These entries are available in the subprocess where the test runs `pnpm install --save-dev ...`. However, the `minimum-release-age-exclude` parameter is an array, and these are problematic in copying across the process barrier via env variables.