### PR TITLE
Add missing changeset for `hardhat-network-helpers`

### DIFF
--- a/.changeset/missing-changeset.md
+++ b/.changeset/missing-changeset.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Improved the documentation


### PR DESCRIPTION
When we update a README.md we need a changeset