### PR TITLE
chore: update readme instructions instructions to use `hh2` tag

### DIFF
--- a/.changeset/cold-parts-shave.md
+++ b/.changeset/cold-parts-shave.md
@@ -1,0 +1,22 @@
+---
+"@nomicfoundation/hardhat-ignition-ethers": patch
+"@nomicfoundation/hardhat-network-helpers": patch
+"@nomicfoundation/hardhat-chai-matchers": patch
+"@nomicfoundation/hardhat-ignition-viem": patch
+"@nomiclabs/hardhat-web3-legacy": patch
+"hardhat-shorthand": patch
+"@nomicfoundation/hardhat-ignition": patch
+"@nomiclabs/hardhat-truffle4": patch
+"@nomiclabs/hardhat-truffle5": patch
+"@nomiclabs/hardhat-solhint": patch
+"@nomicfoundation/hardhat-web3-v4": patch
+"@nomicfoundation/hardhat-ethers": patch
+"@nomicfoundation/hardhat-ledger": patch
+"@nomicfoundation/hardhat-verify": patch
+"@nomiclabs/hardhat-solpp": patch
+"@nomiclabs/hardhat-vyper": patch
+"@nomicfoundation/hardhat-viem": patch
+"@nomiclabs/hardhat-web3": patch
+---
+
+Update README installation instructions to point to the Hardhat 2 tag: `hh2` ([#7636](https://github.com/NomicFoundation/hardhat/pull/7636))

--- a/packages/hardhat-chai-matchers/README.md
+++ b/packages/hardhat-chai-matchers/README.md
@@ -11,19 +11,19 @@ Check [its documentation](https://v2.hardhat.org/hardhat-chai-matchers/docs) to 
 We recommend using npm 7 or later. If you do that, then you just need to install the plugin itself:
 
 ```bash
-npm install --save-dev @nomicfoundation/hardhat-chai-matchers
+npm install --save-dev @nomicfoundation/hardhat-chai-matchers@hh2
 ```
 
 If you are using an older version of npm, you'll also need to install all the packages used by the plugin.
 
 ```bash
-npm install --save-dev @nomicfoundation/hardhat-chai-matchers chai@4 @nomicfoundation/hardhat-ethers ethers
+npm install --save-dev @nomicfoundation/hardhat-chai-matchers@hh2 chai@4 @nomicfoundation/hardhat-ethers@hh2 ethers
 ```
 
 That's also the case if you are using yarn:
 
 ```bash
-yarn add --dev @nomicfoundation/hardhat-chai-matchers chai@4 @nomicfoundation/hardhat-ethers ethers
+yarn add --dev @nomicfoundation/hardhat-chai-matchers@hh2 chai@4 @nomicfoundation/hardhat-ethers@hh2 ethers
 ```
 
 ### Usage

--- a/packages/hardhat-core/README.md
+++ b/packages/hardhat-core/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-> **🚀 Hardhat 3 alpha release is out! [Learn more.](https://hardhat.org)**
+> **🚀 Hardhat 3 Beta release is out! [Learn more.](https://hardhat.org)**
 
 Hardhat is an Ethereum development environment for professionals. It facilitates performing frequent tasks, such as running tests, automatically checking code for mistakes or interacting with a smart contract. Check out the [plugin list](https://v2.hardhat.org/plugins/) to use it with your existing tools.
 
@@ -18,10 +18,10 @@ Join our [Hardhat Support Discord server](https://hardhat.org/discord) to stay u
 
 ## Installation
 
-To install Hardhat, go to an empty folder, initialize an `npm` project (i.e. `npm init`), and run
+To install Hardhat 2, go to an empty folder, initialize an `npm` project (i.e. `npm init`), and run
 
 ```
-npm install --save-dev hardhat
+npm install --save-dev hardhat@hh2
 ```
 
 Once it's installed, just run this command and follow its instructions:

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -11,7 +11,7 @@ This plugin brings to Hardhat the Ethereum library `ethers.js`, which allows you
 ## Installation
 
 ```bash
-npm install --save-dev @nomicfoundation/hardhat-ethers ethers
+npm install --save-dev @nomicfoundation/hardhat-ethers@hh2 ethers
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-ignition-ethers/README.md
+++ b/packages/hardhat-ignition-ethers/README.md
@@ -15,7 +15,7 @@ Join the Hardhat Ignition channel of our [Hardhat Community Discord server](http
 ## Installation
 
 ```bash
-npm install --save-dev @nomicfoundation/hardhat-ignition-ethers
+npm install --save-dev @nomicfoundation/hardhat-ignition-ethers@hh2
 ```
 
 Import the plugin in your `hardhat.config.js``:

--- a/packages/hardhat-ignition-viem/README.md
+++ b/packages/hardhat-ignition-viem/README.md
@@ -15,7 +15,7 @@ Join the Hardhat Ignition channel of our [Hardhat Community Discord server](http
 ## Installation
 
 ```bash
-npm install --save-dev @nomicfoundation/hardhat-ignition-viem
+npm install --save-dev @nomicfoundation/hardhat-ignition-viem@hh2
 ```
 
 Import the plugin in your `hardhat.config.js``:

--- a/packages/hardhat-ignition/README.md
+++ b/packages/hardhat-ignition/README.md
@@ -14,10 +14,10 @@ Join the Hardhat Ignition channel of our [Hardhat Community Discord server](http
 
 ```bash
 # ethers users
-npm install --save-dev @nomicfoundation/hardhat-ignition-ethers
+npm install --save-dev @nomicfoundation/hardhat-ignition-ethers@hh2
 
 # viem users
-npm install --save-dev @nomicfoundation/hardhat-ignition-viem
+npm install --save-dev @nomicfoundation/hardhat-ignition-viem@hh2
 ```
 
 Import the plugin in your `hardhat.config.js``:

--- a/packages/hardhat-ledger/README.md
+++ b/packages/hardhat-ledger/README.md
@@ -11,7 +11,7 @@ This plugin extends the Hardhat provider enabling it to work with a connected Le
 ## Installation
 
 ```bash
-npm install --save-dev @nomicfoundation/hardhat-ledger
+npm install --save-dev @nomicfoundation/hardhat-ledger@hh2
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-network-helpers/README.md
+++ b/packages/hardhat-network-helpers/README.md
@@ -9,7 +9,7 @@ Hardhat Network Helpers is a library that provides a set of utility functions to
 We recommend using npm 7 or later:
 
 ```
-npm install --save-dev @nomicfoundation/hardhat-network-helpers
+npm install --save-dev @nomicfoundation/hardhat-network-helpers@hh2
 ```
 
 ### Usage

--- a/packages/hardhat-shorthand/README.md
+++ b/packages/hardhat-shorthand/README.md
@@ -9,5 +9,5 @@ Check [the guide](https://v2.hardhat.org/hardhat-runner/docs/guides/command-line
 ## Installation
 
 ```bash
-npm install --global hardhat-shorthand
+npm install --global hardhat-shorthand@hh2
 ```

--- a/packages/hardhat-solhint/README.md
+++ b/packages/hardhat-solhint/README.md
@@ -11,7 +11,7 @@ This plugin runs solhint on the project's sources and prints the report.
 ## Installation
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-solhint
+npm install --save-dev @nomiclabs/hardhat-solhint@hh2
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-solpp/README.md
+++ b/packages/hardhat-solpp/README.md
@@ -11,7 +11,7 @@ This plugin hooks into the compilation pipeline and runs the solpp preprocessor.
 ## Installation
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-solpp
+npm install --save-dev @nomiclabs/hardhat-solpp@hh2
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-truffle4/README.md
+++ b/packages/hardhat-truffle4/README.md
@@ -17,7 +17,7 @@ This plugin requires [hardhat-web3-legacy](https://github.com/nomiclabs/hardhat/
 ## Installation
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-truffle4 @nomiclabs/hardhat-web3-legacy web3@^0.20.7
+npm install --save-dev @nomiclabs/hardhat-truffle4@hh2 @nomiclabs/hardhat-web3-legacy@hh2 web3@^0.20.7
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-truffle5/README.md
+++ b/packages/hardhat-truffle5/README.md
@@ -15,7 +15,7 @@ This plugin requires [hardhat-web3](https://github.com/nomiclabs/hardhat/tree/ma
 ## Installation
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-truffle5 @nomiclabs/hardhat-web3 'web3@^1.0.0-beta.36'
+npm install --save-dev @nomiclabs/hardhat-truffle5@hh2 @nomiclabs/hardhat-web3@hh2 'web3@^1.0.0-beta.36'
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-verify/README.md
+++ b/packages/hardhat-verify/README.md
@@ -18,7 +18,7 @@ It's smart and it tries to do as much as possible to facilitate the process:
 ## Installation
 
 ```bash
-npm install --save-dev @nomicfoundation/hardhat-verify
+npm install --save-dev @nomicfoundation/hardhat-verify@hh2
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-viem/README.md
+++ b/packages/hardhat-viem/README.md
@@ -15,7 +15,7 @@ Note: This plugin relies on the Viem library, so familiarity with [Viem's docume
 ## Installation
 
 ```bash
-npm install --save-dev @nomicfoundation/hardhat-viem viem
+npm install --save-dev @nomicfoundation/hardhat-viem@hh2 viem
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-vyper/README.md
+++ b/packages/hardhat-vyper/README.md
@@ -17,7 +17,7 @@ The Vyper compiler is run using the [official binary releases](https://github.co
 First, you need to install the plugin by running
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-vyper
+npm install --save-dev @nomiclabs/hardhat-vyper@hh2
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-web3-legacy/README.md
+++ b/packages/hardhat-web3-legacy/README.md
@@ -11,7 +11,7 @@ This plugin brings to Hardhat the Web3 module and an initialized instance of Web
 # Installation
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-web3-legacy web3@^0.20.7
+npm install --save-dev @nomiclabs/hardhat-web3-legacy@hh2 web3@^0.20.7
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-web3-v4/README.md
+++ b/packages/hardhat-web3-v4/README.md
@@ -13,7 +13,7 @@ This plugin brings to Hardhat the Web3 module and an initialized instance of Web
 # Installation
 
 ```bash
-npm install --save-dev @nomicfoundation/hardhat-web3-v4 'web3@4'
+npm install --save-dev @nomicfoundation/hardhat-web3-v4@hh2 'web3@4'
 ```
 
 And add the following statement to your `hardhat.config.js`:

--- a/packages/hardhat-web3/README.md
+++ b/packages/hardhat-web3/README.md
@@ -11,7 +11,7 @@ This plugin brings to Hardhat the Web3 module and an initialized instance of Web
 # Installation
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-web3 'web3@^1.0.0-beta.36'
+npm install --save-dev @nomiclabs/hardhat-web3@hh2 'web3@^1.0.0-beta.36'
 ```
 
 And add the following statement to your `hardhat.config.js`:


### PR DESCRIPTION
With Hardhat 3 as `latest`, intentionally installing the Hardhat 2 version of a package involves installing based on the `hh2` tag.

The README installation instructions have been updated for all published packages to reflect the use of this new tag.
