### PR TITLE
test: constrain the process exit code type

### DIFF
--- a/v-next/hardhat-verify/test/tasks/verify/task-action.ts
+++ b/v-next/hardhat-verify/test/tasks/verify/task-action.ts
@@ -42,7 +42,7 @@ describe("verify/task-action", () => {
       consoleErrorSpy = mock.method(console, "error", () => {});
     });
 
-    let exitCode: string | number | undefined;
+    let exitCode: typeof process.exitCode;
     beforeEach(() => {
       exitCode = process.exitCode;
       consoleLogSpy.mock.resetCalls();


### PR DESCRIPTION
This line was failing in the CI job for testing new dependencies. I am not sure why, but some combination of test builds during the job leads to a type of `string | number | null | undefined` in defiance of the expected types.

I have switched to explicitly matching the `process.exitCode` type to get the tests back to passing.
