### PR TITLE
feat: return typed Result from test runner and telemetry task actions

### DIFF
--- a/.changeset/swift-ladybugs-cover.md
+++ b/.changeset/swift-ladybugs-cover.md
@@ -4,4 +4,4 @@
 "hardhat": patch
 ---
 
-Return typed `Result` from test runners and telemetry tasks.
+Return typed `Result` from test runners and telemetry tasks ([#8015](https://github.com/NomicFoundation/hardhat/pull/8015)).

--- a/.changeset/swift-ladybugs-cover.md
+++ b/.changeset/swift-ladybugs-cover.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/hardhat-mocha": patch
+"@nomicfoundation/hardhat-node-test-runner": patch
+"hardhat": patch
+---
+
+Return typed `Result` from test runners and telemetry tasks.

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -10,12 +10,12 @@
     {
       "package": "@nomicfoundation/hardhat-mocha",
       "peer": "hardhat",
-      "reason": "It depends on the new TestHooks#onTestRunStart, TestHooks#onTestWorkerDone, and TestHooks#onTestRunDone hooks"
+      "reason": "It depends on the new TestHooks#onTestRunStart, TestHooks#onTestWorkerDone, and TestHooks#onTestRunDone hooks, the Result type helpers from hardhat/utils/result, and the TestSummary type from hardhat/types/test"
     },
     {
       "package": "@nomicfoundation/hardhat-node-test-runner",
       "peer": "hardhat",
-      "reason": "It depends on the new TestHooks#onTestRunStart, TestHooks#onTestWorkerDone, and TestHooks#onTestRunDone hooks"
+      "reason": "It depends on the new TestHooks#onTestRunStart, TestHooks#onTestWorkerDone, and TestHooks#onTestRunDone hooks, the Result type helpers from hardhat/utils/result, and the TestSummary type from hardhat/types/test"
     },
     {
       "package": "@nomicfoundation/hardhat-verify",

--- a/v-next/hardhat-ethers-chai-matchers/test/index.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/index.ts
@@ -22,6 +22,9 @@ describe("hardhat-ethers-chai-matchers plugin correctly initialized", () => {
       noCompile: true,
     });
 
-    assert.deepEqual(result, { failed: 0, passed: 1 });
+    assert.deepEqual(result, {
+      success: true,
+      value: { failed: 0, passed: 1 },
+    });
   });
 });

--- a/v-next/hardhat-ethers-chai-matchers/test/index.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/index.ts
@@ -24,7 +24,7 @@ describe("hardhat-ethers-chai-matchers plugin correctly initialized", () => {
 
     assert.deepEqual(result, {
       success: true,
-      value: { failed: 0, passed: 1 },
+      value: { failed: 0, passed: 1, skipped: 0, todo: 0 },
     });
   });
 });

--- a/v-next/hardhat-mocha/src/task-action.ts
+++ b/v-next/hardhat-mocha/src/task-action.ts
@@ -1,7 +1,7 @@
 import type { HardhatConfig } from "hardhat/types/config";
-import type { Result } from "hardhat/types/result";
 import type { NewTaskActionFunction } from "hardhat/types/tasks";
 import type { TestSummary } from "hardhat/types/test";
+import type { Result } from "hardhat/types/utils";
 import type { MochaOptions } from "mocha";
 
 import { resolve as pathResolve } from "node:path";
@@ -10,7 +10,7 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { setGlobalOptionsAsEnvVariables } from "@nomicfoundation/hardhat-utils/env";
 import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
 import debug from "debug";
-import { errorResult, successResult } from "hardhat/utils/result";
+import { errorResult, successfulResult } from "hardhat/utils/result";
 
 import { createPerformanceTracker } from "./performance.js";
 
@@ -95,7 +95,12 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   perf.endPhase("Get test files");
 
   if (files.length === 0) {
-    return successResult({});
+    return successfulResult({
+      failed: 0,
+      passed: 0,
+      skipped: 0,
+      todo: 0,
+    });
   }
 
   const unhandledRejectionHookPath = "./unhandled-rejection-mocha-hook.js";
