### PR TITLE
Fix documentation typos and formatting issues

### DIFF
--- a/archive/hardhat-verify/README.md
+++ b/archive/hardhat-verify/README.md
@@ -2,7 +2,7 @@
 
 # hardhat-verify
 
-[Hardhat](https://hardhat.org) plugin to verify the source of code of deployed contracts.
+[Hardhat](https://hardhat.org) plugin to verify the source code of deployed contracts.
 
 ## What
 

--- a/v-next/hardhat-ethers-chai-matchers/README.md
+++ b/v-next/hardhat-ethers-chai-matchers/README.md
@@ -240,7 +240,7 @@ await expect(token.transfer(receiver, 1000)).to.changeTokenBalances(
 
 ### Other matchers
 
-#### `.withargs`
+#### `.withArgs`
 
 Can be used after a `.emit` or a `.revertedWithCustomError` matcher to assert the values of the event/error's arguments:
 

--- a/v-next/hardhat-verify/README.md
+++ b/v-next/hardhat-verify/README.md
@@ -1,6 +1,6 @@
 # hardhat-verify
 
-[Hardhat](https://hardhat.org) plugin to verify the source of code of deployed contracts.
+[Hardhat](https://hardhat.org) plugin to verify the source code of deployed contracts.
 
 ## Installation
 

--- a/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/README.md
+++ b/v-next/hardhat/templates/hardhat-3/01-node-test-runner-viem/README.md
@@ -10,7 +10,7 @@ This example project includes:
 
 - A simple Hardhat configuration file.
 - Foundry-compatible Solidity unit tests.
-- TypeScript integration tests using [`node:test`](nodejs.org/api/test.html), the new Node.js native test runner, and [`viem`](https://viem.sh/).
+- TypeScript integration tests using [`node:test`](https://nodejs.org/api/test.html), the new Node.js native test runner, and [`viem`](https://viem.sh/).
 - Examples demonstrating how to connect to different types of networks, including locally simulating OP mainnet.
 
 ## Usage


### PR DESCRIPTION
## Summary
- Fix "source of code" to "source code" in hardhat-verify README files (archive and v-next)
- Fix `.withargs` to `.withArgs` in hardhat-ethers-chai-matchers README (to match the actual method name)
- Fix missing `https://` prefix in node:test URL in template README

## Test plan
- [ ] Visual review of the README files to verify the fixes are correct