### PR TITLE
build: upgrade to @nomicfoundation/edr v0.12.0-next.x (v2)

### DIFF
--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -67,7 +67,6 @@ import {
   MempoolOrder,
 } from "./node-types";
 import {
-  edrRpcDebugTraceToHardhat,
   edrTracingMessageResultToMinimalEVMResult,
   edrTracingMessageToMinimalMessage,
   edrTracingStepToMinimalInterpreterStep,
@@ -479,11 +478,6 @@ export class EdrProviderWrapper
     // e.g. `HardhatNetwork/2.19.0/@nomicfoundation/edr/0.2.0-dev`
     if (args.method === "web3_clientVersion") {
       return clientVersion(response.result);
-    } else if (
-      args.method === "debug_traceTransaction" ||
-      args.method === "debug_traceCall"
-    ) {
-      return edrRpcDebugTraceToHardhat(response.result);
     } else {
       return response.result;
     }

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -21,7 +21,11 @@ import type {
   AccountOverride,
 } from "@nomicfoundation/edr";
 import { privateToAddress } from "@ethereumjs/util";
-import { ContractDecoder, precompileP256Verify } from "@nomicfoundation/edr";
+import {
+  ContractDecoder,
+  IncludeTraces,
+  precompileP256Verify,
+} from "@nomicfoundation/edr";
 import picocolors from "picocolors";
 import debug from "debug";
 import { EventEmitter } from "events";
@@ -267,7 +271,9 @@ export class EdrProviderWrapper
         },
       },
       networkId: BigInt(config.networkId),
-      observability: {},
+      observability: {
+        includeCallTraces: IncludeTraces.All,
+      },
       ownedAccounts,
       // Turn off the Osaka EIP-7825 per transaction gas limit for HH2
       // when being run from `solidity-coverage`.

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/provider.ts
@@ -25,6 +25,7 @@ import {
   ContractDecoder,
   IncludeTraces,
   precompileP256Verify,
+  StackSnapshotType,
 } from "@nomicfoundation/edr";
 import picocolors from "picocolors";
 import debug from "debug";
@@ -164,7 +165,9 @@ export class EdrProviderWrapper
     // calls, in case there is switching between local and fork configurations.
     private readonly _originalGenesisAccounts: GenesisAccount[],
     private readonly _originalCacheDir: string | undefined,
-    private readonly _originalChainOverrides: ChainOverride[] | undefined
+    private readonly _originalChainOverrides: ChainOverride[] | undefined,
+    private readonly _originalGenesisBlockGasLimit: bigint,
+    private readonly _originalGenesisBlockTime: bigint | undefined
   ) {
     super();
   }
@@ -203,24 +206,28 @@ export class EdrProviderWrapper
 
     const cacheDir = config.forkCachePath;
 
-    let fork;
-    if (config.forkConfig !== undefined) {
-      fork = {
-        blockNumber:
-          config.forkConfig.blockNumber !== undefined
-            ? BigInt(config.forkConfig.blockNumber)
-            : undefined,
-        cacheDir,
-        chainOverrides,
-        httpHeaders: httpHeadersToEdr(config.forkConfig.httpHeaders),
-        url: config.forkConfig.jsonRpcUrl,
-      };
-    }
-
-    const initialDate =
+    const genesisBlockGasLimit = BigInt(config.blockGasLimit);
+    const genesisBlockTime =
       config.initialDate !== undefined
         ? BigInt(Math.floor(config.initialDate.getTime() / 1000))
         : undefined;
+
+    const network =
+      config.forkConfig !== undefined
+        ? {
+            blockNumber:
+              config.forkConfig.blockNumber !== undefined
+                ? BigInt(config.forkConfig.blockNumber)
+                : undefined,
+            cacheDir,
+            chainOverrides,
+            httpHeaders: httpHeadersToEdr(config.forkConfig.httpHeaders),
+            url: config.forkConfig.jsonRpcUrl,
+          }
+        : {
+            genesisBlockGasLimit,
+            genesisBlockTime,
+          };
 
     // To accommodate construction ordering, we need an adapter to forward events
     // from the EdrProvider callback to the wrapper's listener
