### PR TITLE
Add `connectOnSingleton` to Hardhat Mocha

### DIFF
--- a/.changeset/all-groups-slide.md
+++ b/.changeset/all-groups-slide.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-errors": patch
+"@nomicfoundation/hardhat-mocha": patch
+---
+
+Added `connectToSingleton` helper to support single network per Mocha test suite patterns ([#7965](https://github.com/NomicFoundation/hardhat/issues/7965))

--- a/end-to-end/openzeppelin-contracts-connect-to-singleton/scenario.json
+++ b/end-to-end/openzeppelin-contracts-connect-to-singleton/scenario.json
@@ -1,7 +1,6 @@
 {
   "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
   "description": "OpenZeppelin fork that uses connectToSingleton in the Mocha test suite",
-  "disabled": true,
   "tags": ["external-repo", "mocha"],
   "repo": "kanej/openzeppelin-contracts",
   "commit": "28699671dd173eb630643e0761024079bfa47c0e",

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -230,10 +230,10 @@ export const ERROR_CATEGORIES: {
         max: 30099,
         websiteSubTitle: "General errors",
       },
-      CONNECT_ON_BEFORE: {
+      CONNECTION_PROXY: {
         min: 30100,
         max: 30199,
-        websiteSubTitle: "connectOnBefore errors",
+        websiteSubTitle: "Connection proxy errors",
       },
     },
   },
@@ -2130,28 +2130,28 @@ Please try again later.`,
           'You have run your tests twice programmatically and your project is an ESM project (you have `"type": "module"` in your `package.json`, or some of your files have the `.mjs` extension). This is not supported by Mocha yet (https://github.com/mochajs/mocha/issues/2706).',
       },
     },
-    CONNECT_ON_BEFORE: {
+    CONNECTION_PROXY: {
       USE_BEFORE_HOOK: {
         number: 30100,
         messageTemplate: `The network connection proxy can't be used before the \`before\` hook runs. Make sure you only use it inside \`it\`, \`before\`, \`beforeEach\`, etc.`,
         websiteTitle:
           "Used network connection before the Mocha `before` hook ran",
         websiteDescription:
-          "You tried to use a `connectOnBefore` network connection proxy before the Mocha `before` hook has run. Make sure you only use the value inside `it`, `before`, `beforeEach`, or other Mocha hooks.",
+          "You tried to use a network connection proxy (created by helpers like `connectOnBefore` or `connectToSingleton`) before the Mocha `before` hook has run. Make sure you only use the value inside `it`, `before`, `beforeEach`, or other Mocha hooks.",
       },
-      AWAIT_CONNECT_ON_BEFORE: {
+      AWAIT_CONNECTION_PROXY: {
         number: 30101,
-        messageTemplate: `\`connectOnBefore\` must not be awaited. It returns a synchronous proxy — remove the \`await\` keyword.`,
-        websiteTitle: "Awaited connectOnBefore",
+        messageTemplate: `The network connection proxy must not be awaited. It returns a synchronous proxy — remove the \`await\` keyword.`,
+        websiteTitle: "Awaited network connection proxy",
         websiteDescription:
-          "You used `await` on the network connection proxy returned by `connectOnBefore`. This function returns a synchronous proxy that is populated by a Mocha `before` hook. Remove the `await` keyword.",
+          "You used `await` on a network connection proxy. These functions return a synchronous proxy that is populated by a Mocha `before` hook. Remove the `await` keyword.",
       },
       UNSUPPORTED_OPERATION: {
         number: 30102,
         messageTemplate: `This operation is not supported on the network connection proxy.`,
         websiteTitle: "Unsupported proxy operation",
         websiteDescription:
-          "You attempted an operation (such as Object.getPrototypeOf, Object.defineProperty, delete, new, or Object.freeze) on a connectOnBefore network connection proxy. These operations are not supported. Use standard property access and assignment instead.",
+          "You attempted an operation (such as Object.getPrototypeOf, Object.defineProperty, delete, new, or Object.freeze) on a network connection proxy. These operations are not supported. Use standard property access and assignment instead.",
       },
     },
   },

