### PR TITLE
docs: update Solidity Hook comment

### DIFF
--- a/.changeset/two-symbols-stand.md
+++ b/.changeset/two-symbols-stand.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Updated the incorrect JSDOC against the `preprocessProjectFileBeforeBuilding` Solidity Hook ([#7870](https://github.com/NomicFoundation/hardhat/pull/7870))

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
@@ -123,7 +123,10 @@ declare module "../../../types/hooks.js" {
     ) => Promise<void>;
 
     /**
-     * Hook triggered within the compilation job when its' solc input is first constructed.
+     * Hook triggered to preprocess a Solidity file and manipulate its contents
+     * before it is passed along for compilation. Only files directly under
+     * the Hardhat project are preprocessed, Solidity files from npm
+     * dependencies are not included.
      *
      * @param context The hook context.
      * @param inputSourceName The input source name of the project file.


### PR DESCRIPTION
There was a copy and paste of the doc of another hook; now there is a clear description for `preprocessProjectFileBeforeBuilding` explaining it is for altering the content of a Solidity file (a direct project Solidity file rather than npm loaded file) before it is passed along for compilation.
