### PR TITLE
Action condition redirected to the changeset-release/main branch

### DIFF
--- a/.github/workflows/ensure-peer-deps-review.yml
+++ b/.github/workflows/ensure-peer-deps-review.yml
@@ -6,7 +6,7 @@ name: Check peer dependency versions have been reviewed
 on:
   pull_request:
     branches:
-      - changeset-release/main
+      - main
     types:
       - opened
       - synchronize
@@ -18,6 +18,7 @@ on:
 
 jobs:
   check-label:
+    if: github.head_ref == 'changeset-release/main'
     name: Check peer dependency versions have been reviewed
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The `on` condition is able to determine only the target branch for PRs, the `if` condition in the action is able to verify the head branch to scope the action correctly