### PR TITLE
feat(network-manager): add logger config passthrough for EDR networks

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts
@@ -108,6 +108,7 @@ export function resolveEdrNetwork(
     throwOnCallFailures: networkConfig.throwOnCallFailures ?? true,
     throwOnTransactionFailures:
       networkConfig.throwOnTransactionFailures ?? true,
+    logger: networkConfig.logger,
   };
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -266,6 +266,7 @@ export class NetworkManagerImplementation implements NetworkManager {
           },
           coverageConfig,
           gasReportConfig,
+          loggerConfig: resolvedNetworkConfig.logger,
         });
       }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/config.ts
@@ -1,4 +1,5 @@
 import type { ChainType, DefaultChainType } from "../../../../types/network.js";
+import type { LoggerConfig } from "../edr/types/logger.js";
 
 import "../../../../types/config.js";
 declare module "../../../../types/config.js" {
@@ -124,6 +125,7 @@ declare module "../../../../types/config.js" {
     networkId?: number;
     throwOnCallFailures?: boolean;
     throwOnTransactionFailures?: boolean;
+    logger?: LoggerConfig;
   }
 
   export type EdrNetworkAccountsUserConfig =
@@ -269,6 +271,7 @@ declare module "../../../../types/config.js" {
     networkId: number;
     throwOnCallFailures: boolean;
     throwOnTransactionFailures: boolean;
+    logger?: LoggerConfig;
   }
 
   export type EdrNetworkAccountsConfig =

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -294,6 +294,12 @@ const edrNetworkMiningUserConfigSchema = z.object({
   mempool: z.optional(edrNetworkMempoolUserConfigSchema),
 });
 
+const loggerConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  printLineFn: z.optional(z.any()),
+  replaceLineFn: z.optional(z.any()),
+});
+
 const edrNetworkUserConfigSchema = z.object({
   type: z.literal("edr-simulated"),
   accounts: z.optional(edrNetworkAccountsUserConfigSchema),
@@ -321,6 +327,7 @@ const edrNetworkUserConfigSchema = z.object({
   networkId: z.optional(chainIdSchema),
   throwOnCallFailures: z.optional(z.boolean()),
   throwOnTransactionFailures: z.optional(z.boolean()),
+  logger: z.optional(loggerConfigSchema),
 });
 
 const networkUserConfigSchema = z.discriminatedUnion("type", [

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/config-resolution.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/config-resolution.ts
@@ -259,6 +259,45 @@ describe("config-resolution", () => {
         getCurrentHardfork(OPTIMISM_CHAIN_TYPE),
       );
     });
+
+    it("should pass through the logger config if it is provided", () => {
+      const printLineFn = (line: string) => console.log(line);
+      const replaceLastLineFn = (line: string) => console.log(line);
+      const userConfig: EdrNetworkUserConfig = {
+        type: "edr-simulated",
+        logger: {
+          enabled: true,
+          printLineFn,
+          replaceLastLineFn,
+        },
+      };
+      const edrNetworkConfig = resolveEdrNetwork(
+        userConfig,
+        GENERIC_CHAIN_TYPE,
+        "",
+        configVarResolver,
+      );
+
+      assert.deepEqual(edrNetworkConfig.logger, {
+        enabled: true,
+        printLineFn,
+        replaceLastLineFn,
+      });
+    });
+
+    it("should return undefined for logger if it is not provided", () => {
+      const userConfig: EdrNetworkUserConfig = {
+        type: "edr-simulated",
+      };
+      const edrNetworkConfig = resolveEdrNetwork(
+        userConfig,
+        GENERIC_CHAIN_TYPE,
+        "",
+        configVarResolver,
+      );
+
+      assert.equal(edrNetworkConfig.logger, undefined);
+    });
   });
 
   describe("resolveGasConfig", () => {

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -2593,5 +2593,57 @@ describe("NetworkManagerImplementation", () => {
         });
       });
     });
+
+    describe("logger", () => {
+      describe("edr config", () => {
+        it("should validate a valid network config", async () => {
+          let validationErrors = await validateNetworkUserConfig(
+            edrConfig({
+              logger: {
+                enabled: true,
+              },
+            }),
+          );
+
+          assertValidationErrors(validationErrors, []);
+
+          validationErrors = await validateNetworkUserConfig(
+            edrConfig({
+              logger: {
+                enabled: false,
+                printLineFn: () => {},
+                replaceLineFn: () => {},
+              },
+            }),
+          );
+
+          assertValidationErrors(validationErrors, []);
+        });
+
+        it("should not validate an invalid network config", async () => {
+          let validationErrors = await validateNetworkUserConfig(
+            edrConfig({ logger: "incorrect" }),
+          );
+
+          assertValidationErrors(validationErrors, [
+            {
+              path: ["networks", "hardhat", "logger"],
+              message: "Expected object, received string",
+            },
+          ]);
+
+          validationErrors = await validateNetworkUserConfig(
+            edrConfig({ logger: { enabled: "incorrect" } }),
+          );
+
+          assertValidationErrors(validationErrors, [
+            {
+              path: ["networks", "hardhat", "logger", "enabled"],
+              message: "Expected boolean, received string",
+            },
+          ]);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Add support for passing logger configuration through to the EDR provider when creating simulated networks. This allows users to configure custom logging behavior via the network config.

### Changes:
- Add logger field to `EdrNetworkUserConfig` and `EdrNetworkConfig` types
- Pass logger config through `resolveEdrNetwork` to resolved config
- Pass `loggerConfig` to `createEdrProvider` in network manager
- Add zod validation schema for logger config
- Add tests for config resolution and validation

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Implementation note:

The `printLineFn` and `replaceLastLineFn` fields are typed as `z.any()` in validation since Zod doesn't have a built-in schema for validating callables. Runtime behavior will fail naturally if non-functions are passed.

Closes #7737 