### PR TITLE
fix(hardhat-verify): normalize Windows paths in getCompilerInput

### DIFF
--- a/v-next/hardhat-verify/src/internal/artifacts.ts
+++ b/v-next/hardhat-verify/src/internal/artifacts.ts
@@ -79,7 +79,7 @@ export async function getCompilerInput(
 ): Promise<CompilerInput> {
   const rootFilePath = isNpmModule
     ? `npm:${sourceName}`
-    : path.join(root, sourceName);
+    : path.join(root, sourceName).replace(/\\/g, "/");
 
   const getCompilationJobsResult = await solidity.getCompilationJobs(
     [rootFilePath],


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [X] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Problem

  `hardhat ignition verify` fails on Windows with:

  HardhatError: HHE100: An internal invariant was violated: The compiler input for the contract source was not found.


  ## Root Cause

  In `packages/hardhat-verify/src/internal/artifacts.ts`, the `getCompilerInput` function constructs `rootFilePath` using
  `path.join(root, sourceName)` (line 82), which produces backslash paths on Windows:



  C:\Users\dev\project\contracts\Token.sol


  However, Hardhat 3's `getCompilationJobs()` returns a `Map` whose keys use forward slashes:



  C:/Users/dev/project/contracts/Token.sol


  This causes `compilationJob.get(rootFilePath)` on line 106 to return `undefined`, triggering the invariant assertion on line 109.     

  ## Fix

  Normalize the path to use forward slashes after `path.join`:

  ```diff
    const rootFilePath = isNpmModule
      ? `npm:${sourceName}`
  -   : path.join(root, sourceName);
  +   : path.join(root, sourceName).replace(/\\/g, "/");


  Reproduction

  1. On Windows, deploy contracts using hardhat ignition deploy
  2. Run hardhat ignition verify <deployment-id> --network <network>
  3. Observe HHE100 error at artifacts.ts:109

  Environment

  - OS: Windows 11
  - Hardhat: 3.1.5
  - @nomicfoundation/hardhat-verify: 3.0.9