### PR TITLE
build: update checkout action to v6

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         runner: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - id: env
         uses: ./.github/actions/setup-env
         with:

--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       # We need to fetch the base ref because the pull request check inspects the diff between the head and the base ref
       - run: git fetch origin "$GITHUB_BASE_REF":"$GITHUB_BASE_REF"

--- a/.github/workflows/check-links-to-docs.yml
+++ b/.github/workflows/check-links-to-docs.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       # We need to fetch the base ref because the pull request check inspects the diff between the head and the base ref
       - run: git fetch origin "$GITHUB_BASE_REF":"$GITHUB_BASE_REF"

--- a/.github/workflows/check-v2-with-latest-dependencies.yml
+++ b/.github/workflows/check-v2-with-latest-dependencies.yml
@@ -13,7 +13,7 @@ jobs:
         system: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.system }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: v2 # Checkout the `v2` branch
       - uses: ./.github/actions/setup-env

--- a/.github/workflows/check-v3-with-latest-dependencies.yml
+++ b/.github/workflows/check-v3-with-latest-dependencies.yml
@@ -13,7 +13,7 @@ jobs:
         system: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.system }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-env
       - name: Delete pnpm-lock.yaml
         run: "rm pnpm-lock.yaml"

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -84,7 +84,7 @@ jobs:
       commands: ${{ inputs.commands || toJson(fromJson(steps.config.outputs.preset).commands) }}
     steps:
       - id: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: NomicFoundation/hardhat
           ref: ${{ inputs.ref || github.ref }}
@@ -124,7 +124,7 @@ jobs:
         shell: bash
         working-directory: crates/edr_napi
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: NomicFoundation/edr
           ref: ${{ needs.inputs.outputs.edr-ref }}
@@ -174,7 +174,7 @@ jobs:
         shell: bash
         working-directory: crates/edr_napi
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: NomicFoundation/edr
           ref: ${{ needs.inputs.outputs.edr-ref }}
@@ -222,7 +222,7 @@ jobs:
         shell: bash
         working-directory: v-next/hardhat
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: NomicFoundation/hardhat
           ref: ${{ needs.inputs.outputs.hardhat-ref }}
@@ -288,7 +288,7 @@ jobs:
         runner: ${{ fromJSON(needs.inputs.outputs.runners) }}
         command: ${{ fromJSON(needs.inputs.outputs.commands) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: NomicFoundation/hardhat
           path: NomicFoundation/hardhat
@@ -393,7 +393,7 @@ jobs:
           version: ${{ fromJSON(steps.config.outputs.repository).forge-version }}
           cache: false
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           repository: ${{ matrix.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
@@ -61,7 +61,7 @@ jobs:
       hasPackages: ${{ steps.detect.outputs.hasPackages }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env
@@ -212,7 +212,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,7 +12,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: streetsidesoftware/cspell-action@v7
         with:

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Check if the folder v-next exists
         id: check
@@ -37,7 +37,7 @@ jobs:
     if: ${{ needs.is-v-next.outputs.is_v_next == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -50,7 +50,7 @@ jobs:
     if: ${{ needs.is-v-next.outputs.is_v_next == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -66,7 +66,7 @@ jobs:
       packages: ${{ steps.filter.outputs.changes }}
       should_bundle: ${{ contains(steps.filter.outputs.hardhat_files, '.github/workflows/v-next-ci.yml') || contains(steps.filter.outputs.hardhat_files, 'pnpm-lock.yaml') }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -117,7 +117,7 @@ jobs:
       run:
         working-directory: v-next/${{ matrix.package }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-env
         with:
           node-version: 24
@@ -202,7 +202,7 @@ jobs:
         working-directory: v-next/${{ matrix.package }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-env
         with:
           node-version: 24
@@ -254,7 +254,7 @@ jobs:
         working-directory: v-next/${{ matrix.package }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}
@@ -301,7 +301,7 @@ jobs:
       run:
         working-directory: v-next/hardhat-node-test-reporter
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}


### PR DESCRIPTION
Bumps to v6 for Node.js 24 support. Requires runner v2.329.0+.

https://github.com/actions/checkout/releases/tag/v6.0.0