### PR TITLE
Round average gas usage in `--gas-stats`

### DIFF
--- a/.changeset/mighty-lilies-kiss.md
+++ b/.changeset/mighty-lilies-kiss.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Round average and mean gas usage in the gas analytics output
+Round average and median gas usage in the gas analytics output

--- a/.changeset/mighty-lilies-kiss.md
+++ b/.changeset/mighty-lilies-kiss.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Round average and mean gas usage in the gas analytics output

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -142,8 +142,8 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
         const stats: GasStats = {
           min: Math.min(...gasValues),
           max: Math.max(...gasValues),
-          avg: roundTo(avg(gasValues), 2),
-          median: roundTo(median(gasValues), 2),
+          avg: Math.round(avg(gasValues)),
+          median: Math.round(median(gasValues)),
           calls: gasValues.length,
         };
 
@@ -331,9 +331,4 @@ export function findDuplicates<T>(arr: T[]): T[] {
   }
 
   return [...duplicates];
-}
-
-export function roundTo(value: number, decimals: number): number {
-  const factor = 10 ** decimals;
-  return Math.round(value * factor) / factor;
 }

--- a/v-next/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -18,7 +18,6 @@ import {
   getUserFqn,
   getFunctionName,
   findDuplicates,
-  roundTo,
   GasAnalyticsManagerImplementation,
 } from "../../../../src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.js";
 
@@ -785,8 +784,8 @@ describe("gas-analytics-manager", () => {
           transferStats !== undefined,
           "transfer function stats should be defined",
         );
-        assert.equal(transferStats.avg, 33334.75);
-        assert.equal(transferStats.median, 33334.5);
+        assert.equal(transferStats.avg, 33335);
+        assert.equal(transferStats.median, 33335);
       });
     });
 
@@ -1079,28 +1078,6 @@ describe("gas-analytics-manager", () => {
 
       it("should handle single element", () => {
         assert.deepEqual(findDuplicates(["a"]), []);
-      });
-    });
-
-    describe("roundTo", () => {
-      it("should round to specified decimal places", () => {
-        assert.equal(roundTo(3.14159, 2), 3.14);
-        assert.equal(roundTo(3.14159, 3), 3.142);
-        assert.equal(roundTo(3.14159, 0), 3);
-      });
-
-      it("should handle rounding up", () => {
-        assert.equal(roundTo(3.156, 2), 3.16);
-        assert.equal(roundTo(3.999, 2), 4);
-      });
-
-      it("should handle negative numbers", () => {
-        assert.equal(roundTo(-3.14159, 2), -3.14);
-        assert.equal(roundTo(-3.156, 2), -3.16);
-      });
-
-      it("should handle zero", () => {
-        assert.equal(roundTo(0, 2), 0);
       });
     });
   });


### PR DESCRIPTION
@k06a reported that `--gas-stats` was displaying two decimals of precision, which is meaningless in this context. This PR rounds them instead.