### PR TITLE
chore: add an eslint rule on implicit use of performance

### DIFF
--- a/v-next/config/eslint.config.js
+++ b/v-next/config/eslint.config.js
@@ -344,6 +344,24 @@ export function createConfig(
       },
     ],
     "use-isnan": "error",
+    "no-restricted-globals": [
+      "error",
+      {
+        name: "performance",
+        message:
+          "Import from 'node:perf_hooks' explicitly e.g. `import { performance } from \"node:perf_hooks\";`",
+      },
+      {
+        name: "fetch",
+        message:
+          'Consider using `request` from `hardhat-utils e.g. `import { getRequest } from "@nomicfoundation/hardhat-utils/request";`',
+      },
+      {
+        name: "structuredClone",
+        message:
+          'Avoid structuredClone, consider `deepClone` instead e.g. `import { deepClone } from "@nomicfoundation/hardhat-utils/lang";`',
+      },
+    ],
     "no-restricted-imports": [
       "error",
       {

--- a/v-next/hardhat-utils/test/synchronization.ts
+++ b/v-next/hardhat-utils/test/synchronization.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { describe, it } from "node:test";
 
 import { readUtf8File } from "../src/fs.js";

--- a/v-next/hardhat/src/internal/cli/telemetry/sentry/transport.ts
+++ b/v-next/hardhat/src/internal/cli/telemetry/sentry/transport.ts
@@ -177,6 +177,7 @@ async function sendSerializedEnvelopeToSentryBackend(
     .filter(Boolean)
     .join(", ");
 
+  // eslint-disable-next-line no-restricted-globals -- TODO: determine whether this should be using undici
   const res = await fetch(ingestUrl, {
     method: "POST",
     headers: {


### PR DESCRIPTION
There are globals that are added implicitly in Node. We prefer an explicit approach.

This PR adds a new global eslint rule has been added to restrict certain globals, specifically: `performance`, `fetch` and `structuredClone`.

## performance

`perforamance` should be imported explicitly e.g.

```ts
import { performance } from "node:perf_hooks";
```

## fetch

`fetch` should be done with `undici`.

## structureClone

`structureClone` should be avoided, with `deepClone` being the likely replacement from `hardhat-utils`.
