### PR TITLE
chore: update oses used in test matrix

### DIFF
--- a/.github/workflows/hardhat-core-ci.yml
+++ b/.github/workflows/hardhat-core-ci.yml
@@ -1,7 +1,5 @@
 name: hardhat-core CI
 
-# Note: this workflow uses `macos-13` to use x86
-
 on:
   push:
     branches:
@@ -40,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.0.0]
-        os: ["macos-13", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
 
@@ -78,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.0.0]
-        os: ["macos-13", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The macos-13 runner is now deprecated. I have updated the os list to use
the latest macos runner.
