### PR TITLE
Install libudev-dev on linux to be able to build node-hid

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -49,4 +49,4 @@ runs:
     - name: Install Linux system dependencies
       if: runner.os == 'Linux'
       shell: bash
-      run: sudo apt-get install -y libusb-1.0-0-dev
+      run: sudo apt-get install -y libusb-1.0-0-dev libudev-dev


### PR DESCRIPTION
This dependency was missing to be able to install node-hid. Example: https://github.com/NomicFoundation/hardhat/actions/runs/22357793289/job/64702327740