### PR TITLE
chore: end to end test harness

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
   "waitFor": "postCreateCommand",
   "containerEnv": {
     "ALCHEMY_URL": "${localEnv:ALCHEMY_URL}",
-    "INFURA_URL": "${localEnv:INFURA_URL}"
+    "INFURA_URL": "${localEnv:INFURA_URL}",
+    "E2E_CLONE_DIR": "/tmp/end-to-end"
   },
   "customizations": {
     "vscode": {

--- a/end-to-end/openzeppelin-contracts/scenario.json
+++ b/end-to-end/openzeppelin-contracts/scenario.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
+  "tags": ["external-repo"],
+  "repo": "kanej/openzeppelin-contracts",
+  "commit": "4ba2af18cad98904fb0a8d64a958fa91d56298c5",
+  "packageManager": "npm",
+  "submodules": true
+}

--- a/package.json
+++ b/package.json
@@ -24,13 +24,16 @@
     "tsc:scripts": "tsc --noEmit -p scripts/tsconfig.json",
     "lint:scripts": "pnpm prettier:scripts --check && pnpm tsc:scripts",
     "lint:scripts:fix": "pnpm prettier:scripts --write && pnpm tsc:scripts",
+    "lint:e2e": "prettier \"end-to-end/**/*.json\" --check",
+    "lint:e2e:fix": "prettier \"end-to-end/**/*.json\" --write",
     "prelint": "pnpm build",
-    "lint": "pnpm run --recursive --if-present lint && pnpm lint:scripts",
+    "lint": "pnpm run --recursive --if-present lint && pnpm lint:scripts && pnpm lint:e2e",
     "prelint:fix": "pnpm build",
-    "lint:fix": "pnpm run --recursive --if-present lint:fix && pnpm lint:scripts:fix",
+    "lint:fix": "pnpm run --recursive --if-present lint:fix && pnpm lint:scripts:fix && pnpm lint:e2e:fix",
     "version-for-release": "pnpm changeset version && node scripts/bump-peers.ts apply && pnpm -w install --lockfile-only",
     "spellcheck": "cspell --no-progress || (echo \"\\n\\n==== cspell failed ===\\n\\nIf you think a word is correctly spelled, please add it to cspell.dictionary.txt\\nTo ignore a word use the comments 'cSpell:ignore wooord' or 'cspell:disable-next-line'\"; exit 1)",
-    "verdaccio": "node ./scripts/verdaccio/main.ts"
+    "verdaccio": "node ./scripts/verdaccio/main.ts",
+    "e2e": "node ./scripts/end-to-end/main.ts"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/scripts/end-to-end/helpers/args.ts
+++ b/scripts/end-to-end/helpers/args.ts
@@ -1,0 +1,60 @@
+import { log } from "node:console";
+import { normalizeScenarioPath } from "./directory.ts";
+
+const DEFAULT_CLONE_DIR = "/tmp/end-to-end";
+
+export function resolveAndValidateArgs(args: string[]) {
+  const scenarioPathRaw =
+    getArgValue(args, "--scenario") ?? process.env.E2E_SCENARIO;
+  const scenarioPath =
+    scenarioPathRaw !== undefined
+      ? normalizeScenarioPath(scenarioPathRaw)
+      : undefined;
+
+  const initFlag = args.includes("init");
+  const execFlag = args.includes("exec");
+  const cleanFlag = args.includes("clean");
+
+  const command = getArgValue(args, "--command");
+
+  let e2eCloneDirectory =
+    getArgValue(args, "--e2e-clone-dir") ?? process.env.E2E_CLONE_DIR;
+
+  const commandFlagCount = [initFlag, execFlag, cleanFlag].filter(
+    (f) => f,
+  ).length;
+
+  if (commandFlagCount > 1) {
+    throw new Error("Only one command can be set either: init, exec or clean");
+  }
+
+  if (commandFlagCount === 1 && scenarioPath === undefined) {
+    throw new Error(
+      "Missing required --scenario argument e.g. --scenario ./end-to-end/openzeppelin-contracts",
+    );
+  }
+
+  if (e2eCloneDirectory === undefined) {
+    e2eCloneDirectory = DEFAULT_CLONE_DIR;
+
+    log(
+      `No --e2e-clone-dir argument or E2E_CLONE_DIR environment variable provided, defaulting to:`,
+    );
+    log(`  ${DEFAULT_CLONE_DIR}`);
+  }
+
+  return {
+    initFlag,
+    execFlag,
+    cleanFlag,
+    e2eCloneDirectory,
+    scenarioPath,
+    command,
+  };
+}
+
+function getArgValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+
+  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}

