### PR TITLE
[CI] Don't always run the node:test reporter ci

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -288,7 +288,7 @@ jobs:
   hardhat-node-test-reporter:
     needs: list-packages
 
-    if: contains(needs.list-packages.outputs.packages, 'hardhat-node-test-reporter')
+    if: contains(fromJson(needs.list-packages.outputs.packages), 'hardhat-node-test-reporter')
 
     strategy:
       fail-fast: false

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -287,6 +287,8 @@ jobs:
   hardhat-node-test-reporter:
     needs: list-packages
 
+    if: contains(needs.list-packages.outputs.packages, 'hardhat-node-test-reporter')
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -268,7 +268,7 @@ jobs:
         run: pnpm run --if-present test
 
   ci-aggregate:
-    needs: ci
+    needs: [ci, hardhat-node-test-reporter]
 
     if: ${{ !cancelled() }}
 
@@ -277,9 +277,10 @@ jobs:
 
     steps:
       - env:
-          result: ${{ needs.ci.result }}
+          ci_result: ${{ needs.ci.result }}
+          reporter_result: ${{ needs.hardhat-node-test-reporter.result }}
         run: |
-          if [[ "$result" == "failure" ]]; then
+          if [[ "$ci_result" == "failure" || "$reporter_result" == "failure" ]]; then
             exit 1
           fi
         shell: bash


### PR DESCRIPTION
The CI was always running for our `node:test` reporter package.