### PR TITLE
build: bump EDR to v0.12.0-next.21 (Hardhat 3)

### DIFF
--- a/.changeset/clear-trams-relax.md
+++ b/.changeset/clear-trams-relax.md
@@ -1,0 +1,13 @@
+---
+"hardhat": patch
+---
+
+Bumped EDR version to [`0.12.0-next.21`](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.12.0-next.21).
+
+### Minor Changes
+
+- NomicFoundation/edr@44e779c: Added function-level configuration overrides for Solidity tests
+
+### Patch Changes
+
+- NomicFoundation/edr@b5ad15c: Added support for instrumentation of Solidity `0.8.32` and `0.8.33`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ importers:
   v-next/hardhat:
     dependencies:
       '@nomicfoundation/edr':
-        specifier: 0.12.0-next.20
-        version: 0.12.0-next.20
+        specifier: 0.12.0-next.21
+        version: 0.12.0-next.21
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.6
         version: link:../hardhat-errors
@@ -2677,36 +2677,36 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.20':
-    resolution: {integrity: sha512-wmMvtP10Ik8ORzVX/+CoUlormDr+eo4TLdReJseCINC+utlHufBINYkN4ZBxQcF1KyVXEBzpUhys8tQEn/ovDw==}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.21':
+    resolution: {integrity: sha512-WUBBIlhW9UcYhEKlpuG+A/9gQsTciWID+shi2p5iYzArIZAHssyuUGOZF+z5/KQTyAC+GRQd/2YvCQacNnpOIg==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.20':
-    resolution: {integrity: sha512-LIjCXXsQhS3x3ksUIIKNqqdbjCORBwEVmPYgSo/IG65g9E1mPXRiXFSXSWhIcX9QQMrQsCxlgPP6ul8+oeZrew==}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.21':
+    resolution: {integrity: sha512-DOLp9TS3pRxX5OVqH2SMv/hLmo2XZcciO+PLaoXcJGMTmUqDJbc1kOS7+e/kvf+f12e2Y4b/wPQGXKGRgcx61w==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.20':
-    resolution: {integrity: sha512-NmFsMVMucEiY9W16PVGoVzCtohNKHLWdD9LF1miu7KbzmrpW98eidQi96CSkfG6CWQSFug7G0A9SMB3EWvLQ4w==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.21':
+    resolution: {integrity: sha512-yYLkOFA9Y51TdHrZIFM6rLzArw/iEQuIGwNnTRUXVBO1bNyKVxfaO7qg4WuRSNWKuZAtMawilcjoyHNuxzm/oQ==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.20':
-    resolution: {integrity: sha512-dwnRIM1gyyVCwR9hwpcEN17+GE2ESlRBf4rBVVd7Q9MGxb05YRwDtmgiCWEm1RHC2Svnu+IRU4t0sxN1EKSjTg==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.21':
+    resolution: {integrity: sha512-/L2hJYoUSHG9RTZRfOfYfsEBo1I30EQt3M+kWTDCS09jITnotWbqS9H/qbjd8u+8/xBBtAxNFhBgrIYu0GESSw==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.20':
-    resolution: {integrity: sha512-mnSEbR1Rsb8Fo4vSJaou6tWZtxAKMrNLwxdVAZlM6o/uekSwFHup/+4n5WjR3QmVYzwzO6HxXPAfp6Pqw1nXAg==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.21':
+    resolution: {integrity: sha512-m5mjLjGbmiRwnv2UX48olr6NxTewt73i3f6pgqpTcQKgHxGWVvEHqDbhdhP2H8Qf31cyya/Qv9p6XQziPfjMYg==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.20':
-    resolution: {integrity: sha512-37zbZyr2mGkGOOM6KU1uAV5T53MLRKgbBQ6kZsvPi93TJaQ6FhJLUSiPynnn/TesIZcijTJ7UBYwd9v5h3DWyg==}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.21':
+    resolution: {integrity: sha512-FRGJwIPBC0UAtoWHd97bQ3OQwngp3vA4EjwZQqiicCapKoiI9BPt4+eyiZq2eq/K0+I0rHs25hw+dzU0QZL1xg==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.20':
-    resolution: {integrity: sha512-aWS3hc7cfggE17XhxLC4lIOQiviAQFMNLIwrjxFlUTmiUIbnTSx+hTShZzpSSoYXoQSho2IQhoeM1Ff9k39wBg==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.21':
+    resolution: {integrity: sha512-rpH/iKqn0Dvbnj+o5tv3CtDNAsA9AnBNHNmEHoJPNnB5rhR7Zw1vVg2MaE1vzCvIONQGKGkArqC+dA7ftsOcpA==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr@0.12.0-next.20':
-    resolution: {integrity: sha512-vkNiVZog3bOBG1AXcbIZOVOlEi2GtHFQFZxq84gPHvQzhJWLN5orFUtWiiUgh+z8PBx6sxtmgNAM9e6J6GFVzA==}
+  '@nomicfoundation/edr@0.12.0-next.21':
+    resolution: {integrity: sha512-j4DXqk/b2T1DK3L/YOZtTjwXqr/as4n+eKulu3KGVxyzOv2plZqTv9WpepQSejc0298tk/DBdMVwqzU3sd8CAA==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -7092,29 +7092,29 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.20': {}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.21': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.20': {}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.21': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.20': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.21': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.20': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.21': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.20': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.21': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.20': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.21': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.20': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.21': {}
 
-  '@nomicfoundation/edr@0.12.0-next.20':
+  '@nomicfoundation/edr@0.12.0-next.21':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.20
-      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.20
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.20
-      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.20
-      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.20
-      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.20
-      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.20
+      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.21
+      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.21
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.21
+      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.21
+      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.21
+      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.21
+      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.21
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -87,7 +87,7 @@
     "typescript": "~5.8.0"
   },
   "dependencies": {
-    "@nomicfoundation/edr": "0.12.0-next.20",
+    "@nomicfoundation/edr": "0.12.0-next.21",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.6",
     "@nomicfoundation/hardhat-utils": "workspace:^3.0.5",
     "@nomicfoundation/hardhat-zod-utils": "workspace:^3.0.1",


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Bumped EDR version to [`0.12.0-next.21`](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.12.0-next.21).

### Minor Changes

- NomicFoundation/edr@44e779c: Added function-level configuration overrides for Solidity tests

### Patch Changes

- NomicFoundation/edr@b5ad15c: Added support for instrumentation of Solidity `0.8.32` and `0.8.33`