--- a/scripts/end-to-end/helpers/directory.ts
+++ b/scripts/end-to-end/helpers/directory.ts
@@ -1,0 +1,60 @@
+import path, { basename, dirname, resolve } from "node:path";
+import type { Scenario, ScenarioDefinition } from "../types.ts";
+import { isScenarioDefinition } from "../schema/scenario-schema.ts";
+import { readFileSync } from "node:fs";
+
+export function loadScenario(
+  e2eCloneDirectory: string,
+  scenarioFilePath: string,
+): Scenario {
+  const id = basename(dirname(scenarioFilePath));
+  const scenarioDir = dirname(scenarioFilePath);
+  const workingDir = resolveScenarioWorkingDir(
+    e2eCloneDirectory,
+    scenarioFilePath,
+  );
+  const definition = _readScenarioJson(scenarioFilePath);
+
+  return {
+    id,
+    scenarioDir,
+    workingDir,
+    definition,
+  };
+}
+
+/**
+ * Resolve the working directory for a scenario.
+ * Always uses the scenario slug (basename of scenarioDir): <cloneBaseDir>/<slug>
+ * e.g. /tmp/end-to-end/openzeppelin-contracts
+ */
+export function resolveScenarioWorkingDir(
+  e2eCloneDirectory: string,
+  scenarioFilePath: string,
+): string {
+  return path.join(e2eCloneDirectory, basename(dirname(scenarioFilePath)));
+}
+
+/**
+ * Normalize a scenario path to always point at the scenario.json file.
+ * Accepts either a directory or a direct path to scenario.json.
+ */
+export function normalizeScenarioPath(scenarioPath: string): string {
+  const abs = resolve(scenarioPath);
+
+  if (abs.endsWith("scenario.json")) {
+    return abs;
+  }
+
+  return resolve(abs, "scenario.json");
+}
+
+function _readScenarioJson(scenarioFilePath: string): ScenarioDefinition {
+  const raw = JSON.parse(readFileSync(scenarioFilePath, "utf-8")) as unknown;
+
+  if (!isScenarioDefinition(raw)) {
+    throw new Error(`Invalid scenario.json at ${scenarioFilePath}`);
+  }
+
+  return raw;
+}

--- a/scripts/end-to-end/helpers/install.ts
+++ b/scripts/end-to-end/helpers/install.ts
@@ -1,0 +1,41 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { which } from "./shell.ts";
+import { log, logStep } from "./log.ts";
+
+import { VERDACCIO_URL } from "../../verdaccio/helpers/shell.ts";
+import type { ScenarioDefinition } from "../types.ts";
+
+/**
+ * Write .npmrc pointing at Verdaccio and run `npm install` for clone tests.
+ * For init tests the setup command handles dependency installation.
+ */
+export function npmInstall(
+  workDir: string,
+  packageManager: "npm",
+  env?: Record<string, string>,
+): void {
+  writeNpmrc(workDir);
+
+  if (packageManager !== "npm") {
+    throw new Error("Only npm is supported as a package manager");
+  }
+
+  logStep("Installing dependencies");
+
+  execFileSync(which("npm"), ["install"], {
+    cwd: workDir,
+    stdio: "inherit",
+    env: { ...process.env, ...env },
+  });
+}
+
+function writeNpmrc(dir: string): void {
+  const npmrcPath = resolve(dir, ".npmrc");
+
+  writeFileSync(npmrcPath, `registry=${VERDACCIO_URL}\n`);
+
+  log(`Wrote .npmrc → ${VERDACCIO_URL}`);
+}