@@ -233,7 +240,7 @@ export class EdrProviderWrapper
     const edrHardfork = ethereumsjsHardforkToEdrSpecId(hardforkName);
 
     const [genesisState, ownedAccounts] = _genesisStateAndOwnedAccounts(
-      fork !== undefined,
+      config.forkConfig !== undefined,
       edrHardfork,
       config.genesisAccounts
     );
@@ -250,14 +257,12 @@ export class EdrProviderWrapper
       allowUnlimitedContractSize: config.allowUnlimitedContractSize,
       bailOnCallFailure: config.throwOnCallFailures,
       bailOnTransactionFailure: config.throwOnTransactionFailures,
-      blockGasLimit: BigInt(config.blockGasLimit),
       chainId: BigInt(config.chainId),
       coinbase: Buffer.from(coinbase.slice(2), "hex"),
+      defaultTransactionGasLimit: BigInt(config.blockGasLimit),
       precompileOverrides,
-      fork,
       genesisState,
       hardfork: edrHardfork,
-      initialDate,
       initialBaseFeePerGas:
         config.initialBaseFeePerGas !== undefined
           ? BigInt(config.initialBaseFeePerGas!)
@@ -265,14 +270,17 @@ export class EdrProviderWrapper
       minGasPrice: config.minGasPrice,
       mining: {
         autoMine: config.automine,
+        blockGasLimit: BigInt(config.blockGasLimit),
         interval: ethereumjsIntervalMiningConfigToEdr(config.intervalMining),
         memPool: {
           order: ethereumjsMempoolOrderToEdrMineOrdering(config.mempoolOrder),
         },
       },
+      network,
       networkId: BigInt(config.networkId),
       observability: {
         includeCallTraces: IncludeTraces.All,
+        recordStack: StackSnapshotType.Top,
       },
       ownedAccounts,
       // Turn off the Osaka EIP-7825 per transaction gas limit for HH2
@@ -337,7 +345,9 @@ export class EdrProviderWrapper
       edrSubscriptionConfig,
       config.genesisAccounts,
       cacheDir,
-      chainOverrides
+      chainOverrides,
+      genesisBlockGasLimit,
+      genesisBlockTime
     );
 
     // Pass through all events from the provider