@@ -213,9 +218,14 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   perf.logInto(performanceLog);
   perf.clear();
 
-  const summary = { failed: testFailures, passed: total - testFailures };
+  const summary = {
+    failed: testFailures,
+    passed: total - testFailures,
+    skipped: 0,
+    todo: 0,
+  };
 
-  return testFailures > 0 ? errorResult(summary) : successResult(summary);
+  return testFailures > 0 ? errorResult(summary) : successfulResult(summary);
 };
 
 export default testWithHardhat;

--- a/v-next/hardhat-mocha/test/env.ts
+++ b/v-next/hardhat-mocha/test/env.ts
@@ -13,7 +13,6 @@ describe("Hardhat Mocha env variables", () => {
     );
     const hre = await createHardhatRuntimeEnvironment(hardhatConfig.default);
 
-    const exitCode = process.exitCode;
     const nodeEnv = process.env.NODE_ENV;
     const hhTest = process.env.HH_TEST;
     try {
@@ -24,7 +23,6 @@ describe("Hardhat Mocha env variables", () => {
     } finally {
       process.env.HH_TEST = hhTest;
       process.env.NODE_ENV = nodeEnv;
-      process.exitCode = exitCode;
     }
   });
 });

--- a/v-next/hardhat-mocha/test/index.ts
+++ b/v-next/hardhat-mocha/test/index.ts
@@ -22,7 +22,10 @@ describe("Hardhat Mocha plugin", () => {
 
       const result = await hre.tasks.getTask(["test", "mocha"]).run({});
 
-      assert.deepEqual(result, { failed: 0, passed: 2 });
+      assert.deepEqual(result, {
+        success: true,
+        value: { failed: 0, passed: 2 },
+      });
     });
   });
 

--- a/v-next/hardhat-mocha/test/index.ts
+++ b/v-next/hardhat-mocha/test/index.ts
@@ -24,7 +24,7 @@ describe("Hardhat Mocha plugin", () => {
 
       assert.deepEqual(result, {
         success: true,
-        value: { failed: 0, passed: 2 },
+        value: { failed: 0, passed: 2, skipped: 0, todo: 0 },
       });
     });
   });

--- a/v-next/hardhat-node-test-runner/src/task-action.ts
+++ b/v-next/hardhat-node-test-runner/src/task-action.ts
@@ -1,8 +1,7 @@
 import type { HardhatConfig } from "hardhat/types/config";
-import type { Result } from "hardhat/types/result";
 import type { NewTaskActionFunction } from "hardhat/types/tasks";
 import type { TestSummary } from "hardhat/types/test";
-import type { LastParameter } from "hardhat/types/utils";
+import type { LastParameter, Result } from "hardhat/types/utils";
 
 import { pipeline } from "node:stream/promises";
 import { run } from "node:test";
@@ -12,7 +11,7 @@ import { hardhatTestReporter } from "@nomicfoundation/hardhat-node-test-reporter
 import { setGlobalOptionsAsEnvVariables } from "@nomicfoundation/hardhat-utils/env";
 import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
 import { createNonClosingWriter } from "@nomicfoundation/hardhat-utils/stream";
-import { errorResult, successResult } from "hardhat/utils/result";
+import { errorResult, successfulResult } from "hardhat/utils/result";
 
 interface TestActionArguments {
   testFiles: string[];
@@ -79,7 +78,12 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   const files = await getTestFiles(testFiles, hre.config);
 
   if (files.length === 0) {
-    return successResult({});
+    return successfulResult({
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      todo: 0,
+    });
   }
 
   const imports = [];
@@ -202,7 +206,7 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
   return testResults.failed > 0
     ? errorResult(testResults)
-    : successResult(testResults);
+    : successfulResult(testResults);
 };
 
 export default testWithHardhat;