--- a/scripts/end-to-end/helpers/log.ts
+++ b/scripts/end-to-end/helpers/log.ts
@@ -1,0 +1,23 @@
+import { styleText } from "node:util";
+
+const PREFIX = "[e2e]";
+
+export const fmt = {
+  pkg: (name: string) => styleText("bold", name),
+  version: (v: string) => styleText("green", v),
+  deemphasize: (text: string) => styleText("dim", text),
+  success: (text: string) => styleText("green", text),
+  fail: (text: string) => styleText("red", text),
+};
+
+export function log(msg: string): void {
+  console.log(`${styleText("cyan", PREFIX)} ${msg}`);
+}
+
+export function logStep(step: string): void {
+  console.log(styleText(["bold", "yellow"], `${PREFIX} === ${step} ===`));
+}
+
+export function logError(msg: string): void {
+  console.error(styleText("red", `${PREFIX} Error: ${msg}`));
+}

--- a/scripts/end-to-end/helpers/shell.ts
+++ b/scripts/end-to-end/helpers/shell.ts
@@ -1,0 +1,24 @@
+import { execFileSync, execSync } from "node:child_process";
+import { resolve } from "node:path";
+
+export const ROOT_DIR = resolve(import.meta.dirname, "../../..");
+
+const whichCache = new Map<string, string>();
+
+export function which(command: string): string {
+  let cached = whichCache.get(command);
+
+  if (cached === undefined) {
+    cached = execSync(`which ${command}`, { encoding: "utf-8" }).trim();
+    whichCache.set(command, cached);
+  }
+
+  return cached;
+}
+
+export function git(args: string[], cwd?: string): string {
+  return execFileSync(which("git"), args, {
+    encoding: "utf-8",
+    cwd,
+  }).trim();
+}

--- a/scripts/end-to-end/main.ts
+++ b/scripts/end-to-end/main.ts
@@ -1,0 +1,72 @@
+import { init } from "./subcommands/init.ts";
+import { clean } from "./subcommands/clean.ts";
+import { exec } from "./subcommands/exec.ts";
+import { logError } from "./helpers/log.ts";
+import { resolveAndValidateArgs } from "./helpers/args.ts";
+
+const USAGE = `
+./scripts/end-to-end/main.ts — Run Hardhat in end-to-end scenarios
+
+DESCRIPTION
+  Run Hardhat using a local Verdaccio registry against specified scenarios e.g. 
+  third party repositories.
+  Each scenario is defined by a scenario.json in end-to-end/<scenario-slug>/.
+
+COMMANDS
+  init --scenario <scenario-path>   Setup scenario (i.e. clone) and install hardhat from Verdaccio
+  exec --scenario <scenario-path>   Run a command in the scenario's working directory
+  clean --scenario <scenario-path>  Remove the scenario's working directory
+
+OPTIONS
+  --e2e-clone-dir <path>   Override clone directory (default: $E2E_CLONE_DIR or "/tmp/end-to-end")
+  --scenario <path>        The scenario folder or file to work on (default: $E2E_SCENARIO)
+  --command <cmd>          Command to run (required with \`exec\`)
+
+VERDACCIO
+  If Verdaccio is already running it will be used as-is.
+  Otherwise it is started automatically, packages are published, and it is
+  stopped once the init phase completes.
+
+EXAMPLES
+  pnpm e2e init --scenario ./end-to-end/openzeppelin-contracts
+  pnpm e2e exec --scenario ./end-to-end/openzeppelin-contracts --command "npx hardhat compile"
+  E2E_SCENARIO=./end-to-end/openzeppelin-contracts pnpm e2e exec --command "npx hardhat test"
+  pnpm e2e clean --scenario ./end-to-end/openzeppelin-contracts
+`;
+
+async function main(): Promise<void> {
+  const {
+    initFlag,
+    execFlag,
+    cleanFlag,
+    e2eCloneDirectory,
+    scenarioPath,
+    command,
+  } = resolveAndValidateArgs(process.argv.slice(2));
+
+  try {
+    if (initFlag) {
+      await init(e2eCloneDirectory, scenarioPath);
+    } else if (execFlag) {
+      if (command === undefined) {
+        throw new Error("`exec` requires --command <cmd>");
+      }
+
+      await exec(e2eCloneDirectory, scenarioPath, command);
+    } else if (cleanFlag) {
+      clean(e2eCloneDirectory, scenarioPath);
+    } else {
+      console.log(USAGE);
+    }
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
+
+    logError(error.message);
+
+    process.exit(1);
+  }
+}
+
+await main();

