### PR TITLE
Alpha v2 version bug

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -230,6 +230,7 @@ export class EdrProviderWrapper
       genesisState.push({
         address: privateToAddress(privateKey),
         balance: BigInt(account.balance),
+        code: new Uint8Array(), // Empty account code, removing potential delegation code when forking
       });
 
       return account.privateKey;


### PR DESCRIPTION
### Issue
The default addresses are EIP-7702 delegated. We fixed this in V3 by zeroing the code of those accounts when starting the network. It's unclear why this works in HH3 but not in the alpha, since both use the same version of EDR and the code that instantiates the network is similar enough.

### Fix
Use same approach as in V3: https://github.com/NomicFoundation/hardhat/blob/8159b3a24b19528885ddf6f445807f6c1dc5ba3f/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts#L456