--- a/v-next/hardhat-node-test-runner/test/index.ts
+++ b/v-next/hardhat-node-test-runner/test/index.ts
@@ -13,7 +13,6 @@ describe("Hardhat Node plugin", () => {
     ).default;
     const hre = await createHardhatRuntimeEnvironment(baseHhConfig);
 
-    const exitCode = process.exitCode;
     const nodeEnv = process.env.NODE_ENV;
     const hhTest = process.env.HH_TEST;
     try {
@@ -24,7 +23,6 @@ describe("Hardhat Node plugin", () => {
     } finally {
       process.env.HH_TEST = hhTest;
       process.env.NODE_ENV = nodeEnv;
-      process.exitCode = exitCode;
     }
   });
 
@@ -34,7 +32,6 @@ describe("Hardhat Node plugin", () => {
     ).default;
     const hre = await createHardhatRuntimeEnvironment(baseHhConfig);
 
-    const exitCode = process.exitCode;
     const nodeEnv = process.env.NODE_ENV;
     const hhTest = process.env.HH_TEST;
     try {
@@ -45,7 +42,6 @@ describe("Hardhat Node plugin", () => {
     } finally {
       process.env.HH_TEST = hhTest;
       process.env.NODE_ENV = nodeEnv;
-      process.exitCode = exitCode;
     }
   });
 });

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -1,8 +1,8 @@
 import type { RunOptions } from "./runner.js";
 import type { TestEvent } from "./types.js";
-import type { Result } from "../../../types/result.js";
 import type { NewTaskActionFunction } from "../../../types/tasks.js";
 import type { TestSummary } from "../../../types/test.js";
+import type { Result } from "../../../types/utils.js";
 import type {
   Artifact as EdrArtifact,
   BuildInfoAndOutput,
@@ -21,7 +21,7 @@ import { resolveFromRoot } from "@nomicfoundation/hardhat-utils/path";
 import { createNonClosingWriter } from "@nomicfoundation/hardhat-utils/stream";
 
 import { getFullyQualifiedName } from "../../../utils/contract-names.js";
-import { errorResult, successResult } from "../../../utils/result.js";
+import { errorResult, successfulResult } from "../../../utils/result.js";
 import { HardhatRuntimeEnvironmentImplementation } from "../../core/hre.js";
 import { isSupportedChainType } from "../../edr/chain-type.js";
 import { ArtifactManagerImplementation } from "../artifacts/artifact-manager.js";
@@ -288,7 +288,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
 
   return includesFailures || includesErrors
     ? errorResult(summary)
-    : successResult(summary);
+    : successfulResult(summary);
 };
 
 export default runSolidityTests;

--- a/v-next/hardhat/src/internal/builtin-plugins/telemetry/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/telemetry/task-action.ts
@@ -1,5 +1,6 @@
 import type { NewTaskActionFunction } from "../../../types/tasks.js";
 
+import { errorResult, successResult } from "../../../utils/result.js";
 import {
   isTelemetryAllowed,
   setTelemetryEnabled,
@@ -15,8 +16,7 @@ const configureTelemetry: NewTaskActionFunction<
 > = async ({ enable, disable }) => {
   if (enable && disable) {
     console.error("Cannot enable and disable telemetry at the same time");
-    process.exitCode = 1;
-    return;
+    return errorResult();
   }
 
   if (enable) {
@@ -40,6 +40,8 @@ const configureTelemetry: NewTaskActionFunction<
       "Telemetry is disabled, to enable it run `npx hardhat telemetry --enable`",
     );
   }
+
+  return successResult();
 };
 
 export default configureTelemetry;

--- a/v-next/hardhat/src/internal/builtin-plugins/telemetry/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/telemetry/task-action.ts
@@ -1,6 +1,6 @@
 import type { NewTaskActionFunction } from "../../../types/tasks.js";
 
