### PR TITLE
chore: update version of ledger in prep for release

### DIFF
--- a/.changeset/poor-stars-talk.md
+++ b/.changeset/poor-stars-talk.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ledger": major
+---
+
+Update `hardhat-ledger` to support Hardhat 3 ([#7272](https://github.com/NomicFoundation/hardhat/issues/7272))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         specifier: workspace:^3.0.3
         version: link:../hardhat-keystore
       '@nomicfoundation/hardhat-ledger':
-        specifier: workspace:^1.2.1
+        specifier: workspace:^2.0.0
         version: link:../hardhat-ledger
       '@nomicfoundation/hardhat-mocha':
         specifier: workspace:^3.0.6

--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -31,7 +31,7 @@
     "@nomicfoundation/ignition-core": "workspace:^3.0.4",
     "@nomicfoundation/hardhat-ignition-viem": "workspace:^3.0.4",
     "@nomicfoundation/hardhat-keystore": "workspace:^3.0.3",
-    "@nomicfoundation/hardhat-ledger": "workspace:^1.2.1",
+    "@nomicfoundation/hardhat-ledger": "workspace:^2.0.0",
     "@nomicfoundation/hardhat-mocha": "workspace:^3.0.6",
     "@nomicfoundation/hardhat-network-helpers": "workspace:^3.0.2",
     "@nomicfoundation/hardhat-node-test-runner": "workspace:^3.0.6",

--- a/v-next/hardhat-ledger/package.json
+++ b/v-next/hardhat-ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/hardhat-ledger",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Hardhat plugin for the Ledger hardware wallet",
   "homepage": "https://github.com/nomicfoundation/hardhat/tree/main/v-next/hardhat-ledger",
   "repository": {


### PR DESCRIPTION
Add a changeset that sets the `hardhat-ledger` version to 3.0.0.

Merging this setup will lead to a release of the Hardhat 3 version of `hardhat-ledger`.
