### PR TITLE
Automatic GitHub link in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.6.0/schema.json",
-  "changelog": "../scripts/custom-changelog.ts",
+  "changelog": [
+    "../scripts/custom-changelog.ts",
+    { "repo": "NomicFoundation/hardhat" }
+  ],
   "commit": false,
   "linked": [],
   "access": "public",

--- a/.changeset/test1.md
+++ b/.changeset/test1.md
@@ -1,0 +1,6 @@
+---
+"hardhat": patch
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Test 1: This will create an unintended bump in ethers of hardhat, so the entire "Updated dependencies" section will be removed

--- a/.changeset/test2.md
+++ b/.changeset/test2.md
@@ -1,0 +1,6 @@
+---
+"hardhat": patch
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Test 1: This will create an unintended bump in viem of hardhat, but that we'll reapply with a peer-bump

--- a/.changeset/test3.md
+++ b/.changeset/test3.md
@@ -1,0 +1,7 @@
+---
+"hardhat": patch
+"@nomicfoundation/hardhat-node-test-runner": patch
+"@nomicfoundation/hardhat-node-test-reporter": patch
+---
+
+Test 3: This will create an unintended bump in node-test-retunner of hardhat, which will be removed, but the entire "Updated dependencies" section will be kept because we also bump hardhat-node-test-reporter

--- a/.changeset/test4.md
+++ b/.changeset/test4.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-vendored": patch
+---
+
+Test 4: This will create a bump in hardhat, which won't be removed. Only its "Updated dependencies" title will be cleaned up.

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -6,5 +6,11 @@
     "v-next/hardhat/templates",
     "v-next/config"
   ],
-  "bumps": []
+  "bumps": [
+    {
+      "package": "@nomicfoundation/hardhat-viem",
+      "peer": "hardhat",
+      "reason": "test"
+    }
+  ]
 }

--- a/cspell.dictionary.txt
+++ b/cspell.dictionary.txt
@@ -2,6 +2,7 @@ abicoder
 Abicoder
 accum
 addy
