### PR TITLE
chore: tweak changeset to cover all ignition packages

### DIFF
--- a/.changeset/bump-hardhat-utils-major.md
+++ b/.changeset/bump-hardhat-utils-major.md
@@ -16,6 +16,9 @@
 "@nomicfoundation/hardhat-viem-assertions": patch
 "@nomicfoundation/hardhat-zod-utils": patch
 "@nomicfoundation/ignition-core": patch
+"@nomicfoundation/hardhat-ignition-ethers": patch
+"@nomicfoundation/ignition-ui": patch
+"@nomicfoundation/hardhat-ignition-viem": patch
 ---
 
 Bump `hardhat-utils` major


### PR DESCRIPTION
To avoid empty changelogs for some of the Ignition packages I have included them in the utils major update changeset.
