### PR TITLE
Latest Soldity version supported by Slang is used in case a newer ver…

### DIFF
--- a/.changeset/hot-hands-dance.md
+++ b/.changeset/hot-hands-dance.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+ Hardhat tries to use the latest Solidity version supported by Slang in case the a newer, unsupported version is selected ([7846](https://github.com/NomicFoundation/hardhat/pull/7846)).

--- a/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { after, before, beforeEach, describe, it } from "node:test";
 
+import { latestSupportedSolidityVersion } from "@nomicfoundation/edr";
 import {
   disableConsole,
   useFixtureProject,
@@ -432,6 +433,41 @@ describe("CoverageManagerImplementation - report data processing", () => {
       );
     });
   }
+
+  it("should should use the latesst supported Solidity version", async () => {
+    const version = await hre.hooks.runHandlerChain(
+      "solidity",
+      "preprocessProjectFileBeforeBuilding",
+      ["", "", "", "0.10.100"],
+      async (
+        nextContext,
+        nextInputSourceName,
+        nextFsPath,
+        nextFileContent,
+        nextSolcVersion,
+      ) => nextSolcVersion,
+    );
+
+    assert.equal(version, latestSupportedSolidityVersion());
+  });
+
+  it("should should use the selected Solidity version", async () => {
+    const supportedVersion = "0.8.28";
+    const version = await hre.hooks.runHandlerChain(
+      "solidity",
+      "preprocessProjectFileBeforeBuilding",
+      ["", "", "", supportedVersion],
+      async (
+        nextContext,
+        nextInputSourceName,
+        nextFsPath,
+        nextFileContent,
+        nextSolcVersion,
+      ) => nextSolcVersion,
+    );
+
+    assert.equal(version, supportedVersion);
+  });
 
   it("should run coverage on multiple files, one is covered by tests, the other is not", async () => {
     const testScenrario = COVERAGE_TEST_SCENARIO_MULTIPLE_FILES;


### PR DESCRIPTION
Hardhat uses the `latestSupportedSolidityVersion()` EDR API to detect if hte selected Solidity version is compatible with Slang for code coverage instrumentation. The `latestSupportedSolidityVersion()` version is selected in case the user selected a newer version and Hardhat displays an error in case the version is not sufficient to compile the contracts.

The code assumes that every version <= `latestSupportedSolidityVersion()` is supported, confirmed by EDR.