### PR TITLE
Convert `action` to `lazyAction`

### DIFF
--- a/v-next/example-project/hardhat.config.ts
+++ b/v-next/example-project/hardhat.config.ts
@@ -24,7 +24,7 @@ const exampleEmptyTask = emptyTask("empty", "An example empty task").build();
 
 const exampleEmptySubtask = task(["empty", "task"])
   .setDescription("An example empty subtask task")
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: async (_, _hre) => {
       console.log("empty task");
     },
@@ -32,7 +32,7 @@ const exampleEmptySubtask = task(["empty", "task"])
   .build();
 
 const exampleTaskOverride = task("example2")
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: async (_, _hre) => {
       console.log("from an override");
     },
@@ -76,7 +76,7 @@ const greeting = task("hello", "Print a greeting")
     defaultValue: false,
     hidden: true,
   })
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: async ({ greeting }, _) => {
       console.log(greeting);
     },
@@ -84,7 +84,7 @@ const greeting = task("hello", "Print a greeting")
   .build();
 
 const printConfig = task("config", "Print the config")
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: async ({}, hre) => {
       console.log(util.inspect(hre.config, { colors: true, depth: null }));
     },
@@ -92,7 +92,7 @@ const printConfig = task("config", "Print the config")
   .build();
 
 const printAccounts = task("accounts", "Print the accounts")
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: async ({}, hre) => {
       const { provider } = await hre.network.connect();
       console.log(await provider.request({ method: "eth_accounts" }));
@@ -109,7 +109,7 @@ const pluginExample = {
         description: "The greeting to print",
         defaultValue: "Hello, World from community-plugin!",
       })
