### PR TITLE
Add `TestRunResult` type wrapping `TestSummary` to allow plugins to extend test results

### DIFF
--- a/.changeset/purple-carrots-clean.md
+++ b/.changeset/purple-carrots-clean.md
@@ -1,0 +1,7 @@
+---
+"hardhat": patch
+"@nomicfoundation/hardhat-mocha": patch
+"@nomicfoundation/hardhat-node-test-runner": patch
+---
+
+Add `TestRunResult` type that wraps `TestSummary`, allowing plugins to extend test results with additional data

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -6,5 +6,16 @@
     "v-next/hardhat/templates",
     "v-next/config"
   ],
-  "bumps": []
+  "bumps": [
+    {
+      "package": "@nomicfoundation/hardhat-mocha",
+      "peer": "hardhat",
+      "reason": "Now imports and uses the new TestRunResult type from hardhat/types/test"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-node-test-runner",
+      "peer": "hardhat",
+      "reason": "Now imports and uses the new TestRunResult type from hardhat/types/test"
+    }
+  ]
 }

--- a/v-next/hardhat-ethers-chai-matchers/test/index.ts
+++ b/v-next/hardhat-ethers-chai-matchers/test/index.ts
@@ -24,7 +24,7 @@ describe("hardhat-ethers-chai-matchers plugin correctly initialized", () => {
 
     assert.deepEqual(result, {
       success: true,
-      value: { failed: 0, passed: 1, skipped: 0, todo: 0 },
+      value: { summary: { failed: 0, passed: 1, skipped: 0, todo: 0 } },
     });
   });
 });

--- a/v-next/hardhat-mocha/src/task-action.ts
+++ b/v-next/hardhat-mocha/src/task-action.ts
@@ -1,6 +1,6 @@
 import type { HardhatConfig } from "hardhat/types/config";
 import type { NewTaskActionFunction } from "hardhat/types/tasks";
-import type { TestSummary } from "hardhat/types/test";
+import type { TestRunResult } from "hardhat/types/test";
 import type { Result } from "hardhat/types/utils";
 import type { MochaOptions } from "mocha";
 
@@ -66,7 +66,7 @@ let testsAlreadyRun = false;
 const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   { testFiles, bail, grep, noCompile },
   hre,
-): Promise<Result<TestSummary, TestSummary>> => {
+): Promise<Result<TestRunResult, TestRunResult>> => {
   // Set an environment variable that plugins can use to detect when a process is running tests
   process.env.HH_TEST = "true";
 
@@ -96,10 +96,12 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
   if (files.length === 0) {
     return successfulResult({
-      failed: 0,
-      passed: 0,
-      skipped: 0,
-      todo: 0,
+      summary: {
+        failed: 0,
+        passed: 0,
+        skipped: 0,
+        todo: 0,
+      },
     });
   }
 
@@ -218,14 +220,16 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   perf.logInto(performanceLog);
   perf.clear();
 
-  const summary = {
-    failed: testFailures,
-    passed: total - testFailures,
-    skipped: 0,
-    todo: 0,
+  const result: TestRunResult = {
+    summary: {
+      failed: testFailures,
+      passed: total - testFailures,
+      skipped: 0,
+      todo: 0,
+    },
   };
 
-  return testFailures > 0 ? errorResult(summary) : successfulResult(summary);
+  return testFailures > 0 ? errorResult(result) : successfulResult(result);
 };
 
 export default testWithHardhat;

--- a/v-next/hardhat-mocha/test/index.ts
+++ b/v-next/hardhat-mocha/test/index.ts
@@ -24,7 +24,9 @@ describe("Hardhat Mocha plugin", () => {
 
       assert.deepEqual(result, {
         success: true,
-        value: { failed: 0, passed: 2, skipped: 0, todo: 0 },
+        value: {
+          summary: { failed: 0, passed: 2, skipped: 0, todo: 0 },
+        },
       });
     });
   });

--- a/v-next/hardhat-node-test-runner/src/task-action.ts
+++ b/v-next/hardhat-node-test-runner/src/task-action.ts
@@ -1,6 +1,6 @@
 import type { HardhatConfig } from "hardhat/types/config";
 import type { NewTaskActionFunction } from "hardhat/types/tasks";
-import type { TestSummary } from "hardhat/types/test";
+import type { TestRunResult } from "hardhat/types/test";
 import type { LastParameter, Result } from "hardhat/types/utils";
 
 import { pipeline } from "node:stream/promises";