--- a/v-next/hardhat-mocha/src/connect-on-before/create-connect-to-singleton.ts
+++ b/v-next/hardhat-mocha/src/connect-on-before/create-connect-to-singleton.ts
@@ -1,0 +1,117 @@
+import type { SingletonConnectionParams } from "../type-extensions.js";
+import type {
+  ChainType,
+  DefaultChainType,
+  NetworkConnection,
+  NetworkManager,
+} from "hardhat/types/network";
+
+import { createNetworkConnectionProxy } from "./create-network-connection-proxy.js";
+
+interface SingletonEntry {
+  proxy: NetworkConnection;
+  connectPromise: Promise<void> | undefined;
+  resolved: NetworkConnection | undefined;
+}
+
+const DEFAULT_NETWORK_NAME = "default";
+const DEFAULT_CHAIN_TYPE = "generic";
+
+/**
+ * Creates a connectToSingleton function that returns a proxy network connection
+ * shared across all callers with the same network name and chain type.
+ *
+ * Unlike `connectOnBefore`, which creates a new connection per `describe` block,
+ * `connectToSingleton` memoizes connections by `networkName:chainType` key.
+ * Every call registers a Mocha `before` hook that connects if the entry has not
+ * yet been resolved and is a no-op otherwise.
+ *
+ * There is no teardown — connections are left for garbage collection when the
+ * process exits.
+ *
+ * @param networkManager The network manager instance from the HRE
+ * @returns A connectToSingleton function
+ */
+export function createConnectToSingleton(
+  networkManager: NetworkManager,
+): <ChainTypeT extends ChainType | string = DefaultChainType>(
+  networkOrParams?: SingletonConnectionParams<ChainTypeT> | string,
+) => NetworkConnection<ChainTypeT> {
+  // Scope the persistence of the singleton network connection proxies
+  // to the lifetime of this HRE.
+  const singletons = new Map<string, SingletonEntry>();
+
+  return function connectToSingleton<
+    ChainTypeT extends ChainType | string = DefaultChainType,
+  >(
+    networkOrParams?: SingletonConnectionParams<ChainTypeT> | string,
+  ): NetworkConnection<ChainTypeT> {
+    const networkName =
+      typeof networkOrParams === "string"
+        ? networkOrParams
+        : networkOrParams?.network;
+
+    const chainType =
+      typeof networkOrParams === "string"
+        ? undefined
+        : networkOrParams?.chainType;
+
+    const key = `${networkName ?? DEFAULT_NETWORK_NAME}:${chainType ?? DEFAULT_CHAIN_TYPE}`;
+
+    const entry = singletons.get(key) ?? createSingletonEntry(singletons, key);
+
+    // Every call registers a before() — connects if needed, no-op if resolved.
+    // The connectPromise is created synchronously in the first before() to
+    // execute, so all concurrent hooks await the same promise.
+    before(async function () {
+      // If the connection has been created, there is nothing to do
+      // the proxy connection is resolved and usable
+      if (entry.resolved !== undefined) {
+        return;
+      }
+
+      // in the first before to run, setup the promise to resolve the connection
+      if (entry.connectPromise === undefined) {
+        const params =
+          networkName !== undefined || chainType !== undefined
+            ? { network: networkName, chainType }
+            : undefined;
+
+        // The setting of connection promise has to happen synchronously
+        // to avoid race conditions with other suites' before hooks,
+        // hence the then that sets resolved.
+        entry.connectPromise = networkManager
+          .connect(params)
+          .then((connection) => {
+            /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+            Connection is generically typed, and the entry is not */
+            entry.resolved = connection as NetworkConnection;
+          });
+      }
+
+      // wait for the connection to be resolved
+      await entry.connectPromise;
+    });
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+       The singletons map erases the ChainTypeT generic, forcing our hand. */
+    return entry.proxy as NetworkConnection<ChainTypeT>;
+  };
+}
+
+function createSingletonEntry(
+  singletons: Map<string, SingletonEntry>,
+  key: string,
+): SingletonEntry {
+  const proxy = createNetworkConnectionProxy(() => entry.resolved);
+
+  const entry: SingletonEntry = {
+    resolved: undefined,
+    connectPromise: undefined,
+    proxy,
+  };
+
+  singletons.set(key, entry);
+
+  return entry;
+}

--- a/v-next/hardhat-mocha/src/connect-on-before/create-network-connection-proxy.ts
+++ b/v-next/hardhat-mocha/src/connect-on-before/create-network-connection-proxy.ts
@@ -40,7 +40,7 @@ export function createNetworkConnectionProxy<
 
       if (prop === "then") {
         throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.AWAIT_CONNECT_ON_BEFORE,
+          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.AWAIT_CONNECTION_PROXY,
         );
       }
 
@@ -90,7 +90,7 @@ export function createNetworkConnectionProxy<
 
       if (resolved === null || resolved === undefined) {
         throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         );
       }
 
@@ -102,7 +102,7 @@ export function createNetworkConnectionProxy<
 
       if (resolved === null || resolved === undefined) {
         throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         );
       }
 
