### PR TITLE
fix: turn off the Osaka transaction gas limit

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -275,6 +275,10 @@ export class EdrProviderWrapper
       networkId: BigInt(config.networkId),
       observability: {},
       ownedAccounts,
+      // Turn off the Osaka EIP-7825 per transaction gas limit for HH2, we will
+      // re-enable this once options are provided to avoid breaking the
+      // coverage plugin.
+      transactionGasCap: 18446744073709551615n,
     };
 
     const edrLoggerConfig = {


### PR DESCRIPTION
The gas limit of 16 million breaks the `coverage` plugin, which adds further instrumentation code, potentially take valid code over the limit.

For the moment we will turn off the transaction limit to avoid breaking existing coverage of test suites.

Our next moves are likely to support toggling the transaction limit via network config and updating the coverage plugin to use that toggle.
