### PR TITLE
fix: prevent untracked coverage output files in fixture project

### DIFF
--- a/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -409,7 +409,7 @@ describe("CoverageManagerImplementation - report data processing", () => {
     COVERAGE_TEST_SCENARIO_WHILE_LOOP,
   ];
 
-  const coverageManagerTmp = new CoverageManagerImplementation("");
+  const coverageManagerTmp = new CoverageManagerImplementation("coverage");
   let hre: HardhatRuntimeEnvironment;
   let originalCoverageFlag: boolean;
 


### PR DESCRIPTION
The `CoverageManagerImplementation - report data processing` test was instantiating `CoverageManagerImplementation("")`, which caused the coverage hooks to write `data/`, `html/`, and `lcov.info` directly to the fixture root, leaving untracked files after each run.

This changes the path to `"coverage"` so all output goes into the `coverage/` directory, which is already gitignored.