### PR TITLE
Change our workflow so that PRs to docs are included in changeset comments

### DIFF
--- a/.github/workflows/check-links-to-docs.yml
+++ b/.github/workflows/check-links-to-docs.yml
@@ -1,5 +1,6 @@
-# Fails if a PR doesn't link to documentation (pr/issue on hardhat-website) and is not labeled
-# as "no docs needed"
+# Fails if a PR doesn't link to the docs repo and is not labeled as "no docs needed".
+# Docs PR links must be in changeset frontmatters (as `# docs:` YAML comments), not in the PR body.
+# Docs issue links must be in the PR body.
 
 name: Check that the PR links to documentation
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,15 +100,19 @@ jobs:
               }`;
             await github.graphql(mutation, { prId: pr.id });
 
-      - name: Post docs comment on release PR
-        if: steps.pr.outputs.hasChangesets == 'true' && steps.docs.outputs.has_docs == 'true'
+      - name: Sync docs comment on release PR
+        if: steps.pr.outputs.hasChangesets == 'true'
         uses: actions/github-script@v7
+        env:
+          HAS_DOCS: ${{ steps.docs.outputs.has_docs }}
+          COMMENT_BODY: ${{ steps.docs.outputs.comment_body }}
         with:
           script: |
             const { number } = ${{ steps.find.outputs.result }};
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const body = `${{ steps.docs.outputs.comment_body }}`;
+            const hasDocs = process.env.HAS_DOCS === "true";
+            const body = process.env.COMMENT_BODY;
             const marker = '## Documentation PRs to merge';
 
             const { data: comments } = await github.rest.issues.listComments({
@@ -119,19 +123,25 @@ jobs:
 
             const existing = comments.find(c => c.body.startsWith(marker));
 
-            if (existing) {
+            if (hasDocs && existing) {
               await github.rest.issues.updateComment({
                 owner,
                 repo,
                 comment_id: existing.id,
                 body,
               });
-            } else {
+            } else if (hasDocs) {
               await github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number: number,
                 body,
+              });
+            } else if (existing) {
+              await github.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: existing.id,
               });
             }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,24 @@ jobs:
               }`;
             await github.graphql(mutation, { prId: pr.id });
 
+      - name: Collect docs URLs from changesets
+        if: steps.pr.outputs.hasChangesets == 'true'
+        id: docs
+        run: node scripts/collect-changeset-docs-urls.ts
+
+      - name: Post docs comment on release PR
+        if: steps.pr.outputs.hasChangesets == 'true' && steps.docs.outputs.has_docs == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { number } = ${{ steps.find.outputs.result }};
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: `${{ steps.docs.outputs.comment_body }}`
+            });
+
   pack:
     name: Generate tarballs for publishing
     needs: pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Collect docs URLs from changesets
+        id: docs
+        run: node scripts/collect-changeset-docs-urls.ts
+
       - name: Create release Pull Request
         id: pr
         env:
