### PR TITLE
build: bump EDR to v0.12.0-next.18 (Hardhat 2)

### DIFF
--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -103,7 +103,7 @@
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",
     "@ethersproject/abi": "^5.1.2",
-    "@nomicfoundation/edr": "0.12.0-next.16",
+    "@nomicfoundation/edr": "0.12.0-next.18",
     "@nomicfoundation/solidity-analyzer": "^0.1.0",
     "@sentry/node": "^5.18.1",
     "adm-zip": "^0.4.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,8 +201,8 @@ importers:
         specifier: ^5.1.2
         version: 5.8.0
       '@nomicfoundation/edr':
-        specifier: 0.12.0-next.16
-        version: 0.12.0-next.16
+        specifier: 0.12.0-next.18
+        version: 0.12.0-next.18
       '@nomicfoundation/solidity-analyzer':
         specifier: ^0.1.0
         version: 0.1.2
@@ -3067,36 +3067,36 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.16':
-    resolution: {integrity: sha512-no/8BPVBzVxDGGbDba0zsAxQmVNIq6SLjKzzhCxVKt4tatArXa6+24mr4jXJEmhVBvTNpQsNBO+MMpuEDVaTzQ==}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.18':
+    resolution: {integrity: sha512-rv4bhD+RtAbT61BPqaB9u6yroGOaZSBY+DS6aReWXv3QSKp1/6/9fenbr4K34/VRaTU4LC2fjVE6nJOfWgYEeA==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.16':
-    resolution: {integrity: sha512-tf36YbcC6po3XYRbi+v0gjwzqg1MvyRqVUujNMXPHgjNWATXNRNOLyjwt2qDn+RD15qtzk70SHVnz9n9mPWzwg==}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.18':
+    resolution: {integrity: sha512-2Kd616y9hLxlhHFlAAZefiI0qVkSH7YbzpczOYXs1YUvph+m/CZIVQ36jRgI015NJf02dOixjVk1CgT3KYwoGg==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.16':
-    resolution: {integrity: sha512-Kr6t9icKSaKtPVbb0TjUcbn3XHqXOGIn+KjKKSSpm6542OkL0HyOi06amh6/8CNke9Gf6Lwion8UJ0aGQhnFwA==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.18':
+    resolution: {integrity: sha512-zVWkW2UkAosXnUhQ5C44f6Vphw2ttesjSOcqTiWftUS7M2zsCUQ8o+Sr29eVwNwFO8mt1/g8lg9STw2by9v77w==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.16':
-    resolution: {integrity: sha512-HaStgfxctSg5PYF+6ooDICL1O59KrgM4XEUsIqoRrjrQax9HnMBXcB8eAj+0O52FWiO9FlchBni2dzh4RjQR2g==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.18':
+    resolution: {integrity: sha512-cnzEuigP9pxhMMs3NY6LE/BvPdxZ2DA4j0dx1lSEiTDaHkBxIUpCVJC8m8yiaog/nDtNF3CIxYWFYSEQPLZDIg==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.16':
-    resolution: {integrity: sha512-8JPTxEZkwOPTgnN4uTWut9ze9R8rp7+T4IfmsKK9i+lDtdbJIxkrFY275YHG2BEYLd7Y5jTa/I4nC74ZpTAvpA==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.18':
+    resolution: {integrity: sha512-vOi6GYzHJqhaFB6Qs6RLVEydWQ4CrkjCOaZ+UUuqO/MYoEq/xoGEjnOwG3mQD8wB8pj0r0Fh4zVDaCiIwOuYRQ==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.16':
-    resolution: {integrity: sha512-KugTrq3iHukbG64DuCYg8uPgiBtrrtX4oZSLba5sjocp0Ul6WWI1FeP1Qule+vClUrHSpJ+wR1G6SE7G0lyS/Q==}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.18':
+    resolution: {integrity: sha512-0OQvQLd2MXBhxtIyKIcel7JQg9WGV5qb6t5+D9qsBLTPT8Xz1CQ1V/pjtLfCtWUb3ATQFWXK1eryYM72pCcCpA==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.16':
-    resolution: {integrity: sha512-Idy0ZjurxElfSmepUKXh6QdptLbW5vUNeIaydvqNogWoTbkJIM6miqZd9lXUy1TYxY7G4Rx5O50c52xc4pFwXQ==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.18':
+    resolution: {integrity: sha512-mN2WKTxMsFR9dw8eFZ5LICoHy/xiznUsmjwZ6h0yRl2uW/on6DKxq85ftm4w0ha4lxtHRdl241x3PGr021OEGA==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr@0.12.0-next.16':
-    resolution: {integrity: sha512-bBL/nHmQwL1WCveALwg01VhJcpVVklJyunG1d/bhJbHgbjzAn6kohVJc7A6gFZegw+Rx38vdxpBkeCDjAEprzw==}
+  '@nomicfoundation/edr@0.12.0-next.18':
+    resolution: {integrity: sha512-Jr6ob2F+PHKVM4dv0YH2DMvCYS8r5V3PzAIxNMCaryOTWlS8ZMYM+DvduRfSZxzzi8xhZUzE3Smy1WkMmOKb5A==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -9897,29 +9897,29 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.16': {}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.18': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.16': {}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.18': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.16': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.18': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.16': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.18': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.16': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.18': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.16': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.18': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.16': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.18': {}
 
-  '@nomicfoundation/edr@0.12.0-next.16':
+  '@nomicfoundation/edr@0.12.0-next.18':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.16
-      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.16
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.16
-      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.16
-      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.16
-      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.16
-      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.16
+      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.18
+      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.18
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.18
+      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.18
+      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.18
+      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.18
+      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.18
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This PR bumps the EDR version in Hardhat 2 to v0.12.0-next.18, with the following changes:

### Patch Changes

- [25b2b2d](https://github.com/NomicFoundation/edr/commit/25b2b2d69f1fc87328c4ce2809648856a45550ff): Added unsupported cheatcode errors for unsupported cheatcodes up to and including Foundry 1.5.0
- [7cc0868](https://github.com/NomicFoundation/edr/commit/7cc08689ddbfef533652884a00ae80f4f4f3db79): Added support for instrumenting Solidity 0.8.31 source code
- [93a1484](https://github.com/NomicFoundation/edr/commit/93a1484be71208a94c811665ecf168d158765736): Added Osaka hardfork activations so EDR can accurately infer the hardfork from the block timestamp
- [c52f1f6](https://github.com/NomicFoundation/edr/commit/c52f1f6a6d6c6ed129074dabab22471dfa7a363b): Added basic support for Jovian hardfork (OP stack)

This PR might need to be merged after https://github.com/NomicFoundation/hardhat/pull/7753