-      .setAction(async () => ({
+      .setLazyAction(async () => ({
         default: async ({ greeting }, _) => {
           console.log(greeting);
 

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -559,12 +559,12 @@ Please install a version of the peer dependency that meets the plugin's requirem
       },
     },
     TASK_DEFINITIONS: {
-      INVALID_FILE_ACTION: {
+      INVALID_LAZY_ACTION: {
         number: 400,
         messageTemplate:
           "Invalid file action: {action} is not a valid file URL",
         websiteTitle: "Invalid file action",
-        websiteDescription: `The setAction function was called with a string parameter that is not a valid file URL. A valid file URL must start with 'file://'.
+        websiteDescription: `The setLazyAction function was called with a string parameter that is not a valid file URL. A valid file URL must start with 'file://'.
 
 Please ensure that you are providing a correct file URL.`,
       },
@@ -704,9 +704,9 @@ Please define the action in a separate file and reference it.`,
       },
       ACTION_ALREADY_SET: {
         number: 418,
-        messageTemplate: `The action for task "{task}" has already been set. You can only call "setAction" or "setInlineAction" once per task definition.`,
+        messageTemplate: `The action for task "{task}" has already been set. You can only call "setLazyAction" or "setInlineAction" once per task definition.`,
         websiteTitle: "Task action already set",
-        websiteDescription: `A task definition can only have one action. You cannot call "setAction" or "setInlineAction" more than once on the same task builder.
+        websiteDescription: `A task definition can only have one action. You cannot call "setLazyAction" or "setInlineAction" more than once on the same task builder.
 
 Please remove the duplicate call.`,
       },

--- a/v-next/hardhat-ignition/src/index.ts
+++ b/v-next/hardhat-ignition/src/index.ts
@@ -63,7 +63,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         description:
           "Write deployment information to disk when deploying to the in-memory network",
       })
-      .setAction(() => import("./internal/tasks/deploy.js"))
+      .setLazyAction(() => import("./internal/tasks/deploy.js"))
       .build(),
     task(["ignition", "status"], "Show the current status of a deployment")
       .addPositionalArgument({
@@ -71,10 +71,10 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "The id of the deployment to show",
       })
-      .setAction(() => import("./internal/tasks/status.js"))
+      .setLazyAction(() => import("./internal/tasks/status.js"))
       .build(),
     task(["ignition", "deployments"], "List all deployment IDs")
-      .setAction(() => import("./internal/tasks/deployments.js"))
+      .setLazyAction(() => import("./internal/tasks/deployments.js"))
       .build(),
     task(
       ["ignition", "transactions"],
@@ -85,7 +85,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "The id of the deployment to show transactions for",
       })
-      .setAction(() => import("./internal/tasks/transactions.js"))
+      .setLazyAction(() => import("./internal/tasks/transactions.js"))
       .build(),
     task(["ignition", "wipe"], "Reset a deployment's future to allow rerunning")
       .addPositionalArgument({
@@ -98,7 +98,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "The id of the future to wipe",
       })
-      .setAction(() => import("./internal/tasks/wipe.js"))
+      .setLazyAction(() => import("./internal/tasks/wipe.js"))
       .build(),
     task(["ignition", "visualize"], "Visualize a module as an HTML report")
       .addPositionalArgument({
@@ -110,7 +110,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         name: "noOpen",
         description: "Disables opening report in browser",
       })
-      .setAction(() => import("./internal/tasks/visualize.js"))
+      .setLazyAction(() => import("./internal/tasks/visualize.js"))
       .build(),
 
     task(
@@ -126,7 +126,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         name: "force",
         description: "Force verification",
       })
-      .setAction(() => import("./internal/tasks/verify.js"))
+      .setLazyAction(() => import("./internal/tasks/verify.js"))
       .build(),
     task(
       ["ignition", "track-tx"],
@@ -142,7 +142,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "The id of the deployment to add the tx to",
       })
-      .setAction(() => import("./internal/tasks/track-tx.js"))
+      .setLazyAction(() => import("./internal/tasks/track-tx.js"))
       .build(),
     task(
       ["ignition", "migrate"],
@@ -153,7 +153,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "The id of the deployment to migrate",
       })
-      .setAction(() => import("./internal/tasks/migrate.js"))
+      .setLazyAction(() => import("./internal/tasks/migrate.js"))
       .build(),
   ],
 };

--- a/v-next/hardhat-ignition/test/deploy/build-profile.ts
+++ b/v-next/hardhat-ignition/test/deploy/build-profile.ts
@@ -28,7 +28,7 @@ describe("build profile", function () {
         plugins: [hardhatIgnitionPlugin],
         tasks: [
           overrideTask("build")
-            .setAction(async () => ({
+            .setLazyAction(async () => ({
               default: async (args, _hre, runSuper) => {
                 defaultBuildProfile = args.defaultBuildProfile;
 

--- a/v-next/hardhat-keystore/src/index.ts
+++ b/v-next/hardhat-keystore/src/index.ts
@@ -35,7 +35,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         description:
           "Use the development keystore instead of the production one",
       })
-      .setAction(() => import("./internal/tasks/set.js"))
+      .setLazyAction(() => import("./internal/tasks/set.js"))
       .build(),
 
     task(["keystore", "get"], "Get a value given a key")
@@ -49,7 +49,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "Specify the key to retrieve the value for",
       })
-      .setAction(() => import("./internal/tasks/get.js"))
+      .setLazyAction(() => import("./internal/tasks/get.js"))
       .build(),
 
     task(["keystore", "list"], "List all keys in the keystore")
@@ -58,7 +58,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         description:
           "Use the development keystore instead of the production one",
       })
-      .setAction(() => import("./internal/tasks/list.js"))
+      .setLazyAction(() => import("./internal/tasks/list.js"))
       .build(),
 
     task(["keystore", "delete"], "Delete a key from the keystore")
@@ -77,7 +77,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         description:
           "Force to not throw an error if the key does not exist during deletion.",
       })
-      .setAction(() => import("./internal/tasks/delete.js"))
+      .setLazyAction(() => import("./internal/tasks/delete.js"))
       .build(),
 
     task(["keystore", "path"], "Display the path where the keystore is stored")
@@ -86,7 +86,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         description:
           "Use the development keystore instead of the production one",
       })
-      .setAction(() => import("./internal/tasks/path.js"))
+      .setLazyAction(() => import("./internal/tasks/path.js"))
       .build(),
 
     task(
@@ -98,7 +98,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         description:
           "Use the development keystore instead of the production one",
       })
-      .setAction(() => import("./internal/tasks/change-password.js"))
+      .setLazyAction(() => import("./internal/tasks/change-password.js"))
       .build(),
   ],
   npmPackage: "@nomicfoundation/hardhat-keystore",

--- a/v-next/hardhat-mocha/src/index.ts
+++ b/v-next/hardhat-mocha/src/index.ts
@@ -28,7 +28,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "noCompile",
         description: "Don't compile the project before running the tests",
       })
-      .setAction(() => import("./task-action.js"))
+      .setLazyAction(() => import("./task-action.js"))
       .build(),
   ],
   hookHandlers: {

--- a/v-next/hardhat-node-test-runner/src/index.ts
+++ b/v-next/hardhat-node-test-runner/src/index.ts
@@ -36,7 +36,7 @@ const hardhatPlugin: HardhatPlugin = {
         defaultValue: 0,
         hidden: true,
       })
-      .setAction(() => import("./task-action.js"))
+      .setLazyAction(() => import("./task-action.js"))
       .build(),
   ],
   hookHandlers: {

--- a/v-next/hardhat-verify/src/internal/tasks/verify/blockscout/index.ts
+++ b/v-next/hardhat-verify/src/internal/tasks/verify/blockscout/index.ts
@@ -7,7 +7,7 @@ import { extendWithVerificationArgs } from "../utils.js";
 const verifyBlockscoutTask: PluginTaskDefinition = extendWithVerificationArgs(
   task(["verify", "blockscout"], "Verify a contract on Blockscout"),
 )
-  .setAction(() => import("./task-action.js"))
+  .setLazyAction(() => import("./task-action.js"))
   .build();
 
 export default verifyBlockscoutTask;

--- a/v-next/hardhat-verify/src/internal/tasks/verify/etherscan/index.ts
+++ b/v-next/hardhat-verify/src/internal/tasks/verify/etherscan/index.ts
@@ -7,7 +7,7 @@ import { extendWithVerificationArgs } from "../utils.js";
 const verifyEtherscanTask: PluginTaskDefinition = extendWithVerificationArgs(
   task(["verify", "etherscan"], "Verify a contract on Etherscan"),
 )
-  .setAction(() => import("./task-action.js"))
+  .setLazyAction(() => import("./task-action.js"))
   .build();
 
 export default verifyEtherscanTask;

--- a/v-next/hardhat-verify/src/internal/tasks/verify/index.ts
+++ b/v-next/hardhat-verify/src/internal/tasks/verify/index.ts
@@ -9,7 +9,7 @@ const verifyTask: PluginTaskDefinition = extendWithSourcifyArgs(
     task("verify", "Verify a contract on all supported explorers"),
   ),
 )
-  .setAction(() => import("./task-action.js"))
+  .setLazyAction(() => import("./task-action.js"))
   .build();
 
 export default verifyTask;

--- a/v-next/hardhat-verify/src/internal/tasks/verify/sourcify/index.ts
+++ b/v-next/hardhat-verify/src/internal/tasks/verify/sourcify/index.ts
@@ -13,7 +13,7 @@ const verifySourcifyTask: PluginTaskDefinition = extendWithSourcifyArgs(
   ),
   false,
 )
-  .setAction(() => import("./task-action.js"))
+  .setLazyAction(() => import("./task-action.js"))
   .build();
 
 export default verifySourcifyTask;

--- a/v-next/hardhat/src/internal/builtin-plugins/clean/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/clean/index.ts
@@ -12,7 +12,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "global",
         description: "Clear the global cache",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setLazyAction(async () => import("./task-action.js"))
       .build(),
   ],
   npmPackage: "hardhat",

--- a/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -20,7 +20,7 @@ const hardhatPlugin: HardhatPlugin = {
         description: "Commands to run when the console starts",
         defaultValue: [],
       })
-      .setAction(async () => import("./task-action.js"))
+      .setLazyAction(async () => import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../solidity/index.js")],

--- a/v-next/hardhat/src/internal/builtin-plugins/flatten/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/flatten/index.ts
@@ -14,7 +14,7 @@ const hardhatPlugin: HardhatPlugin = {
         description: "An optional list of files to flatten",
         type: ArgumentType.FILE,
       })
-      .setAction(async () => import("./task-action.js"))
+      .setLazyAction(async () => import("./task-action.js"))
       .build(),
   ],
 };

--- a/v-next/hardhat/src/internal/builtin-plugins/node/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/node/index.ts
@@ -46,7 +46,7 @@ const hardhatPlugin: HardhatPlugin = {
         type: ArgumentType.INT,
         defaultValue: -1,
       })
-      .setAction(async () => import("./task-action.js"))
+      .setLazyAction(async () => import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../network-manager/index.js")],

--- a/v-next/hardhat/src/internal/builtin-plugins/run/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/run/index.ts
@@ -14,7 +14,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "noCompile",
         description: "Do not compile the project before running the script",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setLazyAction(async () => import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../solidity/index.js")],

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -49,7 +49,7 @@ const hardhatPlugin: HardhatPlugin = {
         defaultValue: 0,
         hidden: true,
       })
-      .setAction(async () => import("./task-action.js"))
+      .setLazyAction(async () => import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/index.ts
@@ -32,7 +32,7 @@ const buildTask = task("build", "Build project")
     name: "noContracts",
     description: "Skip solidity contracts compilation",
   })
-  .setAction(async () => import("./tasks/build.js"))
+  .setLazyAction(async () => import("./tasks/build.js"))
   .build();
 
 const hardhatPlugin: HardhatPlugin = {

--- a/v-next/hardhat/src/internal/builtin-plugins/telemetry/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/telemetry/index.ts
@@ -14,7 +14,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "disable",
         description: "Disable telemetry",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setLazyAction(async () => import("./task-action.js"))
       .build(),
   ],
   npmPackage: "hardhat",

--- a/v-next/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -39,7 +39,7 @@ const hardhatPlugin: HardhatPlugin = {
         description: "Verbosity level of the test output",
         defaultValue: DEFAULT_VERBOSITY,
       })
-      .setAction(async () => import("./task-action.js"))
+      .setLazyAction(async () => import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../solidity/index.js")],

--- a/v-next/hardhat/src/internal/core/config-validation.ts
+++ b/v-next/hardhat/src/internal/core/config-validation.ts
@@ -339,33 +339,33 @@ export function validateTaskOverride(
 }
 
 function validateActionFields(
-  task: { action?: unknown; inlineAction?: unknown },
+  task: { lazyAction?: unknown; inlineAction?: unknown },
   path: Array<string | number>,
 ): HardhatUserConfigValidationError[] {
   const validationErrors: HardhatUserConfigValidationError[] = [];
 
-  // Mutual exclusivity: cannot have both action and inlineAction
-  if (task.action !== undefined && task.inlineAction !== undefined) {
+  // Mutual exclusivity: cannot have both lazyAction and inlineAction
+  if (task.lazyAction !== undefined && task.inlineAction !== undefined) {
     validationErrors.push({
       path: [...path],
-      message: 'task cannot define both "action" and "inlineAction"',
+      message: 'task cannot define both "lazyAction" and "inlineAction"',
     });
   }
 
   // At least one action must be defined
-  if (task.action === undefined && task.inlineAction === undefined) {
+  if (task.lazyAction === undefined && task.inlineAction === undefined) {
     validationErrors.push({
-      path: [...path, "action"],
-      message: 'task must define either "action" or "inlineAction"',
+      path: [...path, "lazyAction"],
+      message: 'task must define either "lazyAction" or "inlineAction"',
     });
   }
 
-  if (task.action !== undefined) {
-    if (typeof task.action !== "function") {
+  if (task.lazyAction !== undefined) {
+    if (typeof task.lazyAction !== "function") {
       validationErrors.push({
-        path: [...path, "action"],
+        path: [...path, "lazyAction"],
         message:
-          "task action must be a lazy import function returning a module with a default export",
+          "task lazyAction must be a lazy import function returning a module with a default export",
       });
     }
   }

--- a/v-next/hardhat/src/internal/core/tasks/builders.ts
+++ b/v-next/hardhat/src/internal/core/tasks/builders.ts
@@ -70,7 +70,7 @@ export class NewTaskDefinitionBuilderImplementation<
 
   #description: string;
 
-  #action?: LazyActionObject<NewTaskActionFunction<TaskArgumentsT>>;
+  #lazyAction?: LazyActionObject<NewTaskActionFunction<TaskArgumentsT>>;
   #inlineAction?: NewTaskActionFunction<TaskArgumentsT>;
 
   constructor(id: string | string[], description: string = "") {
@@ -85,12 +85,12 @@ export class NewTaskDefinitionBuilderImplementation<
     return this;
   }
 
-  public setAction(
-    action: LazyActionObject<NewTaskActionFunction<TaskArgumentsT>>,
+  public setLazyAction(
+    lazyAction: LazyActionObject<NewTaskActionFunction<TaskArgumentsT>>,
   ): NewTaskDefinitionBuilder<TaskArgumentsT, "LAZY_ACTION"> {
     this.#ensureNoActionSet();
 
-    this.#action = action;
+    this.#lazyAction = lazyAction;
 
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     -- Cast to update the ActionTypeT to the expected type for this scenario. */
@@ -226,12 +226,12 @@ export class NewTaskDefinitionBuilderImplementation<
   public build(): ActionTypeT extends "LAZY_ACTION"
     ? Extract<
         NewTaskDefinition,
-        { action: LazyActionObject<NewTaskActionFunction> }
+        { lazyAction: LazyActionObject<NewTaskActionFunction> }
       >
     : ActionTypeT extends "INLINE_ACTION"
       ? Extract<NewTaskDefinition, { inlineAction: NewTaskActionFunction }>
       : never {
-    if (this.#action === undefined && this.#inlineAction === undefined) {
+    if (this.#lazyAction === undefined && this.#inlineAction === undefined) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.TASK_DEFINITIONS.NO_ACTION,
         {
@@ -248,18 +248,18 @@ export class NewTaskDefinitionBuilderImplementation<
       id: this.#id,
       description: this.#description,
       /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      -- The type of the action is narrowed in the setAction function or setInlineAction to
+      -- The type of the action is narrowed in the setLazyAction function or setInlineAction to
       improve the argument types. Once the task is built, we use the more
       general type to avoid having to parameterize the NewTaskDefinition */
-      ...((this.#action !== undefined
-        ? { action: this.#action }
+      ...((this.#lazyAction !== undefined
+        ? { lazyAction: this.#lazyAction }
         : { inlineAction: this.#inlineAction }) as TaskAction),
       options: this.#options,
       positionalArguments: this.#positionalArgs,
     } as ActionTypeT extends "LAZY_ACTION"
       ? Extract<
           NewTaskDefinition,
-          { action: LazyActionObject<NewTaskActionFunction> }
+          { lazyAction: LazyActionObject<NewTaskActionFunction> }
         >
       : ActionTypeT extends "INLINE_ACTION"
         ? Extract<NewTaskDefinition, { inlineAction: NewTaskActionFunction }>
@@ -317,7 +317,7 @@ export class NewTaskDefinitionBuilderImplementation<
   }
 
   #ensureNoActionSet(): void {
-    if (this.#action !== undefined || this.#inlineAction !== undefined) {
+    if (this.#lazyAction !== undefined || this.#inlineAction !== undefined) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.TASK_DEFINITIONS.ACTION_ALREADY_SET,
         {
@@ -342,7 +342,7 @@ export class TaskOverrideDefinitionBuilderImplementation<
 
   #description?: string;
 
-  #action?: LazyActionObject<TaskOverrideActionFunction<TaskArgumentsT>>;
+  #lazyAction?: LazyActionObject<TaskOverrideActionFunction<TaskArgumentsT>>;
   #inlineAction?: TaskOverrideActionFunction<TaskArgumentsT>;
 
   constructor(id: string | string[]) {
@@ -356,12 +356,12 @@ export class TaskOverrideDefinitionBuilderImplementation<
     return this;
   }
 
-  public setAction(
-    action: LazyActionObject<TaskOverrideActionFunction<TaskArgumentsT>>,
+  public setLazyAction(
+    lazyAction: LazyActionObject<TaskOverrideActionFunction<TaskArgumentsT>>,
   ): TaskOverrideDefinitionBuilder<TaskArgumentsT, "LAZY_ACTION"> {
     this.#ensureNoActionSet();
 
-    this.#action = action;
+    this.#lazyAction = lazyAction;
 
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     -- Cast to update the ActionTypeT to the expected type for this scenario. */
@@ -472,7 +472,7 @@ export class TaskOverrideDefinitionBuilderImplementation<
   public build(): ActionTypeT extends "LAZY_ACTION"
     ? Extract<
         TaskOverrideDefinition,
-        { action: LazyActionObject<TaskOverrideActionFunction> }
+        { lazyAction: LazyActionObject<TaskOverrideActionFunction> }
       >
     : ActionTypeT extends "INLINE_ACTION"
       ? Extract<
@@ -480,7 +480,7 @@ export class TaskOverrideDefinitionBuilderImplementation<
           { inlineAction: TaskOverrideActionFunction }
         >
       : never {
-    if (this.#action === undefined && this.#inlineAction === undefined) {
+    if (this.#lazyAction === undefined && this.#inlineAction === undefined) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.TASK_DEFINITIONS.NO_ACTION,
         {
@@ -497,12 +497,12 @@ export class TaskOverrideDefinitionBuilderImplementation<
       id: this.#id,
       description: this.#description,
       /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      -- The type of the action is narrowed in the setAction function or setInlineAction to
+      -- The type of the action is narrowed in the setLazyAction function or setInlineAction to
       improve the argument types. Once the task is built, we use the more
       general type to avoid having to parameterize the TaskOverrideDefinition */
-      ...((this.#action !== undefined
+      ...((this.#lazyAction !== undefined
         ? {
-            action: this.#action,
+            lazyAction: this.#lazyAction,
           }
         : {
             inlineAction: this.#inlineAction,
@@ -511,7 +511,7 @@ export class TaskOverrideDefinitionBuilderImplementation<
     } as ActionTypeT extends "LAZY_ACTION"
       ? Extract<
           TaskOverrideDefinition,
-          { action: LazyActionObject<TaskOverrideActionFunction> }
+          { lazyAction: LazyActionObject<TaskOverrideActionFunction> }
         >
       : ActionTypeT extends "INLINE_ACTION"
         ? Extract<
@@ -522,7 +522,7 @@ export class TaskOverrideDefinitionBuilderImplementation<
   }
 
   #ensureNoActionSet(): void {
-    if (this.#action !== undefined || this.#inlineAction !== undefined) {
+    if (this.#lazyAction !== undefined || this.#inlineAction !== undefined) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.TASK_DEFINITIONS.ACTION_ALREADY_SET,
         {

--- a/v-next/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/v-next/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -37,7 +37,7 @@ export class ResolvedTask implements Task {
     return new ResolvedTask(
       id,
       description,
-      [{ pluginId, action: undefined, inlineAction: undefined }],
+      [{ pluginId, lazyAction: undefined, inlineAction: undefined }],
       new Map(),
       [],
       pluginId,
@@ -88,7 +88,7 @@ export class ResolvedTask implements Task {
   public get isEmpty(): boolean {
     return (
       this.actions.length === 1 &&
-      this.actions[0].action === undefined &&
+      this.actions[0].lazyAction === undefined &&
       this.actions[0].inlineAction === undefined
     );
   }
@@ -161,7 +161,7 @@ export class ResolvedTask implements Task {
         actionFn = currentTaskAction.inlineAction;
       } else {
         const lazyAction =
-          currentTaskAction.action ??
+          currentTaskAction.lazyAction ??
           (async () => ({
             default: () => {},
           }));

--- a/v-next/hardhat/src/internal/core/tasks/task-manager.ts
+++ b/v-next/hardhat/src/internal/core/tasks/task-manager.ts
@@ -172,8 +172,8 @@ export class TaskManagerImplementation implements TaskManager {
           this.#hre,
           taskDefinition.id,
           taskDefinition.description,
-          taskDefinition.action !== undefined
-            ? { action: taskDefinition.action }
+          taskDefinition.lazyAction !== undefined
+            ? { lazyAction: taskDefinition.lazyAction }
             : { inlineAction: taskDefinition.inlineAction },
           taskDefinition.options,
           taskDefinition.positionalArguments,
@@ -283,8 +283,8 @@ export class TaskManagerImplementation implements TaskManager {
 
     task.actions.push({
       pluginId,
-      ...(taskDefinition.action !== undefined
-        ? { action: taskDefinition.action }
+      ...(taskDefinition.lazyAction !== undefined
+        ? { lazyAction: taskDefinition.lazyAction }
         : { inlineAction: taskDefinition.inlineAction }),
     });
   }
@@ -301,7 +301,7 @@ export class TaskManagerImplementation implements TaskManager {
     }
 
     validateAction(
-      taskDefinition.action,
+      taskDefinition.lazyAction,
       taskDefinition.inlineAction,
       taskDefinition.id,
       isPlugin,

--- a/v-next/hardhat/src/internal/core/tasks/validations.ts
+++ b/v-next/hardhat/src/internal/core/tasks/validations.ts
@@ -30,7 +30,7 @@ export function validateId(id: string | string[]): void {
 }
 
 export function validateAction(
-  action:
+  lazyAction:
     | LazyActionObject<NewTaskActionFunction<TaskArguments>>
     | LazyActionObject<TaskOverrideActionFunction<TaskArguments>>
     | undefined,
@@ -49,14 +49,14 @@ export function validateAction(
     );
   }
 
-  if (action !== undefined && inlineAction !== undefined) {
+  if (lazyAction !== undefined && inlineAction !== undefined) {
     throw new HardhatError(
       HardhatError.ERRORS.CORE.TASK_DEFINITIONS.ACTION_ALREADY_SET,
       { task: formatTaskId(taskId) },
     );
   }
 
-  if (action === undefined && inlineAction === undefined) {
+  if (lazyAction === undefined && inlineAction === undefined) {
     throw new HardhatError(
       HardhatError.ERRORS.CORE.TASK_DEFINITIONS.NO_ACTION,
       { task: formatTaskId(taskId) },

--- a/v-next/hardhat/src/types/plugins.ts
+++ b/v-next/hardhat/src/types/plugins.ts
@@ -34,11 +34,11 @@ export type PluginTaskDefinition =
   | EmptyTaskDefinition
   | Extract<
       NewTaskDefinition,
-      { action: LazyActionObject<NewTaskActionFunction> }
+      { lazyAction: LazyActionObject<NewTaskActionFunction> }
     >
   | Extract<
       TaskOverrideDefinition,
-      { action: LazyActionObject<TaskOverrideActionFunction> }
+      { lazyAction: LazyActionObject<TaskOverrideActionFunction> }
     >;
 
 /**

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/base-project/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/base-project/hardhat.config.ts
@@ -13,7 +13,7 @@ const customTask = task("task")
   .addVariadicArgument({ name: "arg3" })
   .addFlag({ name: "arg4", shortName: "f" })
   .addLevel({ name: "arg5", shortName: "l" })
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: () => {
       tasksResults.wasArg1Used = true;
     },

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/default-values/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/default-values/hardhat.config.ts
@@ -3,7 +3,7 @@ import type { HardhatUserConfig } from "../../../../../src/config.js";
 import { task } from "../../../../../src/config.js";
 
 const customTask = task("test-task", "description")
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: () => {},
   }))
   .addOption({

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/hidden-option/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/hidden-option/hardhat.config.ts
@@ -3,7 +3,7 @@ import type { HardhatUserConfig } from "../../../../../src/config.js";
 import { task } from "../../../../../src/config.js";
 
 const customTask = task("test-task", "description")
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: () => {},
   }))
   .addOption({

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/tasks-and-subtasks/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/tasks-and-subtasks/hardhat.config.ts
@@ -24,7 +24,7 @@ const customTask = task("task")
   .addVariadicArgument({ name: "arg3" })
   .addFlag({ name: "arg4", shortName: "f" })
   .addLevel({ name: "arg5", shortName: "l" })
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: (taskArguments) => {
       resetResults();
 
@@ -44,7 +44,7 @@ const customTask = task("task")
 
 const customTask2 = task("task-default")
   .addOption({ name: "arg1", shortName: "o", defaultValue: "<default-value1>" })
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: (taskArguments) => {
       resetResults();
 
@@ -62,7 +62,7 @@ const customSubtask = task(["task", "subtask"])
   .addVariadicArgument({ name: "arg3" })
   .addFlag({ name: "arg4", shortName: "f" })
   .addLevel({ name: "arg5", shortName: "l" })
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: (taskArguments) => {
       resetResults();
 
@@ -80,7 +80,7 @@ const customSubtask = task(["task", "subtask"])
 
 const customSubtask2 = task(["task-default", "subtask-default"])
   .addOption({ name: "arg1", shortName: "o", defaultValue: "<default-value1>" })
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: (taskArguments) => {
       resetResults();
 
@@ -90,7 +90,7 @@ const customSubtask2 = task(["task-default", "subtask-default"])
   }))
   .build();
 const customSubtask3 = task(["task-default-3", "subtask-default-3"])
-  .setAction(async () => ({ default: () => {} }))
+  .setLazyAction(async () => ({ default: () => {} }))
   .build();
 
 const config: HardhatUserConfig = {

--- a/v-next/hardhat/test/fixture-projects/cli/parsing/user-config/user-hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/cli/parsing/user-config/user-hardhat.config.ts
@@ -7,7 +7,7 @@ export const tasksResults = {
 };
 
 const customTask = task("user-task")
-  .setAction(async () => ({
+  .setLazyAction(async () => ({
     default: () => {
       tasksResults.wasArg1Used = true;
     },

--- a/v-next/hardhat/test/fixture-projects/run-js-script/hardhat.config.js
+++ b/v-next/hardhat/test/fixture-projects/run-js-script/hardhat.config.js
@@ -3,7 +3,7 @@ import { task } from "hardhat/config";
 export default {
   tasks: [
     task("test-task", "Print a test")
-      .setAction(async () => {
+      .setLazyAction(async () => {
         console.log("test!");
       })
       .build(),

--- a/v-next/hardhat/test/fixture-projects/run-ts-script/hardhat.config.ts
+++ b/v-next/hardhat/test/fixture-projects/run-ts-script/hardhat.config.ts
@@ -5,7 +5,7 @@ import { task } from "hardhat/config";
 const config: HardhatUserConfig = {
   tasks: [
     task("test-task", "Print a test")
-      .setAction(async () => ({
+      .setLazyAction(async () => ({
         default: () => {
           console.log("test!");
         },

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -229,7 +229,7 @@ describe("solidity-test/task-action", function () {
           ...hardhatConfigAllTests,
           tasks: [
             overrideTask("build")
-              .setAction(async () => {
+              .setLazyAction(async () => {
                 return {
                   default: (args, _hre, runSuper) => {
                     buildArgs.push(args);

--- a/v-next/hardhat/test/internal/cli/help/get-global-help-string.ts
+++ b/v-next/hardhat/test/internal/cli/help/get-global-help-string.ts
@@ -45,7 +45,7 @@ To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
             actions: [
               {
                 pluginId: "task1-plugin-id",
-                action: async () => ({
+                lazyAction: async () => ({
                   default: () => {},
                 }),
               },
@@ -66,7 +66,7 @@ To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
             actions: [
               {
                 pluginId: "task2-plugin-id",
-                action: async () => ({
+                lazyAction: async () => ({
                   default: () => {},
                 }),
               },
@@ -142,7 +142,7 @@ To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
             actions: [
               {
                 pluginId: "task1-plugin-id",
-                action: async () => ({
+                lazyAction: async () => ({
                   default: () => {},
                 }),
               },
@@ -156,8 +156,8 @@ To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
               actions: [
                 {
                   pluginId: "task1-plugin-id",
-                  action: {
-                    action: async () => ({
+                  lazyAction: {
+                    lazyAction: async () => ({
                       default: () => {},
                     }),
                   },
@@ -182,7 +182,7 @@ To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
             actions: [
               {
                 pluginId: "task2-plugin-id",
-                action: async () => ({
+                lazyAction: async () => ({
                   default: () => {},
                 }),
               },
@@ -284,7 +284,7 @@ To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
             actions: [
               {
                 pluginId: "task1-plugin-id",
-                action: async () => ({
+                lazyAction: async () => ({
                   default: () => {},
                 }),
               },
@@ -298,8 +298,8 @@ To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
               actions: [
                 {
                   pluginId: "task1-plugin-id",
-                  action: {
-                    action: async () => ({
+                  lazyAction: {
+                    lazyAction: async () => ({
                       default: () => {},
                     }),
                   },
@@ -324,7 +324,7 @@ To get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
             actions: [
               {
                 pluginId: "task2-plugin-id",
-                action: async () => ({
+                lazyAction: async () => ({
                   default: () => {},
                 }),
               },

--- a/v-next/hardhat/test/internal/cli/help/get-help-string.ts
+++ b/v-next/hardhat/test/internal/cli/help/get-help-string.ts
@@ -18,7 +18,7 @@ describe("getHelpString", function () {
         actions: [
           {
             pluginId: "task-plugin-id",
-            action: async () => ({
+            lazyAction: async () => ({
               default: () => {},
             }),
           },
@@ -94,7 +94,7 @@ To get help for a specific task run: npx hardhat task <SUBTASK> --help`;
           actions: [
             {
               pluginId: "task-plugin-id",
-              action: async () => ({
+              lazyAction: async () => ({
                 default: () => {},
               }),
             },
@@ -147,7 +147,7 @@ GLOBAL OPTIONS:
           actions: [
             {
               pluginId: "task-plugin-id",
-              action: async () => ({
+              lazyAction: async () => ({
                 default: () => {},
               }),
             },
@@ -218,7 +218,7 @@ GLOBAL OPTIONS:
           actions: [
             {
               pluginId: "task-plugin-id",
-              action: async () => ({
+              lazyAction: async () => ({
                 default: () => {},
               }),
             },

--- a/v-next/hardhat/test/internal/cli/help/utils.ts
+++ b/v-next/hardhat/test/internal/cli/help/utils.ts
@@ -24,7 +24,7 @@ describe("utils", function () {
         actions: [
           {
             pluginId: "task-plugin-id",
-            action: async () => ({
+            lazyAction: async () => ({
               default: () => {},
             }),
           },
@@ -62,7 +62,7 @@ describe("utils", function () {
         actions: [
           {
             pluginId: "task-plugin-id",
-            action: async () => ({
+            lazyAction: async () => ({
               default: () => {},
             }),
           },
@@ -100,7 +100,7 @@ describe("utils", function () {
         actions: [
           {
             pluginId: "task-plugin-id",
-            action: async () => ({
+            lazyAction: async () => ({
               default: () => {},
             }),
           },
@@ -140,7 +140,7 @@ describe("utils", function () {
         actions: [
           {
             pluginId: "task-plugin-id",
-            action: async () => ({
+            lazyAction: async () => ({
               default: () => {},
             }),
           },
@@ -175,7 +175,7 @@ describe("utils", function () {
         actions: [
           {
             pluginId: "task-plugin-id",
-            action: async () => ({
+            lazyAction: async () => ({
               default: () => {},
             }),
           },
@@ -212,7 +212,7 @@ describe("utils", function () {
         actions: [
           {
             pluginId: "task-plugin-id",
-            action: async () => ({
+            lazyAction: async () => ({
               default: () => {},
             }),
           },
@@ -290,7 +290,7 @@ describe("utils", function () {
         actions: [
           {
             pluginId: "task-plugin-id",
-            action: async () => ({
+            lazyAction: async () => ({
               default: () => {},
             }),
           },
@@ -432,7 +432,7 @@ Section Title:
           actions: [
             {
               pluginId: "task-plugin-id",
-              action: async () => ({
+              lazyAction: async () => ({
                 default: () => {},
               }),
             },
@@ -512,7 +512,7 @@ Section Title:
           actions: [
             {
               pluginId: "task-plugin-id",
-              action: async () => ({
+              lazyAction: async () => ({
                 default: () => {},
               }),
             },

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -56,7 +56,7 @@ async function getTasksAndHreEnvironment(
   for (const t of tasksBuilders) {
     tasks.push(
       t
-        .setAction(async () => ({
+        .setLazyAction(async () => ({
           default: () => {},
         }))
         .build(),
@@ -66,7 +66,7 @@ async function getTasksAndHreEnvironment(
   for (const s of subtasksBuilders) {
     subtasks.push(
       s
-        .setAction(async () => ({
+        .setLazyAction(async () => ({
           default: () => {},
         }))
         .build(),

--- a/v-next/hardhat/test/internal/core/config-validation.ts
+++ b/v-next/hardhat/test/internal/core/config-validation.ts
@@ -1065,7 +1065,7 @@ describe("config validation", function () {
         type: TaskDefinitionType.NEW_TASK,
         id: ["task-id"],
         description: "task description",
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         options: {},
@@ -1081,7 +1081,7 @@ describe("config validation", function () {
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
         id: 1 as any,
         description: "task description",
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         options: {},
@@ -1093,7 +1093,7 @@ describe("config validation", function () {
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
         id: [1] as any,
         description: "task description",
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         options: {},
@@ -1121,7 +1121,7 @@ describe("config validation", function () {
         id: ["task-id"],
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
         description: 1 as any,
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         options: {},
@@ -1142,7 +1142,7 @@ describe("config validation", function () {
         id: ["task-id"],
         description: "task description",
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
-        action: 1 as any,
+        lazyAction: 1 as any,
         options: {},
         positionalArguments: [],
       };
@@ -1150,8 +1150,8 @@ describe("config validation", function () {
       assert.deepEqual(validateNewTask(task, []), [
         {
           message:
-            "task action must be a lazy import function returning a module with a default export",
-          path: ["action"],
+            "task lazyAction must be a lazy import function returning a module with a default export",
+          path: ["lazyAction"],
         },
       ]);
     });
@@ -1161,7 +1161,7 @@ describe("config validation", function () {
         type: TaskDefinitionType.NEW_TASK,
         id: ["task-id"],
         description: "task description",
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
@@ -1182,7 +1182,7 @@ describe("config validation", function () {
         type: TaskDefinitionType.NEW_TASK,
         id: ["task-id"],
         description: "task description",
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         options: {},
@@ -1205,7 +1205,7 @@ describe("config validation", function () {
         type: TaskDefinitionType.NEW_TASK,
         id: ["task-id"],
         description: "task description",
-        action: async () => ({ default: () => {} }),
+        lazyAction: async () => ({ default: () => {} }),
         inlineAction: () => {},
         options: {},
         positionalArguments: [],
@@ -1216,7 +1216,7 @@ describe("config validation", function () {
       assert.deepEqual(errors[0].path, []);
       assert.equal(
         errors[0].message,
-        'task cannot define both "action" and "inlineAction"',
+        'task cannot define both "lazyAction" and "inlineAction"',
       );
     });
 
@@ -1233,10 +1233,10 @@ describe("config validation", function () {
 
       const errors = validateNewTask(task, []);
       assert.equal(errors.length, 1);
-      assert.deepEqual(errors[0].path, ["action"]);
+      assert.deepEqual(errors[0].path, ["lazyAction"]);
       assert.equal(
         errors[0].message,
-        'task must define either "action" or "inlineAction"',
+        'task must define either "lazyAction" or "inlineAction"',
       );
     });
 
@@ -1281,7 +1281,7 @@ describe("config validation", function () {
         type: TaskDefinitionType.TASK_OVERRIDE,
         id: ["task-id"],
         description: "task description",
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         options: {},
@@ -1296,7 +1296,7 @@ describe("config validation", function () {
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
         id: 1 as any,
         description: "task description",
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         options: {},
@@ -1307,7 +1307,7 @@ describe("config validation", function () {
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
         id: [1] as any,
         description: "task description",
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         options: {},
@@ -1334,7 +1334,7 @@ describe("config validation", function () {
         id: ["task-id"],
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
         description: 1 as any,
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         options: {},
@@ -1354,15 +1354,15 @@ describe("config validation", function () {
         id: ["task-id"],
         description: "task description",
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
-        action: 1 as any,
+        lazyAction: 1 as any,
         options: {},
       };
 
       assert.deepEqual(validateTaskOverride(task, []), [
         {
           message:
-            "task action must be a lazy import function returning a module with a default export",
-          path: ["action"],
+            "task lazyAction must be a lazy import function returning a module with a default export",
+          path: ["lazyAction"],
         },
       ]);
     });
@@ -1372,7 +1372,7 @@ describe("config validation", function () {
         type: TaskDefinitionType.TASK_OVERRIDE,
         id: ["task-id"],
         description: "task description",
-        action: async () => ({
+        lazyAction: async () => ({
           default: () => {},
         }),
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
@@ -1394,7 +1394,7 @@ describe("config validation", function () {
         type: TaskDefinitionType.TASK_OVERRIDE,
         id: ["task-id"],
         description: "task description",
-        action: async () => ({ default: () => {} }),
+        lazyAction: async () => ({ default: () => {} }),
         inlineAction: () => {},
         options: {},
       } as unknown as TaskOverrideDefinition;
@@ -1404,7 +1404,7 @@ describe("config validation", function () {
       assert.deepEqual(errors[0].path, []);
       assert.equal(
         errors[0].message,
-        'task cannot define both "action" and "inlineAction"',
+        'task cannot define both "lazyAction" and "inlineAction"',
       );
     });
 
@@ -1420,10 +1420,10 @@ describe("config validation", function () {
 
       const errors = validateTaskOverride(task, []);
       assert.equal(errors.length, 1);
-      assert.deepEqual(errors[0].path, ["action"]);
+      assert.deepEqual(errors[0].path, ["lazyAction"]);
       assert.equal(
         errors[0].message,
-        'task must define either "action" or "inlineAction"',
+        'task must define either "lazyAction" or "inlineAction"',
       );
     });
 
@@ -1589,7 +1589,7 @@ describe("config validation", function () {
           /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing validations for js users who can bypass type checks */
           type: "invalid" as any,
           id: ["task-id"],
-          action: async () => ({
+          lazyAction: async () => ({
             default: () => {},
           }),
           options: {},

--- a/v-next/hardhat/test/internal/core/tasks/builders.ts
+++ b/v-next/hardhat/test/internal/core/tasks/builders.ts
@@ -112,13 +112,13 @@ describe("Task builders", () => {
       const taskAction = async () => ({
         default: () => {},
       });
-      const taskDefinition = builder.setAction(taskAction).build();
+      const taskDefinition = builder.setLazyAction(taskAction).build();
 
       assert.deepEqual(taskDefinition, {
         type: TaskDefinitionType.NEW_TASK,
         id: ["task-id"],
         description: "",
-        action: taskAction,
+        lazyAction: taskAction,
         options: {},
         positionalArguments: [],
       });
@@ -130,13 +130,13 @@ describe("Task builders", () => {
       const taskAction = async () => ({
         default: () => {},
       });
-      const taskDefinition = builder.setAction(taskAction).build();
+      const taskDefinition = builder.setLazyAction(taskAction).build();
 
       assert.deepEqual(taskDefinition, {
         type: TaskDefinitionType.NEW_TASK,
         id: ids,
         description: "",
-        action: taskAction,
+        lazyAction: taskAction,
         options: {},
         positionalArguments: [],
       });
@@ -170,13 +170,13 @@ describe("Task builders", () => {
         const lazyAction: LazyActionObject<NewTaskActionFunction> = () =>
           import(taskActionUrl);
 
-        const taskDefinition = builder.setAction(lazyAction).build();
+        const taskDefinition = builder.setLazyAction(lazyAction).build();
 
         assert.deepEqual(taskDefinition, {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: lazyAction,
+          lazyAction,
           options: {},
           positionalArguments: [],
         });
@@ -203,13 +203,13 @@ describe("Task builders", () => {
         const taskAction = async () => ({
           default: () => {},
         });
-        const taskDefinition = builder.setAction(taskAction).build();
+        const taskDefinition = builder.setLazyAction(taskAction).build();
 
         assert.deepEqual(taskDefinition, {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "Task description",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [],
         });
@@ -221,7 +221,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .setDescription("Task description")
           .build();
 
@@ -229,7 +229,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "Task description",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [],
         });
@@ -244,7 +244,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .setDescription("New task description")
           .build();
 
@@ -252,7 +252,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "New task description",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [],
         });
@@ -266,7 +266,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addOption({
             name: "arg",
             defaultValue: "default",
@@ -277,7 +277,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             arg: {
               name: "arg",
@@ -298,7 +298,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addOption({
             name: "arg",
             description: "Argument description",
@@ -310,7 +310,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             arg: {
               name: "arg",
@@ -331,7 +331,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addOption({
             name: "arg",
             type: ArgumentType.INT,
@@ -343,7 +343,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             arg: {
               name: "arg",
@@ -364,7 +364,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addOption({
             name: "arg",
             shortName: "a",
@@ -376,7 +376,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             arg: {
               name: "arg",
@@ -397,7 +397,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addOption({
             name: "arg",
             defaultValue: "default",
@@ -409,7 +409,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             arg: {
               name: "arg",
@@ -432,7 +432,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addFlag({ name: "flag" })
           .build();
 
@@ -440,7 +440,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             flag: {
               name: "flag",
@@ -461,7 +461,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addFlag({ name: "flag", description: "Flag description" })
           .build();
 
@@ -469,7 +469,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             flag: {
               name: "flag",
@@ -490,7 +490,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addFlag({ name: "flag", shortName: "f" })
           .build();
 
@@ -498,7 +498,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             flag: {
               name: "flag",
@@ -519,7 +519,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addFlag({ name: "flag", hidden: true })
           .build();
 
@@ -527,7 +527,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             flag: {
               name: "flag",
@@ -550,7 +550,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addPositionalArgument({ name: "arg" })
           .build();
 
@@ -558,7 +558,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [
             {
@@ -578,7 +578,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addPositionalArgument({
             name: "arg",
             description: "Argument description",
@@ -589,7 +589,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [
             {
@@ -609,7 +609,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addPositionalArgument({
             name: "arg",
             defaultValue: "default",
@@ -620,7 +620,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [
             {
@@ -640,7 +640,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addPositionalArgument({
             name: "arg",
             type: ArgumentType.INT,
@@ -651,7 +651,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [
             {
@@ -673,7 +673,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addVariadicArgument({ name: "arg" })
           .build();
 
@@ -681,7 +681,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [
             {
@@ -701,7 +701,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addVariadicArgument({
             name: "arg",
             description: "Argument description",
@@ -712,7 +712,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [
             {
@@ -732,7 +732,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addVariadicArgument({
             name: "arg",
             defaultValue: ["default1", "default2"],
@@ -743,7 +743,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [
             {
@@ -763,7 +763,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addVariadicArgument({ name: "arg", type: ArgumentType.INT })
           .build();
 
@@ -771,7 +771,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.NEW_TASK,
           id: ["task-id"],
           description: "",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
           positionalArguments: [
             {
@@ -1081,7 +1081,7 @@ describe("Task builders", () => {
     });
 
     describe("actions", () => {
-      const action: LazyActionObject<NewTaskActionFunction> = async () => ({
+      const lazyAction: LazyActionObject<NewTaskActionFunction> = async () => ({
         default: () => {},
       });
       const inlineAction: NewTaskActionFunction = () => {};
@@ -1093,13 +1093,13 @@ describe("Task builders", () => {
 
         assert.equal(result.type, TaskDefinitionType.NEW_TASK);
         assert.equal(result.inlineAction, inlineAction);
-        assert.equal(result.action, undefined);
+        assert.equal(result.lazyAction, undefined);
       });
 
       it("should be invalid with action + inline action", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
 
-        builder.setAction(action);
+        builder.setLazyAction(lazyAction);
 
         assertThrowsHardhatError(
           () => builder.setInlineAction(inlineAction),
@@ -1114,7 +1114,7 @@ describe("Task builders", () => {
         builder.setInlineAction(inlineAction);
 
         assertThrowsHardhatError(
-          () => builder.setAction(action),
+          () => builder.setLazyAction(lazyAction),
           HardhatError.ERRORS.CORE.TASK_DEFINITIONS.ACTION_ALREADY_SET,
           { task: "task-id" },
         );
@@ -1122,14 +1122,16 @@ describe("Task builders", () => {
 
       it("should be invalid with double action", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
-        const action2: LazyActionObject<NewTaskActionFunction> = async () => ({
+        const lazyAction2: LazyActionObject<
+          NewTaskActionFunction
+        > = async () => ({
           default: () => {},
         });
 
-        builder.setAction(action);
+        builder.setLazyAction(lazyAction);
 
         assertThrowsHardhatError(
-          () => builder.setAction(action2),
+          () => builder.setLazyAction(lazyAction2),
           HardhatError.ERRORS.CORE.TASK_DEFINITIONS.ACTION_ALREADY_SET,
           { task: "task-id" },
         );
@@ -1158,13 +1160,13 @@ describe("Task builders", () => {
       const taskAction = async () => ({
         default: () => {},
       });
-      const taskDefinition = builder.setAction(taskAction).build();
+      const taskDefinition = builder.setLazyAction(taskAction).build();
 
       assert.deepEqual(taskDefinition, {
         type: TaskDefinitionType.TASK_OVERRIDE,
         id: ["task-id"],
         description: undefined,
-        action: taskAction,
+        lazyAction: taskAction,
         options: {},
       });
     });
@@ -1175,13 +1177,13 @@ describe("Task builders", () => {
       const taskAction = async () => ({
         default: () => {},
       });
-      const taskDefinition = builder.setAction(taskAction).build();
+      const taskDefinition = builder.setLazyAction(taskAction).build();
 
       assert.deepEqual(taskDefinition, {
         type: TaskDefinitionType.TASK_OVERRIDE,
         id: ids,
         description: undefined,
-        action: taskAction,
+        lazyAction: taskAction,
         options: {},
       });
     });
@@ -1216,13 +1218,13 @@ describe("Task builders", () => {
         const lazyAction: LazyActionObject<NewTaskActionFunction> = () =>
           import(taskActionUrl);
 
-        const taskDefinition = builder.setAction(lazyAction).build();
+        const taskDefinition = builder.setLazyAction(lazyAction).build();
 
         assert.deepEqual(taskDefinition, {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: undefined,
-          action: lazyAction,
+          lazyAction,
           options: {},
         });
       });
@@ -1250,7 +1252,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .setDescription("Task description")
           .build();
 
@@ -1258,7 +1260,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: "Task description",
-          action: taskAction,
+          lazyAction: taskAction,
           options: {},
         });
       });
@@ -1273,7 +1275,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addOption({
             name: "arg",
             defaultValue: "default",
@@ -1284,7 +1286,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: undefined,
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             arg: {
               name: "arg",
@@ -1306,7 +1308,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addOption({
             name: "arg",
             description: "Argument description",
@@ -1318,7 +1320,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: undefined,
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             arg: {
               name: "arg",
@@ -1340,7 +1342,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addOption({
             name: "arg",
             type: ArgumentType.INT,
@@ -1352,7 +1354,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: undefined,
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             arg: {
               name: "arg",
@@ -1374,7 +1376,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addOption({
             name: "arg",
             shortName: "a",
@@ -1388,7 +1390,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: undefined,
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             arg: {
               name: "arg",
@@ -1410,7 +1412,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addOption({
             name: "arg",
             defaultValue: "default",
@@ -1422,7 +1424,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: undefined,
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             arg: {
               name: "arg",
@@ -1446,7 +1448,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addFlag({ name: "flag" })
           .build();
 
@@ -1454,7 +1456,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: undefined,
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             flag: {
               name: "flag",
@@ -1476,7 +1478,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addFlag({ name: "flag", description: "Flag description" })
           .build();
 
@@ -1484,7 +1486,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: undefined,
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             flag: {
               name: "flag",
@@ -1506,7 +1508,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addFlag({ name: "flag", shortName: "f" })
           .build();
 
@@ -1514,7 +1516,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: undefined,
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             flag: {
               name: "flag",
@@ -1536,7 +1538,7 @@ describe("Task builders", () => {
           default: () => {},
         });
         const taskDefinition = builder
-          .setAction(taskAction)
+          .setLazyAction(taskAction)
           .addFlag({ name: "flag", hidden: true })
           .build();
 
@@ -1544,7 +1546,7 @@ describe("Task builders", () => {
           type: TaskDefinitionType.TASK_OVERRIDE,
           id: ["task-id"],
           description: undefined,
-          action: taskAction,
+          lazyAction: taskAction,
           options: {
             flag: {
               name: "flag",
@@ -1764,7 +1766,7 @@ describe("Task builders", () => {
     });
 
     describe("actions", () => {
-      const action: LazyActionObject<
+      const lazyAction: LazyActionObject<
         TaskOverrideActionFunction
       > = async () => ({
         default: () => {},
@@ -1780,7 +1782,7 @@ describe("Task builders", () => {
 
         assert.equal(result.type, TaskDefinitionType.TASK_OVERRIDE);
         assert.equal(result.inlineAction, inlineAction);
-        assert.equal(result.action, undefined);
+        assert.equal(result.lazyAction, undefined);
       });
 
       it("should be invalid with action + inline action", () => {
@@ -1788,7 +1790,7 @@ describe("Task builders", () => {
           "task-id",
         );
 
-        builder.setAction(action);
+        builder.setLazyAction(lazyAction);
 
         assertThrowsHardhatError(
           () => builder.setInlineAction(inlineAction),
@@ -1805,7 +1807,7 @@ describe("Task builders", () => {
         builder.setInlineAction(inlineAction);
 
         assertThrowsHardhatError(
-          () => builder.setAction(action),
+          () => builder.setLazyAction(lazyAction),
           HardhatError.ERRORS.CORE.TASK_DEFINITIONS.ACTION_ALREADY_SET,
           { task: "task-id" },
         );
@@ -1815,14 +1817,14 @@ describe("Task builders", () => {
         const builder = new TaskOverrideDefinitionBuilderImplementation(
           "task-id",
         );
-        const action2 = async () => ({
+        const lazyAction2 = async () => ({
           default: () => {},
         });
 
-        builder.setAction(action);
+        builder.setLazyAction(lazyAction);
 
         assertThrowsHardhatError(
-          () => builder.setAction(action2),
+          () => builder.setLazyAction(lazyAction2),
           HardhatError.ERRORS.CORE.TASK_DEFINITIONS.ACTION_ALREADY_SET,
           { task: "task-id" },
         );

--- a/v-next/hardhat/test/internal/core/tasks/task-manager.ts
+++ b/v-next/hardhat/test/internal/core/tasks/task-manager.ts
@@ -44,13 +44,13 @@ describe("TaskManagerImplementation", () => {
             tasks: [
               new NewTaskDefinitionBuilderImplementation("task1")
                 .addOption({ name: "arg1", defaultValue: "default" })
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
               new NewTaskDefinitionBuilderImplementation("task2")
                 .addFlag({ name: "flag1" })
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -70,7 +70,7 @@ describe("TaskManagerImplementation", () => {
               new NewTaskDefinitionBuilderImplementation("task3")
                 .addPositionalArgument({ name: "posArg1" })
                 .addVariadicArgument({ name: "varArg1" })
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -109,20 +109,20 @@ describe("TaskManagerImplementation", () => {
         tasks: [
           new NewTaskDefinitionBuilderImplementation("task1")
             .addOption({ name: "arg1", defaultValue: "default" })
-            .setAction(async () => ({
+            .setLazyAction(async () => ({
               default: () => {},
             }))
             .build(),
           new NewTaskDefinitionBuilderImplementation("task2")
             .addFlag({ name: "flag1" })
-            .setAction(async () => ({
+            .setLazyAction(async () => ({
               default: () => {},
             }))
             .build(),
           new NewTaskDefinitionBuilderImplementation("task3")
             .addPositionalArgument({ name: "posArg1" })
             .addVariadicArgument({ name: "varArg1" })
-            .setAction(async () => ({
+            .setLazyAction(async () => ({
               default: () => {},
             }))
             .build(),
@@ -166,7 +166,7 @@ describe("TaskManagerImplementation", () => {
                 .addFlag({ name: "flag1" })
                 .addPositionalArgument({ name: "posArg1" })
                 .addVariadicArgument({ name: "varArg1" })
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -175,7 +175,7 @@ describe("TaskManagerImplementation", () => {
                 .setDescription("description2")
                 .addOption({ name: "arg2", defaultValue: "default" })
                 .addFlag({ name: "flag2" })
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -223,7 +223,7 @@ describe("TaskManagerImplementation", () => {
                 .addFlag({ name: "flag1" })
                 .addPositionalArgument({ name: "posArg1" })
                 .addVariadicArgument({ name: "varArg1" })
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -237,7 +237,7 @@ describe("TaskManagerImplementation", () => {
                 .setDescription("description2")
                 .addOption({ name: "arg2", defaultValue: "default" })
                 .addFlag({ name: "flag2" })
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -285,7 +285,7 @@ describe("TaskManagerImplementation", () => {
                 .addFlag({ name: "flag1" })
                 .addPositionalArgument({ name: "posArg1" })
                 .addVariadicArgument({ name: "varArg1" })
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -294,7 +294,7 @@ describe("TaskManagerImplementation", () => {
                 .setDescription("description2")
                 .addOption({ name: "arg2", defaultValue: "default" })
                 .addFlag({ name: "flag2" })
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -308,7 +308,7 @@ describe("TaskManagerImplementation", () => {
                 .setDescription("description3")
                 .addOption({ name: "arg3", defaultValue: "default" })
                 .addFlag({ name: "flag3" })
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -382,7 +382,7 @@ describe("TaskManagerImplementation", () => {
               ).build(),
               // adds a subtask to the empty task
               new NewTaskDefinitionBuilderImplementation(["task1", "subtask1"])
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -398,7 +398,7 @@ describe("TaskManagerImplementation", () => {
                 "subtask1",
                 "subsubtask1",
               ])
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -442,7 +442,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addOption({ name: "arg1", defaultValue: "default" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -488,7 +488,7 @@ describe("TaskManagerImplementation", () => {
                       shortName: "a",
                       defaultValue: "default",
                     })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -531,7 +531,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addPositionalArgument({ name: "arg1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -576,7 +576,7 @@ describe("TaskManagerImplementation", () => {
                     type: TaskDefinitionType.NEW_TASK,
                     id: [], // empty id
                     description: "",
-                    action: async () => ({
+                    lazyAction: async () => ({
                       default: () => {},
                     }),
                     options: {},
@@ -606,7 +606,7 @@ describe("TaskManagerImplementation", () => {
                     "subtask1",
                   ])
                     .addOption({ name: "arg1", defaultValue: "default" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -634,7 +634,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addOption({ name: "arg1", defaultValue: "default" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -645,7 +645,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addOption({ name: "arg2", defaultValue: "default" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -674,7 +674,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -702,7 +702,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addOption({ name: "arg1", defaultValue: "default" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -713,7 +713,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
                     .addOption({ name: "arg1", defaultValue: "default" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -742,7 +742,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addOption({ name: "arg1", defaultValue: "default" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -753,7 +753,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
                     .addFlag({ name: "arg1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -784,7 +784,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addFlag({ name: "flag1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -795,7 +795,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
                     .addOption({ name: "flag1", defaultValue: "default" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -824,7 +824,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addFlag({ name: "flag1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -835,7 +835,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
                     .addFlag({ name: "flag1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -866,7 +866,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addPositionalArgument({ name: "arg1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -877,7 +877,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
                     .addOption({ name: "arg1", defaultValue: "default" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -906,7 +906,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addPositionalArgument({ name: "flag1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -917,7 +917,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
                     .addFlag({ name: "flag1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -948,7 +948,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addVariadicArgument({ name: "arg1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -959,7 +959,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
                     .addOption({ name: "arg1", defaultValue: "default" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -988,7 +988,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addVariadicArgument({ name: "flag1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -999,7 +999,7 @@ describe("TaskManagerImplementation", () => {
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
                     .addFlag({ name: "flag1" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -1027,7 +1027,7 @@ describe("TaskManagerImplementation", () => {
           {
             tasks: [
               new NewTaskDefinitionBuilderImplementation("task1")
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: () => {},
                 }))
                 .build(),
@@ -1037,7 +1037,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -1089,7 +1089,7 @@ describe("TaskManagerImplementation", () => {
                       type: TaskDefinitionType.NEW_TASK,
                       id: [],
                       description: "",
-                      action: async () => ({
+                      lazyAction: async () => ({
                         default: () => {},
                       }),
                       options: {},
@@ -1116,7 +1116,7 @@ describe("TaskManagerImplementation", () => {
                       type: TaskDefinitionType.TASK_OVERRIDE,
                       id: [],
                       description: "",
-                      action: async () => ({
+                      lazyAction: async () => ({
                         default: () => {},
                       }),
                       options: {},
@@ -1145,7 +1145,7 @@ describe("TaskManagerImplementation", () => {
                       type: TaskDefinitionType.NEW_TASK,
                       id: ["task-id"],
                       description: "",
-                      action: async () => ({
+                      lazyAction: async () => ({
                         default: () => {},
                       }),
                       options: {
@@ -1181,7 +1181,7 @@ describe("TaskManagerImplementation", () => {
                       type: TaskDefinitionType.TASK_OVERRIDE,
                       id: ["task-id"],
                       description: "",
-                      action: async () => ({
+                      lazyAction: async () => ({
                         default: () => {},
                       }),
                       options: {
@@ -1219,7 +1219,7 @@ describe("TaskManagerImplementation", () => {
                         type: TaskDefinitionType.NEW_TASK,
                         id: ["task-id"],
                         description: "",
-                        action: async () => ({
+                        lazyAction: async () => ({
                           default: () => {},
                         }),
                         options: {
@@ -1255,7 +1255,7 @@ describe("TaskManagerImplementation", () => {
                         type: TaskDefinitionType.TASK_OVERRIDE,
                         id: ["task-id"],
                         description: "",
-                        action: async () => ({
+                        lazyAction: async () => ({
                           default: () => {},
                         }),
                         options: {
@@ -1294,7 +1294,7 @@ describe("TaskManagerImplementation", () => {
                       type: TaskDefinitionType.NEW_TASK,
                       id: ["task-id"],
                       description: "",
-                      action: async () => ({
+                      lazyAction: async () => ({
                         default: () => {},
                       }),
                       options: {
@@ -1337,7 +1337,7 @@ describe("TaskManagerImplementation", () => {
                       type: TaskDefinitionType.NEW_TASK,
                       id: ["task-id"],
                       description: "",
-                      action: async () => ({
+                      lazyAction: async () => ({
                         default: () => {},
                       }),
                       options: {},
@@ -1382,7 +1382,7 @@ describe("TaskManagerImplementation", () => {
                       type: TaskDefinitionType.NEW_TASK,
                       id: ["task-id"],
                       description: "",
-                      action: async () => ({
+                      lazyAction: async () => ({
                         default: () => {},
                       }),
                       options: {},
@@ -1421,7 +1421,7 @@ describe("TaskManagerImplementation", () => {
                         type: TaskDefinitionType.NEW_TASK,
                         id: ["task-id"],
                         description: "",
-                        action: async () => ({
+                        lazyAction: async () => ({
                           default: () => {},
                         }),
                         options: {},
@@ -1460,7 +1460,7 @@ describe("TaskManagerImplementation", () => {
                       type: TaskDefinitionType.NEW_TASK,
                       id: ["task-id"],
                       description: "",
-                      action: async () => ({
+                      lazyAction: async () => ({
                         default: () => {},
                       }),
                       options: {},
@@ -1504,7 +1504,7 @@ describe("TaskManagerImplementation", () => {
               id: "plugin1",
               tasks: [
                 new NewTaskDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: () => {},
                   }))
                   .build(),
@@ -1513,7 +1513,7 @@ describe("TaskManagerImplementation", () => {
           ],
           tasks: [
             new NewTaskDefinitionBuilderImplementation("task2")
-              .setAction(async () => ({
+              .setLazyAction(async () => ({
                 default: () => {},
               }))
               .build(),
@@ -1558,7 +1558,7 @@ describe("TaskManagerImplementation", () => {
               id: "plugin1",
               tasks: [
                 new NewTaskDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: () => {
                       taskRun = true;
                     },
@@ -1585,7 +1585,7 @@ describe("TaskManagerImplementation", () => {
               id: "plugin1",
               tasks: [
                 new NewTaskDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: () => {
                       return "task run successfully";
                     },
@@ -1613,14 +1613,14 @@ describe("TaskManagerImplementation", () => {
               id: "plugin1",
               tasks: [
                 new NewTaskDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: () => {
                       taskRun = true;
                     },
                   }))
                   .build(),
                 new TaskOverrideDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: async (args, _hre, runSuper) => {
                       await runSuper(args);
                       overrideTaskRun = true;
@@ -1654,14 +1654,14 @@ describe("TaskManagerImplementation", () => {
               id: "plugin1",
               tasks: [
                 new NewTaskDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: () => {
                       taskRun = true;
                     },
                   }))
                   .build(),
                 new TaskOverrideDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: async (args, _hre, runSuper) => {
                       await runSuper(args);
                       override1TaskRun = true;
@@ -1674,7 +1674,7 @@ describe("TaskManagerImplementation", () => {
               id: "plugin2",
               tasks: [
                 new TaskOverrideDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: async (args, _hre, runSuper) => {
                       await runSuper(args);
                       override2TaskRun = true;
@@ -1686,7 +1686,7 @@ describe("TaskManagerImplementation", () => {
           ],
           tasks: [
             new TaskOverrideDefinitionBuilderImplementation("task1")
-              .setAction(async () => ({
+              .setLazyAction(async () => ({
                 default: async (args, _hre, runSuper) => {
                   await runSuper(args);
                   override3TaskRun = true;
@@ -1720,14 +1720,14 @@ describe("TaskManagerImplementation", () => {
               id: "plugin1",
               tasks: [
                 new NewTaskDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: () => {
                       taskRun = true;
                     },
                   }))
                   .build(),
                 new TaskOverrideDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: (_args, _hre, _runSuper) => {
                       overrideTaskRun = true;
                     },
@@ -1761,7 +1761,7 @@ describe("TaskManagerImplementation", () => {
                   .addFlag({ name: "flag1" })
                   .addPositionalArgument({ name: "posArg" })
                   .addVariadicArgument({ name: "varArg" })
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: (args) => {
                       assert.deepEqual(args, {
                         arg1: "arg1Value",
@@ -1776,7 +1776,7 @@ describe("TaskManagerImplementation", () => {
                 new TaskOverrideDefinitionBuilderImplementation("task1")
                   .addOption({ name: "arg2", defaultValue: "default" })
                   .addFlag({ name: "flag2" })
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: async (
                       { arg2, flag2, ...args },
                       _hre,
@@ -1847,7 +1847,7 @@ describe("TaskManagerImplementation", () => {
                     name: "varArg",
                     defaultValue: ["varValue1", "varValue2"],
                   })
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: (args) => {
                       assert.deepEqual(args, {
                         arg1: "arg1DefaultValue",
@@ -1882,7 +1882,7 @@ describe("TaskManagerImplementation", () => {
                   "description1",
                 ).build(),
                 new TaskOverrideDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: async (args, _hre, runSuper) => {
                       await runSuper(args);
                       overrideTaskRun = true;
@@ -1912,7 +1912,7 @@ describe("TaskManagerImplementation", () => {
               id: "plugin1",
               tasks: [
                 new NewTaskDefinitionBuilderImplementation("task1")
-                  .setAction(async () => ({
+                  .setLazyAction(async () => ({
                     default: (args) => {
                       return args;
                     },
@@ -1920,7 +1920,7 @@ describe("TaskManagerImplementation", () => {
                   .build(),
                 new TaskOverrideDefinitionBuilderImplementation("task1")
                   .addOption({ name: "arg1", defaultValue: "default" })
-                  .setAction(() => import(actionUrl))
+                  .setLazyAction(() => import(actionUrl))
                   .build(),
               ],
             },
@@ -1945,11 +1945,11 @@ describe("TaskManagerImplementation", () => {
               id: "plugin1",
               tasks: [
                 new NewTaskDefinitionBuilderImplementation("task1")
-                  .setAction(() => import(invalidUrl))
+                  .setLazyAction(() => import(invalidUrl))
                   .build(),
                 new TaskOverrideDefinitionBuilderImplementation("task1")
                   .addOption({ name: "arg1", defaultValue: "default" })
-                  .setAction(() => import(validActionUrl))
+                  .setLazyAction(() => import(validActionUrl))
                   .build(),
               ],
             },
@@ -1996,7 +1996,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {
                         taskRun = true;
                       },
@@ -2169,7 +2169,7 @@ describe("TaskManagerImplementation", () => {
                 })
                 .build(),
               new TaskOverrideDefinitionBuilderImplementation("task1")
-                .setAction(async () => ({
+                .setLazyAction(async () => ({
                   default: async (args, _hre, runSuper) => {
                     const superResult = await runSuper(args);
                     overrideTaskRun = true;
@@ -2225,7 +2225,7 @@ describe("TaskManagerImplementation", () => {
                   id: "plugin1",
                   tasks: [
                     new NewTaskDefinitionBuilderImplementation("task1")
-                      .setAction(async () => ({
+                      .setLazyAction(async () => ({
                         default: () => {},
                       }))
                       .build(),
@@ -2284,7 +2284,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -2316,7 +2316,7 @@ describe("TaskManagerImplementation", () => {
                   new NewTaskDefinitionBuilderImplementation("task1")
                     .addPositionalArgument({ name: "posArg" })
                     .addVariadicArgument({ name: "varArg" })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -2379,7 +2379,7 @@ describe("TaskManagerImplementation", () => {
                       name: "varArg",
                       type: ArgumentType.FILE,
                     })
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -2467,7 +2467,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(() => import(invalidUrl))
+                    .setLazyAction(() => import(invalidUrl))
                     .build(),
                 ],
                 npmPackage: null,
@@ -2505,7 +2505,7 @@ describe("TaskManagerImplementation", () => {
                 npmPackage: "non-installed-package",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(() => import(nonInstalledPackageActionUrl))
+                    .setLazyAction(() => import(nonInstalledPackageActionUrl))
                     .build(),
                 ],
               },
@@ -2530,7 +2530,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(async () => ({
+                    .setLazyAction(async () => ({
                       default: () => {},
                     }))
                     .build(),
@@ -2541,7 +2541,7 @@ describe("TaskManagerImplementation", () => {
                 npmPackage: "non-installed-package",
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
-                    .setAction(() => import(nonInstalledPackageActionUrl))
+                    .setLazyAction(() => import(nonInstalledPackageActionUrl))
                     .build(),
                 ],
               },
@@ -2569,7 +2569,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(() => import(actionUrl))
+                    .setLazyAction(() => import(actionUrl))
                     .build(),
                 ],
               },
@@ -2599,7 +2599,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(() => import(actionUrl))
+                    .setLazyAction(() => import(actionUrl))
                     .build(),
                 ],
               },

--- a/v-next/hardhat/test/internal/core/tasks/validations.ts
+++ b/v-next/hardhat/test/internal/core/tasks/validations.ts
@@ -6,20 +6,20 @@ import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
 import { validateAction } from "../../../../src/internal/core/tasks/validations.js";
 
 describe("validateAction", () => {
-  const action = async () => ({ default: () => {} });
+  const lazyAction = async () => ({ default: () => {} });
   const inlineAction = () => {};
 
-  it("should not throw when only action is provided", () => {
-    validateAction(action, undefined, ["task-id"], false);
+  it("should not throw when only lazyAction is provided", () => {
+    validateAction(lazyAction, undefined, ["task-id"], false);
   });
 
   it("should not throw when only inlineAction is provided for user tasks", () => {
     validateAction(undefined, inlineAction, ["task-id"], false);
   });
 
-  it("should throw when both action and inlineAction are provided", () => {
+  it("should throw when both lazyAction and inlineAction are provided", () => {
     assertThrowsHardhatError(
-      () => validateAction(action, inlineAction, ["task-id"], false),
+      () => validateAction(lazyAction, inlineAction, ["task-id"], false),
       HardhatError.ERRORS.CORE.TASK_DEFINITIONS.ACTION_ALREADY_SET,
       { task: "task-id" },
     );
@@ -34,7 +34,7 @@ describe("validateAction", () => {
     );
   });
 
-  it("should throw when neither action nor inlineAction is provided", () => {
+  it("should throw when neither lazyAction nor inlineAction is provided", () => {
     assertThrowsHardhatError(
       () => validateAction(undefined, undefined, ["task-id"], false),
       HardhatError.ERRORS.CORE.TASK_DEFINITIONS.NO_ACTION,
@@ -42,7 +42,7 @@ describe("validateAction", () => {
     );
   });
 
-  it("should throw when neither action nor inlineAction is provided for plugin tasks", () => {
+  it("should throw when neither lazyAction nor inlineAction is provided for plugin tasks", () => {
     assertThrowsHardhatError(
       () => validateAction(undefined, undefined, ["task-id"], true),
       HardhatError.ERRORS.CORE.TASK_DEFINITIONS.NO_ACTION,
@@ -50,13 +50,13 @@ describe("validateAction", () => {
     );
   });
 
-  it("should allow action for plugin tasks", () => {
-    validateAction(action, undefined, ["task-id"], true);
+  it("should allow lazyAction for plugin tasks", () => {
+    validateAction(lazyAction, undefined, ["task-id"], true);
   });
 
-  it("should throw plugin-specific error when both action and inlineAction are provided for plugins", () => {
+  it("should throw plugin-specific error when both lazyAction and inlineAction are provided for plugins", () => {
     assertThrowsHardhatError(
-      () => validateAction(action, inlineAction, ["task-id"], true),
+      () => validateAction(lazyAction, inlineAction, ["task-id"], true),
       HardhatError.ERRORS.CORE.TASK_DEFINITIONS
         .INLINE_ACTION_CANNOT_BE_USED_IN_PLUGINS,
       { task: "task-id" },

--- a/v-next/hardhat/test/internal/example-mock-artifacts-plugin-using-test.ts
+++ b/v-next/hardhat/test/internal/example-mock-artifacts-plugin-using-test.ts
@@ -28,7 +28,7 @@ describe("createMockHardhatRuntimeEnvironment", () => {
       id: "my-plugin",
       tasks: [
         task("hello-artifact-using-world", "Test artifact loading")
-          .setAction(async () => ({
+          .setLazyAction(async () => ({
             default: (_args, hre) => {
               return hre.artifacts.readArtifact("MyContract");
             },


### PR DESCRIPTION
This PR is created on top of this one: https://github.com/NomicFoundation/hardhat/pull/7950

In this PR, the **ONLY** changes are the renames from `action` to `lazyAction`.
These affects:
- src code
- tests
- comments
- types