### PR TITLE
Move the libusb-dev installation to actions/setup-env

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -42,3 +42,11 @@ runs:
       with:
         path: ${{ steps.pnpm.outputs.path }}
         key: node-cache-${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+    # Needed for node-hid, which is used by @ledgerhq/hw-transport-node-hid
+    # We need to install it because downloading the prebuilt binaries is not
+    # reliable, so the CI sometimes falls back to building it from source,
+    # which needs this package.
+    - name: Install Linux system dependencies
+      if: runner.os == 'Linux'
+      shell: bash
+      run: sudo apt-get install -y libusb-1.0-0-dev

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -258,13 +258,6 @@ jobs:
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}
-      # Needed for node-hid, which is used by @ledgerhq/hw-transport-node-hid
-      # We need to install it because downloading the prebuilt binaries is not
-      # reliable, so the CI sometimes falls back to building it from source,
-      # which needs this package.
-      - name: Install Linux system dependencies
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build


### PR DESCRIPTION
This PR improves on https://github.com/NomicFoundation/hardhat/pull/7978. The existing solution only installs the dependency in the CI jobs, and not the rest.

~(I'm also trying to avoid running apt update if possible — Using the CI to test it)~ This change also removes the unnecessary `apt update`.