### PR TITLE
Bump Node 22 in our CI to the min supported version by Hardhat

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -240,10 +240,10 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.list-packages.outputs.packages) }}
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
-        node: [22.0.0, 24.0.0]
+        node: [22.10.0, 24.0.0]
         exclude:
           - package: hardhat-node-test-reporter
-            node: 22.0.0
+            node: 22.10.0
           - package: hardhat-node-test-reporter
             node: 24.0.0
 


### PR DESCRIPTION
This PR bumps the Node 22 version that we use on the CI to the minimum version supported by Hardhat (i.e. 22.10.0).

I believe bumping this will fix this sporadic v8-related failure in the CI:

```
1) (...)

   Error: Unable to deserialize cloned data due to invalid or unsupported version.
       at #proccessRawBuffer (node:internal/test_runner/runner:317:20)
       at FileTest.parseMessage (node:internal/test_runner/runner:253:28)
       at Socket.<anonymous> (node:internal/test_runner/runner:352:15)
       at Socket.emit (node:events:520:28)
       at addChunk (node:internal/streams/readable:559:12)
       at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
       at Readable.push (node:internal/streams/readable:390:5)
       at Pipe.onStreamRead (node:internal/stream_base_commons:191:23)
```

To validate what's the minimum supported version, take a look at: https://github.com/NomicFoundation/hardhat/blob/main/v-next/hardhat/src/internal/cli/node-version.ts#L6