@@ -94,11 +98,6 @@ jobs:
                 }
               }`;
             await github.graphql(mutation, { prId: pr.id });
-
-      - name: Collect docs URLs from changesets
-        if: steps.pr.outputs.hasChangesets == 'true'
-        id: docs
-        run: node scripts/collect-changeset-docs-urls.ts
 
       - name: Post docs comment on release PR
         if: steps.pr.outputs.hasChangesets == 'true' && steps.docs.outputs.has_docs == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,12 +106,34 @@ jobs:
         with:
           script: |
             const { number } = ${{ steps.find.outputs.result }};
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const body = `${{ steps.docs.outputs.comment_body }}`;
+            const marker = '## Documentation PRs to merge';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
               issue_number: number,
-              body: `${{ steps.docs.outputs.comment_body }}`
             });
+
+            const existing = comments.find(c => c.body.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: number,
+                body,
+              });
+            }
 
   pack:
     name: Generate tarballs for publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       pull-requests: write # This allows us to create pull requests
       contents: write
+      issues: write # Needed for posting/updating docs comments on release PRs
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v5

--- a/scripts/collect-changeset-docs-urls.ts
+++ b/scripts/collect-changeset-docs-urls.ts
@@ -38,7 +38,8 @@ async function collectDocsUrls() {
 
   if (hasDocs) {
     const lines = ["## Documentation PRs to merge"];
-    for (const url of allUrls) {
+    const sortedUrls = Array.from(allUrls).sort();
+    for (const url of sortedUrls) {
       lines.push(`- ${url}`);
     }
     const commentBody = lines.join("\n");

--- a/scripts/collect-changeset-docs-urls.ts
+++ b/scripts/collect-changeset-docs-urls.ts
@@ -21,10 +21,7 @@ async function collectDocsUrls() {
   const allUrls = new Set();
 
   for (const file of files) {
-    const content = await readFile(
-      path.join(changesetDir, file),
-      "utf-8",
-    );
+    const content = await readFile(path.join(changesetDir, file), "utf-8");
     const { frontMatter } = parseFrontMatter(content);
     const urls = extractDocsUrlsFromFrontMatter(frontMatter);
     for (const url of urls) {

--- a/scripts/collect-changeset-docs-urls.ts
+++ b/scripts/collect-changeset-docs-urls.ts
@@ -1,0 +1,53 @@
+import { readdir, readFile, appendFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import {
+  parseFrontMatter,
+  extractDocsUrlsFromFrontMatter,
+} from "./lib/changesets.ts";
+
+const changesetDir = ".changeset";
+
+async function collectDocsUrls() {
+  if (process.env.GITHUB_OUTPUT === undefined) {
+    throw new Error("GITHUB_OUTPUT is not defined");
+  }
+
+  const files = (await readdir(changesetDir)).filter(
+    (file) => file.endsWith(".md") && file !== "README.md",
+  );
+
+  const allUrls = new Set();
+
+  for (const file of files) {
+    const content = await readFile(
+      path.join(changesetDir, file),
+      "utf-8",
+    );
+    const { frontMatter } = parseFrontMatter(content);
+    const urls = extractDocsUrlsFromFrontMatter(frontMatter);
+    for (const url of urls) {
+      allUrls.add(url);
+    }
+  }
+
+  const hasDocs = allUrls.size > 0;
+  console.log(`has_docs: ${hasDocs}`);
+  await appendFile(process.env.GITHUB_OUTPUT, `has_docs=${hasDocs}\n`);
+
+  if (hasDocs) {
+    const lines = ["## Documentation PRs to merge"];
+    for (const url of allUrls) {
+      lines.push(`- ${url}`);
+    }
+    const commentBody = lines.join("\n");
+    console.log(`comment_body:\n${commentBody}`);
+    await appendFile(
+      process.env.GITHUB_OUTPUT,
+      `comment_body<<EOF\n${commentBody}\nEOF\n`,
+    );
+  }
+}
+
+await collectDocsUrls();

--- a/scripts/lib/changesets.test.ts
+++ b/scripts/lib/changesets.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  extractDocsUrlsFromFrontMatter,
+  parseFrontMatter,
+} from "./changesets.ts";
+
+describe("changesets helpers", () => {
+  describe("parseFrontMatter", () => {
+    it("should parse markdown with frontmatter", () => {
+      assert.deepEqual(
+        parseFrontMatter(`---
+# docs: https://github.com/NomicFoundation/hardhat-website/pull/123
+"hardhat": patch
+---
+Body`),
+        {
+          frontMatter:
+            '# docs: https://github.com/NomicFoundation/hardhat-website/pull/123\n"hardhat": patch',
+          content: "Body",
+        },
+      );
+    });
+
+    it("should parse markdown with frontmatter with spaces in the docs comment", () => {
+      assert.deepEqual(
+        parseFrontMatter(`---
+   # docs: https://github.com/NomicFoundation/hardhat-website/pull/123
+"hardhat": patch
+---
+Body`),
+        {
+          frontMatter:
+            '   # docs: https://github.com/NomicFoundation/hardhat-website/pull/123\n"hardhat": patch',
+          content: "Body",
+        },
+      );
+    });
+
+    it("should return null frontmatter when markdown has none", () => {
+      assert.deepEqual(parseFrontMatter("Body"), {
+        frontMatter: null,
+        content: "Body",
+      });
+    });
+  });
+
+  describe("extractDocsUrlsFromFrontMatter", () => {
+    it("should extract one docs URL", () => {
+      assert.deepEqual(
+        extractDocsUrlsFromFrontMatter(
+          "# docs: https://github.com/NomicFoundation/hardhat-website/pull/123",
+        ),
+        ["https://github.com/NomicFoundation/hardhat-website/pull/123"],
+      );
+    });
+
+    it("should extract one docs URL with spaces", () => {
+      assert.deepEqual(
+        extractDocsUrlsFromFrontMatter(
+          "  #  docs: https://github.com/NomicFoundation/hardhat-website/pull/123",
+        ),
+        ["https://github.com/NomicFoundation/hardhat-website/pull/123"],
+      );
+    });
+
+    it("should extract multiple docs URLs", () => {
+      assert.deepEqual(
+        extractDocsUrlsFromFrontMatter(`"hardhat": patch
+# docs: https://github.com/NomicFoundation/hardhat-website/pull/123
+# docs: https://github.com/NomicFoundation/hardhat-website/pull/456`),
+        [
+          "https://github.com/NomicFoundation/hardhat-website/pull/123",
+          "https://github.com/NomicFoundation/hardhat-website/pull/456",
+        ],
+      );
+    });
+
+    it("should ignore non-docs comments", () => {
+      assert.deepEqual(
+        extractDocsUrlsFromFrontMatter(
+          "# note: https://github.com/NomicFoundation/hardhat-website/pull/123",
+        ),
+        [],
+      );
+    });
+
+    it("should ignore docs issue URLs", () => {
+      assert.deepEqual(
+        extractDocsUrlsFromFrontMatter(
+          "# docs: https://github.com/NomicFoundation/hardhat-website/issues/123",
+        ),
+        [],
+      );
+    });
+
+    it("should match case-insensitively", () => {
+      assert.deepEqual(
+        extractDocsUrlsFromFrontMatter(
+          "# DoCs: https://github.com/nomicfoundation/hardhat-website/pull/123",
+        ),
+        ["https://github.com/nomicfoundation/hardhat-website/pull/123"],
+      );
+    });
+  });
+});

