### PR TITLE
chore: migrate coverage table to formatTableV2 and remove old formatTable

### DIFF
--- a/.changeset/bump-hardhat-utils-major.md
+++ b/.changeset/bump-hardhat-utils-major.md
@@ -1,0 +1,21 @@
+---
+"@nomicfoundation/hardhat-errors": patch
+"@nomicfoundation/hardhat-ethers": patch
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+"@nomicfoundation/hardhat-ignition": patch
+"@nomicfoundation/hardhat-keystore": patch
+"@nomicfoundation/hardhat-ledger": patch
+"@nomicfoundation/hardhat-mocha": patch
+"@nomicfoundation/hardhat-network-helpers": patch
+"@nomicfoundation/hardhat-node-test-runner": patch
+"@nomicfoundation/hardhat-test-utils": patch
+"@nomicfoundation/hardhat-toolbox-mocha-ethers": patch
+"@nomicfoundation/hardhat-typechain": patch
+"@nomicfoundation/hardhat-verify": patch
+"@nomicfoundation/hardhat-viem": patch
+"@nomicfoundation/hardhat-viem-assertions": patch
+"@nomicfoundation/hardhat-zod-utils": patch
+"@nomicfoundation/ignition-core": patch
+---
+
+Bump `hardhat-utils` major

--- a/.changeset/small-penguins-smash.md
+++ b/.changeset/small-penguins-smash.md
@@ -1,6 +1,23 @@
 ---
-"@nomicfoundation/hardhat-utils": patch
+"@nomicfoundation/hardhat-utils": major
 "hardhat": patch
+"@nomicfoundation/hardhat-errors": patch
+"@nomicfoundation/hardhat-ethers": patch
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+"@nomicfoundation/hardhat-ignition": patch
+"@nomicfoundation/hardhat-keystore": patch
+"@nomicfoundation/hardhat-ledger": patch
+"@nomicfoundation/hardhat-mocha": patch
+"@nomicfoundation/hardhat-network-helpers": patch
+"@nomicfoundation/hardhat-node-test-runner": patch
+"@nomicfoundation/hardhat-test-utils": patch
+"@nomicfoundation/hardhat-toolbox-mocha-ethers": patch
+"@nomicfoundation/hardhat-typechain": patch
+"@nomicfoundation/hardhat-verify": patch
+"@nomicfoundation/hardhat-viem": patch
+"@nomicfoundation/hardhat-viem-assertions": patch
+"@nomicfoundation/hardhat-zod-utils": patch
+"@nomicfoundation/ignition-core": patch
 ---
 
 chore: migrate coverage table to formatTableV2 and remove old formatTable

--- a/.changeset/small-penguins-smash.md
+++ b/.changeset/small-penguins-smash.md
@@ -1,23 +1,6 @@
 ---
 "@nomicfoundation/hardhat-utils": major
 "hardhat": patch
-"@nomicfoundation/hardhat-errors": patch
-"@nomicfoundation/hardhat-ethers": patch
-"@nomicfoundation/hardhat-ethers-chai-matchers": patch
-"@nomicfoundation/hardhat-ignition": patch
-"@nomicfoundation/hardhat-keystore": patch
-"@nomicfoundation/hardhat-ledger": patch
-"@nomicfoundation/hardhat-mocha": patch
-"@nomicfoundation/hardhat-network-helpers": patch
-"@nomicfoundation/hardhat-node-test-runner": patch
-"@nomicfoundation/hardhat-test-utils": patch
-"@nomicfoundation/hardhat-toolbox-mocha-ethers": patch
-"@nomicfoundation/hardhat-typechain": patch
-"@nomicfoundation/hardhat-verify": patch
-"@nomicfoundation/hardhat-viem": patch
-"@nomicfoundation/hardhat-viem-assertions": patch
-"@nomicfoundation/hardhat-zod-utils": patch
-"@nomicfoundation/ignition-core": patch
 ---
 
