### PR TITLE
Fix `hardhat-ethers-chai-matchers`

### DIFF
--- a/.changeset/lemon-flies-reply.md
+++ b/.changeset/lemon-flies-reply.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+---
+
+Only use `AssertionError`s within assertion functions [#7993](https://github.com/NomicFoundation/hardhat/pull/7993)

--- a/.changeset/wild-buckets-beam.md
+++ b/.changeset/wild-buckets-beam.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-mocha": patch
+---
+
+Improve the error message shown when an `await` is missing [#7993](https://github.com/NomicFoundation/hardhat/pull/7993)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,9 +338,6 @@ importers:
 
   v-next/hardhat-ethers-chai-matchers:
     dependencies:
-      '@nomicfoundation/hardhat-errors':
-        specifier: workspace:^3.0.5
-        version: link:../hardhat-errors
       '@nomicfoundation/hardhat-ethers':
         specifier: workspace:^4.0.0
         version: link:../hardhat-ethers

--- a/v-next/hardhat-ethers-chai-matchers/package.json
+++ b/v-next/hardhat-ethers-chai-matchers/package.json
@@ -63,7 +63,6 @@
     "typescript": "~5.8.0"
   },
   "dependencies": {
-    "@nomicfoundation/hardhat-errors": "workspace:^3.0.5",
     "@nomicfoundation/hardhat-utils": "workspace:^3.0.5",
     "@types/chai-as-promised": "^8.0.1",
     "chai-as-promised": "^8.0.0",

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/addressable.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/addressable.ts
@@ -1,4 +1,4 @@
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import { assert as chaiAssert } from "chai";
 import { isAddress, isAddressable } from "ethers";
 
 import { tryDereference } from "../utils/typed.js";
@@ -35,9 +35,9 @@ function tryGetAddressSync(value: any): string | undefined {
     if ("address" in value) {
       value = value.address;
     } else {
-      assertHardhatInvariant(
+      chaiAssert.ok(
         "target" in value,
-        "target property should exist in value",
+        "Addressable value should have the property target",
       );
       value = value.target;
     }

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/addressable.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/addressable.ts
@@ -39,7 +39,11 @@ function tryGetAddressSync(value: any): string | undefined {
         "target" in value,
         "Addressable value should have the property target",
       );
-      value = value.target;
+
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- This cast is here so the CI job with @types/chai@4.3.0 builds. Note
+        that we have the assertion that target exists above. */
+      value = (value as any).target;
     }
   }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/big-number.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/big-number.ts
@@ -1,8 +1,7 @@
 import util from "node:util";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { toBigInt } from "@nomicfoundation/hardhat-utils/bigint";
-import { AssertionError } from "chai";
+import { assert as chaiAssert, AssertionError } from "chai";
 import deepEqual from "deep-eql";
 
 import { isBigInt } from "../utils/bigint.js";
@@ -120,11 +119,9 @@ function overwriteBigNumberFunction(
       } else if (method === "lte") {
         return lhs <= rhs;
       } else {
-        throw new HardhatError(
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.UNKNOWN_COMPARISON_OPERATION,
-          {
-            method,
-          },
+        chaiAssert.fail(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Unreachable
+          `Unknown comparison operation "${method as any}"`,
         );
       }
     }

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/changeEtherBalances.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/changeEtherBalances.ts
@@ -3,7 +3,7 @@ import type { HardhatEthers } from "@nomicfoundation/hardhat-ethers/types";
 import type { Addressable } from "ethers/address";
 import type { TransactionResponse } from "ethers/providers";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assert as chaiAssert } from "chai";
 import { toBigInt } from "ethers/utils";
 
 import { CHANGE_ETHER_BALANCES_MATCHER } from "../constants.js";
@@ -120,12 +120,8 @@ function validateInput(
       Array.isArray(balanceChanges) &&
       accounts.length !== balanceChanges.length
     ) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.ACCOUNTS_NUMBER_DIFFERENT_FROM_BALANCE_CHANGES,
-        {
-          accounts: accounts.length,
-          balanceChanges: balanceChanges.length,
-        },
+      chaiAssert.fail(
+        `The number of accounts (${accounts.length}) is different than the number of expected balance changes (${balanceChanges.length})`,
       );
     }
   } catch (e) {

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/changeEtherBalances.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/changeEtherBalances.ts
@@ -145,7 +145,10 @@ export async function getBalanceChanges(
   const txResponse = await transaction;
 
   const txReceipt = await txResponse.wait();
-  assertIsNotNull(txReceipt, "txReceipt");
+  assertIsNotNull(
+    txReceipt,
+    "Transaction's receipt cannot be fetched from the network",
+  );
   const txBlockNumber = txReceipt.blockNumber;
 
   const balancesAfter = await getBalances(ethers, accounts, txBlockNumber);
@@ -170,7 +173,10 @@ async function getTxFees(
         (await getAddressOf(account)) === txResponse.from
       ) {
         const txReceipt = await txResponse.wait();
-        assertIsNotNull(txReceipt, "txReceipt");
+        assertIsNotNull(
+          txReceipt,
+          "Transaction's receipt cannot be fetched from the network",
+        );
         const gasPrice = txReceipt.gasPrice ?? txResponse.gasPrice;
         const gasUsed = txReceipt.gasUsed;
         const txFee = gasPrice * gasUsed;

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/changeTokenBalance.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/changeTokenBalance.ts
@@ -8,11 +8,9 @@ import type {
 } from "ethers";
 import type { TransactionResponse } from "ethers/providers";
 
-import {
-  assertHardhatInvariant,
-  HardhatError,
-} from "@nomicfoundation/hardhat-errors";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
+import { assert as chaiAssert } from "chai";
 import { toBigInt } from "ethers/utils";
 
 import {
@@ -237,15 +235,22 @@ export async function getBalanceChange(
   const txResponse = await transaction;
 
   const txReceipt = await txResponse.wait();
-  assertIsNotNull(txReceipt, "txReceipt");
+  assertIsNotNull(
+    txReceipt,
+    "Transaction's receipt cannot be fetched from the network",
+  );
   const txBlockNumber = txReceipt.blockNumber;
 
   const block = await ethers.provider.getBlock(txReceipt.blockHash, false);
 
-  assertHardhatInvariant(block !== null, "The block doesn't exist");
+  assertIsNotNull(
+    block,
+    "The transaction's block cannot be fetched from the network",
+  );
 
-  assertHardhatInvariant(
-    Array.isArray(block.transactions) && block.transactions.length === 1,
+  chaiAssert.equal(
+    block.transactions.length,
+    1,
     "There should be only 1 transaction in the block",
   );
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/changeTokenBalance.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/changeTokenBalance.ts
@@ -8,7 +8,6 @@ import type {
 } from "ethers";
 import type { TransactionResponse } from "ethers/providers";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 import { assert as chaiAssert } from "chai";
 import { toBigInt } from "ethers/utils";
@@ -188,12 +187,8 @@ function validateInput(
       Array.isArray(balanceChanges) &&
       accounts.length !== balanceChanges.length
     ) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.ACCOUNTS_NUMBER_DIFFERENT_FROM_BALANCE_CHANGES,
-        {
-          accounts: accounts.length,
-          balanceChanges: balanceChanges.length,
-        },
+      chaiAssert.fail(
+        `The number of accounts (${accounts.length}) is different than the number of expected balance changes (${balanceChanges.length})`,
       );
     }
   } catch (e) {
@@ -206,11 +201,8 @@ function validateInput(
 
 function checkToken(token: unknown, method: string) {
   if (!isObject(token) || token === null || !("interface" in token)) {
-    throw new HardhatError(
-      HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.FIRST_ARGUMENT_MUST_BE_A_CONTRACT_INSTANCE,
-      {
-        method,
-      },
+    chaiAssert.fail(
+      `The first argument of "${method}" must be the contract instance of the token`,
     );
   } else if (
     isObject(token) &&
@@ -220,9 +212,7 @@ function checkToken(token: unknown, method: string) {
     typeof token.interface.getFunction === "function" &&
     token.interface.getFunction("balanceOf") === null
   ) {
-    throw new HardhatError(
-      HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.CONTRACT_IS_NOT_AN_ERC20_TOKEN,
-    );
+    chaiAssert.fail("The given contract instance is not an ERC20 token");
   }
 }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
@@ -131,7 +131,10 @@ export function supportEmit(
 
         return waitForPendingTransaction(tx, contract.runner.provider).then(
           (receipt) => {
-            assertIsNotNull(receipt, "receipt");
+            assertIsNotNull(
+              receipt,
+              "Transaction's receipt cannot be fetched from the network",
+            );
             return onSuccess(receipt);
           },
         );
@@ -183,7 +186,7 @@ const tryAssertArgsArraysEqual = (
     const parsedLog = chaiUtils
       .flag(context, "contract")
       .interface.parseLog(logs[0]);
-    assertIsNotNull(parsedLog, "parsedLog");
+    assertIsNotNull(parsedLog, "Can't parse the first log");
 
     return assertArgsArraysEqual(
       Assertion,
@@ -204,7 +207,7 @@ const tryAssertArgsArraysEqual = (
         const parsedLog = chaiUtils
           .flag(context, "contract")
           .interface.parseLog(logs[index]);
-        assertIsNotNull(parsedLog, "parsedLog");
+        assertIsNotNull(parsedLog, `Can't parse the log index ${index}`);
 
         assertArgsArraysEqual(
           Assertion,

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
@@ -74,8 +74,9 @@ export function supportEmit(
         } catch (e) {
           if (e instanceof TypeError) {
             const errorMessage = e.message.split(" (argument=")[0];
-            // eslint-disable-next-line no-restricted-syntax -- keep the original chai error structure
-            throw new AssertionError(errorMessage);
+            const error = new AssertionError(errorMessage);
+            error.cause = e;
+            throw error;
           }
         }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
@@ -71,7 +71,10 @@ export function supportEmit(
           if (e instanceof TypeError) {
             const errorMessage = e.message.split(" (argument=")[0];
             const error = new AssertionError(errorMessage);
-            error.cause = e;
+            /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions 
+              -- This cast is here because otherwise the CI job that ensures that
+              this package still works with chai v5 will fail */
+            (error as any).cause = e;
             throw error;
           }
         }

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
@@ -6,8 +6,7 @@ import type { Transaction } from "ethers/transaction";
 
 import util from "node:util";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import { AssertionError } from "chai";
+import { assert as chaiAssert, AssertionError } from "chai";
 
 import { ASSERTION_ABORTED, EMIT_MATCHER } from "../constants.js";
 import { assertArgsArraysEqual, assertIsNotNull } from "../utils/asserts.js";
@@ -30,10 +29,7 @@ async function waitForPendingTransaction(
   }
 
   if (hash === null) {
-    throw new HardhatError(
-      HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.INVALID_TRANSACTION,
-      { transaction: JSON.stringify(tx) },
-    );
+    chaiAssert.fail(`"${JSON.stringify(tx)}" is not a valid transaction`);
   }
 
   return provider.getTransactionReceipt(hash);
@@ -90,14 +86,12 @@ export function supportEmit(
         const topic = eventFragment.topicHash;
         const contractAddress = contract.target;
         if (typeof contractAddress !== "string") {
-          throw new HardhatError(
-            HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.CONTRACT_TARGET_MUST_BE_A_STRING,
-          );
+          chaiAssert.fail("The contract target should be a string");
         }
 
         if (args.length > 0) {
-          throw new HardhatError(
-            HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.EMIT_EXPECTS_TWO_ARGUMENTS,
+          chaiAssert.fail(
+            "The .emit matcher expects two arguments: the contract and the event name. Arguments should be asserted with the .withArgs helper.",
           );
         }
 
@@ -125,9 +119,7 @@ export function supportEmit(
         }
 
         if (contract.runner === null || contract.runner.provider === null) {
-          throw new HardhatError(
-            HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.CONTRACT_RUNNER_PROVIDER_NOT_NULL,
-          );
+          chaiAssert.fail("contract.runner.provider shouldn't be null");
         }
 
         return waitForPendingTransaction(tx, contract.runner.provider).then(

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/legacyReverted.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/legacyReverted.ts
@@ -1,4 +1,4 @@
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assert as chaiAssert } from "chai";
 
 import { LEGACY_REVERTED_MATCHER } from "../../constants.js";
 
@@ -12,8 +12,8 @@ export function supportLegacyReverted(
       this._obj.catch(() => {});
     }
 
-    throw new HardhatError(
-      HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.DEPRECATED_REVERTED_MATCHER,
+    chaiAssert.fail(
+      "The .reverted matcher has been deprecated. Use .revert(ethers) instead.",
     );
   });
 }

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
@@ -1,7 +1,7 @@
 import type { HardhatEthers } from "@nomicfoundation/hardhat-ethers/types";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { assert as chaiAssert } from "chai";
 
 import { REVERT_MATCHER } from "../../constants.js";
 import { assertIsNotNull } from "../../utils/asserts.js";
@@ -40,11 +40,8 @@ export function supportRevert(
           const hash = typeof value === "string" ? value : value.hash;
 
           if (!isValidTransactionHash(hash)) {
-            throw new HardhatError(
-              HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.EXPECTED_VALID_TRANSACTION_HASH,
-              {
-                hash,
-              },
+            chaiAssert.fail(
+              `Expected a valid transaction hash, but got "${hash}"`,
             );
           }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
@@ -58,7 +58,10 @@ export function supportRevert(
             }
           }
 
-          assertIsNotNull(receipt, "receipt");
+          assertIsNotNull(
+            receipt,
+            "Transaction's receipt cannot be fetched from the network",
+          );
           assert(
             receipt.status === 0,
             "Expected transaction to be reverted",

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWith.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWith.ts
@@ -1,5 +1,5 @@
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { assert as chaiAssert } from "chai";
 
 import { REVERTED_WITH_MATCHER } from "../../constants.js";
 import { buildAssert } from "../../utils/build-assert.js";
@@ -26,8 +26,8 @@ export function supportRevertedWith(
         // potentially be a rejected promise
         Promise.resolve(this._obj).catch(() => {});
 
-        throw new HardhatError(
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.EXPECT_STRING_OR_REGEX_AS_REVERT_REASON,
+        chaiAssert.fail(
+          "Expected the revert reason to be a string or a regular expression",
         );
       }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithCustomError.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithCustomError.ts
@@ -224,7 +224,10 @@ export async function revertedWithCustomErrorWithArgs(
 
   const errorFragment = contractInterface.getError(customError.name);
 
-  assertIsNotNull(errorFragment, "errorFragment");
+  assertIsNotNull(
+    errorFragment,
+    "Error type can't be found in the contract's interface",
+  );
 
   // We transform ether's Array-like object into an actual array as it's safer
   const actualArgs = resultToArray(

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithCustomError.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithCustomError.ts
@@ -2,8 +2,8 @@ import type { Ssfi } from "../../utils/ssfi.js";
 import type { ErrorFragment, Interface } from "ethers/abi";
 import type { BaseContract } from "ethers/contract";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { assert as chaiAssert } from "chai";
 
 import {
   ASSERTION_ABORTED,
@@ -160,16 +160,14 @@ function validateInput(
     // argument
     if (typeof contract === "string" || contract?.interface === undefined) {
       // discard subject since it could potentially be a rejected promise
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.FIRST_ARGUMENT_MUST_BE_A_CONTRACT,
+      chaiAssert.fail(
+        "The first argument of .revertedWithCustomError must be the contract that defines the custom error",
       );
     }
 
     // validate custom error name
     if (typeof expectedCustomErrorName !== "string") {
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.STRING_EXPECTED_AS_CUSTOM_ERROR_NAME,
-      );
+      chaiAssert.fail("Expected the custom error name to be a string");
     }
 
     const iface = contract.interface;
@@ -177,17 +175,14 @@ function validateInput(
 
     // check that interface contains the given custom error
     if (expectedCustomError === null) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.CONTRACT_DOES_NOT_HAVE_CUSTOM_ERROR,
-        {
-          customErrorName: expectedCustomErrorName,
-        },
+      chaiAssert.fail(
+        `The given contract doesn't have a custom error named "${expectedCustomErrorName}"`,
       );
     }
 
     if (args.length > 0) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.REVERT_INVALID_ARGUMENTS_LENGTH,
+      chaiAssert.fail(
+        "The .revertedWithCustomError matcher expects two arguments: the contract and the custom error name. Arguments should be asserted with the .withArgs helper.",
       );
     }
 
@@ -214,8 +209,8 @@ export async function revertedWithCustomErrorWithArgs(
     context.customErrorData;
 
   if (customErrorAssertionData === undefined) {
-    throw new HardhatError(
-      HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.WITH_ARGS_FORBIDDEN,
+    chaiAssert.fail(
+      "[.withArgs] should never happen, please submit an issue to the Hardhat repository",
     );
   }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithPanic.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithPanic.ts
@@ -1,5 +1,6 @@
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { toBigInt } from "@nomicfoundation/hardhat-utils/bigint";
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
 
 import { REVERTED_WITH_PANIC_MATCHER } from "../../constants.js";
@@ -24,7 +25,9 @@ export function supportRevertedWithPanic(
         if (expectedCodeArg !== undefined) {
           expectedCode = toBigInt(expectedCodeArg);
         }
-      } catch {
+      } catch (e) {
+        ensureError(e);
+
         // if the input validation fails, we discard the subject since it could
         // potentially be a rejected promise
         Promise.resolve(this._obj).catch(() => {});
@@ -34,6 +37,7 @@ export function supportRevertedWithPanic(
           {
             panicCode: expectedCodeArg,
           },
+          e,
         );
       }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithPanic.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithPanic.ts
@@ -1,7 +1,7 @@
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { toBigInt } from "@nomicfoundation/hardhat-utils/bigint";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { assert as chaiAssert } from "chai";
 
 import { REVERTED_WITH_PANIC_MATCHER } from "../../constants.js";
 import { buildAssert } from "../../utils/build-assert.js";
@@ -25,20 +25,22 @@ export function supportRevertedWithPanic(
         if (expectedCodeArg !== undefined) {
           expectedCode = toBigInt(expectedCodeArg);
         }
-      } catch (e) {
-        ensureError(e);
+      } catch (cause) {
+        ensureError(cause);
 
         // if the input validation fails, we discard the subject since it could
         // potentially be a rejected promise
         Promise.resolve(this._obj).catch(() => {});
 
-        throw new HardhatError(
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.PANIC_CODE_EXPECTED,
-          {
-            panicCode: expectedCodeArg,
-          },
-          e,
-        );
+        try {
+          chaiAssert.fail(
+            `Expected the given panic code to be a number-like value, but got "${expectedCodeArg}"`,
+          );
+        } catch (e) {
+          ensureError(e);
+          e.cause = cause;
+          throw e;
+        }
       }
 
       const code: bigint | undefined = expectedCode;

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
@@ -102,7 +102,7 @@ export function decodeReturnData(returnData: string): DecodedReturnData {
 
       try {
         chaiAssert.fail(
-          `There was an error decoding "${encodedReason}" as a "uint256. Reason: ${cause.message}"`,
+          `There was an error decoding "${encodedReason}" as a "uint256". Reason: ${cause.message}`,
         );
       } catch (e) {
         ensureError(e);

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
@@ -1,8 +1,7 @@
 import type { Result } from "ethers/abi";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
-import { AssertionError } from "chai";
+import { assert as chaiAssert, AssertionError } from "chai";
 import { AbiCoder, decodeBytes32String } from "ethers/abi";
 
 import { panicErrorCodeToReason } from "./panic.js";
@@ -75,18 +74,18 @@ export function decodeReturnData(returnData: string): DecodedReturnData {
 
     try {
       reason = abi.decode(["string"], `0x${encodedReason}`)[0];
-    } catch (e) {
-      ensureError(e);
+    } catch (cause) {
+      ensureError(cause);
 
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.DECODING_ERROR,
-        {
-          encodedData: encodedReason,
-          type: "string",
-          reason: e.message,
-        },
-        e,
-      );
+      try {
+        chaiAssert.fail(
+          `There was an error decoding "${encodedReason}" as a "string. Reason: ${cause.message}"`,
+        );
+      } catch (e) {
+        ensureError(e);
+        e.cause = cause;
+        throw e;
+      }
     }
 
     return {
@@ -98,18 +97,18 @@ export function decodeReturnData(returnData: string): DecodedReturnData {
     let code: bigint;
     try {
       code = abi.decode(["uint256"], `0x${encodedReason}`)[0];
-    } catch (e) {
-      ensureError(e);
+    } catch (cause) {
+      ensureError(cause);
 
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.DECODING_ERROR,
-        {
-          encodedData: encodedReason,
-          type: "uint256",
-          reason: e.message,
-        },
-        e,
-      );
+      try {
+        chaiAssert.fail(
+          `There was an error decoding "${encodedReason}" as a "uint256. Reason: ${cause.message}"`,
+        );
+      } catch (e) {
+        ensureError(e);
+        e.cause = cause;
+        throw e;
+      }
     }
 
     const description = panicErrorCodeToReason(code) ?? "unknown panic code";

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
@@ -85,6 +85,7 @@ export function decodeReturnData(returnData: string): DecodedReturnData {
           type: "string",
           reason: e.message,
         },
+        e,
       );
     }
 
@@ -107,6 +108,7 @@ export function decodeReturnData(returnData: string): DecodedReturnData {
           type: "uint256",
           reason: e.message,
         },
+        e,
       );
     }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/withArgs.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/matchers/withArgs.ts
@@ -1,6 +1,5 @@
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { toBigInt } from "@nomicfoundation/hardhat-utils/bigint";
-import { AssertionError } from "chai";
+import { assert as chaiAssert, AssertionError } from "chai";
 import { isAddressable } from "ethers/address";
 
 import { ASSERTION_ABORTED } from "../constants.js";
@@ -104,9 +103,7 @@ function validateInput(
 ): { emitCalled: boolean } {
   try {
     if (Boolean(this.__flags.negate)) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.WITH_ARGS_CANNOT_BE_COMBINED_WITH_NOT,
-      );
+      chaiAssert.fail("Do not combine .not. with .withArgs()");
     }
 
     const emitCalled = chaiUtils.flag(this, EMIT_CALLED) === true;
@@ -115,14 +112,14 @@ function validateInput(
       chaiUtils.flag(this, REVERTED_WITH_CUSTOM_ERROR_CALLED) === true;
 
     if (!emitCalled && !revertedWithCustomErrorCalled) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.WITH_ARGS_WRONG_COMBINATION,
+      chaiAssert.fail(
+        "withArgs can only be used in combination with a previous .emit or .revertedWithCustomError assertion",
       );
     }
 
     if (emitCalled && revertedWithCustomErrorCalled) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.WITH_ARGS_COMBINED_WITH_INCOMPATIBLE_ASSERTIONS,
+      chaiAssert.fail(
+        "withArgs called with both .emit and .revertedWithCustomError, but these assertions cannot be combined",
       );
     }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/utils/account.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/utils/account.ts
@@ -1,7 +1,7 @@
 import type { Addressable } from "ethers/address";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { isAddress } from "@nomicfoundation/hardhat-utils/eth";
+import { assert as chaiAssert } from "chai";
 import { isAddressable } from "ethers/address";
 
 export async function getAddressOf(
@@ -15,10 +15,5 @@ export async function getAddressOf(
     return account.getAddress();
   }
 
-  throw new HardhatError(
-    HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.EXPECTED_STRING_OR_ADDRESSABLE,
-    {
-      account,
-    },
-  );
+  chaiAssert.fail(`Expected string or addressable, but got "${account}"`);
 }

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/utils/asserts.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/utils/asserts.ts
@@ -86,12 +86,18 @@ function innerAssertArgEqual(
     } catch (e) {
       ensureError(e);
 
-      assert(
-        false,
-        `The predicate threw when called: ${e.message}`,
-        // no need for a negated message, since we disallow mixing .not. with
-        // .withArgs
-      );
+      try {
+        assert(
+          false,
+          `The predicate threw when called: ${e.message}`,
+          // no need for a negated message, since we disallow mixing .not. with
+          // .withArgs
+        );
+      } catch (assertError) {
+        ensureError(assertError);
+        assertError.cause = e;
+        throw assertError;
+      }
     }
     assert(
       false,

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/utils/asserts.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/utils/asserts.ts
@@ -1,10 +1,8 @@
 import type { AssertWithSsfi, Ssfi } from "./ssfi.js";
 
-import {
-  assertHardhatInvariant,
-  HardhatError,
-} from "@nomicfoundation/hardhat-errors";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
+import { assert as chaiAssert } from "chai";
 import { keccak256 } from "ethers/crypto";
 import { getBytes, hexlify, isHexString, toUtf8Bytes } from "ethers/utils";
 
@@ -12,9 +10,9 @@ import { ordinal } from "./ordinal.js";
 
 export function assertIsNotNull<T>(
   value: T,
-  valueName: string,
+  errorMessage: string,
 ): asserts value is Exclude<T, null> {
-  assertHardhatInvariant(value !== null, `${valueName} should not be null`);
+  chaiAssert.notEqual(value, null, errorMessage);
 }
 
 export function assertArgsArraysEqual(
@@ -147,7 +145,7 @@ function innerAssertArgEqual(
 export function assertCanBeConvertedToBigint(
   value: unknown,
 ): asserts value is string | number | bigint {
-  assertHardhatInvariant(
+  chaiAssert.ok(
     typeof value === "string" ||
       typeof value === "number" ||
       typeof value === "bigint",

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/utils/asserts.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/utils/asserts.ts
@@ -1,6 +1,5 @@
 import type { AssertWithSsfi, Ssfi } from "./ssfi.js";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { assert as chaiAssert } from "chai";
 import { keccak256 } from "ethers/crypto";
@@ -122,8 +121,8 @@ function innerAssertArgEqual(
   } else {
     if (actualArg.hash !== undefined && actualArg._isIndexed === true) {
       if (assertionType !== "event") {
-        throw new HardhatError(
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.INDEXED_EVENT_FORBIDDEN,
+        chaiAssert.fail(
+          "Should not get an indexed event when the assertion type is not event. Please open an issue about this.",
         );
       }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/utils/build-assert.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/utils/build-assert.ts
@@ -1,7 +1,6 @@
 import type { Ssfi } from "./ssfi.js";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import { AssertionError } from "chai";
+import { assert as chaiAssert, AssertionError } from "chai";
 
 /**
  * This function is used by the matchers to obtain an `assert` function, which
@@ -27,8 +26,8 @@ export function buildAssert(negated: boolean, ssfi: Ssfi) {
   ): void {
     if (!negated && !condition) {
       if (messageFalse === undefined) {
-        throw new HardhatError(
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.ASSERTION_WITHOUT_ERROR_MESSAGE,
+        chaiAssert.fail(
+          "Assertion doesn't have an error message. Please open an issue to report this.",
         );
       }
 
@@ -40,8 +39,8 @@ export function buildAssert(negated: boolean, ssfi: Ssfi) {
 
     if (negated && condition) {
       if (messageTrue === undefined) {
-        throw new HardhatError(
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.ASSERTION_WITHOUT_ERROR_MESSAGE,
+        chaiAssert.fail(
+          "Assertion doesn't have an error message. Please open an issue to report this.",
         );
       }
 

--- a/v-next/hardhat-ethers-chai-matchers/src/internal/utils/prevent-chaining.ts
+++ b/v-next/hardhat-ethers-chai-matchers/src/internal/utils/prevent-chaining.ts
@@ -1,4 +1,4 @@
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assert as chaiAssert } from "chai";
 
 import { PREVIOUS_MATCHER_NAME } from "../constants.js";
 
@@ -23,11 +23,7 @@ export function preventAsyncMatcherChaining(
     return;
   }
 
-  throw new HardhatError(
-    HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.MATCHER_CANNOT_BE_CHAINED_AFTER,
-    {
-      matcher: matcherName,
-      previousMatcher: previousMatcherName,
-    },
+  chaiAssert.fail(
+    `The matcher "${matcherName}" cannot be chained after "${previousMatcherName}". For more information, please refer to the documentation at: (https://hardhat.org/chaining-async-matchers).`,
   );
 }

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
@@ -101,7 +101,7 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
               includeFee: true,
             }),
           ).to.be.eventually.rejectedWith(
-            "There should be only 1 transaction in the block",
+            "There should be only 1 transaction in the block: expected 2 to equal 1",
           );
         });
 

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
@@ -10,9 +10,8 @@ import path from "node:path";
 import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
-  assertThrowsHardhatError,
+  assertThrows,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { expect, AssertionError } from "chai";
@@ -621,7 +620,7 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
         });
 
         it("should throw if chained to another non-chainable method", () => {
-          assertThrowsHardhatError(
+          assertThrows(
             () =>
               expect(
                 sender.sendTransaction({
@@ -631,12 +630,11 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
               )
                 .to.changeTokenBalance(ethers, mockToken, receiver, 0)
                 .and.to.changeEtherBalance(ethers, sender, "-200"),
-            HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-              .MATCHER_CANNOT_BE_CHAINED_AFTER,
-            {
-              matcher: "changeEtherBalance",
-              previousMatcher: "changeTokenBalance",
-            },
+            (e) =>
+              e.message.includes(
+                'The matcher "changeEtherBalance" cannot be chained after "changeTokenBalance"',
+              ),
+            "Expected chaining error message",
           );
         });
       });

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalances.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalances.ts
@@ -10,9 +10,8 @@ import path from "node:path";
 import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
-  assertThrowsHardhatError,
+  assertThrows,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { expect, AssertionError } from "chai";
@@ -349,7 +348,7 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
       });
 
       it("should throw if chained to another non-chainable method", () => {
-        assertThrowsHardhatError(
+        assertThrows(
           () =>
             expect(
               sender.sendTransaction({
@@ -368,12 +367,11 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
                 [sender, contract],
                 [-200, 200],
               ),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .MATCHER_CANNOT_BE_CHAINED_AFTER,
-          {
-            matcher: "changeEtherBalances",
-            previousMatcher: "changeTokenBalances",
-          },
+          (e) =>
+            e.message.includes(
+              'The matcher "changeEtherBalances" cannot be chained after "changeTokenBalances"',
+            ),
+          "Expected chaining error message",
         );
       });
 

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/changeTokenBalance.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/changeTokenBalance.ts
@@ -16,9 +16,8 @@ import path from "node:path";
 import { afterEach, before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
-  assertThrowsHardhatError,
+  assertThrows,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { AssertionError, expect } from "chai";
@@ -655,22 +654,21 @@ describe(
           });
 
           it("changeTokenBalance: Should throw if chained to another non-chainable method", () => {
-            assertThrowsHardhatError(
+            assertThrows(
               () =>
                 expect(contract.emitWithoutArgs())
                   .to.emit(contract, "WithoutArgs")
                   .and.to.changeTokenBalance(ethers, mockToken, receiver, 0),
-              HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-                .MATCHER_CANNOT_BE_CHAINED_AFTER,
-              {
-                matcher: "changeTokenBalance",
-                previousMatcher: "emit",
-              },
+              (e) =>
+                e.message.includes(
+                  'The matcher "changeTokenBalance" cannot be chained after "emit"',
+                ),
+              "Expected chaining error message",
             );
           });
 
           it("changeTokenBalances: should throw if chained to another non-chainable method", () => {
-            assertThrowsHardhatError(
+            assertThrows(
               () =>
                 expect(matchers.revertWithCustomErrorWithInt(1))
                   .to.be.revert(ethers)
@@ -680,12 +678,11 @@ describe(
                     [sender, receiver],
                     [-50, 100],
                   ),
-              HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-                .MATCHER_CANNOT_BE_CHAINED_AFTER,
-              {
-                matcher: "changeTokenBalances",
-                previousMatcher: "revert",
-              },
+              (e) =>
+                e.message.includes(
+                  'The matcher "changeTokenBalances" cannot be chained after "revert"',
+                ),
+              "Expected chaining error message",
             );
           });
         });
@@ -694,31 +691,31 @@ describe(
       describe("validation errors", () => {
         describe(CHANGE_TOKEN_BALANCE_MATCHER, () => {
           it("token is not specified", async () => {
-            assertThrowsHardhatError(
+            assertThrows(
               () =>
                 expect(
                   mockToken.transfer(receiver.address, 50),
                   // @ts-expect-error -- force error scenario: token should be specified
                 ).to.changeTokenBalance(ethers, receiver, 50),
-              HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-                .FIRST_ARGUMENT_MUST_BE_A_CONTRACT_INSTANCE,
-              {
-                method: CHANGE_TOKEN_BALANCE_MATCHER,
-              },
+              (e) =>
+                e.message.includes(
+                  `The first argument of "${CHANGE_TOKEN_BALANCE_MATCHER}" must be the contract instance of the token`,
+                ),
+              "Expected contract instance error message",
             );
 
             // if an address is used (receiver.address)
-            assertThrowsHardhatError(
+            assertThrows(
               () =>
                 expect(
                   mockToken.transfer(receiver.address, 50),
                   // @ts-expect-error -- force error scenario: token should be specified
                 ).to.changeTokenBalance(ethers, receiver.address, 50),
-              HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-                .FIRST_ARGUMENT_MUST_BE_A_CONTRACT_INSTANCE,
-              {
-                method: CHANGE_TOKEN_BALANCE_MATCHER,
-              },
+              (e) =>
+                e.message.includes(
+                  `The first argument of "${CHANGE_TOKEN_BALANCE_MATCHER}" must be the contract instance of the token`,
+                ),
+              "Expected contract instance error message",
             );
           });
 
@@ -777,17 +774,17 @@ describe(
 
         describe(CHANGE_TOKEN_BALANCES_MATCHER, () => {
           it("token is not specified", async () => {
-            assertThrowsHardhatError(
+            assertThrows(
               () =>
                 expect(
                   mockToken.transfer(receiver.address, 50),
                   // @ts-expect-error -- force error scenario: token should be specified
                 ).to.changeTokenBalances(ethers, [sender, receiver], [-50, 50]),
-              HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-                .FIRST_ARGUMENT_MUST_BE_A_CONTRACT_INSTANCE,
-              {
-                method: CHANGE_TOKEN_BALANCES_MATCHER,
-              },
+              (e) =>
+                e.message.includes(
+                  `The first argument of "${CHANGE_TOKEN_BALANCES_MATCHER}" must be the contract instance of the token`,
+                ),
+              "Expected contract instance error message",
             );
           });
 

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/changeTokenBalance.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/changeTokenBalance.ts
@@ -758,7 +758,7 @@ describe(
                 mockToken.transfer(receiver.address, 50, { gasLimit: 100_000 }),
               ).to.changeTokenBalance(ethers, mockToken, sender, -50),
             ).to.be.rejectedWith(
-              "There should be only 1 transaction in the block",
+              "There should be only 1 transaction in the block: expected 2 to equal 1",
             );
           });
 
@@ -867,7 +867,9 @@ describe(
 
             await expect(
               expect(
-                mockToken.transfer(receiver.address, 50, { gasLimit: 100_000 }),
+                mockToken.transfer(receiver.address, 50, {
+                  gasLimit: 100_000,
+                }),
               ).to.changeTokenBalances(
                 ethers,
                 mockToken,
@@ -875,7 +877,7 @@ describe(
                 [-50, 50],
               ),
             ).to.be.rejectedWith(
-              "There should be only 1 transaction in the block",
+              "There should be only 1 transaction in the block: expected 2 to equal 1",
             );
           });
 

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/events.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/events.ts
@@ -8,9 +8,8 @@ import type { HardhatEthers } from "@nomicfoundation/hardhat-ethers/types";
 
 import { before, beforeEach, describe, it } from "node:test";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
-  assertRejectsWithHardhatError,
+  assertRejects,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { expect, AssertionError } from "chai";
@@ -80,12 +79,15 @@ describe(".to.emit (contract events)", { timeout: 60000 }, () => {
     });
 
     it("should fail when matcher is called with too many arguments", async () => {
-      await assertRejectsWithHardhatError(
+      await assertRejects(
         () =>
           // @ts-expect-error -- force error scenario: emit should not be called with more than two arguments
           expect(contract.emitUint(1)).not.to.emit(contract, "WithoutArgs", 1),
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.EMIT_EXPECTS_TWO_ARGUMENTS,
-        {},
+        (e) =>
+          e.message.includes(
+            "The .emit matcher expects two arguments: the contract and the event name. Arguments should be asserted with the .withArgs helper.",
+          ),
+        "Expected emit arguments error message",
       );
     });
 

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/reverted/legacyReverted.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/reverted/legacyReverted.ts
@@ -1,9 +1,8 @@
 import { describe, it } from "node:test";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
-  assertRejectsWithHardhatError,
-  assertThrowsHardhatError,
+  assertRejects,
+  assertThrows,
 } from "@nomicfoundation/hardhat-test-utils";
 import { expect } from "chai";
 
@@ -14,34 +13,43 @@ addChaiMatchers();
 describe("INTEGRATION: Reverted", { timeout: 60000 }, () => {
   describe("Throwing deprecation error", () => {
     it("Should throw the right error", async () => {
-      await assertRejectsWithHardhatError(
+      await assertRejects(
         async () => {
           await expect(() => {}).to.reverted;
         },
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.DEPRECATED_REVERTED_MATCHER,
-        {},
+        (e) =>
+          e.message.includes(
+            "The .reverted matcher has been deprecated. Use .revert(ethers) instead.",
+          ),
+        "Expected deprecated reverted matcher error message",
       );
     });
 
     it("Should also throw in a sync context", async () => {
-      assertThrowsHardhatError(
+      assertThrows(
         () => {
           void expect(() => {}).to.reverted;
         },
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.DEPRECATED_REVERTED_MATCHER,
-        {},
+        (e) =>
+          e.message.includes(
+            "The .reverted matcher has been deprecated. Use .revert(ethers) instead.",
+          ),
+        "Expected deprecated reverted matcher error message",
       );
     });
 
     it("Should work with a promise that rejects", async () => {
-      await assertRejectsWithHardhatError(
+      await assertRejects(
         async () => {
           await expect(async () => {
             throw new Error("foo");
           }).to.reverted;
         },
-        HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.DEPRECATED_REVERTED_MATCHER,
-        {},
+        (e) =>
+          e.message.includes(
+            "The .reverted matcher has been deprecated. Use .revert(ethers) instead.",
+          ),
+        "Expected deprecated reverted matcher error message",
       );
     });
   });

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
@@ -6,10 +6,9 @@ import path from "node:path";
 import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
-  assertRejectsWithHardhatError,
-  assertThrowsHardhatError,
+  assertRejects,
+  assertThrows,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { AssertionError, expect } from "chai";
@@ -80,22 +79,22 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
       });
 
       it("invalid string", async () => {
-        await assertRejectsWithHardhatError(
+        await assertRejects(
           () => expect("0x123").to.be.revert(ethers),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .EXPECTED_VALID_TRANSACTION_HASH,
-          {
-            hash: "0x123",
-          },
+          (e) =>
+            e.message.includes(
+              'Expected a valid transaction hash, but got "0x123"',
+            ),
+          "Expected invalid transaction hash error message",
         );
 
-        await assertRejectsWithHardhatError(
+        await assertRejects(
           () => expect("0x123").to.not.be.revert(ethers),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .EXPECTED_VALID_TRANSACTION_HASH,
-          {
-            hash: "0x123",
-          },
+          (e) =>
+            e.message.includes(
+              'Expected a valid transaction hash, but got "0x123"',
+            ),
+          "Expected invalid transaction hash error message",
         );
       });
 
@@ -122,22 +121,22 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
       });
 
       it("promise of an invalid string", async () => {
-        await assertRejectsWithHardhatError(
+        await assertRejects(
           () => expect(Promise.resolve("0x123")).to.be.revert(ethers),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .EXPECTED_VALID_TRANSACTION_HASH,
-          {
-            hash: "0x123",
-          },
+          (e) =>
+            e.message.includes(
+              'Expected a valid transaction hash, but got "0x123"',
+            ),
+          "Expected invalid transaction hash error message",
         );
 
-        await assertRejectsWithHardhatError(
+        await assertRejects(
           () => expect(Promise.resolve("0x123")).to.not.be.revert(ethers),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .EXPECTED_VALID_TRANSACTION_HASH,
-          {
-            hash: "0x123",
-          },
+          (e) =>
+            e.message.includes(
+              'Expected a valid transaction hash, but got "0x123"',
+            ),
+          "Expected invalid transaction hash error message",
         );
       });
 
@@ -192,69 +191,65 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
       });
 
       it("reverted: should throw if chained to another non-chainable method", () => {
-        assertThrowsHardhatError(
+        assertThrows(
           () =>
             expect(matchers.revertsWith("bar"))
               .to.be.revertedWith("bar")
               .and.to.be.revert(ethers),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .MATCHER_CANNOT_BE_CHAINED_AFTER,
-          {
-            matcher: "revert",
-            previousMatcher: "revertedWith",
-          },
+          (e) =>
+            e.message.includes(
+              'The matcher "revert" cannot be chained after "revertedWith"',
+            ),
+          "Expected chaining error message",
         );
       });
 
       it("revertedWith: should throw if chained to another non-chainable method", () => {
-        assertThrowsHardhatError(
+        assertThrows(
           () =>
             expect(matchers.revertWithCustomErrorWithInt(1))
               .to.be.revertedWithCustomError(matchers, "CustomErrorWithInt")
               .and.to.be.revertedWith("an error message"),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .MATCHER_CANNOT_BE_CHAINED_AFTER,
-          {
-            matcher: "revertedWith",
-            previousMatcher: "revertedWithCustomError",
-          },
+          (e) =>
+            e.message.includes(
+              'The matcher "revertedWith" cannot be chained after "revertedWithCustomError"',
+            ),
+          "Expected chaining error message",
         );
       });
 
       it("revertedWithCustomError: should throw if chained to another non-chainable method", () => {
-        assertThrowsHardhatError(
+        assertThrows(
           () =>
             expect(matchers.revertsWithoutReason())
               .to.be.revertedWithoutReason(ethers)
               .and.to.be.revertedWithCustomError(matchers, "SomeCustomError"),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .MATCHER_CANNOT_BE_CHAINED_AFTER,
-          {
-            matcher: "revertedWithCustomError",
-            previousMatcher: "revertedWithoutReason",
-          },
+          (e) =>
+            e.message.includes(
+              'The matcher "revertedWithCustomError" cannot be chained after "revertedWithoutReason"',
+            ),
+          "Expected chaining error message",
         );
       });
 
       it("revertedWithoutReason: should throw if chained to another non-chainable method", () => {
-        assertThrowsHardhatError(
+        assertThrows(
           () =>
             expect(matchers.panicAssert())
               .to.be.revertedWithPanic()
               .and.to.be.revertedWithoutReason(ethers),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .MATCHER_CANNOT_BE_CHAINED_AFTER,
-          {
-            matcher: "revertedWithoutReason",
-            previousMatcher: "revertedWithPanic",
-          },
+          (e) =>
+            e.message.includes(
+              'The matcher "revertedWithoutReason" cannot be chained after "revertedWithPanic"',
+            ),
+          "Expected chaining error message",
         );
       });
 
       it("revertedWithPanic: should throw if chained to another non-chainable method", async () => {
         const [sender, receiver] = await ethers.getSigners();
 
-        assertThrowsHardhatError(
+        assertThrows(
           () =>
             expect(() =>
               sender.sendTransaction({
@@ -264,12 +259,11 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
             )
               .to.changeEtherBalance(ethers, sender, "-200")
               .and.to.be.revertedWithPanic(),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .MATCHER_CANNOT_BE_CHAINED_AFTER,
-          {
-            matcher: "revertedWithPanic",
-            previousMatcher: "changeEtherBalance",
-          },
+          (e) =>
+            e.message.includes(
+              'The matcher "revertedWithPanic" cannot be chained after "changeEtherBalance"',
+            ),
+          "Expected chaining error message",
         );
       });
     });

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWith.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWith.ts
@@ -6,9 +6,8 @@ import path from "node:path";
 import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
-  assertThrowsHardhatError,
+  assertThrows,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { AssertionError, expect } from "chai";
@@ -200,24 +199,28 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
       it("non-string as expectation", async () => {
         const { hash } = await mineSuccessfulTransaction(provider, ethers);
 
-        assertThrowsHardhatError(
+        assertThrows(
           // @ts-expect-error -- force error scenario: reason should be a string or a regular expression
           () => expect(hash).to.be.revertedWith(10),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .EXPECT_STRING_OR_REGEX_AS_REVERT_REASON,
-          {},
+          (e) =>
+            e.message.includes(
+              "Expected the revert reason to be a string or a regular expression",
+            ),
+          "Expected revert reason type error message",
         );
       });
 
       it("non-string as expectation, subject is a rejected promise", async () => {
         const tx = matchers.revertsWithoutReason();
 
-        assertThrowsHardhatError(
+        assertThrows(
           // @ts-expect-error -- force error scenario: reason should be a string or a regular expression
           () => expect(tx).to.be.revertedWith(10),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .EXPECT_STRING_OR_REGEX_AS_REVERT_REASON,
-          {},
+          (e) =>
+            e.message.includes(
+              "Expected the revert reason to be a string or a regular expression",
+            ),
+          "Expected revert reason type error message",
         );
       });
 

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithCustomError.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithCustomError.ts
@@ -6,9 +6,8 @@ import path from "node:path";
 import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
-  assertThrowsHardhatError,
+  assertThrows,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { AssertionError, expect } from "chai";
@@ -459,37 +458,43 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
       it("non-string as expectation", async () => {
         const { hash } = await mineSuccessfulTransaction(provider, ethers);
 
-        assertThrowsHardhatError(
+        assertThrows(
           // @ts-expect-error -- force error scenario: reason should be a string or a regular expression
           () => expect(hash).to.be.revertedWith(10),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .EXPECT_STRING_OR_REGEX_AS_REVERT_REASON,
-          {},
+          (e) =>
+            e.message.includes(
+              "Expected the revert reason to be a string or a regular expression",
+            ),
+          "Expected revert reason type error message",
         );
       });
 
       it("the contract is not specified", async () => {
-        assertThrowsHardhatError(
+        assertThrows(
           () =>
             expect(
               matchers.revertWithSomeCustomError(),
               // @ts-expect-error -- force error scenario: contract should be specified
             ).to.be.revertedWithCustomError("SomeCustomError"),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .FIRST_ARGUMENT_MUST_BE_A_CONTRACT,
-          {},
+          (e) =>
+            e.message.includes(
+              "The first argument of .revertedWithCustomError must be the contract that defines the custom error",
+            ),
+          "Expected contract argument error message",
         );
       });
 
       it("the contract doesn't have a custom error with that name", async () => {
-        assertThrowsHardhatError(
+        assertThrows(
           () =>
             expect(
               matchers.revertWithSomeCustomError(),
             ).to.be.revertedWithCustomError(matchers, "SomeCustmError"),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .CONTRACT_DOES_NOT_HAVE_CUSTOM_ERROR,
-          { customErrorName: "SomeCustmError" },
+          (e) =>
+            e.message.includes(
+              `The given contract doesn't have a custom error named "SomeCustmError"`,
+            ),
+          "Expected custom error not found error message",
         );
       });
 
@@ -518,7 +523,7 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
       });
 
       it("extra arguments", async () => {
-        assertThrowsHardhatError(
+        assertThrows(
           () =>
             expect(
               matchers.revertWithSomeCustomError(),
@@ -528,9 +533,11 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
               // @ts-expect-error -- force error scenario: extra arguments should not be specified
               "extraArgument",
             ),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL
-            .REVERT_INVALID_ARGUMENTS_LENGTH,
-          {},
+          (e) =>
+            e.message.includes(
+              "The .revertedWithCustomError matcher expects two arguments: the contract and the custom error name. Arguments should be asserted with the .withArgs helper.",
+            ),
+          "Expected invalid arguments length error message",
         );
       });
     });

--- a/v-next/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithPanic.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithPanic.ts
@@ -6,9 +6,8 @@ import path from "node:path";
 import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
-  assertThrowsHardhatError,
+  assertThrows,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { AssertionError, expect } from "chai";
@@ -272,24 +271,26 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
       it("non-number as expectation", async () => {
         const { hash } = await mineSuccessfulTransaction(provider, ethers);
 
-        assertThrowsHardhatError(
+        assertThrows(
           () => expect(hash).to.be.revertedWithPanic("invalid"),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.PANIC_CODE_EXPECTED,
-          {
-            panicCode: "invalid",
-          },
+          (e) =>
+            e.message.includes(
+              'Expected the given panic code to be a number-like value, but got "invalid"',
+            ),
+          "Expected panic code type error message",
         );
       });
 
       it("non-number as expectation, subject is a rejected promise", async () => {
         const tx = matchers.revertsWithoutReason();
 
-        assertThrowsHardhatError(
+        assertThrows(
           () => expect(tx).to.be.revertedWithPanic("invalid"),
-          HardhatError.ERRORS.CHAI_MATCHERS.GENERAL.PANIC_CODE_EXPECTED,
-          {
-            panicCode: "invalid",
-          },
+          (e) =>
+            e.message.includes(
+              'Expected the given panic code to be a number-like value, but got "invalid"',
+            ),
+          "Expected panic code type error message",
         );
       });
 

--- a/v-next/hardhat-mocha/src/unhandled-rejection-mocha-hook.ts
+++ b/v-next/hardhat-mocha/src/unhandled-rejection-mocha-hook.ts
@@ -15,6 +15,7 @@ process.on("unhandledRejection", (e: Error) => {
 
 process.on("exit", () => {
   if (showNotAwaitedError) {
+    console.log();
     console.log(
       chalk.red(
         [


### PR DESCRIPTION
_This PR is a result of investigating https://github.com/NomicFoundation/hardhat/pull/7726 and replaces it_

This PR introduces to three fixes to `hardhat-ethers-chai-matchers`:

1. It remove all the usages of `assertHardhatInvariant` with `assert.fail` with descriptive messages. The `assertHardhatInvariant` function should only be used for things that should *always* be true. It should not be used to validate inputs or return values.
2. It preservers all the `error.cause`s
3. It removes `HardhatError`s from within assertions, as they play nicely with mocha.

It also introduces a small formatting improvement to a `hardhat-mocha` error message.