### PR TITLE
Improve ignition viem build

### DIFF
--- a/v-next/example-project/package.json
+++ b/v-next/example-project/package.json
@@ -16,7 +16,6 @@
     "lint": "pnpm prettier --check",
     "lint:fix": "pnpm prettier --write",
     "prettier": "prettier \"**/*.{ts,js,md,json}\"",
-    "prebuild": "pnpm run --dir ../hardhat-ignition-viem build",
     "build": "tsc --build .",
     "clean": "rimraf dist artifacts cache ignition/deployments types",
     "pretest": "pnpm build && pnpm install",

--- a/v-next/hardhat-ignition-ui/package.json
+++ b/v-next/hardhat-ignition-ui/package.json
@@ -20,7 +20,7 @@
     "prettier": "prettier \"**/*.{ts,js,md,json}\"",
     "eslint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "preview": "vite preview",
-    "clean": "rimraf dist",
+    "clean": "rimraf ./dist ./tsconfig.node.tsbuildinfo ./tsconfig.tsbuildinfo",
     "prepack": "pnpm build && vite build"
   },
   "files": [

--- a/v-next/hardhat-ignition-viem/eslint.config.js
+++ b/v-next/hardhat-ignition-viem/eslint.config.js
@@ -1,3 +1,15 @@
+import path from "node:path";
 import { createConfig } from "../config/eslint.config.js";
 
-export default createConfig(import.meta.filename);
+const config = createConfig(import.meta.filename);
+
+// Use the tsconfig.test.json file for linting as it
+// includes the test files
+const parserOptions = config[0].languageOptions.parserOptions;
+parserOptions.project = path.join(
+  path.dirname(import.meta.filename),
+  "tsconfig.test.json",
+);
+parserOptions.projectService = undefined;
+
+export default config;

--- a/v-next/hardhat-ignition-viem/package.json
+++ b/v-next/hardhat-ignition-viem/package.json
@@ -34,7 +34,7 @@
     "test": "node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:coverage": "c8 --reporter html --reporter text --all --exclude test --exclude \"src/**/{types,type-extensions}.ts\" --src src node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
-    "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo ./test/fixture-projects/**/deployments ./test/fixture-projects/**/artifacts",
+    "clean": "rimraf .nyc_output coverage dist artifacts cache tsconfig.tsbuildinfo ./test/fixture-projects/**/deployments ./test/fixture-projects/**/artifacts ./test/fixture-projects/**/cache ./test/fixture-projects/tmp",
     "prepack": "pnpm build",
     "pretest": "pnpm build",
     "pretest:only": "pnpm build"

--- a/v-next/hardhat-ignition-viem/package.json
+++ b/v-next/hardhat-ignition-viem/package.json
@@ -25,10 +25,10 @@
     "viem"
   ],
   "scripts": {
-    "prebuild": "pnpm run --dir ../hardhat-viem build && node ./scripts/compile-test-fixture-project.js create2 && node ./scripts/compile-test-fixture-project.js minimal",
-    "build": "tsc --build .",
+    "build": "tsc --build tsconfig.json",
     "lint": "pnpm prettier --check && pnpm eslint",
     "lint:fix": "pnpm prettier --write && pnpm eslint --fix",
+    "preeslint": "pnpm test-build",
     "eslint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prettier": "prettier \"**/*.{ts,js,md,json}\"",
     "test": "node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
@@ -36,8 +36,9 @@
     "test:coverage": "c8 --reporter html --reporter text --all --exclude test --exclude \"src/**/{types,type-extensions}.ts\" --src src node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "clean": "rimraf .nyc_output coverage dist artifacts cache tsconfig.tsbuildinfo ./test/fixture-projects/**/deployments ./test/fixture-projects/**/artifacts ./test/fixture-projects/**/cache ./test/fixture-projects/tmp",
     "prepack": "pnpm build",
-    "pretest": "pnpm build",
-    "pretest:only": "pnpm build"
+    "test-build": "tsc --build tsconfig.json && node ./scripts/compile-test-fixture-project.js create2 && node ./scripts/compile-test-fixture-project.js minimal && tsc --build tsconfig.test.json",
+    "pretest": "pnpm test-build",
+    "pretest:only": "pnpm test-build"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-ignition-viem/tsconfig.json
+++ b/v-next/hardhat-ignition-viem/tsconfig.json
@@ -8,5 +8,5 @@
     { "path": "../hardhat-viem" },
     { "path": "../hardhat-test-utils" }
   ],
-  "exclude": ["${configDir}/dist", "${configDir}/node_modules"]
+  "exclude": ["test", "${configDir}/dist", "${configDir}/node_modules"]
 }

--- a/v-next/hardhat-ignition-viem/tsconfig.test.json
+++ b/v-next/hardhat-ignition-viem/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["${configDir}/dist", "${configDir}/node_modules"]
+}

--- a/v-next/hardhat-toolbox-viem/package.json
+++ b/v-next/hardhat-toolbox-viem/package.json
@@ -32,7 +32,6 @@
     "test:coverage": "c8 --reporter html --reporter text --all --exclude test --exclude \"src/**/{types,type-extensions}.ts\" --src src node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "pretest": "pnpm build",
     "pretest:only": "pnpm build",
-    "prebuild": "pnpm run --dir ../hardhat-ignition-viem build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
     "clean": "rimraf dist"


### PR DESCRIPTION
We check the types of the generated output of `hardhat-ignition-viem` using ts expected error lines within the tests.

Previously this was checked on build, but that required a prebuild step - which leads to a mirroring hierarchy of prebuild steps matching with the tsc references.

Now build of the package will exclude the tests. Triggering the tests will lead to a prestep that runs the viem type generation for the test fixture projects via a Hardhat build. It will then run a tsc build on the test files including the ts expected error lines, before finally running the tests.