-chore: migrate coverage table to formatTableV2 and remove old formatTable
+Update the `--coverage` table output to match the style used by `--gas-stats`. Thanks @jose-blockchain! ([#7733](https://github.com/NomicFoundation/hardhat/issues/7733))

--- a/.changeset/small-penguins-smash.md
+++ b/.changeset/small-penguins-smash.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+"hardhat": patch
+---
+
+chore: migrate coverage table to formatTableV2 and remove old formatTable

--- a/v-next/hardhat-utils/src/format.ts
+++ b/v-next/hardhat-utils/src/format.ts
@@ -9,114 +9,31 @@ import {
   renderSectionClose,
 } from "./internal/format.js";
 
-export type TableRow = string[];
-export interface TableDivider {
-  type: "divider";
-}
-export type TableItem = TableRow | TableDivider;
-
-export const divider: TableDivider = { type: "divider" };
-
-/**
- * Formats an array of rows and dividers into a table string.
- *
- * @param items An array of table rows (string arrays) and dividers.
- * Dividers are objects with type: "divider" and will be rendered as table dividers.
- * @returns The formatted table as a string, ready to be rendered.
- *
- * @example
- * ```ts
- * formatTable([
- *   ["Name", "Age"],
- *   divider,
- *   ["Alice", "30"],
- *   ["Bob", "25"],
- *   divider,
- *   ["Average", "27.5"]
- * ]);
- *
- * // =>
- * // | Name    | Age  |
- * // | ------- | ---- |
- * // | Alice   | 30   |
- * // | Bob     | 25   |
- * // | ------- | ---- |
- * // | Average | 27.5 |
- * ```
- */
-export function formatTable(items: TableItem[]): string {
-  const widths: number[] = [];
-  const dataRows: string[][] = [];
-
-  for (const item of items) {
-    if (Array.isArray(item)) {
-      dataRows.push([...item]);
-    }
-  }
-
-  // Calculate maximum width for each column
-  for (const row of dataRows) {
-    for (let i = 0; i < row.length; i++) {
-      while (i >= widths.length) {
-        widths.push(0);
-      }
-      widths[i] = Math.max(widths[i], getStringWidth(row[i]));
-    }
-  }
-
-  const dividerRow = widths.map((width) => "-".repeat(width));
-  const outputRows: string[][] = [];
-
-  for (const item of items) {
-    if (Array.isArray(item)) {
-      const row = [...item];
-      // Pad the row to match the number of columns
-      while (row.length < widths.length) {
-        row.push("");
-      }
-      outputRows.push(row);
-    } else {
-      outputRows.push([...dividerRow]);
-    }
-  }
-
-  outputRows.forEach((row) => {
-    for (let i = 0; i < row.length; i++) {
-      const displayWidth = getStringWidth(row[i]);
-      const actualLength = row[i].length;
-      // Adjust padding to account for difference between display width and actual length
-      row[i] = row[i].padEnd(widths[i] + actualLength - displayWidth);
-    }
-  });
-
-  return outputRows.map((row) => `| ${row.join(" | ")} |`).join("\n");
-}
-
-export interface TableTitleV2 {
+export interface TableTitle {
   type: "title";
   text: string;
 }
 
-export interface TableSectionHeaderV2 {
+export interface TableSectionHeader {
   type: "section-header";
   text: string;
 }
 
-export interface TableHeaderV2 {
+export interface TableHeader {
   type: "header";
   cells: string[];
 }
 
-export interface TableRowV2 {
+export interface TableRow {
   type: "row";
   cells: string[];
 }
 
-export type TableItemV2 =
-  | TableTitleV2
-  | TableSectionHeaderV2
-  | TableHeaderV2
-  | TableRowV2;
+export type TableItem =
+  | TableTitle
+  | TableSectionHeader
+  | TableHeader
+  | TableRow;
 
 /**
  * Formats an array of titles, section headers, headers, and rows into a table
@@ -135,7 +52,7 @@ export type TableItemV2 =
  *
  * @example
  * ```ts
- * formatTableV2([
+ * formatTable([
  *   { type: "title", text: "My Table" },
  *   { type: "section-header", text: "User Data" },
  *   { type: "header", cells: ["Name", "Age", "City"] },
@@ -168,7 +85,7 @@ export type TableItemV2 =
  * // ╚═══════╧═══════════╝
  * ```
  */
-export function formatTableV2(items: TableItemV2[]): string {
+export function formatTable(items: TableItem[]): string {
   if (items.length === 0) {
     return "";
   }

--- a/v-next/hardhat-utils/src/internal/format.ts
+++ b/v-next/hardhat-utils/src/internal/format.ts
@@ -1,4 +1,4 @@
-import type { TableItemV2 } from "../format.js";
+import type { TableItem } from "../format.js";
 
 /**
  * Calculate the display width of a string by removing ANSI escape codes.
@@ -17,7 +17,7 @@ export function getStringWidth(str: string): number {
  * Calculates the minimum width needed by each column in the table
  * to fit its content (accounting for ANSI color codes).
  */
-export function getColumnWidths(items: TableItemV2[]): number[] {
+export function getColumnWidths(items: TableItem[]): number[] {
   const columnWidths: number[] = [];
 
   for (const item of items) {
@@ -53,7 +53,7 @@ export function getContentWidth(columnWidths: number[]): number {
  * Each title/header is padded by 1 space on each side.
  * Accounts for ANSI color codes.
  */
-export function getHeadingWidth(items: TableItemV2[]): number {
+export function getHeadingWidth(items: TableItem[]): number {
   let headingWidth = 0;
   for (const item of items) {
     if (item.type === "section-header" || item.type === "title") {

--- a/v-next/hardhat-utils/test/format.ts
+++ b/v-next/hardhat-utils/test/format.ts
@@ -10,17 +10,11 @@ describe("format", () => {
     });
 
     it("Should create a table with a title", () => {
-      const result = formatTable([
-        { type: "title", text: "My Title" },
-      ]);
+      const result = formatTable([{ type: "title", text: "My Title" }]);
 
       assert.equal(
         result,
-        [
-          "╔══════════╗",
-          "║ My Title ║",
-          "╚══════════╝",
-        ].join("\n"),
+        ["╔══════════╗", "║ My Title ║", "╚══════════╝"].join("\n"),
       );
     });
 
@@ -113,13 +107,18 @@ describe("format", () => {
         { type: "row", cells: ["X", "Y", "Z"] },
       ]);
 
-      assert.ok(
-        result.includes("Very Long Header"),
-        "Should contain the long header",
-      );
-      assert.ok(
-        result.includes("Very Long Content"),
-        "Should contain the long content",
+      assert.equal(
+        result,
+        [
+          "╔══════════════════════════════════════════════╗",
+          "║ Data                                         ║",
+          "╟───────┬──────────────────┬───────────────────╢",
+          "║ A     │ Very Long Header │ C                 ║",
+          "╟───────┼──────────────────┼───────────────────╢",
+          "║ Short │ B                │ Very Long Content ║",
+          "║ X     │ Y                │ Z                 ║",
+          "╚═══════╧══════════════════╧═══════════════════╝",
+        ].join("\n"),
       );
     });
 
@@ -137,13 +136,18 @@ describe("format", () => {
         },
       ]);
 
-      assert.ok(
-        result.includes("\u001b[32mPASS\u001b[0m"),
-        "Should contain ANSI-styled PASS",
-      );
-      assert.ok(
-        result.includes("\u001b[31mFAIL\u001b[0m"),
-        "Should contain ANSI-styled FAIL",
+      assert.equal(
+        result,
+        [
+          "╔══════════════════════╗",
+          "║ Status               ║",
+          "╟────────┬─────────────╢",
+          "║ Result │ Message     ║",
+          "╟────────┼─────────────╢",
+          "║ \u001b[32mPASS\u001b[0m   │ Test passed ║",
+          "║ \u001b[31mFAIL\u001b[0m   │ Test failed ║",
+          "╚════════╧═════════════╝",
+        ].join("\n"),
       );
     });
 
@@ -159,13 +163,127 @@ describe("format", () => {
         { type: "row", cells: ["12345", "567"] },
       ]);
 
-      assert.ok(
-        result.includes("transfer"),
-        "Should contain the function row",
+      assert.equal(
+        result,
+        [
+          "╔════════════════════════════════════════════╗",
+          "║ Contract                                   ║",
+          "╟────────────┬───────┬───────┬───────┬───────╢",
+          "║ Function   │ Min   │ Max   │ Avg   │ Calls ║",
+          "╟────────────┼───────┼───────┼───────┼───────╢",
+          "║ transfer   │ 21000 │ 42000 │ 31500 │ 10    ║",
+          "╟────────────┼───────┼───────┴───────┴───────╢",
+          "║ Deployment │ Cost  │                       ║",
+          "╟────────────┼───────┤                       ║",
+          "║ 12345      │ 567   │                       ║",
+          "╚════════════╧═══════╧═══════════════════════╝",
+        ].join("\n"),
       );
-      assert.ok(
-        result.includes("Deployment"),
-        "Should contain the deployment header",
+    });
+
+    it("Should handle a single column", () => {
+      const result = formatTable([
+        { type: "section-header", text: "Items" },
+        { type: "header", cells: ["Name"] },
+        { type: "row", cells: ["Apple"] },
+        { type: "row", cells: ["Banana"] },
+        { type: "row", cells: ["Cherry"] },
+      ]);
+
+      assert.equal(
+        result,
+        [
+          "╔════════╗",
+          "║ Items  ║",
+          "╟────────╢",
+          "║ Name   ║",
+          "╟────────╢",
+          "║ Apple  ║",
+          "║ Banana ║",
+          "║ Cherry ║",
+          "╚════════╝",
+        ].join("\n"),
+      );
+    });
+
+    it("Should handle empty strings in cells", () => {
+      const result = formatTable([
+        { type: "section-header", text: "Data" },
+        { type: "header", cells: ["Name", "Value"] },
+        { type: "row", cells: ["", "123"] },
+        { type: "row", cells: ["Test", ""] },
+        { type: "row", cells: ["", ""] },
+      ]);
+
+      assert.equal(
+        result,
+        [
+          "╔══════════════╗",
+          "║ Data         ║",
+          "╟──────┬───────╢",
+          "║ Name │ Value ║",
+          "╟──────┼───────╢",
+          "║      │ 123   ║",
+          "║ Test │       ║",
+          "║      │       ║",
+          "╚══════╧═══════╝",
+        ].join("\n"),
+      );
+    });
+
+    it("Should expand last column when section header is wider than content", () => {
+      const result = formatTable([
+        { type: "section-header", text: "A Very Wide Section Header" },
+        { type: "header", cells: ["A", "B"] },
+        { type: "row", cells: ["1", "2"] },
+      ]);
+
+      assert.equal(
+        result,
+        [
+          "╔════════════════════════════╗",
+          "║ A Very Wide Section Header ║",
+          "╟───┬────────────────────────╢",
+          "║ A │ B                      ║",
+          "╟───┼────────────────────────╢",
+          "║ 1 │ 2                      ║",
+          "╚═══╧════════════════════════╝",
+        ].join("\n"),
+      );
+    });
+
+    it("Should close a section when a title appears mid-table", () => {
+      const result = formatTable([
+        { type: "section-header", text: "Section A" },
+        { type: "header", cells: ["X", "Y"] },
+        { type: "row", cells: ["1", "2"] },
+        { type: "title", text: "Break" },
+        { type: "section-header", text: "Section B" },
+        { type: "header", cells: ["X", "Y"] },
+        { type: "row", cells: ["3", "4"] },
+      ]);
+
+      assert.equal(
+        result,
+        [
+          "╔═══════════╗",
+          "║ Section A ║",
+          "╟───┬───────╢",
+          "║ X │ Y     ║",
+          "╟───┼───────╢",
+          "║ 1 │ 2     ║",
+          "╚═══╧═══════╝",
+          "╔═══════════╗",
+          "║   Break   ║",
+          "╚═══════════╝",
+          "╔═══════════╗",
+          "║ Section B ║",
+          "╟───┬───────╢",
+          "║ X │ Y     ║",
+          "╟───┼───────╢",
+          "║ 3 │ 4     ║",
+          "╚═══╧═══════╝",
+        ].join("\n"),
       );
     });
   });

--- a/v-next/hardhat-utils/test/format.ts
+++ b/v-next/hardhat-utils/test/format.ts
@@ -1,174 +1,171 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { formatTable, divider } from "../src/format.js";
+import { formatTable } from "../src/format.js";
 
 describe("format", () => {
   describe("formatTable", () => {
-    it("Should create a basic table with a single divider", () => {
-      const rows = [
-        ["Name", "Age", "City"],
-        divider,
-        ["Alice", "25", "New York"],
-        ["Bob", "30", "London"],
-      ];
-      const result = formatTable(rows);
+    it("Should return an empty string for empty items", () => {
+      assert.equal(formatTable([]), "");
+    });
+
+    it("Should create a table with a title", () => {
+      const result = formatTable([
+        { type: "title", text: "My Title" },
+      ]);
 
       assert.equal(
         result,
-        `
-| Name  | Age | City     |
-| ----- | --- | -------- |
-| Alice | 25  | New York |
-| Bob   | 30  | London   |`.trim(),
+        [
+          "╔══════════╗",
+          "║ My Title ║",
+          "╚══════════╝",
+        ].join("\n"),
       );
     });
 
-    it("Should create a table without dividers", () => {
-      const rows = [
-        ["Alice", "25", "New York"],
-        ["Bob", "30", "London"],
-      ];
-      const result = formatTable(rows);
+    it("Should create a table with a section header, header, and rows", () => {
+      const result = formatTable([
+        { type: "section-header", text: "User Data" },
+        { type: "header", cells: ["Name", "Age"] },
+        { type: "row", cells: ["Alice", "30"] },
+        { type: "row", cells: ["Bob", "25"] },
+      ]);
 
       assert.equal(
         result,
-        `
-| Alice | 25 | New York |
-| Bob   | 30 | London   |`.trim(),
+        [
+          "╔═════════════╗",
+          "║ User Data   ║",
+          "╟───────┬─────╢",
+          "║ Name  │ Age ║",
+          "╟───────┼─────╢",
+          "║ Alice │ 30  ║",
+          "║ Bob   │ 25  ║",
+          "╚═══════╧═════╝",
+        ].join("\n"),
       );
     });
 
-    it("Should create a table with multiple dividers", () => {
-      const rows = [
-        ["Name", "Age"],
-        divider,
-        ["Alice", "25"],
-        ["Bob", "30"],
-        divider,
-        ["Total", "55"],
-      ];
-      const result = formatTable(rows);
+    it("Should create a table with title, section header, header, and rows", () => {
+      const result = formatTable([
+        { type: "title", text: "My Table" },
+        { type: "section-header", text: "User Data" },
+        { type: "header", cells: ["Name", "Age", "City"] },
+        { type: "row", cells: ["Alice", "30", "NYC"] },
+        { type: "row", cells: ["Bob", "25", "LA"] },
+      ]);
 
       assert.equal(
         result,
-        `
-| Name  | Age |
-| ----- | --- |
-| Alice | 25  |
-| Bob   | 30  |
-| ----- | --- |
-| Total | 55  |`.trim(),
+        [
+          "╔════════════════════╗",
+          "║      My Table      ║",
+          "╚════════════════════╝",
+          "╔════════════════════╗",
+          "║ User Data          ║",
+          "╟───────┬─────┬──────╢",
+          "║ Name  │ Age │ City ║",
+          "╟───────┼─────┼──────╢",
+          "║ Alice │ 30  │ NYC  ║",
+          "║ Bob   │ 25  │ LA   ║",
+          "╚═══════╧═════╧══════╝",
+        ].join("\n"),
+      );
+    });
+
+    it("Should handle multiple sections", () => {
+      const result = formatTable([
+        { type: "section-header", text: "Section A" },
+        { type: "header", cells: ["Name", "Value"] },
+        { type: "row", cells: ["x", "1"] },
+        { type: "section-header", text: "Section B" },
+        { type: "header", cells: ["Name", "Value"] },
+        { type: "row", cells: ["y", "2"] },
+      ]);
+
+      assert.equal(
+        result,
+        [
+          "╔══════════════╗",
+          "║ Section A    ║",
+          "╟──────┬───────╢",
+          "║ Name │ Value ║",
+          "╟──────┼───────╢",
+          "║ x    │ 1     ║",
+          "╚══════╧═══════╝",
+          "╔══════════════╗",
+          "║ Section B    ║",
+          "╟──────┬───────╢",
+          "║ Name │ Value ║",
+          "╟──────┼───────╢",
+          "║ y    │ 2     ║",
+          "╚══════╧═══════╝",
+        ].join("\n"),
       );
     });
 
     it("Should handle varying column widths", () => {
-      const rows = [
-        ["A", "Very Long Header", "C"],
-        divider,
-        ["Short", "B", "Very Long Content"],
-        ["X", "Y", "Z"],
-      ];
-      const result = formatTable(rows);
+      const result = formatTable([
+        { type: "section-header", text: "Data" },
+        { type: "header", cells: ["A", "Very Long Header", "C"] },
+        { type: "row", cells: ["Short", "B", "Very Long Content"] },
+        { type: "row", cells: ["X", "Y", "Z"] },
+      ]);
 
-      assert.equal(
-        result,
-        `
-| A     | Very Long Header | C                 |
-| ----- | ---------------- | ----------------- |
-| Short | B                | Very Long Content |
-| X     | Y                | Z                 |`.trim(),
+      assert.ok(
+        result.includes("Very Long Header"),
+        "Should contain the long header",
       );
-    });
-
-    it("Should handle rows with different lengths", () => {
-      const rows = [
-        ["A", "B", "C", "D"],
-        divider,
-        ["1", "2"],
-        ["3", "4", "5"],
-        ["6", "7", "8", "9"],
-      ];
-      const result = formatTable(rows);
-
-      assert.equal(
-        result,
-        `
-| A | B | C | D |
-| - | - | - | - |
-| 1 | 2 |   |   |
-| 3 | 4 | 5 |   |
-| 6 | 7 | 8 | 9 |`.trim(),
-      );
-    });
-
-    it("Should handle single column table", () => {
-      const rows = [["Items"], divider, ["Apple"], ["Banana"], ["Cherry"]];
-      const result = formatTable(rows);
-
-      assert.equal(
-        result,
-        `
-| Items  |
-| ------ |
-| Apple  |
-| Banana |
-| Cherry |`.trim(),
-      );
-    });
-
-    it("Should handle empty strings in cells", () => {
-      const rows = [
-        ["Name", "Value"],
-        divider,
-        ["", "123"],
-        ["Test", ""],
-        ["", ""],
-      ];
-      const result = formatTable(rows);
-
-      assert.equal(
-        result,
-        `
-| Name | Value |
-| ---- | ----- |
-|      | 123   |
-| Test |       |
-|      |       |`.trim(),
+      assert.ok(
+        result.includes("Very Long Content"),
+        "Should contain the long content",
       );
     });
 
     it("Should handle ANSI escape codes in content", () => {
-      const rows = [
-        ["Status", "Message"],
-        divider,
-        ["\u001b[32mPASS\u001b[0m", "Test passed"],
-        ["\u001b[31mFAIL\u001b[0m", "Test failed"],
-      ];
-      const result = formatTable(rows);
+      const result = formatTable([
+        { type: "section-header", text: "Status" },
+        { type: "header", cells: ["Result", "Message"] },
+        {
+          type: "row",
+          cells: ["\u001b[32mPASS\u001b[0m", "Test passed"],
+        },
+        {
+          type: "row",
+          cells: ["\u001b[31mFAIL\u001b[0m", "Test failed"],
+        },
+      ]);
 
-      assert.equal(
-        result,
-        `
-| Status | Message     |
-| ------ | ----------- |
-| \u001b[32mPASS\u001b[0m   | Test passed |
-| \u001b[31mFAIL\u001b[0m   | Test failed |`.trim(),
+      assert.ok(
+        result.includes("\u001b[32mPASS\u001b[0m"),
+        "Should contain ANSI-styled PASS",
+      );
+      assert.ok(
+        result.includes("\u001b[31mFAIL\u001b[0m"),
+        "Should contain ANSI-styled FAIL",
       );
     });
 
-    it("Should handle mixed ANSI and regular content", () => {
-      const rows = [
-        ["Normal", "\u001b[1mBold\u001b[0m", "Regular"],
-        ["\u001b[33mYellow\u001b[0m", "Plain", "\u001b[4mUnderline\u001b[0m"],
-      ];
-      const result = formatTable(rows);
+    it("Should handle headers with different cell counts", () => {
+      const result = formatTable([
+        { type: "section-header", text: "Contract" },
+        {
+          type: "header",
+          cells: ["Function", "Min", "Max", "Avg", "Calls"],
+        },
+        { type: "row", cells: ["transfer", "21000", "42000", "31500", "10"] },
+        { type: "header", cells: ["Deployment", "Cost"] },
+        { type: "row", cells: ["12345", "567"] },
+      ]);
 
-      assert.equal(
-        result,
-        `
-| Normal | \u001b[1mBold\u001b[0m  | Regular   |
-| \u001b[33mYellow\u001b[0m | Plain | \u001b[4mUnderline\u001b[0m |`.trim(),
+      assert.ok(
+        result.includes("transfer"),
+        "Should contain the function row",
+      );
+      assert.ok(
+        result.includes("Deployment"),
+        "Should contain the deployment header",
       );
     });
   });

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -8,7 +8,7 @@ import type { TableItem } from "@nomicfoundation/hardhat-utils/format";
 
 import path from "node:path";
 
-import { divider, formatTable } from "@nomicfoundation/hardhat-utils/format";
+import { formatTable } from "@nomicfoundation/hardhat-utils/format";
 import {
   ensureDir,
   getAllFilesMatching,
@@ -433,55 +433,60 @@ export class CoverageManagerImplementation implements CoverageManager {
 
     const rows: TableItem[] = [];
 
-    rows.push([chalk.bold("Coverage Report")]);
-    rows.push(divider);
+    rows.push({
+      type: "title",
+      text: chalk.bold("Coverage Report"),
+    });
 
-    rows.push(
-      ["File Path", "Line %", "Statement %", "Uncovered Lines"].map((s) =>
-        chalk.yellow(s),
+    rows.push({
+      type: "section-header",
+      text: chalk.bold("File Coverage"),
+    });
+
+    rows.push({
+      type: "header",
+      cells: ["File Path", "Line %", "Statement %", "Uncovered Lines"].map(
+        (s) => chalk.yellow(s),
       ),
-    );
+    });
 
-    const bodyRows = Object.entries(report).map(
-      ([
-        relativePath,
-        {
-          executedStatementsCount,
-          unexecutedStatementsCount,
-          lineExecutionCounts,
-          executedLinesCount,
-          unexecutedLines,
-        },
-      ]) => {
-        const lineCoverage =
-          lineExecutionCounts.size === 0
-            ? 0
-            : (executedLinesCount * 100.0) / lineExecutionCounts.size;
-        const statementCoverage =
-          executedStatementsCount === 0
-            ? 0
-            : (executedStatementsCount * 100.0) /
-              (executedStatementsCount + unexecutedStatementsCount);
+    for (const [
+      relativePath,
+      {
+        executedStatementsCount,
+        unexecutedStatementsCount,
+        lineExecutionCounts,
+        executedLinesCount,
+        unexecutedLines,
+      },
+    ] of Object.entries(report)) {
+      const lineCoverage =
+        lineExecutionCounts.size === 0
+          ? 0
+          : (executedLinesCount * 100.0) / lineExecutionCounts.size;
+      const statementCoverage =
+        executedStatementsCount === 0
+          ? 0
+          : (executedStatementsCount * 100.0) /
+            (executedStatementsCount + unexecutedStatementsCount);
 
-        totalExecutedLines += executedLinesCount;
-        totalExecutableLines += lineExecutionCounts.size;
+      totalExecutedLines += executedLinesCount;
+      totalExecutableLines += lineExecutionCounts.size;
 
-        totalExecutedStatements += executedStatementsCount;
-        totalExecutableStatements +=
-          executedStatementsCount + unexecutedStatementsCount;
+      totalExecutedStatements += executedStatementsCount;
+      totalExecutableStatements +=
+        executedStatementsCount + unexecutedStatementsCount;
 
-        const row: string[] = [
+      rows.push({
+        type: "row",
+        cells: [
           this.formatRelativePath(relativePath),
           this.formatCoverage(lineCoverage),
           this.formatCoverage(statementCoverage),
           this.formatLines(unexecutedLines),
-        ];
-
-        return row;
-      },
-    );
-
-    rows.push(...bodyRows);
+        ],
+      });
+    }
 
     const totalLineCoverage =
       totalExecutableLines === 0
@@ -492,13 +497,15 @@ export class CoverageManagerImplementation implements CoverageManager {
         ? 0
         : (totalExecutedStatements * 100.0) / totalExecutableStatements;
 
-    rows.push(divider);
-    rows.push([
-      chalk.yellow("Total"),
-      this.formatCoverage(totalLineCoverage),
-      this.formatCoverage(totalStatementCoverage),
-      "",
-    ]);
+    rows.push({
+      type: "header",
+      cells: [
+        chalk.yellow("Total"),
+        this.formatCoverage(totalLineCoverage),
+        this.formatCoverage(totalStatementCoverage),
+        "",
+      ],
+    });
 
     return formatTable(rows);
   }

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -1,10 +1,10 @@
 import type { GasAnalyticsManager, GasMeasurement } from "./types.js";
-import type { TableItemV2 } from "@nomicfoundation/hardhat-utils/format";
+import type { TableItem } from "@nomicfoundation/hardhat-utils/format";
 
 import crypto from "node:crypto";
 import path from "node:path";
 
-import { formatTableV2 } from "@nomicfoundation/hardhat-utils/format";
+import { formatTable } from "@nomicfoundation/hardhat-utils/format";
 import {
   ensureDir,
   getAllFilesMatching,
@@ -209,7 +209,7 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
   public _generateGasStatsReport(
     gasStatsByContract: GasStatsByContract,
   ): string {
-    const rows: TableItemV2[] = [];
+    const rows: TableItem[] = [];
 
     if (gasStatsByContract.size > 0) {
       rows.push({ type: "title", text: chalk.bold("Gas Usage Statistics") });
@@ -279,7 +279,7 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
       }
     }
 
-    return formatTableV2(rows);
+    return formatTable(rows);
   }
 }
 

--- a/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -304,17 +304,52 @@ describe("CoverageManagerImplementation", () => {
   it("should format the markdown report", async () => {
     const actual = coverageManager.formatMarkdownReport(report);
 
-    const expected = [
-      `| ${chalk.bold("Coverage Report")}     |        |             |                 |`,
-      "| ------------------- | ------ | ----------- | --------------- |",
-      `| ${chalk.yellow("File Path")}           | ${chalk.yellow("Line %")} | ${chalk.yellow("Statement %")} | ${chalk.yellow("Uncovered Lines")} |`,
-      "| contracts/test.sol  | 80.00  | 75.00       | 6               |",
-      "| contracts/other.sol | 0.00   | 0.00        | 1-2             |",
-      "| ------------------- | ------ | ----------- | --------------- |",
-      `| ${chalk.yellow("Total")}               | 57.14  | 50.00       |                 |`,
-    ].join("\n");
-
-    assert.equal(actual, expected);
+    // The report now uses formatTable (formerly formatTableV2) with box-drawing characters
+    assert.ok(
+      actual.includes("Coverage Report"),
+      "Should contain the title",
+    );
+    assert.ok(
+      actual.includes("File Coverage"),
+      "Should contain the section header",
+    );
+    assert.ok(
+      actual.includes("contracts/test.sol"),
+      "Should contain the test.sol file path",
+    );
+    assert.ok(
+      actual.includes("contracts/other.sol"),
+      "Should contain the other.sol file path",
+    );
+    assert.ok(
+      actual.includes("80.00"),
+      "Should contain the line coverage for test.sol",
+    );
+    assert.ok(
+      actual.includes("75.00"),
+      "Should contain the statement coverage for test.sol",
+    );
+    assert.ok(
+      actual.includes("0.00"),
+      "Should contain the zero coverage for other.sol",
+    );
+    assert.ok(
+      actual.includes("57.14"),
+      "Should contain the total line coverage",
+    );
+    assert.ok(
+      actual.includes("50.00"),
+      "Should contain the total statement coverage",
+    );
+    // Verify box-drawing characters are used (V2 format)
+    assert.ok(
+      actual.includes("╔"),
+      "Should use box-drawing characters",
+    );
+    assert.ok(
+      actual.includes("║"),
+      "Should use box-drawing border characters",
+    );
   });
 
   const expectedRelativePath: Array<[string, string]> = [

--- a/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -302,54 +302,33 @@ describe("CoverageManagerImplementation", () => {
   });
 
   it("should format the markdown report", async () => {
-    const actual = coverageManager.formatMarkdownReport(report);
+    const originalChalkLevel = chalk.level;
+    chalk.level = 0;
 
-    // The report now uses formatTable (formerly formatTableV2) with box-drawing characters
-    assert.ok(
-      actual.includes("Coverage Report"),
-      "Should contain the title",
-    );
-    assert.ok(
-      actual.includes("File Coverage"),
-      "Should contain the section header",
-    );
-    assert.ok(
-      actual.includes("contracts/test.sol"),
-      "Should contain the test.sol file path",
-    );
-    assert.ok(
-      actual.includes("contracts/other.sol"),
-      "Should contain the other.sol file path",
-    );
-    assert.ok(
-      actual.includes("80.00"),
-      "Should contain the line coverage for test.sol",
-    );
-    assert.ok(
-      actual.includes("75.00"),
-      "Should contain the statement coverage for test.sol",
-    );
-    assert.ok(
-      actual.includes("0.00"),
-      "Should contain the zero coverage for other.sol",
-    );
-    assert.ok(
-      actual.includes("57.14"),
-      "Should contain the total line coverage",
-    );
-    assert.ok(
-      actual.includes("50.00"),
-      "Should contain the total statement coverage",
-    );
-    // Verify box-drawing characters are used (V2 format)
-    assert.ok(
-      actual.includes("╔"),
-      "Should use box-drawing characters",
-    );
-    assert.ok(
-      actual.includes("║"),
-      "Should use box-drawing border characters",
-    );
+    try {
+      const actual = coverageManager.formatMarkdownReport(report);
+
+      assert.equal(
+        actual,
+        [
+          "╔══════════════════════════════════════════════════════════════╗",
+          "║                       Coverage Report                        ║",
+          "╚══════════════════════════════════════════════════════════════╝",
+          "╔══════════════════════════════════════════════════════════════╗",
+          "║ File Coverage                                                ║",
+          "╟─────────────────────┬────────┬─────────────┬─────────────────╢",
+          "║ File Path           │ Line % │ Statement % │ Uncovered Lines ║",
+          "╟─────────────────────┼────────┼─────────────┼─────────────────╢",
+          "║ contracts/test.sol  │ 80.00  │ 75.00       │ 6               ║",
+          "║ contracts/other.sol │ 0.00   │ 0.00        │ 1-2             ║",
+          "╟─────────────────────┼────────┼─────────────┼─────────────────╢",
+          "║ Total               │ 57.14  │ 50.00       │                 ║",
+          "╚═════════════════════╧════════╧═════════════╧═════════════════╝",
+        ].join("\n"),
+      );
+    } finally {
+      chalk.level = originalChalkLevel;
+    }
   });
 
   const expectedRelativePath: Array<[string, string]> = [


### PR DESCRIPTION
Migrate coverage report from the old markdown-style formatTable to the box-drawing formatTableV2. Remove old formatTable, rename formatTableV2 to formatTable, and update all types, imports, and tests accordingly.

Closes #7733

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

### Changes

- **`hardhat-utils/src/format.ts`** — Removed old `formatTable`, `TableRow`, `TableDivider`, `TableItem`, `divider`. Renamed `formatTableV2` → `formatTable` and all V2 types (`TableTitleV2` → `TableTitle`, etc.)
- **`hardhat-utils/src/internal/format.ts`** — Updated type imports from `TableItemV2` → `TableItem`
- **`hardhat/src/.../coverage/coverage-manager.ts`** — Migrated `formatMarkdownReport` to use the new `formatTable` API (title, section-header, header, row items)
- **`hardhat/src/.../gas-analytics/gas-analytics-manager.ts`** — Updated imports from V2 names to final names
- **`hardhat-utils/test/format.ts`** — Replaced old markdown-style tests with 8 new box-drawing format tests
- **`hardhat/test/.../coverage/coverage-manager.ts`** — Updated expected output assertions for the new format

### Before / After

Old (markdown-style):
```
    | Coverage Report     |        |             |                 |
    | ------------------- | ------ | ----------- | --------------- |
    | File Path           | Line % | Statement % | Uncovered Lines |
    | contracts/test.sol  | 80.00  | 75.00       | 6               |
```

New (box-drawing):
```
    ╔══════════════════════════════════════════════════════════════╗
    ║                       Coverage Report                        ║
    ╚══════════════════════════════════════════════════════════════╝
    ╔══════════════════════════════════════════════════════════════╗
    ║ File Coverage                                                ║
    ╟─────────────────────┬────────┬─────────────┬─────────────────╢
    ║ File Path           │ Line % │ Statement % │ Uncovered Lines ║
    ╟─────────────────────┼────────┼─────────────┼─────────────────╢
    ║ contracts/test.sol  │ 80.00  │ 75.00       │ 6               ║
```

