### PR TITLE
chore: add "no-downgrade" as pnpm trust policy

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -5,7 +5,7 @@ inputs:
   pnpm-version:
     description: Version of pnpm to install
     required: false
-    default: "10.17.1"
+    default: "10.28.2"
   node-version:
     description: Version of node to install
     required: false

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ hoist-pattern[]=!@types/*
 minimum-release-age=10080
 minimum-release-age-exclude[]="hardhat"
 minimum-release-age-exclude[]="@nomicfoundation/*"
+trust-policy=no-downgrade

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Nomic Foundation",
   "license": "SEE LICENSE IN EACH PACKAGE'S LICENSE FILE",
   "private": true,
-  "packageManager": "pnpm@10.17.1",
+  "packageManager": "pnpm@10.28.2",
   "devDependencies": {
     "@changesets/cli": "^2.16.0",
     "typescript": "~5.8.0"


### PR DESCRIPTION
Update to the latest pnpm to take advantage of the new trust policy setting.

This guards against malicious npm releases by insisting that a package that was previously published with trusted publising can't be installed if it reverts to standard publishing (an indication of stolen publishing credentials).

See https://pnpm.io/settings#trustpolicy
