### PR TITLE
fix: maintain original `MinimalEthereumJsVm` instance

### DIFF
--- a/.changeset/spicy-lies-stick.md
+++ b/.changeset/spicy-lies-stick.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed an issue affecting the hardhat-tracer community plugin causing traces to stop being reported after calling `hardhat_reset`

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -77,11 +77,7 @@ import {
   httpHeadersToEdr,
 } from "./utils/convertToEdr";
 import { LoggerConfig, printLine, replaceLastLine } from "./modules/logger";
-import {
-  MinimalEthereumJsVm,
-  getMinimalEthereumJsStateManager,
-  getMinimalEthereumJsVm,
-} from "./vm/minimal-vm";
+import { MinimalEthereumJsVm, getMinimalEthereumJsVm } from "./vm/minimal-vm";
 
 const log = debug("hardhat:core:hardhat-network:provider");
 
@@ -558,7 +554,7 @@ export class EdrProviderWrapper
     );
 
     this._provider = provider;
-    this._node._vm.stateManager = getMinimalEthereumJsStateManager(provider);
+    this._node._vm.stateManager.updateProvider(provider);
 
     this.emit(HARDHAT_NETWORK_RESET_EVENT);
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -77,7 +77,11 @@ import {
   httpHeadersToEdr,
 } from "./utils/convertToEdr";
 import { LoggerConfig, printLine, replaceLastLine } from "./modules/logger";
-import { MinimalEthereumJsVm, getMinimalEthereumJsVm } from "./vm/minimal-vm";
+import {
+  MinimalEthereumJsVm,
+  getMinimalEthereumJsStateManager,
+  getMinimalEthereumJsVm,
+} from "./vm/minimal-vm";
 
 const log = debug("hardhat:core:hardhat-network:provider");
 
@@ -553,12 +557,8 @@ export class EdrProviderWrapper
       this._provider.contractDecoder()
     );
 
-    const minimalEthereumJsNode = {
-      _vm: getMinimalEthereumJsVm(provider),
-    };
-
     this._provider = provider;
-    this._node = minimalEthereumJsNode;
+    this._node._vm.stateManager = getMinimalEthereumJsStateManager(provider);
 
     this.emit(HARDHAT_NETWORK_RESET_EVENT);
 

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/vm/minimal-vm.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/vm/minimal-vm.ts
@@ -17,7 +17,7 @@ export interface MinimalEthereumJsVm {
   evm: {
     events: AsyncEventEmitter<MinimalEthereumJsEvmEvents>;
   };
-  stateManager: MinimalEthereumJSStateManager;
+  stateManager: MinimalEthereumJsStateManager;
 }
 
 // we need to use a type instead of an interface to satisfy the type constraint
@@ -49,7 +49,7 @@ type MinimalEthereumJsEvmEvents = {
 export class MinimalEthereumJsVmEventEmitter extends AsyncEventEmitter<MinimalEthereumJsVmEvents> {}
 export class MinimalEthereumJsEvmEventEmitter extends AsyncEventEmitter<MinimalEthereumJsEvmEvents> {}
 
-export interface MinimalEthereumJSStateManager {
+export interface MinimalEthereumJsStateManager {
   putContractCode: (address: Address, code: Buffer) => Promise<void>;
   getContractStorage: (address: Address, slotHash: Buffer) => Promise<Buffer>;
   putContractStorage: (
@@ -57,6 +57,7 @@ export interface MinimalEthereumJSStateManager {
     slotHash: Buffer,
     slotValue: Buffer
   ) => Promise<void>;
+  updateProvider: (newProvider: EdrProviderT) => void;
 }
 
 export function getMinimalEthereumJsVm(
@@ -73,9 +74,11 @@ export function getMinimalEthereumJsVm(
   return minimalEthereumJsVm;
 }
 
-export function getMinimalEthereumJsStateManager(
-  provider: EdrProviderT
-): MinimalEthereumJSStateManager {
+function getMinimalEthereumJsStateManager(
+  initialProvider: EdrProviderT
+): MinimalEthereumJsStateManager {
+  let provider = initialProvider;
+
   return {
     putContractCode: async (address: Address, code: Buffer) => {
       await provider.handleRequest(
@@ -117,6 +120,9 @@ export function getMinimalEthereumJsStateManager(
           ],
         })
       );
+    },
+    updateProvider: (newProvider: EdrProviderT) => {
+      provider = newProvider;
     },
   };
 }


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Community plugins were using the original `MinimalEthereumJsVm` instance, so instead of replacing it, we now change its internal `stateManager` using an `updateProvider` function, which was the only thing that needs an updated provider.

This should fix the secondary issue reported in #7834.
