### PR TITLE
Official Linux Arm64 compiler support added

### DIFF
--- a/.changeset/early-comics-unite.md
+++ b/.changeset/early-comics-unite.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add support for the official builds of `solc` for ARM64 Linux ([#7752](https://github.com/NomicFoundation/hardhat/issues/7752))

--- a/v-next/example-project/contracts/E.sol
+++ b/v-next/example-project/contracts/E.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.33;
+
+import "./C.sol";
+
+contract D {}

--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -210,6 +210,9 @@ export default defineConfig({
             // Required for @uniswap/core
             version: "0.8.26",
           },
+          {
+            version: "0.8.33",
+          },
         ],
         overrides: {
           "foo/bar.sol": {

--- a/v-next/hardhat-verify/test/fixture-projects/integration/contracts/Counter.sol
+++ b/v-next/hardhat-verify/test/fixture-projects/integration/contracts/Counter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.33;
 
 contract Counter {
   uint public x;

--- a/v-next/hardhat-verify/test/fixture-projects/integration/hardhat.config.ts
+++ b/v-next/hardhat-verify/test/fixture-projects/integration/hardhat.config.ts
@@ -12,10 +12,24 @@ const config: HardhatUserConfig = {
   solidity: {
     profiles: {
       default: {
-        version: "0.8.28",
+        compilers: [
+          {
+            version: "0.8.28",
+          },
+          {
+            version: "0.8.33",
+          },
+        ],
       },
       production: {
-        version: "0.8.28",
+        compilers: [
+          {
+            version: "0.8.28",
+          },
+          {
+            version: "0.8.33",
+          },
+        ],
       },
     },
   },

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -40,7 +40,7 @@ const LINUX_ARM64_REPOSITORY_URL =
 
 export enum CompilerPlatform {
   LINUX = "linux-amd64",
-  LINUX_ARM64 = "linux-aarch64",
+  LINUX_ARM64 = "linux-arm64",
   WINDOWS = "windows-amd64",
   MACOS = "macosx-amd64",
   WASM = "wasm",
@@ -48,6 +48,7 @@ export enum CompilerPlatform {
 
 interface CompilerBuild {
   path: string;
+  url?: string;
   version: string;
   longVersion: string;
   sha256: string;
@@ -341,46 +342,59 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
       }
     }
 
-    return false;
+    // download the list in case the cached list contains older ARM64 Linux builds without URL
+    return list.builds
+      .map((b) => b.path.startsWith("solc-v") && b.url === undefined)
+      .reduce((a, b) => a || b, false);
   }
 
   async #downloadCompilerList(): Promise<void> {
     log(`Downloading compiler list for platform ${this.#platform}`);
-    let url: string;
-
-    if (this.#onLinuxArm()) {
-      url = `${LINUX_ARM64_REPOSITORY_URL}/list.json`;
-    } else {
-      url = `${COMPILER_REPOSITORY_URL}/${this.#platform}/list.json`;
-    }
     const downloadPath = this.#getCompilerListPath();
 
-    await this.#downloadFunction(url, downloadPath);
+    // download hte official solc compiler list (now that ARM64 Linus is supported)
+    await this.#downloadFunction(
+      `${COMPILER_REPOSITORY_URL}/${this.#platform}/list.json`,
+      downloadPath,
+    );
 
-    // If using the arm64 binary mirror, the list.json file has different information than the solc official mirror, so we complete it
-    if (this.#onLinuxArm()) {
-      const compilerList: CompilerList = await readJsonFile(downloadPath);
-      for (const build of compilerList.builds) {
+    // for Linux ARM64, we need to merge the official list with our custom builds
+    if (this.#platform === CompilerPlatform.LINUX_ARM64) {
+      // cache the official list since the file will be overwritten below
+      const officialCompilerList: CompilerList =
+        await readJsonFile(downloadPath);
+
+      await this.#downloadFunction(
+        `${LINUX_ARM64_REPOSITORY_URL}/list.json`,
+        downloadPath,
+      );
+
+      // add missing information and an explicit URL for download
+      const armLinuxcompilerList: CompilerList =
+        await readJsonFile(downloadPath);
+      for (const build of armLinuxcompilerList.builds) {
         build.path = `solc-v${build.version}`;
+        build.url = LINUX_ARM64_REPOSITORY_URL;
         build.longVersion = build.version;
       }
 
-      await writeJsonFile(downloadPath, compilerList);
-    }
-  }
+      // merge the official and custom lists
+      officialCompilerList.builds = officialCompilerList.builds.concat(
+        armLinuxcompilerList.builds,
+      );
+      officialCompilerList.releases = {
+        ...officialCompilerList.releases,
+        ...armLinuxcompilerList.releases,
+      };
 
-  #onLinuxArm() {
-    return this.#platform === CompilerPlatform.LINUX_ARM64;
+      await writeJsonFile(downloadPath, officialCompilerList);
+    }
   }
 
   async #downloadCompiler(build: CompilerBuild): Promise<string> {
-    let url: string;
-
-    if (this.#onLinuxArm()) {
-      url = `${LINUX_ARM64_REPOSITORY_URL}/${build.path}`;
-    } else {
-      url = `${COMPILER_REPOSITORY_URL}/${this.#platform}/${build.path}`;
-    }
+    // use the explicit URL if available or the default solc download URL if not
+    const defaultUrl = `${COMPILER_REPOSITORY_URL}/${this.#platform}`;
+    const url = `${build.url ?? defaultUrl}/${build.path}`;
 
     log(`Downloading compiler ${build.version} from ${url}`);
 

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -498,11 +498,11 @@ describe(
       });
 
       describe("updateCompilerListIfNeeded", function () {
-        it("downloads the list.json file from the linux-aarch64 repo and populates the expected fields", async () => {
+        it("downloads the list.json file from the linux-arm64 repo and populates the expected fields", async () => {
           await downloader.updateCompilerListIfNeeded(new Set(["0.8.28"]));
 
           const compilerList: any = await fs.readJsonFile(
-            path.join(process.cwd(), "linux-aarch64", "list.json"),
+            path.join(process.cwd(), "linux-arm64", "list.json"),
           );
 
           const build = compilerList.builds.find(
@@ -513,6 +513,7 @@ describe(
             version: "0.8.28",
             longVersion: "0.8.28",
             path: "solc-v0.8.28",
+            url: "https://solc-linux-arm64-mirror.hardhat.org/linux/aarch64",
             sha256:
               "891ecdd8f92a8211ee99f21bc3052b63fa098b4807f21ed8311d66e35d5aeb84",
           });
@@ -520,13 +521,13 @@ describe(
       });
 
       describe("downloadCompiler", function () {
-        it("downloads the compiler from the linux-aarch64 repo", async () => {
+        it("downloads the compiler from the linux-arm64 repo", async () => {
           await downloader.updateCompilerListIfNeeded(new Set(["0.8.28"]));
           await downloader.downloadCompiler("0.8.28");
 
           const binaryPath = path.join(
             process.cwd(),
-            "linux-aarch64",
+            "linux-arm64",
             "solc-v0.8.28",
           );
           // Check the binary exists
@@ -548,7 +549,7 @@ describe(
           // Trick the system by deleting the .does.not.work file, because this test might not be running on an arm64 linux machine
           const binaryPath = path.join(
             process.cwd(),
-            "linux-aarch64",
+            "linux-arm64",
             "solc-v0.8.28",
           );
           await fs.remove(`${binaryPath}.does.not.work`);


### PR DESCRIPTION
The official solc Linux ARM64 compiler support added.

The official list supports only version `0.8.31+` so it is necessary to merge the official compiler list and our own build list to maintain support for older versions (our own builds), while adding new versions (from the official list).

The builds can now have an optional URL property that is used for the older ARM64 Linux builds which are downloaded from a different URL than the official ones. The property can be also leveraged later down the line for other compiler.