### PR TITLE
Research: replace direct usage of `markTestRunStart` with `onTestRunStart` hook

### DIFF
--- a/v-next/hardhat-mocha/src/task-action.ts
+++ b/v-next/hardhat-mocha/src/task-action.ts
@@ -7,11 +7,7 @@ import { resolve as pathResolve } from "node:path";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { setGlobalOptionsAsEnvVariables } from "@nomicfoundation/hardhat-utils/env";
 import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
-import {
-  markTestRunDone,
-  markTestRunStart,
-  markTestWorkerDone,
-} from "hardhat/internal/coverage";
+import { markTestRunDone, markTestWorkerDone } from "hardhat/internal/coverage";
 
 interface TestActionArguments {
   testFiles: string[];
@@ -120,7 +116,8 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   // which supports both ESM and CJS
   await mocha.loadFilesAsync();
 
-  await markTestRunStart("mocha");
+  // await markTestRunStart("mocha");
+  await hre.hooks.runParallelHandlers("test", "onTestRunStart", ["mocha"]);
 
   const testFailures = await new Promise<number>((resolve) => {
     mocha.run(resolve);

--- a/v-next/hardhat-node-test-runner/src/task-action.ts
+++ b/v-next/hardhat-node-test-runner/src/task-action.ts
@@ -10,7 +10,7 @@ import { hardhatTestReporter } from "@nomicfoundation/hardhat-node-test-reporter
 import { setGlobalOptionsAsEnvVariables } from "@nomicfoundation/hardhat-utils/env";
 import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
 import { createNonClosingWriter } from "@nomicfoundation/hardhat-utils/stream";
-import { markTestRunStart, markTestRunDone } from "hardhat/internal/coverage";
+import { markTestRunDone } from "hardhat/internal/coverage";
 
 interface TestActionArguments {
   testFiles: string[];
@@ -130,7 +130,8 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
     return failures;
   }
 
-  await markTestRunStart("nodejs");
+  // await markTestRunStart("nodejs");
+  await hre.hooks.runParallelHandlers("test", "onTestRunStart", ["nodejs"]);
 
   const testFailures = await runTests();
 

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/test.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/test.ts
@@ -1,0 +1,14 @@
+import type { TestHooks } from "hardhat/types/hooks";
+
+import { markTestRunStart } from "../helpers.js";
+
+export default async (): Promise<Partial<TestHooks>> => {
+  const handlers: Partial<TestHooks> = {
+    onTestRunStart: async (_context, id) => {
+      console.log(`onTestRunStart coverage hook handler called with id: ${id}`);
+      await markTestRunStart(id);
+    },
+  };
+
+  return handlers;
+};

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/index.ts
@@ -17,6 +17,7 @@ const hardhatPlugin: HardhatPlugin = {
     clean: () => import("./hook-handlers/clean.js"),
     hre: () => import("./hook-handlers/hre.js"),
     solidity: () => import("./hook-handlers/solidity.js"),
+    test: () => import("./hook-handlers/test.js"),
   },
   npmPackage: "hardhat",
 };

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -19,11 +19,7 @@ import { createNonClosingWriter } from "@nomicfoundation/hardhat-utils/stream";
 import { HardhatRuntimeEnvironmentImplementation } from "../../core/hre.js";
 import { isSupportedChainType } from "../../edr/chain-type.js";
 import { ArtifactManagerImplementation } from "../artifacts/artifact-manager.js";
-import {
-  markTestRunDone,
-  markTestRunStart,
-  markTestWorkerDone,
-} from "../coverage/helpers.js";
+import { markTestRunDone, markTestWorkerDone } from "../coverage/helpers.js";
 
 import { getEdrArtifacts, getBuildInfos } from "./edr-artifacts.js";
 import {
@@ -148,7 +144,8 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   const options: RunOptions =
     solidityTestConfigToRunOptions(solidityTestConfig);
 
-  await markTestRunStart("solidity");
+  // await markTestRunStart("solidity");
+  await hre.hooks.runParallelHandlers("test", "onTestRunStart", ["solidity"]);
 
   const runStream = run(
     chainType,

--- a/v-next/hardhat/src/internal/builtin-plugins/test/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/type-extensions.ts
@@ -39,5 +39,7 @@ declare module "../../../types/hooks.js" {
         filePath: string,
       ) => Promise<string | undefined>,
     ) => Promise<string | undefined>;
+
+    onTestRunStart(context: HookContext, id: string): Promise<void>;
   }
 }


### PR DESCRIPTION
On this PR I've demonstrated that the helper functions exported from the `coverage` and `gas-analytics` plugins can be replaced by using hooks for the `test` task, with handlers defined directly in those plugins.

In this demo, I've removed the `markTestRunStart` function call from the test runner actions and replaced it with the `onTestRunStart` hook. The same approach can be applied to `markTestRunDone` and `markTestWorkerDone`, eliminating the plugin dependency as well as allowing users to define their own handlers.

**Note:** Hook names and types are illustrative only. This PR is not intended to be merged.