### PR TITLE
Fix duplicate word typos in resolver comments

### DIFF
--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
@@ -536,7 +536,7 @@ export class RemappedNpmPackagesGraphImplementation
     // an npm module's (i.e. `<package-name>/<file-path>`), except that
     // `<file-path>` here could be a prefix, and not a file path.
     //
-    // Note that that package name is the installation name of the dependency
+    // Note that the package name is the installation name of the dependency
     // within the npm package, not the actual dependency name.
     const installationName = getNpmPackageName(targetWithoutNodeModules);
 

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/types.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/types.ts
@@ -222,7 +222,7 @@ export interface RemappedNpmPackagesGraphJson {
 }
 
 /**
- * A Resolver is a stateful object that can be used to to construct a dependency
+ * A Resolver is a stateful object that can be used to construct a dependency
  * graph, by resolving both the local project and npm files, and their imports.
  *
  * This resolver uses `inputSourceName`s to identify the resolved files, which


### PR DESCRIPTION
## Summary
- Fix "that that" to "that the" in `remapped-npm-packages-graph.ts` comment
- Fix "to to" to "to" in `types.ts` JSDoc comment

## Test plan
- [ ] Verify the changes do not affect functionality (these are comment-only changes)