### PR TITLE
Add `--init --template <template-name>` to make initialization non-interactive

### DIFF
--- a/.changeset/nice-walls-remain.md
+++ b/.changeset/nice-walls-remain.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-errors": patch
+"hardhat": patch
+---
+
+Add `--init --template <template-name>` to make initialization non-interactive.

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -525,6 +525,24 @@ Please install Hardhat locally using pnpm, npm or yarn, and try again.`,
         websiteTitle: "Invalid resolved config",
         websiteDescription: `The configuration you provided is seemingly valid, but once resolved it contains errors. Please check the documentation to learn how to configure Hardhat correctly.`,
       },
+      TEMPLATE_NOT_FOUND_WITH_LIST_OF_OPTIONS: {
+        number: 25,
+        messageTemplate: `Template "{template}" not found.
+
+The available templates are:
+{availableTemplates}`,
+        websiteTitle: "Template not found",
+        websiteDescription: `The template you provided is not found. Please check the documentation to learn which templates are available.`,
+      },
+      NON_INTERACTIVE_INIT_WOULD_OVERWRITE_FILES: {
+        number: 26,
+        messageTemplate: `The following files already exist in the current working directory, preventing the initialization of a new Hardhat project:
+{files}
+
+Remove them or move them to a different place and try again.`,
+        websiteTitle: "Non-interactive init failed due to existing files",
+        websiteDescription: `The non-interactive project initialization refuses to overwrite existing files. Remove the conflicting files and retry.`,
+      },
     },
     INTERNAL: {
       ASSERTION_ERROR: {
@@ -864,6 +882,16 @@ Please double check your arguments.`,
           'The option "{option}" is hidden and cannot be used from the CLI.',
         websiteTitle: "Hidden options cannot be used from the CLI",
         websiteDescription: `You are trying to use a hidden option from the CLI, which is not allowed.`,
+      },
+      CANNOT_COMBINE_TEMPLATE_AND_TEMPLATES: {
+        number: 513,
+        messageTemplate:
+          'The options "--template" and "--templates" cannot be used together. Use "--init --template <name>" to initialize a project with a specific template, or "--init --templates" to list the available templates.',
+        websiteTitle:
+          'The options "--template" and "--templates" cannot be used together',
+        websiteDescription: `The options "--template" and "--templates" cannot be used together.
+
+Use "--init --template <name>" to initialize a project with a specific template, or "--init --templates" to list the available templates.`,
       },
     },
     BUILTIN_TASKS: {

--- a/packages/hardhat/src/internal/builtin-global-options.ts
+++ b/packages/hardhat/src/internal/builtin-global-options.ts
@@ -37,7 +37,8 @@ export const BUILTIN_GLOBAL_OPTIONS_DEFINITIONS: GlobalOptionDefinitions =
         pluginId: "builtin",
         option: globalFlag({
           name: "init",
-          description: "Initializes a Hardhat project.",
+          description:
+            "Initializes a Hardhat project. Use `--init --template <name>` to initialize in non-interactive mode, and `--init --templates` to list the template names.",
         }),
       },
     ],

