### PR TITLE
fix: remove redundant id assignment in getJsonRpcRequest

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/json-rpc.ts
@@ -26,10 +26,6 @@ export function getJsonRpcRequest(
 
   requestObject.params = getRequestParams({ method, params });
 
-  if (id !== undefined) {
-    requestObject.id = id;
-  }
-
   return requestObject;
 }
 


### PR DESCRIPTION
Remove dead code in `getJsonRpcRequest` function. The `id` parameter has type `number | string` (not optional), so the check `if (id !== undefined)` is always true. Additionally, `id` was already assigned during object creation, making the subsequent conditional assignment redundant.