--- a/scripts/end-to-end/schema/scenario-schema.test.ts
+++ b/scripts/end-to-end/schema/scenario-schema.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isScenarioDefinition } from "./scenario-schema.ts";
+
+describe("isScenarioDefinition", () => {
+  it("accepts a minimal valid scenario", () => {
+    const value = {
+      repo: "OpenZeppelin/openzeppelin-contracts",
+      commit: "abc123",
+      packageManager: "npm",
+      tags: ["solidity-compile"],
+    };
+
+    assert.equal(isScenarioDefinition(value), true);
+  });
+
+  it("accepts a scenario with all optional fields", () => {
+    const value = {
+      repo: "OpenZeppelin/openzeppelin-contracts",
+      commit: "abc123",
+      packageManager: "npm",
+      preinstall: "./preinstall.sh",
+      install: "./install.sh",
+      tags: ["solidity-compile"],
+      env: { FOO: "bar" },
+      submodules: true,
+    };
+
+    assert.equal(isScenarioDefinition(value), true);
+  });
+
+  it("rejects when repo is missing", () => {
+    assert.equal(
+      isScenarioDefinition({
+        commit: "abc",
+        packageManager: "npm",
+        tags: [],
+      }),
+      false,
+    );
+  });
+
+  it("rejects when packageManager is not 'npm'", () => {
+    assert.equal(
+      isScenarioDefinition({
+        repo: "org/repo",
+        commit: "abc",
+        packageManager: "pnpm",
+        tags: [],
+      }),
+      false,
+    );
+  });
+
+  it("rejects when tags contains non-string", () => {
+    assert.equal(
+      isScenarioDefinition({
+        repo: "org/repo",
+        commit: "abc",
+        packageManager: "npm",
+        tags: [42],
+      }),
+      false,
+    );
+  });
+
+  it("rejects when env has non-string values", () => {
+    assert.equal(
+      isScenarioDefinition({
+        repo: "org/repo",
+        commit: "abc",
+        packageManager: "npm",
+        tags: [],
+        env: { FOO: 123 },
+      }),
+      false,
+    );
+  });
+
+  it("rejects null", () => {
+    assert.equal(isScenarioDefinition(null), false);
+  });
+
+  it("rejects non-object", () => {
+    assert.equal(isScenarioDefinition("not an object"), false);
+  });
+});

--- a/scripts/end-to-end/schema/scenario-schema.ts
+++ b/scripts/end-to-end/schema/scenario-schema.ts
@@ -1,0 +1,33 @@
+import type { ScenarioDefinition } from "../types.ts";
+
+export function isScenarioDefinition(
+  value: unknown,
+): value is ScenarioDefinition {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  return (
+    typeof obj.repo === "string" &&
+    typeof obj.commit === "string" &&
+    obj.packageManager === "npm" &&
+    Array.isArray(obj.tags) &&
+    obj.tags.every((t: unknown) => typeof t === "string") &&
+    (obj.env === undefined || isStringRecord(obj.env)) &&
+    (obj.preinstall === undefined || typeof obj.preinstall === "string") &&
+    (obj.install === undefined || typeof obj.install === "string") &&
+    (obj.submodules === undefined || typeof obj.submodules === "boolean")
+  );
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  return Object.values(value as Record<string, unknown>).every(
+    (v) => typeof v === "string",
+  );
+}

