### PR TITLE
Use latest supported solc in coverage instrumentation

### DIFF
--- a/.changeset/angry-mugs-bow.md
+++ b/.changeset/angry-mugs-bow.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Make the coverage work with versions of Solidity that aren't fully supported by EDR [#7982 ](https://github.com/NomicFoundation/hardhat/pull/7982)

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/instrumentation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/instrumentation.ts
@@ -1,0 +1,52 @@
+import type { InstrumentationMetadata } from "@nomicfoundation/edr";
+
+import {
+  addStatementCoverageInstrumentation,
+  latestSupportedSolidityVersion,
+} from "@nomicfoundation/edr";
+import { satisfies } from "semver";
+
+/**
+ * Instruments a solidity source file as part of a compilation job. i.e. the
+ * file is about to be compile as either a root file or a transitive dependency
+ * of one of the root files.
+ *
+ * @param compilationJobSolcVersion The solc version that the compilation job
+ *  will use.
+ * @param sourceName The source name of the file, as present in the compilation
+ *  job.
+ * @param fileContent The contents of the file.
+ * @param coverageLibraryPath The path to the coverage library. i.e. where to
+ *  import it from.
+ * @returns An object with the instrumented source and its metadata, and the
+ *  solidity version used to instrument the sources.
+ */
+export function instrumentSolidityFileForCompilationJob({
+  compilationJobSolcVersion,
+  sourceName,
+  fileContent,
+  coverageLibraryPath,
+}: {
+  compilationJobSolcVersion: string;
+  sourceName: string;
+  fileContent: string;
+  coverageLibraryPath: string;
+}): {
+  source: string;
+  metadata: InstrumentationMetadata[];
+  instrumentationVersion: string;
+} {
+  const latestSupportedVersion = latestSupportedSolidityVersion();
+  let instrumentationVersion = compilationJobSolcVersion;
+  if (!satisfies(instrumentationVersion, `<=${latestSupportedVersion}`)) {
+    instrumentationVersion = latestSupportedVersion;
+  }
+  const { source, metadata } = addStatementCoverageInstrumentation(
+    fileContent,
+    sourceName,
+    instrumentationVersion,
+    coverageLibraryPath,
+  );
+
+  return { source, metadata, instrumentationVersion };
+}

--- a/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -10,7 +10,6 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { after, before, beforeEach, describe, it } from "node:test";
 
-import { latestSupportedSolidityVersion } from "@nomicfoundation/edr";
 import {
   disableConsole,
   useFixtureProject,
@@ -437,41 +436,6 @@ describe("CoverageManagerImplementation - report data processing", () => {
       );
     });
   }
-
-  it("should should use the latesst supported Solidity version", async () => {
-    const version = await hre.hooks.runHandlerChain(
-      "solidity",
-      "preprocessProjectFileBeforeBuilding",
-      ["", "", "", "0.10.100"],
-      async (
-        nextContext,
-        nextInputSourceName,
-        nextFsPath,
-        nextFileContent,
-        nextSolcVersion,
-      ) => nextSolcVersion,
-    );
-
-    assert.equal(version, latestSupportedSolidityVersion());
-  });
-
-  it("should should use the selected Solidity version", async () => {
-    const supportedVersion = "0.8.28";
-    const version = await hre.hooks.runHandlerChain(
-      "solidity",
-      "preprocessProjectFileBeforeBuilding",
-      ["", "", "", supportedVersion],
-      async (
-        nextContext,
-        nextInputSourceName,
-        nextFsPath,
-        nextFileContent,
-        nextSolcVersion,
-      ) => nextSolcVersion,
-    );
-
-    assert.equal(version, supportedVersion);
-  });
 
   it("should run coverage on multiple files, one is covered by tests, the other is not", async () => {
     const testScenrario = COVERAGE_TEST_SCENARIO_MULTIPLE_FILES;

--- a/v-next/hardhat/test/internal/builtin-plugins/coverage/instrumentation.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/coverage/instrumentation.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { latestSupportedSolidityVersion } from "@nomicfoundation/edr";
+
+import { instrumentSolidityFileForCompilationJob } from "../../../../src/internal/builtin-plugins/coverage/instrumentation.js";
+
+describe("Instrumentation version selection", () => {
+  it("should should use the latesst supported Solidity version", async () => {
+    const { instrumentationVersion } = instrumentSolidityFileForCompilationJob({
+      sourceName: "Foo.sol",
+      compilationJobSolcVersion: "100.0.0",
+      coverageLibraryPath: "coverage.sol",
+      fileContent: "",
+    });
+
+    assert.equal(instrumentationVersion, latestSupportedSolidityVersion());
+  });
+
+  it("should should use the selected Solidity version", async () => {
+    const supportedVersion = "0.8.28";
+
+    const { instrumentationVersion } = instrumentSolidityFileForCompilationJob({
+      sourceName: "Foo.sol",
+      compilationJobSolcVersion: supportedVersion,
+      coverageLibraryPath: "coverage.sol",
+      fileContent: "",
+    });
+
+    assert.equal(instrumentationVersion, supportedVersion);
+  });
+});


### PR DESCRIPTION
This PR fixes an integration issue between Hardhat and EDR. Previously, when a compilation job tried to use a version of solc that wasn't fully supported by EDR, the plugin would try to change the solcVersion of the compilation job, instead of just limiting itself to use a different version for instrumentation. Changing the version in a hook is forbidden and throws.

In order to test this, I moved the instrumentation logic to its own module, and test it directly.

Note: This PR also removes a `console.log` that was printed ever time the version was changed.