### PR TITLE
Expose etherscan instance

### DIFF
--- a/.changeset/beige-tomatoes-act.md
+++ b/.changeset/beige-tomatoes-act.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Expose an `Etherscan` instance through `network.connect()` for advanced use cases. This version also adds a `customApiCall` method to the Etherscan instance, allowing custom requests to the Etherscan API ([#7644](https://github.com/NomicFoundation/hardhat/issues/7644))

--- a/.changeset/beige-tomatoes-act.md
+++ b/.changeset/beige-tomatoes-act.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-verify": patch
 ---
 
-Expose an `Etherscan` instance through `network.connect()` for advanced use cases. This version also adds a `customApiCall` method to the Etherscan instance, allowing custom requests to the Etherscan API ([#7644](https://github.com/NomicFoundation/hardhat/issues/7644))
+Expose an `Etherscan` instance through the `verification` property on `network.connect()` for advanced use cases. This version also adds a `customApiCall` method to the Etherscan instance, allowing custom requests to the Etherscan API ([#7644](https://github.com/NomicFoundation/hardhat/issues/7644))

--- a/v-next/hardhat-verify/README.md
+++ b/v-next/hardhat-verify/README.md
@@ -95,10 +95,10 @@ If you're building a Hardhat plugin that needs direct access to the Etherscan AP
 import type { HardhatRuntimeEnvironment } from "hardhat/types";
 
 export async function myCustomVerificationTask(hre: HardhatRuntimeEnvironment) {
-  const { verifier } = await hre.network.connect();
+  const { verification } = await hre.network.connect();
 
   // Access Etherscan instance
-  const etherscan = verifier.etherscan;
+  const etherscan = verification.etherscan;
 
   // Check if a contract is already verified
   const isVerified = await etherscan.isVerified("0x1234...");
@@ -131,10 +131,10 @@ export async function myCustomVerificationTask(hre: HardhatRuntimeEnvironment) {
 For API endpoints not covered by the standard methods, use `customApiCall()`:
 
 ```typescript
-const { verifier } = await hre.network.connect();
+const { verification } = await hre.network.connect();
 
 // Make a custom API call (apikey and chainid are added automatically)
-const response = await verifier.etherscan.customApiCall({
+const response = await verification.etherscan.customApiCall({
   module: "contract",
   action: "getsourcecode",
   address: "0x1234...",

--- a/v-next/hardhat-verify/package.json
+++ b/v-next/hardhat-verify/package.json
@@ -14,7 +14,8 @@
   "types": "dist/src/index.d.ts",
   "exports": {
     ".": "./dist/src/index.js",
-    "./verify": "./dist/src/verify.js"
+    "./verify": "./dist/src/verify.js",
+    "./types": "./dist/src/types.js"
   },
   "keywords": [
     "ethereum",

--- a/v-next/hardhat-verify/src/index.ts
+++ b/v-next/hardhat-verify/src/index.ts
@@ -10,6 +10,7 @@ const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-verify",
   hookHandlers: {
     config: () => import("./internal/hook-handlers/config.js"),
+    network: () => import("./internal/hook-handlers/network.js"),
   },
   tasks: [
     verifyTask,

--- a/v-next/hardhat-verify/src/internal/etherscan.ts
+++ b/v-next/hardhat-verify/src/internal/etherscan.ts
@@ -465,10 +465,8 @@ export class Etherscan implements VerificationProvider {
 
   public async customApiCall(
     params: Record<string, unknown>,
-    options: EtherscanCustomApiCallOptions = {},
+    options: EtherscanCustomApiCallOptions = { method: "GET" },
   ): Promise<EtherscanResponseBody> {
-    const { method = "GET", body = {} } = options;
-
     const queryParams = {
       chainid: this.chainId,
       apikey: this.apiKey,
@@ -477,7 +475,7 @@ export class Etherscan implements VerificationProvider {
 
     let response: HttpResponse;
     try {
-      if (method === "GET") {
+      if (options.method === "GET") {
         response = await getRequest(
           this.apiUrl,
           { queryParams },
@@ -486,7 +484,7 @@ export class Etherscan implements VerificationProvider {
       } else {
         response = await postFormRequest(
           this.apiUrl,
-          body,
+          options.body,
           { queryParams },
           this.dispatcherOrDispatcherOptions,
         );

--- a/v-next/hardhat-verify/src/internal/etherscan.ts
+++ b/v-next/hardhat-verify/src/internal/etherscan.ts
@@ -605,6 +605,10 @@ export class LazyEtherscanImpl implements LazyEtherscan {
     this.#verificationProvidersConfig = verificationProvidersConfig;
   }
 
+  /**
+   * Lazily initializes the underlying Etherscan verification provider and caches
+   * the created instance so that subsequent calls reuse the same object.
+   */
   async #getEtherscan(): Promise<Etherscan> {
     if (this.#etherscan === undefined) {
       const { createVerificationProviderInstance } = await import(

--- a/v-next/hardhat-verify/src/internal/etherscan.types.ts
+++ b/v-next/hardhat-verify/src/internal/etherscan.types.ts
@@ -75,20 +75,183 @@ export type EtherscanCustomApiCallOptions =
       body?: Record<string, unknown>;
     };
 
+/**
+ * Provides access to the Etherscan API for contract verification and
+ * custom API calls.
+ *
+ * This interface is designed for plugin authors who need direct access
+ * to Etherscan's verification API beyond the standard verification
+ * workflow. It can be accessed through `network.connect()` in the
+ * Hardhat Runtime Environment.
+ *
+ * @example
+ * ```typescript
+ * const { verifier } = await hre.network.connect();
+ * const etherscan = verifier.etherscan;
+ *
+ * // Use Etherscan methods
+ * const isVerified = await etherscan.isVerified("0x1234...");
+ * ```
+ */
 export interface LazyEtherscan {
+  /**
+   * Gets the chain ID that this Etherscan instance is configured for.
+   *
+   * @returns The chain ID as a string (e.g., "1" for Ethereum mainnet)
+   */
   getChainId(): Promise<string>;
+
+  /**
+   * Gets the name of the block explorer.
+   *
+   * @returns The explorer name (e.g., "Etherscan", "BscScan",
+   *   "PolygonScan")
+   */
   getName(): Promise<string>;
+
+  /**
+   * Gets the base URL of the block explorer web interface.
+   *
+   * @returns The block explorer web URL (e.g., "https://etherscan.io")
+   */
   getUrl(): Promise<string>;
+
+  /**
+   * Gets the API URL used for verification requests.
+   *
+   * @returns The API endpoint URL
+   */
   getApiUrl(): Promise<string>;
+
+  /**
+   * Gets the configured API key for this Etherscan instance.
+   *
+   * @returns The API key
+   */
   getApiKey(): Promise<string>;
+
+  /**
+   * Gets the block explorer URL for a specific contract address.
+   *
+   * @param address - The contract address
+   * @returns The full URL to view the contract on the block explorer
+   */
   getContractUrl(address: string): Promise<string>;
+
+  /**
+   * Checks whether a contract at the given address is verified on the
+   * block explorer.
+   *
+   * @param address - The contract address to check
+   * @returns True if the contract is verified, false otherwise
+   */
   isVerified(address: string): Promise<boolean>;
+
+  /**
+   * Submits a contract for verification on the block explorer.
+   *
+   * @param args - The verification arguments containing:
+   *   - contractAddress: The deployed contract address to verify
+   *   - compilerInput: The Solidity compiler input JSON containing
+   *     sources and settings
+   *   - contractName: The fully qualified name of the contract
+   *     (e.g., "contracts/Token.sol:Token")
+   *   - compilerVersion: The Solidity compiler version used
+   *     (e.g., "v0.8.19+commit.7dd6d404")
+   *   - constructorArguments: The ABI-encoded constructor arguments
+   *     as a hex string
+   * @returns A GUID (Globally Unique Identifier) that can be used with
+   *   `pollVerificationStatus()` to check the verification progress
+   *
+   * @throws {HardhatError} CONTRACT_VERIFICATION_MISSING_BYTECODE -
+   *   If the contract bytecode is not found on the network
+   * @throws {HardhatError} CONTRACT_ALREADY_VERIFIED -
+   *   If the contract is already verified
+   * @throws {HardhatError} CONTRACT_VERIFICATION_REQUEST_FAILED -
+   *   If the verification request fails
+   * @throws {HardhatError} EXPLORER_REQUEST_FAILED -
+   *   If the HTTP request fails
+   */
   verify(args: EtherscanVerifyArgs): Promise<string>;
+
+  /**
+   * Polls the block explorer to check the status of a pending
+   * verification request.
+   *
+   * This method recursively polls the verification status until the
+   * verification completes (either successfully or with a failure).
+   * It automatically waits between poll attempts to avoid overwhelming
+   * the API.
+   *
+   * @param guid - The verification GUID returned by the verify method
+   * @param contractAddress - The address of the contract being verified
+   * @param contractName - The name of the contract being verified
+   * @returns An object containing:
+   *   - `success`: true if verification succeeded, false if it failed
+   *   - `message`: The status message from Etherscan
+   *     (e.g., "Pass - Verified", "Fail - Unable to verify")
+   *
+   * @throws {HardhatError} CONTRACT_ALREADY_VERIFIED -
+   *   If the contract was already verified
+   * @throws {HardhatError} CONTRACT_VERIFICATION_STATUS_POLLING_FAILED -
+   *   If the API returns an unexpected error
+   * @throws {HardhatError} EXPLORER_REQUEST_FAILED -
+   *   If the HTTP request fails
+   */
   pollVerificationStatus(
     guid: string,
     contractAddress: string,
     contractName: string,
   ): Promise<{ success: boolean; message: string }>;
+
+  /**
+   * Makes a custom API call to the Etherscan API with specified
+   * parameters.
+   *
+   * This method is designed for advanced use cases where plugins need
+   * to call Etherscan API endpoints that aren't covered by the standard
+   * methods. It automatically handles authentication and chain
+   * identification.
+   *
+   * @param params - The API call parameters as key-value pairs
+   *   (e.g., `{ module: "contract", action: "getsourcecode",
+   *   address: "0x..." }`)
+   * @param options - Optional request options:
+   *   - `method`: HTTP method to use ("GET" or "POST", defaults to
+   *     "GET")
+   *   - `body`: Request body for POST requests as key-value pairs
+   *
+   * @returns The raw response body from the Etherscan API containing:
+   *   - `status`: "0" for error, "1" for success
+   *   - `message`: Status message (e.g., "OK", "NOTOK")
+   *   - `result`: Response data (type varies by endpoint - can be
+   *     string, array, or object)
+   *
+   * @throws {HardhatError} EXPLORER_REQUEST_FAILED -
+   *   If the HTTP request fails
+   * @throws {HardhatError} EXPLORER_REQUEST_STATUS_CODE_ERROR -
+   *   If the response status code is not 2xx
+   *
+   * @remarks
+   * - The `apikey` and `chainid` parameters are automatically added
+   *   to the query parameters. You can override these by explicitly
+   *   passing them in the `params` object.
+   * - This method returns the raw API response. Callers should check
+   *   the `status` field and handle `result` appropriately.
+   *
+   * @example
+   * ```typescript
+   * const response = await verifier.etherscan.customApiCall({
+   *   module: "contract",
+   *   action: "getsourcecode",
+   *   address: "0x1234..."
+   * });
+   *
+   * if (response.status === "1") {
+   *   console.log("Success:", response.result);
+   * }
+   * ```
+   */
   customApiCall(
     params: Record<string, unknown>,
     options?: EtherscanCustomApiCallOptions,

--- a/v-next/hardhat-verify/src/internal/etherscan.types.ts
+++ b/v-next/hardhat-verify/src/internal/etherscan.types.ts
@@ -1,8 +1,16 @@
+import type { BaseVerifyFunctionArgs } from "./types.js";
+
+export interface EtherscanResponseBody {
+  status: string;
+  message: string;
+  result: any;
+}
+
 export type EtherscanGetSourceCodeResponse =
   | EtherscanNotOkResponse
   | EtherscanGetSourceCodeOkResponse;
 
-interface EtherscanGetSourceCodeOkResponse {
+interface EtherscanGetSourceCodeOkResponse extends EtherscanResponseBody {
   status: "1";
   message: "OK";
   result: EtherscanContract[];
@@ -29,13 +37,13 @@ interface EtherscanContract {
 
 export type EtherscanResponse = EtherscanNotOkResponse | EtherscanOkResponse;
 
-interface EtherscanNotOkResponse {
+interface EtherscanNotOkResponse extends EtherscanResponseBody {
   status: "0";
   message: "NOTOK";
   result: string;
 }
 
-interface EtherscanOkResponse {
+interface EtherscanOkResponse extends EtherscanResponseBody {
   status: "1";
   message: "OK";
   result: string;
@@ -52,4 +60,33 @@ export interface EtherscanChainListResponse {
     status: number;
     comment: string;
   }>;
+}
+
+export interface EtherscanVerifyArgs extends BaseVerifyFunctionArgs {
+  constructorArguments: string;
+}
+
+export interface EtherscanCustomApiCallOptions {
+  method?: "GET" | "POST";
+  body?: Record<string, unknown>;
+}
+
+export interface LazyEtherscan {
+  getChainId(): Promise<string>;
+  getName(): Promise<string>;
+  getUrl(): Promise<string>;
+  getApiUrl(): Promise<string>;
+  getApiKey(): Promise<string>;
+  getContractUrl(address: string): Promise<string>;
+  isVerified(address: string): Promise<boolean>;
+  verify(args: EtherscanVerifyArgs): Promise<string>;
+  pollVerificationStatus(
+    guid: string,
+    contractAddress: string,
+    contractName: string,
+  ): Promise<{ success: boolean; message: string }>;
+  customApiCall(
+    params: Record<string, unknown>,
+    options?: EtherscanCustomApiCallOptions,
+  ): Promise<EtherscanResponseBody>;
 }

--- a/v-next/hardhat-verify/src/internal/etherscan.types.ts
+++ b/v-next/hardhat-verify/src/internal/etherscan.types.ts
@@ -66,10 +66,14 @@ export interface EtherscanVerifyArgs extends BaseVerifyFunctionArgs {
   constructorArguments: string;
 }
 
-export interface EtherscanCustomApiCallOptions {
-  method?: "GET" | "POST";
-  body?: Record<string, unknown>;
-}
+export type EtherscanCustomApiCallOptions =
+  | {
+      method: "GET";
+    }
+  | {
+      method: "POST";
+      body?: Record<string, unknown>;
+    };
 
 export interface LazyEtherscan {
   getChainId(): Promise<string>;

--- a/v-next/hardhat-verify/src/internal/etherscan.types.ts
+++ b/v-next/hardhat-verify/src/internal/etherscan.types.ts
@@ -86,8 +86,8 @@ export type EtherscanCustomApiCallOptions =
  *
  * @example
  * ```typescript
- * const { verifier } = await hre.network.connect();
- * const etherscan = verifier.etherscan;
+ * const { verification } = await hre.network.connect();
+ * const etherscan = verification.etherscan;
  *
  * // Use Etherscan methods
  * const isVerified = await etherscan.isVerified("0x1234...");
@@ -241,7 +241,7 @@ export interface LazyEtherscan {
    *
    * @example
    * ```typescript
-   * const response = await verifier.etherscan.customApiCall({
+   * const response = await verification.etherscan.customApiCall({
    *   module: "contract",
    *   action: "getsourcecode",
    *   address: "0x1234..."

--- a/v-next/hardhat-verify/src/internal/hook-handlers/network.ts
+++ b/v-next/hardhat-verify/src/internal/hook-handlers/network.ts
@@ -8,9 +8,9 @@ export default async (): Promise<Partial<NetworkHooks>> => ({
   ) {
     const connection = await next(context);
 
-    const { Verifier } = await import("../verifier.js");
+    const { Verification } = await import("../verification-helpers.js");
 
-    connection.verifier = new Verifier(
+    connection.verification = new Verification(
       connection.provider,
       connection.networkName,
       context.config.chainDescriptors,

--- a/v-next/hardhat-verify/src/internal/hook-handlers/network.ts
+++ b/v-next/hardhat-verify/src/internal/hook-handlers/network.ts
@@ -1,0 +1,22 @@
+import type { HookContext, NetworkHooks } from "hardhat/types/hooks";
+import type { ChainType, NetworkConnection } from "hardhat/types/network";
+
+export default async (): Promise<Partial<NetworkHooks>> => ({
+  async newConnection<ChainTypeT extends ChainType | string>(
+    context: HookContext,
+    next: (nextContext: HookContext) => Promise<NetworkConnection<ChainTypeT>>,
+  ) {
+    const connection = await next(context);
+
+    const { Verifier } = await import("../verifier.js");
+
+    connection.verifier = new Verifier(
+      connection.provider,
+      connection.networkName,
+      context.config.chainDescriptors,
+      context.config.verify,
+    );
+
+    return connection;
+  },
+});

--- a/v-next/hardhat-verify/src/internal/verification-helpers.ts
+++ b/v-next/hardhat-verify/src/internal/verification-helpers.ts
@@ -1,4 +1,4 @@
-import type { VerifierHelpers } from "../types.js";
+import type { VerificationHelpers } from "../types.js";
 import type { LazyEtherscan } from "./etherscan.types.js";
 import type {
   ChainDescriptorsConfig,
@@ -8,7 +8,7 @@ import type { EthereumProvider } from "hardhat/types/providers";
 
 import { LazyEtherscanImpl } from "./etherscan.js";
 
-export class Verifier implements VerifierHelpers {
+export class Verification implements VerificationHelpers {
   public readonly etherscan: LazyEtherscan;
 
   constructor(

--- a/v-next/hardhat-verify/src/internal/verification.ts
+++ b/v-next/hardhat-verify/src/internal/verification.ts
@@ -333,7 +333,7 @@ export function validateArgs({ address, contract }: VerifyContractArgs): void {
   }
 }
 
-async function createVerificationProviderInstance({
+export async function createVerificationProviderInstance({
   provider,
   networkName,
   chainDescriptors,

--- a/v-next/hardhat-verify/src/internal/verifier.ts
+++ b/v-next/hardhat-verify/src/internal/verifier.ts
@@ -1,0 +1,27 @@
+import type { VerifierHelpers } from "../types.js";
+import type { LazyEtherscan } from "./etherscan.types.js";
+import type {
+  ChainDescriptorsConfig,
+  VerificationProvidersConfig,
+} from "hardhat/types/config";
+import type { EthereumProvider } from "hardhat/types/providers";
+
+import { LazyEtherscanImpl } from "./etherscan.js";
+
+export class Verifier implements VerifierHelpers {
+  public readonly etherscan: LazyEtherscan;
+
+  constructor(
+    provider: EthereumProvider,
+    networkName: string,
+    chainDescriptors: ChainDescriptorsConfig,
+    verificationProvidersConfig: VerificationProvidersConfig,
+  ) {
+    this.etherscan = new LazyEtherscanImpl(
+      provider,
+      networkName,
+      chainDescriptors,
+      verificationProvidersConfig,
+    );
+  }
+}

--- a/v-next/hardhat-verify/src/type-extensions.ts
+++ b/v-next/hardhat-verify/src/type-extensions.ts
@@ -1,4 +1,4 @@
-import type { VerifierHelpers } from "./types.js";
+import type { VerificationHelpers } from "./types.js";
 
 import "hardhat/types/config";
 declare module "hardhat/types/config" {
@@ -62,6 +62,6 @@ declare module "hardhat/types/network" {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- the ChainTypeT must be declared in the interface but in this scenario it's not used
     ChainTypeT extends ChainType | string = DefaultChainType,
   > {
-    verifier: VerifierHelpers;
+    verification: VerificationHelpers;
   }
 }

--- a/v-next/hardhat-verify/src/type-extensions.ts
+++ b/v-next/hardhat-verify/src/type-extensions.ts
@@ -1,3 +1,5 @@
+import type { VerifierHelpers } from "./types.js";
+
 import "hardhat/types/config";
 declare module "hardhat/types/config" {
   export interface HardhatUserConfig {
@@ -51,5 +53,15 @@ declare module "hardhat/types/config" {
   export interface SourcifyConfig {
     apiUrl?: string;
     enabled: boolean;
+  }
+}
+
+import "hardhat/types/network";
+declare module "hardhat/types/network" {
+  interface NetworkConnection<
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- the ChainTypeT must be declared in the interface but in this scenario it's not used
+    ChainTypeT extends ChainType | string = DefaultChainType,
+  > {
+    verifier: VerifierHelpers;
   }
 }

--- a/v-next/hardhat-verify/src/types.ts
+++ b/v-next/hardhat-verify/src/types.ts
@@ -1,0 +1,12 @@
+import type { LazyEtherscan } from "./internal/etherscan.types.js";
+
+export interface VerifierHelpers {
+  readonly etherscan: LazyEtherscan;
+}
+
+export type {
+  EtherscanVerifyArgs,
+  EtherscanCustomApiCallOptions,
+  EtherscanResponseBody,
+  LazyEtherscan as Etherscan,
+} from "./internal/etherscan.types.js";

--- a/v-next/hardhat-verify/src/types.ts
+++ b/v-next/hardhat-verify/src/types.ts
@@ -1,6 +1,6 @@
 import type { LazyEtherscan } from "./internal/etherscan.types.js";
 
-export interface VerifierHelpers {
+export interface VerificationHelpers {
   readonly etherscan: LazyEtherscan;
 }
 

--- a/v-next/hardhat-verify/test/hook-handlers/network.ts
+++ b/v-next/hardhat-verify/test/hook-handlers/network.ts
@@ -1,0 +1,110 @@
+import type {
+  GenericChainType,
+  NetworkConnection,
+} from "hardhat/types/network";
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+import { isObject } from "@nomicfoundation/hardhat-utils/lang";
+import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+
+import hardhatVerify from "../../src/index.js";
+
+describe("hook-handlers/network", () => {
+  describe("newConnection", () => {
+    let connection: NetworkConnection<GenericChainType>;
+
+    before(async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        plugins: [hardhatVerify],
+      });
+      connection = await hre.network.connect();
+    });
+
+    it("should extend connection with verifier property", () => {
+      assert.ok(isObject(connection.verifier), "verifier should be defined");
+    });
+
+    it("should have verifier with etherscan property", () => {
+      assert.ok(
+        isObject(connection.verifier.etherscan),
+        "verifier.etherscan should be defined",
+      );
+    });
+
+    it("should have etherscan with all getter methods", () => {
+      const { etherscan } = connection.verifier;
+
+      assert.equal(
+        typeof etherscan.getChainId,
+        "function",
+        "etherscan should have a getChainId function",
+      );
+      assert.equal(
+        typeof etherscan.getName,
+        "function",
+        "etherscan should have a getName function",
+      );
+      assert.equal(
+        typeof etherscan.getUrl,
+        "function",
+        "etherscan should have a getUrl function",
+      );
+      assert.equal(
+        typeof etherscan.getApiUrl,
+        "function",
+        "etherscan should have a getApiUrl function",
+      );
+      assert.equal(
+        typeof etherscan.getApiKey,
+        "function",
+        "etherscan should have a getApiKey function",
+      );
+      assert.equal(
+        typeof etherscan.getContractUrl,
+        "function",
+        "etherscan should have a getContractUrl function",
+      );
+    });
+
+    it("should have etherscan with all verification methods", () => {
+      const { etherscan } = connection.verifier;
+
+      assert.equal(
+        typeof etherscan.isVerified,
+        "function",
+        "etherscan should have an isVerified function",
+      );
+      assert.equal(
+        typeof etherscan.verify,
+        "function",
+        "etherscan should have a verify function",
+      );
+      assert.equal(
+        typeof etherscan.pollVerificationStatus,
+        "function",
+        "etherscan should have a pollVerificationStatus function",
+      );
+      assert.equal(
+        typeof etherscan.customApiCall,
+        "function",
+        "etherscan should have a customApiCall function",
+      );
+    });
+
+    it("should create independent verifier instances for each connection", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        plugins: [hardhatVerify],
+      });
+      const connection1 = await hre.network.connect();
+      const connection2 = await hre.network.connect();
+
+      assert.notEqual(
+        connection1.verifier,
+        connection2.verifier,
+        "Each connection should have its own verifier instance",
+      );
+    });
+  });
+});

--- a/v-next/hardhat-verify/test/hook-handlers/network.ts
+++ b/v-next/hardhat-verify/test/hook-handlers/network.ts
@@ -22,19 +22,22 @@ describe("hook-handlers/network", () => {
       connection = await hre.network.connect();
     });
 
-    it("should extend connection with verifier property", () => {
-      assert.ok(isObject(connection.verifier), "verifier should be defined");
+    it("should extend connection with verification property", () => {
+      assert.ok(
+        isObject(connection.verification),
+        "verification should be defined",
+      );
     });
 
-    it("should have verifier with etherscan property", () => {
+    it("should have verification with etherscan property", () => {
       assert.ok(
-        isObject(connection.verifier.etherscan),
-        "verifier.etherscan should be defined",
+        isObject(connection.verification.etherscan),
+        "verification.etherscan should be defined",
       );
     });
 
     it("should have etherscan with all getter methods", () => {
-      const { etherscan } = connection.verifier;
+      const { etherscan } = connection.verification;
 
       assert.equal(
         typeof etherscan.getChainId,
@@ -69,7 +72,7 @@ describe("hook-handlers/network", () => {
     });
 
     it("should have etherscan with all verification methods", () => {
-      const { etherscan } = connection.verifier;
+      const { etherscan } = connection.verification;
 
       assert.equal(
         typeof etherscan.isVerified,
@@ -93,7 +96,7 @@ describe("hook-handlers/network", () => {
       );
     });
 
-    it("should create independent verifier instances for each connection", async () => {
+    it("should create independent verification instances for each connection", async () => {
       const hre = await createHardhatRuntimeEnvironment({
         plugins: [hardhatVerify],
       });
@@ -101,9 +104,9 @@ describe("hook-handlers/network", () => {
       const connection2 = await hre.network.connect();
 
       assert.notEqual(
-        connection1.verifier,
-        connection2.verifier,
-        "Each connection should have its own verifier instance",
+        connection1.verification,
+        connection2.verification,
+        "Each connection should have its own verification instance",
       );
     });
   });


### PR DESCRIPTION
Closes: https://github.com/NomicFoundation/hardhat/issues/7644

Documentation: (readme) was updated with the new API.

## Usage examples

### Contract deployment and verification
```typescript
/**
 * NOTE: This script demonstrates manual contract verification using the
 * low-level verifier API. This is NOT the recommended way to verify contracts.
 *
 * For standard contract verification, use the `verifyContract` function instead:
 * https://github.com/NomicFoundation/hardhat/tree/main/v-next/hardhat-verify#programmatic-verification
 *
 * Only use this manual approach if you have a specific scenario that cannot be
 * covered by the standard `verifyContract` function.
 */

import type { BuildInfo } from "hardhat/types/artifacts";

import fsPromises from "node:fs/promises";
import path from "node:path";
import { setTimeout } from "node:timers/promises";

import { network, artifacts } from "hardhat";

const { viem, verifier } = await network.connect("sepolia");

const contract = await viem.deployContract("Counter", [], { confirmations: 5 });
const contractAddress = contract.address;

console.log("Contract deployed at:", contractAddress);

const artifact = await artifacts.readArtifact("Counter");

const buildInfoPath = path.join(
  process.cwd(),
  "artifacts",
  "build-info",
  `${artifact.buildInfoId}.json`,
);
const content = await fsPromises.readFile(buildInfoPath, { encoding: "utf8" });
const buildInfo: BuildInfo = JSON.parse(content);

const guid = await verifier.etherscan.verify({
  contractAddress: contractAddress,
  compilerInput: buildInfo.input,
  contractName: `${artifact.inputSourceName}:Counter`,
  compilerVersion: `v${buildInfo.solcLongVersion}`,
  constructorArguments: "",
});

// wait for 1 second before polling so that Etherscan has time to process
// the verification request
await setTimeout(1000);

const response = await verifier.etherscan.pollVerificationStatus(
  guid,
  contractAddress,
  `${artifact.inputSourceName}:Counter`,
);

console.log("Verification response:", response);
```

### Using `customApiCall` to fetch event logs
```typescript
import { network } from "hardhat";
import { keccak256, toBytes } from "viem";

const { verifier } = await network.connect("sepolia");

const logs = await verifier.etherscan.customApiCall({
  module: "logs",
  action: "getLogs",
  fromBlock: "0",
  toBlock: "latest",
  address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
  topic0: keccak256(toBytes("Transfer(address,address,uint256)")),
});

console.log("Logs:", logs);
```