--- a/scripts/end-to-end/schema/scenario.schema.json
+++ b/scripts/end-to-end/schema/scenario.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "End-to-End Test Definition",
+  "description": "Defines a single end-to-end test for the Hardhat test harness.",
+  "type": "object",
+  "required": ["repo", "commit", "packageManager", "tags"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "repo": {
+      "type": "string",
+      "description": "GitHub repo in org/name format (e.g. OpenZeppelin/openzeppelin-contracts)"
+    },
+    "commit": {
+      "type": "string",
+      "description": "Full SHA or tag to checkout"
+    },
+    "packageManager": {
+      "type": "string",
+      "enum": ["npm"],
+      "description": "Package manager used by the repo (npm only for now)"
+    },
+    "preinstall": {
+      "type": "string",
+      "description": "Relative path to a shell script for patching the repo before install"
+    },
+    "install": {
+      "type": "string",
+      "description": "Relative path to a custom install script (overrides built-in Verdaccio flow)"
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1,
+      "description": "Tags for filtering (e.g. [\"solidity-compile\", \"solidity-test\"])"
+    },
+    "env": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Environment variables to set during install/exec"
+    },
+    "submodules": {
+      "type": "boolean",
+      "description": "Initialize git submodules recursively (default: false)"
+    }
+  }
+}

--- a/scripts/end-to-end/subcommands/clean.ts
+++ b/scripts/end-to-end/subcommands/clean.ts
@@ -1,0 +1,22 @@
+import { existsSync, rmSync } from "node:fs";
+import { fmt, log, logStep } from "../helpers/log.ts";
+import { resolveScenarioWorkingDir } from "../helpers/directory.ts";
+
+export function clean(e2eCloneDirectory: string, scenarioPath: string): void {
+  const scenarioWorkingDir = resolveScenarioWorkingDir(
+    e2eCloneDirectory,
+    scenarioPath,
+  );
+
+  if (!existsSync(scenarioWorkingDir)) {
+    log(`Nothing to clean: ${fmt.deemphasize(scenarioWorkingDir)}`);
+
+    return;
+  }
+
+  logStep(`Cleaning ${scenarioWorkingDir}`);
+
+  rmSync(scenarioWorkingDir, { recursive: true });
+
+  log(`Removed: ${fmt.deemphasize(scenarioWorkingDir)}`);
+}

