### PR TITLE
Build system fixes

### DIFF
--- a/.changeset/slimy-bottles-begin.md
+++ b/.changeset/slimy-bottles-begin.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+"hardhat": patch
+---
+
+Multiple internal fixes to the solidity build system

--- a/v-next/hardhat-verify/src/internal/artifacts.ts
+++ b/v-next/hardhat-verify/src/internal/artifacts.ts
@@ -103,11 +103,7 @@ export async function getCompilerInput(
     "The compilation job for the contract source was not found.",
   );
 
-  const compilationJobKey = isNpmModule ? `npm:${sourceName}` : sourceName;
-
-  const compilerInput = await compilationJob
-    .get(compilationJobKey)
-    ?.getSolcInput();
+  const compilerInput = await compilationJob.get(rootFilePath)?.getSolcInput();
 
   // TODO: should this be an error instead?
   assertHardhatInvariant(

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -471,9 +471,12 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
           "individual subgraph doesn't have exactly 1 root file",
         );
 
-        const rootFilePath = Array.from(subgraph.getRoots().keys())[0];
+        const [userSourceName, root] = [...subgraph.getRoots().entries()][0];
 
-        indexedIndividualJobs.set(rootFilePath, individualJob);
+        indexedIndividualJobs.set(
+          formatRootPath(userSourceName, root),
+          individualJob,
+        );
       }),
     );
 
@@ -551,7 +554,8 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
           "there should be only 1 root file on subgraph",
         );
 
-        const rootFile = Array.from(subgraph.getRoots().keys())[0];
+        const [userSourceName, root] = [...subgraph.getRoots().entries()][0];
+        const rootFile = formatRootPath(userSourceName, root);
 
         // Skip root files with cache hit (should not recompile)
         if (!rootFilesToCompile.has(rootFile)) {
@@ -577,7 +581,8 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
             "there should be only 1 root file on subgraph",
           );
 
-          const rootFile = Array.from(subgraph.getRoots().keys())[0];
+          const [userSourceName, root] = [...subgraph.getRoots().entries()][0];
+          const rootFile = formatRootPath(userSourceName, root);
 
           return rootFilesToCompile.has(rootFile);
         },
@@ -763,7 +768,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
         }
       }
 
-      artifactsPerFile.set(userSourceName, paths);
+      artifactsPerFile.set(formatRootPath(userSourceName, root), paths);
 
       // Write the type declaration file, only for contracts
       if (scope === "contracts") {
@@ -771,7 +776,10 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
           fileFolder,
           "artifacts.d.ts",
         );
-        typeFilePaths.set(userSourceName, artifactsDeclarationFilePath);
+        typeFilePaths.set(
+          formatRootPath(userSourceName, root),
+          artifactsDeclarationFilePath,
+        );
 
         const artifactsDeclarationFile = getArtifactsDeclarationFile(artifacts);
 
