### PR TITLE
Revert trustPolicyExclude

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,3 @@ hoist-pattern[]=!@types/*
 minimum-release-age=10080
 minimum-release-age-exclude[]="hardhat"
 minimum-release-age-exclude[]="@nomicfoundation/*"
-trust-policy=no-downgrade


### PR DESCRIPTION
Reverting this setting as it's giving problems with older dependencies that publishers new versions (that we don't use) with trusted publishers. In practices it'd force everyone to publish new patch versions with trusted publishers.

We found this in chokidar, and then excluded that one, and then found it in @types/node, both as a direct and indirect dependency.