### PR TITLE
[Compiler download] Allow multiple parallel downloads of different compilers

### DIFF
--- a/.changeset/sweet-seas-shake.md
+++ b/.changeset/sweet-seas-shake.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Allow multiple parallel downloads of different compilers ([7946](https://github.com/NomicFoundation/hardhat/pull/7946)).


### PR DESCRIPTION
Previously, `downloadCompiler()` used a single shared `MultiProcessMutex("compiler-download")`, a file-based lock at, for example, `/tmp/compiler-download.txt`. This meant that across all parallel test workers, only one could download or even check if a compiler exists at a time. Workers needing different compiler versions would still block each other.

The fix makes the mutex version-specific `(compiler-download-${version})`, so workers downloading different versions proceed in parallel. Same-version downloads are still correctly serialized.