### PR TITLE
Solidity test UI improvements

### DIFF
--- a/.changeset/little-poets-film.md
+++ b/.changeset/little-poets-film.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Improve how solidity tests are displayed, making it more consistent with the js reporters.

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -139,7 +139,7 @@ export async function* testReporter(
 
           switch (status) {
             case "Success": {
-              let successOutput = `${colorizer.green("✔")} ${name}`;
+              let successOutput = `${colorizer.green("✔")} ${colorizer.grey(name)}`;
               if (details !== "") {
                 successOutput += colorizer.dim(details);
               }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -139,7 +139,7 @@ export async function* testReporter(
 
           switch (status) {
             case "Success": {
-              let successOutput = colorizer.green(`✔ ${name}`);
+              let successOutput = `${colorizer.green("✔")} ${name}`;
               if (details !== "") {
                 successOutput += colorizer.dim(details);
               }

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
@@ -477,7 +477,7 @@ debug log
         [90] <green>Bar</green>
           └─ [80] <green>Baz</green>
 
-    <green>✔ successful test</green>
+    <green>✔</green> successful test
 
 
   <green>1 passing</green>

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
@@ -196,9 +196,8 @@ debug log
   0 passing
   1 failing
 
-  TestSuite.sol:TestSuite
-    1) failing test
-      Error: Unknown error
+  1) TestSuite#failing test
+    Error: Unknown error
 `.replace("\n", ""); // the first newline is only here to make the expected output more readable
 
       assert.deepEqual(result.join(""), expectedOutput);
@@ -284,9 +283,8 @@ debug log
   1 failing
   1 skipped
 
-  TestSuite.sol:TestSuite
-    1) failing test
-      Error: Unknown error
+  1) TestSuite#failing test
+    Error: Unknown error
 `.replace("\n", ""); // the first newline is only here to make the expected output more readable
 
       assert.deepEqual(result.join(""), expectedOutput);
@@ -412,19 +410,17 @@ debug log
   0 passing
   4 failing
 
-  TestSuite.sol:TestSuite1
-    1) failing test1
-      Error: Unknown error
+  1) TestSuite1#failing test1
+    Error: Unknown error
 
-    2) failing test2
-      Error: Unknown error
+  2) TestSuite1#failing test2
+    Error: Unknown error
 
-  TestSuite.sol:TestSuite2
-    3) failing test3
-      Error: Unknown error
+  3) TestSuite2#failing test3
+    Error: Unknown error
 
-    4) failing test4
-      Error: Unknown error
+  4) TestSuite2#failing test4
+    Error: Unknown error
 `.replace("\n", ""); // the first newline is only here to make the expected output more readable
 
       assert.deepEqual(result.join(""), expectedOutput);
@@ -484,9 +480,8 @@ debug log
   <red>1 failing</red>
   <cyan>1 skipped</cyan>
 
-  TestSuite.sol:TestSuite
-    1) failing test
-      <red>Error: Unknown error</red>
+  1) TestSuite#failing test
+    <red>Error: Unknown error</red>
 `.replace("\n", ""); // the first newline is only here to make the expected output more readable
 
       assert.deepEqual(result.join(""), expectedOutput);

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
@@ -473,7 +473,7 @@ debug log
         [90] <green>Bar</green>
           └─ [80] <green>Baz</green>
 
-    <green>✔</green> successful test
+    <green>✔</green> <grey>successful test</grey>
 
 
   <green>1 passing</green>


### PR DESCRIPTION
This PR implements two improvements to the UI of the solidity test reporter:

1. It colors the passing tests as gray, to make it consistent with the js reporters (more important now with the integrated output)
2. It changes how failure titles are created so that they are in a single line.

Note that (2) doesn't include the file name now, but that's present in the error stack trace.