### PR TITLE
Remove unused category for `hh-ledger` from `hh-errors`

### DIFF
--- a/.changeset/young-penguins-think.md
+++ b/.changeset/young-penguins-think.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/hardhat-errors": patch
----
-
-Removed an unused `hardhat-ledger` category from `hardhat-errors` [7610](https://github.com/NomicFoundation/hardhat/pull/7610)


### PR DESCRIPTION
Fix for an issue that also impact `hardhat-website`: https://github.com/NomicFoundation/hardhat-website/pull/105#issuecomment-3431561468