### PR TITLE
Publish packages  in dependency order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
             echo "hasPackages=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # The --filter parameter filters by exact package name, so there's no risk of a package name being a substring of another package name
       - name: Generate tarballs for packages that need publishing
         id: pack
         if: steps.detect.outputs.hasPackages == 'true'


### PR DESCRIPTION
This changes the order in which the packages (tarballs) are published. Instead of publishing them sorted alphabetically, now the `pnpm-publish-summary.json` file is used to iterate over the packages in the order established by pnpm. This is the exact same as we were using with the old release workflow, which relied on a single `pnpm publish -r` command.

