### PR TITLE
fix: isolate clean task tests to prevent deleting global solc cache

### DIFF
--- a/v-next/hardhat-utils/src/global-dir.ts
+++ b/v-next/hardhat-utils/src/global-dir.ts
@@ -21,8 +21,9 @@ export async function getConfigDir(
  * Returns the cache directory path for a given package (defaults to "hardhat").
  * Ensures that the directory exists before returning the path.
  *
- * The cache directory can be overridden by setting the `HARDHAT_CACHE_DIR`
- * environment variable.
+ * For testing purposes only, the cache directory can be overridden by setting
+ * the `HARDHAT_TEST_CACHE_DIR` environment variable. This is intended to
+ * isolate tests from the real global cache.
  *
  * @param packageName The name of the package for which to generate paths. Defaults to "hardhat" if no package name is provided.
  * @returns The path to the hardhat cache directory.
@@ -31,11 +32,11 @@ export async function getConfigDir(
 export async function getCacheDir(
   packageName: string = HARDHAT_PACKAGE_NAME,
 ): Promise<string> {
-  // Allow explicit override via environment variable
-  const overrideDir = process.env.HARDHAT_CACHE_DIR;
-  if (overrideDir !== undefined) {
-    await ensureDir(overrideDir);
-    return overrideDir;
+  // Allow override for testing purposes only
+  const testOverrideDir = process.env.HARDHAT_TEST_CACHE_DIR;
+  if (testOverrideDir !== undefined) {
+    await ensureDir(testOverrideDir);
+    return testOverrideDir;
   }
 
   const { cache } = await generatePaths(packageName);

--- a/v-next/hardhat-utils/src/global-dir.ts
+++ b/v-next/hardhat-utils/src/global-dir.ts
@@ -21,6 +21,9 @@ export async function getConfigDir(
  * Returns the cache directory path for a given package (defaults to "hardhat").
  * Ensures that the directory exists before returning the path.
  *
+ * The cache directory can be overridden by setting the `HARDHAT_CACHE_DIR`
+ * environment variable.
+ *
  * @param packageName The name of the package for which to generate paths. Defaults to "hardhat" if no package name is provided.
  * @returns The path to the hardhat cache directory.
  * @throws FileSystemAccessError for any error.
@@ -28,6 +31,13 @@ export async function getConfigDir(
 export async function getCacheDir(
   packageName: string = HARDHAT_PACKAGE_NAME,
 ): Promise<string> {
+  // Allow explicit override via environment variable
+  const overrideDir = process.env.HARDHAT_CACHE_DIR;
+  if (overrideDir !== undefined) {
+    await ensureDir(overrideDir);
+    return overrideDir;
+  }
+
   const { cache } = await generatePaths(packageName);
   await ensureDir(cache);
   return cache;

--- a/v-next/hardhat-utils/test/global-dir.ts
+++ b/v-next/hardhat-utils/test/global-dir.ts
@@ -54,23 +54,23 @@ describe("global-dir", () => {
       );
     });
 
-    it("should use HARDHAT_CACHE_DIR when set", async () => {
+    it("should use HARDHAT_TEST_CACHE_DIR when set (for testing purposes only)", async () => {
       const customPath = path.join(
         os.tmpdir(),
         `hardhat-test-cache-override-${Date.now()}`,
       );
       await mkdir(customPath);
-      const originalValue = process.env.HARDHAT_CACHE_DIR;
+      const originalValue = process.env.HARDHAT_TEST_CACHE_DIR;
 
       try {
-        process.env.HARDHAT_CACHE_DIR = customPath;
+        process.env.HARDHAT_TEST_CACHE_DIR = customPath;
         const result = await getCacheDir();
         assert.equal(result, customPath);
       } finally {
         if (originalValue === undefined) {
-          delete process.env.HARDHAT_CACHE_DIR;
+          delete process.env.HARDHAT_TEST_CACHE_DIR;
         } else {
-          process.env.HARDHAT_CACHE_DIR = originalValue;
+          process.env.HARDHAT_TEST_CACHE_DIR = originalValue;
         }
         await remove(customPath);
       }

--- a/v-next/hardhat-utils/test/global-dir.ts
+++ b/v-next/hardhat-utils/test/global-dir.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
 import { describe, it } from "node:test";
 
+import { mkdir, remove } from "../src/fs.js";
 import {
   getCacheDir,
   getConfigDir,
@@ -18,37 +21,77 @@ describe("global-dir", () => {
 
   describe("getConfigDir", () => {
     it("should return the path to the configuration directory with default name 'hardhat'", async () => {
-      const path = await getConfigDir();
-      assert.equal(path, (await getExpectedPath(HARDHAT_PACKAGE_NAME)).config);
+      const configPath = await getConfigDir();
+      assert.equal(
+        configPath,
+        (await getExpectedPath(HARDHAT_PACKAGE_NAME)).config,
+      );
     });
 
     it("should return the path to the configuration directory with custom name", async () => {
-      const path = await getConfigDir(CUSTOM_PACKAGE_NAME);
-      assert.equal(path, (await getExpectedPath(CUSTOM_PACKAGE_NAME)).config);
+      const configPath = await getConfigDir(CUSTOM_PACKAGE_NAME);
+      assert.equal(
+        configPath,
+        (await getExpectedPath(CUSTOM_PACKAGE_NAME)).config,
+      );
     });
   });
 
   describe("getCacheDir", () => {
     it("should return the path to the cache directory with default name 'hardhat'", async () => {
-      const path = await getCacheDir();
-      assert.equal(path, (await getExpectedPath(HARDHAT_PACKAGE_NAME)).cache);
+      const cachePath = await getCacheDir();
+      assert.equal(
+        cachePath,
+        (await getExpectedPath(HARDHAT_PACKAGE_NAME)).cache,
+      );
     });
 
     it("should return the path to the cache directory with custom name", async () => {
-      const path = await getCacheDir(CUSTOM_PACKAGE_NAME);
-      assert.equal(path, (await getExpectedPath(CUSTOM_PACKAGE_NAME)).cache);
+      const cachePath = await getCacheDir(CUSTOM_PACKAGE_NAME);
+      assert.equal(
+        cachePath,
+        (await getExpectedPath(CUSTOM_PACKAGE_NAME)).cache,
+      );
+    });
+
+    it("should use HARDHAT_CACHE_DIR when set", async () => {
+      const customPath = path.join(
+        os.tmpdir(),
+        `hardhat-test-cache-override-${Date.now()}`,
+      );
+      await mkdir(customPath);
+      const originalValue = process.env.HARDHAT_CACHE_DIR;
+
+      try {
+        process.env.HARDHAT_CACHE_DIR = customPath;
+        const result = await getCacheDir();
+        assert.equal(result, customPath);
+      } finally {
+        if (originalValue === undefined) {
+          delete process.env.HARDHAT_CACHE_DIR;
+        } else {
+          process.env.HARDHAT_CACHE_DIR = originalValue;
+        }
+        await remove(customPath);
+      }
     });
   });
 
   describe("getTelemetryDir", () => {
     it("should return the path to the telemetry directory with default name 'hardhat'", async () => {
-      const path = await getTelemetryDir();
-      assert.equal(path, (await getExpectedPath(HARDHAT_PACKAGE_NAME)).data);
+      const telemetryPath = await getTelemetryDir();
+      assert.equal(
+        telemetryPath,
+        (await getExpectedPath(HARDHAT_PACKAGE_NAME)).data,
+      );
     });
 
     it("should return the path to the telemetry directory with custom name", async () => {
-      const path = await getTelemetryDir(CUSTOM_PACKAGE_NAME);
-      assert.equal(path, (await getExpectedPath(CUSTOM_PACKAGE_NAME)).data);
+      const telemetryPath = await getTelemetryDir(CUSTOM_PACKAGE_NAME);
+      assert.equal(
+        telemetryPath,
+        (await getExpectedPath(CUSTOM_PACKAGE_NAME)).data,
+      );
     });
   });
 });

--- a/v-next/hardhat/test/internal/builtin-plugins/clean/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/clean/task-action.ts
@@ -26,7 +26,7 @@ let cacheDir: string;
 let artifactsDir: string;
 
 // Variables for isolating the global cache during tests
-let originalHardhatCacheDir: string | undefined;
+let originalHardhatTestCacheDir: string | undefined;
 let testGlobalCacheRoot: string;
 
 const onClean = mock.fn(async () => {});
@@ -71,9 +71,9 @@ describe("clean/task-action", () => {
 
     before(async function () {
       // Set up isolated cache directory to avoid deleting the real global cache
-      originalHardhatCacheDir = process.env.HARDHAT_CACHE_DIR;
+      originalHardhatTestCacheDir = process.env.HARDHAT_TEST_CACHE_DIR;
       testGlobalCacheRoot = await getTmpDir("clean-task-global-cache");
-      process.env.HARDHAT_CACHE_DIR = testGlobalCacheRoot;
+      process.env.HARDHAT_TEST_CACHE_DIR = testGlobalCacheRoot;
 
       globalCacheDir = await getCacheDir();
       cacheDir = path.join(process.cwd(), "cache");
@@ -89,10 +89,10 @@ describe("clean/task-action", () => {
 
     after(async function () {
       // Restore original environment
-      if (originalHardhatCacheDir === undefined) {
-        delete process.env.HARDHAT_CACHE_DIR;
+      if (originalHardhatTestCacheDir === undefined) {
+        delete process.env.HARDHAT_TEST_CACHE_DIR;
       } else {
-        process.env.HARDHAT_CACHE_DIR = originalHardhatCacheDir;
+        process.env.HARDHAT_TEST_CACHE_DIR = originalHardhatTestCacheDir;
       }
 
       // Clean up temp directory

--- a/v-next/hardhat/test/internal/builtin-plugins/clean/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/clean/task-action.ts
@@ -2,9 +2,12 @@ import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
 
 import assert from "node:assert/strict";
 import path from "node:path";
-import { before, beforeEach, describe, it, mock } from "node:test";
+import { after, before, beforeEach, describe, it, mock } from "node:test";
 
-import { useFixtureProject } from "@nomicfoundation/hardhat-test-utils";
+import {
+  getTmpDir,
+  useFixtureProject,
+} from "@nomicfoundation/hardhat-test-utils";
 import {
   exists,
   mkdir,
@@ -21,6 +24,10 @@ let hre: HardhatRuntimeEnvironment;
 let globalCacheDir: string;
 let cacheDir: string;
 let artifactsDir: string;
+
+// Variables for isolating the global cache during tests
+let originalXdgCacheHome: string | undefined;
+let testGlobalCacheRoot: string;
 
 const onClean = mock.fn(async () => {});
 
@@ -63,6 +70,11 @@ describe("clean/task-action", () => {
     useFixtureProject("loaded-config");
 
     before(async function () {
+      // Set up isolated cache directory to avoid deleting the real global cache
+      originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+      testGlobalCacheRoot = await getTmpDir("clean-task-global-cache");
+      process.env.XDG_CACHE_HOME = testGlobalCacheRoot;
+
       globalCacheDir = await getCacheDir();
       cacheDir = path.join(process.cwd(), "cache");
       artifactsDir = path.join(process.cwd(), "artifacts");
@@ -73,6 +85,18 @@ describe("clean/task-action", () => {
       hre.hooks.registerHandlers("clean", {
         onClean,
       });
+    });
+
+    after(async function () {
+      // Restore original environment
+      if (originalXdgCacheHome === undefined) {
+        delete process.env.XDG_CACHE_HOME;
+      } else {
+        process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+      }
+
+      // Clean up temp directory
+      await remove(testGlobalCacheRoot);
     });
 
     beforeEach(async () => {

--- a/v-next/hardhat/test/internal/builtin-plugins/clean/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/clean/task-action.ts
@@ -26,7 +26,7 @@ let cacheDir: string;
 let artifactsDir: string;
 
 // Variables for isolating the global cache during tests
-let originalXdgCacheHome: string | undefined;
+let originalHardhatCacheDir: string | undefined;
 let testGlobalCacheRoot: string;
 
 const onClean = mock.fn(async () => {});
@@ -71,9 +71,9 @@ describe("clean/task-action", () => {
 
     before(async function () {
       // Set up isolated cache directory to avoid deleting the real global cache
-      originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+      originalHardhatCacheDir = process.env.HARDHAT_CACHE_DIR;
       testGlobalCacheRoot = await getTmpDir("clean-task-global-cache");
-      process.env.XDG_CACHE_HOME = testGlobalCacheRoot;
+      process.env.HARDHAT_CACHE_DIR = testGlobalCacheRoot;
 
       globalCacheDir = await getCacheDir();
       cacheDir = path.join(process.cwd(), "cache");
@@ -89,10 +89,10 @@ describe("clean/task-action", () => {
 
     after(async function () {
       // Restore original environment
-      if (originalXdgCacheHome === undefined) {
-        delete process.env.XDG_CACHE_HOME;
+      if (originalHardhatCacheDir === undefined) {
+        delete process.env.HARDHAT_CACHE_DIR;
       } else {
-        process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+        process.env.HARDHAT_CACHE_DIR = originalHardhatCacheDir;
       }
 
       // Clean up temp directory

--- a/v-next/hardhat/test/internal/builtin-plugins/clean/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/clean/task-action.ts
@@ -15,7 +15,11 @@ import {
   remove,
   writeUtf8File,
 } from "@nomicfoundation/hardhat-utils/fs";
-import { getCacheDir } from "@nomicfoundation/hardhat-utils/global-dir";
+import {
+  getCacheDir,
+  resetMockCacheDir,
+  setMockCacheDir,
+} from "@nomicfoundation/hardhat-utils/global-dir";
 
 import cleanAction from "../../../../src/internal/builtin-plugins/clean/task-action.js";
 import { createHardhatRuntimeEnvironment } from "../../../../src/internal/hre-initialization.js";
@@ -25,8 +29,7 @@ let globalCacheDir: string;
 let cacheDir: string;
 let artifactsDir: string;
 
-// Variables for isolating the global cache during tests
-let originalHardhatTestCacheDir: string | undefined;
+// Variable for isolating the global cache during tests
 let testGlobalCacheRoot: string;
 
 const onClean = mock.fn(async () => {});
@@ -71,9 +74,8 @@ describe("clean/task-action", () => {
 
     before(async function () {
       // Set up isolated cache directory to avoid deleting the real global cache
-      originalHardhatTestCacheDir = process.env.HARDHAT_TEST_CACHE_DIR;
       testGlobalCacheRoot = await getTmpDir("clean-task-global-cache");
-      process.env.HARDHAT_TEST_CACHE_DIR = testGlobalCacheRoot;
+      setMockCacheDir(testGlobalCacheRoot);
 
       globalCacheDir = await getCacheDir();
       cacheDir = path.join(process.cwd(), "cache");
@@ -88,12 +90,8 @@ describe("clean/task-action", () => {
     });
 
     after(async function () {
-      // Restore original environment
-      if (originalHardhatTestCacheDir === undefined) {
-        delete process.env.HARDHAT_TEST_CACHE_DIR;
-      } else {
-        process.env.HARDHAT_TEST_CACHE_DIR = originalHardhatTestCacheDir;
-      }
+      // Reset mock cache directory
+      resetMockCacheDir();
 
       // Clean up temp directory
       await remove(testGlobalCacheRoot);


### PR DESCRIPTION
The clean task tests were explicitly deleting the real global cache directory, causing the user's solc binaries to be deleted after running tests. This fix uses an isolated temporary directory via XDG_CACHE_HOME environment variable, ensuring the real global cache is preserved.