@@ -114,7 +114,7 @@ export function createNetworkConnectionProxy<
 
       if (resolved === null || resolved === undefined) {
         throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         );
       }
 
@@ -126,7 +126,7 @@ export function createNetworkConnectionProxy<
 
       if (resolved === null || resolved === undefined) {
         throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         );
       }
 
@@ -188,7 +188,7 @@ function createNestedProxyForPath(getTarget: () => unknown): any {
 
       if (target === null || target === undefined) {
         throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         );
       }
 
@@ -200,7 +200,7 @@ function createNestedProxyForPath(getTarget: () => unknown): any {
 
       if (target === null || target === undefined) {
         throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         );
       }
 
@@ -212,7 +212,7 @@ function createNestedProxyForPath(getTarget: () => unknown): any {
 
       if (target === null || target === undefined) {
         throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         );
       }
 
@@ -224,7 +224,7 @@ function createNestedProxyForPath(getTarget: () => unknown): any {
 
       if (target === null || target === undefined) {
         throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         );
       }
 
@@ -236,7 +236,7 @@ function createNestedProxyForPath(getTarget: () => unknown): any {
 
       if (target === null || target === undefined) {
         throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+          HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         );
       }
 
@@ -256,67 +256,67 @@ function createNestedProxyForPath(getTarget: () => unknown): any {
 const defaultProxyHandlerTraps: Required<ProxyHandler<object>> = {
   apply() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   construct() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   defineProperty() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   deleteProperty() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   get() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   getOwnPropertyDescriptor() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   getPrototypeOf() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   has() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   isExtensible() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   ownKeys() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   preventExtensions() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   set() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
   setPrototypeOf() {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.UNSUPPORTED_OPERATION,
+      HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.UNSUPPORTED_OPERATION,
     );
   },
 };

--- a/v-next/hardhat-mocha/src/hookHandlers/hre.ts
+++ b/v-next/hardhat-mocha/src/hookHandlers/hre.ts
@@ -1,13 +1,16 @@
 import type { HardhatRuntimeEnvironmentHooks } from "hardhat/types/hooks";
 
 import { createConnectOnBefore } from "../connect-on-before/create-connect-on-before.js";
+import { createConnectToSingleton } from "../connect-on-before/create-connect-to-singleton.js";
 
 export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
   created: async (_context, hre) => {
     const connectOnBefore = createConnectOnBefore(hre.network);
+    const connectToSingleton = createConnectToSingleton(hre.network);
 
     hre.network.mocha = {
       connectOnBefore,
+      connectToSingleton,
     };
   },
 });

