### PR TITLE
Improve `hardhat-viem` and `hardhat-ethers` autocompletion and type-level errors

### DIFF
--- a/.changeset/eighty-shirts-brush.md
+++ b/.changeset/eighty-shirts-brush.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+"@nomicfoundation/hardhat-viem": patch
+"hardhat": patch
+---
+
+Use concrete value types for contract names in hardhat-viem and hardhat-ethers

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -26,6 +26,16 @@
       "package": "@nomicfoundation/hardhat-typechain",
       "peer": "hardhat",
       "reason": "Uses the new api to detect errors in SolidityBuildSystem#build"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-viem",
+      "peer": "hardhat",
+      "reason": "It now uses ArtifactContractNames"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-viem",
+      "peer": "hardhat",
+      "reason": "It now uses ArtifactContractNames"
     }
   ]
 }

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -30,12 +30,12 @@
     {
       "package": "@nomicfoundation/hardhat-viem",
       "peer": "hardhat",
-      "reason": "It now uses ArtifactContractNames"
+      "reason": "It now uses StringWithArtifactContractNamesAutocompletion"
     },
     {
-      "package": "@nomicfoundation/hardhat-viem",
+      "package": "@nomicfoundation/hardhat-ethers",
       "peer": "hardhat",
-      "reason": "It now uses ArtifactContractNames"
+      "reason": "It now uses StringWithArtifactContractNamesAutocompletion"
     }
   ]
 }

--- a/v-next/example-project/test/node/example-test.ts
+++ b/v-next/example-project/test/node/example-test.ts
@@ -21,6 +21,8 @@ describe("Example EDR based test", () => {
     });
 
     assert.equal(blockNumberAfter, `0x5`);
