### PR TITLE
[Code coverage] Add HTML coverage report

### DIFF
--- a/.changeset/strange-games-dance.md
+++ b/.changeset/strange-games-dance.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added HTML coverage report for solidity tests ([7787](https://github.com/NomicFoundation/hardhat/pull/7787)).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@nomicfoundation/hardhat-utils':
         specifier: workspace:^3.0.5
         version: link:../hardhat-utils
+      '@nomicfoundation/hardhat-vendored':
+        specifier: workspace:^3.0.0
+        version: link:../hardhat-vendored
       '@nomicfoundation/hardhat-zod-utils':
         specifier: workspace:^3.0.1
         version: link:../hardhat-zod-utils

--- a/v-next/hardhat-vendored/package.json
+++ b/v-next/hardhat-vendored/package.json
@@ -3,7 +3,6 @@
   "version": "3.0.0",
   "description": "Internal dependencies used by Hardhat that have been vendored to prevent bloating the main package",
   "homepage": "https://github.com/nomicfoundation/hardhat/tree/main/v-next/hardhat-vendored",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/NomicFoundation/hardhat",

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -90,6 +90,7 @@
     "@nomicfoundation/edr": "0.12.0-next.16",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.6",
     "@nomicfoundation/hardhat-utils": "workspace:^3.0.5",
+    "@nomicfoundation/hardhat-vendored": "workspace:^3.0.0",
     "@nomicfoundation/hardhat-zod-utils": "workspace:^3.0.1",
     "@nomicfoundation/solidity-analyzer": "^0.1.1",
     "@sentry/core": "^9.4.0",

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -21,6 +21,7 @@ import chalk from "chalk";
 import debug from "debug";
 
 import { getProcessedCoverageInfo } from "./process-coverage.js";
+import { generateHtmlReport } from "./reports/html.js";
 
 const log = debug("hardhat:core:coverage:coverage-manager");
 
@@ -123,6 +124,10 @@ export class CoverageManagerImplementation implements CoverageManager {
     const lcovReportPath = path.join(this.#coveragePath, "lcov.info");
     await writeUtf8File(lcovReportPath, lcovReport);
     log(`Saved lcov report to ${lcovReportPath}`);
+
+    const htmlReportPath = path.join(this.#coveragePath, "html");
+    await generateHtmlReport(report, htmlReportPath);
+    console.log(`Saved html report to ${htmlReportPath}`);
 
     console.log(markdownReport);
     console.log();

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/reports/html.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/reports/html.ts
@@ -1,0 +1,56 @@
+import type { Report } from "../coverage-manager.js";
+import type { FileCoverageData } from "@nomicfoundation/hardhat-vendored/coverage/types";
+
+import path from "node:path";
+
+import { mkdir } from "@nomicfoundation/hardhat-utils/fs";
+import {
+  istanbulLibCoverage,
+  istanbulLibReport,
+  istanbulReports,
+} from "@nomicfoundation/hardhat-vendored/coverage";
+
+export async function generateHtmlReport(
+  report: Report,
+  htmlReportPath: string,
+): Promise<void> {
+  const baseDir = process.cwd();
+  const coverageMap = istanbulLibCoverage.createCoverageMap({});
+
+  // Construct coverage data for each tested file,
+  // detailing whether each line was executed or not.
+  for (const [p, fileCoverageInput] of Object.entries(report)) {
+    const testedFilePath = path.join(baseDir, p);
+
+    const fc: FileCoverageData = {
+      path: testedFilePath,
+      statementMap: {},
+      fnMap: {}, // Cannot be derived from current report data
+      branchMap: {}, // Cannot be derived from current report data
+      s: {},
+      f: {}, // Cannot be derived from current report data
+      b: {},
+    };
+
+    for (const [line, count] of fileCoverageInput.lineExecutionCounts) {
+      fc.statementMap[line] = {
+        start: { line, column: 0 },
+        end: { line, column: 0 },
+      };
+
+      // TODO: currently EDR does not provide per-statement coverage counts
+      fc.s[line] = count > 0 ? 1 : 0; // mark as covered if hit at least once
+    }
+
+    coverageMap.addFileCoverage(fc);
+  }
+
+  await mkdir(htmlReportPath);
+
+  const context = istanbulLibReport.createContext({
+    dir: htmlReportPath,
+    coverageMap,
+  });
+
+  istanbulReports.create("html", undefined).execute(context);
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/reports/html.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/reports/html.ts
@@ -17,9 +17,11 @@ export async function generateHtmlReport(
   const baseDir = process.cwd();
   const coverageMap = istanbulLibCoverage.createCoverageMap({});
 
+  await mkdir(htmlReportPath);
+
   // Construct coverage data for each tested file,
   // detailing whether each line was executed or not.
-  for (const [p, fileCoverageInput] of Object.entries(report)) {
+  for (const [p, coverageInfo] of Object.entries(report)) {
     const testedFilePath = path.join(baseDir, p);
 
     const fc: FileCoverageData = {
@@ -32,7 +34,7 @@ export async function generateHtmlReport(
       b: {},
     };
 
-    for (const [line, count] of fileCoverageInput.lineExecutionCounts) {
+    for (const [line, count] of coverageInfo.lineExecutionCounts) {
       fc.statementMap[line] = {
         start: { line, column: 0 },
         end: { line, column: 0 },
@@ -44,8 +46,6 @@ export async function generateHtmlReport(
 
     coverageMap.addFileCoverage(fc);
   }
-
-  await mkdir(htmlReportPath);
 
   const context = istanbulLibReport.createContext({
     dir: htmlReportPath,

--- a/v-next/hardhat/tsconfig.json
+++ b/v-next/hardhat/tsconfig.json
@@ -14,6 +14,9 @@
       "path": "../hardhat-utils"
     },
     {
+      "path": "../hardhat-vendored"
+    },
+    {
       "path": "../hardhat-zod-utils"
     }
   ],


### PR DESCRIPTION
Related to: https://github.com/NomicFoundation/hardhat/pull/7767

Docs updated in this PR: https://github.com/NomicFoundation/hardhat-website/pull/198

#### How to run
In the `example-project` just run `pnpm hardhat test solidity --coverage`.
Just modify the `.sol` file to add an additional scenario and test different coverage cases.

The HTML report will be generated in the `example-project` in the file at the path: `./coverage/html/index.html`