### PR TITLE
Install `libusb-1.0-0-dev` on CI

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -258,6 +258,13 @@ jobs:
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}
+      # Needed for node-hid, which is used by @ledgerhq/hw-transport-node-hid
+      # We need to install it because downloading the prebuilt binaries is not
+      # reliable, so the CI sometimes falls back to building it from source,
+      # which needs this package.
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build


### PR DESCRIPTION
This change addresses this kind of sporadic CI failure: https://github.com/NomicFoundation/hardhat/actions/runs/22157700985/job/64073155843

The reason for this is that `node-hid` downloads some prebuilt binaries, which can fail. When it does fail, it falls back to building from source, and in that case, we need `libusb-1.0-0-dev` to be installed.

This is only relevant to Linux, as windows and mac use other usb backends.