### PR TITLE
Add downloadCompilers parallel hook for extensible compiler downloads

### DIFF
--- a/.changeset/good-eels-buy.md
+++ b/.changeset/good-eels-buy.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add downloadCompilers parallel hook for extensible compiler downloads

--- a/.changeset/good-eels-buy.md
+++ b/.changeset/good-eels-buy.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Add `downloadCompilers` and `getCompiler` hooks for extensible custom compiler support
+Add `SolidityHooks#downloadCompilers` and `SolidityHooks#getCompiler` hooks for extensible custom compiler support ([#8009](https://github.com/NomicFoundation/hardhat/pull/8009))

--- a/.changeset/good-eels-buy.md
+++ b/.changeset/good-eels-buy.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Add downloadCompilers parallel hook for extensible compiler downloads
+Add `downloadCompilers` and `getCompiler` hooks for extensible custom compiler support

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -58,6 +58,7 @@ import pMap from "p-map";
 
 import { FileBuildResultType } from "../../../../types/solidity/build-system.js";
 import { DEFAULT_BUILD_PROFILE } from "../build-profiles.js";
+import { getSolcCompilerForConfig } from "../solidity-hooks.js";
 
 import {
   getArtifactsDeclarationFile,
@@ -89,20 +90,6 @@ export function isSolcSolidityCompilerConfig(
   config: SolidityCompilerConfig,
 ): config is SolcSolidityCompilerConfig {
   return config.type === undefined || config.type === "solc";
-}
-
-/**
- * Resolves the preferWasm setting for a given compiler config, falling back
- * to the build profile's preferWasm if not set on the compiler.
- */
-function resolvePreferWasm(
-  compilerConfig: SolidityCompilerConfig,
-  buildProfilePreferWasm: boolean,
-): boolean {
-  if (isSolcSolidityCompilerConfig(compilerConfig)) {
-    return compilerConfig.preferWasm ?? buildProfilePreferWasm;
-  }
-  return false;
 }
 
 // Compiler warnings to suppress from build output.
@@ -511,10 +498,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
           "getCompiler",
           [compilerConfig],
           async (_context, cfg) =>
-            getCompiler(cfg.version, {
-              preferWasm: resolvePreferWasm(cfg, buildProfile.preferWasm),
-              compilerPath: cfg.path,
-            }),
+            getSolcCompilerForConfig(cfg, buildProfile.preferWasm),
         );
         longVersion = compiler.longVersion;
         longVersionMap.set(compilerConfig.version, longVersion);
@@ -758,10 +742,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       "getCompiler",
       [runnableCompilationJob.solcConfig],
       async (_context, cfg) =>
-        getCompiler(cfg.version, {
-          preferWasm: resolvePreferWasm(cfg, buildProfile.preferWasm),
-          compilerPath: cfg.path,
-        }),
+        getSolcCompilerForConfig(cfg, buildProfile.preferWasm),
     );
 
     log(

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1294,16 +1294,21 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     }
 
     for (const job of runnableCompilationJobs) {
+      const compilerType = job.solcConfig.type ?? "solc";
       const solcVersion = job.solcConfig.version;
       const solcInput = await job.getSolcInput();
       const evmVersion =
         solcInput.settings.evmVersion ??
         `Check solc ${solcVersion}'s doc for its default evm version`;
 
-      let jobsPerVersion = jobsPerVersionAndEvmVersion.get(solcVersion);
+      // Group by compiler type + Solidity version to produce separate log
+      // lines for e.g. "solc 0.8.33" vs "solx 0.1.3 (Solidity 0.8.33)".
+      const groupKey = `${compilerType}\0${solcVersion}`;
+
+      let jobsPerVersion = jobsPerVersionAndEvmVersion.get(groupKey);
       if (jobsPerVersion === undefined) {
         jobsPerVersion = new Map();
-        jobsPerVersionAndEvmVersion.set(solcVersion, jobsPerVersion);
+        jobsPerVersionAndEvmVersion.set(groupKey, jobsPerVersion);
       }
 
       let jobsPerEvmVersion = jobsPerVersion.get(evmVersion);
@@ -1315,10 +1320,11 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       jobsPerEvmVersion.push(job);
     }
 
-    for (const solcVersion of [...jobsPerVersionAndEvmVersion.keys()].sort()) {
+    for (const groupKey of [...jobsPerVersionAndEvmVersion.keys()].sort()) {
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion --
       This is a valid key, just sorted */
-      const jobsPerEvmVersion = jobsPerVersionAndEvmVersion.get(solcVersion)!;
+      const jobsPerEvmVersion = jobsPerVersionAndEvmVersion.get(groupKey)!;
+      const [compilerType, solidityVersion] = groupKey.split("\0");
 
       for (const evmVersion of [...jobsPerEvmVersion.keys()].sort()) {
         /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion --
@@ -1330,12 +1336,25 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
           0,
         );
 
+        // For solc, the compiler version is the Solidity version.
+        // For other compilers, extract the compiler's own version from the
+        // longVersion stored on the compilation job, and show the Solidity
+        // version separately.
+        let compilerLabel: string;
+        if (compilerType === "solc") {
+          compilerLabel = `solc ${solidityVersion}`;
+        } else {
+          const longVersion = jobs[0].solcLongVersion;
+          const compilerVersion = longVersion.split("+")[0];
+          compilerLabel = `${compilerType} ${compilerVersion} (Solidity ${solidityVersion})`;
+        }
+
         console.log(
           chalk.bold(
             `Compiled ${rootFiles} Solidity ${pluralize(
               options.scope === "contracts" ? "file" : "test file",
               rootFiles,
-            )} with solc ${solcVersion}`,
+            )} with ${compilerLabel}`,
           ),
           `(evm target: ${evmVersion})`,
         );

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -584,7 +584,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
 
       assertHardhatInvariant(
         isWasm !== undefined,
-        `Version ${compilationJob.solcConfig.version} not present in isWasm map`,
+        `Compiler config ${compilationJob.solcConfig.type ?? "solc"} ${compilationJob.solcConfig.version} not present in isWasm map`,
       );
 
       // If there's no cache for the root file, or the compilation job changed, or using force flag, or isolated mode changed, compile it
@@ -765,7 +765,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     );
 
     log(
-      `Compiling ${numberOfRootFiles} root files and ${numberOfFiles - numberOfRootFiles} dependency files with solc ${runnableCompilationJob.solcConfig.version} using ${compiler.compilerPath}`,
+      `Compiling ${numberOfRootFiles} root files and ${numberOfFiles - numberOfRootFiles} dependency files with ${runnableCompilationJob.solcConfig.type ?? "solc"} ${runnableCompilationJob.solcConfig.version} using ${compiler.compilerPath}`,
     );
 
     assertHardhatInvariant(
@@ -1092,8 +1092,10 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
   ): Promise<CompilerOutput> {
     const quiet = options?.quiet ?? false;
 
-    // We download the compiler for the build info as it may not be configured
-    // in the HH config, hence not downloaded with the other compilers
+    // Build info recompilation is always solc-only: build info files are
+    // produced by solc and must be recompiled with the same solc version.
+    // We download solc directly rather than going through the
+    // downloadCompilers hook, as this version may not be in the HH config.
     await downloadSolcCompilers(new Set([buildInfo.solcVersion]), quiet);
 
     const compilerConfig: SolidityCompilerConfig = {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -584,7 +584,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
 
       assertHardhatInvariant(
         isWasm !== undefined,
-        `Compiler config ${compilationJob.solcConfig.type ?? "solc"} ${compilationJob.solcConfig.version} not present in isWasm map`,
+        `Version ${compilationJob.solcConfig.version} not present in isWasm map`,
       );
 
       // If there's no cache for the root file, or the compilation job changed, or using force flag, or isolated mode changed, compile it
@@ -1094,25 +1094,13 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
 
     // Build info recompilation is always solc-only: build info files are
     // produced by solc and must be recompiled with the same solc version.
-    // We download solc directly rather than going through the
-    // downloadCompilers hook, as this version may not be in the HH config.
+    // We bypass both downloadCompilers and getCompiler hooks — this is a
+    // self-contained solc replay path, not plugin-configurable compilation.
     await downloadSolcCompilers(new Set([buildInfo.solcVersion]), quiet);
 
-    const compilerConfig: SolidityCompilerConfig = {
-      version: buildInfo.solcVersion,
-      settings: {},
-    };
-
-    const compiler = await this.#hooks.runHandlerChain(
-      "solidity",
-      "getCompiler",
-      [compilerConfig],
-      async (_context, cfg) =>
-        getCompiler(cfg.version, {
-          preferWasm: false,
-          compilerPath: cfg.path,
-        }),
-    );
+    const compiler = await getCompiler(buildInfo.solcVersion, {
+      preferWasm: false,
+    });
 
     return compiler.compile(buildInfo.input);
   }
@@ -1305,7 +1293,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
 
       // Group by compiler type + Solidity version to produce separate log
       // lines for e.g. "solc 0.8.33" vs "solx 0.1.3 (Solidity 0.8.33)".
-      const groupKey = `${compilerType}\0${solcVersion}`;
+      const groupKey = `${compilerType}#${solcVersion}`;
 
       let jobsPerVersion = jobsPerVersionAndEvmVersion.get(groupKey);
       if (jobsPerVersion === undefined) {
@@ -1326,7 +1314,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion --
       This is a valid key, just sorted */
       const jobsPerEvmVersion = jobsPerVersionAndEvmVersion.get(groupKey)!;
-      const [compilerType, solidityVersion] = groupKey.split("\0");
+      const [compilerType, solidityVersion] = groupKey.split("#");
 
       for (const evmVersion of [...jobsPerEvmVersion.keys()].sort()) {
         /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion --

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -506,13 +506,16 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       let longVersion = longVersionMap.get(compilerConfig.version);
 
       if (longVersion === undefined) {
-        const compiler = await getCompiler(compilerConfig.version, {
-          preferWasm: resolvePreferWasm(
-            compilerConfig,
-            buildProfile.preferWasm,
-          ),
-          compilerPath: compilerConfig.path,
-        });
+        const compiler = await this.#hooks.runHandlerChain(
+          "solidity",
+          "getCompiler",
+          [compilerConfig],
+          async (_context, cfg) =>
+            getCompiler(cfg.version, {
+              preferWasm: resolvePreferWasm(cfg, buildProfile.preferWasm),
+              compilerPath: cfg.path,
+            }),
+        );
         longVersion = compiler.longVersion;
         longVersionMap.set(compilerConfig.version, longVersion);
         isWasmMap.set(compilerConfig.version, compiler.isSolcJs);
@@ -750,15 +753,15 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
 
     const { buildProfile } = this.#getBuildProfile(options?.buildProfile);
 
-    const compiler = await getCompiler(
-      runnableCompilationJob.solcConfig.version,
-      {
-        preferWasm: resolvePreferWasm(
-          runnableCompilationJob.solcConfig,
-          buildProfile.preferWasm,
-        ),
-        compilerPath: runnableCompilationJob.solcConfig.path,
-      },
+    const compiler = await this.#hooks.runHandlerChain(
+      "solidity",
+      "getCompiler",
+      [runnableCompilationJob.solcConfig],
+      async (_context, cfg) =>
+        getCompiler(cfg.version, {
+          preferWasm: resolvePreferWasm(cfg, buildProfile.preferWasm),
+          compilerPath: cfg.path,
+        }),
     );
 
     log(
@@ -1093,9 +1096,21 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     // in the HH config, hence not downloaded with the other compilers
     await downloadSolcCompilers(new Set([buildInfo.solcVersion]), quiet);
 
-    const compiler = await getCompiler(buildInfo.solcVersion, {
-      preferWasm: false,
-    });
+    const compilerConfig: SolidityCompilerConfig = {
+      version: buildInfo.solcVersion,
+      settings: {},
+    };
+
+    const compiler = await this.#hooks.runHandlerChain(
+      "solidity",
+      "getCompiler",
+      [compilerConfig],
+      async (_context, cfg) =>
+        getCompiler(cfg.version, {
+          preferWasm: false,
+          compilerPath: cfg.path,
+        }),
+    );
 
     return compiler.compile(buildInfo.input);
   }

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1107,20 +1107,17 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       return;
     }
 
-    await downloadSolcCompilers(this.#getAllCompilerVersions(), quiet);
+    const allSolidityCompilerConfigs = this.#getAllSolidityCompilerConfigs();
+    await this.#hooks.runParallelHandlers("solidity", "downloadCompilers", [
+      allSolidityCompilerConfigs,
+      quiet,
+    ]);
     this.#configuredCompilersDownloaded = true;
   }
 
-  #getAllCompilerVersions(): Set<string> {
-    return new Set(
-      Object.values(this.#options.solidityConfig.profiles)
-        .map((profile) => [
-          ...profile.compilers.map((compiler) => compiler.version),
-          ...Object.values(profile.overrides).map(
-            (override) => override.version,
-          ),
-        ])
-        .flat(1),
+  #getAllSolidityCompilerConfigs(): SolidityCompilerConfig[] {
+    return Object.values(this.#options.solidityConfig.profiles).flatMap(
+      (profile) => [...profile.compilers, ...Object.values(profile.overrides)],
     );
   }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/solidity.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/solidity.ts
@@ -1,0 +1,16 @@
+import type { SolidityHooks } from "../../../../types/hooks.js";
+
+import { isSolcConfig } from "../build-system/build-system.js";
+import { downloadSolcCompilers } from "../build-system/compiler/index.js";
+
+export default async (): Promise<Partial<SolidityHooks>> => ({
+  downloadCompilers: async (_context, compilerConfigs, quiet) => {
+    const solcVersions = new Set(
+      compilerConfigs.filter(isSolcConfig).map((c) => c.version),
+    );
+
+    if (solcVersions.size > 0) {
+      await downloadSolcCompilers(solcVersions, quiet);
+    }
+  },
+});

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/solidity.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/solidity.ts
@@ -1,16 +1,9 @@
 import type { SolidityHooks } from "../../../../types/hooks.js";
 
-import { isSolcConfig } from "../build-system/build-system.js";
-import { downloadSolcCompilers } from "../build-system/compiler/index.js";
+import { downloadSolcCompilersHandler } from "../solidity-hooks.js";
 
 export default async (): Promise<Partial<SolidityHooks>> => ({
   downloadCompilers: async (_context, compilerConfigs, quiet) => {
-    const solcVersions = new Set(
-      compilerConfigs.filter(isSolcConfig).map((c) => c.version),
-    );
-
-    if (solcVersions.size > 0) {
-      await downloadSolcCompilers(solcVersions, quiet);
-    }
+    await downloadSolcCompilersHandler(compilerConfigs, quiet);
   },
 });

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/index.ts
@@ -41,6 +41,7 @@ const hardhatPlugin: HardhatPlugin = {
   hookHandlers: {
     config: () => import("./hook-handlers/config.js"),
     hre: () => import("./hook-handlers/hre.js"),
+    solidity: () => import("./hook-handlers/solidity.js"),
   },
   tasks: [
     {

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/solidity-hooks.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/solidity-hooks.ts
@@ -1,0 +1,53 @@
+import type { SolidityCompilerConfig } from "../../../types/config.js";
+import type { Compiler } from "../../../types/solidity.js";
+
+import { isSolcSolidityCompilerConfig } from "./build-system/build-system.js";
+import {
+  downloadSolcCompilers,
+  getCompiler,
+} from "./build-system/compiler/index.js";
+
+/**
+ * Downloads solc compilers for the given configs, filtering out non-solc types.
+ * This is the default implementation of the `downloadCompilers` hook handler.
+ */
+export async function downloadSolcCompilersHandler(
+  compilerConfigs: SolidityCompilerConfig[],
+  quiet: boolean,
+): Promise<void> {
+  const solcVersions = new Set(
+    compilerConfigs.filter(isSolcSolidityCompilerConfig).map((c) => c.version),
+  );
+
+  if (solcVersions.size > 0) {
+    await downloadSolcCompilers(solcVersions, quiet);
+  }
+}
+
+/**
+ * Resolves the preferWasm setting for a given compiler config, falling back
+ * to the build profile's preferWasm if not set on the compiler.
+ */
+export function resolvePreferWasm(
+  compilerConfig: SolidityCompilerConfig,
+  buildProfilePreferWasm: boolean,
+): boolean {
+  if (isSolcSolidityCompilerConfig(compilerConfig)) {
+    return compilerConfig.preferWasm ?? buildProfilePreferWasm;
+  }
+  return false;
+}
+
+/**
+ * Creates a solc Compiler for the given config. This is the default
+ * implementation used as the fallback in the `getCompiler` hook chain.
+ */
+export async function getSolcCompilerForConfig(
+  compilerConfig: SolidityCompilerConfig,
+  buildProfilePreferWasm: boolean,
+): Promise<Compiler> {
+  return getCompiler(compilerConfig.version, {
+    preferWasm: resolvePreferWasm(compilerConfig, buildProfilePreferWasm),
+    compilerPath: compilerConfig.path,
+  });
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
@@ -310,6 +310,21 @@ declare module "../../../types/hooks.js" {
 
   export interface SolidityHooks {
     /**
+     * Hook triggered to download compilers needed for compilation.
+     * Each handler should download compilers it is responsible for.
+     * Runs in parallel — all registered handlers execute concurrently.
+     *
+     * @param context The hook context.
+     * @param compilerConfigs All compiler configurations from all build profiles.
+     * @param quiet Whether to suppress download progress output.
+     */
+    downloadCompilers: (
+      context: HookContext,
+      compilerConfigs: SolidityCompilerConfig[],
+      quiet: boolean,
+    ) => Promise<void>;
+
+    /**
      * Hook triggered during the cleanup process of Solidity compilation artifacts.
      * This hook runs after unused artifacts and build-info files have been removed.
      *

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
@@ -325,6 +325,25 @@ declare module "../../../types/hooks.js" {
     ) => Promise<void>;
 
     /**
+     * Hook to obtain a Compiler instance for a given compiler configuration.
+     * The default handler returns a solc compiler. Plugins can intercept to
+     * return their own compiler (e.g. SolxCompiler for type: "solx").
+     *
+     * @param context The hook context.
+     * @param compilerConfig The compiler configuration to get a compiler for.
+     * @param next A function to call the next handler for this hook.
+     * @returns A Compiler instance.
+     */
+    getCompiler: (
+      context: HookContext,
+      compilerConfig: SolidityCompilerConfig,
+      next: (
+        nextContext: HookContext,
+        nextCompilerConfig: SolidityCompilerConfig,
+      ) => Promise<Compiler>,
+    ) => Promise<Compiler>;
+
+    /**
      * Hook triggered during the cleanup process of Solidity compilation artifacts.
      * This hook runs after unused artifacts and build-info files have been removed.
      *

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -24,6 +24,7 @@ import {
 } from "@nomicfoundation/hardhat-utils/fs";
 
 import { SolidityBuildSystemImplementation } from "../../../../../src/internal/builtin-plugins/solidity/build-system/build-system.js";
+import createSolidityHookHandlers from "../../../../../src/internal/builtin-plugins/solidity/hook-handlers/solidity.js";
 import { HookManagerImplementation } from "../../../../../src/internal/core/hook-manager.js";
 
 async function emitArtifacts(solidity: SolidityBuildSystem): Promise<void> {
@@ -107,6 +108,7 @@ describe(
       const hooks = new HookManagerImplementation(process.cwd(), []);
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We don't care about hooks in this context
       hooks.setContext({} as HookContext);
+      hooks.registerHandlers("solidity", await createSolidityHookHandlers());
       solidity = new SolidityBuildSystemImplementation(hooks, {
         solidityConfig,
         projectRoot: process.cwd(),
@@ -130,6 +132,7 @@ describe(
       const hooks = new HookManagerImplementation(process.cwd(), []);
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We don't care about hooks in this context
       hooks.setContext({} as HookContext);
+      hooks.registerHandlers("solidity", await createSolidityHookHandlers());
       solidity = new SolidityBuildSystemImplementation(hooks, {
         solidityConfig,
         projectRoot: process.cwd(),

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
@@ -29,10 +29,10 @@ import { useFixtureProject } from "@nomicfoundation/hardhat-test-utils";
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
 
 /**
- * Creates a plugin that registers additional compiler types so they pass
+ * Creates a mock plugin for testing that registers additional compiler types so they pass
  * the registeredCompilerTypes post-validation.
  */
-function createTypeRegistrationPlugin(types: string[]): HardhatPlugin {
+function createTypeRegistrationMockPlugin(types: string[]): HardhatPlugin {
   return {
     id: `test-register-types-${types.join("-")}`,
     hookHandlers: {
@@ -460,7 +460,7 @@ describe("solidity - hooks", () => {
       };
 
       const hre = await createHardhatRuntimeEnvironment({
-        plugins: [downloadPlugin, createTypeRegistrationPlugin(["solx"])],
+        plugins: [downloadPlugin, createTypeRegistrationMockPlugin(["solx"])],
         solidity: {
           compilers: [
             { version: "0.8.23" },
@@ -475,7 +475,7 @@ describe("solidity - hooks", () => {
         quiet: true,
       });
 
-      // Verify both configs are passed (the hook receives ALL configs)
+      // Verify both configs are passed (the hook receives all configs)
       assert.equal(
         capturedConfigs.filter((c) => c.type === undefined).length > 0,
         true,
@@ -494,7 +494,7 @@ describe("solidity - hooks", () => {
       // versions should be downloaded. If it tried to download a non-existent
       // "solx" version via the solc downloader, the build would fail.
       const hre = await createHardhatRuntimeEnvironment({
-        plugins: [createTypeRegistrationPlugin(["solx"])],
+        plugins: [createTypeRegistrationMockPlugin(["solx"])],
         solidity: {
           compilers: [
             { version: "0.8.23" },
@@ -504,7 +504,7 @@ describe("solidity - hooks", () => {
       });
 
       const roots = await hre.solidity.getRootFilePaths();
-      // This should NOT throw — the built-in handler should skip the solx
+      // This should not throw — the built-in handler should skip the solx
       // config and only download solc 0.8.23 (which is cached)
       await hre.solidity.build(roots, {
         force: true,
@@ -620,9 +620,10 @@ describe("solidity - hooks", () => {
       const hre = await createHardhatRuntimeEnvironment({
         plugins: [
           customCompilerPlugin,
-          createTypeRegistrationPlugin(["custom"]),
+          createTypeRegistrationMockPlugin(["custom"]),
         ],
         solidity: {
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test uses unregistered compiler type
           compilers: [{ type: "custom" as any, version: "0.8.23" }],
         },
       });

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions -- We use `as any` casts
+   for non-solc compiler configs in tests because "solx" is not registered in the base type system. */
 import type {
   ConfigurationVariableResolver,
   HardhatConfig,
@@ -464,7 +466,7 @@ describe("solidity - hooks", () => {
         solidity: {
           compilers: [
             { version: "0.8.23" },
-            { type: "solx", version: "0.8.23" },
+            { type: "solx", version: "0.8.23" } as any,
           ],
         },
       });
@@ -482,7 +484,7 @@ describe("solidity - hooks", () => {
         "Should include solc configs (type undefined)",
       );
       assert.equal(
-        capturedConfigs.filter((c) => c.type === "solx").length > 0,
+        capturedConfigs.filter((c) => (c as any).type === "solx").length > 0,
         true,
         "Should include non-solc configs (type solx)",
       );
@@ -498,7 +500,11 @@ describe("solidity - hooks", () => {
         solidity: {
           compilers: [
             { version: "0.8.23" },
-            { type: "solx", version: "0.8.23", path: "/mock/path/to/solx" },
+            {
+              type: "solx",
+              version: "0.8.23",
+              path: "/mock/path/to/solx",
+            } as any,
           ],
         },
       });

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
@@ -1,4 +1,9 @@
-import type { SolidityCompilerConfig } from "../../../../src/types/config.js";
+import type {
+  ConfigurationVariableResolver,
+  HardhatConfig,
+  HardhatUserConfig,
+  SolidityCompilerConfig,
+} from "../../../../src/types/config.js";
 import type {
   HookContext,
   SolidityHooks,
@@ -22,6 +27,38 @@ import { beforeEach, describe, it } from "node:test";
 import { useFixtureProject } from "@nomicfoundation/hardhat-test-utils";
 
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
+
+/**
+ * Creates a plugin that registers additional compiler types so they pass
+ * the registeredCompilerTypes post-validation.
+ */
+function createTypeRegistrationPlugin(types: string[]): HardhatPlugin {
+  return {
+    id: `test-register-types-${types.join("-")}`,
+    hookHandlers: {
+      config: async () => ({
+        default: async () => ({
+          resolveUserConfig: async (
+            userConfig: HardhatUserConfig,
+            resolveConfigurationVariable: ConfigurationVariableResolver,
+            next: (
+              nextUserConfig: HardhatUserConfig,
+              nextResolveConfigurationVariable: ConfigurationVariableResolver,
+            ) => Promise<HardhatConfig>,
+          ) => {
+            const resolved = await next(
+              userConfig,
+              resolveConfigurationVariable,
+            );
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test registers unregistered types
+            resolved.solidity.registeredCompilerTypes.push(...(types as any[]));
+            return resolved;
+          },
+        }),
+      }),
+    },
+  };
+}
 
 describe("solidity - hooks", () => {
   describe("invokeSolc", () => {
@@ -411,8 +448,8 @@ describe("solidity - hooks", () => {
                   _quiet: boolean,
                 ) => {
                   capturedConfigs = compilerConfigs;
-                  // Don't call next — we handle all downloads here
-                  // to prevent the built-in handler from running
+                  // downloadCompilers is a parallel hook (no next parameter),
+                  // so all registered handlers run concurrently.
                 },
               };
 
@@ -423,7 +460,7 @@ describe("solidity - hooks", () => {
       };
 
       const hre = await createHardhatRuntimeEnvironment({
-        plugins: [downloadPlugin],
+        plugins: [downloadPlugin, createTypeRegistrationPlugin(["solx"])],
         solidity: {
           compilers: [
             { version: "0.8.23" },
@@ -457,6 +494,7 @@ describe("solidity - hooks", () => {
       // versions should be downloaded. If it tried to download a non-existent
       // "solx" version via the solc downloader, the build would fail.
       const hre = await createHardhatRuntimeEnvironment({
+        plugins: [createTypeRegistrationPlugin(["solx"])],
         solidity: {
           compilers: [
             { version: "0.8.23" },
@@ -472,6 +510,133 @@ describe("solidity - hooks", () => {
         force: true,
         quiet: true,
       });
+    });
+  });
+
+  describe("getCompiler", () => {
+    useFixtureProject("solidity/simple-project");
+
+    it("should invoke getCompiler hook during build", async () => {
+      let getCompilerCalled = false;
+      let capturedConfig: SolidityCompilerConfig | undefined;
+
+      const getCompilerPlugin: HardhatPlugin = {
+        id: "test-get-compiler-plugin",
+        hookHandlers: {
+          solidity: async () => ({
+            default: async () => {
+              const handlers: Partial<SolidityHooks> = {
+                getCompiler: async (
+                  context: HookContext,
+                  compilerConfig: SolidityCompilerConfig,
+                  next: (
+                    nextContext: HookContext,
+                    nextCompilerConfig: SolidityCompilerConfig,
+                  ) => Promise<Compiler>,
+                ) => {
+                  getCompilerCalled = true;
+                  capturedConfig = compilerConfig;
+
+                  // Fall through to the default handler (solc)
+                  return next(context, compilerConfig);
+                },
+              };
+
+              return handlers;
+            },
+          }),
+        },
+      };
+
+      const hre = await createHardhatRuntimeEnvironment({
+        plugins: [getCompilerPlugin],
+        solidity: "0.8.23",
+      });
+
+      const roots = await hre.solidity.getRootFilePaths();
+      await hre.solidity.build(roots, {
+        force: true,
+        quiet: true,
+      });
+
+      assert.ok(getCompilerCalled, "The getCompiler hook should be called");
+      assert.equal(
+        capturedConfig?.version,
+        "0.8.23",
+        "Should receive the compiler config with the expected version",
+      );
+    });
+
+    it("should allow plugins to return a custom compiler", async () => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentional fake for test
+      const fakeOutput: CompilerOutput = {
+        contracts: {},
+        sources: {},
+        errors: [],
+      } as any;
+
+      let customCompilerUsed = false;
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentional mocking of compiler
+      const customCompiler: Compiler = {
+        version: "0.8.23",
+        longVersion: "0.8.23+custom",
+        compilerPath: "/mock/custom-compiler",
+        isSolcJs: false,
+        compile: async () => {
+          customCompilerUsed = true;
+          return fakeOutput;
+        },
+      } as any;
+
+      const customCompilerPlugin: HardhatPlugin = {
+        id: "test-custom-compiler-plugin",
+        hookHandlers: {
+          solidity: async () => ({
+            default: async () => {
+              const handlers: Partial<SolidityHooks> = {
+                getCompiler: async (
+                  _context: HookContext,
+                  compilerConfig: SolidityCompilerConfig,
+                  next: (
+                    nextContext: HookContext,
+                    nextCompilerConfig: SolidityCompilerConfig,
+                  ) => Promise<Compiler>,
+                ) => {
+                  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test uses unregistered type
+                  if ((compilerConfig.type as string) === "custom") {
+                    return customCompiler;
+                  }
+                  return next(_context, compilerConfig);
+                },
+              };
+
+              return handlers;
+            },
+          }),
+        },
+      };
+
+      const hre = await createHardhatRuntimeEnvironment({
+        plugins: [
+          customCompilerPlugin,
+          createTypeRegistrationPlugin(["custom"]),
+        ],
+        solidity: {
+          compilers: [{ type: "custom" as any, version: "0.8.23" }],
+        },
+      });
+
+      const roots = await hre.solidity.getRootFilePaths();
+      await hre.solidity.build(roots, {
+        force: true,
+        quiet: true,
+      });
+
+      assert.ok(
+        customCompilerUsed,
+        "The custom compiler should have been used for compilation",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Create and export two new hooks in the build system, `downloadCompilers` and `getCompiler`, which can later be used for the solx plugin. 
This is part 2 in the chain of PRs to introduce solx support in Hardhat 3. 

The `downloadCompilers` hook is a parallel hook that allows each compiler plugin to handle the downloads for their own `compiler.type`, and we need the `getCompiler` chained hook to be able to correctly set the path to the new downloaded binaries prior to compilation invocation. 

The previous Part 1 PR is here: https://github.com/NomicFoundation/hardhat/pull/8008

## Details 

- Extract solc download logic into a new downloadCompilers parallel hook.
- All registered handlers run concurrently via runParallelHandlers.
- Built-in handler filters for solc configs only (type undefined or "solc") using isSolcConfig()
- Third-party plugins register their own handlers for custom compiler types
- Collect all compiler configs from all build profiles (including overrides) before downloading

Depends on: #8008 (multi-compiler abstraction)