### PR TITLE
Fix duplicate word typos in code and documentation

### DIFF
--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -649,7 +649,7 @@ Please ensure that an action is defined for each task.`,
         messageTemplate: 'Unable to import the action for task "{task}".',
         websiteTitle: "Unable to import action for task",
         websiteDescription:
-          "Unable to import action for task. Please verify that the the file exists and that it provides a default function export.",
+          "Unable to import action for task. Please verify that the file exists and that it provides a default function export.",
       },
       INVALID_ACTION: {
         number: 412,

--- a/v-next/hardhat-network-helpers/test/network-helpers/set-next-block-base-fee-per-gas.ts
+++ b/v-next/hardhat-network-helpers/test/network-helpers/set-next-block-base-fee-per-gas.ts
@@ -64,7 +64,7 @@ describe("network-helpers - setNextBlockBaseFeePerGas", () => {
       });
     }
 
-    it("should throw because the the string is not 0x-prefixed", async () => {
+    it("should throw because the string is not 0x-prefixed", async () => {
       await assertRejectsWithHardhatError(
         async () => networkHelpers.setNextBlockBaseFeePerGas("3"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL

--- a/v-next/hardhat-utils/src/internal/eth.ts
+++ b/v-next/hardhat-utils/src/internal/eth.ts
@@ -43,7 +43,7 @@ export async function getAddressGenerator(): Promise<RandomBytesGenerator> {
 
 /**
  * Checks if a value is an Ethereum address and if the checksum is valid.
- * This method is a a an adaptation of the ethereumjs methods at this link:
+ * This method is an adaptation of the ethereumjs methods at this link:
  * https://github.com/ethereumjs/ethereumjs-monorepo/blob/47f388bfeec553519d11259fee7e7161a77b29b2/packages/util/src/account.ts#L440-L478
  * The main differences are:
  * - the two methods have been merged into one

--- a/v-next/hardhat/src/internal/cli/init/template.ts
+++ b/v-next/hardhat/src/internal/cli/init/template.ts
@@ -57,7 +57,7 @@ export async function getTemplates(
         return;
       }
 
-      // Validate that the the template has a package.json file
+      // Validate that the template has a package.json file
       assertHardhatInvariant(
         await exists(pathToPackageJson),
         `package.json for template ${name} is missing`,

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
@@ -76,7 +76,7 @@ describe("Resolver utils", () => {
       },
     };
 
-    it("Should return the the resolved path", () => {
+    it("Should return the resolved path", () => {
       assert.deepEqual(resolveSubpathWithPackageExports(npmPackage, "A.sol"), {
         success: true,
         value: "src/A.sol",

--- a/v-next/hardhat/test/internal/core/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/README.md
+++ b/v-next/hardhat/test/internal/core/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/README.md
@@ -1,3 +1,3 @@
-# Installed Peer Dependencies as in the the `node_modules` of the package
+# Installed Peer Dependencies in the `node_modules` of the package
 
 This is part of the plugin validation tests. We have checked in a `node_modules` folder to simulate an installed `example` package. Inside the example package is a further `node_modules` with both peer deps: `peer1` and `peer2`.


### PR DESCRIPTION
## Summary
- Fix "the the" to "the" in multiple locations:
  - Error descriptor in `hardhat-errors/src/descriptors.ts`
  - Comment in `hardhat/src/internal/cli/init/template.ts`
  - Test description in `hardhat-network-helpers/test/network-helpers/set-next-block-base-fee-per-gas.ts`
  - Test description in `hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/utils.ts`
  - README title in `hardhat/test/internal/core/plugins/fixture-projects/installed-peer-deps-as-sub-node-modules/README.md`
- Fix "a a an" to "an" in code comment in `hardhat-utils/src/internal/eth.ts`

## Test plan
- [ ] Verify the changes do not affect functionality (these are all string/comment changes)