+
+    await connection.viem.deployContract("Counter2");
   });
 
   it("should show stack traces when a transaction reverts", async () => {

--- a/v-next/example-project/test/node/example-test.ts
+++ b/v-next/example-project/test/node/example-test.ts
@@ -21,8 +21,6 @@ describe("Example EDR based test", () => {
     });
 
     assert.equal(blockNumberAfter, `0x5`);
-
-    await connection.viem.deployContract("Counter2");
   });
 
   it("should show stack traces when a transaction reverts", async () => {

--- a/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
+++ b/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
@@ -6,7 +6,12 @@ import type {
 import type { HardhatEthersProvider } from "../hardhat-ethers-provider/hardhat-ethers-provider.js";
 import type { HardhatEthersSigner } from "../signers/signers.js";
 import type { ethers as EthersT } from "ethers";
-import type { Abi, Artifact, ArtifactManager } from "hardhat/types/artifacts";
+import type {
+  Abi,
+  Artifact,
+  ArtifactContractNames,
+  ArtifactManager,
+} from "hardhat/types/artifacts";
 import type { NetworkConfig } from "hardhat/types/config";
 
 import {
@@ -78,7 +83,7 @@ export class HardhatHelpers {
   }
 
   public getContractFactory<A extends any[] = any[], I = EthersT.Contract>(
-    name: string,
+    name: ArtifactContractNames,
     signerOrOptions?: EthersT.Signer | FactoryOptions,
   ): Promise<EthersT.ContractFactory<A, I>>;
 
@@ -92,7 +97,7 @@ export class HardhatHelpers {
     A extends any[] = any[],
     I = EthersT.Contract,
   >(
-    nameOrAbi: string | any[] | Abi,
+    nameOrAbi: ArtifactContractNames | any[] | Abi,
     bytecodeOrFactoryOptions?:
       | (EthersT.Signer | FactoryOptions)
       | EthersT.BytesLike,
@@ -164,7 +169,7 @@ export class HardhatHelpers {
   }
 
   public async getContractAt(
-    nameOrAbi: string | Abi,
+    nameOrAbi: ArtifactContractNames | Abi,
     address: string | EthersT.Addressable,
     signer?: EthersT.Signer,
   ): Promise<EthersT.Contract> {
@@ -232,18 +237,18 @@ export class HardhatHelpers {
   }
 
   public async deployContract(
-    name: string,
+    name: ArtifactContractNames,
     args?: any[],
     signerOrOptions?: EthersT.Signer | DeployContractOptions,
   ): Promise<EthersT.Contract>;
 
   public async deployContract(
-    name: string,
+    name: ArtifactContractNames,
     signerOrOptions?: EthersT.Signer | DeployContractOptions,
   ): Promise<EthersT.Contract>;
 
   public async deployContract(
-    name: string,
+    name: ArtifactContractNames,
     argsOrSignerOrOptions?: any[] | EthersT.Signer | DeployContractOptions,
     signerOrOptions?: EthersT.Signer | DeployContractOptions,
   ): Promise<EthersT.Contract> {

--- a/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
+++ b/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
@@ -9,8 +9,8 @@ import type { ethers as EthersT } from "ethers";
 import type {
   Abi,
   Artifact,
-  ArtifactContractNames,
   ArtifactManager,
+  StringWithArtifactContractNamesAutocompletion,
 } from "hardhat/types/artifacts";
 import type { NetworkConfig } from "hardhat/types/config";
 
@@ -83,7 +83,7 @@ export class HardhatHelpers {
   }
 
   public getContractFactory<A extends any[] = any[], I = EthersT.Contract>(
-    name: ArtifactContractNames,
+    name: StringWithArtifactContractNamesAutocompletion,
     signerOrOptions?: EthersT.Signer | FactoryOptions,
   ): Promise<EthersT.ContractFactory<A, I>>;
 
@@ -97,7 +97,7 @@ export class HardhatHelpers {
     A extends any[] = any[],
     I = EthersT.Contract,
   >(
-    nameOrAbi: ArtifactContractNames | any[] | Abi,
+    nameOrAbi: StringWithArtifactContractNamesAutocompletion | any[] | Abi,
     bytecodeOrFactoryOptions?:
       | (EthersT.Signer | FactoryOptions)
       | EthersT.BytesLike,
@@ -169,7 +169,7 @@ export class HardhatHelpers {
   }
 
   public async getContractAt(
-    nameOrAbi: ArtifactContractNames | Abi,
+    nameOrAbi: StringWithArtifactContractNamesAutocompletion | Abi,
     address: string | EthersT.Addressable,
     signer?: EthersT.Signer,
   ): Promise<EthersT.Contract> {
@@ -237,18 +237,18 @@ export class HardhatHelpers {
   }
 
   public async deployContract(
-    name: ArtifactContractNames,
+    name: StringWithArtifactContractNamesAutocompletion,
     args?: any[],
     signerOrOptions?: EthersT.Signer | DeployContractOptions,
   ): Promise<EthersT.Contract>;
 
   public async deployContract(
-    name: ArtifactContractNames,
+    name: StringWithArtifactContractNamesAutocompletion,
     signerOrOptions?: EthersT.Signer | DeployContractOptions,
   ): Promise<EthersT.Contract>;
 
   public async deployContract(
-    name: ArtifactContractNames,
+    name: StringWithArtifactContractNamesAutocompletion,
     argsOrSignerOrOptions?: any[] | EthersT.Signer | DeployContractOptions,
     signerOrOptions?: EthersT.Signer | DeployContractOptions,
   ): Promise<EthersT.Contract> {

--- a/v-next/hardhat-ethers/src/types.ts
+++ b/v-next/hardhat-ethers/src/types.ts
@@ -1,5 +1,9 @@
 import type * as ethers from "ethers";
-import type { Abi, Artifact } from "hardhat/types/artifacts";
+import type {
+  Abi,
+  Artifact,
+  ArtifactContractNames,
+} from "hardhat/types/artifacts";
 
 export type HardhatEthers = typeof ethers & HardhatEthersHelpers;
 
@@ -27,7 +31,7 @@ export interface HardhatEthersHelpers {
   provider: HardhatEthersProvider;
 
   getContractFactory<A extends any[] = any[], I = ethers.Contract>(
-    name: string,
+    name: ArtifactContractNames,
     signerOrOptions?: ethers.Signer | FactoryOptions,
   ): Promise<ethers.ContractFactory<A, I>>;
   getContractFactory<A extends any[] = any[], I = ethers.Contract>(
@@ -42,7 +46,7 @@ export interface HardhatEthersHelpers {
   ): Promise<ethers.ContractFactory<A, I>>;
 
   getContractAt(
-    nameOrAbi: string | any[] | Abi,
+    nameOrAbi: ArtifactContractNames | any[] | Abi,
     address: string | ethers.Addressable,
     signer?: ethers.Signer,
   ): Promise<ethers.Contract>;
@@ -54,11 +58,11 @@ export interface HardhatEthersHelpers {
   ) => Promise<ethers.Contract>;
 
   deployContract(
-    name: string,
+    name: ArtifactContractNames,
     signerOrOptions?: ethers.Signer | DeployContractOptions,
   ): Promise<ethers.Contract>;
   deployContract(
-    name: string,
+    name: ArtifactContractNames,
     args: any[],
     signerOrOptions?: ethers.Signer | DeployContractOptions,
   ): Promise<ethers.Contract>;

--- a/v-next/hardhat-ethers/src/types.ts
+++ b/v-next/hardhat-ethers/src/types.ts
@@ -2,7 +2,7 @@ import type * as ethers from "ethers";
 import type {
   Abi,
   Artifact,
-  ArtifactContractNames,
+  StringWithArtifactContractNamesAutocompletion,
 } from "hardhat/types/artifacts";
 
 export type HardhatEthers = typeof ethers & HardhatEthersHelpers;
@@ -31,7 +31,7 @@ export interface HardhatEthersHelpers {
   provider: HardhatEthersProvider;
 
   getContractFactory<A extends any[] = any[], I = ethers.Contract>(
-    name: ArtifactContractNames,
+    name: StringWithArtifactContractNamesAutocompletion,
     signerOrOptions?: ethers.Signer | FactoryOptions,
   ): Promise<ethers.ContractFactory<A, I>>;
   getContractFactory<A extends any[] = any[], I = ethers.Contract>(
@@ -46,7 +46,7 @@ export interface HardhatEthersHelpers {
   ): Promise<ethers.ContractFactory<A, I>>;
 
   getContractAt(
-    nameOrAbi: ArtifactContractNames | any[] | Abi,
+    nameOrAbi: StringWithArtifactContractNamesAutocompletion | any[] | Abi,
     address: string | ethers.Addressable,
     signer?: ethers.Signer,
   ): Promise<ethers.Contract>;
@@ -58,11 +58,11 @@ export interface HardhatEthersHelpers {
   ) => Promise<ethers.Contract>;
 
   deployContract(
-    name: ArtifactContractNames,
+    name: StringWithArtifactContractNamesAutocompletion,
     signerOrOptions?: ethers.Signer | DeployContractOptions,
   ): Promise<ethers.Contract>;
   deployContract(
-    name: ArtifactContractNames,
+    name: StringWithArtifactContractNamesAutocompletion,
     args: any[],
     signerOrOptions?: ethers.Signer | DeployContractOptions,
   ): Promise<ethers.Contract>;

--- a/v-next/hardhat-viem/src/internal/contracts.ts
+++ b/v-next/hardhat-viem/src/internal/contracts.ts
@@ -9,7 +9,10 @@ import type {
   WalletClient,
 } from "../types.js";
 import type { PrefixedHexString } from "@nomicfoundation/hardhat-utils/hex";
-import type { ArtifactManager } from "hardhat/types/artifacts";
+import type {
+  ArtifactContractNames,
+  ArtifactManager,
+} from "hardhat/types/artifacts";
 import type { EthereumProvider } from "hardhat/types/providers";
 import type { Abi as ViemAbi, Address as ViemAddress } from "viem";
 
@@ -21,7 +24,9 @@ import { getContractAddress, getContract } from "viem";
 
 import { getDefaultWalletClient, getPublicClient } from "./clients.js";
 
-export async function deployContract<ContractName extends string>(
+export async function deployContract<
+  ContractName extends ArtifactContractNames,
+>(
   provider: EthereumProvider,
   artifactManager: ArtifactManager,
   contractName: ContractName,
@@ -110,7 +115,9 @@ export async function deployContract<ContractName extends string>(
   return contract;
 }
 
-export async function sendDeploymentTransaction<ContractName extends string>(
+export async function sendDeploymentTransaction<
+  ContractName extends ArtifactContractNames,
+>(
   provider: EthereumProvider,
   artifactManager: ArtifactManager,
   contractName: ContractName,
@@ -173,7 +180,7 @@ export async function sendDeploymentTransaction<ContractName extends string>(
   return { contract, deploymentTransaction: deploymentTx };
 }
 
-export async function getContractAt<ContractName extends string>(
+export async function getContractAt<ContractName extends ArtifactContractNames>(
   provider: EthereumProvider,
   artifactManager: ArtifactManager,
   contractName: ContractName,
@@ -196,7 +203,7 @@ export async function getContractAt<ContractName extends string>(
   );
 }
 
-function createContractInstance<ContractName extends string>(
+function createContractInstance<ContractName extends ArtifactContractNames>(
   _contractName: ContractName,
   publicClient: PublicClient,
   walletClient: WalletClient,

--- a/v-next/hardhat-viem/src/internal/contracts.ts
+++ b/v-next/hardhat-viem/src/internal/contracts.ts
@@ -10,8 +10,8 @@ import type {
 } from "../types.js";
 import type { PrefixedHexString } from "@nomicfoundation/hardhat-utils/hex";
 import type {
-  ArtifactContractNames,
   ArtifactManager,
+  StringWithArtifactContractNamesAutocompletion,
 } from "hardhat/types/artifacts";
 import type { EthereumProvider } from "hardhat/types/providers";
 import type { Abi as ViemAbi, Address as ViemAddress } from "viem";
@@ -25,7 +25,7 @@ import { getContractAddress, getContract } from "viem";
 import { getDefaultWalletClient, getPublicClient } from "./clients.js";
 
 export async function deployContract<
-  ContractName extends ArtifactContractNames,
+  ContractName extends StringWithArtifactContractNamesAutocompletion,
 >(
   provider: EthereumProvider,
   artifactManager: ArtifactManager,
@@ -116,7 +116,7 @@ export async function deployContract<
 }
 
 export async function sendDeploymentTransaction<
-  ContractName extends ArtifactContractNames,
+  ContractName extends StringWithArtifactContractNamesAutocompletion,
 >(
   provider: EthereumProvider,
   artifactManager: ArtifactManager,
@@ -180,7 +180,9 @@ export async function sendDeploymentTransaction<
   return { contract, deploymentTransaction: deploymentTx };
 }
 
-export async function getContractAt<ContractName extends ArtifactContractNames>(
+export async function getContractAt<
+  ContractName extends StringWithArtifactContractNamesAutocompletion,
+>(
   provider: EthereumProvider,
   artifactManager: ArtifactManager,
   contractName: ContractName,
@@ -203,7 +205,9 @@ export async function getContractAt<ContractName extends ArtifactContractNames>(
   );
 }
 
-function createContractInstance<ContractName extends ArtifactContractNames>(
+function createContractInstance<
+  ContractName extends StringWithArtifactContractNamesAutocompletion,
+>(
   _contractName: ContractName,
   publicClient: PublicClient,
   walletClient: WalletClient,

--- a/v-next/hardhat-viem/src/types.ts
+++ b/v-next/hardhat-viem/src/types.ts
@@ -1,4 +1,7 @@
-import type { ArtifactMap } from "hardhat/types/artifacts";
+import type {
+  ArtifactContractNames,
+  ArtifactMap,
+} from "hardhat/types/artifacts";
 import type { ChainType, DefaultChainType } from "hardhat/types/network";
 import type {
   Abi as ViemAbi,
@@ -88,7 +91,7 @@ export interface HardhatViemHelpers<
    * {@link DeployContractConfig} for more details.
    * @returns The deployed contract instance.
    */
-  deployContract: <ContractName extends string>(
+  deployContract: <ContractName extends ArtifactContractNames>(
     contractName: ContractName,
     constructorArgs?: ConstructorArgs<ContractName>,
     deployContractConfig?: DeployContractConfig,
@@ -106,7 +109,7 @@ export interface HardhatViemHelpers<
    * @returns An object containing the deployed contract instance and the
    * deployment transaction.
    */
-  sendDeploymentTransaction: <ContractName extends string>(
+  sendDeploymentTransaction: <ContractName extends ArtifactContractNames>(
     contractName: ContractName,
     constructorArgs?: ConstructorArgs<ContractName>,
     sendDeploymentTransactionConfig?: SendDeploymentTransactionConfig,
@@ -125,7 +128,7 @@ export interface HardhatViemHelpers<
    * {@link GetContractAtConfig} for more details.
    * @returns The contract instance.
    */
-  getContractAt: <ContractName extends string>(
+  getContractAt: <ContractName extends ArtifactContractNames>(
     contractName: ContractName,
     address: ViemAddress,
     getContractAtConfig?: GetContractAtConfig,

--- a/v-next/hardhat-viem/src/types.ts
+++ b/v-next/hardhat-viem/src/types.ts
@@ -1,6 +1,6 @@
 import type {
-  ArtifactContractNames,
   ArtifactMap,
+  StringWithArtifactContractNamesAutocompletion,
 } from "hardhat/types/artifacts";
 import type { ChainType, DefaultChainType } from "hardhat/types/network";
 import type {
@@ -91,7 +91,9 @@ export interface HardhatViemHelpers<
    * {@link DeployContractConfig} for more details.
    * @returns The deployed contract instance.
    */
-  deployContract: <ContractName extends ArtifactContractNames>(
+  deployContract: <
+    ContractName extends StringWithArtifactContractNamesAutocompletion,
+  >(
     contractName: ContractName,
     constructorArgs?: ConstructorArgs<ContractName>,
     deployContractConfig?: DeployContractConfig,
@@ -109,7 +111,9 @@ export interface HardhatViemHelpers<
    * @returns An object containing the deployed contract instance and the
    * deployment transaction.
    */
-  sendDeploymentTransaction: <ContractName extends ArtifactContractNames>(
+  sendDeploymentTransaction: <
+    ContractName extends StringWithArtifactContractNamesAutocompletion,
+  >(
     contractName: ContractName,
     constructorArgs?: ConstructorArgs<ContractName>,
     sendDeploymentTransactionConfig?: SendDeploymentTransactionConfig,
@@ -128,7 +132,9 @@ export interface HardhatViemHelpers<
    * {@link GetContractAtConfig} for more details.
    * @returns The contract instance.
    */
-  getContractAt: <ContractName extends ArtifactContractNames>(
+  getContractAt: <
+    ContractName extends StringWithArtifactContractNamesAutocompletion,
+  >(
     contractName: ContractName,
     address: ViemAddress,
     getContractAtConfig?: GetContractAtConfig,

--- a/v-next/hardhat-viem/src/types.ts
+++ b/v-next/hardhat-viem/src/types.ts
@@ -85,7 +85,10 @@ export interface HardhatViemHelpers<
    * returns the viem's contract instance.
    *
    * @param contractName The name of the contract to deploy. This is required
-   * to return the correct contract type.
+   * to return the correct contract type. TypeScript's language server
+   * autocompletes the names of the contracts that have already been built. If
+   * your contract name isn't in the list, you can still use it, and/or run
+   * `hardhat build` to get it in the list.
    * @param constructorArgs The arguments to pass to the contract's constructor.
    * @param deployContractConfig A configuration object. See
    * {@link DeployContractConfig} for more details.
@@ -104,7 +107,10 @@ export interface HardhatViemHelpers<
    * The function does not wait for the transaction to be mined.
    *
    * @param contractName The name of the contract to deploy. This is required
-   * to return the correct contract type.
+   * to return the correct contract type. TypeScript's language server
+   * autocompletes the names of the contracts that have already been built. If
+   * your contract name isn't in the list, you can still use it, and/or run
+   * `hardhat build` to get it in the list.
    * @param constructorArgs The arguments to pass to the contract's constructor.
    * @param sendDeploymentTransactionConfig A configuration object. See
    * {@link SendDeploymentTransactionConfig} for more details.
@@ -126,7 +132,10 @@ export interface HardhatViemHelpers<
    * address.
    *
    * @param contractName The name of the contract to get an instance of. This
-   * is required to return the correct contract type.
+   * is required to return the correct contract type. TypeScript's language
+   * server autocompletes the names of the contracts that have already been
+   * built. If your contract name isn't in the list, you can still use it,
+   * and/or run `hardhat build` to get it in the list.
    * @param address The address of the contract.
    * @param getContractAtConfig A configuration object. See
    * {@link GetContractAtConfig} for more details.

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -1,6 +1,7 @@
 import type {
   ArtifactManager,
   GetArtifactByName,
+  StringWithArtifactContractNamesAutocompletion,
 } from "../../../types/artifacts.js";
 
 import { EOL } from "node:os";
@@ -47,7 +48,9 @@ export class ArtifactManagerImplementation implements ArtifactManager {
     this.#readFsData = readFsData ?? (() => this.#readFsDataFromFileSystem());
   }
 
-  public async readArtifact<ContractNameT extends string>(
+  public async readArtifact<
+    ContractNameT extends StringWithArtifactContractNamesAutocompletion,
+  >(
     contractNameOrFullyQualifiedName: ContractNameT,
   ): Promise<GetArtifactByName<ContractNameT>> {
     const artifactPath = await this.getArtifactPath(

--- a/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -1,6 +1,7 @@
 import type {
   ArtifactManager,
   GetArtifactByName,
+  StringWithArtifactContractNamesAutocompletion,
 } from "../../../../types/artifacts.js";
 import type { HardhatRuntimeEnvironmentHooks } from "../../../../types/hooks.js";
 
@@ -13,7 +14,9 @@ class LazyArtifactManager implements ArtifactManager {
     this.#artifactsPath = artifactsPath;
   }
 
-  public async readArtifact<ContractNameT extends string>(
+  public async readArtifact<
+    ContractNameT extends StringWithArtifactContractNamesAutocompletion,
+  >(
     contractNameOrFullyQualifiedName: ContractNameT,
   ): Promise<GetArtifactByName<ContractNameT>> {
     const artifactManager = await this.#getArtifactManager();

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -20,7 +20,10 @@ export type GetArtifactByName<ContractNameT extends string> =
 
 /**
  * A type type that represents the contract names (bare and fully qualified) of
- * all the artifacts that have been built in a project.
+ * all the artifacts that have been built in a project. This enables the
+ * autocomplete of the TS Language Server to list the actual contracts, without
+ * leading to a compilation error for general strings, so it doesn't fail
+ * before `hardhat build` is run.
  *
  * This is meant to be used in functions like this:
  * @example
@@ -33,7 +36,7 @@ export type GetArtifactByName<ContractNameT extends string> =
  */
 export type ArtifactContractNames = keyof ArtifactMap extends never
   ? string
-  : NonNeverKeys<ArtifactMap>;
+  : NonNeverKeys<ArtifactMap> | (string & {});
 
 /**
  * The ArtifactManager is responsible for reading and writing artifacts from

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -1,4 +1,5 @@
 import type { SolidityBuildInfo } from "./solidity/solidity-artifacts.js";
+import type { NonNeverKeys } from "./utils.js";
 
 /**
  * A map of bare contract names and fully qualified contract names to their
@@ -16,6 +17,23 @@ export type GetArtifactByName<ContractNameT extends string> =
   ContractNameT extends keyof ArtifactMap
     ? ArtifactMap[ContractNameT]
     : Artifact;
+
+/**
+ * A type type that represents the contract names (bare and fully qualified) of
+ * all the artifacts that have been built in a project.
+ *
+ * This is meant to be used in functions like this:
+ * @example
+ * ```
+ * function doSomething<ContractNameT extends ArtifactContractNames>(
+ *   contractName: ContractNameT,
+ *   ...
+ * ): DoSomethingReturnType<ContractNameT> {
+ * }
+ */
+export type ArtifactContractNames = keyof ArtifactMap extends never
+  ? string
+  : NonNeverKeys<ArtifactMap>;
 
 /**
  * The ArtifactManager is responsible for reading and writing artifacts from

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -36,7 +36,18 @@ export type GetArtifactByName<ContractNameT extends string> =
  */
 export type ArtifactContractNames = keyof ArtifactMap extends never
   ? string
-  : NonNeverKeys<ArtifactMap> | (string & {});
+  : NonNeverKeys<ArtifactMap>;
+
+/**
+ * A type that represents a string that should match an artifact contract name,
+ * but it doesn't fail if the string is not a contract name. It's mostly used
+ * to offer autocompletion.
+ *
+ * @see {@link ArtifactContractNames}
+ */
+export type StringWithArtifactContractNamesAutocompletion =
+  | ArtifactContractNames
+  | (string & {});
 
 /**
  * The ArtifactManager is responsible for reading and writing artifacts from
@@ -55,7 +66,9 @@ export interface ArtifactManager {
    *   indicating which fully qualified names can be used instead.
    * @throws Throws an error if the artifact doesn't exist.
    */
-  readArtifact<ContractNameT extends string>(
+  readArtifact<
+    ContractNameT extends StringWithArtifactContractNamesAutocompletion,
+  >(
     contractNameOrFullyQualifiedName: ContractNameT,
   ): Promise<GetArtifactByName<ContractNameT>>;
 

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -60,7 +60,10 @@ export interface ArtifactManager {
    * @param contractNameOrFullyQualifiedName The name of the contract.
    *   It can be a contract bare contract name (e.g. "Token") if it's
    *   unique in your project, or a fully qualified contract name
-   *   (e.g. "contract/token.sol:Token") otherwise.
+   *   (e.g. "contract/token.sol:Token") otherwise. TypeScript's language server
+   *   autocompletes the names of the contracts that have already been built. If
+   *   your contract name isn't in the list, you can still use it, and/or run
+   *   `hardhat build` to get it in the list.
    *
    * @throws Throws an error if a non-unique contract name is used,
    *   indicating which fully qualified names can be used instead.

--- a/v-next/hardhat/src/types/artifacts.ts
+++ b/v-next/hardhat/src/types/artifacts.ts
@@ -19,8 +19,8 @@ export type GetArtifactByName<ContractNameT extends string> =
     : Artifact;
 
 /**
- * A type type that represents the contract names (bare and fully qualified) of
- * all the artifacts that have been built in a project. This enables the
+ * A type that represents the contract names (bare and fully qualified) of all
+ * the artifacts that have been built in a project. This enables the
  * autocomplete of the TS Language Server to list the actual contracts, without
  * leading to a compilation error for general strings, so it doesn't fail
  * before `hardhat build` is run.

--- a/v-next/hardhat/src/types/utils.ts
+++ b/v-next/hardhat/src/types/utils.ts
@@ -57,3 +57,10 @@ export type RequireField<T, K extends keyof T> = T & {
 export type Result<ValueT, ErrorT> =
   | { readonly success: true; readonly value: ValueT }
   | { readonly success: false; readonly error: ErrorT };
+
+/**
+ * Returns the keys of T tht don't map to never.
+ */
+export type NonNeverKeys<T> = {
+  [K in keyof T]: T[K] extends never ? never : K;
+}[keyof T];

--- a/v-next/hardhat/test/test-helpers/mock-artifact-manager.ts
+++ b/v-next/hardhat/test/test-helpers/mock-artifact-manager.ts
@@ -2,6 +2,7 @@ import type {
   ArtifactManager,
   Artifact,
   GetArtifactByName,
+  StringWithArtifactContractNamesAutocompletion,
 } from "../../src/types/artifacts.js";
 
 import {
@@ -20,7 +21,9 @@ export class MockArtifactManager implements ArtifactManager {
     this.#artifacts.set(artifact.contractName, artifact);
   }
 
-  public async readArtifact<ContractNameT extends string>(
+  public async readArtifact<
+    ContractNameT extends StringWithArtifactContractNamesAutocompletion,
+  >(
     contractNameOrFullyQualifiedName: ContractNameT,
   ): Promise<GetArtifactByName<ContractNameT>> {
     const artifact = this.#artifacts.get(contractNameOrFullyQualifiedName);


### PR DESCRIPTION
_This PR is the result of investigating this issue https://github.com/NomicFoundation/hardhat-vscode/issues/714_

Currently `hardhat-viem` and `hardhat-ethers` use functions like this:

```ts
function doSomething<ContractNameT extends string>(
   contractName: ContractNameT,
   // ...
): DoSomethingReturnType<ContractNameT> {
  // ...
}
```

Which has the result of `doSomething` accepting any string, and offering no autocompletion.

This PR changes that so that they use a new `ArtifactContractNames`, which has the actual types of the **compiled** artifacts:

```ts
function doSomething<ContractNameT extends ArtifactContractNames>(
   contractName: ContractNameT,
   // ...
): DoSomethingReturnType<ContractNameT> {
  // ...
}
```

This leads to better autocomplete (it suggest the real contract names, including failing if there are multiple contracts with the same name), and generates a typescript error if the contract doesn't exist.

The only drawback is that if you add a contract, you will get a type error until you run `hardhat build`. Note that this happens in other places too though, like when using a contract abstraction instance. For example, this happens in the `hardhat-viem` sample project.

## Missing work

* This same change hasn't been implemented in the ignition packages, because they don't depend on `hardhat` (only as dev dependency, so they don't have the type. I think an optional peer dependency or something like that can be used. Maybe it can work without any modification to the `package.json`, but that sounds more risky.
* There's a test that fails, but i think it's because of how it was built, not because it should fail.