### PR TITLE
build: upgrade to @nomicfoundation/edr v0.12.0-next.24 (Hardhat 3)

### DIFF
--- a/.changeset/two-numbers-admire.md
+++ b/.changeset/two-numbers-admire.md
@@ -1,0 +1,8 @@
+---
+"hardhat": patch
+---
+
+Bumped EDR version to [`0.12.0-next.24`](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.12.0-next.24).
+
+- NomicFoundation/edr@7bf3576: Added the ability to specify the hardfork when running Solidity tests. Added support for the Osaka hardfork in Solidity tests.
+- NomicFoundation/edr@b505164: Added structured errors for unsupported Solidity test cheatcodes

--- a/.changeset/two-numbers-admire.md
+++ b/.changeset/two-numbers-admire.md
@@ -2,7 +2,4 @@
 "hardhat": patch
 ---
 
-Bumped EDR version to [`0.12.0-next.24`](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.12.0-next.24).
-
-- NomicFoundation/edr@7bf3576: Added the ability to specify the hardfork when running Solidity tests. Added support for the Osaka hardfork in Solidity tests.
-- NomicFoundation/edr@b505164: Added structured errors for unsupported Solidity test cheatcodes
+Fixed missing EIP-7212 precompile in Solidity Tests ([#7872](https://github.com/NomicFoundation/hardhat/issues/7872))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ importers:
   v-next/hardhat:
     dependencies:
       '@nomicfoundation/edr':
-        specifier: 0.12.0-next.23
-        version: 0.12.0-next.23
+        specifier: 0.12.0-next.24
+        version: 0.12.0-next.24
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.6
         version: link:../hardhat-errors
@@ -2680,36 +2680,36 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.23':
-    resolution: {integrity: sha512-Amh7mRoDzZyJJ4efqoePqdoZOzharmSOttZuJDlVE5yy07BoE8hL6ZRpa5fNYn0LCqn/KoWs8OHANWxhKDGhvQ==}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.24':
+    resolution: {integrity: sha512-lYcD9IM52G0hk/3Sso2Rpdpyfafy3aHH0GsSy/FVog9UrEkmmU14AmccE18/zTL+UyV0yzYMDOmh6y83SD/lbg==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.23':
-    resolution: {integrity: sha512-9wn489FIQm7m0UCD+HhktjWx6vskZzeZD9oDc2k9ZvbBzdXwPp5tiDqUBJ+eQpByAzCDfteAJwRn2lQCE0U+Iw==}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.24':
+    resolution: {integrity: sha512-cHDJZlPDpDXJXxQDVM0TGzEuNvV3wW94gipEdjNxZHeC9T2/NU/5GUoQajMJgvCZ6PWDlRMwIBRtM1jC/ny5DA==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.23':
-    resolution: {integrity: sha512-nlk5EejSzEUfEngv0Jkhqq3/wINIfF2ED9wAofc22w/V1DV99ASh9l3/e/MIHOQFecIZ9MDqt0Em9/oDyB1Uew==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.24':
+    resolution: {integrity: sha512-G/iln4W79CR9f68+crBZM1kBdmmK3IbQCD4b5u+iqby+H5BOLSPQmjeW9UREK5WSecnv7Oxr/ZTHHRq/w9pUPA==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.23':
-    resolution: {integrity: sha512-SJuPBp3Rc6vM92UtVTUxZQ/QlLhLfwTftt2XUiYohmGKB3RjGzpgduEFMCA0LEnucUckU6UHrJNFHiDm77C4PQ==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.24':
+    resolution: {integrity: sha512-wt6UuOutufL3UTSyMiwPOyfRly3uQEFHASXqLsNjgp4qBrm0s+kkyaYpAe8h53lGzZmXIDOAbO0P/fwxnLCnWw==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.23':
-    resolution: {integrity: sha512-NU+Qs3u7Qt6t3bJFdmmjd5CsvgI2bPPzO31KifM2Ez96/jsXYho5debtTQnimlb5NAqiHTSlxjh/F8ROcptmeQ==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.24':
+    resolution: {integrity: sha512-mHgkUSynINTnnIvZuZymJ4dMqjemGjdrzQ87rP5/SQQGRQVV82uDomSEglp9btSmbBWfPj4r4tWsV+a3844W0w==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.23':
-    resolution: {integrity: sha512-F78fZA2h6/ssiCSZOovlgIu0dUeI7ItKPsDDF3UUlIibef052GCXmliMinC90jVPbrjUADMd1BUwjfI0Z8OllQ==}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.24':
+    resolution: {integrity: sha512-E0XNSlPc8Hx5Nhowe5VIvAqVeT+1VUWSRqG0cZtYcpUgJZxTp8p03ojPtbyfjL4T+78GfnpmzkkLhB6S2jZ1FQ==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.23':
-    resolution: {integrity: sha512-IfJZQJn7d/YyqhmguBIGoCKjE9dKjbu6V6iNEPApfwf5JyyjHYyyfkLU4rf7hygj57bfH4sl1jtQ6r8HnT62lw==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.24':
+    resolution: {integrity: sha512-PbtY2zWc4k8HK4gVnVbPohJnfrICboo6J91vxTlhnPKCWGvfGbsqLfDUAp91ExHHY+80qRfQnwaLbhJiIqLFGw==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr@0.12.0-next.23':
-    resolution: {integrity: sha512-F2/6HZh8Q9RsgkOIkRrckldbhPjIZY7d4mT9LYuW68miwGQ5l7CkAgcz9fRRiurA0+YJhtsbx/EyrD9DmX9BOw==}
+  '@nomicfoundation/edr@0.12.0-next.24':
+    resolution: {integrity: sha512-/NwB9yX7uBs/FIJKHBZo2hVhP7g3v6LbE21JvTLvshgb+XscyaRRUmzB//ankxLGJ1TehtXAf/Qh/a19vgpiig==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -7096,29 +7096,29 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.23': {}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.24': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.23': {}
+  '@nomicfoundation/edr-darwin-x64@0.12.0-next.24': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.23': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.24': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.23': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.24': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.23': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.24': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.23': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.24': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.23': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.24': {}
 
-  '@nomicfoundation/edr@0.12.0-next.23':
+  '@nomicfoundation/edr@0.12.0-next.24':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.23
-      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.23
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.23
-      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.23
-      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.23
-      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.23
-      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.23
+      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.24
+      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.24
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.24
+      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.24
+      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.24
+      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.24
+      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.24
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -87,7 +87,7 @@
     "typescript": "~5.8.0"
   },
   "dependencies": {
-    "@nomicfoundation/edr": "0.12.0-next.23",
+    "@nomicfoundation/edr": "0.12.0-next.24",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.6",
     "@nomicfoundation/hardhat-utils": "workspace:^3.0.6",
     "@nomicfoundation/hardhat-vendored": "workspace:^3.0.1",

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -24,6 +24,7 @@ import { hexStringToBytes } from "@nomicfoundation/hardhat-utils/hex";
 import chalk from "chalk";
 
 import { DEFAULT_VERBOSITY, OPTIMISM_CHAIN_TYPE } from "../../constants.js";
+import { hardhatHardforkToEdrSpecId } from "../network-manager/edr/utils/convert-to-edr.js";
 
 import { type Colorizer, formatArtifactId } from "./formatters.js";
 
@@ -97,10 +98,11 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
       : hexStringToBuffer(config.coinbase);
 
   const resolvedHardfork =
-    hardfork ??
-    (chainType === OPTIMISM_CHAIN_TYPE
-      ? opHardforkToString(opLatestHardfork())
-      : l1HardforkToString(l1HardforkLatest()));
+    hardfork !== undefined
+      ? hardhatHardforkToEdrSpecId(hardfork, chainType)
+      : chainType === OPTIMISM_CHAIN_TYPE
+        ? opHardforkToString(opLatestHardfork())
+        : l1HardforkToString(l1HardforkLatest());
 
   const localPredeploys =
     chainType === OPTIMISM_CHAIN_TYPE

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -17,6 +17,8 @@ import {
   IncludeTraces,
   FsAccessPermission,
   CollectStackTraces,
+  opHardforkToString,
+  l1HardforkToString,
 } from "@nomicfoundation/edr";
 import { hexStringToBytes } from "@nomicfoundation/hardhat-utils/hex";
 import chalk from "chalk";
@@ -28,6 +30,7 @@ import { type Colorizer, formatArtifactId } from "./formatters.js";
 interface SolidityTestConfigParams {
   chainType: ChainType;
   projectRoot: string;
+  hardfork?: string;
   config: SolidityTestConfig;
   verbosity: number;
   observability?: ObservabilityConfig;
@@ -48,6 +51,7 @@ export function solidityTestConfigToRunOptions(
 export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
   chainType,
   projectRoot,
+  hardfork,
   config,
   verbosity,
   observability,
@@ -92,6 +96,12 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
       ? undefined
       : hexStringToBuffer(config.coinbase);
 
+  const resolvedHardfork =
+    hardfork ??
+    (chainType === OPTIMISM_CHAIN_TYPE
+      ? opHardforkToString(opLatestHardfork())
+      : l1HardforkToString(l1HardforkLatest()));
+
   const localPredeploys =
     chainType === OPTIMISM_CHAIN_TYPE
       ? opGenesisState(opLatestHardfork())
@@ -131,6 +141,7 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
 
   return {
     projectRoot,
+    hardfork: resolvedHardfork,
     ...config,
     fsPermissions,
     localPredeploys,

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -17,13 +17,12 @@ import {
   IncludeTraces,
   FsAccessPermission,
   CollectStackTraces,
-  opHardforkToString,
-  l1HardforkToString,
 } from "@nomicfoundation/edr";
 import { hexStringToBytes } from "@nomicfoundation/hardhat-utils/hex";
 import chalk from "chalk";
 
 import { DEFAULT_VERBOSITY, OPTIMISM_CHAIN_TYPE } from "../../constants.js";
+import { resolveHardfork } from "../network-manager/config-resolution.js";
 import { hardhatHardforkToEdrSpecId } from "../network-manager/edr/utils/convert-to-edr.js";
 
 import { type Colorizer, formatArtifactId } from "./formatters.js";
@@ -97,12 +96,10 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
       ? undefined
       : hexStringToBuffer(config.coinbase);
 
-  const resolvedHardfork =
-    hardfork !== undefined
-      ? hardhatHardforkToEdrSpecId(hardfork, chainType)
-      : chainType === OPTIMISM_CHAIN_TYPE
-        ? opHardforkToString(opLatestHardfork())
-        : l1HardforkToString(l1HardforkLatest());
+  const resolvedHardfork = hardhatHardforkToEdrSpecId(
+    resolveHardfork(hardfork, chainType),
+    chainType,
+  );
 
   const localPredeploys =
     chainType === OPTIMISM_CHAIN_TYPE

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -11,12 +11,12 @@ import type {
 
 import {
   opGenesisState,
-  opLatestHardfork,
   l1GenesisState,
-  l1HardforkLatest,
   IncludeTraces,
   FsAccessPermission,
   CollectStackTraces,
+  opHardforkFromString,
+  l1HardforkFromString,
 } from "@nomicfoundation/edr";
 import { hexStringToBytes } from "@nomicfoundation/hardhat-utils/hex";
 import chalk from "chalk";
@@ -103,8 +103,8 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
 
   const localPredeploys =
     chainType === OPTIMISM_CHAIN_TYPE
-      ? opGenesisState(opLatestHardfork())
-      : l1GenesisState(l1HardforkLatest());
+      ? opGenesisState(opHardforkFromString(resolvedHardfork))
+      : l1GenesisState(l1HardforkFromString(resolvedHardfork));
 
   let includeTraces: IncludeTraces = IncludeTraces.None;
   if (verbosity >= 5) {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -158,10 +158,21 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     };
   }
 
+  // Extract hardfork from the selected network configuration
+  let hardfork: string | undefined;
+  if (hre.globalOptions.network !== undefined) {
+    const networkName = hre.globalOptions.network;
+    const networkConfig = hre.config.networks[networkName];
+    if (networkConfig !== undefined && networkConfig.type === "edr-simulated") {
+      hardfork = networkConfig.hardfork;
+    }
+  }
+
   const config: SolidityTestRunnerConfigArgs =
     await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType,
       projectRoot: hre.config.paths.root,
+      hardfork,
       config: solidityTestConfig,
       verbosity,
       observability: observabilityConfig,

--- a/v-next/hardhat/test/fixture-projects/solidity-test/test/contracts/hardfork/hardfork.t.sol
+++ b/v-next/hardhat/test/fixture-projects/solidity-test/test/contracts/hardfork/hardfork.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract EIP7212Test {
+  address constant P256_PRECOMPILE = address(0x100);
+
+  function testPrecompileExistence() public view {
+    // Pre-generated values
+    bytes32 msgHash = 0x7547e7989971d6c63cf140647fefc5c3043460ea96763f529feef8bc83b67680;
+    bytes32 r = 0x4456df631c55951140b184cc1b4db60e78f1ae4b003e336348bc7d3c1cc8daab;
+    bytes32 s = 0xfd26094146960c9f1df540c823a3c44d969b48fd42da2142450772ce2d45c064;
+    bytes32 x = 0x703bbc0830e0238b0030e03cff350561ae96ac5f00edc3be1c72bbc04e0f0180;
+    bytes32 y = 0x958533939e7571d60f6e895709ab5d3f9f339e0a26cc8baaf61200340d8e6c90;
+
+    bytes memory input = abi.encodePacked(msgHash, r, s, x, y);
+
+    (, bytes memory ret) = P256_PRECOMPILE.staticcall(input);
+
+    // CHECK 1: The precompile must exist
+    // If this fails (length == 0), the precompile is missing
+    require(ret.length == 32, "EIP-7212 Precompile missing: Returned 0 bytes");
+
+    // CHECK 2: The signature must be valid
+    // If the precompile exists, this should return 1
+    uint256 result = abi.decode(ret, (uint256));
+    require(result == 1, "Signature verification failed");
+  }
+}

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
@@ -4,7 +4,16 @@ import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
-import { CollectStackTraces, IncludeTraces } from "@nomicfoundation/edr";
+import {
+  CANCUN,
+  CollectStackTraces,
+  ECOTONE,
+  IncludeTraces,
+  l1HardforkLatest,
+  l1HardforkToString,
+  opHardforkToString,
+  opLatestHardfork,
+} from "@nomicfoundation/edr";
 
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
 import { resolveSolidityTestForkingConfig } from "../../../../src/internal/builtin-plugins/solidity-test/config.js";
@@ -12,6 +21,8 @@ import { solidityTestConfigToSolidityTestRunnerConfigArgs } from "../../../../sr
 import {
   DEFAULT_VERBOSITY,
   GENERIC_CHAIN_TYPE,
+  L1_CHAIN_TYPE,
+  OPTIMISM_CHAIN_TYPE,
 } from "../../../../src/internal/constants.js";
 import { resolveConfigurationVariable } from "../../../../src/internal/core/configuration-variables.js";
 
@@ -184,5 +195,61 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     });
 
     assert.equal(args.generateGasReport, false);
+  });
+
+  describe("hardfork parameter", () => {
+    it("should use provided hardfork for EDR", async () => {
+      const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
+        chainType: L1_CHAIN_TYPE,
+        projectRoot: process.cwd(),
+        hardfork: "cancun",
+        config: {},
+        verbosity: 2,
+        generateGasReport: false,
+      });
+
+      assert.equal(args.hardfork, CANCUN);
+    });
+
+    it("should use provided hardfork for OP", async () => {
+      const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
+        chainType: OPTIMISM_CHAIN_TYPE,
+        projectRoot: process.cwd(),
+        hardfork: "ecotone",
+        config: {},
+        verbosity: 2,
+        generateGasReport: false,
+      });
+
+      assert.equal(args.hardfork, ECOTONE);
+    });
+
+    it("should use latest L1 hardfork when hardfork is undefined", async () => {
+      const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
+        chainType: L1_CHAIN_TYPE,
+        projectRoot: process.cwd(),
+        hardfork: undefined,
+        config: {},
+        verbosity: 2,
+        generateGasReport: false,
+      });
+
+      const expectedHardfork = l1HardforkToString(l1HardforkLatest());
+      assert.equal(args.hardfork, expectedHardfork);
+    });
+
+    it("should use latest OP hardfork when hardfork is undefined", async () => {
+      const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
+        chainType: OPTIMISM_CHAIN_TYPE,
+        projectRoot: process.cwd(),
+        hardfork: undefined,
+        config: {},
+        verbosity: 2,
+        generateGasReport: false,
+      });
+
+      const expectedHardfork = opHardforkToString(opLatestHardfork());
+      assert.equal(args.hardfork, expectedHardfork);
+    });
   });
 });

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -43,6 +43,11 @@ const hardhatConfigOpTests = {
   paths: { tests: { solidity: "test/contracts/op" } },
 };
 
+const hardhatConfigHardforkTests = {
+  ...hardhatConfig,
+  paths: { tests: { solidity: "test/contracts/hardfork" } },
+};
+
 describe("solidity-test/task-action", function () {
   let hre: HardhatRuntimeEnvironment;
 
@@ -342,5 +347,16 @@ describe("solidity-test/task-action", function () {
         });
       });
     });
+  });
+
+  it("should support EIP-7212 precompile at address 0x100", async () => {
+    hre = await createHardhatRuntimeEnvironment(hardhatConfigHardforkTests);
+
+    await hre.tasks.getTask(["test", "solidity"]).run({
+      noCompile: false,
+    });
+
+    // The test should not throw, which means the precompile exists
+    // and works as expected
   });
 });


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Bumped EDR version to [`0.12.0-next.24`](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.12.0-next.24).

### Minor Changes
- NomicFoundation/edr@7bf3576: Added the ability to specify the hardfork when running Solidity tests. Added support for the Osaka hardfork in Solidity tests.
- NomicFoundation/edr@b505164: Added structured errors for unsupported Solidity test cheatcodes