--- a/scripts/end-to-end/subcommands/exec.ts
+++ b/scripts/end-to-end/subcommands/exec.ts
@@ -1,0 +1,36 @@
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { loadScenario } from "../helpers/directory.ts";
+import { init } from "./init.ts";
+import { logStep } from "../helpers/log.ts";
+
+export async function exec(
+  e2eCloneDirectory: string,
+  scenarioPath: string,
+  command: string,
+): Promise<void> {
+  const scenario = loadScenario(e2eCloneDirectory, scenarioPath);
+
+  if (!existsSync(scenario.workingDir)) {
+    await init(e2eCloneDirectory, scenarioPath);
+  }
+
+  runCommand(command, scenario.workingDir, scenario.definition.env);
+}
+
+function runCommand(
+  command: string,
+  cwd: string,
+  env?: Record<string, string>,
+): void {
+  logStep(`Running: ${command}`);
+
+  execSync(command, {
+    cwd,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+}

--- a/scripts/end-to-end/subcommands/init.ts
+++ b/scripts/end-to-end/subcommands/init.ts
@@ -1,0 +1,159 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { npmInstall } from "../helpers/install.ts";
+import { git, which, ROOT_DIR } from "../helpers/shell.ts";
+import { log, logStep } from "../helpers/log.ts";
+import { isVerdaccioRunning } from "../../verdaccio/helpers/shell.ts";
+import { loadScenario } from "../helpers/directory.ts";
+import { start as verdaccioStart } from "../../verdaccio/start.ts";
+import { publish as verdaccioPublish } from "../../verdaccio/publish.ts";
+import { stop as verdaccioStop } from "../../verdaccio/stop.ts";
+import type { Scenario } from "../types.ts";
+
+export async function init(
+  e2eCloneDirectory: string,
+  scenarioPath: string,
+): Promise<void> {
+  const scenario = loadScenario(e2eCloneDirectory, scenarioPath);
+
+  const runTemporaryVerdaccioInstance = !isVerdaccioRunning();
+
+  if (runTemporaryVerdaccioInstance) {
+    await verdaccioStart(true);
+
+    verdaccioPublish(false, true);
+  }
+
+  try {
+    initializeScenario(scenario);
+  } finally {
+    if (runTemporaryVerdaccioInstance) {
+      verdaccioStop();
+    }
+  }
+
+  log("Scenario initialization complete, working directory setup:");
+  log(`  cd ${scenario.workingDir}`);
+}
+
+/**
+ * Clone/setup a scenario repo and install hardhat from Verdaccio.
+ * Idempotent: reuses existing checkouts (fetch + checkout + clean).
+ */
+function initializeScenario(scenario: Scenario): void {
+  const { scenarioDir, workingDir, definition } = scenario;
+  const submodules = definition.submodules ?? false;
+
+  if (!existsSync(workingDir)) {
+    // Fresh clone flow
+    clone(workingDir, definition.repo);
+    checkout(workingDir, definition.commit);
+
+    if (submodules) {
+      updateSubmodules(workingDir);
+    }
+  } else {
+    // Re-init flow
+    fetch(workingDir, definition.repo);
+    checkout(workingDir, definition.commit);
+    clean(workingDir);
+
+    if (submodules) {
+      updateSubmodules(workingDir);
+    }
+  }
+
+  if (definition.preinstall !== undefined) {
+    runPreinstallScript(
+      resolve(scenarioDir, definition.preinstall),
+      scenarioDir,
+      workingDir,
+      definition.env,
+    );
+  }
+
+  if (scenario.definition.install !== undefined) {
+    runCustomInstallScript(
+      resolve(scenarioDir, definition.install),
+      scenarioDir,
+      workingDir,
+      definition.env,
+    );
+  } else {
+    npmInstall(workingDir, definition.packageManager, definition.env);
+  }
+}
+
+function clone(scenarioWorkingDir: string, repo: string): void {
+  logStep(`Cloning ${repo}`);
+
+  git(
+    ["clone", `https://github.com/${repo}.git`, scenarioWorkingDir],
+    ROOT_DIR,
+  );
+}
+
+function fetch(scenarioWorkingDir: string, repo: string): void {
+  logStep(`Fetching ${repo}`);
+
+  git(["fetch", "origin"], scenarioWorkingDir);
+}
+
+function updateSubmodules(scenarioWorkingDir: string): void {
+  logStep("Updating submodules");
+
+  git(["submodule", "update", "--init", "--recursive"], scenarioWorkingDir);
+}
+
+function checkout(scenarioWorkingDir: string, commit: string): void {
+  logStep(`Checking out ${commit}`);
+
+  git(["checkout", commit], scenarioWorkingDir);
+}
+
+function clean(scenarioWorkingDir: string): void {
+  logStep("Cleaning working tree");
+
+  git(["checkout", "."], scenarioWorkingDir);
+  git(["clean", "-fdx"], scenarioWorkingDir);
+}
+
+function runPreinstallScript(
+  scriptPath: string,
+  scenarioDir: string,
+  workingDir: string,
+  env?: Record<string, string>,
+): void {
+  logStep("Running preinstall script");
+
+  execFileSync(which("bash"), [scriptPath], {
+    cwd: workingDir,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      ...env,
+      E2E_TEST_DIR: scenarioDir,
+    },
+  });
+}
+
+function runCustomInstallScript(
+  scriptPath: string,
+  testDir: string,
+  workDir: string,
+  env?: Record<string, string>,
+): void {
+  logStep("Running custom install script");
+
+  execFileSync(which("bash"), [scriptPath], {
+    cwd: workDir,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      ...env,
+      E2E_REPO_DIR: workDir,
+      E2E_TEST_DIR: testDir,
+    },
+  });
+}

--- a/scripts/end-to-end/types.ts
+++ b/scripts/end-to-end/types.ts
@@ -1,0 +1,17 @@
+export interface Scenario {
+  id: string;
+  scenarioDir: string;
+  workingDir: string;
+  definition: ScenarioDefinition;
+}
+
+export interface ScenarioDefinition {
+  repo: string;
+  commit: string;
+  packageManager: "npm";
+  preinstall?: string;
+  install?: string;
+  tags: string[];
+  env?: Record<string, string>;
+  submodules?: boolean;
+}

