### PR TITLE
chore: improve the changelog formatting

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.6.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "../scripts/custom-changelog.mjs",
   "commit": false,
   "linked": [],
   "access": "public",

--- a/scripts/custom-changelog.mjs
+++ b/scripts/custom-changelog.mjs
@@ -1,0 +1,12 @@
+import defaultChangelog from "@changesets/cli/changelog";
+
+export default {
+  getReleaseLine: async (changeset) => {
+    return defaultChangelog.getReleaseLine(changeset);
+  },
+  // We do not want dependency releases included in
+  // our changelogs e.g. "  - Updated dependencies [e5ff273]"
+  getDependencyReleaseLine: async () => {
+    return "";
+  },
+};


### PR DESCRIPTION
Remove the dependency release lines in our changeset generation of changelogs e.g. "Updated dependencies [e5ff273]". We remove them manually, so instead lets not generate them by providing our own override of the `@changesets/changelog-git` module.
