### PR TITLE
Add solx example project

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,6 +12,7 @@
   "ignore": [
     "@nomicfoundation/config",
     "@nomicfoundation/example-project",
+    "@nomicfoundation/example-project-solx",
     "@nomicfoundation/template-package",
     "template-*"
   ],

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -3,6 +3,7 @@
   "excludedFolders": [
     "archive",
     "v-next/example-project",
+    "v-next/example-project-solx",
     "v-next/hardhat/templates",
     "v-next/config"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,27 @@ importers:
         specifier: ^2.43.0
         version: 2.43.5(typescript@5.8.3)(zod@3.25.76)
 
+  v-next/example-project-solx:
+    devDependencies:
+      '@nomicfoundation/hardhat-solx':
+        specifier: workspace:*
+        version: link:../hardhat-solx
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.18.7
+      hardhat:
+        specifier: workspace:^3.1.11
+        version: link:../hardhat
+      prettier:
+        specifier: 3.2.5
+        version: 3.2.5
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      typescript:
+        specifier: ~5.8.0
+        version: 5.8.3
+
   v-next/hardhat:
     dependencies:
       '@nomicfoundation/edr':

--- a/scripts/check-npm-scripts.ts
+++ b/scripts/check-npm-scripts.ts
@@ -29,8 +29,8 @@ for (const dir of dirs) {
     continue;
   }
 
-  // Same with the example project, we don't use the same scripts
-  if (dir.name === "example-project") {
+  // Same with the example projects, we don't use the same scripts
+  if (dir.name === "example-project" || dir.name === "example-project-solx") {
     continue;
   }
 

--- a/scripts/lib/packages.ts
+++ b/scripts/lib/packages.ts
@@ -11,6 +11,7 @@ export async function readAllReleasablePackages() {
       ![
         "config",
         "example-project",
+        "example-project-solx",
         "template-package",
         "hardhat-test-utils",
         "hardhat-vendored",

--- a/v-next/example-project-solx/.gitignore
+++ b/v-next/example-project-solx/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/dist
+/artifacts
+/cache

--- a/v-next/example-project-solx/README.md
+++ b/v-next/example-project-solx/README.md
@@ -1,0 +1,13 @@
+# Hardhat solx example project
+
+This is an example Hardhat 3 project that uses the `hardhat-solx` plugin for test builds and test execution.
+
+To use it you have to `cd` into this folder and run:
+
+```sh
+pnpm install
+pnpm build
+pnpm hardhat compile --build-profile test
+```
+
+This will compile the project using solx instead of solc via the `test` build profile that the plugin creates automatically.

--- a/v-next/example-project-solx/README.md
+++ b/v-next/example-project-solx/README.md
@@ -1,13 +1,19 @@
 # Hardhat solx example project
 
-This is an example Hardhat 3 project that uses the `hardhat-solx` plugin for test builds and test execution.
+This is an example Hardhat 3 project that uses the `hardhat-solx` plugin.
 
 To use it you have to `cd` into this folder and run:
 
 ```sh
 pnpm install
 pnpm build
-pnpm hardhat compile --build-profile test
+pnpm hardhat compile --build-profile solx
 ```
 
-This will compile the project using solx instead of solc via the `test` build profile that the plugin creates automatically.
+This will compile the project using solx instead of solc via the `solx` build profile defined in `hardhat.config.ts`.
+
+To compile with the default solc profile:
+
+```sh
+pnpm hardhat compile
+```

--- a/v-next/example-project-solx/contracts/Counter.sol
+++ b/v-next/example-project-solx/contracts/Counter.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.33;
+
+contract Counter {
+    uint256 public count;
+
+    function increment() public {
+        count += 1;
+    }
+
+    function decrement() public {
+        require(count > 0, "Counter: decrement overflow");
+        count -= 1;
+    }
+}

--- a/v-next/example-project-solx/contracts/Counter.sol
+++ b/v-next/example-project-solx/contracts/Counter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.29;
 
 contract Counter {
     uint256 public count;

--- a/v-next/example-project-solx/hardhat.config.ts
+++ b/v-next/example-project-solx/hardhat.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "hardhat/config";
+import hardhatSolx from "@nomicfoundation/hardhat-solx";
+
+export default defineConfig({
+  plugins: [hardhatSolx],
+  solidity: "0.8.33",
+});

--- a/v-next/example-project-solx/hardhat.config.ts
+++ b/v-next/example-project-solx/hardhat.config.ts
@@ -3,5 +3,16 @@ import hardhatSolx from "@nomicfoundation/hardhat-solx";
 
 export default defineConfig({
   plugins: [hardhatSolx],
-  solidity: "0.8.33",
+  solidity: {
+    profiles: {
+      default: {
+        version: "0.8.29",
+      },
+      solx: {
+        type: "solx",
+        // solx currently only supports Solidity version 0.8.33
+        version: "0.8.33",
+      },
+    },
+  },
 });

--- a/v-next/example-project-solx/package.json
+++ b/v-next/example-project-solx/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@nomicfoundation/example-project-solx",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Example project using Hardhat v3 with the hardhat-solx plugin",
+  "author": "Nomic Foundation",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "lint": "pnpm prettier --check",
+    "lint:fix": "pnpm prettier --write",
+    "prettier": "prettier \"**/*.{ts,js,md,json}\"",
+    "build": "tsc --build .",
+    "clean": "rimraf dist artifacts cache"
+  },
+  "devDependencies": {
+    "hardhat": "workspace:^3.1.11",
+    "@nomicfoundation/hardhat-solx": "workspace:*",
+    "@types/node": "^22.0.0",
+    "prettier": "3.2.5",
+    "rimraf": "^5.0.5",
+    "typescript": "~5.8.0"
+  }
+}

--- a/v-next/example-project-solx/tsconfig.json
+++ b/v-next/example-project-solx/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../config/tsconfig.base.json",
+  "compilerOptions": {
+    "isolatedDeclarations": false
+  },
+  "references": [
+    {
+      "path": "../hardhat"
+    },
+    {
+      "path": "../hardhat-solx"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `v-next/example-project-solx/`, a minimal Hardhat 3 project configured with the `hardhat-solx` plugin for showcasing solx usage in test builds and for manual testing.

## Usage
```bash
# Compile with solc (default profile)
npx hardhat compile

# Compile with solx (test profile, auto-created by plugin)
npx hardhat compile --build-profile solx
```