+alcuadrado
 anonymization
 APDU
 arrayified

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "devDependencies": {
+    "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.16.0",
     "@types/node": "^24.1.0",
     "cspell": "9.7.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "pnpm run --recursive --if-present build",
     "clean": "pnpm run --recursive --if-present clean && rimraf .verdaccio",
     "test": "pnpm run --recursive --if-present test",
-    "test:scripts": "node --test ./scripts/**/*.test.ts",
+    "test:scripts": "node --test \"./scripts/**/*.test.ts\"",
     "prettier:scripts": "prettier \"scripts/**/*.{ts,json}\"",
     "tsc:scripts": "tsc --noEmit -p scripts/tsconfig.json",
     "lint:scripts": "pnpm prettier:scripts --check && pnpm tsc:scripts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.6.0
+        version: 0.6.0(encoding@0.1.13)
       '@changesets/cli':
         specifier: ^2.16.0
         version: 2.29.7(@types/node@24.10.14)
@@ -2061,6 +2064,9 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
+  '@changesets/changelog-github@0.6.0':
+    resolution: {integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==}
+
   '@changesets/cli@2.29.7':
     resolution: {integrity: sha512-R7RqWoaksyyKXbKXBTbT4REdy22yH81mcFK6sWtqSanxUCbUi9Uf+6aqxZtDQouIqPdem2W56CdxXgsxdq7FLQ==}
     hasBin: true
@@ -2073,6 +2079,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+
+  '@changesets/get-github-info@0.8.0':
+    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
 
   '@changesets/get-release-plan@4.0.13':
     resolution: {integrity: sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==}
@@ -4459,6 +4468,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
@@ -4594,6 +4606,10 @@ packages:
 
   dompurify@3.1.6:
     resolution: {integrity: sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -6003,6 +6019,15 @@ packages:
 
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -7541,6 +7566,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
+  '@changesets/changelog-github@0.6.0(encoding@0.1.13)':
+    dependencies:
+      '@changesets/get-github-info': 0.8.0(encoding@0.1.13)
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.29.7(@types/node@24.10.14)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.13
@@ -7594,6 +7627,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.4
+
+  '@changesets/get-github-info@0.8.0(encoding@0.1.13)':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
@@ -10181,6 +10221,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dataloader@1.4.0: {}
+
   dayjs@1.11.13: {}
 
   dayjs@1.11.18: {}
@@ -10282,6 +10324,8 @@ snapshots:
       esutils: 2.0.3
 
   dompurify@3.1.6: {}
+
+  dotenv@8.6.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -11962,6 +12006,12 @@ snapshots:
   node-addon-api@6.1.0: {}
 
   node-fetch@2.6.7(encoding@0.1.13):
+    dependencies:
+      whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
+
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
     optionalDependencies:

--- a/scripts/bump-peers.test.ts
+++ b/scripts/bump-peers.test.ts
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { getLastChangelogEntry, cleanChangelogEntry } from "./bump-peers.ts";
 
 // Fixtures based on actual `pnpm changeset version` output with GITHUB_TOKEN
-// set, with added changesets for testing purpuses.
+// set, with added changesets for testing purposes.
 
 const HARDHAT_ETHERS_CHANGELOG = `# @nomicfoundation/hardhat-ethers
 

--- a/scripts/bump-peers.test.ts
+++ b/scripts/bump-peers.test.ts
@@ -1,0 +1,257 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { getLastChangelogEntry, cleanChangelogEntry } from "./bump-peers.ts";
+
+// Fixtures based on actual `pnpm changeset version` output with GITHUB_TOKEN
+// set, with added changesets for testing purpuses.
+
+const HARDHAT_ETHERS_CHANGELOG = `# @nomicfoundation/hardhat-ethers
+
+## 4.0.7
+
+### Patch Changes
+
+- [\`a09c8a6\`](https://github.com/NomicFoundation/hardhat/commit/a09c8a6140ac75598d29c0b0550a36e745ffd3bb) Thanks [@alcuadrado](https://github.com/alcuadrado)! - patch bump in hardhat-ethers and hardhat-viem
+
+- Updated dependencies [[\`01b41ee\`](https://github.com/NomicFoundation/hardhat/commit/01b41ee70fe643a3bf6f98ef5f22298e80f66e5f), [\`e37f96c\`](https://github.com/NomicFoundation/hardhat/commit/e37f96c0c1b38fca41b8645042d51a649e7f5bda), [\`bda5a0a\`](https://github.com/NomicFoundation/hardhat/commit/bda5a0a7aeaccb8246fe3cdac050cab21e772629)]:
+  - @nomicfoundation/hardhat-errors@3.0.8
+  - @nomicfoundation/hardhat-utils@4.0.1
+  - hardhat@3.1.12
+
+## 4.0.6
+
+### Patch Changes
+
+- bc193be: Use concrete value types for contract names in hardhat-viem and hardhat-ethers
+`;
+
+const HARDHAT_VIEM_CHANGELOG = `# @nomicfoundation/hardhat-viem
+
+## 4.0.0
+
+### Major Changes
+
+- [\`65236d1\`](https://github.com/NomicFoundation/hardhat/commit/65236d18b07abced51722b61179b12c20bc7b713) Thanks [@alcuadrado](https://github.com/alcuadrado)! - major bump in hardhat-viem
+
+### Minor Changes
+
+- [\`65236d1\`](https://github.com/NomicFoundation/hardhat/commit/65236d18b07abced51722b61179b12c20bc7b713) Thanks [@alcuadrado](https://github.com/alcuadrado)! - minor bump in hardhat-viem
+
+### Patch Changes
+
+- [\`a09c8a6\`](https://github.com/NomicFoundation/hardhat/commit/a09c8a6140ac75598d29c0b0550a36e745ffd3bb) Thanks [@alcuadrado](https://github.com/alcuadrado)! - patch bump in hardhat-ethers and hardhat-viem
+
+- Updated dependencies [[\`01b41ee\`](https://github.com/NomicFoundation/hardhat/commit/01b41ee70fe643a3bf6f98ef5f22298e80f66e5f), [\`e37f96c\`](https://github.com/NomicFoundation/hardhat/commit/e37f96c0c1b38fca41b8645042d51a649e7f5bda), [\`bda5a0a\`](https://github.com/NomicFoundation/hardhat/commit/bda5a0a7aeaccb8246fe3cdac050cab21e772629)]:
+  - @nomicfoundation/hardhat-errors@3.0.8
+  - @nomicfoundation/hardhat-utils@4.0.1
+  - hardhat@3.1.12
+
+## 3.0.4
+
+### Patch Changes
+
+- bc193be: Use concrete value types for contract names in hardhat-viem and hardhat-ethers
+`;
+
+const HARDHAT_MOCHA_CHANGELOG = `# @nomicfoundation/hardhat-mocha
+
+## 3.0.13
+
+### Patch Changes
+
+- [#8051](https://github.com/NomicFoundation/hardhat/pull/8051) [\`e37f96c\`](https://github.com/NomicFoundation/hardhat/commit/e37f96c0c1b38fca41b8645042d51a649e7f5bda) Thanks [@schaable](https://github.com/schaable)! - Add \`TestRunResult\` type that wraps \`TestSummary\`, allowing plugins to extend test results with additional data
+
+- Updated dependencies [[\`01b41ee\`](https://github.com/NomicFoundation/hardhat/commit/01b41ee70fe643a3bf6f98ef5f22298e80f66e5f), [\`e37f96c\`](https://github.com/NomicFoundation/hardhat/commit/e37f96c0c1b38fca41b8645042d51a649e7f5bda), [\`bda5a0a\`](https://github.com/NomicFoundation/hardhat/commit/bda5a0a7aeaccb8246fe3cdac050cab21e772629)]:
+  - @nomicfoundation/hardhat-errors@3.0.8
+  - @nomicfoundation/hardhat-utils@4.0.1
+  - hardhat@3.1.12
+
+## 3.0.12
+
+### Patch Changes
+
+- 4ff11c1: Return typed result from test runners
+`;
+
+describe("bump-peers", () => {
+  describe("cleanChangelogs", () => {
+    describe("getLastChangelogEntry", () => {
+      it("Should get the last entry of the CHANGELOG.md file", () => {
+        const { entry, startIndex, endIndex } = getLastChangelogEntry(
+          HARDHAT_ETHERS_CHANGELOG,
+        );
+
+        const expectedEntry = `## 4.0.7
+
+### Patch Changes
+
+- [\`a09c8a6\`](https://github.com/NomicFoundation/hardhat/commit/a09c8a6140ac75598d29c0b0550a36e745ffd3bb) Thanks [@alcuadrado](https://github.com/alcuadrado)! - patch bump in hardhat-ethers and hardhat-viem
+
+- Updated dependencies [[\`01b41ee\`](https://github.com/NomicFoundation/hardhat/commit/01b41ee70fe643a3bf6f98ef5f22298e80f66e5f), [\`e37f96c\`](https://github.com/NomicFoundation/hardhat/commit/e37f96c0c1b38fca41b8645042d51a649e7f5bda), [\`bda5a0a\`](https://github.com/NomicFoundation/hardhat/commit/bda5a0a7aeaccb8246fe3cdac050cab21e772629)]:
+  - @nomicfoundation/hardhat-errors@3.0.8
+  - @nomicfoundation/hardhat-utils@4.0.1
+  - hardhat@3.1.12
+
+`;
+
+        assert.equal(entry, expectedEntry);
+        assert.equal(
+          HARDHAT_ETHERS_CHANGELOG.slice(startIndex, endIndex),
+          entry,
+        );
+      });
+
+      it("Should get the last entry of the CHANGELOG.md file, even in the presence of multiple kinds of bumps", () => {
+        const { entry, startIndex, endIndex } = getLastChangelogEntry(
+          HARDHAT_VIEM_CHANGELOG,
+        );
+
+        const expectedEntry = `## 4.0.0
+
+### Major Changes
+
+- [\`65236d1\`](https://github.com/NomicFoundation/hardhat/commit/65236d18b07abced51722b61179b12c20bc7b713) Thanks [@alcuadrado](https://github.com/alcuadrado)! - major bump in hardhat-viem
+
+### Minor Changes
+
+- [\`65236d1\`](https://github.com/NomicFoundation/hardhat/commit/65236d18b07abced51722b61179b12c20bc7b713) Thanks [@alcuadrado](https://github.com/alcuadrado)! - minor bump in hardhat-viem
+
+### Patch Changes
+
+- [\`a09c8a6\`](https://github.com/NomicFoundation/hardhat/commit/a09c8a6140ac75598d29c0b0550a36e745ffd3bb) Thanks [@alcuadrado](https://github.com/alcuadrado)! - patch bump in hardhat-ethers and hardhat-viem
+
+- Updated dependencies [[\`01b41ee\`](https://github.com/NomicFoundation/hardhat/commit/01b41ee70fe643a3bf6f98ef5f22298e80f66e5f), [\`e37f96c\`](https://github.com/NomicFoundation/hardhat/commit/e37f96c0c1b38fca41b8645042d51a649e7f5bda), [\`bda5a0a\`](https://github.com/NomicFoundation/hardhat/commit/bda5a0a7aeaccb8246fe3cdac050cab21e772629)]:
+  - @nomicfoundation/hardhat-errors@3.0.8
+  - @nomicfoundation/hardhat-utils@4.0.1
+  - hardhat@3.1.12
+
+`;
+
+        assert.equal(entry, expectedEntry);
+        assert.equal(HARDHAT_VIEM_CHANGELOG.slice(startIndex, endIndex), entry);
+      });
+
+      it("Should only affect the last entry", () => {
+        const { startIndex, endIndex } = getLastChangelogEntry(
+          HARDHAT_MOCHA_CHANGELOG,
+        );
+
+        const expectedBefore = `# @nomicfoundation/hardhat-mocha
+
+`;
+        const expectedAfter = `## 3.0.12
+
+### Patch Changes
+
+- 4ff11c1: Return typed result from test runners
+`;
+
+        assert.equal(
+          HARDHAT_MOCHA_CHANGELOG.slice(0, startIndex),
+          expectedBefore,
+        );
+        assert.equal(HARDHAT_MOCHA_CHANGELOG.slice(endIndex), expectedAfter);
+      });
+    });
+
+    describe("Dependencies list cleanup", () => {
+      it("should remove all links to Updated dependencies title, even if we didn't revert any bump", () => {
+        const { entry } = getLastChangelogEntry(HARDHAT_ETHERS_CHANGELOG);
+        const cleaned = cleanChangelogEntry(entry, new Set());
+
+        const expected = `## 4.0.7
+
+### Patch Changes
+
+- [\`a09c8a6\`](https://github.com/NomicFoundation/hardhat/commit/a09c8a6140ac75598d29c0b0550a36e745ffd3bb) Thanks [@alcuadrado](https://github.com/alcuadrado)! - patch bump in hardhat-ethers and hardhat-viem
+
+- Updated dependencies:
+  - @nomicfoundation/hardhat-errors@3.0.8
+  - @nomicfoundation/hardhat-utils@4.0.1
+  - hardhat@3.1.12
+
+`;
+
+        assert.equal(cleaned, expected);
+      });
+
+      it("should remove the reverted bumps from the list of dependencies in the Updated dependencies sections", () => {
+        const { entry } = getLastChangelogEntry(HARDHAT_VIEM_CHANGELOG);
+        const reverted = new Set(["hardhat"]);
+        const cleaned = cleanChangelogEntry(entry, reverted);
+
+        const expected = `## 4.0.0
+
+### Major Changes
+
+- [\`65236d1\`](https://github.com/NomicFoundation/hardhat/commit/65236d18b07abced51722b61179b12c20bc7b713) Thanks [@alcuadrado](https://github.com/alcuadrado)! - major bump in hardhat-viem
+
+### Minor Changes
+
+- [\`65236d1\`](https://github.com/NomicFoundation/hardhat/commit/65236d18b07abced51722b61179b12c20bc7b713) Thanks [@alcuadrado](https://github.com/alcuadrado)! - minor bump in hardhat-viem
+
+### Patch Changes
+
+- [\`a09c8a6\`](https://github.com/NomicFoundation/hardhat/commit/a09c8a6140ac75598d29c0b0550a36e745ffd3bb) Thanks [@alcuadrado](https://github.com/alcuadrado)! - patch bump in hardhat-ethers and hardhat-viem
+
+- Updated dependencies:
+  - @nomicfoundation/hardhat-errors@3.0.8
+  - @nomicfoundation/hardhat-utils@4.0.1
+
+`;
+
+        assert.equal(cleaned, expected);
+      });
+
+      it("should not remove the bumps that are intentionally applied from the list of dependencies in the Updated dependencies sections", () => {
+        const { entry } = getLastChangelogEntry(HARDHAT_MOCHA_CHANGELOG);
+        const reverted = new Set<string>();
+        const cleaned = cleanChangelogEntry(entry, reverted);
+
+        const expected = `## 3.0.13
+
+### Patch Changes
+
+- [#8051](https://github.com/NomicFoundation/hardhat/pull/8051) [\`e37f96c\`](https://github.com/NomicFoundation/hardhat/commit/e37f96c0c1b38fca41b8645042d51a649e7f5bda) Thanks [@schaable](https://github.com/schaable)! - Add \`TestRunResult\` type that wraps \`TestSummary\`, allowing plugins to extend test results with additional data
+
+- Updated dependencies:
+  - @nomicfoundation/hardhat-errors@3.0.8
+  - @nomicfoundation/hardhat-utils@4.0.1
+  - hardhat@3.1.12
+
+`;
+
+        assert.equal(cleaned, expected);
+      });
+
+      it('Should completely remove the "Updated dependencies" section when all dependencies are reverted', () => {
+        const { entry } = getLastChangelogEntry(HARDHAT_VIEM_CHANGELOG);
+        const reverted = new Set([
+          "@nomicfoundation/hardhat-errors",
+          "@nomicfoundation/hardhat-utils",
+          "hardhat",
+        ]);
+
+        const expectedEntry = `## 4.0.0
+
+### Major Changes
+
+- [\`65236d1\`](https://github.com/NomicFoundation/hardhat/commit/65236d18b07abced51722b61179b12c20bc7b713) Thanks [@alcuadrado](https://github.com/alcuadrado)! - major bump in hardhat-viem
+
+### Minor Changes
+
+- [\`65236d1\`](https://github.com/NomicFoundation/hardhat/commit/65236d18b07abced51722b61179b12c20bc7b713) Thanks [@alcuadrado](https://github.com/alcuadrado)! - minor bump in hardhat-viem
+
+### Patch Changes
+
+- [\`a09c8a6\`](https://github.com/NomicFoundation/hardhat/commit/a09c8a6140ac75598d29c0b0550a36e745ffd3bb) Thanks [@alcuadrado](https://github.com/alcuadrado)! - patch bump in hardhat-ethers and hardhat-viem
+
+`;
+
+        const cleaned = cleanChangelogEntry(entry, reverted);
+        assert.equal(cleaned, expectedEntry);
+      });
+    });
+  });
+});

--- a/scripts/bump-peers.ts
+++ b/scripts/bump-peers.ts
@@ -107,6 +107,14 @@ function apply(): void {
   // Revert automatic peer dependency bumps
   const modifications = revertPeerDependencies(packages);
 
+  // Snapshot reverted peers before intentional bumps are re-applied
+  const revertedPeers = new Map<string, Set<string>>();
+  for (const [pkgName, mod] of modifications) {
+    if (mod.peerChanges.size > 0) {
+      revertedPeers.set(pkgName, new Set(mod.peerChanges.keys()));
+    }
+  }
+
   // Apply intentional bumps
   applyIntentionalBumps(
     config.bumps,
@@ -114,6 +122,18 @@ function apply(): void {
     config.excludedFolders,
     modifications,
   );
+
+  // Remove re-applied bumps from reverted set
+  for (const bump of config.bumps) {
+    const peers = revertedPeers.get(bump.package);
+    if (peers !== undefined) {
+      peers.delete(bump.peer);
+      if (peers.size === 0) revertedPeers.delete(bump.package);
+    }
+  }
+
+  // Clean stale dependency references from CHANGELOGs
+  cleanChangelogs(revertedPeers, modifications);
 
   // Sync peer deps to dev deps
   syncPeerToDevDependencies(modifications);
@@ -137,6 +157,12 @@ DESCRIPTION
 
   1. Reverting all workspace peer dependency changes made by changesets
   2. Applying only intentional bumps declared in ${CONFIG_FILE}
+  3. Cleans up the "Updated dependencies" entry from the changelog when using
+    the GitHub changelog generator (i.e. process.env.GITHUB_TOKEN is set). This
+    does the following:
+      - Removes any reverted bumps from the list of dependencies
+      - Removes all the links from the "Updated dependencies" section, as
+        cleaning them up is too complex to be worth it.
 
 WORKFLOW
   1. Run \`pnpm changeset version --no-commit\`
@@ -479,6 +505,131 @@ function clearBumpsInConfig(): void {
 }
 
 // =============================================================================
+// Changelog Cleanup
+// =============================================================================
+
+function cleanChangelogs(
+  revertedPeers: Map<string, Set<string>>,
+  modifications: Map<string, PackageModification>,
+): void {
+  logStep("Cleaning CHANGELOGs");
+  if (process.env.GITHUB_TOKEN === undefined) {
+    log(fmt.deemphasize("  Skipping changelog cleanup: GITHUB_TOKEN not set"));
+    return;
+  }
+
+  // Collect all package paths that need changelog cleanup:
+  // 1. Packages in modifications (may have reverted peers)
+  // 2. All workspace packages (may have "Updated dependencies" sections to clean)
+  const packagesToClean = new Map<string, /* reverted peers */ Set<string>>();
+
+  // Add modified packages with their reverted peers
+  for (const [pkgName, mod] of modifications) {
+    const peers = revertedPeers.get(pkgName) ?? new Set<string>();
+    packagesToClean.set(mod.packagePath, peers);
+  }
+
+  // Also scan all workspace packages for "Updated dependencies" sections
+  const allPackages = getWorkspacePackages();
+  const changedFiles = new Set(
+    git(["diff", "--name-only", "HEAD", "--"])
+      .split("\n")
+      .filter((line) => line.length > 0),
+  );
+  for (const pkg of allPackages) {
+    if (packagesToClean.has(pkg.path)) {
+      continue;
+    }
+
+    // Normalize to POSIX separators so the comparison works on Windows,
+    // where relative() uses "\" but git always uses "/".
+    const relChangelog = relative(ROOT_DIR, resolve(pkg.path, "CHANGELOG.md"))
+      .split("\\")
+      .join("/");
+
+    // If the package's CHANGELOG hasn't been modified, we skip it.
+    if (!changedFiles.has(relChangelog)) {
+      continue;
+    }
+
+    packagesToClean.set(pkg.path, new Set<string>());
+  }
+
+  for (const [packagePath, peers] of packagesToClean) {
+    const changelogPath = resolve(packagePath, "CHANGELOG.md");
+    if (!existsSync(changelogPath)) continue;
+
+    const changelog = readFileSync(changelogPath, "utf-8");
+    const { entry, startIndex, endIndex } = getLastChangelogEntry(changelog);
+    if (entry === "") continue;
+
+    // Only process if the entry has "Updated dependencies" sections
+    if (!entry.includes("- Updated dependencies [")) continue;
+
+    const cleanedEntry = cleanChangelogEntry(entry, peers);
+
+    if (cleanedEntry !== entry) {
+      const newChangelog =
+        changelog.slice(0, startIndex) +
+        cleanedEntry +
+        changelog.slice(endIndex);
+      writeFileSync(changelogPath, newChangelog);
+      const pkgName = relative(ROOT_DIR, packagePath);
+      log(`  Cleaned CHANGELOG for ${fmt.pkg(pkgName)}`);
+    }
+  }
+}
+
+export function getLastChangelogEntry(changelog: string): {
+  entry: string;
+  startIndex: number;
+  endIndex: number;
+} {
+  const firstHeading = changelog.indexOf("\n## ");
+  if (firstHeading === -1) {
+    return { entry: "", startIndex: 0, endIndex: 0 };
+  }
+
+  const startIndex = firstHeading + 1; // skip the leading newline
+  const nextHeading = changelog.indexOf("\n## ", startIndex);
+  const endIndex = nextHeading === -1 ? changelog.length : nextHeading + 1;
+
+  return {
+    entry: changelog.slice(startIndex, endIndex),
+    startIndex,
+    endIndex,
+  };
+}
+
+export function cleanChangelogEntry(
+  entry: string,
+  revertedPeers: Set<string>,
+): string {
+  // Match "- Updated dependencies [<links>]:" blocks followed by indented dep lines.
+  // The leading \n is captured so it can be removed when the entire section is dropped.
+  const updatedDepsPattern =
+    /\n- Updated dependencies \[.*?\]:\n((?:  - .+\n)*)/gm;
+
+  return entry.replace(updatedDepsPattern, (_match, depBlock: string) => {
+    const depLines = depBlock.split("\n").filter((line) => line.length > 0);
+
+    const keptLines = depLines.filter((line) => {
+      // Extract package name from "  - @scope/pkg@version" or "  - pkg@version"
+      const depMatch = line.match(/^\s{2}- (.+)@/);
+      if (depMatch === null) return true;
+      return !revertedPeers.has(depMatch[1]);
+    });
+
+    if (keptLines.length === 0) {
+      // Remove the entire section including the preceding blank line
+      return "";
+    }
+
+    return `\n- Updated dependencies:\n${keptLines.join("\n")}\n`;
+  });
+}
+
+// =============================================================================
 // Package Helpers
 // =============================================================================
 
@@ -702,4 +853,6 @@ function logError(msg: string): void {
 // Run
 // =============================================================================
 
-main();
+if (import.meta.main) {
+  main();
+}

--- a/scripts/custom-changelog.ts
+++ b/scripts/custom-changelog.ts
@@ -1,13 +1,15 @@
 import defaultChangelog from "@changesets/cli/changelog";
+import githubChangelog from "@changesets/changelog-github";
+import util from "node:util";
 
-export default {
-  getReleaseLine: async (changeset, type, changelogOpts) => {
-    return defaultChangelog.getReleaseLine(changeset, type, changelogOpts);
-  },
+const hasGithubToken = process.env.GITHUB_TOKEN !== undefined;
 
-  // We do not want dependency releases included in
-  // our changelogs e.g. "  - Updated dependencies [e5ff273]"
-  getDependencyReleaseLine: async () => {
-    return "";
-  },
-};
+if (!hasGithubToken) {
+  console.log(
+    util.styleText(["bold", "yellow"], "WARNING:"),
+    "GITHUB_TOKEN is not set using default changelog locally",
+  );
+  console.log();
+}
+
+export default hasGithubToken ? githubChangelog : defaultChangelog;


### PR DESCRIPTION
This PR sets up `@changeset/changelog-github` on the CI, so that it automatically add links to the PRs in the changelog. Locally, it defaults to the standard changelog, because it needs a GITHUB_TOKEN.

It also enables the list of "Updated dependencies" generated by that packages, and updates `bump-peers.ts` to clean it up:
- Removing any reverted bump
- Removing all the links of the "Updated dependencies" title (to keep the scope smaller)

This CHANGELOG.md process only happens on CI.