### PR TITLE
fix(hardhat-ledger): Reconnect when device is unplugged

### DIFF
--- a/.changeset/bhham-rsdem-drzyn.md
+++ b/.changeset/bhham-rsdem-drzyn.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ledger": patch
+---
+
+Fixed reconnection when Ledger device is unplugged/replugged during operations ([#7896](https://github.com/NomicFoundation/hardhat/issues/7896)).

--- a/v-next/hardhat-ledger/test/helpers/transport-node-hid-mock.ts
+++ b/v-next/hardhat-ledger/test/helpers/transport-node-hid-mock.ts
@@ -7,12 +7,21 @@ import Transport from "@ledgerhq/hw-transport";
  * This mock initializes a new Transport instance and exposes only the create method, which is the sole method used by hardhat-ledger.
  */
 
-export function getTransportNodeHidMock(): typeof TransportNodeHid.default {
-  const transport = new Transport.default();
+export interface TransportMockState {
+  createCount: number;
+}
 
+export function getTransportNodeHidMock(
+  state?: TransportMockState,
+): typeof TransportNodeHid.default {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this is a mock for testing purpose
   const transportNodeHid = {
-    create: () => transport,
+    create: () => {
+      if (state !== undefined) {
+        state.createCount++;
+      }
+      return new Transport.default();
+    },
   } as unknown as typeof TransportNodeHid.default;
 
   return transportNodeHid;


### PR DESCRIPTION
Fixes #7896

## Summary

When a Ledger device is unplugged/replugged during a Hardhat session, subsequent signing operations would fail because the plugin kept trying to use a stale connection.

This PR adds automatic reconnection logic that:
- Detects `DisconnectedDevice` and `DisconnectedDeviceDuringOperation` errors from the transport layer
- Closes the stale transport and clears the cached connection
- Reconnects and retries the operation (once)

Added unit tests. This required updating the mock to enable introducing connection failures after a given number of calls. Also manually tested to ensure the fix works as expected. 

Note: `LockedDeviceError` cases are for now handled by existing code, which shows a user-friendly error asking to unlock the device and try again. Will address handling this in a subsequent PR.