@@ -1053,11 +1061,10 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     isolated: boolean,
     scope: BuildScope,
   ): Promise<void> {
-    const rootFilePaths = result.compilationJob.dependencyGraph
+    for (const [userSourceName, root] of result.compilationJob.dependencyGraph
       .getRoots()
-      .keys();
-
-    for (const rootFilePath of rootFilePaths) {
+      .entries()) {
+      const rootFilePath = formatRootPath(userSourceName, root);
       const individualJob = indexedIndividualJobs.get(rootFilePath);
 
       assertHardhatInvariant(

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/root-paths-utils.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/root-paths-utils.ts
@@ -63,7 +63,7 @@ export function isNpmParsedRootPath(
 
 /**
  * Formats the path of a root file, making it compatible with the
- * SolidityBuildSystem APIs.
+ * SolidityBuildSystem APIs, which expect an absolute path or an npm: root path.
  *
  * @param userSourceName The user source name of the root file.
  * @param rootFile The root file.
@@ -74,7 +74,7 @@ export function formatRootPath(
   rootFile: ResolvedFile,
 ): string {
   if (rootFile.type !== ResolvedFileType.NPM_PACKAGE_FILE) {
-    return userSourceName;
+    return rootFile.fsPath;
   }
 
   return `npm:${userSourceName}`;

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
@@ -114,7 +114,10 @@ async function buildForScope(
 
   // If we recompiled the entire project we cleanup the artifacts
   if (isFullCompilation) {
-    await solidity.cleanupArtifacts(rootPaths, { scope });
+    // Use the root files from the build results, which may include
+    // additional files added by plugins hooking into solidity#build
+    const builtRootPaths = [...results.keys()];
+    await solidity.cleanupArtifacts(builtRootPaths, { scope });
   }
 
   return { rootPaths, usedFiles };

--- a/v-next/hardhat/src/types/solidity/build-system.ts
+++ b/v-next/hardhat/src/types/solidity/build-system.ts
@@ -146,9 +146,8 @@ export type FileBuildResult =
 
 export interface CacheHitFileBuildResult {
   type: FileBuildResultType.CACHE_HIT;
-  compilationJob: CompilationJob;
+  buildId: string;
   contractArtifactsGenerated: string[];
-  warnings: CompilerOutputError[];
 }
 
 export interface SuccessfulFileBuildResult {
@@ -183,6 +182,10 @@ export interface GetCompilationJobsResult {
    * Map from root file path to individual (non-merged) compilation job.
    */
   indexedIndividualJobs: Map<string, CompilationJob>;
+  /**
+   * Map from root file path to cache hit info for files that don't need recompilation.
+   */
+  cacheHits: Map<string, CacheHitInfo>;
 }
 
 /**

--- a/v-next/hardhat/src/types/solidity/build-system.ts
+++ b/v-next/hardhat/src/types/solidity/build-system.ts
@@ -164,14 +164,39 @@ export interface FailedFileBuildResult {
   errors: CompilerOutputError[];
 }
 
+export interface CacheHitInfo {
+  buildId: string;
+  artifactPaths: string[];
+}
+
+/**
+ * The result of calling `getCompilationJobs`.
+ *
+ * The keys in the maps of this interface are Root File Paths, which means either absolute paths or `npm:<package>/<file>` URIs.
+ */
 export interface GetCompilationJobsResult {
+  /**
+   * Map from root file path to compilation job for files that need compilation.
+   */
   compilationJobsPerFile: Map<string, CompilationJob>;
+  /**
+   * Map from root file path to individual (non-merged) compilation job.
+   */
   indexedIndividualJobs: Map<string, CompilationJob>;
 }
 
+/**
+ * The result of emitting artifacts for a compilation job.
+ */
 export interface EmitArtifactsResult {
+  /**
+   * Map from root file path to artifact file paths.
+   */
   artifactsPerFile: ReadonlyMap<string, string[]>;
   buildInfoPath: string;
+  /**
+   * Map from root file path to type declaration file path.
+   */
   typeFilePaths: ReadonlyMap<string, string>;
   buildInfoOutputPath: string;
 }

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/cache-hit-results.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/cache-hit-results.ts
@@ -1,0 +1,178 @@
+import type { HardhatRuntimeEnvironment } from "../../../../../../src/types/hre.js";
+import type { TestProject } from "../resolver/helpers.js";
+
+import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { createHardhatRuntimeEnvironment } from "../../../../../../src/internal/hre-initialization.js";
+import { FileBuildResultType } from "../../../../../../src/types/solidity/build-system.js";
+import { useTestProjectTemplate } from "../resolver/helpers.js";
+
+async function getHRE(
+  project: TestProject,
+): Promise<HardhatRuntimeEnvironment> {
+  return createHardhatRuntimeEnvironment(
+    {
+      solidity: {
+        profiles: {
+          default: { version: "0.8.28", isolated: false },
+        },
+      },
+    },
+    {},
+    project.path,
+  );
+}
+
+describe("CacheHitFileBuildResult", () => {
+  describe("build() cache hit results", () => {
+    it("should return CacheHitFileBuildResult with buildId string on cache hit", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {
+          "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+        },
+      });
+
+      const hre = await getHRE(project);
+      const filePath = path.join(project.path, "contracts/Foo.sol");
+
+      // First build
+      const firstResult = await hre.solidity.build([filePath], { quiet: true });
+      assert(!("reason" in firstResult), "First build should succeed");
+      const firstBuildResult = firstResult.get(filePath);
+      assert.equal(firstBuildResult?.type, FileBuildResultType.BUILD_SUCCESS);
+      const originalBuildId =
+        await firstBuildResult.compilationJob.getBuildId();
+
+      // Second build - cache hit
+      const secondResult = await hre.solidity.build([filePath], {
+        quiet: true,
+      });
+      assert(!("reason" in secondResult), "Second build should succeed");
+      const cacheHitResult = secondResult.get(filePath);
+
+      assert.equal(cacheHitResult?.type, FileBuildResultType.CACHE_HIT);
+      assert.equal(
+        typeof cacheHitResult.buildId,
+        "string",
+        "buildId should be a string",
+      );
+      assert.equal(
+        cacheHitResult.buildId,
+        originalBuildId,
+        "buildId should match original",
+      );
+    });
+
+    it("should include contractArtifactsGenerated in cache hit result", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {
+          "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}
+contract Bar {}`,
+        },
+      });
+
+      const hre = await getHRE(project);
+      const filePath = path.join(project.path, "contracts/Foo.sol");
+
+      // First build
+      await hre.solidity.build([filePath], { quiet: true });
+
+      // Second build - cache hit
+      const secondResult = await hre.solidity.build([filePath], {
+        quiet: true,
+      });
+      assert(!("reason" in secondResult), "Second build should succeed");
+      const cacheHitResult = secondResult.get(filePath);
+
+      assert.equal(cacheHitResult?.type, FileBuildResultType.CACHE_HIT);
+      assert.equal(
+        cacheHitResult.contractArtifactsGenerated.length,
+        2,
+        "Should have 2 artifacts (Foo, Bar)",
+      );
+    });
+
+    it("should return BUILD_SUCCESS for modified file, CACHE_HIT for unchanged", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {
+          "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+          "contracts/Bar.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Bar {}`,
+        },
+      });
+
+      const hre = await getHRE(project);
+      const fooPath = path.join(project.path, "contracts/Foo.sol");
+      const barPath = path.join(project.path, "contracts/Bar.sol");
+
+      // First build
+      await hre.solidity.build([fooPath, barPath], { quiet: true });
+
+      // Modify only Foo.sol
+      await writeFile(
+        fooPath,
+        `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo { uint256 public value; }`,
+      );
+
+      // Second build
+      const result = await hre.solidity.build([fooPath, barPath], {
+        quiet: true,
+      });
+      assert(!("reason" in result), "Build should succeed");
+
+      assert.equal(
+        result.get(fooPath)?.type,
+        FileBuildResultType.BUILD_SUCCESS,
+      );
+      assert.equal(result.get(barPath)?.type, FileBuildResultType.CACHE_HIT);
+    });
+
+    it("should return BUILD_SUCCESS with force: true even for unchanged files", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {
+          "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+        },
+      });
+
+      const hre = await getHRE(project);
+      const filePath = path.join(project.path, "contracts/Foo.sol");
+
+      // First build
+      await hre.solidity.build([filePath], { quiet: true });
+
+      // Second build with force: true
+      const result = await hre.solidity.build([filePath], {
+        quiet: true,
+        force: true,
+      });
+      assert(!("reason" in result), "Build should succeed");
+
+      assert.equal(
+        result.get(filePath)?.type,
+        FileBuildResultType.BUILD_SUCCESS,
+      );
+    });
+  });
+});

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/cache-hit-results.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/cache-hit-results.ts
@@ -1,30 +1,12 @@
-import type { HardhatRuntimeEnvironment } from "../../../../../../src/types/hre.js";
-import type { TestProject } from "../resolver/helpers.js";
-
 import assert from "node:assert/strict";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, it } from "node:test";
 
