### PR TITLE
Node network config

### DIFF
--- a/.changeset/big-rings-listen.md
+++ b/.changeset/big-rings-listen.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Update `hardhat node` to always use the new `node` network (#7989)[https://github.com/NomicFoundation/hardhat/pull/7989]

--- a/v-next/hardhat-ethers/test/plugin-functionalities.ts
+++ b/v-next/hardhat-ethers/test/plugin-functionalities.ts
@@ -18,6 +18,7 @@ import {
   assertIsSigner,
   initializeTestEthers,
   spawnTestRpcServer,
+  tryUntil,
 } from "./helpers/helpers.js";
 
 describe("Ethers plugin", () => {
@@ -719,12 +720,9 @@ describe("Ethers plugin", () => {
 
             await greeter.setGreeting("Hola");
 
-            // wait for 1.5 polling intervals for the event to fire
-            await new Promise((resolve) => setTimeout(resolve, 100));
+            await tryUntil(() => assert.equal(eventEmitted, true));
 
             await greeter.removeAllListeners();
-
-            assert.equal(eventEmitted, true);
           });
 
           describe("with hardhat's signer", () => {
@@ -948,11 +946,9 @@ describe("Ethers plugin", () => {
 
         await deployedGreeter.setGreeting("Hola");
 
-        // wait for 1.5 polling intervals for the event to fire
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await tryUntil(() => assert.equal(eventEmitted, true));
 
         deployedGreeter.removeAllListeners();
-        assert.equal(eventEmitted, true);
       });
     });
 
@@ -1160,11 +1156,9 @@ describe("Ethers plugin", () => {
 
       await deployedGreeter.setGreeting("Hola");
 
-      // wait for the event to fire
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await tryUntil(() => assert.equal(emitted, true));
 
       await wsProvider.destroy();
-      assert.equal(emitted, true);
     });
   });
 });

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -40,6 +40,7 @@ export async function extendUserConfig(
 
   const localhostConfig: NetworkUserConfig | undefined = networks.localhost;
   const defaultConfig: NetworkUserConfig | undefined = networks.default;
+  const nodeConfig: NetworkUserConfig | undefined = networks.node;
 
   let extendedLocalhostConfig: NetworkUserConfig;
   if (
@@ -59,6 +60,14 @@ export async function extendUserConfig(
     extendedLocalhostConfig = localhostConfig;
   }
 
+  const defaultEdrNetworkConfigValues = {
+    chainId: 31337,
+    gas: "auto",
+    gasMultiplier: 1,
+    gasPrice: "auto",
+    type: "edr-simulated",
+  } as const;
+
   let extendedDefaultConfig: NetworkUserConfig;
   if (
     defaultConfig === undefined ||
@@ -66,11 +75,7 @@ export async function extendUserConfig(
     defaultConfig.type === "edr-simulated"
   ) {
     extendedDefaultConfig = {
-      chainId: 31337,
-      gas: "auto",
-      gasMultiplier: 1,
-      gasPrice: "auto",
-      type: "edr-simulated",
+      ...defaultEdrNetworkConfigValues,
       /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         -- We cast it here because otherwise TS complains that some fields are
         always overwritten, which is not true for js incomplete configs. */
@@ -80,12 +85,30 @@ export async function extendUserConfig(
     extendedDefaultConfig = defaultConfig;
   }
 
+  let extendedNodeConfig: NetworkUserConfig;
+  if (
+    nodeConfig === undefined ||
+    nodeConfig.type === undefined ||
+    nodeConfig.type === "edr-simulated"
+  ) {
+    extendedNodeConfig = {
+      ...defaultEdrNetworkConfigValues,
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- We cast it here because otherwise TS complains that url and http will
+        be always overwritten, which is not true for js incomplete configs. */
+      ...(nodeConfig as Partial<EdrNetworkUserConfig>),
+    };
+  } else {
+    extendedNodeConfig = nodeConfig;
+  }
+
   return {
     ...extendedConfig,
     networks: {
       ...networks,
       localhost: extendedLocalhostConfig,
       [DEFAULT_NETWORK_NAME]: extendedDefaultConfig,
+      node: extendedNodeConfig,
     },
   };
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -344,6 +344,15 @@ function refineEdrNetworkUserConfig(
   { defaultChainType = GENERIC_CHAIN_TYPE, networks = {} }: HardhatUserConfig,
   ctx: RefinementCtx,
 ): void {
+  const nodeNetwork = networks.node;
+  if (nodeNetwork !== undefined && nodeNetwork.type !== "edr-simulated") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["networks", "node", "type"],
+      message: "The node network type must be 'edr-simulated'",
+    });
+  }
+
   for (const [networkName, network] of Object.entries(networks)) {
     if (network.type === "edr-simulated") {
       const { chainType, hardfork, minGasPrice, initialBaseFeePerGas } =

--- a/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
@@ -12,7 +12,6 @@ import { ensureDir, exists } from "@nomicfoundation/hardhat-utils/fs";
 import chalk from "chalk";
 import debug from "debug";
 
-import { DEFAULT_NETWORK_NAME } from "../../constants.js";
 import { isSupportedChainType } from "../../edr/chain-type.js";
 import { BUILD_INFO_DIR_NAME } from "../artifacts/artifact-manager.js";
 import { EdrProvider } from "../network-manager/edr/edr-provider.js";
@@ -39,31 +38,19 @@ const nodeAction: NewTaskActionFunction<NodeActionArguments> = async (
   args,
   hre,
 ) => {
-  const network =
-    hre.globalOptions.network !== undefined
-      ? hre.globalOptions.network
-      : DEFAULT_NETWORK_NAME;
-
-  if (!(network in hre.config.networks)) {
-    throw new HardhatError(HardhatError.ERRORS.CORE.NETWORK.NETWORK_NOT_FOUND, {
-      networkName: network,
-    });
-  }
-
-  if (hre.config.networks[network].type !== "edr-simulated") {
-    throw new HardhatError(HardhatError.ERRORS.CORE.NODE.INVALID_NETWORK_TYPE, {
-      networkType: hre.config.networks[network].type,
-      networkName: network,
-    });
-  }
+  assertHardhatInvariant(
+    hre.config.networks.node.type === "edr-simulated",
+    "`node` network type must be `edr-simulated`",
+  );
 
   const connectionParams: {
     network: string;
     chainType?: ChainType;
     override?: EdrNetworkConfigOverride;
   } = {
-    network,
+    network: "node",
   };
+
   // NOTE: We create an empty network config override here. We add to it based
   // on the result of arguments parsing. We can expand the list of arguments
   // as much as needed.

--- a/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/node/task-action.ts
@@ -38,17 +38,30 @@ const nodeAction: NewTaskActionFunction<NodeActionArguments> = async (
   args,
   hre,
 ) => {
-  assertHardhatInvariant(
-    hre.config.networks.node.type === "edr-simulated",
-    "`node` network type must be `edr-simulated`",
-  );
+  const network =
+    hre.globalOptions.network !== undefined
+      ? hre.globalOptions.network
+      : "node";
+
+  if (!(network in hre.config.networks)) {
+    throw new HardhatError(HardhatError.ERRORS.CORE.NETWORK.NETWORK_NOT_FOUND, {
+      networkName: network,
+    });
+  }
+
+  if (hre.config.networks[network].type !== "edr-simulated") {
+    throw new HardhatError(HardhatError.ERRORS.CORE.NODE.INVALID_NETWORK_TYPE, {
+      networkType: hre.config.networks[network].type,
+      networkName: network,
+    });
+  }
 
   const connectionParams: {
     network: string;
     chainType?: ChainType;
     override?: EdrNetworkConfigOverride;
   } = {
-    network: "node",
+    network,
   };
 
   // NOTE: We create an empty network config override here. We add to it based

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -156,10 +156,6 @@ describe("network-manager/hook-handlers/config", () => {
       const next = async (nextConfig: HardhatUserConfig) => nextConfig;
 
       const extendedConfig = await extendUserConfig(config, next);
-      assert.ok(
-        extendedConfig.networks?.node !== undefined,
-        "node network should be defined",
-      );
       assert.deepEqual(extendedConfig.networks?.node, {
         chainId: 31337,
         gas: "auto",
@@ -280,11 +276,9 @@ describe("network-manager/hook-handlers/config", () => {
             url: "http://localhost:8545",
           },
         },
-      };
+      } as const;
 
-      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      -- testing invalid network type for js users */
-      const validationErrors = await validateNetworkUserConfig(config as any);
+      const validationErrors = await validateNetworkUserConfig(config);
 
       assertValidationErrors(validationErrors, [
         {


### PR DESCRIPTION
This PR introduces a new `node` network config, which is present by default, and whose type must always be `edr-simulated`. This last requirement is enforced during the validation of the config.

Depends on: https://github.com/NomicFoundation/hardhat/pull/7805
Docs PR: https://github.com/NomicFoundation/hardhat-website/pull/222