### PR TITLE
chore: add isDeprecated flag to ErrorDescriptor interface

### DIFF
--- a/.changeset/sharp-pets-tap.md
+++ b/.changeset/sharp-pets-tap.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-errors": patch
+"hardhat": patch
+---
+
+chore: add isDeprecated flag to ErrorDescriptor interface

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -33,6 +33,16 @@ export interface ErrorDescriptor {
    * can use markdown.
    */
   websiteDescription: string;
+
+  /**
+   * `true` if this error descriptor is deprecated.
+   *
+   * Deprecated error descriptors are kept for backwards compatibility, as older
+   * Hardhat versions may still throw them and they are shown on the website.
+   * They should be clearly marked as deprecated on the website, and users
+   * should be encouraged to upgrade Hardhat.
+   */
+  isDeprecated?: true;
 }
 
 export const ERROR_CATEGORIES: {

--- a/v-next/hardhat-errors/test/errors.ts
+++ b/v-next/hardhat-errors/test/errors.ts
@@ -23,6 +23,14 @@ const mockErrorDescriptor = {
   websiteDescription: "This is a mock error",
 } as const;
 
+const mockDeprecatedErrorDescriptor = {
+  number: 456,
+  messageTemplate: "deprecated error message",
+  websiteTitle: "Deprecated mock error",
+  websiteDescription: "This is a deprecated mock error",
+  isDeprecated: true,
+} as const;
+
 describe("HardhatError", () => {
   describe("Type guard", () => {
     it("Should return true for HardhatErrors", () => {
@@ -152,6 +160,31 @@ describe("HardhatError", () => {
         new Error(),
       );
       assert.equal(error.message, "HHE12: a b 123");
+    });
+  });
+
+  describe("Deprecated error descriptor", () => {
+    it("should have the right error number", () => {
+      const error = new HardhatError(mockDeprecatedErrorDescriptor);
+      assert.equal(error.number, mockDeprecatedErrorDescriptor.number);
+    });
+
+    it("should have the right error message", () => {
+      const error = new HardhatError(mockDeprecatedErrorDescriptor);
+      assert.equal(
+        error.message,
+        `HHE456: ${mockDeprecatedErrorDescriptor.messageTemplate}`,
+      );
+    });
+
+    it("should expose the isDeprecated flag via the descriptor", () => {
+      const error = new HardhatError(mockDeprecatedErrorDescriptor);
+      assert.equal(error.descriptor.isDeprecated, true);
+    });
+
+    it("should not have isDeprecated on non-deprecated descriptors", () => {
+      const error = new HardhatError(mockErrorDescriptor);
+      assert.equal(error.descriptor.isDeprecated, undefined);
     });
   });
 

--- a/v-next/hardhat/src/internal/cli/error-handler.ts
+++ b/v-next/hardhat/src/internal/cli/error-handler.ts
@@ -124,16 +124,26 @@ function getErrorWithCategory(error: Error): ErrorWithCategory {
 function getErrorMessages(error: Error): ErrorMessages {
   const { category, categorizedError } = getErrorWithCategory(error);
   switch (category) {
-    case ErrorCategory.HARDHAT:
+    case ErrorCategory.HARDHAT: {
+      const deprecationNotice =
+        categorizedError.descriptor.isDeprecated === true
+          ? `\n${chalk.yellow("Note: This error is deprecated and will be removed in a future version of Hardhat. Please consider upgrading Hardhat.")}`
+          : "";
       return {
-        formattedErrorMessage: `${chalk.red.bold(`Error ${categorizedError.errorCode}:`)} ${categorizedError.formattedMessage}`,
+        formattedErrorMessage: `${chalk.red.bold(`Error ${categorizedError.errorCode}:`)} ${categorizedError.formattedMessage}${deprecationNotice}`,
         showMoreInfoMessage: `For more info go to ${HARDHAT_WEBSITE_URL}${categorizedError.errorCode} or run ${HARDHAT_NAME} with --show-stack-traces`,
       };
-    case ErrorCategory.PLUGIN:
+    }
+    case ErrorCategory.PLUGIN: {
+      const deprecationNotice =
+        categorizedError.descriptor.isDeprecated === true
+          ? `\n${chalk.yellow("Note: This error is deprecated and will be removed in a future version of Hardhat. Please consider upgrading Hardhat.")}`
+          : "";
       return {
-        formattedErrorMessage: `${chalk.red.bold(`Error ${categorizedError.errorCode} in plugin ${categorizedError.pluginId}:`)} ${categorizedError.formattedMessage}`,
+        formattedErrorMessage: `${chalk.red.bold(`Error ${categorizedError.errorCode} in plugin ${categorizedError.pluginId}:`)} ${categorizedError.formattedMessage}${deprecationNotice}`,
         showMoreInfoMessage: `For more info go to ${HARDHAT_WEBSITE_URL}${categorizedError.errorCode} or run ${HARDHAT_NAME} with --show-stack-traces`,
       };
+    }
     case ErrorCategory.COMMUNITY_PLUGIN:
       return {
         formattedErrorMessage: `${chalk.red.bold(`Error in community plugin ${categorizedError.pluginId}:`)} ${categorizedError.message}`,

--- a/v-next/hardhat/test/internal/cli/error-handler.ts
+++ b/v-next/hardhat/test/internal/cli/error-handler.ts
@@ -27,6 +27,22 @@ const mockPluginErrorDescriptor = {
   websiteDescription: "This is a mock error in the range of a plugin",
 } as const;
 
+const mockDeprecatedCoreErrorDescriptor = {
+  number: 124,
+  messageTemplate: "deprecated error message",
+  websiteTitle: "Deprecated mock error",
+  websiteDescription: "This is a deprecated mock error",
+  isDeprecated: true,
+} as const;
+
+const mockDeprecatedPluginErrorDescriptor = {
+  number: 50001,
+  messageTemplate: "deprecated plugin error message",
+  websiteTitle: "Deprecated mock plugin error",
+  websiteDescription: "This is a deprecated mock plugin error",
+  isDeprecated: true,
+} as const;
+
 describe("error-handler", () => {
   describe("printErrorMessages", () => {
     describe("with a Hardhat error", () => {
@@ -104,6 +120,62 @@ describe("error-handler", () => {
         );
         assert.equal(lines[1], "");
         assert.equal(lines[2], error);
+      });
+    });
+
+    describe("with a deprecated Hardhat error", () => {
+      it("should print the error message with deprecation notice", () => {
+        const lines: Array<string | Error> = [];
+        const error = new HardhatError(mockDeprecatedCoreErrorDescriptor);
+
+        printErrorMessages(error, false, (msg: string | Error) => {
+          lines.push(msg);
+        });
+
+        assert.equal(lines.length, 3);
+        assert.ok(
+          (lines[0] as string).includes(error.formattedMessage),
+          "should contain the error message",
+        );
+        assert.ok(
+          (lines[0] as string).includes(
+            "This error is deprecated and will be removed in a future version of Hardhat",
+          ),
+          "should contain the deprecation notice",
+        );
+        assert.equal(lines[1], "");
+        assert.equal(
+          lines[2],
+          `For more info go to ${HARDHAT_WEBSITE_URL}${error.errorCode} or run ${HARDHAT_NAME} with --show-stack-traces`,
+        );
+      });
+    });
+
+    describe("with a deprecated Hardhat plugin error", () => {
+      it("should print the error message with deprecation notice", () => {
+        const lines: Array<string | Error> = [];
+        const error = new HardhatError(mockDeprecatedPluginErrorDescriptor);
+
+        printErrorMessages(error, false, (msg: string | Error) => {
+          lines.push(msg);
+        });
+
+        assert.equal(lines.length, 3);
+        assert.ok(
+          (lines[0] as string).includes(error.formattedMessage),
+          "should contain the error message",
+        );
+        assert.ok(
+          (lines[0] as string).includes(
+            "This error is deprecated and will be removed in a future version of Hardhat",
+          ),
+          "should contain the deprecation notice",
+        );
+        assert.equal(lines[1], "");
+        assert.equal(
+          lines[2],
+          `For more info go to ${HARDHAT_WEBSITE_URL}${error.errorCode} or run ${HARDHAT_NAME} with --show-stack-traces`,
+        );
       });
     });
 


### PR DESCRIPTION
Add optional `isDeprecated` field to ErrorDescriptor so unused error descriptors can be marked as deprecated instead of deleted. The CLI error handler now shows a deprecation notice for deprecated errors.

Closes #7732

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

### Changes

- Added optional `isDeprecated?: true` field to the `ErrorDescriptor` interface in `hardhat-errors`
- Updated the CLI error handler to append a yellow deprecation notice when a deprecated error is thrown (both core and plugin errors)
- Added tests for the new field in `hardhat-errors/test/errors.ts` (4 tests)
- Added tests for the deprecation notice in `hardhat/test/internal/cli/error-handler.ts` (2 tests)

### How it works

When an error descriptor has `isDeprecated: true`, the CLI output includes:

> Note: This error is deprecated and will be removed in a future version of Hardhat. Please consider upgrading Hardhat.

This allows the website to clearly mark deprecated errors and avoids deleting descriptors that older Hardhat versions may still throw.