### PR TITLE
feat: don't compile solidity test contracts from js/ts tests

### DIFF
--- a/.changeset/slow-doors-enjoy.md
+++ b/.changeset/slow-doors-enjoy.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/hardhat-node-test-runner": patch
+"@nomicfoundation/hardhat-mocha": patch
+"hardhat": patch
+---
+
+Improved JS/TS test tasks to not compile Solidity tests ([#7626](https://github.com/NomicFoundation/hardhat/pull/7626))

--- a/v-next/hardhat-mocha/src/task-action.ts
+++ b/v-next/hardhat-mocha/src/task-action.ts
@@ -66,7 +66,9 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   setGlobalOptionsAsEnvVariables(hre.globalOptions);
 
   if (!noCompile) {
-    await hre.tasks.getTask("compile").run({});
+    await hre.tasks.getTask("compile").run({
+      noTests: true,
+    });
     console.log();
   }
 

--- a/v-next/hardhat-node-test-runner/src/task-action.ts
+++ b/v-next/hardhat-node-test-runner/src/task-action.ts
@@ -74,7 +74,9 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   setGlobalOptionsAsEnvVariables(hre.globalOptions);
 
   if (!noCompile) {
-    await hre.tasks.getTask("compile").run({});
+    await hre.tasks.getTask("compile").run({
+      noTests: true,
+    });
     console.log();
   }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -35,7 +35,9 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
   const thisTask = hre.tasks.getTask("test");
 
   if (!noCompile) {
-    await hre.tasks.getTask("compile").run({});
+    await hre.tasks.getTask("compile").run({
+      noTests: true,
+    });
     console.log();
   }
 


### PR DESCRIPTION
Previously both core contracts and tests were compiled for the mocha/nodejs tests. Now only the core contracts are compiled as these are the only contracts that are needed for JS/TS tests.

Both js/ts tasks now don't compile tests. Note: the `npx hardhat test` overrarching task no longer compiles Solidity tests either - this is handled by the Solidity test task - it basically always compiles the tests.

## Manual testing

To check that this works I ran manual tests against the example project. Specifically running `npx hardhat clean` then:

* `npx hardhat test`
* `npx hardhat test mocha`
* `npx hardhat test nodejs`
* `npx hardhat test solidity`
