### PR TITLE
Update release workflow to use trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,8 @@ jobs:
           cd tarballs
           for filename in *.tgz; do
             echo "Publishing $filename"
-            npm publish $filename --tag latest
+            # We can switch to pnpm publish when pnpm supports Trusted publishing
+            npm publish $filename --tag latest --access public
           done
 
   tag:


### PR DESCRIPTION
The release workflow is now split into 5 jobs:
1. PR: Execute the changesets action. This will either create a PR bumping packages versions, or enable the rest of the workflow for publishing packages.
2. Pack: Build packages,execute a dry run, and pack them into tarballs to be uploaded as artifacts of the workflow run. The pack/publish steps are separated to minimize attack surface, since only the publish job runs in an environment whitelisted for publishing. Only packages with changes are affected (by leveraging dry-run output report).
3. Review: A diff is shown between proposed packages and latest published versions of those packages
4. Publish: This action is the only one that runs in an environment allowed to publish. Also at repository level this should be configured to require approvers. These should double check the output of the previous job (diff) before approving the release. The action itself downloads the previously generated tarballs and pushes them to npm.
5. Tag: Tags are created using changesets and pushed to the repo.

Preparation:
- Set up the github environment that will be used for publishing. Set up approvers and any other additional protection rule.
- Set up trusted publishing on npm.js both for the organization and the `hardhat` package. The workflow file name and the github environment id must be specified.
