### PR TITLE
chore: update CI run to include ready for review

### DIFF
--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The ready for review event is not enabled by default, instead we add it in explicitly with the other default events.

This is to support the release PR, which is created in draft, but can leverage the user's permissions on switching from draft to ready to trigger the full CI test suite.
