### PR TITLE
chore: add missing peer bump

### DIFF
--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -11,6 +11,11 @@
       "package": "@nomicfoundation/hardhat-verify",
       "peer": "hardhat",
       "reason": "#7900 fixed some inconsistency issues in the SolidityBuildSystem API that will be shipped in the next version of Hardhat"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-typechain",
+      "peer": "hardhat",
+      "reason": "#7902 switched the build system hook used to trigger the type generation from `onCleanUpArtifacts` to `build`"
     }
   ]
 }


### PR DESCRIPTION
The changes to typechain imply updating the peer dependency on Hardhat.
