### PR TITLE
fix: restore removed export paths for backward compat with older test runners

### DIFF
--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -37,6 +37,8 @@
     "./types/utils": "./dist/src/types/utils.js",
     "./types/solidity": "./dist/src/types/solidity.js",
     "./console.sol": "./console.sol",
+    "./internal/coverage": "./dist/src/internal/builtin-plugins/coverage/exports.js",
+    "./internal/gas-analytics": "./dist/src/internal/builtin-plugins/gas-analytics/exports.js",
     "./utils/contract-names": "./dist/src/utils/contract-names.js",
     "./utils/result": "./dist/src/utils/result.js",
     "./types/runtime": "./dist/src/internal/deprecated-module-imported-from-hardhat2-plugin.js",

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/exports.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/exports.ts
@@ -1,0 +1,5 @@
+export {
+  markTestRunStart,
+  markTestRunDone,
+  markTestWorkerDone,
+} from "./helpers.js";

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/test.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/test.ts
@@ -1,8 +1,9 @@
 import type { HookContext, TestHooks } from "../../../../types/hooks.js";
 
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { HardhatRuntimeEnvironmentImplementation } from "../../../core/hre.js";
+import { CoverageManagerImplementation } from "../coverage-manager.js";
 
 export default async (): Promise<Partial<TestHooks>> => ({
   onTestRunStart: async (context, id, next) => {
@@ -22,37 +23,46 @@ export default async (): Promise<Partial<TestHooks>> => ({
 });
 
 export async function testRunStart(
-  hre: HookContext,
+  context: HookContext,
   id: string,
 ): Promise<void> {
-  if (hre.globalOptions.coverage === true) {
+  if (context.globalOptions.coverage === true) {
     assertHardhatInvariant(
-      hre instanceof HardhatRuntimeEnvironmentImplementation,
-      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+      "_coverage" in context &&
+        isObject(context._coverage) &&
+        context._coverage instanceof CoverageManagerImplementation,
+      "Expected HookContext#_coverage to be an instance of CoverageManagerImplementation",
     );
-    await hre._coverage.clearData(id);
+    await context._coverage.clearData(id);
   }
 }
 
 export async function testWorkerDone(
-  hre: HookContext,
+  context: HookContext,
   id: string,
 ): Promise<void> {
-  if (hre.globalOptions.coverage === true) {
+  if (context.globalOptions.coverage === true) {
     assertHardhatInvariant(
-      hre instanceof HardhatRuntimeEnvironmentImplementation,
-      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+      "_coverage" in context &&
+        isObject(context._coverage) &&
+        context._coverage instanceof CoverageManagerImplementation,
+      "Expected HookContext#_coverage to be an instance of CoverageManagerImplementation",
     );
-    await hre._coverage.saveData(id);
+    await context._coverage.saveData(id);
   }
 }
 
-export async function testRunDone(hre: HookContext, id: string): Promise<void> {
-  if (hre.globalOptions.coverage === true) {
+export async function testRunDone(
+  context: HookContext,
+  id: string,
+): Promise<void> {
+  if (context.globalOptions.coverage === true) {
     assertHardhatInvariant(
-      hre instanceof HardhatRuntimeEnvironmentImplementation,
-      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+      "_coverage" in context &&
+        isObject(context._coverage) &&
+        context._coverage instanceof CoverageManagerImplementation,
+      "Expected HookContext#_coverage to be an instance of CoverageManagerImplementation",
     );
-    await hre._coverage.report(id);
+    await context._coverage.report(id);
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/test.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/test.ts
@@ -1,4 +1,4 @@
-import type { TestHooks } from "../../../../types/hooks.js";
+import type { HookContext, TestHooks } from "../../../../types/hooks.js";
 
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 
@@ -7,37 +7,52 @@ import { HardhatRuntimeEnvironmentImplementation } from "../../../core/hre.js";
 export default async (): Promise<Partial<TestHooks>> => ({
   onTestRunStart: async (context, id, next) => {
     await next(context, id);
-
-    if (context.globalOptions.coverage === true) {
-      assertHardhatInvariant(
-        context instanceof HardhatRuntimeEnvironmentImplementation,
-        "Expected context to be an instance of HardhatRuntimeEnvironmentImplementation",
-      );
-      await context._coverage.clearData(id);
-    }
+    await testRunStart(context, id);
   },
 
   onTestWorkerDone: async (context, id, next) => {
     await next(context, id);
-
-    if (context.globalOptions.coverage === true) {
-      assertHardhatInvariant(
-        context instanceof HardhatRuntimeEnvironmentImplementation,
-        "Expected context to be an instance of HardhatRuntimeEnvironmentImplementation",
-      );
-      await context._coverage.saveData(id);
-    }
+    await testWorkerDone(context, id);
   },
 
   onTestRunDone: async (context, id, next) => {
     await next(context, id);
-
-    if (context.globalOptions.coverage === true) {
-      assertHardhatInvariant(
-        context instanceof HardhatRuntimeEnvironmentImplementation,
-        "Expected context to be an instance of HardhatRuntimeEnvironmentImplementation",
-      );
-      await context._coverage.report(id);
-    }
+    await testRunDone(context, id);
   },
 });
+
+export async function testRunStart(
+  hre: HookContext,
+  id: string,
+): Promise<void> {
+  if (hre.globalOptions.coverage === true) {
+    assertHardhatInvariant(
+      hre instanceof HardhatRuntimeEnvironmentImplementation,
+      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+    );
+    await hre._coverage.clearData(id);
+  }
+}
+
+export async function testWorkerDone(
+  hre: HookContext,
+  id: string,
+): Promise<void> {
+  if (hre.globalOptions.coverage === true) {
+    assertHardhatInvariant(
+      hre instanceof HardhatRuntimeEnvironmentImplementation,
+      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+    );
+    await hre._coverage.saveData(id);
+  }
+}
+
+export async function testRunDone(hre: HookContext, id: string): Promise<void> {
+  if (hre.globalOptions.coverage === true) {
+    assertHardhatInvariant(
+      hre instanceof HardhatRuntimeEnvironmentImplementation,
+      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+    );
+    await hre._coverage.report(id);
+  }
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/exports.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/exports.ts
@@ -1,0 +1,5 @@
+export {
+  markTestRunStart,
+  markTestRunDone,
+  markTestWorkerDone,
+} from "./helpers.js";

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/helpers.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/helpers.ts
@@ -1,19 +1,13 @@
-import path from "node:path";
-
 import {
   testRunDone,
   testRunStart,
   testWorkerDone,
 } from "./hook-handlers/test.js";
 
-export function getCoveragePath(rootPath: string): string {
-  return path.join(rootPath, "coverage");
-}
-
 /**
  * The following helpers are kept for backward compatibility with older versions
  * of test runner plugins (hardhat-mocha, hardhat-node-test-runner) that import
- * from "hardhat/internal/coverage".
+ * from "hardhat/internal/gas-analytics".
  */
 
 export async function markTestRunStart(id: string): Promise<void> {

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/test.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/test.ts
@@ -1,8 +1,9 @@
 import type { HookContext, TestHooks } from "../../../../types/hooks.js";
 
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { HardhatRuntimeEnvironmentImplementation } from "../../../core/hre.js";
+import { GasAnalyticsManagerImplementation } from "../gas-analytics-manager.js";
 
 export default async (): Promise<Partial<TestHooks>> => ({
   onTestRunStart: async (context, id, next) => {
@@ -22,37 +23,46 @@ export default async (): Promise<Partial<TestHooks>> => ({
 });
 
 export async function testRunStart(
-  hre: HookContext,
+  context: HookContext,
   id: string,
 ): Promise<void> {
-  if (hre.globalOptions.gasStats === true) {
+  if (context.globalOptions.gasStats === true) {
     assertHardhatInvariant(
-      hre instanceof HardhatRuntimeEnvironmentImplementation,
-      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+      "_gasAnalytics" in context &&
+        isObject(context._gasAnalytics) &&
+        context._gasAnalytics instanceof GasAnalyticsManagerImplementation,
+      "Expected HookContext#_gasAnalytics to be an instance of GasAnalyticsManagerImplementation",
     );
-    await hre._gasAnalytics.clearGasMeasurements(id);
+    await context._gasAnalytics.clearGasMeasurements(id);
   }
 }
 
 export async function testWorkerDone(
-  hre: HookContext,
+  context: HookContext,
   id: string,
 ): Promise<void> {
-  if (hre.globalOptions.gasStats === true) {
+  if (context.globalOptions.gasStats === true) {
     assertHardhatInvariant(
-      hre instanceof HardhatRuntimeEnvironmentImplementation,
-      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+      "_gasAnalytics" in context &&
+        isObject(context._gasAnalytics) &&
+        context._gasAnalytics instanceof GasAnalyticsManagerImplementation,
+      "Expected HookContext#_gasAnalytics to be an instance of GasAnalyticsManagerImplementation",
     );
-    await hre._gasAnalytics.saveGasMeasurements(id);
+    await context._gasAnalytics.saveGasMeasurements(id);
   }
 }
 
-export async function testRunDone(hre: HookContext, id: string): Promise<void> {
-  if (hre.globalOptions.gasStats === true) {
+export async function testRunDone(
+  context: HookContext,
+  id: string,
+): Promise<void> {
+  if (context.globalOptions.gasStats === true) {
     assertHardhatInvariant(
-      hre instanceof HardhatRuntimeEnvironmentImplementation,
-      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+      "_gasAnalytics" in context &&
+        isObject(context._gasAnalytics) &&
+        context._gasAnalytics instanceof GasAnalyticsManagerImplementation,
+      "Expected HookContext#_gasAnalytics to be an instance of GasAnalyticsManagerImplementation",
     );
-    await hre._gasAnalytics.reportGasStats(id);
+    await context._gasAnalytics.reportGasStats(id);
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/test.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/test.ts
@@ -1,4 +1,4 @@
-import type { TestHooks } from "../../../../types/hooks.js";
+import type { HookContext, TestHooks } from "../../../../types/hooks.js";
 
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 
@@ -7,37 +7,52 @@ import { HardhatRuntimeEnvironmentImplementation } from "../../../core/hre.js";
 export default async (): Promise<Partial<TestHooks>> => ({
   onTestRunStart: async (context, id, next) => {
     await next(context, id);
-
-    if (context.globalOptions.gasStats === true) {
-      assertHardhatInvariant(
-        context instanceof HardhatRuntimeEnvironmentImplementation,
-        "Expected context to be an instance of HardhatRuntimeEnvironmentImplementation",
-      );
-      await context._gasAnalytics.clearGasMeasurements(id);
-    }
+    await testRunStart(context, id);
   },
 
   onTestWorkerDone: async (context, id, next) => {
     await next(context, id);
-
-    if (context.globalOptions.gasStats === true) {
-      assertHardhatInvariant(
-        context instanceof HardhatRuntimeEnvironmentImplementation,
-        "Expected context to be an instance of HardhatRuntimeEnvironmentImplementation",
-      );
-      await context._gasAnalytics.saveGasMeasurements(id);
-    }
+    await testWorkerDone(context, id);
   },
 
   onTestRunDone: async (context, id, next) => {
     await next(context, id);
-
-    if (context.globalOptions.gasStats === true) {
-      assertHardhatInvariant(
-        context instanceof HardhatRuntimeEnvironmentImplementation,
-        "Expected context to be an instance of HardhatRuntimeEnvironmentImplementation",
-      );
-      await context._gasAnalytics.reportGasStats(id);
-    }
+    await testRunDone(context, id);
   },
 });
+
+export async function testRunStart(
+  hre: HookContext,
+  id: string,
+): Promise<void> {
+  if (hre.globalOptions.gasStats === true) {
+    assertHardhatInvariant(
+      hre instanceof HardhatRuntimeEnvironmentImplementation,
+      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+    );
+    await hre._gasAnalytics.clearGasMeasurements(id);
+  }
+}
+
+export async function testWorkerDone(
+  hre: HookContext,
+  id: string,
+): Promise<void> {
+  if (hre.globalOptions.gasStats === true) {
+    assertHardhatInvariant(
+      hre instanceof HardhatRuntimeEnvironmentImplementation,
+      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+    );
+    await hre._gasAnalytics.saveGasMeasurements(id);
+  }
+}
+
+export async function testRunDone(hre: HookContext, id: string): Promise<void> {
+  if (hre.globalOptions.gasStats === true) {
+    assertHardhatInvariant(
+      hre instanceof HardhatRuntimeEnvironmentImplementation,
+      "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
+    );
+    await hre._gasAnalytics.reportGasStats(id);
+  }
+}


### PR DESCRIPTION
[PR #8001](https://github.com/NomicFoundation/hardhat/pull/8001) removed the `hardhat/internal/coverage` and `hardhat/internal/gas-analytics` export paths, breaking users who upgrade `hardhat` but keep older versions of `hardhat-mocha` or `hardhat-node-test-runner`. This restores those exports as thin wrappers around shared logic extracted from the new hook handlers.