--- a/scripts/lib/changesets.ts
+++ b/scripts/lib/changesets.ts
@@ -36,7 +36,7 @@ export async function readAllNewChangsets() {
   return changesets;
 }
 
-function parseFrontMatter(markdown) {
+export function parseFrontMatter(markdown) {
   const match = markdown.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!match) {
     return { frontMatter: null, content: markdown };
@@ -46,6 +46,19 @@ function parseFrontMatter(markdown) {
     frontMatter: match[1],
     content: match[2],
   };
+}
+
+const DOCS_URL_PATTERN =
+  /^#\s*docs:\s*(https?:\/\/github\.com\/NomicFoundation\/hardhat-website\/pull\/\d+)/i;
+
+export function extractDocsUrlsFromFrontMatter(frontMatter) {
+  if (frontMatter === null) return [];
+  const urls = [];
+  for (const line of frontMatter.split("\n")) {
+    const match = line.match(DOCS_URL_PATTERN);
+    if (match !== null) urls.push(match[1]);
+  }
+  return urls;
 }
 
 async function getAddingCommit(filePath) {

--- a/scripts/lib/changesets.ts
+++ b/scripts/lib/changesets.ts
@@ -36,7 +36,7 @@ export async function readAllNewChangsets() {
   return changesets;
 }
 
-export function parseFrontMatter(markdown) {
+export function parseFrontMatter(markdown: string) {
   const match = markdown.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!match) {
     return { frontMatter: null, content: markdown };
@@ -51,7 +51,7 @@ export function parseFrontMatter(markdown) {
 const DOCS_URL_PATTERN =
   /^\s*#\s*docs:\s*(https?:\/\/github\.com\/NomicFoundation\/hardhat-website\/pull\/\d+)/i;
 
-export function extractDocsUrlsFromFrontMatter(frontMatter) {
+export function extractDocsUrlsFromFrontMatter(frontMatter: null | string) {
   if (frontMatter === null) return [];
   const urls = [];
   for (const line of frontMatter.split("\n")) {
@@ -61,7 +61,7 @@ export function extractDocsUrlsFromFrontMatter(frontMatter) {
   return urls;
 }
 
-async function getAddingCommit(filePath) {
+async function getAddingCommit(filePath: string) {
   try {
     const { stdout } = await exec(
       `git log --diff-filter=A --follow --format=%h -- "${filePath}"`,

--- a/scripts/lib/changesets.ts
+++ b/scripts/lib/changesets.ts
@@ -1,9 +1,9 @@
-import { exec as execSync } from "node:child_process";
+import { exec as execCb } from "node:child_process";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 
-const exec = promisify(execSync);
+const exec = promisify(execCb);
 
 const changesetDir = ".changeset";
 
@@ -49,7 +49,7 @@ export function parseFrontMatter(markdown) {
 }
 
 const DOCS_URL_PATTERN =
-  /^#\s*docs:\s*(https?:\/\/github\.com\/NomicFoundation\/hardhat-website\/pull\/\d+)/i;
+  /^\s*#\s*docs:\s*(https?:\/\/github\.com\/NomicFoundation\/hardhat-website\/pull\/\d+)/i;
 
 export function extractDocsUrlsFromFrontMatter(frontMatter) {
   if (frontMatter === null) return [];

--- a/scripts/validate-pull-request-docs.ts
+++ b/scripts/validate-pull-request-docs.ts
@@ -72,7 +72,7 @@ async function hasDocsLinkInChangesets() {
   }
 
   const { stdout } = await exec(
-    `git diff --name-only --diff-filter=A ${process.env.GITHUB_BASE_REF} -- ${changesetDir}`,
+    `git diff --name-only --diff-filter=d ${process.env.GITHUB_BASE_REF} -- ${changesetDir}`,
   );
 
   const changesetFiles = stdout

--- a/scripts/validate-pull-request-docs.ts
+++ b/scripts/validate-pull-request-docs.ts
@@ -1,4 +1,4 @@
-import { exec as execSync } from "node:child_process";
+import { exec as execCb } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import process from "node:process";
 import { promisify } from "node:util";
@@ -19,7 +19,7 @@ import {
  * (those must go in changeset frontmatters instead).
  */
 
-const exec = promisify(execSync);
+const exec = promisify(execCb);
 
 const SKIP_LABEL = "no docs needed";
 const changesetDir = ".changeset";

--- a/scripts/validate-pull-request-docs.ts
+++ b/scripts/validate-pull-request-docs.ts
@@ -49,9 +49,9 @@ function hasDocsLinkInPRBody() {
     throw new Error("GITHUB_EVENT_PULL_REQUEST_BODY is not defined");
   }
 
-  return prBody
-    .toLowerCase()
-    .includes("github.com/nomicfoundation/hardhat-website/pull");
+  return /github\.com\/nomicfoundation\/hardhat-website\/pull\/\d+/i.test(
+    prBody,
+  );
 }
 
 function hasIssueLinkInPRBody() {
@@ -61,9 +61,9 @@ function hasIssueLinkInPRBody() {
     throw new Error("GITHUB_EVENT_PULL_REQUEST_BODY is not defined");
   }
 
-  return prBody
-    .toLowerCase()
-    .includes("github.com/nomicfoundation/hardhat-website/issues");
+  return /github\.com\/nomicfoundation\/hardhat-website\/issues\/\d+/i.test(
+    prBody,
+  );
 }
 
 async function hasDocsLinkInChangesets() {

--- a/scripts/validate-pull-request-docs.ts
+++ b/scripts/validate-pull-request-docs.ts
@@ -1,13 +1,28 @@
+import { exec as execSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import process from "node:process";
+import { promisify } from "node:util";
+
+import {
+  parseFrontMatter,
+  extractDocsUrlsFromFrontMatter,
+} from "./lib/changesets.ts";
 
 /**
  * A pull request is valid if:
- * - it is a release PR (i.e. it's head ref starts with "changeset-release/")
+ * - it is a release PR (i.e. its head ref starts with "changeset-release/")
  * - or it is labeled as "no docs needed"
- * - or it links to a pr/issue on the hardhat-website repo.
+ * - or it has a `# docs:` URL in a changeset frontmatter pointing to a hardhat-website PR
+ * - or the PR body links to a hardhat-website issue
+ *
+ * A pull request FAILS if the PR body contains a hardhat-website /pull/ link
+ * (those must go in changeset frontmatters instead).
  */
 
+const exec = promisify(execSync);
+
 const SKIP_LABEL = "no docs needed";
+const changesetDir = ".changeset";
 
 function isReleasePR() {
   if (process.env.GITHUB_HEAD_REF === undefined) {
@@ -27,23 +42,52 @@ function hasNoDocsNeededLabel() {
   return labels.some((l) => l.name === SKIP_LABEL);
 }
 
-function hasLinksToDocs() {
+function hasDocsLinkInPRBody() {
   const prBody = process.env.GITHUB_EVENT_PULL_REQUEST_BODY;
 
   if (prBody === undefined) {
     throw new Error("GITHUB_EVENT_PULL_REQUEST_BODY is not defined");
   }
 
-  console.log(JSON.stringify({ prBody }, null, 2));
+  return prBody
+    .toLowerCase()
+    .includes("github.com/nomicfoundation/hardhat-website/pull");
+}
 
-  const lowerCaseBody = prBody.toLowerCase();
+function hasIssueLinkInPRBody() {
+  const prBody = process.env.GITHUB_EVENT_PULL_REQUEST_BODY;
 
-  return (
-    lowerCaseBody.includes(
-      "github.com/nomicfoundation/hardhat-website/issues",
-    ) ||
-    lowerCaseBody.includes("github.com/nomicfoundation/hardhat-website/pull")
+  if (prBody === undefined) {
+    throw new Error("GITHUB_EVENT_PULL_REQUEST_BODY is not defined");
+  }
+
+  return prBody
+    .toLowerCase()
+    .includes("github.com/nomicfoundation/hardhat-website/issues");
+}
+
+async function hasDocsLinkInChangesets() {
+  if (process.env.GITHUB_BASE_REF === undefined) {
+    throw new Error("GITHUB_BASE_REF is not defined");
+  }
+
+  const { stdout } = await exec(
+    `git diff --name-only --diff-filter=A ${process.env.GITHUB_BASE_REF} -- ${changesetDir}`,
   );
+
+  const changesetFiles = stdout
+    .trim()
+    .split("\n")
+    .filter((file) => file.endsWith(".md"));
+
+  for (const file of changesetFiles) {
+    const content = await readFile(file, "utf-8");
+    const { frontMatter } = parseFrontMatter(content);
+    const urls = extractDocsUrlsFromFrontMatter(frontMatter);
+    if (urls.length > 0) return true;
+  }
+
+  return false;
 }
 
 async function validatePullRequest() {
@@ -57,12 +101,37 @@ async function validatePullRequest() {
     return;
   }
 
-  if (hasLinksToDocs()) {
-    console.log("Links to docs found");
+  if (hasDocsLinkInPRBody()) {
+    throw new Error(
+      "Found a hardhat-website PR link in the PR body. " +
+        "Please move it to a changeset frontmatter as a YAML comment instead:\n\n" +
+        "  ---\n" +
+        "  # docs: https://github.com/NomicFoundation/hardhat-website/pull/<number>\n" +
+        '  "package-name": patch\n' +
+        "  ---",
+    );
+  }
+
+  if (await hasDocsLinkInChangesets()) {
+    console.log("Docs link found in changeset frontmatter");
     return;
   }
 
-  throw new Error("No links to docs found");
+  if (hasIssueLinkInPRBody()) {
+    console.log("Issue link to docs found in PR body");
+    return;
+  }
+
+  throw new Error(
+    "No links to docs found. Either:\n" +
+      `- Add the '${SKIP_LABEL}' label\n` +
+      "- Add a `# docs:` comment in your changeset frontmatter:\n\n" +
+      "  ---\n" +
+      "  # docs: https://github.com/NomicFoundation/hardhat-website/pull/<number>\n" +
+      '  "package-name": patch\n' +
+      "  ---\n\n" +
+      "- Or link to a hardhat-website issue in the PR body",
+  );
 }
 
 await validatePullRequest();


### PR DESCRIPTION
This PR updates our workflows so that:

- Now the docs PRs are included as comments in the changesets' frontmatters.
- The workflows that check if there are docs prs/issues in the PR comment only accept issues. Failing if it's a PR, and telling you to use a changeset instead.
- The release workflow creates a comment, or updates an existing one, with all the docs PR links.
