### PR TITLE
chore: reenabe caching in macos runners

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -38,8 +38,7 @@ runs:
       shell: bash
     - uses: actions/cache/restore@v4
       id: cache-restore
-      # TODO: remove OS check when https://github.com/actions/runner-images/issues/13341 is resolved
-      if: inputs.cache-save == 'false' && runner.os != 'macOS'
+      if: inputs.cache-save == 'false'
       with:
         path: ${{ steps.pnpm.outputs.path }}
         key: node-cache-${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
This was disabled due to this issue: https://github.com/actions/runner-images/issues/13341

That issue is now resolved so we are re-enabling the macos caching.

Resolves #7714.