### PR TITLE
Error when testing coverage: html folders flaky creation

### DIFF
--- a/.changeset/few-paws-jump.md
+++ b/.changeset/few-paws-jump.md
@@ -1,6 +1,0 @@
----
-"@nomicfoundation/hardhat": patch
-"@nomicfoundation/hardhat-vendored": patch
----
-
-Fixed a bug where nested folders were not created during the HTML coverage report generation ([7889](https://github.com/NomicFoundation/hardhat/pull/7889)).

--- a/.changeset/few-paws-jump.md
+++ b/.changeset/few-paws-jump.md
@@ -1,4 +1,5 @@
 ---
+"@nomicfoundation/hardhat": patch
 "@nomicfoundation/hardhat-vendored": patch
 ---
 

--- a/.changeset/few-paws-jump.md
+++ b/.changeset/few-paws-jump.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-vendored": patch
+---
+
+Fixed a bug where nested folders were not created during the HTML coverage report generation ([7889](https://github.com/NomicFoundation/hardhat/pull/7889)).

--- a/.changeset/nasty-brooms-hug.md
+++ b/.changeset/nasty-brooms-hug.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-vendored": patch
+"hardhat": patch
+---
+
+Fixed a bug where nested folders were not created during the HTML coverage report generation ([7889](https://github.com/NomicFoundation/hardhat/pull/7889)).

--- a/v-next/hardhat-vendored/src/coverage-module/istanbul-lib-report/lib/file-writer.cjs
+++ b/v-next/hardhat-vendored/src/coverage-module/istanbul-lib-report/lib/file-writer.cjs
@@ -8,7 +8,6 @@
  */
 const path = require("node:path");
 const fs = require("node:fs");
-const { mkdir } = require("node:fs/promises");
 
 /**
  * Base class for writing content
@@ -155,7 +154,7 @@ class FileWriter {
       throw new Error(`Cannot write to absolute path: ${dest}`);
     }
     dest = path.resolve(this.baseDir, dest);
-    mkdir(path.dirname(dest), { recursive: true });
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
     let contents;
     if (header) {
       contents = header + fs.readFileSync(source, "utf8");
@@ -179,7 +178,7 @@ class FileWriter {
       throw new Error(`Cannot write to absolute path: ${file}`);
     }
     file = path.resolve(this.baseDir, file);
-    mkdir(path.dirname(file), { recursive: true });
+    fs.mkdirSync(path.dirname(file), { recursive: true });
     return new FileContentWriter(fs.openSync(file, "w"));
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/reports/html.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/reports/html.ts
@@ -3,7 +3,6 @@ import type { FileCoverageData } from "@nomicfoundation/hardhat-vendored/coverag
 
 import path from "node:path";
 
-import { mkdir } from "@nomicfoundation/hardhat-utils/fs";
 import {
   istanbulLibCoverage,
   istanbulLibReport,

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/reports/html.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/reports/html.ts
@@ -17,8 +17,6 @@ export async function generateHtmlReport(
   const baseDir = process.cwd();
   const coverageMap = istanbulLibCoverage.createCoverageMap({});
 
-  await mkdir(htmlReportPath);
-
   // Construct coverage data for each tested file,
   // detailing whether each line was executed or not.
   for (const [p, coverageInfo] of Object.entries(report)) {

--- a/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -526,13 +526,28 @@ describe("report generation", () => {
 
   it("should generate the html report", async () => {
     const coveragePath = path.join(process.cwd(), "coverage");
-    const htmlIndexPath = path.join(coveragePath, "html", "index.html");
+    const htmlRootIndexPath = path.join(coveragePath, "html", "index.html");
+    const htmlNestedIndexPath = path.join(
+      coveragePath,
+      "html",
+      "do-while-loop", // One of the nested contract folders
+      "index.html",
+    );
 
     await remove(coveragePath);
 
     await coverageManagerTmp.report();
 
-    const htmlContent = await readUtf8File(htmlIndexPath);
-    assert.ok(htmlContent.length > 0, "HTML report should have content");
+    const htmlRootContent = await readUtf8File(htmlRootIndexPath);
+    assert.ok(
+      htmlRootContent.length > 0,
+      "HTML root report should have content",
+    );
+
+    const htmlNestedContent = await readUtf8File(htmlNestedIndexPath);
+    assert.ok(
+      htmlNestedContent.length > 0,
+      "HTML nested report should have content",
+    );
   });
 });


### PR DESCRIPTION
Fixes https://github.com/NomicFoundation/hardhat/issues/7887#issuecomment-3785495439.

Reason: the `mkdir` function was not awaited in our `vendored-package`, so nested paths were not created in time, causing the error. The root path was created automatically, which hid the bug and caused it to surface only for nested folders.

Solution: await the creation of all folders before proceeding.