@@ -58,7 +58,7 @@ async function getTestFiles(
 const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   { testFiles, only, grep, noCompile, testSummaryIndex },
   hre,
-): Promise<Result<TestSummary, TestSummary>> => {
+): Promise<Result<TestRunResult, TestRunResult>> => {
   // Set an environment variable that plugins can use to detect when a process is running tests
   process.env.HH_TEST = "true";
 
@@ -79,10 +79,12 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
   if (files.length === 0) {
     return successfulResult({
-      passed: 0,
-      failed: 0,
-      skipped: 0,
-      todo: 0,
+      summary: {
+        passed: 0,
+        failed: 0,
+        skipped: 0,
+        todo: 0,
+      },
     });
   }
 
@@ -204,9 +206,11 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
   console.log();
 
+  const result: TestRunResult = { summary: testResults };
+
   return testResults.failed > 0
-    ? errorResult(testResults)
-    : successfulResult(testResults);
+    ? errorResult(result)
+    : successfulResult(result);
 };
 
 export default testWithHardhat;

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -1,7 +1,7 @@
 import type { RunOptions } from "./runner.js";
 import type { TestEvent } from "./types.js";
 import type { NewTaskActionFunction } from "../../../types/tasks.js";
-import type { TestSummary } from "../../../types/test.js";
+import type { TestRunResult } from "../../../types/test.js";
 import type { Result } from "../../../types/utils.js";
 import type {
   Artifact as EdrArtifact,
@@ -49,7 +49,7 @@ interface TestActionArguments {
 const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   { testFiles, chainType, grep, noCompile, verbosity, testSummaryIndex },
   hre,
-): Promise<Result<TestSummary, TestSummary>> => {
+): Promise<Result<TestRunResult, TestRunResult>> => {
   assertHardhatInvariant(
     hre instanceof HardhatRuntimeEnvironmentImplementation,
     "Expected HRE to be an instance of HardhatRuntimeEnvironmentImplementation",
@@ -284,11 +284,13 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
 
   console.log();
 
-  const summary = { failed, passed, skipped, todo: 0, failureOutput };
+  const result: TestRunResult = {
+    summary: { failed, passed, skipped, todo: 0, failureOutput },
+  };
 
   return includesFailures || includesErrors
-    ? errorResult(summary)
-    : successfulResult(summary);
+    ? errorResult(result)
+    : successfulResult(result);
 };
 
 export default runSolidityTests;

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -46,6 +46,12 @@ function isTestSummary(value: unknown): value is PartialTestSummary {
   );
 }
 
+function isTestRunResult(
+  value: unknown,
+): value is { summary: PartialTestSummary } {
+  return isObject(value) && "summary" in value && isTestSummary(value.summary);
+}
+
 const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
   { testFiles, chainType, grep, noCompile, verbosity },
   hre,
@@ -107,18 +113,29 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
 
     const subtaskResult = await subtask.run(args);
 
-    const isSubtaskResult = isResult(
-      subtaskResult,
-      isTestSummary,
-      isTestSummary,
-    );
-    const summary = isSubtaskResult
-      ? subtaskResult.success
+    let summary: PartialTestSummary | undefined;
+    let subtaskFailed = false;
+
+    if (isResult(subtaskResult, isTestRunResult, isTestRunResult)) {
+      const testRunResult = subtaskResult.success
         ? subtaskResult.value
-        : subtaskResult.error
-      : isTestSummary(subtaskResult)
-        ? subtaskResult
-        : undefined;
+        : subtaskResult.error;
+      summary = testRunResult.summary;
+      subtaskFailed = !subtaskResult.success;
+    } else if (isResult(subtaskResult, isTestSummary, isTestSummary)) {
+      // Support plugins that return Result<TestSummary, TestSummary>
+      summary = subtaskResult.success
+        ? subtaskResult.value
+        : subtaskResult.error;
+      subtaskFailed = !subtaskResult.success;
+    } else if (isTestSummary(subtaskResult)) {
+      // Support plugins that return TestSummary directly
+      summary = subtaskResult;
+      subtaskFailed = process.exitCode !== undefined && process.exitCode !== 0;
+    } else {
+      // Fallback for plugins that don't return a summary at all
+      subtaskFailed = process.exitCode !== undefined && process.exitCode !== 0;
+    }
 
     if (summary !== undefined) {
       const summaryId = subtask.id[subtask.id.length - 1];
@@ -133,12 +150,7 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
       }
     }
 
