### PR TITLE
fix: Guard v-next script validation against missing package scripts

### DIFF
--- a/scripts/check-v-next-npm-scripts.js
+++ b/scripts/check-v-next-npm-scripts.js
@@ -65,8 +65,28 @@ for (const dir of dirs) {
 
   for (const scriptName in templatePackageJson.scripts) {
     if (scriptName === "clean") {
+      if (packageJson.scripts === undefined) {
+        console.error(`Missing scripts section in ${dir.name}`);
+        console.error();
+
+        errorsFound = true;
+
+        continue;
+      }
+
+      const actualCleanScript = packageJson.scripts[scriptName];
+
+      if (actualCleanScript === undefined) {
+        console.error(`Missing script ${scriptName} in ${dir.name}`);
+        console.error();
+
+        errorsFound = true;
+
+        continue;
+      }
+
       if (
-        !packageJson.scripts[scriptName].startsWith(
+        !actualCleanScript.startsWith(
           templatePackageJson.scripts[scriptName],
         )
       ) {
@@ -85,11 +105,11 @@ for (const dir of dirs) {
 
     if (
       templatePackageJson.scripts[scriptName] !==
-      packageJson.scripts[scriptName]
+      (packageJson.scripts?.[scriptName] ?? "")
     ) {
       console.error(`Mismatch in script ${scriptName} in ${dir.name}`);
       console.error(`  Expected: ${templatePackageJson.scripts[scriptName]}`);
-      console.error(`  Actual:   ${packageJson.scripts[scriptName] ?? ""}`);
+      console.error(`  Actual:   ${packageJson.scripts?.[scriptName] ?? ""}`);
       console.error();
 
       errorsFound = true;


### PR DESCRIPTION
This makes the validation script resilient when a package lacks a scripts section or its clean entry, so the tooling reports actionable errors instead of crashing. It’s important because a single incomplete package.json could previously halt the check and hide other issues across the workspace.