### PR TITLE
1-line fix for `deploy-website-on-release` workflow

### DIFF
--- a/.github/workflows/deploy-website-on-release.yml
+++ b/.github/workflows/deploy-website-on-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'hardhat.3')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'hardhat@3.')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Vercel Deploy


### PR DESCRIPTION
The filter for Hardhat 3 releases was wrong. This just fixes it.