--- a/scripts/verdaccio/helpers/shell.ts
+++ b/scripts/verdaccio/helpers/shell.ts
@@ -1,4 +1,5 @@
 import { execFileSync, execSync, type StdioOptions } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 export const ROOT_DIR = resolve(import.meta.dirname, "../../..");
@@ -13,6 +14,21 @@ export const VERDACCIO_SERVER = resolve(import.meta.dirname, "../server.ts");
 export const VERDACCIO_HOST = "127.0.0.1";
 export const VERDACCIO_PORT = 4873;
 export const VERDACCIO_URL = `http://${VERDACCIO_HOST}:${VERDACCIO_PORT}`;
+
+export function isVerdaccioRunning(): boolean {
+  if (!existsSync(VERDACCIO_PID_FILE)) {
+    return false;
+  }
+
+  const pid = parseInt(readFileSync(VERDACCIO_PID_FILE, "utf-8").trim(), 10);
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 let gitPath: string | undefined;
 

--- a/scripts/verdaccio/publish.ts
+++ b/scripts/verdaccio/publish.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { fmt, log, logStep } from "./helpers/logging.ts";
 import {
   git,
+  isVerdaccioRunning,
   npm,
   pnpm,
   ROOT_DIR,
@@ -56,7 +57,7 @@ function ensureCleanWorkingTree(): void {
 }
 
 function ensureVerdaccioRunning(): void {
-  if (!existsSync(VERDACCIO_PID_FILE)) {
+  if (!isVerdaccioRunning()) {
     throw new Error(
       "Verdaccio is not running. Start it first with:\n" +
         "  pnpm verdaccio start",
@@ -66,6 +67,7 @@ function ensureVerdaccioRunning(): void {
   const pid = parseInt(readFileSync(VERDACCIO_PID_FILE, "utf-8").trim(), 10);
 
   try {
+    // This is a check that the process is running
     process.kill(pid, 0);
   } catch {
     throw new Error(


### PR DESCRIPTION

Adds a `./scripts/end-to-end/test.ts` script that operates over metadata files stored under `./end-to-end`.

There is one example currently: `./end-to-end/openzeppelin-contracts`

There are three subcommands:

* init # Clone and setup the scenario with npm install running through verdaccio
* clean # Delete the working directory for the scenario (i.e. the cloned repo)
* exec # Run a command with a scenario working directory

The clone directory can be passed at the command line or alternatively set as an ENV variable. In the devcontainer it is set to:

`/tmp/end-to-end/`

Example:

```shell
node ./scripts/end-to-end/scenario.ts exec \
  --scenario ./end-to-end/openzeppelin-contracts \ # Run the particular scenario
  --command "npx hardhat test solidity" \ # The command to run
```

The `--with-init` command triggers `init`, the cloning and setup of the scenario based on the scenario file at `./end-to-end/openzeppelin-contracts/scenario.json`:

```json
{
  "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
  "tags": ["external-repo"],
  "repo": "kanej/openzeppelin-contracts",
  "commit": "4ba2af18cad98904fb0a8d64a958fa91d56298c5",
  "packageManager": "npm",
  "submodules": true
}
```

The `--command` will be run once the scenario setup has been complete from the working directory of the setup scenario.

## Usage

To run a single command within the context of a cloned repo:

```shell
pnpm e2e exec \
  --scenario ./end-to-end/openzeppelin-contracts \
  --command "npx hardhat test solidity"
```

To explore or rerun commands you can pull apart the commands:

```shell
pnpm e2e init --scenario ./end-to-end/openzeppelin-contracts

# cd into the working directory `/tmp/end-to-end/openzeppelin-contracts` and mess around or run a command over and over again:
pnpm e2e exec --scenario ./end-to-end/openzeppelin-contracts --command "npx hardhat test mocha"
pnpm e2e clean --scenario ./end-to-end/openzeppelin-contracts
```



