### PR TITLE
Use block annotation instead of natspec comment for memory safe assembly

### DIFF
--- a/v-next/hardhat/console.sol
+++ b/v-next/hardhat/console.sol
@@ -7,8 +7,7 @@ library console {
 
     function _sendLogPayloadImplementation(bytes memory payload) internal view {
         address consoleAddress = CONSOLE_ADDRESS;
-        /// @solidity memory-safe-assembly
-        assembly {
+        assembly ("memory-safe") {
             pop(
                 staticcall(
                     gas(),

--- a/v-next/hardhat/coverage.sol
+++ b/v-next/hardhat/coverage.sol
@@ -7,8 +7,7 @@ library __HardhatCoverage {
 
   function _sendHitImplementation(uint256 coverageId) private view {
     address coverageAddress = COVERAGE_ADDRESS;
-    /// @solidity memory-safe-assembly
-    assembly {
+    assembly ("memory-safe") {
       let ptr := mload(0x40)           // Get free memory pointer
       mstore(ptr, coverageId)          // Store coverageId at free memory
       pop(


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
This PR moves away from the deprecated natspec comment flagging a block of assembly memory safe. This causes a warning due to deprecation when compiling with solc 0.8.31.