### PR TITLE
chore: update to dep check CIs to prebuild

### DIFF
--- a/.github/workflows/check-v2-with-latest-dependencies.yml
+++ b/.github/workflows/check-v2-with-latest-dependencies.yml
@@ -23,6 +23,9 @@ jobs:
         run: pnpm install --no-frozen-lockfile
       - name: List dependencies
         run: pnpm list -r --depth 2
+      - name: Run build
+        # Ensure all projects are built before parallel test execution
+        run: pnpm build
       - name: Run tests
         env:
           DO_NOT_SET_THIS_ENV_VAR____IS_HARDHAT_CI: true

--- a/.github/workflows/check-v3-with-latest-dependencies.yml
+++ b/.github/workflows/check-v3-with-latest-dependencies.yml
@@ -21,6 +21,9 @@ jobs:
         run: pnpm install --no-frozen-lockfile
       - name: List dependencies
         run: pnpm list -r --depth 2
+      - name: Run build
+        # Ensure all projects are built before parallel test execution
+        run: pnpm build
       - name: Run tests
         run: pnpm test || (echo "===== Retry =====" && pnpm test)
         env:


### PR DESCRIPTION
We sometimes see a build failure in the parallel testing triggered by the `check-v2/3-with-latest-dependencies.yml`.

The tests are run in parallel, which likely causes builds in parallel, instead we now do a build step serially first before running the tests in parallel. The prebuilt packages will therefore not require a rebuild in each test step avoiding clashes.