-    if (
-      (isSubtaskResult && !subtaskResult.success) ||
-      // Backwards compatibility: old plugins may not return a Result, so fall
-      // back to the process exit code to detect failures
-      (process.exitCode !== undefined && process.exitCode !== 0)
-    ) {
+    if (subtaskFailed) {
       hasFailures = true;
     }
   }

--- a/v-next/hardhat/src/types/test.ts
+++ b/v-next/hardhat/src/types/test.ts
@@ -17,3 +17,11 @@ export interface TestSummary {
   todo: number;
   failureOutput?: string;
 }
+
+/**
+ * Result of a test run, wrapping a TestSummary. Plugins can extend this
+ * interface to include additional data (e.g., suite results).
+ */
+export interface TestRunResult {
+  summary: TestSummary;
+}

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -187,7 +187,15 @@ describe("solidity-test/task-action", function () {
         .run({ noCompile: true });
       assert.deepEqual(result, {
         success: false,
-        error: { failed: 0, passed: 0, skipped: 0, todo: 0, failureOutput: "" },
+        error: {
+          summary: {
+            failed: 0,
+            passed: 0,
+            skipped: 0,
+            todo: 0,
+            failureOutput: "",
+          },
+        },
       });
     });
 
@@ -199,7 +207,15 @@ describe("solidity-test/task-action", function () {
         .run({ noCompile: true });
       assert.deepEqual(result, {
         success: true,
-        value: { failed: 0, passed: 0, skipped: 0, todo: 0, failureOutput: "" },
+        value: {
+          summary: {
+            failed: 0,
+            passed: 0,
+            skipped: 0,
+            todo: 0,
+            failureOutput: "",
+          },
+        },
       });
     });
 

--- a/v-next/hardhat/test/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/test/task-action.ts
@@ -34,7 +34,43 @@ describe("test/task-action", function () {
     process.exitCode = undefined;
   });
 
-  describe("subtask returning Result<TestSummary, TestSummary>", function () {
+  describe("subtask returning Result<TestRunResult, TestRunResult>", function () {
+    it("should return a successful result when the subtask returns a successful Result", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () =>
+            successfulResult({
+              summary: { passed: 3, failed: 0, skipped: 0, todo: 0 },
+            }),
+          ),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: true, value: undefined });
+    });
+
+    it("should return an error result when the subtask returns a failed Result", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () =>
+            errorResult({
+              summary: { passed: 1, failed: 2, skipped: 0, todo: 0 },
+            }),
+          ),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: false, error: undefined });
+    });
+  });
+
+  describe("subtask returning Result<TestSummary, TestSummary> (backwards compat)", function () {
     it("should return a successful result when the subtask returns a successful Result", async () => {
       const hre = await createHardhatRuntimeEnvironment({
         tasks: [
@@ -210,6 +246,47 @@ describe("test/task-action", function () {
       const result = await hre.tasks.getTask("test").run({ noCompile: true });
 
       assert.deepEqual(result, { success: false, error: undefined });
+    });
+
+    it("should return an error result when a TestRunResult subtask succeeds but a plain summary subtask fails", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () =>
+            successfulResult({
+              summary: { passed: 3, failed: 0, skipped: 0, todo: 0 },
+            }),
+          ),
+          mockRunner("runner-b", () => {
+            process.exitCode = 1;
+            return { passed: 2, failed: 1, skipped: 0, todo: 0 };
+          }),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: false, error: undefined });
+    });
+
+    it("should return a successful result when TestRunResult and TestSummary Result subtasks both succeed", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [
+          solidityNoOp,
+          mockRunner("runner-a", () =>
+            successfulResult({
+              summary: { passed: 3, failed: 0, skipped: 0, todo: 0 },
+            }),
+          ),
+          mockRunner("runner-b", () =>
+            successfulResult({ passed: 2, failed: 0, skipped: 0, todo: 0 }),
+          ),
+        ],
+      });
+
+      const result = await hre.tasks.getTask("test").run({ noCompile: true });
+
+      assert.deepEqual(result, { success: true, value: undefined });
     });
   });
 });


### PR DESCRIPTION
Previously, test runners could only return the test summary. This change allows them to return additional data by extending the `TestRunResult` interface. `TestSummary` remains available through the `summary` property in `TestRunResult`.