--- a/v-next/hardhat-mocha/src/type-extensions.ts
+++ b/v-next/hardhat-mocha/src/type-extensions.ts
@@ -31,16 +31,19 @@ declare module "hardhat/types/test" {
 
 import "hardhat/types/network";
 declare module "hardhat/types/network" {
-  export interface NetworkManager<
-    ChainTypeT extends ChainType | string = DefaultChainType,
-  > {
-    mocha: MochaNetworkHelpers<ChainTypeT>;
+  export interface NetworkManager {
+    mocha: MochaNetworkHelpers;
   }
 }
 
-export interface MochaNetworkHelpers<
+export interface SingletonConnectionParams<
   ChainTypeT extends ChainType | string = DefaultChainType,
 > {
+  network?: string;
+  chainType?: ChainTypeT;
+}
+
+export interface MochaNetworkHelpers {
   /**
    * A Mocha test suite helper that returns a proxy network connection
    * and adds a Mocha `before` hook to the surrounding `describe` block
@@ -84,8 +87,48 @@ export interface MochaNetworkHelpers<
    * @returns A proxy to the {@link NetworkConnection} that resolves lazily
    * when its properties are accessed inside a test or hook.
    */
-  connectOnBefore(
+  connectOnBefore<ChainTypeT extends ChainType | string = DefaultChainType>(
     networkOrParams?: NetworkConnectionParams<ChainTypeT> | string,
     closeOnAfter?: boolean,
+  ): NetworkConnection<ChainTypeT>;
+
+  /**
+   * A Mocha test suite helper that returns a singleton proxy network
+   * connection. All calls to `connectToSingleton` for the same network name
+   * and chain type will receive the same proxy network connection.
+   *
+   * This helper should be used if you want to share the same network instance
+   * across multiple Mocha test files.
+   *
+   * The proxy will be resolved to a full network connection within the first
+   * test suite to use it. Connections are cleaned up at the end of the test
+   * suite run.
+   *
+   * @example
+   * // In any test file:
+   * const { provider } = network.mocha.connectToSingleton();
+   *
+   * describe("a test suite", function ()  {
+   *   it("gets the block number", async function () {
+   *     const blockNumber = await provider.request({ method: "eth_blockNumber" });
+   *   });
+   * });
+   *
+   * @example
+   * // With a network name:
+   * const connection = network.mocha.connectToSingleton("localhost");
+   *
+   * @example
+   * // With a specific network name and chain type:
+   * const connection = network.mocha.connectToSingleton({ network: "localhost", chainType: "l1" });
+   *
+   * @param networkOrParams - The network to connect to. Can be a network
+   * name string, a {@link SingletonConnectionParams} object for network and
+   * chain type, or omitted to connect to the default network.
+   * @returns A proxy to the {@link NetworkConnection} that resolves lazily
+   * when its properties are accessed inside a test or hook.
+   */
+  connectToSingleton<ChainTypeT extends ChainType | string = DefaultChainType>(
+    networkOrParams?: SingletonConnectionParams<ChainTypeT> | string,
   ): NetworkConnection<ChainTypeT>;
 }

--- a/v-next/hardhat-mocha/test/connect-to-singleton-linear.ts
+++ b/v-next/hardhat-mocha/test/connect-to-singleton-linear.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { useEphemeralFixtureProject } from "@nomicfoundation/hardhat-test-utils";
+import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+
+describe("connect-to-singleton (linear)", () => {
+  useEphemeralFixtureProject("connect-to-singleton");
+
+  it("should successfully run a mocha test suite that uses `network.mocha.connectToSingleton`", async () => {
+    const hardhatConfig = await import(
+      "./fixture-projects/connect-to-singleton/hardhat.config.js"
+    );
+
+    const hre = await createHardhatRuntimeEnvironment({
+      ...hardhatConfig.default,
+      test: {
+        mocha: {
+          parallel: false,
+        },
+      },
+    });
+
+    const result = await hre.tasks.getTask(["test", "mocha"]).run({});
+
+    assert.equal(result.success, true, "Test run should succeed");
+    assert.equal(
+      result.value.summary.failed,
+      0,
+      "No tests should fail in the example project",
+    );
+    assert.ok(
+      result.value.summary.passed > 0,
+      "There should be passing tests in the example project",
+    );
+  });
+});

--- a/v-next/hardhat-mocha/test/connect-to-singleton-parallel.ts
+++ b/v-next/hardhat-mocha/test/connect-to-singleton-parallel.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { useEphemeralFixtureProject } from "@nomicfoundation/hardhat-test-utils";
+import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+
+describe("connect-to-singleton (parallel)", () => {
+  useEphemeralFixtureProject("connect-to-singleton");
+
+  it("should successfully run a mocha test suite that uses `network.mocha.connectToSingleton`", async () => {
+    const hardhatConfig = await import(
+      "./fixture-projects/connect-to-singleton/hardhat.config.js"
+    );
+
+    const hre = await createHardhatRuntimeEnvironment({
+      ...hardhatConfig.default,
+      test: {
+        mocha: {
+          parallel: true,
+        },
+      },
+    });
+
+    const result = await hre.tasks.getTask(["test", "mocha"]).run({});
+
+    assert.equal(result.success, true, "Test run should succeed");
+    assert.equal(
+      result.value.summary.failed,
+      0,
+      "No tests should fail in the example project",
+    );
+    assert.ok(
+      result.value.summary.passed > 0,
+      "There should be passing tests in the example project",
+    );
+  });
+});

--- a/v-next/hardhat-mocha/test/create-connect-to-singleton.ts
+++ b/v-next/hardhat-mocha/test/create-connect-to-singleton.ts
@@ -1,0 +1,164 @@
+import type { NetworkConnection, NetworkManager } from "hardhat/types/network";
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { assertRejects } from "@nomicfoundation/hardhat-test-utils";
+
+import { createConnectToSingleton } from "../src/connect-on-before/create-connect-to-singleton.js";
+
+// We capture the hooks registered by `connectToSingleton` so we can invoke
+// them manually in the test, rather than relying on a real Mocha runtime.
+let capturedBeforeHooks: Array<() => Promise<void>>;
+let originalBefore: typeof globalThis.before;
+
+describe("createConnectToSingleton", () => {
+  beforeEach(() => {
+    capturedBeforeHooks = [];
+    originalBefore = globalThis.before;
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mocking Mocha's before() for unit testing
+    globalThis.before = ((beforeFn: () => Promise<void>) => {
+      capturedBeforeHooks.push(beforeFn);
+    }) as any;
+  });
+
+  afterEach(() => {
+    globalThis.before = originalBefore;
+  });
+
+  describe("successful connection", () => {
+    it("should resolve the proxy for all callers sharing the singleton", async () => {
+      const mockConnection = buildMockConnection({ id: 42 });
+      const mockNetworkManager = buildMockNetworkManager(
+        async () => mockConnection,
+      );
+
+      const connectToSingleton = createConnectToSingleton(mockNetworkManager);
+
+      const proxy1 = connectToSingleton();
+      const proxy2 = connectToSingleton();
+
+      // Both calls for the same key should return the same proxy.
+      assert.equal(
+        proxy1,
+        proxy2,
+        "Same singleton key should return the same proxy",
+      );
+
+      // Run the before hooks to resolve the connection.
+      await capturedBeforeHooks[0]();
+      await capturedBeforeHooks[1]();
+
+      // The proxy should now forward to the real connection.
+      assert.equal(proxy1.id, 42);
+    });
+
+    it("should only call connect() once for multiple callers", async () => {
+      let connectCallCount = 0;
+      const mockConnection = buildMockConnection();
+      const mockNetworkManager = buildMockNetworkManager(async () => {
+        connectCallCount++;
+        return mockConnection;
+      });
+
+      const connectToSingleton = createConnectToSingleton(mockNetworkManager);
+
+      connectToSingleton();
+      connectToSingleton();
+      connectToSingleton();
+
+      // Run all three hooks.
+      for (const hook of capturedBeforeHooks) {
+        await hook();
+      }
+
+      assert.equal(
+        connectCallCount,
+        1,
+        "connect() should be called exactly once for the same singleton key",
+      );
+    });
+  });
+
+  describe("key isolation", () => {
+    it("should create separate singletons for different network names", async () => {
+      let connectCallCount = 0;
+      const mockNetworkManager = buildMockNetworkManager(async () => {
+        connectCallCount++;
+        return buildMockConnection({ id: connectCallCount });
+      });
+
+      const connectToSingleton = createConnectToSingleton(mockNetworkManager);
+
+      const proxyA = connectToSingleton("networkA");
+      const proxyB = connectToSingleton("networkB");
+
+      assert.notEqual(
+        proxyA,
+        proxyB,
+        "Different networks should get different proxies",
+      );
+
+      for (const hook of capturedBeforeHooks) {
+        await hook();
+      }
+
+      assert.equal(
+        connectCallCount,
+        2,
+        "connect() should be called once per unique key",
+      );
+      assert.equal(proxyA.id, 1);
+      assert.equal(proxyB.id, 2);
+    });
+  });
+
+  describe("error propagation", () => {
+    it("should propagate a connect() rejection to all before hooks sharing the singleton", async () => {
+      const connectError = new Error("network connection failed");
+
+      const mockNetworkManager = buildMockNetworkManager(async () => {
+        throw connectError;
+      });
+      const connectToSingleton = createConnectToSingleton(mockNetworkManager);
+
+      // Simulate two test files both calling connectToSingleton() for the
+      // same (default) network — they should share the same singleton entry.
+      connectToSingleton();
+      connectToSingleton();
+
+      assert.equal(
+        capturedBeforeHooks.length,
+        2,
+        "Two before hooks should be registered",
+      );
+
+      // Both hooks should reject with the same error instance.
+      await assertRejects(
+        capturedBeforeHooks[0](),
+        (error) => error === connectError,
+        "First hook should reject with the connect error",
+      );
+      await assertRejects(
+        capturedBeforeHooks[1](),
+        (error) => error === connectError,
+        "Second hook should reject with the same connect error",
+      );
+    });
+  });
+});
+
+function buildMockConnection({
+  id = 1,
+}: { id?: number } = {}): NetworkConnection {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock for testing
+  return { id } as NetworkConnection;
+}
+
+function buildMockNetworkManager(
+  connect: () => Promise<NetworkConnection>,
+): NetworkManager {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock for testing
+  return { connect } as NetworkManager;
+}

--- a/v-next/hardhat-mocha/test/create-network-connection-proxy.ts
+++ b/v-next/hardhat-mocha/test/create-network-connection-proxy.ts
@@ -230,8 +230,8 @@ describe("createNetworkConnectionProxy", () => {
       assertThrowsHardhatError(
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing proxy behavior with plain objects
         () => (proxy as any).then,
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE
-          .AWAIT_CONNECT_ON_BEFORE,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY
+          .AWAIT_CONNECTION_PROXY,
         {},
       );
     });
@@ -269,7 +269,7 @@ describe("createNetworkConnectionProxy", () => {
         () => {
           proxy.close = async () => {};
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });
@@ -282,7 +282,7 @@ describe("createNetworkConnectionProxy", () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- trigger the has trap
           "id" in proxy;
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });
@@ -294,7 +294,7 @@ describe("createNetworkConnectionProxy", () => {
         () => {
           Object.keys(proxy);
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });
@@ -306,7 +306,7 @@ describe("createNetworkConnectionProxy", () => {
         () => {
           Object.getOwnPropertyDescriptor(proxy, "id");
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });
@@ -317,8 +317,8 @@ describe("createNetworkConnectionProxy", () => {
       assertThrowsHardhatError(
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing `then` which is not part of the type
         () => (proxy as any).then,
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE
-          .AWAIT_CONNECT_ON_BEFORE,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY
+          .AWAIT_CONNECTION_PROXY,
         {},
       );
     });
@@ -648,7 +648,7 @@ describe("createNetworkConnectionProxy", () => {
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentionally allow set to test edge case
           (networkConfig as any).chainId = 1;
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });
@@ -663,7 +663,7 @@ describe("createNetworkConnectionProxy", () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- trigger the has trap
           "chainId" in networkConfig;
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });
@@ -677,7 +677,7 @@ describe("createNetworkConnectionProxy", () => {
         () => {
           Object.keys(networkConfig);
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });
@@ -814,7 +814,7 @@ describe("createNetworkConnectionProxy", () => {
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- testing set on proxy
           (deep as any).name = "x";
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });
@@ -829,7 +829,7 @@ describe("createNetworkConnectionProxy", () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- trigger the has trap
           "name" in deep;
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });
@@ -843,7 +843,7 @@ describe("createNetworkConnectionProxy", () => {
         () => {
           Object.keys(deep);
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });
@@ -857,7 +857,7 @@ describe("createNetworkConnectionProxy", () => {
         () => {
           Object.getOwnPropertyDescriptor(deep, "name");
         },
-        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECT_ON_BEFORE.USE_BEFORE_HOOK,
+        HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.USE_BEFORE_HOOK,
         {},
       );
     });

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-on-before/test/connect-on-before-ethers-usage.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-on-before/test/connect-on-before-ethers-usage.ts
@@ -43,7 +43,11 @@ describe("connectOnBefore ethers usage", function () {
   });
 
   describe("destructuring usage", () => {
-    const { ethers } = network.mocha.connectOnBefore();
+    const { ethers } = network.mocha.connectOnBefore({
+      network: "default",
+      chainType: "l1",
+    });
+
     let counter: Contract;
 
     before(async () => {

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/contracts/Counter.sol
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/contracts/Counter.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Counter {
+  uint public x;
+
+  event Increment(uint by);
+
+  function inc() public {
+    x++;
+    emit Increment(1);
+  }
+
+  function incBy(uint by) public {
+    require(by > 0, "incBy: increment should be positive");
+    x += by;
+    emit Increment(by);
+  }
+}

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/hardhat.config.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/hardhat.config.ts
@@ -1,0 +1,16 @@
+import type { HardhatUserConfig } from "hardhat/config";
+
+import hardhatEthersPlugin from "@nomicfoundation/hardhat-ethers";
+import hardhatNetworkHelpersPlugin from "@nomicfoundation/hardhat-network-helpers";
+
+import HardhatMochaPlugin from "../../../src/index.js";
+
+const config: HardhatUserConfig = {
+  plugins: [
+    hardhatEthersPlugin,
+    hardhatNetworkHelpersPlugin,
+    HardhatMochaPlugin,
+  ],
+};
+
+export default config;

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/package.json
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "devDependencies": {
+    "@nomicfoundation/hardhat-test-utils": "workspace:*"
+  }
+}

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-ethers-deep-destructuring-usage.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-ethers-deep-destructuring-usage.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import type { Contract } from "ethers";
+import { network } from "hardhat";
+
+const {
+  ethers: { deployContract, getSigners },
+} = network.mocha.connectToSingleton();
+
+describe("connectToSingleton ethers - deep nested destructuring usage", function () {
+  let counter: Contract;
+
+  before(async () => {
+    const [_first, _second, third] = await getSigners();
+
+    counter = await deployContract("Counter", [], third);
+  });
+
+  it("should support invoking read and write functions on the contract", async function () {
+    assert.equal(await counter.x(), 0n);
+    await counter.inc();
+    assert.equal(await counter.x(), 1n);
+  });
+});

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-ethers-destructuring-usage.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-ethers-destructuring-usage.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import type { Contract } from "ethers";
+import { network } from "hardhat";
+
+const { ethers } = network.mocha.connectToSingleton();
+
+describe("connectToSingleton ethers - destructuring usage", function () {
+  const expectedDeploymentAddress =
+    "0x8464135c8F25Da09e49BC8782676a84730C318bC";
+
+  let counter: Contract;
+
+  before(async () => {
+    const [_first, second] = await ethers.getSigners();
+
+    counter = await ethers.deployContract("Counter", [], second);
+  });
+
+  it("should support deploying a contract", async function () {
+    assert.equal(await counter.getAddress(), expectedDeploymentAddress);
+  });
+
+  it("should support invoking read and write functions on the contract", async function () {
+    assert.equal(await counter.x(), 0n);
+    await counter.inc();
+    assert.equal(await counter.x(), 1n);
+  });
+});

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-ethers-usage.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-ethers-usage.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import type { Contract } from "ethers";
+import { network } from "hardhat";
+
+const connection = network.mocha.connectToSingleton({
+  network: "default",
+  chainType: "l1",
+});
+
+describe("connectToSingleton ethers - direct usage", function () {
+  const expectedDeploymentAddress =
+    "0x057ef64E23666F000b34aE31332854aCBd1c8544";
+
+  let counter: Contract;
+
+  before(async () => {
+    const [_first, _second, _third, fourth] =
+      await connection.ethers.getSigners();
+
+    counter = await connection.ethers.deployContract("Counter", [], fourth);
+  });
+
+  it("should support deploying a contract", async function () {
+    assert.equal(await counter.getAddress(), expectedDeploymentAddress);
+  });
+
+  it("should support invoking read and write functions on the contract", async function () {
+    assert.equal(await counter.x(), 0n);
+    await counter.inc();
+    assert.equal(await counter.x(), 1n);
+  });
+
+  it("should support invoking events", async () => {
+    const increment = 5n;
+    const before = await counter.x();
+
+    const tx = await counter.incBy(increment);
+    const receipt = await tx.wait();
+
+    assert.equal(await counter.x(), before + increment);
+
+    const log = receipt.logs
+      .map((l: any) => counter.interface.parseLog(l))
+      .find((parsed: any) => parsed?.name === "Increment");
+
+    assert.ok(log !== null && log !== undefined);
+    assert.equal(log.args.by, increment);
+  });
+});

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-network-helpers-direct-deep-destructuring-usage.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-network-helpers-direct-deep-destructuring-usage.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { network } from "hardhat";
+
+const {
+  networkHelpers: { mineUpTo },
+  provider,
+} = network.mocha.connectToSingleton();
+
+describe("connectToSingleton network helpers - deep destructuring usage", function () {
+  it("should allow invocation of network helpers like mineUpTo", async function () {
+    const beforeMiningBlock = await provider.request({
+      method: "eth_blockNumber",
+    });
+
+    await mineUpTo(Number(beforeMiningBlock) + 101);
+
+    const result = await provider.request({
+      method: "eth_blockNumber",
+    });
+
+    assert.equal(result, numberToHexString(Number(beforeMiningBlock) + 101));
+  });
+});

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-network-helpers-direct-destructuring-usage.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-network-helpers-direct-destructuring-usage.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { network } from "hardhat";
+
+const { networkHelpers, provider } = network.mocha.connectToSingleton();
+
+describe("connectToSingleton network helpers - destructuring usage", function () {
+  it("should allow invocation of network helpers like mineUpTo", async function () {
+    const beforeMiningBlock = await provider.request({
+      method: "eth_blockNumber",
+    });
+
+    await networkHelpers.mineUpTo(Number(beforeMiningBlock) + 101);
+
+    const result = await provider.request({
+      method: "eth_blockNumber",
+    });
+
+    assert.equal(result, numberToHexString(Number(beforeMiningBlock) + 101));
+  });
+});

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-network-helpers-direct-usage.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-network-helpers-direct-usage.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { network } from "hardhat";
+
+const connection = network.mocha.connectToSingleton();
+
+describe("connectToSingleton network helpers - direct usage", function () {
+  it("should allow invocation of network helpers like mineUpTo", async function () {
+    const beforeMiningBlock = await connection.provider.request({
+      method: "eth_blockNumber",
+    });
+
+    await connection.networkHelpers.mineUpTo(Number(beforeMiningBlock) + 101);
+
+    const result = await connection.provider.request({
+      method: "eth_blockNumber",
+    });
+
+    assert.equal(result, numberToHexString(Number(beforeMiningBlock) + 101));
+  });
+});

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-with-await.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-with-await.ts
@@ -3,16 +3,17 @@ import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-uti
 import { network } from "hardhat";
 
 /**
- * `connectOnBefore` intentionally does not require an await; indeed it is
- * intended to be run within a describe block, which in Mocha cannot be async.
+ * `connectToSingleton` intentionally does not require an await; indeed it is
+ * intended to be run at the files top level.
+ *
  * Hence we should throw a HardhatError if the user attempts to use an
  * await on the returned proxy.
  */
-describe("connectOnBefore with await", function () {
+describe("connectToSingleton with await", function () {
   it("should throw if awaited", async function () {
     await assertRejectsWithHardhatError(
       async () => {
-        await network.mocha.connectOnBefore();
+        await network.mocha.connectToSingleton();
       },
       HardhatError.ERRORS.HARDHAT_MOCHA.CONNECTION_PROXY.AWAIT_CONNECTION_PROXY,
       {},

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-with-explicit-hre.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton-with-explicit-hre.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import type { Contract } from "ethers";
+import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+
+import hardhatEthersPlugin from "@nomicfoundation/hardhat-ethers";
+import HardhatMochaPlugin from "../../../../src/index.js";
+
+const hre = await createHardhatRuntimeEnvironment({
+  plugins: [hardhatEthersPlugin, HardhatMochaPlugin],
+});
+
+describe("connectToSingleton via `createHardhatRuntimeEnvironment`", function () {
+  const expectedDeploymentAddress =
+    "0x5FbDB2315678afecb367f032d93F642f64180aa3";
+
+  describe("direct usage", () => {
+    const connection = hre.network.mocha.connectToSingleton();
+    let counter: Contract;
+
+    before(async () => {
+      counter = await connection.ethers.deployContract("Counter");
+    });
+
+    it("should support deploying a contract", async function () {
+      assert.equal(await counter.getAddress(), expectedDeploymentAddress);
+    });
+
+    it("should support invoking read and write functions on the contract", async function () {
+      assert.equal(await counter.x(), 0n);
+      await counter.inc();
+      assert.equal(await counter.x(), 1n);
+    });
+  });
+});

--- a/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton.ts
+++ b/v-next/hardhat-mocha/test/fixture-projects/connect-to-singleton/test/connect-to-singleton.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { network } from "hardhat";
+
+const connection = network.mocha.connectToSingleton();
+
+describe("connectToSingleton", function () {
+  it("should have a valid connection", function () {
+    assert.ok(connection !== undefined);
+    assert.ok(typeof connection.id === "number");
+  });
+
+  it("should have a valid provider", async function () {
+    const result = await connection.provider.request({
+      method: "eth_blockNumber",
+    });
+
+    assert.ok(result !== undefined);
+  });
+
+  it("should allow sending transactions", async function () {
+    const [sender, recipient] = await connection.provider.request({
+      method: "eth_accounts",
+    });
+
+    await connection.provider.request({
+      method: "eth_sendTransaction",
+      params: [
+        {
+          from: sender,
+          to: recipient,
+          value: numberToHexString(10n ** 18n),
+        },
+      ],
+    });
+
+    const balance = await connection.provider.request({
+      method: "eth_getBalance",
+      params: [recipient],
+    });
+
+    assert.ok(BigInt(balance) > 0n);
+  });
+});


### PR DESCRIPTION
Add a `connectOnSingleton` helper modeled after `connectOnBefore` to `hardhat-mocha`. This helper function supports using a singleton EDR instance across an entire Mocha test suite:

```ts
import { expect } from "chai";
import { network } from "hardhat";
import type { Counter } from "../../types/ethers-contracts/contracts/Counter.js";

const { provider } = network.mocha.connectToSingleton();

describe("Example", function () { 
  it("gets the block number", async function () {
    const blockNumber = await provider.request({ method: "eth_blockNumber" });
  });
});
```

A network name can be passed (taking the config from the `hardhat.config.ts`):

```ts
const connection = network.mocha.connectToSingleton("localhost");
```

A reduced version of the network params (no overrides) can also be passed:

```ts
const connection = network.mocha.connectToSingleton({ network: "localhost", chainType: "l1" });
```

## API

Signature `network.mocha.connectToSingleton`:

```ts
connectToSingleton<ChainTypeT extends ChainType | string = DefaultChainType>(
  networkOrParams?: SingletonConnectionParams<ChainTypeT> | string,
): NetworkConnection<ChainTypeT>;
```

Where `SingletonConnectionParams` is `{ network?: string; chainType?: ChainTypeT }` — a subset of `NetworkConnectionParams` without `override`.

## Implementation

The helper creates proxy network connection instances per network name and chainType. The proxy is initialized into a real connection in the first test to run using the proxy. There is no explicit cleanup, with network connections are cleaned up once the complete suite has run.

Parallel mode is supported, but the singleton will be scoped per worker negating much of the performance gain.
