### PR TITLE
Generate typechain types on partial compilation

### DIFF
--- a/.changeset/fancy-adults-strive.md
+++ b/.changeset/fancy-adults-strive.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-typechain": patch
+"hardhat": patch
+---
+
+Generate typechain types on partial compilation

--- a/v-next/hardhat-ethers/test/helpers/artifact-manager-mock.ts
+++ b/v-next/hardhat-ethers/test/helpers/artifact-manager-mock.ts
@@ -80,6 +80,15 @@ export class MockArtifactManager implements ArtifactManager {
     );
   }
 
+  public async getAllArtifactPaths(): Promise<ReadonlySet<string>> {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.INTERNAL.NOT_IMPLEMENTED_ERROR,
+      {
+        message: "Not implemented in MockArtifactManager",
+      },
+    );
+  }
+
   public async getBuildInfoId(
     _contractNameOrFullyQualifiedName: string,
   ): Promise<string | undefined> {

--- a/v-next/hardhat-typechain/src/internal/hook-handlers/solidity.ts
+++ b/v-next/hardhat-typechain/src/internal/hook-handlers/solidity.ts
@@ -4,14 +4,14 @@ import { generateTypes } from "../generate-types.js";
 
 export default async (): Promise<Partial<SolidityHooks>> => {
   const handlers: Partial<SolidityHooks> = {
-    async onCleanUpArtifacts(
+    async onBuildCompleted(
       context: HookContext,
-      artifactPaths: string[],
-      next: (
-        nextContext: HookContext,
-        artifactPaths: string[],
-      ) => Promise<void>,
+      next: (nextContext: HookContext) => Promise<void>,
     ) {
+      const artifactPaths = Array.from(
+        await context.artifacts.getAllArtifactPaths(),
+      );
+
       await generateTypes(
         context.config.paths.root,
         context.config.typechain,
@@ -19,7 +19,7 @@ export default async (): Promise<Partial<SolidityHooks>> => {
         artifactPaths,
       );
 
-      return next(context, artifactPaths);
+      return next(context);
     },
   };
 

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -109,6 +109,11 @@ export class ArtifactManagerImplementation implements ArtifactManager {
     return allFullyQualifiedNames;
   }
 
+  public async getAllArtifactPaths(): Promise<ReadonlySet<string>> {
+    const { allArtifactPaths } = await this.#getFsData();
+    return allArtifactPaths;
+  }
+
   public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
     const paths = await getAllFilesMatching(
       path.join(this.#artifactsPath, BUILD_INFO_DIR_NAME),

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -39,6 +39,11 @@ class LazyArtifactManager implements ArtifactManager {
     return artifactManager.getAllFullyQualifiedNames();
   }
 
+  public async getAllArtifactPaths(): Promise<ReadonlySet<string>> {
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.getAllArtifactPaths();
+  }
+
   public async getBuildInfoId(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string | undefined> {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
@@ -62,6 +62,13 @@ const buildAction: NewTaskActionFunction<BuildActionArguments> = async (
     }
   }
 
+  await hre.hooks.runHandlerChain(
+    "solidity",
+    "onBuildCompleted",
+    [],
+    async () => {},
+  );
+
   return { contractRootPaths, testRootPaths };
 };
 

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
@@ -123,6 +123,18 @@ declare module "../../../types/hooks.js" {
     ) => Promise<void>;
 
     /**
+     * Hook triggered after a build task is finished successfully
+     *
+     * @param context The hook context.
+     * @param next A function to call the next handler for this hook, or the
+     * default implementation if no more handlers exist.
+     */
+    onBuildCompleted: (
+      context: HookContext,
+      next: (nextContext: HookContext) => Promise<void>,
+    ) => Promise<void>;
+
+    /**
      * Hook triggered within the compilation job when its' solc input is first constructed.
      *
      * @param context The hook context.

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -66,6 +66,11 @@ export interface ArtifactManager {
   getAllFullyQualifiedNames(): Promise<ReadonlySet<string>>;
 
   /**
+   * Returns a set with the paths of all the artifacts.
+   */
+  getAllArtifactPaths(): Promise<ReadonlySet<string>>;
+
+  /**
    * Returns the BuildInfo id associated with the solc run that compiled a
    * contract.
    *

--- a/v-next/hardhat/test/test-helpers/mock-artifact-manager.ts
+++ b/v-next/hardhat/test/test-helpers/mock-artifact-manager.ts
@@ -68,6 +68,15 @@ export class MockArtifactManager implements ArtifactManager {
     );
   }
 
+  public async getAllArtifactPaths(): Promise<ReadonlySet<string>> {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.INTERNAL.NOT_IMPLEMENTED_ERROR,
+      {
+        message: "Not implemented in MockArtifactManager",
+      },
+    );
+  }
+
   public async getBuildInfoId(
     _contractNameOrFullyQualifiedName: string,
   ): Promise<string | undefined> {


### PR DESCRIPTION
A new hook was added to the solidity plugin, `onBuildComplete`. The type generation is now fired off this hook instead of the `onCleanupArtifacts`, because this last one is only triggered when a full compilation is performed. The artifact paths, needed by typechain, are retrieved through the artifact manager. So typechain can have access to all artifact paths even if a partial compilation was performed.

Closes #6311 