-import { errorResult, successResult } from "../../../utils/result.js";
+import { errorResult, successfulResult } from "../../../utils/result.js";
 import {
   isTelemetryAllowed,
   setTelemetryEnabled,
@@ -41,7 +41,7 @@ const configureTelemetry: NewTaskActionFunction<
     );
   }
 
-  return successResult();
+  return successfulResult();
 };
 
 export default configureTelemetry;

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -31,7 +31,7 @@ function isTestSummary(value: unknown): value is TestSummary {
 const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
   { testFiles, chainType, grep, noCompile, verbosity },
   hre,
-) => {
+) => Result<void, void> {
   // If this code is executed, it means the user has not specified a test runner.
   // If file paths are specified, we need to determine which test runner applies to each test file.
   // If no file paths are specified, each test runner will execute all tests located under its configured path in the Hardhat configuration.

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -5,6 +5,7 @@ import type {
   TaskArguments,
 } from "../../../types/tasks.js";
 import type { TestSummary } from "../../../types/test.js";
+import type { Result } from "../../../types/utils.js";
 
 import {
   assertHardhatInvariant,
@@ -13,7 +14,11 @@ import {
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 import chalk, { type ChalkInstance } from "chalk";
 
-import { errorResult, isResult, successResult } from "../../../utils/result.js";
+import {
+  errorResult,
+  isResult,
+  successfulResult,
+} from "../../../utils/result.js";
 import { HardhatRuntimeEnvironmentImplementation } from "../../core/hre.js";
 
 interface TestActionArguments {
@@ -24,14 +29,27 @@ interface TestActionArguments {
   verbosity: number;
 }
 
-function isTestSummary(value: unknown): value is TestSummary {
-  return isObject(value);
+// Old plugins may only return { failed, passed } without skipped/todo,
+// so we accept a partial shape and fill defaults in the coordinator.
+interface PartialTestSummary extends Omit<TestSummary, "skipped" | "todo"> {
+  skipped?: number;
+  todo?: number;
+}
+
+function isTestSummary(value: unknown): value is PartialTestSummary {
+  return (
+    isObject(value) &&
+    typeof value.failed === "number" &&
+    typeof value.passed === "number" &&
+    (value.skipped === undefined || typeof value.skipped === "number") &&
+    (value.todo === undefined || typeof value.todo === "number")
+  );
 }
 
 const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
   { testFiles, chainType, grep, noCompile, verbosity },
   hre,
-) => Result<void, void> {
+): Promise<Result<void, void>> => {
   // If this code is executed, it means the user has not specified a test runner.
   // If file paths are specified, we need to determine which test runner applies to each test file.
   // If no file paths are specified, each test runner will execute all tests located under its configured path in the Hardhat configuration.
@@ -83,30 +101,45 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
       args.verbosity = verbosity;
     }
 
-    const summaryId = subtask.id[subtask.id.length - 1];
-
     if (subtask.options.has("testSummaryIndex")) {
       args.testSummaryIndex = failureIndex;
     }
 
     const subtaskResult = await subtask.run(args);
 
-    if (isResult(subtaskResult, isTestSummary, isTestSummary)) {
-      const summary = subtaskResult.success
+    const isSubtaskResult = isResult(
+      subtaskResult,
+      isTestSummary,
+      isTestSummary,
+    );
+    const summary = isSubtaskResult
+      ? subtaskResult.success
         ? subtaskResult.value
-        : subtaskResult.error;
+        : subtaskResult.error
+      : isTestSummary(subtaskResult)
+        ? subtaskResult
+        : undefined;
 
-      if (summary !== undefined) {
-        testSummaries[summaryId] = summary;
+    if (summary !== undefined) {
+      const summaryId = subtask.id[subtask.id.length - 1];
+      testSummaries[summaryId] = {
+        skipped: 0,
+        todo: 0,
+        ...summary,
+      };
 
-        if (subtask.options.has("testSummaryIndex")) {
-          failureIndex += summary.failed ?? 0;
-        }
+      if (subtask.options.has("testSummaryIndex")) {
+        failureIndex += summary.failed;
       }
+    }
 
-      if (!subtaskResult.success) {
-        hasFailures = true;
-      }
+    if (
+      (isSubtaskResult && !subtaskResult.success) ||
+      // Backwards compatibility: old plugins may not return a Result, so fall
+      // back to the process exit code to detect failures
+      (process.exitCode !== undefined && process.exitCode !== 0)
+    ) {
+      hasFailures = true;
     }
   }
 
@@ -117,19 +150,19 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
   const outputLines: string[] = [];
 
   for (const [subtaskName, results] of Object.entries(testSummaries)) {
-    if (results.passed !== undefined && results.passed > 0) {
+    if (results.passed > 0) {
       passed.push([subtaskName, results.passed]);
     }
 
-    if (results.failed !== undefined && results.failed > 0) {
+    if (results.failed > 0) {
       failed.push([subtaskName, results.failed]);
     }
 
-    if (results.skipped !== undefined && results.skipped > 0) {
+    if (results.skipped > 0) {
       skipped.push([subtaskName, results.skipped]);
     }
 
-    if (results.todo !== undefined && results.todo > 0) {
+    if (results.todo > 0) {
       todo.push([subtaskName, results.todo]);
     }
 
@@ -191,7 +224,7 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
     console.error("Test run failed");
   }
 
-  return hasFailures ? errorResult() : successResult();
+  return hasFailures ? errorResult() : successfulResult();
 };
 
 function logSummaryLine(

--- a/v-next/hardhat/src/types/test.ts
+++ b/v-next/hardhat/src/types/test.ts
@@ -5,3 +5,16 @@ export interface HardhatTestUserConfig {}
 /* eslint-disable-next-line @typescript-eslint/no-empty-interface -- Empty
 interface allow plugins to extend the Test configuration for Hardhat. */
 export interface HardhatTestConfig {}
+
+/**
+ * Summary of a test run, containing counts of test outcomes and optional
+ * failure output. All fields are optional because different test runners
+ * may provide different subsets.
+ */
+export interface TestSummary {
+  failed?: number;
+  passed?: number;
+  skipped?: number;
+  todo?: number;
+  failureOutput?: string;
+}

--- a/v-next/hardhat/src/types/test.ts
+++ b/v-next/hardhat/src/types/test.ts
@@ -8,13 +8,12 @@ export interface HardhatTestConfig {}
 
 /**
  * Summary of a test run, containing counts of test outcomes and optional
- * failure output. All fields are optional because different test runners
- * may provide different subsets.
+ * failure output.
  */
 export interface TestSummary {
-  failed?: number;
-  passed?: number;
-  skipped?: number;
-  todo?: number;
+  failed: number;
+  passed: number;
+  skipped: number;
+  todo: number;
   failureOutput?: string;
 }

--- a/v-next/hardhat/test/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/test/task-action.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { overrideTask, task } from "../../../../src/config.js";
+import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
+import { ArgumentType } from "../../../../src/types/arguments.js";
+import { successfulResult, errorResult } from "../../../../src/utils/result.js";
+
+// Override the builtin solidity subtask to be a no-op
+const solidityNoOp = overrideTask(["test", "solidity"])
+  .setInlineAction(async () => undefined)
+  .build();
+
+function mockRunner(name: string, action: (...args: any[]) => unknown) {
+  return task(["test", name])
+    .addVariadicArgument({
+      name: "testFiles",
+      description: "Test files",
+      defaultValue: [],
+    })
+    .addOption({
+      name: "grep",
+      description: "Only run tests matching the given string or regexp",
+      type: ArgumentType.STRING_WITHOUT_DEFAULT,
+      defaultValue: undefined,
+    })
+    .addFlag({ name: "noCompile" })
+    .setInlineAction(action)
+    .build();
+}
+
+describe("test/task-action", function () {
+  afterEach(function () {
+    process.exitCode = undefined;
+  });
+
+  describe("subtask returning Result<TestSummary, TestSummary>", function () {
+    it("should return a successful result when the subtask returns a successful Result", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () =>
+            successfulResult({ passed: 3, failed: 0, skipped: 0, todo: 0 }),
+          ),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: true, value: undefined });
+    });
+
+    it("should return an error result when the subtask returns a failed Result", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () =>
+            errorResult({ passed: 1, failed: 2, skipped: 0, todo: 0 }),
+          ),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: false, error: undefined });
+    });
+  });
+
+  describe("subtask returning a plain TestSummary (backwards compat)", function () {
+    it("should return a successful result when the subtask returns a plain TestSummary and exitCode is not set", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () => ({
+            passed: 5,
+            failed: 0,
+            skipped: 0,
+            todo: 0,
+          })),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: true, value: undefined });
+    });
+
+    it("should return an error result when the subtask returns a plain TestSummary and exitCode is 1", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () => {
+            process.exitCode = 1;
+            return { passed: 1, failed: 3, skipped: 0, todo: 0 };
+          }),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: false, error: undefined });
+    });
+  });
+
+  describe("subtask returning undefined with process.exitCode (backwards compat)", function () {
+    it("should return an error result when the subtask returns undefined and exitCode is 1", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () => {
+            process.exitCode = 1;
+          }),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: false, error: undefined });
+    });
+  });
+
+  describe("subtask returning a partial TestSummary (backwards compat)", function () {
+    it("should return a successful result when the subtask returns only failed and passed", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () => ({
+            passed: 3,
+            failed: 0,
+          })),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: true, value: undefined });
+    });
+
+    it("should return an error result when the subtask returns a partial TestSummary and exitCode is 1", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () => {
+            process.exitCode = 1;
+            return { passed: 1, failed: 2 };
+          }),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: false, error: undefined });
+    });
+  });
+
+  describe("mixed subtask return types", function () {
+    it("should return an error result when a Result subtask succeeds but a plain summary subtask fails", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () =>
+            successfulResult({ passed: 3, failed: 0, skipped: 0, todo: 0 }),
+          ),
+          mockRunner("runner-b", () => {
+            process.exitCode = 1;
+            return { passed: 2, failed: 1, skipped: 0, todo: 0 };
+          }),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: false, error: undefined });
+    });
+
+    it("should return a successful result when all subtasks succeed with different return styles", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () =>
+            successfulResult({ passed: 3, failed: 0, skipped: 0, todo: 0 }),
+          ),
+          mockRunner("runner-b", () => ({
+            passed: 2,
+            failed: 0,
+            skipped: 0,
+            todo: 0,
+          })),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: true, value: undefined });
+    });
+
+    it("should return an error result when a Result subtask succeeds but another subtask only sets exitCode", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () =>
+            successfulResult({ passed: 3, failed: 0, skipped: 0, todo: 0 }),
+          ),
+          mockRunner("runner-b", () => {
+            process.exitCode = 1;
+          }),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: false, error: undefined });
+    });
+  });
+});

--- a/v-next/hardhat/test/utils/result.ts
+++ b/v-next/hardhat/test/utils/result.ts
@@ -8,7 +8,7 @@ import {
 } from "../../src/utils/result.js";
 
 describe("result", function () {
-  describe("successResult", function () {
+  describe("successfulResult", function () {
     it("should create a successful Result with the given value", function () {
       const result = successfulResult(42);
       assert.deepEqual(result, { success: true, value: 42 });


### PR DESCRIPTION
Update test runner (`solidity`, `node`, `mocha`) and `telemetry` task actions to return `Result` instead of setting `process.exitCode`. Define a shared `TestSummary` type and use `isResult` with type guards in the parent test task to aggregate results without type assertions.

This should be reviewed after https://github.com/NomicFoundation/hardhat/pull/8012.