### PR TITLE
Allow overriding the type of the default network

### DIFF
--- a/.changeset/four-lies-flash.md
+++ b/.changeset/four-lies-flash.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Allow overriding the type of the network configs `default` and `localhost` [#7805](https://github.com/NomicFoundation/hardhat/pull/7805)

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -42,13 +42,17 @@ export async function extendUserConfig(
   const defaultConfig: NetworkUserConfig | undefined = networks.default;
 
   let extendedLocalhostConfig: NetworkUserConfig;
-  if (localhostConfig === undefined || localhostConfig.type === "http") {
+  if (
+    localhostConfig === undefined ||
+    localhostConfig.type === undefined ||
+    localhostConfig.type === "http"
+  ) {
     extendedLocalhostConfig = {
       url: "http://localhost:8545",
       type: "http",
       /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        -- We cast it here because otherwise TS complains that url and http will
-        be always overwritten, which is not true for js incomplete configs. */
+        -- We cast it here because otherwise TS complains that some fields are
+        always overwritten, which is not true for js incomplete configs. */
       ...(localhostConfig as Partial<HttpNetworkUserConfig>),
     };
   } else {
@@ -56,7 +60,11 @@ export async function extendUserConfig(
   }
 
   let extendedDefaultConfig: NetworkUserConfig;
-  if (defaultConfig === undefined || defaultConfig.type === "edr-simulated") {
+  if (
+    defaultConfig === undefined ||
+    defaultConfig.type === undefined ||
+    defaultConfig.type === "edr-simulated"
+  ) {
     extendedDefaultConfig = {
       chainId: 31337,
       gas: "auto",
@@ -64,8 +72,8 @@ export async function extendUserConfig(
       gasPrice: "auto",
       type: "edr-simulated",
       /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        -- We cast it here because otherwise TS complains that url and http will
-        be always overwritten, which is not true for js incomplete configs. */
+        -- We cast it here because otherwise TS complains that some fields are
+        always overwritten, which is not true for js incomplete configs. */
       ...(defaultConfig as Partial<EdrNetworkUserConfig>),
     };
   } else {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -62,8 +62,8 @@ export async function extendUserConfig(
         gas: "auto",
         gasMultiplier: 1,
         gasPrice: "auto",
-        ...defaultConfig,
         type: "edr-simulated",
+        ...defaultConfig,
       },
     },
   };

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -38,33 +38,46 @@ export async function extendUserConfig(
   const networks: Record<string, NetworkUserConfig> =
     extendedConfig.networks ?? {};
 
-  const localhostConfig: Omit<HttpNetworkUserConfig, "url"> = {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- This is always http
-    ...(networks.localhost as HttpNetworkUserConfig),
-  };
+  const localhostConfig: NetworkUserConfig | undefined = networks.localhost;
+  const defaultConfig: NetworkUserConfig | undefined = networks.default;
 
-  const defaultConfig: Partial<EdrNetworkUserConfig> = {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- This is always edr
-    ...(networks.default as EdrNetworkUserConfig),
-  };
+  let extendedLocalhostConfig: NetworkUserConfig;
+  if (localhostConfig === undefined || localhostConfig.type === "http") {
+    extendedLocalhostConfig = {
+      url: "http://localhost:8545",
+      type: "http",
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- We cast it here because otherwise TS complains that url and http will
+        be always overwritten, which is not true for js incomplete configs. */
+      ...(localhostConfig as Partial<HttpNetworkUserConfig>),
+    };
+  } else {
+    extendedLocalhostConfig = localhostConfig;
+  }
+
+  let extendedDefaultConfig: NetworkUserConfig;
+  if (defaultConfig === undefined || defaultConfig.type === "edr-simulated") {
+    extendedDefaultConfig = {
+      chainId: 31337,
+      gas: "auto",
+      gasMultiplier: 1,
+      gasPrice: "auto",
+      type: "edr-simulated",
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- We cast it here because otherwise TS complains that url and http will
+        be always overwritten, which is not true for js incomplete configs. */
+      ...(defaultConfig as Partial<EdrNetworkUserConfig>),
+    };
+  } else {
+    extendedDefaultConfig = defaultConfig;
+  }
 
   return {
     ...extendedConfig,
     networks: {
       ...networks,
-      localhost: {
-        url: "http://localhost:8545",
-        ...localhostConfig,
-        type: "http",
-      },
-      [DEFAULT_NETWORK_NAME]: {
-        chainId: 31337,
-        gas: "auto",
-        gasMultiplier: 1,
-        gasPrice: "auto",
-        type: "edr-simulated",
-        ...defaultConfig,
-      },
+      localhost: extendedLocalhostConfig,
+      [DEFAULT_NETWORK_NAME]: extendedDefaultConfig,
     },
   };
 }

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -41,6 +41,43 @@ describe("network-manager/hook-handlers/config", () => {
       });
     });
 
+    it("should extend the localhost network when its type is undefined", async () => {
+      const config = {
+        networks: {
+          localhost: {},
+        },
+      };
+      const next = async (nextConfig: HardhatUserConfig) => nextConfig;
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing incomplete config for js users */
+      const extendedConfig = await extendUserConfig(config as any, next);
+      assert.deepEqual(extendedConfig.networks?.localhost, {
+        type: "http",
+        url: "http://localhost:8545",
+      });
+    });
+
+    it("should extend the default network when its type is undefined", async () => {
+      const config = {
+        networks: {
+          default: {},
+        },
+      };
+      const next = async (nextConfig: HardhatUserConfig) => nextConfig;
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing incomplete config for js users */
+      const extendedConfig = await extendUserConfig(config as any, next);
+      assert.deepEqual(extendedConfig.networks?.default, {
+        chainId: 31337,
+        gas: "auto",
+        gasMultiplier: 1,
+        gasPrice: "auto",
+        type: "edr-simulated",
+      });
+    });
+
     it("should allow setting other properties of the localhost network", async () => {
       const config: HardhatUserConfig = {
         networks: {
@@ -1396,10 +1433,11 @@ describe("network-manager/hook-handlers/config", () => {
         "blockGasLimit" in localhost && localhost.blockGasLimit,
         60_000_000n,
       );
-      assert.deepEqual(
-        "mining" in localhost && localhost.mining,
-        { auto: true, interval: 0, mempool: { order: "priority" } },
-      );
+      assert.deepEqual("mining" in localhost && localhost.mining, {
+        auto: true,
+        interval: 0,
+        mempool: { order: "priority" },
+      });
       assert.equal(
         "throwOnCallFailures" in localhost && localhost.throwOnCallFailures,
         true,
@@ -1413,14 +1451,8 @@ describe("network-manager/hook-handlers/config", () => {
         "loggingEnabled" in localhost && localhost.loggingEnabled,
         false,
       );
-      assert.equal(
-        "minGasPrice" in localhost && localhost.minGasPrice,
-        0n,
-      );
-      assert.equal(
-        "networkId" in localhost && localhost.networkId,
-        31337,
-      );
+      assert.equal("minGasPrice" in localhost && localhost.minGasPrice, 0n);
+      assert.equal("networkId" in localhost && localhost.networkId, 31337);
       assert.equal(
         "forking" in localhost ? localhost.forking : undefined,
         undefined,

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -123,12 +123,10 @@ describe("network-manager/hook-handlers/config", () => {
             type: "edr-simulated",
           },
         },
-      };
+      } as const;
       const next = async (nextConfig: HardhatUserConfig) => nextConfig;
 
-      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      -- testing invalid network type for js users */
-      const extendedConfig = await extendUserConfig(config as any, next);
+      const extendedConfig = await extendUserConfig(config, next);
       assert.deepEqual(extendedConfig.networks?.localhost, {
         type: "edr-simulated",
       });
@@ -142,12 +140,10 @@ describe("network-manager/hook-handlers/config", () => {
             url: "http://localhost:8545",
           },
         },
-      };
+      } as const;
       const next = async (nextConfig: HardhatUserConfig) => nextConfig;
 
-      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      -- testing invalid network type for js users */
-      const extendedConfig = await extendUserConfig(config as any, next);
+      const extendedConfig = await extendUserConfig(config, next);
       assert.equal(extendedConfig.networks?.default.type, "http");
       assert.equal(
         extendedConfig.networks?.default.url,
@@ -1410,7 +1406,11 @@ describe("network-manager/hook-handlers/config", () => {
       );
 
       const localhost = resolvedConfig.networks.localhost;
-      assert.equal(localhost.type, "edr-simulated");
+      assert(
+        localhost.type === "edr-simulated",
+        "The network type should be edr-simulated",
+      );
+
       assert.equal(localhost.chainId, 31337);
       assert.equal(localhost.chainType, undefined);
       assert.equal(localhost.from, undefined);
@@ -1419,44 +1419,20 @@ describe("network-manager/hook-handlers/config", () => {
       assert.equal(localhost.gasPrice, "auto");
 
       // EDR-specific fields
-      assert.equal(
-        "allowBlocksWithSameTimestamp" in localhost &&
-          localhost.allowBlocksWithSameTimestamp,
-        false,
-      );
-      assert.equal(
-        "allowUnlimitedContractSize" in localhost &&
-          localhost.allowUnlimitedContractSize,
-        false,
-      );
-      assert.equal(
-        "blockGasLimit" in localhost && localhost.blockGasLimit,
-        60_000_000n,
-      );
-      assert.deepEqual("mining" in localhost && localhost.mining, {
+      assert.equal(localhost.allowBlocksWithSameTimestamp, false);
+      assert.equal(localhost.allowUnlimitedContractSize, false);
+      assert.equal(localhost.blockGasLimit, 60_000_000n);
+      assert.deepEqual(localhost.mining, {
         auto: true,
         interval: 0,
         mempool: { order: "priority" },
       });
-      assert.equal(
-        "throwOnCallFailures" in localhost && localhost.throwOnCallFailures,
-        true,
-      );
-      assert.equal(
-        "throwOnTransactionFailures" in localhost &&
-          localhost.throwOnTransactionFailures,
-        true,
-      );
-      assert.equal(
-        "loggingEnabled" in localhost && localhost.loggingEnabled,
-        false,
-      );
-      assert.equal("minGasPrice" in localhost && localhost.minGasPrice, 0n);
-      assert.equal("networkId" in localhost && localhost.networkId, 31337);
-      assert.equal(
-        "forking" in localhost ? localhost.forking : undefined,
-        undefined,
-      );
+      assert.equal(localhost.throwOnCallFailures, true);
+      assert.equal(localhost.throwOnTransactionFailures, true);
+      assert.equal(localhost.loggingEnabled, false);
+      assert.equal(localhost.minGasPrice, 0n);
+      assert.equal(localhost.networkId, 31337);
+      assert.equal(localhost.forking, undefined);
     });
 
     it("should resolve the default network when its type is overridden to http", async () => {

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -97,6 +97,27 @@ describe("network-manager/hook-handlers/config", () => {
         type: "http",
       });
     });
+
+    it("should allow overriding the type of the default network", async () => {
+      const config = {
+        networks: {
+          default: {
+            type: "http",
+            url: "http://localhost:8545",
+          },
+        },
+      };
+      const next = async (nextConfig: HardhatUserConfig) => nextConfig;
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+      const extendedConfig = await extendUserConfig(config as any, next);
+      assert.equal(extendedConfig.networks?.default.type, "http");
+      assert.equal(
+        extendedConfig.networks?.default.url,
+        "http://localhost:8545",
+      );
+    });
   });
 
   describe("validateUserConfig", () => {


### PR DESCRIPTION
This fixes https://github.com/NomicFoundation/hardhat/issues/7795, but I'm not fully convinced about the change.

The problem is that we are always setting the type of default network to be a simulated network, and we also set some other default values. This makes sense, but it does seem to assume that the network is not of type `http`. My concern is that a user's settings could interact in the wrong way with those default values.

On the other hand, without this change there's no way to have an http network as the default network, something that was possible in HH2.

One alternative here is to re-introduce the `defaultNetwork` config, and default it to "default" (yes).

Another alternative is to only use those default values if the user doesn't change the type, but that starts feeling a bit too complex.