-import { createHardhatRuntimeEnvironment } from "../../../../../../src/internal/hre-initialization.js";
 import { FileBuildResultType } from "../../../../../../src/types/solidity/build-system.js";
 import { useTestProjectTemplate } from "../resolver/helpers.js";
 
-async function getHRE(
-  project: TestProject,
-): Promise<HardhatRuntimeEnvironment> {
-  return createHardhatRuntimeEnvironment(
-    {
-      solidity: {
-        profiles: {
-          default: { version: "0.8.28", isolated: false },
-        },
-      },
-    },
-    {},
-    project.path,
-  );
-}
+import { getHRE } from "./helpers.js";
 
 describe("CacheHitFileBuildResult", () => {
   describe("build() cache hit results", () => {

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/get-compilation-jobs-cache-hits.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/get-compilation-jobs-cache-hits.ts
@@ -1,30 +1,12 @@
-import type { HardhatRuntimeEnvironment } from "../../../../../../src/types/hre.js";
-import type { TestProject } from "../resolver/helpers.js";
-
 import assert from "node:assert/strict";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, it } from "node:test";
 
-import { createHardhatRuntimeEnvironment } from "../../../../../../src/internal/hre-initialization.js";
 import { FileBuildResultType } from "../../../../../../src/types/solidity/build-system.js";
 import { useTestProjectTemplate } from "../resolver/helpers.js";
 
-async function getHRE(
-  project: TestProject,
-): Promise<HardhatRuntimeEnvironment> {
-  return createHardhatRuntimeEnvironment(
-    {
-      solidity: {
-        profiles: {
-          default: { version: "0.8.28", isolated: false },
-        },
-      },
-    },
-    {},
-    project.path,
-  );
-}
+import { getHRE } from "./helpers.js";
 
 describe("getCompilationJobs() cacheHits", () => {
   it("should return cacheHits map for unchanged local files", async () => {

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/get-compilation-jobs-cache-hits.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/get-compilation-jobs-cache-hits.ts
@@ -1,0 +1,273 @@
+import type { HardhatRuntimeEnvironment } from "../../../../../../src/types/hre.js";
+import type { TestProject } from "../resolver/helpers.js";
+
+import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { createHardhatRuntimeEnvironment } from "../../../../../../src/internal/hre-initialization.js";
+import { FileBuildResultType } from "../../../../../../src/types/solidity/build-system.js";
+import { useTestProjectTemplate } from "../resolver/helpers.js";
+
+async function getHRE(
+  project: TestProject,
+): Promise<HardhatRuntimeEnvironment> {
+  return createHardhatRuntimeEnvironment(
+    {
+      solidity: {
+        profiles: {
+          default: { version: "0.8.28", isolated: false },
+        },
+      },
+    },
+    {},
+    project.path,
+  );
+}
+
+describe("getCompilationJobs() cacheHits", () => {
+  it("should return cacheHits map for unchanged local files", async () => {
+    await using project = await useTestProjectTemplate({
+      name: "test-project",
+      version: "1.0.0",
+      files: {
+        "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+      },
+    });
+
+    const hre = await getHRE(project);
+    const filePath = path.join(project.path, "contracts/Foo.sol");
+
+    // First build to populate cache
+    await hre.solidity.build([filePath], { quiet: true });
+
+    // Call getCompilationJobs
+    const result = await hre.solidity.getCompilationJobs([filePath], {
+      quiet: true,
+    });
+
+    assert(!("reason" in result), "getCompilationJobs should succeed");
+    assert.equal(result.cacheHits.size, 1, "Should have one cache hit");
+    assert.equal(
+      result.compilationJobsPerFile.size,
+      0,
+      "Should have no compilation jobs",
+    );
+    assert(
+      result.cacheHits.has(filePath),
+      "Cache hit should be keyed by absolute path",
+    );
+  });
+
+  it("should return correct CacheHitInfo structure", async () => {
+    await using project = await useTestProjectTemplate({
+      name: "test-project",
+      version: "1.0.0",
+      files: {
+        "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+      },
+    });
+
+    const hre = await getHRE(project);
+    const filePath = path.join(project.path, "contracts/Foo.sol");
+
+    // First build to get original buildId
+    const buildResult = await hre.solidity.build([filePath], { quiet: true });
+    assert(!("reason" in buildResult), "Build should succeed");
+    const fileBuildResult = buildResult.get(filePath);
+    assert.equal(fileBuildResult?.type, FileBuildResultType.BUILD_SUCCESS);
+    const originalBuildId = await fileBuildResult.compilationJob.getBuildId();
+
+    // Call getCompilationJobs
+    const result = await hre.solidity.getCompilationJobs([filePath], {
+      quiet: true,
+    });
+
+    assert(!("reason" in result), "getCompilationJobs should succeed");
+    const cacheHitInfo = result.cacheHits.get(filePath);
+
+    assert(cacheHitInfo !== undefined, "Should have cache hit info");
+    assert.equal(
+      cacheHitInfo.buildId,
+      originalBuildId,
+      "buildId should match original",
+    );
+    assert(
+      Array.isArray(cacheHitInfo.artifactPaths),
+      "artifactPaths should be an array",
+    );
+    assert.equal(
+      cacheHitInfo.artifactPaths.length,
+      1,
+      "Should have one artifact path",
+    );
+  });
+
+  it("should put modified file in compilationJobsPerFile, unchanged in cacheHits", async () => {
+    await using project = await useTestProjectTemplate({
+      name: "test-project",
+      version: "1.0.0",
+      files: {
+        "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+        "contracts/Bar.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Bar {}`,
+      },
+    });
+
+    const hre = await getHRE(project);
+    const fooPath = path.join(project.path, "contracts/Foo.sol");
+    const barPath = path.join(project.path, "contracts/Bar.sol");
+
+    // First build
+    await hre.solidity.build([fooPath, barPath], { quiet: true });
+
+    // Modify Foo.sol
+    await writeFile(
+      fooPath,
+      `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo { uint256 public value; }`,
+    );
+
+    // Call getCompilationJobs
+    const result = await hre.solidity.getCompilationJobs([fooPath, barPath], {
+      quiet: true,
+    });
+
+    assert(!("reason" in result), "getCompilationJobs should succeed");
+    assert(
+      result.compilationJobsPerFile.has(fooPath),
+      "Modified file should be in compilationJobsPerFile",
+    );
+    assert(
+      result.cacheHits.has(barPath),
+      "Unchanged file should be in cacheHits",
+    );
+    assert.equal(result.compilationJobsPerFile.size, 1);
+    assert.equal(result.cacheHits.size, 1);
+  });
+
+  it("should return empty cacheHits with force: true", async () => {
+    await using project = await useTestProjectTemplate({
+      name: "test-project",
+      version: "1.0.0",
+      files: {
+        "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+      },
+    });
+
+    const hre = await getHRE(project);
+    const filePath = path.join(project.path, "contracts/Foo.sol");
+
+    // First build
+    await hre.solidity.build([filePath], { quiet: true });
+
+    // Call getCompilationJobs with force: true
+    const result = await hre.solidity.getCompilationJobs([filePath], {
+      quiet: true,
+      force: true,
+    });
+
+    assert(!("reason" in result), "getCompilationJobs should succeed");
+    assert.equal(
+      result.cacheHits.size,
+      0,
+      "Should have no cache hits with force: true",
+    );
+    assert.equal(
+      result.compilationJobsPerFile.size,
+      1,
+      "Should have compilation job",
+    );
+  });
+
+  it("should return empty cacheHits when all files need recompilation", async () => {
+    await using project = await useTestProjectTemplate({
+      name: "test-project",
+      version: "1.0.0",
+      files: {
+        "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+      },
+    });
+
+    const hre = await getHRE(project);
+    const filePath = path.join(project.path, "contracts/Foo.sol");
+
+    // First getCompilationJobs call (no prior build)
+    const result = await hre.solidity.getCompilationJobs([filePath], {
+      quiet: true,
+    });
+
+    assert(!("reason" in result), "getCompilationJobs should succeed");
+    assert.equal(
+      result.cacheHits.size,
+      0,
+      "Should have no cache hits on fresh project",
+    );
+    assert.equal(
+      result.compilationJobsPerFile.size,
+      1,
+      "Should have compilation job",
+    );
+  });
+
+  it("should invalidate cache when dependency changes", async () => {
+    await using project = await useTestProjectTemplate({
+      name: "test-project",
+      version: "1.0.0",
+      files: {
+        "contracts/Base.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Base {}`,
+        "contracts/Child.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "./Base.sol";
+contract Child is Base {}`,
+      },
+    });
+
+    const hre = await getHRE(project);
+    const basePath = path.join(project.path, "contracts/Base.sol");
+    const childPath = path.join(project.path, "contracts/Child.sol");
+
+    // First build
+    await hre.solidity.build([childPath], { quiet: true });
+
+    // Modify Base.sol (dependency)
+    await writeFile(
+      basePath,
+      `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Base { uint256 public value; }`,
+    );
+
+    // Call getCompilationJobs for Child
+    const result = await hre.solidity.getCompilationJobs([childPath], {
+      quiet: true,
+    });
+
+    assert(!("reason" in result), "getCompilationJobs should succeed");
+    assert.equal(
+      result.cacheHits.size,
+      0,
+      "Should have no cache hits when dependency changed",
+    );
+    assert.equal(
+      result.compilationJobsPerFile.size,
+      1,
+      "Should need recompilation",
+    );
+  });
+});

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/npm-cache-hits.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/npm-cache-hits.ts
@@ -1,0 +1,429 @@
+import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { FileBuildResultType } from "../../../../../../src/types/solidity/build-system.js";
+import { useTestProjectTemplate } from "../resolver/helpers.js";
+
+import { getHRE } from "./helpers.js";
+
+describe("npm file cache hits", () => {
+  describe("build() with npm files", () => {
+    it("should return CACHE_HIT for unchanged npm file on second build", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {},
+        dependencies: {
+          "@openzeppelin/contracts": {
+            name: "@openzeppelin/contracts",
+            version: "5.0.0",
+            files: {
+              "token/ERC20.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract ERC20 {}`,
+            },
+            exports: {
+              "./*": "./*",
+              "./token/*": "./token/*",
+            },
+          },
+        },
+      });
+
+      const hre = await getHRE(project);
+
+      const npmRootPath = "npm:@openzeppelin/contracts/token/ERC20.sol";
+
+      // First build
+      const firstResult = await hre.solidity.build([npmRootPath], {
+        quiet: true,
+      });
+
+      assert(
+        !("reason" in firstResult),
+        `Build should be successful, got: ${JSON.stringify(firstResult)}`,
+      );
+      assert.equal(firstResult.size, 1, "Should have one result");
+      const firstBuildResult = firstResult.get(npmRootPath);
+      assert.equal(
+        firstBuildResult?.type,
+        FileBuildResultType.BUILD_SUCCESS,
+        "First build should be BUILD_SUCCESS",
+      );
+
+      // Second build without changes - should be cache hit
+      const secondResult = await hre.solidity.build([npmRootPath], {
+        quiet: true,
+      });
+
+      assert(!("reason" in secondResult), "Second build should be successful");
+      assert.equal(secondResult.size, 1, "Should have one result");
+      const secondBuildResult = secondResult.get(npmRootPath);
+      assert.equal(
+        secondBuildResult?.type,
+        FileBuildResultType.CACHE_HIT,
+        "Second build should be CACHE_HIT",
+      );
+    });
+
+    it("should return correct buildId for npm file cache hit", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {},
+        dependencies: {
+          "@openzeppelin/contracts": {
+            name: "@openzeppelin/contracts",
+            version: "5.0.0",
+            files: {
+              "token/ERC20.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract ERC20 {}`,
+            },
+            exports: {
+              "./*": "./*",
+              "./token/*": "./token/*",
+            },
+          },
+        },
+      });
+
+      const hre = await getHRE(project);
+
+      const npmRootPath = "npm:@openzeppelin/contracts/token/ERC20.sol";
+
+      // First build
+      const firstResult = await hre.solidity.build([npmRootPath], {
+        quiet: true,
+      });
+      assert(!("reason" in firstResult), "First build should be successful");
+      const firstBuildResult = firstResult.get(npmRootPath);
+      assert.equal(firstBuildResult?.type, FileBuildResultType.BUILD_SUCCESS);
+      const originalBuildId =
+        await firstBuildResult.compilationJob.getBuildId();
+
+      // Second build - cache hit
+      const secondResult = await hre.solidity.build([npmRootPath], {
+        quiet: true,
+      });
+
+      assert(!("reason" in secondResult), "Second build should be successful");
+      const secondBuildResult = secondResult.get(npmRootPath);
+      assert.equal(secondBuildResult?.type, FileBuildResultType.CACHE_HIT);
+      assert.equal(
+        secondBuildResult.buildId,
+        originalBuildId,
+        "Cache hit buildId should match original compilation",
+      );
+    });
+
+    it("should handle mixed local and npm file cache hits", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {
+          "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+        },
+        dependencies: {
+          "@openzeppelin/contracts": {
+            name: "@openzeppelin/contracts",
+            version: "5.0.0",
+            files: {
+              "token/ERC20.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract ERC20 {}`,
+            },
+            exports: {
+              "./*": "./*",
+              "./token/*": "./token/*",
+            },
+          },
+        },
+      });
+
+      const hre = await getHRE(project);
+
+      const localPath = path.join(project.path, "contracts/Foo.sol");
+      const npmRootPath = "npm:@openzeppelin/contracts/token/ERC20.sol";
+
+      // First build both files
+      const firstResult = await hre.solidity.build([localPath, npmRootPath], {
+        quiet: true,
+      });
+
+      assert(!("reason" in firstResult), "First build should be successful");
+      assert.equal(firstResult.size, 2, "Should have two results");
+
+      // Modify only local file
+      await writeFile(
+        localPath,
+        `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo { uint256 public value; }`,
+      );
+
+      // Second build
+      const secondResult = await hre.solidity.build([localPath, npmRootPath], {
+        quiet: true,
+      });
+
+      assert(!("reason" in secondResult), "Second build should be successful");
+      assert.equal(secondResult.size, 2, "Should have two results");
+
+      // Local file was modified - BUILD_SUCCESS
+      const localResult = secondResult.get(localPath);
+      assert.equal(
+        localResult?.type,
+        FileBuildResultType.BUILD_SUCCESS,
+        "Modified local file should be BUILD_SUCCESS",
+      );
+
+      // npm file unchanged - CACHE_HIT
+      const npmResult = secondResult.get(npmRootPath);
+      assert.equal(
+        npmResult?.type,
+        FileBuildResultType.CACHE_HIT,
+        "Unchanged npm file should be CACHE_HIT",
+      );
+    });
+  });
+
+  describe("getCompilationJobs() with npm files", () => {
+    it("should return npm file in cacheHits when unchanged", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {},
+        dependencies: {
+          "@openzeppelin/contracts": {
+            name: "@openzeppelin/contracts",
+            version: "5.0.0",
+            files: {
+              "token/ERC20.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract ERC20 {}`,
+            },
+            exports: {
+              "./*": "./*",
+              "./token/*": "./token/*",
+            },
+          },
+        },
+      });
+
+      const hre = await getHRE(project);
+
+      const npmRootPath = "npm:@openzeppelin/contracts/token/ERC20.sol";
+
+      // First build to populate cache
+      await hre.solidity.build([npmRootPath], { quiet: true });
+
+      // Call getCompilationJobs
+      const result = await hre.solidity.getCompilationJobs([npmRootPath], {
+        quiet: true,
+      });
+
+      assert(!("reason" in result), "getCompilationJobs should succeed");
+      assert.equal(
+        result.cacheHits.size,
+        1,
+        "Should have one cache hit for unchanged npm file",
+      );
+      assert.equal(
+        result.compilationJobsPerFile.size,
+        0,
+        "Should have no compilation jobs for unchanged npm file",
+      );
+      assert(
+        result.cacheHits.has(npmRootPath),
+        "Cache hit should be keyed by npm root path",
+      );
+    });
+
+    it("should return correct CacheHitInfo for npm file", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {},
+        dependencies: {
+          "@openzeppelin/contracts": {
+            name: "@openzeppelin/contracts",
+            version: "5.0.0",
+            files: {
+              "token/ERC20.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract ERC20 {}`,
+            },
+            exports: {
+              "./*": "./*",
+              "./token/*": "./token/*",
+            },
+          },
+        },
+      });
+
+      const hre = await getHRE(project);
+
+      const npmRootPath = "npm:@openzeppelin/contracts/token/ERC20.sol";
+
+      // First build to get the original buildId
+      const buildResult = await hre.solidity.build([npmRootPath], {
+        quiet: true,
+      });
+      assert(!("reason" in buildResult), "Build should succeed");
+      const fileBuildResult = buildResult.get(npmRootPath);
+      assert.equal(fileBuildResult?.type, FileBuildResultType.BUILD_SUCCESS);
+      const originalBuildId = await fileBuildResult.compilationJob.getBuildId();
+
+      // Call getCompilationJobs
+      const result = await hre.solidity.getCompilationJobs([npmRootPath], {
+        quiet: true,
+      });
+
+      assert(!("reason" in result), "getCompilationJobs should succeed");
+      const cacheHitInfo = result.cacheHits.get(npmRootPath);
+
+      assert(cacheHitInfo !== undefined, "Should have cache hit info");
+      assert.equal(
+        cacheHitInfo.buildId,
+        originalBuildId,
+        "Cache hit buildId should match original compilation buildId",
+      );
+      assert(
+        Array.isArray(cacheHitInfo.artifactPaths),
+        "artifactPaths should be an array",
+      );
+      assert.equal(
+        cacheHitInfo.artifactPaths.length,
+        1,
+        "Should have one artifact path for ERC20 contract",
+      );
+    });
+
+    it("should handle mixed local and npm files correctly", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {
+          "contracts/Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+        },
+        dependencies: {
+          "@openzeppelin/contracts": {
+            name: "@openzeppelin/contracts",
+            version: "5.0.0",
+            files: {
+              "token/ERC20.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract ERC20 {}`,
+            },
+            exports: {
+              "./*": "./*",
+              "./token/*": "./token/*",
+            },
+          },
+        },
+      });
+
+      const hre = await getHRE(project);
+
+      const localPath = path.join(project.path, "contracts/Foo.sol");
+      const npmRootPath = "npm:@openzeppelin/contracts/token/ERC20.sol";
+
+      // First build to populate cache
+      await hre.solidity.build([localPath, npmRootPath], { quiet: true });
+
+      // Modify only local file
+      await writeFile(
+        localPath,
+        `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo { uint256 public value; }`,
+      );
+
+      // Call getCompilationJobs
+      const result = await hre.solidity.getCompilationJobs(
+        [localPath, npmRootPath],
+        { quiet: true },
+      );
+
+      assert(!("reason" in result), "getCompilationJobs should succeed");
+
+      // Local file was modified, should be in compilationJobsPerFile
+      assert(
+        result.compilationJobsPerFile.has(localPath),
+        "Modified local file should be in compilationJobsPerFile",
+      );
+
+      // npm file unchanged, should be in cacheHits
+      assert(
+        result.cacheHits.has(npmRootPath),
+        "Unchanged npm file should be in cacheHits",
+      );
+
+      assert.equal(
+        result.compilationJobsPerFile.size,
+        1,
+        "Should have one compilation job",
+      );
+      assert.equal(result.cacheHits.size, 1, "Should have one cache hit");
+    });
+
+    it("should return npm file in compilationJobsPerFile with force: true", async () => {
+      await using project = await useTestProjectTemplate({
+        name: "test-project",
+        version: "1.0.0",
+        files: {},
+        dependencies: {
+          "@openzeppelin/contracts": {
+            name: "@openzeppelin/contracts",
+            version: "5.0.0",
+            files: {
+              "token/ERC20.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract ERC20 {}`,
+            },
+            exports: {
+              "./*": "./*",
+              "./token/*": "./token/*",
+            },
+          },
+        },
+      });
+
+      const hre = await getHRE(project);
+
+      const npmRootPath = "npm:@openzeppelin/contracts/token/ERC20.sol";
+
+      // First build to populate cache
+      await hre.solidity.build([npmRootPath], { quiet: true });
+
+      // Call getCompilationJobs with force: true
+      const result = await hre.solidity.getCompilationJobs([npmRootPath], {
+        quiet: true,
+        force: true,
+      });
+
+      assert(!("reason" in result), "getCompilationJobs should succeed");
+      assert.equal(
+        result.compilationJobsPerFile.size,
+        1,
+        "Should have one compilation job when force: true",
+      );
+      assert.equal(
+        result.cacheHits.size,
+        0,
+        "Should have no cache hits when force: true",
+      );
+      assert(
+        result.compilationJobsPerFile.has(npmRootPath),
+        "npm file should be in compilationJobsPerFile when force: true",
+      );
+    });
+  });
+});

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
@@ -29,6 +29,8 @@ describe("build task - cleanupArtifacts", () => {
             "contracts/Original.sol": `// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 contract Original {}`,
+            // This file is not part of in contracts/ so it won't be included
+            // as a root by default.
             "extra/AddedByHook.sol": `// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 contract AddedByHook {}`,
@@ -61,13 +63,11 @@ contract AddedByHook {}`,
                     );
 
                     // Add extra file to the build
-                    const extendedPaths = rootFilePaths.some(
-                      (p) => p === extraFile,
-                    )
-                      ? rootFilePaths
-                      : [...rootFilePaths, extraFile];
-
-                    return next(context, extendedPaths, options);
+                    return next(
+                      context,
+                      [...rootFilePaths, extraFile],
+                      options,
+                    );
                   },
                 };
 

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
@@ -1,0 +1,420 @@
+import type {
+  HookContext,
+  SolidityHooks,
+} from "../../../../../src/types/hooks.js";
+import type { HardhatPlugin } from "../../../../../src/types/plugins.js";
+import type {
+  BuildOptions,
+  CompilationJobCreationError,
+  FileBuildResult,
+} from "../../../../../src/types/solidity/build-system.js";
+
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { exists, remove } from "@nomicfoundation/hardhat-utils/fs";
+
+import { createHardhatRuntimeEnvironment } from "../../../../../src/hre.js";
+import { useTestProjectTemplate } from "../build-system/resolver/helpers.js";
+
+describe("build task - cleanupArtifacts", () => {
+  describe("cleanupArtifacts uses built root files from results", () => {
+    describe("when hook adds extra root files", () => {
+      it("should keep artifacts for hook-added files", async () => {
+        await using project = await useTestProjectTemplate({
+          name: "test-cleanup-hook-adds",
+          version: "1.0.0",
+          files: {
+            "contracts/Original.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Original {}`,
+            "extra/AddedByHook.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract AddedByHook {}`,
+          },
+        });
+
+        // Plugin that adds an extra file in the build hook
+        const hookAddingPlugin: HardhatPlugin = {
+          id: "test-hook-adding-plugin",
+          hookHandlers: {
+            solidity: async () => ({
+              default: async () => {
+                const handlers: Partial<SolidityHooks> = {
+                  build: async (
+                    context: HookContext,
+                    rootFilePaths: string[],
+                    options: BuildOptions | undefined,
+                    next: (
+                      nextContext: HookContext,
+                      nextRootFilePaths: string[],
+                      nextOptions: BuildOptions | undefined,
+                    ) => Promise<
+                      CompilationJobCreationError | Map<string, FileBuildResult>
+                    >,
+                  ) => {
+                    // Find the AddedByHook.sol file and add it if not present
+                    const extraFile = path.join(
+                      project.path,
+                      "extra/AddedByHook.sol",
+                    );
+
+                    // Add extra file to the build
+                    const extendedPaths = rootFilePaths.some(
+                      (p) => p === extraFile,
+                    )
+                      ? rootFilePaths
+                      : [...rootFilePaths, extraFile];
+
+                    return next(context, extendedPaths, options);
+                  },
+                };
+
+                return handlers;
+              },
+            }),
+          },
+        };
+
+        const hre = await createHardhatRuntimeEnvironment(
+          {
+            plugins: [hookAddingPlugin],
+            solidity: "0.8.28",
+          },
+          {},
+          project.path,
+        );
+
+        // Run full build
+        await hre.tasks.getTask("build").run({
+          force: true,
+          noTests: true,
+          quiet: true,
+        });
+
+        // Verify artifacts exist for both Original.sol and AddedByHook.sol
+        const artifactsDir = path.join(project.path, "artifacts");
+        const originalArtifact = path.join(
+          artifactsDir,
+          "contracts",
+          "Original.sol",
+          "Original.json",
+        );
+        const hookAddedArtifact = path.join(
+          artifactsDir,
+          "extra",
+          "AddedByHook.sol",
+          "AddedByHook.json",
+        );
+
+        assert.ok(
+          await exists(originalArtifact),
+          "Original.sol artifact should exist",
+        );
+        assert.ok(
+          await exists(hookAddedArtifact),
+          "AddedByHook.sol artifact should exist (added by hook)",
+        );
+      });
+    });
+
+    describe("when hook filters out root files", () => {
+      it("should remove artifacts for filtered-out files on rebuild", async () => {
+        await using project = await useTestProjectTemplate({
+          name: "test-cleanup-hook-filters",
+          version: "1.0.0",
+          files: {
+            "contracts/Keep.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Keep {}`,
+            "contracts/Filter.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Filter {}`,
+          },
+        });
+
+        // First, build without any filtering to create artifacts for both files
+        const hreNoFilter = await createHardhatRuntimeEnvironment(
+          {
+            solidity: "0.8.28",
+          },
+          {},
+          project.path,
+        );
+
+        await hreNoFilter.tasks.getTask("build").run({
+          force: true,
+          noTests: true,
+          quiet: true,
+        });
+
+        // Verify both artifacts exist
+        const artifactsDir = path.join(project.path, "artifacts", "contracts");
+        const keepArtifact = path.join(artifactsDir, "Keep.sol", "Keep.json");
+        const filterArtifact = path.join(
+          artifactsDir,
+          "Filter.sol",
+          "Filter.json",
+        );
+
+        assert.ok(
+          await exists(keepArtifact),
+          "Keep.sol artifact should exist after first build",
+        );
+        assert.ok(
+          await exists(filterArtifact),
+          "Filter.sol artifact should exist after first build",
+        );
+
+        // Now rebuild with a plugin that filters out Filter.sol
+        const filteringPlugin: HardhatPlugin = {
+          id: "test-filtering-plugin",
+          hookHandlers: {
+            solidity: async () => ({
+              default: async () => {
+                const handlers: Partial<SolidityHooks> = {
+                  build: async (
+                    context: HookContext,
+                    rootFilePaths: string[],
+                    options: BuildOptions | undefined,
+                    next: (
+                      nextContext: HookContext,
+                      nextRootFilePaths: string[],
+                      nextOptions: BuildOptions | undefined,
+                    ) => Promise<
+                      CompilationJobCreationError | Map<string, FileBuildResult>
+                    >,
+                  ) => {
+                    // Filter out Filter.sol
+                    const filteredPaths = rootFilePaths.filter(
+                      (p) => !p.includes("Filter"),
+                    );
+                    return next(context, filteredPaths, options);
+                  },
+                };
+
+                return handlers;
+              },
+            }),
+          },
+        };
+
+        const hreWithFilter = await createHardhatRuntimeEnvironment(
+          {
+            plugins: [filteringPlugin],
+            solidity: "0.8.28",
+          },
+          {},
+          project.path,
+        );
+
+        // Run full build with filtering
+        await hreWithFilter.tasks.getTask("build").run({
+          force: true,
+          noTests: true,
+          quiet: true,
+        });
+
+        // Keep.sol artifact should still exist
+        assert.ok(
+          await exists(keepArtifact),
+          "Keep.sol artifact should exist after filtered build",
+        );
+
+        // Filter.sol artifact should be removed by cleanupArtifacts
+        // because it was not in the build results
+        assert.ok(
+          !(await exists(filterArtifact)),
+          "Filter.sol artifact should be removed after filtered build",
+        );
+      });
+    });
+
+    describe("basic full compilation", () => {
+      it("should keep artifacts for all built files", async () => {
+        await using project = await useTestProjectTemplate({
+          name: "test-cleanup-basic",
+          version: "1.0.0",
+          files: {
+            "contracts/First.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract First {}`,
+            "contracts/Second.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Second {}`,
+            "contracts/Third.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Third {}`,
+          },
+        });
+
+        const hre = await createHardhatRuntimeEnvironment(
+          {
+            solidity: "0.8.28",
+          },
+          {},
+          project.path,
+        );
+
+        // Run full build
+        await hre.tasks.getTask("build").run({
+          force: true,
+          noTests: true,
+          quiet: true,
+        });
+
+        // All three contracts should have artifacts
+        const artifactsDir = path.join(project.path, "artifacts", "contracts");
+
+        assert.ok(
+          await exists(path.join(artifactsDir, "First.sol", "First.json")),
+          "First.sol artifact should exist",
+        );
+        assert.ok(
+          await exists(path.join(artifactsDir, "Second.sol", "Second.json")),
+          "Second.sol artifact should exist",
+        );
+        assert.ok(
+          await exists(path.join(artifactsDir, "Third.sol", "Third.json")),
+          "Third.sol artifact should exist",
+        );
+      });
+
+      it("should not run cleanupArtifacts for partial compilation", async () => {
+        await using project = await useTestProjectTemplate({
+          name: "test-cleanup-partial",
+          version: "1.0.0",
+          files: {
+            "contracts/One.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract One {}`,
+            "contracts/Two.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Two {}`,
+          },
+        });
+
+        // First, build all files
+        const hre = await createHardhatRuntimeEnvironment(
+          {
+            solidity: "0.8.28",
+          },
+          {},
+          project.path,
+        );
+
+        await hre.tasks.getTask("build").run({
+          force: true,
+          noTests: true,
+          quiet: true,
+        });
+
+        const artifactsDir = path.join(project.path, "artifacts", "contracts");
+        const oneArtifact = path.join(artifactsDir, "One.sol", "One.json");
+        const twoArtifact = path.join(artifactsDir, "Two.sol", "Two.json");
+
+        assert.ok(
+          await exists(oneArtifact),
+          "One.sol artifact should exist after full build",
+        );
+        assert.ok(
+          await exists(twoArtifact),
+          "Two.sol artifact should exist after full build",
+        );
+
+        // Run partial build with only One.sol
+        await hre.tasks.getTask("build").run({
+          force: true,
+          noTests: true,
+          quiet: true,
+          files: [path.join(project.path, "contracts/One.sol")],
+        });
+
+        // Both artifacts should still exist because cleanupArtifacts
+        // is not called for partial compilation
+        assert.ok(
+          await exists(oneArtifact),
+          "One.sol artifact should exist after partial build",
+        );
+        assert.ok(
+          await exists(twoArtifact),
+          "Two.sol artifact should still exist after partial build (cleanup not run)",
+        );
+      });
+    });
+
+    describe("stale artifact cleanup", () => {
+      it("should remove artifacts for deleted source files on full rebuild", async () => {
+        await using project = await useTestProjectTemplate({
+          name: "test-cleanup-stale",
+          version: "1.0.0",
+          files: {
+            "contracts/Permanent.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Permanent {}`,
+            "contracts/ToDelete.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract ToDelete {}`,
+          },
+        });
+
+        // First, build all files
+        const hre = await createHardhatRuntimeEnvironment(
+          {
+            solidity: "0.8.28",
+          },
+          {},
+          project.path,
+        );
+
+        await hre.tasks.getTask("build").run({
+          force: true,
+          noTests: true,
+          quiet: true,
+        });
+
+        const artifactsDir = path.join(project.path, "artifacts", "contracts");
+        const permanentArtifact = path.join(
+          artifactsDir,
+          "Permanent.sol",
+          "Permanent.json",
+        );
+        const toDeleteArtifact = path.join(
+          artifactsDir,
+          "ToDelete.sol",
+          "ToDelete.json",
+        );
+
+        assert.ok(
+          await exists(permanentArtifact),
+          "Permanent.sol artifact should exist",
+        );
+        assert.ok(
+          await exists(toDeleteArtifact),
+          "ToDelete.sol artifact should exist",
+        );
+
+        // Delete the source file
+        await remove(path.join(project.path, "contracts/ToDelete.sol"));
+
+        // Rebuild
+        await hre.tasks.getTask("build").run({
+          force: true,
+          noTests: true,
+          quiet: true,
+        });
+
+        // Permanent artifact should exist, ToDelete should be cleaned up
+        assert.ok(
+          await exists(permanentArtifact),
+          "Permanent.sol artifact should still exist after rebuild",
+        );
+        assert.ok(
+          !(await exists(toDeleteArtifact)),
+          "ToDelete.sol artifact should be removed after source file deleted",
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces three fixes to the build system, one per commit:

1. It fixes some inconsistencies in the SolidityBuildSystem API and its usage. We were mixing userSourceNames and rootFilepaths. This requires updating `hardhat-verify` in tandem, but I think we should fix this while we are still in a beta. The code was pretty hard to reason about with the inconsistencies in place.

2. It restructures how we keep track of cache hits, and returns them in `SolidityBuildSystem#build`. According to its type, we were returning the hits, but in practice that never happened. I had to update the type we use to represent cache hits to make it feasible and performant, which in theory is a breaking change, but again, this type was never used in practice.

3. Updated how we clean up artifacts after a complete build in the build task, as it was preventing the `Solidity#build` hook from adding/removing root files.