### PR TITLE
Fix typos in code comments

### DIFF
--- a/v-next/hardhat-ignition-core/src/internal/execution/abi.ts
+++ b/v-next/hardhat-ignition-core/src/internal/execution/abi.ts
@@ -785,7 +785,7 @@ function validateOverloadedName(
 }
 
 /**
- * Returns teh param type of an event argument, throwing a validation error if it's not found.
+ * Returns the param type of an event argument, throwing a validation error if it's not found.
  * @param eventFragment
  * @param argument
  */

--- a/v-next/hardhat-utils/src/internal/eth.ts
+++ b/v-next/hardhat-utils/src/internal/eth.ts
@@ -47,7 +47,7 @@ export async function getAddressGenerator(): Promise<RandomBytesGenerator> {
  * https://github.com/ethereumjs/ethereumjs-monorepo/blob/47f388bfeec553519d11259fee7e7161a77b29b2/packages/util/src/account.ts#L440-L478
  * The main differences are:
  * - the two methods have been merged into one
- * - tha `eip1191ChainId` parameter has been removed.
+ * - the `eip1191ChainId` parameter has been removed.
  * - the code has been modified to use the `hardhat-utils` methods
  *
  */


### PR DESCRIPTION
## Summary
- Fix "tha" to "the" in `hardhat-utils/src/internal/eth.ts` comment
- Fix "teh" to "the" in `hardhat-ignition-core/src/internal/execution/abi.ts` JSDoc comment

## Test plan
- [ ] Verify the changes do not affect functionality (these are comment-only changes)