### PR TITLE
replace memory-safe-assembly natspec comments with memory-safe assemb…

### DIFF
--- a/v-next/hardhat/console.sol
+++ b/v-next/hardhat/console.sol
@@ -7,8 +7,7 @@ library console {
 
     function _sendLogPayloadImplementation(bytes memory payload) internal view {
         address consoleAddress = CONSOLE_ADDRESS;
-        /// @solidity memory-safe-assembly
-        assembly {
+        assembly ('memory-safe') {
             pop(
                 staticcall(
                     gas(),

--- a/v-next/hardhat/coverage.sol
+++ b/v-next/hardhat/coverage.sol
@@ -7,8 +7,7 @@ library __HardhatCoverage {
 
   function _sendHitImplementation(uint256 coverageId) private view {
     address coverageAddress = COVERAGE_ADDRESS;
-    /// @solidity memory-safe-assembly
-    assembly {
+    assembly ('memory-safe') {
       let ptr := mload(0x40)           // Get free memory pointer
       mstore(ptr, coverageId)          // Store coverageId at free memory
       pop(


### PR DESCRIPTION
This should fix a compiler warning about the deprecation of the "memory-safe-assembly" comment.