### PR TITLE
test: change assertion

### DIFF
--- a/packages/hardhat-solpp/test/tests.ts
+++ b/packages/hardhat-solpp/test/tests.ts
@@ -30,9 +30,7 @@ describe("Solpp plugin", function () {
     });
 
     it("should compile without errors", async function () {
-      assert.doesNotThrow(async () => {
-        await this.env.run(TASK_COMPILE);
-      });
+      await this.env.run(TASK_COMPILE);
     });
   });
 


### PR DESCRIPTION
The `doesNotThrow` assertion is not made for async. Instead just test directly.