--- a/packages/hardhat/src/internal/cli/init/init.ts
+++ b/packages/hardhat/src/internal/cli/init/init.ts
@@ -49,6 +49,10 @@ import {
 import { spawn } from "./subprocess.js";
 import { getTemplates } from "./template.js";
 
+export interface NonInteractiveInitHardhat3Options {
+  template: string;
+}
+
 export interface InitHardhatOptions {
   hardhatVersion?: "hardhat-2" | "hardhat-3";
   workspace?: string;
@@ -59,6 +63,55 @@ export interface InitHardhatOptions {
 }
 
 const log = debug("hardhat:cli:init");
+
+export async function initHardhat3NonInteractive(
+  options: NonInteractiveInitHardhat3Options,
+): Promise<void> {
+  const [template, projectTypeAnalyticsPromise] = await getTemplate(
+    "hardhat-3",
+    options.template,
+    true,
+  );
+
+  const workspace = process.cwd();
+
+  try {
+    const configFilePath = await findClosestHardhatConfig(workspace);
+
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.GENERAL.HARDHAT_PROJECT_ALREADY_CREATED,
+      {
+        hardhatProjectRootPath: configFilePath,
+      },
+    );
+  } catch (err) {
+    if (
+      !HardhatError.isHardhatError(
+        err,
+        HardhatError.ERRORS.CORE.GENERAL.NO_CONFIG_FILE_FOUND,
+      )
+    ) {
+      throw err;
+    }
+  }
+
+  await assertNoNonInteractiveClashes(workspace, template);
+
+  console.log("Initializing project...");
+
+  await validatePackageJson(workspace, template.packageJson, true);
+
+  await copyProjectFilesNonInteractive(workspace, template);
+
+  console.log("Installing dependencies...");
+
+  await Promise.all([
+    installProjectDependencies(workspace, template, true, true),
+    projectTypeAnalyticsPromise,
+  ]);
+
+  console.log("Project initialized");
+}
 
 /**
  * initHardhat implements the project initialization wizard flow.
@@ -274,6 +327,7 @@ export async function getWorkspace(workspace?: string): Promise<string> {
 export async function getTemplate(
   hardhatVersion: "hardhat-2" | "hardhat-3",
   template?: string,
+  includeAvailableTemplatesInErrors = false,
 ): Promise<[Template, Promise<boolean>]> {
   const templates = await getTemplates(hardhatVersion);
 
@@ -297,9 +351,38 @@ export async function getTemplate(
   // we wait for the GA hit before throwing
   await projectTypeAnalyticsPromise;
 
-  throw new HardhatError(HardhatError.ERRORS.CORE.GENERAL.TEMPLATE_NOT_FOUND, {
-    template,
-  });
+  if (!includeAvailableTemplatesInErrors) {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.GENERAL.TEMPLATE_NOT_FOUND,
+      {
+        template,
+      },
+    );
+  }
+
+  const availableTemplates = templates.map((t) => `  - ${t.name}`).join("\n");
+  throw new HardhatError(
+    HardhatError.ERRORS.CORE.GENERAL.TEMPLATE_NOT_FOUND_WITH_LIST_OF_OPTIONS,
+    {
+      template,
+      availableTemplates,
+    },
+  );
+}
+
+/**
+ * Prints the list of available templates for the specified Hardhat version.
+ *
+ * @param hardhatVersion The version of Hardhat whose template's should be
+ *  printed.
+ */
+export async function printTemplatesList(
+  hardhatVersion: "hardhat-2" | "hardhat-3",
+  print: (message: string) => void = console.log,
+): Promise<void> {
+  const templates = await getTemplates(hardhatVersion);
+  const lines = templates.map((t) => `  - ${t.name}`).join("\n");
+  print(`Available templates:\n${lines}`);
 }
 
 /**
@@ -492,6 +575,74 @@ export async function copyProjectFiles(
   }
 
   console.log(`✨ ${chalk.cyan(`Template files copied`)} ✨`);
+}
+
+// NOTE: This function is exported for testing purposes
+export async function assertNoNonInteractiveClashes(
+  workspace: string,
+  template: Template,
+): Promise<void> {
+  const clashes: string[] = [];
+
+  for (const relativeTemplatePath of template.files) {
+    const relativeWorkspacePath =
+      relativeTemplateToWorkspacePath(relativeTemplatePath);
+
+    if (
+      relativeWorkspacePath === "package.json" ||
+      relativeWorkspacePath === "README.md" ||
+      path.basename(relativeWorkspacePath) === ".gitignore"
+    ) {
+      continue;
+    }
+
+    if (await exists(path.join(workspace, relativeWorkspacePath))) {
+      clashes.push(relativeWorkspacePath);
+    }
+  }
+
+  if (clashes.length === 0) {
+    return;
+  }
+
+  throw new HardhatError(
+    HardhatError.ERRORS.CORE.GENERAL.NON_INTERACTIVE_INIT_WOULD_OVERWRITE_FILES,
+    {
+      files: clashes.map((f) => `  - ${f}`).join("\n"),
+    },
+  );
+}
+
+// NOTE: This function is exported for testing purposes
+export async function copyProjectFilesNonInteractive(
+  workspace: string,
+  template: Template,
+): Promise<void> {
+  for (const relativeTemplatePath of template.files) {
+    const relativeWorkspacePath =
+      relativeTemplateToWorkspacePath(relativeTemplatePath);
+    let absoluteWorkspacePath = path.join(workspace, relativeWorkspacePath);
+
+    if (path.basename(relativeWorkspacePath) === ".gitignore") {
+      if (await exists(absoluteWorkspacePath)) {
+        continue;
+      }
+    } else if (
+      relativeWorkspacePath === "README.md" &&
+      (await exists(absoluteWorkspacePath))
+    ) {
+      absoluteWorkspacePath = path.join(workspace, "HARDHAT.md");
+      if (await exists(absoluteWorkspacePath)) {
+        continue;
+      }
+    }
+
+    await ensureDir(path.dirname(absoluteWorkspacePath));
+    await copy(
+      path.join(template.path, relativeTemplatePath),
+      absoluteWorkspacePath,
+    );
+  }
 }
 
 /**

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -95,7 +95,57 @@ export async function main(
     }
 
     if (builtinGlobalOptions.init) {
-      const { initHardhat } = await import("./init/init.js");
+      const { initHardhat, initHardhat3NonInteractive, printTemplatesList } =
+        await import("./init/init.js");
+
+      let templateName: string | undefined;
+      let listTemplates = false;
+
+      for (let i = 0; i < cliArguments.length; i++) {
+        if (usedCliArguments[i]) {
+          continue;
+        }
+
+        if (cliArguments[i] === "--templates") {
+          usedCliArguments[i] = true;
+          listTemplates = true;
+        }
+
+        if (cliArguments[i] === "--template") {
+          usedCliArguments[i] = true;
+
+          if (
+            usedCliArguments[i + 1] === undefined ||
+            usedCliArguments[i + 1] === true ||
+            cliArguments[i + 1] === undefined ||
+            cliArguments[i + 1].startsWith("-")
+          ) {
+            throw new HardhatError(
+              HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+              { argument: "--template" },
+            );
+          }
+
+          templateName = cliArguments[i + 1];
+          i++;
+          usedCliArguments[i] = true;
+        }
+      }
+
+      if (templateName !== undefined && listTemplates) {
+        throw new HardhatError(
+          HardhatError.ERRORS.CORE.ARGUMENTS.CANNOT_COMBINE_TEMPLATE_AND_TEMPLATES,
+        );
+      }
+
+      if (listTemplates) {
+        return await printTemplatesList("hardhat-3", print);
+      }
+
+      if (templateName !== undefined) {
+        return await initHardhat3NonInteractive({ template: templateName });
+      }
+
       return await initHardhat();
     }
 

--- a/packages/hardhat/test/internal/cli/help/get-global-help-string.ts
+++ b/packages/hardhat/test/internal/cli/help/get-global-help-string.ts
@@ -261,7 +261,7 @@ GLOBAL OPTIONS:
 
   --config                 A Hardhat config file
   --help, -h               Show this message, or a task's help if its name is provided
-  --init                   Initializes a Hardhat project
+  --init                   Initializes a Hardhat project. Use \`--init --template <name>\` to initialize in non-interactive mode, and \`--init --templates\` to list the template names
   --show-stack-traces      Show stack traces (always enabled on CI servers)
   --user-option-1          userOption1 description
   --user-option-2          userOption2 description
@@ -383,7 +383,7 @@ GLOBAL OPTIONS:
 
   --config                 A Hardhat config file
   --help, -h               Show this message, or a task's help if its name is provided
-  --init                   Initializes a Hardhat project
+  --init                   Initializes a Hardhat project. Use \`--init --template <name>\` to initialize in non-interactive mode, and \`--init --templates\` to list the template names
   --show-stack-traces      Show stack traces (always enabled on CI servers)
   --user-option-1          userOption1 description
   --user-option-2          userOption2 description

--- a/packages/hardhat/test/internal/cli/init/init.ts
+++ b/packages/hardhat/test/internal/cli/init/init.ts
@@ -25,11 +25,14 @@ import {
 } from "@nomicfoundation/hardhat-utils/fs";
 
 import {
+  assertNoNonInteractiveClashes,
   copyProjectFiles,
+  copyProjectFilesNonInteractive,
   validatePackageJson,
   getTemplate,
   getWorkspace,
   initHardhat,
+  initHardhat3NonInteractive,
   installProjectDependencies,
   printWelcomeMessage,
   relativeTemplateToWorkspacePath,
@@ -829,4 +832,394 @@ describe("shouldUpdateDependency", () => {
       );
     });
   }
+});
+
+describe("initHardhat3NonInteractive", async () => {
+  describe("templates", async () => {
+    useTmpDir("initHardhat3NonInteractiveTemplates");
+
+    disableConsole();
+
+    const templates = await getTemplates("hardhat-3");
+
+    for (const template of templates) {
+      // NOTE: This test uses network to access the npm registry
+      it(
+        `should initialize the project using the ${template.name} template in an empty folder`,
+        {
+          skip:
+            process.env.HARDHAT_DISABLE_SLOW_TESTS === "true" ||
+            process.env.GITHUB_EVENT_NAME === "push" ||
+            process.env.GITHUB_EVENT_NAME === "merge_group" ||
+            process.env.GITHUB_HEAD_REF?.startsWith("changeset-release/"),
+        },
+        async () => {
+          await writeUtf8File(
+            ".npmrc",
+            'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
+          );
+          await initHardhat3NonInteractive({ template: template.name });
+          assert.ok(await exists("package.json"), "package.json should exist");
+          const pkg: PackageJson = await readJsonFile(
+            path.join(process.cwd(), "package.json"),
+          );
+          assert.equal(pkg.type, "module");
+          const workspaceFiles = template.files.map(
+            relativeTemplateToWorkspacePath,
+          );
+          for (const file of workspaceFiles) {
+            const pathToFile = path.join(process.cwd(), file);
+            assert.ok(await exists(pathToFile), `File ${file} should exist`);
+          }
+          assert.ok(
+            !(await exists("HARDHAT.md")),
+            "HARDHAT.md should not exist when there was no pre-existing README.md",
+          );
+        },
+      );
+    }
+  });
+
+  describe("unknown template", () => {
+    useTmpDir("initHardhat3NonInteractiveUnknownTemplate");
+
+    it("should throw with the list of available templates", async () => {
+      const templates = await getTemplates("hardhat-3");
+      const availableTemplates = templates
+        .map((t) => `  - ${t.name}`)
+        .join("\n");
+
+      await assertRejectsWithHardhatError(
+        async () =>
+          await initHardhat3NonInteractive({ template: "non-existent" }),
+        HardhatError.ERRORS.CORE.GENERAL
+          .TEMPLATE_NOT_FOUND_WITH_LIST_OF_OPTIONS,
+        {
+          template: "non-existent",
+          availableTemplates,
+        },
+      );
+    });
+  });
+
+  describe("overwrite protection", () => {
+    useTmpDir("initHardhat3NonInteractiveOverwrite");
+
+    disableConsole();
+
+    it("should refuse to overwrite a pre-existing template file", async () => {
+      await writeUtf8File("tsconfig.json", "pre-existing");
+
+      await assertRejectsWithHardhatError(
+        async () =>
+          await initHardhat3NonInteractive({ template: "mocha-ethers" }),
+        HardhatError.ERRORS.CORE.GENERAL
+          .NON_INTERACTIVE_INIT_WOULD_OVERWRITE_FILES,
+        {
+          files: "  - tsconfig.json",
+        },
+      );
+
+      assert.equal(
+        await readUtf8File("tsconfig.json"),
+        "pre-existing",
+        "tsconfig.json should not have been modified",
+      );
+    });
+
+    it("should reject when the workspace is already a Hardhat project", async () => {
+      await writeUtf8File("hardhat.config.js", "");
+
+      await assertRejectsWithHardhatError(
+        async () =>
+          await initHardhat3NonInteractive({ template: "mocha-ethers" }),
+        HardhatError.ERRORS.CORE.GENERAL.HARDHAT_PROJECT_ALREADY_CREATED,
+        {
+          hardhatProjectRootPath: path.join(process.cwd(), "hardhat.config.js"),
+        },
+      );
+    });
+  });
+
+  describe("exceptions to overwrite protection", () => {
+    useTmpDir("initHardhat3NonInteractiveExceptions");
+
+    disableConsole();
+
+    it(
+      "should allow a pre-existing package.json and preserve its extra keys",
+      {
+        skip:
+          process.env.HARDHAT_DISABLE_SLOW_TESTS === "true" ||
+          process.env.GITHUB_EVENT_NAME === "push" ||
+          process.env.GITHUB_EVENT_NAME === "merge_group" ||
+          process.env.GITHUB_HEAD_REF?.startsWith("changeset-release/"),
+      },
+      async () => {
+        await writeJsonFile("package.json", {
+          name: "user-chosen-name",
+          type: "module",
+        });
+        await writeUtf8File(
+          ".npmrc",
+          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
+        );
+
+        await initHardhat3NonInteractive({ template: "mocha-ethers" });
+
+        const pkg: PackageJson = await readJsonFile(
+          path.join(process.cwd(), "package.json"),
+        );
+        assert.equal(pkg.name, "user-chosen-name");
+        assert.equal(pkg.type, "module");
+      },
+    );
+
+    it(
+      "should preserve a pre-existing .gitignore",
+      {
+        skip:
+          process.env.HARDHAT_DISABLE_SLOW_TESTS === "true" ||
+          process.env.GITHUB_EVENT_NAME === "push" ||
+          process.env.GITHUB_EVENT_NAME === "merge_group" ||
+          process.env.GITHUB_HEAD_REF?.startsWith("changeset-release/"),
+      },
+      async () => {
+        await writeUtf8File(".gitignore", "user-gitignore-marker");
+        await writeUtf8File(
+          ".npmrc",
+          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
+        );
+
+        await initHardhat3NonInteractive({ template: "mocha-ethers" });
+
+        assert.equal(
+          await readUtf8File(".gitignore"),
+          "user-gitignore-marker",
+          ".gitignore should not have been overwritten",
+        );
+      },
+    );
+
+    it(
+      "should redirect the template README.md to HARDHAT.md when README.md exists",
+      {
+        skip:
+          process.env.HARDHAT_DISABLE_SLOW_TESTS === "true" ||
+          process.env.GITHUB_EVENT_NAME === "push" ||
+          process.env.GITHUB_EVENT_NAME === "merge_group" ||
+          process.env.GITHUB_HEAD_REF?.startsWith("changeset-release/"),
+      },
+      async () => {
+        await writeUtf8File("README.md", "user readme");
+        await writeUtf8File(
+          ".npmrc",
+          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
+        );
+
+        const [template] = await getTemplate("hardhat-3", "mocha-ethers");
+        const templateReadme = await readUtf8File(
+          path.join(template.path, "README.md"),
+        );
+
+        await initHardhat3NonInteractive({ template: "mocha-ethers" });
+
+        assert.equal(await readUtf8File("README.md"), "user readme");
+        assert.ok(await exists("HARDHAT.md"), "HARDHAT.md should exist");
+        assert.equal(await readUtf8File("HARDHAT.md"), templateReadme);
+      },
+    );
+
+    it(
+      "should preserve both README.md and HARDHAT.md when both pre-exist",
+      {
+        skip:
+          process.env.HARDHAT_DISABLE_SLOW_TESTS === "true" ||
+          process.env.GITHUB_EVENT_NAME === "push" ||
+          process.env.GITHUB_EVENT_NAME === "merge_group" ||
+          process.env.GITHUB_HEAD_REF?.startsWith("changeset-release/"),
+      },
+      async () => {
+        await writeUtf8File("README.md", "user readme");
+        await writeUtf8File("HARDHAT.md", "user hardhat md");
+        await writeUtf8File(
+          ".npmrc",
+          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
+        );
+
+        await initHardhat3NonInteractive({ template: "mocha-ethers" });
+
+        assert.equal(await readUtf8File("README.md"), "user readme");
+        assert.equal(await readUtf8File("HARDHAT.md"), "user hardhat md");
+      },
+    );
+  });
+
+  describe("progress output", () => {
+    useTmpDir("initHardhat3NonInteractiveOutput");
+
+    it(
+      "should print the progress sequence on success",
+      {
+        skip:
+          process.env.HARDHAT_DISABLE_SLOW_TESTS === "true" ||
+          process.env.GITHUB_EVENT_NAME === "push" ||
+          process.env.GITHUB_EVENT_NAME === "merge_group" ||
+          process.env.GITHUB_HEAD_REF?.startsWith("changeset-release/"),
+      },
+      async () => {
+        await writeUtf8File(
+          ".npmrc",
+          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
+        );
+
+        const logLines: string[] = [];
+        const originalLog = console.log;
+        console.log = (...args: unknown[]) => {
+          logLines.push(args.map((a) => String(a)).join(" "));
+        };
+
+        try {
+          await initHardhat3NonInteractive({ template: "mocha-ethers" });
+        } finally {
+          console.log = originalLog;
+        }
+
+        assert.equal(logLines[0], "Initializing project...");
+        const installingIdx = logLines.indexOf("Installing dependencies...");
+        assert.ok(
+          installingIdx > 0,
+          "should have 'Installing dependencies...' after the initial line",
+        );
+        assert.equal(logLines[logLines.length - 1], "Project initialized");
+      },
+    );
+  });
+});
+
+describe("assertNoNonInteractiveClashes / copyProjectFilesNonInteractive", () => {
+  useTmpDir("copyProjectFilesNonInteractive");
+
+  async function buildFixtureTemplate(): Promise<Template> {
+    const templateDir = path.join(process.cwd(), "__template_fixture__");
+    await ensureDir(templateDir);
+    await writeUtf8File(
+      path.join(templateDir, "hardhat.config.ts"),
+      "template-hardhat-config",
+    );
+    await writeUtf8File(
+      path.join(templateDir, "README.md"),
+      "template-readme",
+    );
+    await writeUtf8File(
+      path.join(templateDir, "gitignore"),
+      "template-gitignore",
+    );
+
+    return {
+      name: "fixture",
+      packageJson: { name: "fixture", version: "0.0.1", type: "module" },
+      path: templateDir,
+      files: ["hardhat.config.ts", "README.md", "gitignore"],
+    };
+  }
+
+  it("should copy all files in an empty workspace", async () => {
+    const template = await buildFixtureTemplate();
+    const workspace = path.join(process.cwd(), "workspace");
+    await ensureDir(workspace);
+
+    await assertNoNonInteractiveClashes(workspace, template);
+    await copyProjectFilesNonInteractive(workspace, template);
+
+    assert.equal(
+      await readUtf8File(path.join(workspace, "hardhat.config.ts")),
+      "template-hardhat-config",
+    );
+    assert.equal(
+      await readUtf8File(path.join(workspace, "README.md")),
+      "template-readme",
+    );
+    assert.equal(
+      await readUtf8File(path.join(workspace, ".gitignore")),
+      "template-gitignore",
+    );
+    assert.ok(
+      !(await exists(path.join(workspace, "HARDHAT.md"))),
+      "HARDHAT.md should not exist",
+    );
+  });
+
+  it("should preserve a pre-existing .gitignore", async () => {
+    const template = await buildFixtureTemplate();
+    const workspace = path.join(process.cwd(), "workspace-gitignore");
+    await ensureDir(workspace);
+    await writeUtf8File(path.join(workspace, ".gitignore"), "user-gitignore");
+
+    await assertNoNonInteractiveClashes(workspace, template);
+    await copyProjectFilesNonInteractive(workspace, template);
+
+    assert.equal(
+      await readUtf8File(path.join(workspace, ".gitignore")),
+      "user-gitignore",
+    );
+  });
+
+  it("should redirect README.md to HARDHAT.md when README.md pre-exists", async () => {
+    const template = await buildFixtureTemplate();
+    const workspace = path.join(process.cwd(), "workspace-readme");
+    await ensureDir(workspace);
+    await writeUtf8File(path.join(workspace, "README.md"), "user-readme");
+
+    await assertNoNonInteractiveClashes(workspace, template);
+    await copyProjectFilesNonInteractive(workspace, template);
+
+    assert.equal(
+      await readUtf8File(path.join(workspace, "README.md")),
+      "user-readme",
+    );
+    assert.equal(
+      await readUtf8File(path.join(workspace, "HARDHAT.md")),
+      "template-readme",
+    );
+  });
+
+  it("should skip README copy when both README.md and HARDHAT.md pre-exist", async () => {
+    const template = await buildFixtureTemplate();
+    const workspace = path.join(process.cwd(), "workspace-both");
+    await ensureDir(workspace);
+    await writeUtf8File(path.join(workspace, "README.md"), "user-readme");
+    await writeUtf8File(path.join(workspace, "HARDHAT.md"), "user-hardhat-md");
+
+    await assertNoNonInteractiveClashes(workspace, template);
+    await copyProjectFilesNonInteractive(workspace, template);
+
+    assert.equal(
+      await readUtf8File(path.join(workspace, "README.md")),
+      "user-readme",
+    );
+    assert.equal(
+      await readUtf8File(path.join(workspace, "HARDHAT.md")),
+      "user-hardhat-md",
+    );
+  });
+
+  it("should throw a clash error for a pre-existing non-exempt file", async () => {
+    const template = await buildFixtureTemplate();
+    const workspace = path.join(process.cwd(), "workspace-clash");
+    await ensureDir(workspace);
+    await writeUtf8File(
+      path.join(workspace, "hardhat.config.ts"),
+      "user-config",
+    );
+
+    await assertRejectsWithHardhatError(
+      async () => await assertNoNonInteractiveClashes(workspace, template),
+      HardhatError.ERRORS.CORE.GENERAL
+        .NON_INTERACTIVE_INIT_WOULD_OVERWRITE_FILES,
+      {
+        files: "  - hardhat.config.ts",
+      },
+    );
+  });
 });

--- a/packages/hardhat/test/internal/cli/main.ts
+++ b/packages/hardhat/test/internal/cli/main.ts
@@ -23,6 +23,7 @@ import {
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
 import chalk from "chalk";
 
+import { getTemplates } from "../../../src/internal/cli/init/template.js";
 import {
   main,
   parseGlobalOptions,
@@ -292,7 +293,7 @@ GLOBAL OPTIONS:
   --gas-stats              Collects and displays gas usage statistics for all function calls during tests
   --gas-stats-json         Write gas usage statistics to a JSON file at the specified path
   --help, -h               Show this message, or a task's help if its name is provided
-  --init                   Initializes a Hardhat project
+  --init                   Initializes a Hardhat project. Use \`--init --template <name>\` to initialize in non-interactive mode, and \`--init --templates\` to list the template names
   --network                The network to connect to
   --show-stack-traces      Show stack traces (always enabled on CI servers)
   --verbosity, -v          Verbosity level of the output
@@ -367,7 +368,7 @@ GLOBAL OPTIONS:
   --gas-stats              Collects and displays gas usage statistics for all function calls during tests
   --gas-stats-json         Write gas usage statistics to a JSON file at the specified path
   --help, -h               Show this message, or a task's help if its name is provided
-  --init                   Initializes a Hardhat project
+  --init                   Initializes a Hardhat project. Use \`--init --template <name>\` to initialize in non-interactive mode, and \`--init --templates\` to list the template names
   --network                The network to connect to
   --show-stack-traces      Show stack traces (always enabled on CI servers)
   --verbosity, -v          Verbosity level of the output
@@ -409,7 +410,7 @@ GLOBAL OPTIONS:
   --gas-stats              Collects and displays gas usage statistics for all function calls during tests
   --gas-stats-json         Write gas usage statistics to a JSON file at the specified path
   --help, -h               Show this message, or a task's help if its name is provided
-  --init                   Initializes a Hardhat project
+  --init                   Initializes a Hardhat project. Use \`--init --template <name>\` to initialize in non-interactive mode, and \`--init --templates\` to list the template names
   --network                The network to connect to
   --show-stack-traces      Show stack traces (always enabled on CI servers)
   --verbosity, -v          Verbosity level of the output
@@ -566,6 +567,116 @@ GLOBAL OPTIONS:
         async () =>
           await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_CONFIG_FILE,
+        {},
+      );
+    });
+  });
+
+  describe("--init --template", function () {
+    it("should throw an error when --template is provided without a value", async function () {
+      const command = "npx hardhat --init --template";
+
+      await assertRejectsWithHardhatError(
+        async () => await runMain(command),
+        HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+        {
+          argument: "--template",
+        },
+      );
+    });
+
+    it("should throw an error when --template value is consumed by another flag", async function () {
+      const command = "npx hardhat --init --template --show-stack-traces";
+
+      await assertRejectsWithHardhatError(
+        async () => await runMain(command),
+        HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+        {
+          argument: "--template",
+        },
+      );
+    });
+
+    it("should throw an error when --template is followed by an unknown flag", async function () {
+      const command = "npx hardhat --init --template --unknown-flag";
+
+      await assertRejectsWithHardhatError(
+        async () => await runMain(command),
+        HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+        {
+          argument: "--template",
+        },
+      );
+    });
+
+    it("should throw an error when --template value is an unknown template name", async function () {
+      const command = "npx hardhat --init --template unknown-template";
+
+      const templates = await getTemplates("hardhat-3");
+      const availableTemplates = templates
+        .map((t) => `  - ${t.name}`)
+        .join("\n");
+
+      await assertRejectsWithHardhatError(
+        async () => await runMain(command),
+        HardhatError.ERRORS.CORE.GENERAL
+          .TEMPLATE_NOT_FOUND_WITH_LIST_OF_OPTIONS,
+        {
+          template: "unknown-template",
+          availableTemplates,
+        },
+      );
+    });
+  });
+
+  describe("--init --templates", function () {
+    it("should list available template names", async function () {
+      const lines: string[] = [];
+
+      const cliArguments = "npx hardhat --init --templates".split(" ").slice(2);
+
+      await main(cliArguments, {
+        print: (message) => {
+          lines.push(message);
+        },
+        rethrowErrors: true,
+        allowNonlocalHardhatInstallation: true,
+      });
+
+      const output = lines.join("\n");
+
+      assert.ok(
+        output.startsWith("Available templates:"),
+        "Output should start with 'Available templates:'",
+      );
+
+      const templates = await getTemplates("hardhat-3");
+      for (const t of templates) {
+        assert.ok(
+          output.includes(`  - ${t.name}`),
+          `Output should contain template name '${t.name}'`,
+        );
+      }
+    });
+
+    it("should throw when --template and --templates are used together", async function () {
+      const command = "npx hardhat --init --template mocha-ethers --templates";
+
+      await assertRejectsWithHardhatError(
+        async () => await runMain(command),
+        HardhatError.ERRORS.CORE.ARGUMENTS
+          .CANNOT_COMBINE_TEMPLATE_AND_TEMPLATES,
+        {},
+      );
+    });
+
+    it("should throw when --templates and --template are used together (reversed order)", async function () {
+      const command = "npx hardhat --init --templates --template mocha-ethers";
+
+      await assertRejectsWithHardhatError(
+        async () => await runMain(command),
+        HardhatError.ERRORS.CORE.ARGUMENTS
+          .CANNOT_COMBINE_TEMPLATE_AND_TEMPLATES,
         {},
       );
     });


### PR DESCRIPTION
This PR adds a `--template <template-name>` option to make the initialization non-interactive. The way this is implemented, non-interactive mode is equivalent to accepting all Yes/No questions. 

Some important details:

- `--template` is manually parsed, and only when `--init` is present. Otherwise, its left to the usual argument parser to handle.
- The template names are each template's `package.json#name` minus the `template-` prefix.
- Given that this option always writes the templates files to the current working directory, it backs up any existing file instead of overwriting it.

Docs PR: https://github.com/NomicFoundation/hardhat-website/pull/231