### PR TITLE
exclude Core and its testnet from zero fee config

### DIFF
--- a/v-next/hardhat-ignition-core/src/internal/execution/jsonrpc-client.ts
+++ b/v-next/hardhat-ignition-core/src/internal/execution/jsonrpc-client.ts
@@ -670,6 +670,7 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
       // of blockchains using Besu. We explicitly exclude BNB
       // Smartchain (chainId 56) and its testnet (chainId 97)
       // as well as opBNB (chainId 204) and its testnet (chainId 5611)
+      // as well as Core (chainId 1116) and its testnet (chainId 1114)
       // from this logic as it is EIP-1559 compliant but
       // only sets a maxPriorityFeePerGas.
       if (
@@ -677,7 +678,9 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
         chainId !== 56 &&
         chainId !== 97 &&
         chainId !== 204 &&
-        chainId !== 5611
+        chainId !== 5611 &&
+        chainId !== 1116 &&
+        chainId !== 1114
       ) {
         return {
           maxFeePerGas: 0n,


### PR DESCRIPTION
This PR replicates the change introduced in [NomicFoundation/hardhat-ignition#755](https://github.com/NomicFoundation/hardhat-ignition/pull/755), where the BNB network was excluded from the baseFee configuration.
Similarly, the Core network requires exclusion from the baseFee logic to support successful deployments via Hardhat Ignition.

Context

- An earlier [PR for Hardhat Ignition](https://github.com/NomicFoundation/hardhat-ignition/pull/866) implementing the same fix for Core was closed before merging.

- Mentioning, [NomicFoundation/hardhat#6857](https://github.com/NomicFoundation/hardhat/pull/6857) introduced support for maxFeePerGas configuration in Ignition.

- However, the corresponding changes do not appear to be included in the current Hardhat v3 release, which results in failed deployments for Core due to incorrect baseFee handling.

Impact

- Without this fix, contract deployments on the Core network via Hardhat Ignition fail during gas estimation due to incompatible baseFee logic.

Request

- Please review and merge this PR to restore deployment compatibility for the Core network.
- If there’s an alternative or preferred approach to handle this configuration, kindly share feedback so we can align and update accordingly.
