### PR TITLE
Hardhat 2 eth_getproof support

### DIFF
--- a/.changeset/gold-hairs-return.md
+++ b/.changeset/gold-hairs-return.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Added support for `eth_getProof` as a JSON-RPC method ([#7933](https://github.com/NomicFoundation/hardhat/pull/7933))

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -103,7 +103,7 @@
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",
     "@ethersproject/abi": "^5.1.2",
-    "@nomicfoundation/edr": "0.12.0-next.22",
+    "@nomicfoundation/edr": "0.12.0-next.23",
     "@nomicfoundation/solidity-analyzer": "^0.1.0",
     "@sentry/node": "^5.18.1",
     "adm-zip": "^0.4.16",

--- a/packages/hardhat-core/test/internal/hardhat-network/jsonrpc/eth-get-proof.ts
+++ b/packages/hardhat-core/test/internal/hardhat-network/jsonrpc/eth-get-proof.ts
@@ -1,0 +1,95 @@
+import { assert } from "chai";
+import { useEnvironment } from "../../../helpers/environment";
+import { useFixtureProject } from "../../../helpers/project";
+import { TASK_COMPILE } from "../../../../src/builtin-tasks/task-names";
+
+describe("eth_getProof", function () {
+  // Set up the test environment - not dependent on the fixture project
+  useFixtureProject("project-0.8.20");
+  useEnvironment();
+
+  it("should return account proof on local network", async function () {
+    await this.env.run(TASK_COMPILE, { quiet: true });
+
+    const accounts = await this.env.network.provider.send("eth_accounts");
+
+    assert.ok(
+      Array.isArray(accounts) && accounts.length > 0,
+      "Accounts should be a non empty array"
+    );
+
+    const account = accounts[0];
+
+    const proof: any = await this.env.network.provider.request({
+      method: "eth_getProof",
+      params: [
+        account,
+        [], // storage keys (empty array)
+        "latest",
+      ],
+    });
+
+    assert.equal(
+      proof.address,
+      account,
+      "Address should match the requested account"
+    );
+
+    // Default hardhat accounts have 10_000 ETH
+    assert.equal(
+      proof.balance,
+      "0x21e19e0c9bab2400000", // numberToHexString(10_000n * 10n ** 18n)
+      "Balance should be 10_000 ETH"
+    );
+
+    // Check cryptographic proof structure
+    assert.ok(
+      Array.isArray(proof.accountProof) && proof.accountProof.length > 0,
+      "accountProof should be a non empty array"
+    );
+    assert.ok(
+      Array.isArray(proof.storageProof) && proof.storageProof.length === 0,
+      // we passed `[]` as storage keys in the request
+      "StorageProof should be an empty array for 0 storage keys"
+    );
+  });
+
+  it("should return storage proof for contract on local network", async function () {
+    await this.env.run(TASK_COMPILE, { quiet: true });
+
+    // Define arbitrary address and storage key
+    const contractAddress = "0x1234567890123456789012345678901234567890";
+    const slotZero =
+      "0x0000000000000000000000000000000000000000000000000000000000000000";
+    const valueOne =
+      "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    // Set storage directly (bypassing deployment & mining)
+    await this.env.network.provider.request({
+      method: "hardhat_setStorageAt",
+      params: [contractAddress, slotZero, valueOne],
+    });
+
+    const proof: any = await this.env.network.provider.request({
+      method: "eth_getProof",
+      params: [contractAddress, [slotZero], "latest"],
+    });
+
+    assert.equal(proof.address, contractAddress, "Address should match");
+    assert.equal(proof.storageProof.length, 1, "Should return 1 storage proof");
+    assert.equal(
+      proof.storageProof[0].key,
+      slotZero,
+      "Storage key should match"
+    );
+    assert.equal(
+      proof.storageProof[0].value,
+      "0x1",
+      "Storage value should be 0x1"
+    );
+    assert.ok(
+      proof.storageProof[0].proof.length > 0,
+      "Storage proof should not be empty"
+    );
+  });
+});

--- a/packages/hardhat-core/test/internal/solidity/helpers.ts
+++ b/packages/hardhat-core/test/internal/solidity/helpers.ts
@@ -13,14 +13,17 @@ import { getRealPathSync } from "../../../src/internal/util/fs-utils";
 const projectRoot = getRealPathSync(".");
 
 export class MockFile {
+  public readonly name: string;
+  public readonly versionPragmas: string[];
+  public readonly libraryName: string | undefined;
   public readonly sourceName: string;
   public readonly absolutePath: string;
 
-  constructor(
-    public name: string,
-    public versionPragmas: string[],
-    public libraryName?: string
-  ) {
+  constructor(name: string, versionPragmas: string[], libraryName?: string) {
+    this.name = name;
+    this.versionPragmas = versionPragmas;
+    this.libraryName = libraryName;
+
     this.sourceName = `contracts/${name}.sol`;
     this.absolutePath = path.join(projectRoot, "contracts", `${name}.sol`);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,8 +201,8 @@ importers:
         specifier: ^5.1.2
         version: 5.8.0
       '@nomicfoundation/edr':
-        specifier: 0.12.0-next.22
-        version: 0.12.0-next.22
+        specifier: 0.12.0-next.23
+        version: 0.12.0-next.23
       '@nomicfoundation/solidity-analyzer':
         specifier: ^0.1.0
         version: 0.1.2
@@ -3067,36 +3067,36 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.22':
-    resolution: {integrity: sha512-TpEBSKyMZJEPvYwBPYclC2b+qobKjn1YhVa7aJ1R7RMPy5dJ/PqsrUK5UuUFFybBqoIorru5NTcsyCMWP5T/Fg==}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.23':
+    resolution: {integrity: sha512-Amh7mRoDzZyJJ4efqoePqdoZOzharmSOttZuJDlVE5yy07BoE8hL6ZRpa5fNYn0LCqn/KoWs8OHANWxhKDGhvQ==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.22':
-    resolution: {integrity: sha512-aK/+m8xUkR4u+czTVGU06nSFVH43AY6XCBoR2YjO8SglAAjCSTWK3WAfVb6FcsriMmKv4PrvoyHLMbMP+fXcGA==}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.23':
+    resolution: {integrity: sha512-9wn489FIQm7m0UCD+HhktjWx6vskZzeZD9oDc2k9ZvbBzdXwPp5tiDqUBJ+eQpByAzCDfteAJwRn2lQCE0U+Iw==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.22':
-    resolution: {integrity: sha512-W5vXMleG14hVzRYGPEwlHLJ6iiQE8Qh63Uj538nAz4YUI6wWSgUOZE7K2Gt1EdujZGnrt7kfDslgJ96n4nKQZw==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.23':
+    resolution: {integrity: sha512-nlk5EejSzEUfEngv0Jkhqq3/wINIfF2ED9wAofc22w/V1DV99ASh9l3/e/MIHOQFecIZ9MDqt0Em9/oDyB1Uew==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.22':
-    resolution: {integrity: sha512-VDp7EB3iY8MH/fFVcgEzLDGYmtS6j2honNc0RNUCFECKPrdsngGrTG8p+YFxyVjq2m5GEsdyKo4e+BKhaUNPdg==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.23':
+    resolution: {integrity: sha512-SJuPBp3Rc6vM92UtVTUxZQ/QlLhLfwTftt2XUiYohmGKB3RjGzpgduEFMCA0LEnucUckU6UHrJNFHiDm77C4PQ==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.22':
-    resolution: {integrity: sha512-XL6oA3ymRSQYyvg6hF1KIax6V/9vlWr5gJ8GPHVVODk1a/YfuEEY1osN5Zmo6aztUkSGKwSuac/3Ax7rfDDiSg==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.23':
+    resolution: {integrity: sha512-NU+Qs3u7Qt6t3bJFdmmjd5CsvgI2bPPzO31KifM2Ez96/jsXYho5debtTQnimlb5NAqiHTSlxjh/F8ROcptmeQ==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.22':
-    resolution: {integrity: sha512-hmkRIXxWa9P0PwfXOAO6WUw11GyV5gpxcMunqWBTkwZ4QW/hi/CkXmlLo6VHd6ceCwpUNLhCGndBtrOPrNRi4A==}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.23':
+    resolution: {integrity: sha512-F78fZA2h6/ssiCSZOovlgIu0dUeI7ItKPsDDF3UUlIibef052GCXmliMinC90jVPbrjUADMd1BUwjfI0Z8OllQ==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.22':
-    resolution: {integrity: sha512-X7f+7KUMm00trsXAHCHJa+x1fc3QAbk2sBctyOgpET+GLrfCXbxqrccKi7op8f0zTweAVGg1Hsc8SjjC7kwFLw==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.23':
+    resolution: {integrity: sha512-IfJZQJn7d/YyqhmguBIGoCKjE9dKjbu6V6iNEPApfwf5JyyjHYyyfkLU4rf7hygj57bfH4sl1jtQ6r8HnT62lw==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr@0.12.0-next.22':
-    resolution: {integrity: sha512-JigYWf2stjpDxSndBsxRoobQHK8kz4SAVaHtTIKQLIHbsBwymE8i120Ejne6Jk+Ndc5CsNINXB8/bK6vLPe9jA==}
+  '@nomicfoundation/edr@0.12.0-next.23':
+    resolution: {integrity: sha512-F2/6HZh8Q9RsgkOIkRrckldbhPjIZY7d4mT9LYuW68miwGQ5l7CkAgcz9fRRiurA0+YJhtsbx/EyrD9DmX9BOw==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -9897,29 +9897,29 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.22': {}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.23': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.22': {}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.23': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.22': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.23': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.22': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.23': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.22': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.23': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.22': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.23': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.22': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.23': {}
 
-  '@nomicfoundation/edr@0.12.0-next.22':
+  '@nomicfoundation/edr@0.12.0-next.23':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.22
-      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.22
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.22
-      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.22
-      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.22
-      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.22
-      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.22
+      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.23
+      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.23
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.23
+      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.23
+      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.23
+      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.23
+      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.23
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true


### PR DESCRIPTION
Provide support for `eth_getProof` as a JSON-RPC method in Hardhat 2.

Both Hardhat 2 and Hardhat 3 use the same underlying EDR library to provide `eth_getProof` support. This is based on the v3 version: https://github.com/NomicFoundation/hardhat/pull/7914.

The `eth_getProof` JSON-RPC call is not supported on a locally-mined block following forking. A `ProviderError` is thrown to explain the unsupported case:

```shell
/workspaces/hardhat/examples/hh2/node_modules/hardhat/src/internal/hardhat-network/provider/provider.ts:462
          error = new ProviderError(
                  ^
ProviderError: The action `Proof of locally modified state in fork mode` is unsupported. Obtaining a proof is not supported in fork mode when local changes have been made. E.g. manual changes to an account or a locally mined block.
    at EdrProviderWrapper.request (/workspaces/hardhat/examples/hh2/node_modules/hardhat/src/internal/hardhat-network/provider/provider.ts:462:19)
    at async main (file:///workspaces/hardhat/examples/hh2/scripts/test-get-proof.js:31:20)
```

## Manual Testing 

I have done a round of manual testing and confirmed that EDR returns a readable `ProviderError` (shown above) for the unsupported case.

`eth_getProof` against a forked mainnet gives the same proof as you would get if going directly.