@@ -449,7 +459,12 @@ export class EdrProviderWrapper
       if (stackTrace?.kind === "StackTrace") {
         error = encodeSolidityStackTrace(
           response.error.message,
-          stackTrace.entries
+          // EDR's `SolidityStackTraceEntry` union includes
+          // `CheatcodeErrorStackTraceEntry`, which Hardhat's local copy
+          // doesn't know about. Cheatcodes only fire from solidity-test
+          // runs, never from the network-provider path; the cast is safe
+          // at runtime.
+          stackTrace.entries as SolidityStackTrace
         );
         // Pass data and transaction hash from the original error
         (error as any).data = response.error.data?.data ?? undefined;
@@ -528,18 +543,19 @@ export class EdrProviderWrapper
     this._providerConfig.genesisState = genesisState;
     this._providerConfig.ownedAccounts = ownedAccounts;
 
+    const currentNetworkConfig = this._providerConfig.network;
+    const currentlyForked = "url" in currentNetworkConfig;
+
     if (forkConfig !== undefined) {
-      const cacheDir =
-        this._providerConfig.fork === undefined
-          ? this._originalCacheDir
-          : this._providerConfig.fork?.cacheDir;
+      const cacheDir = currentlyForked
+        ? currentNetworkConfig.cacheDir
+        : this._originalCacheDir;
 
-      const chainOverrides =
-        this._providerConfig.fork === undefined
-          ? this._originalChainOverrides
-          : this._providerConfig.fork?.chainOverrides;
+      const chainOverrides = currentlyForked
+        ? currentNetworkConfig.chainOverrides
+        : this._originalChainOverrides;
 
-      this._providerConfig.fork = {
+      this._providerConfig.network = {
         blockNumber:
           forkConfig.blockNumber !== undefined
             ? BigInt(forkConfig.blockNumber)
@@ -550,7 +566,18 @@ export class EdrProviderWrapper
         url: forkConfig.jsonRpcUrl,
       };
     } else {
-      this._providerConfig.fork = undefined;
+      const genesisBlockGasLimit = currentlyForked
+        ? this._originalGenesisBlockGasLimit
+        : currentNetworkConfig.genesisBlockGasLimit;
+
+      const genesisBlockTime = currentlyForked
+        ? this._originalGenesisBlockTime
+        : currentNetworkConfig.genesisBlockTime;
+
+      this._providerConfig.network = {
+        genesisBlockGasLimit,
+        genesisBlockTime,
+      };
     }
 
     const context = await getGlobalEdrContext();

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/convertToEdr.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/convertToEdr.ts
@@ -174,62 +174,6 @@ export function ethereumjsMempoolOrderToEdrMineOrdering(
   }
 }
 
-export function edrRpcDebugTraceToHardhat(
-  rpcDebugTrace: DebugTraceResult
-): RpcDebugTraceOutput {
-  const structLogs = rpcDebugTrace.structLogs.map((log) => {
-    const result: RpcStructLog = {
-      depth: Number(log.depth),
-      gas: Number(log.gas),
-      gasCost: Number(log.gasCost),
-      op: log.opName,
-      pc: Number(log.pc),
-    };
-
-    if (log.memory !== undefined) {
-      result.memory = log.memory;
-    }
-
-    if (log.stack !== undefined) {
-      // Remove 0x prefix which is required by EIP-3155, but not expected by Hardhat.
-      result.stack = log.stack?.map((item) => item.slice(2));
-    }
-
-    if (log.storage !== undefined) {
-      result.storage = Object.fromEntries(
-        Object.entries(log.storage).map(([key, value]) => {
-          return [key.slice(2), value.slice(2)];
-        })
-      );
-    }
-
-    if (log.error !== undefined) {
-      result.error = {
-        message: log.error,
-      };
-    }
-
-    return result;
-  });
-
-  // REVM trace adds initial STOP that Hardhat doesn't expect
-  if (structLogs.length > 0 && structLogs[0].op === "STOP") {
-    structLogs.shift();
-  }
-
-  let returnValue = rpcDebugTrace.output?.toString() ?? "";
-  if (returnValue === "0x") {
-    returnValue = "";
-  }
-
-  return {
-    failed: !rpcDebugTrace.pass,
-    gas: Number(rpcDebugTrace.gasUsed),
-    returnValue,
-    structLogs,
-  };
-}
-
 export function edrTracingStepToMinimalInterpreterStep(
   step: TracingStep
 ): MinimalInterpreterStep {

--- a/packages/hardhat-core/src/internal/hardhat-network/provider/utils/convertToEdr.ts
+++ b/packages/hardhat-core/src/internal/hardhat-network/provider/utils/convertToEdr.ts
@@ -178,17 +178,14 @@ export function edrTracingStepToMinimalInterpreterStep(
   step: TracingStep
 ): MinimalInterpreterStep {
   const minimalInterpreterStep: MinimalInterpreterStep = {
-    pc: Number(step.pc),
+    pc: step.pc,
     depth: step.depth,
     opcode: {
-      name: step.opcode,
+      name: step.opcode.name,
     },
     stack: step.stack,
+    memory: step.memory,
   };
-
-  if (step.memory !== undefined) {
-    minimalInterpreterStep.memory = step.memory;
-  }
 
   return minimalInterpreterStep;
 }
@@ -196,34 +193,23 @@ export function edrTracingStepToMinimalInterpreterStep(
 export function edrTracingMessageResultToMinimalEVMResult(
   tracingMessageResult: TracingMessageResult
 ): MinimalEVMResult {
-  const { result, contractAddress } = tracingMessageResult.executionResult;
-
-  // only SuccessResult has logs
-  const success = "logs" in result;
+  const execResult = tracingMessageResult.execResult;
 
   const minimalEVMResult: MinimalEVMResult = {
     execResult: {
-      executionGasUsed: result.gasUsed,
-      success,
+      success: execResult.success,
+      executionGasUsed: execResult.executionGasUsed,
+      contractAddress:
+        execResult.contractAddress !== undefined
+          ? new Address(execResult.contractAddress)
+          : undefined,
+      reason: execResult.reason,
+      output:
+        execResult.output !== undefined
+          ? Buffer.from(execResult.output)
+          : undefined,
     },
   };
-
-  // only success and exceptional halt have reason
-  if ("reason" in result) {
-    minimalEVMResult.execResult.reason = result.reason;
-  }
-  if ("output" in result) {
-    const { output } = result;
-    if (output instanceof Uint8Array) {
-      minimalEVMResult.execResult.output = Buffer.from(output);
-    } else {
-      minimalEVMResult.execResult.output = Buffer.from(output.returnValue);
-    }
-  }
-
-  if (contractAddress !== undefined) {
-    minimalEVMResult.execResult.contractAddress = new Address(contractAddress);
-  }
 
   return minimalEVMResult;
 }

--- a/packages/hardhat-core/test/builtin-tasks/compile.ts
+++ b/packages/hardhat-core/test/builtin-tasks/compile.ts
@@ -1,4 +1,4 @@
-import { getLatestSupportedSolcVersion } from "@nomicfoundation/edr";
+import { latestSupportedSolidityVersion } from "@nomicfoundation/edr";
 import { assert, expect } from "chai";
 import ci from "ci-info";
 import * as fsExtra from "fs-extra";
@@ -57,7 +57,7 @@ describe("compile task", function () {
       // Test to check that the last version of solc is being tested
       const userConfigSolcVersion = this.env.userConfig.solidity;
 
-      const lastSolcVersion = getLatestSupportedSolcVersion();
+      const lastSolcVersion = latestSupportedSolidityVersion();
 
       assert.equal(
         userConfigSolcVersion,

--- a/packages/hardhat-core/test/helpers/compilation.ts
+++ b/packages/hardhat-core/test/helpers/compilation.ts
@@ -1,4 +1,4 @@
-import { getLatestSupportedSolcVersion } from "@nomicfoundation/edr";
+import { latestSupportedSolidityVersion } from "@nomicfoundation/edr";
 import semver from "semver";
 
 import {
@@ -161,7 +161,7 @@ async function downloadCompiler(solidityVersion: string): Promise<void> {
 }
 
 export const getNextUnsupportedVersion = () =>
-  semver.inc(getLatestSupportedSolcVersion(), "patch")!;
+  semver.inc(latestSupportedSolidityVersion(), "patch")!;
 
 export const getNextNextUnsupportedVersion = () =>
   semver.inc(getNextUnsupportedVersion(), "patch")!;


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Previously, we temporarily broke backwards compatibility in EDR to ship faster to Hardhat 3, resulting in a stoppage of integrations for Hardhat 2. This is a draft PR tracking changes required to backport the latest version of @nomicfoundation/edr to Hardhat 2. 

### Minor Changes

- NomicFoundation/edr@3974769: Added `callTraces()` to `Response` object, inclusion of which is configurable through the `includeCallTraces` option on the `ObservabilityConfig`
- NomicFoundation/edr@f4bdc36: Removed `getLatestSupportedSolcVersion` API

  BREAKING CHANGE: A new API `latestSupportedSolidityVersion` was previously introduced to replace the deprecated `getLatestSupportedSolcVersion`. The old API has now been removed. Users should update their code to use `latestSupportedSolidityVersion` instead.

- NomicFoundation/edr@3974769: Removed `traces()` API from the `Response` object
- NomicFoundation/edr@f4bdc36: Added support to the `debug_traceCall` & `debug_traceTransaction` JSON-RPC methods for different tracers (`4byteTracer`, `callTracer`, `flatCallTracer`, `prestateTracer`, `noopTracer`, and `muxTracer`).

  Our API is now aligned with Geth's tracing capabilities.

  BREAKING CHANGE: Memory capture used to be enabled by default on geth, but has since been flipped <https://github.com/ethereum/go-ethereum/pull/23558> and is now disabled by default. We have followed suit and disabled it by default as well. If you were relying on memory capture, you will need to explicitly enable it by setting the `enableMemory` option to `true` in your tracer configuration.

**To Do**
- [ ] Bump EDR version once released to fix tests