### PR TITLE
Remove mock changesets and peer-bump

### DIFF
--- a/.changeset/test1.md
+++ b/.changeset/test1.md
@@ -1,6 +1,0 @@
----
-"hardhat": patch
-"@nomicfoundation/hardhat-ethers": patch
----
-
-Test 1: This will create an unintended bump in ethers of hardhat, so the entire "Updated dependencies" section will be removed

--- a/.changeset/test2.md
+++ b/.changeset/test2.md
@@ -1,6 +1,0 @@
----
-"hardhat": patch
-"@nomicfoundation/hardhat-viem": patch
----
-
-Test 1: This will create an unintended bump in viem of hardhat, but that we'll reapply with a peer-bump

--- a/.changeset/test3.md
+++ b/.changeset/test3.md
@@ -1,7 +1,0 @@
----
-"hardhat": patch
-"@nomicfoundation/hardhat-node-test-runner": patch
-"@nomicfoundation/hardhat-node-test-reporter": patch
----
-
-Test 3: This will create an unintended bump in node-test-retunner of hardhat, which will be removed, but the entire "Updated dependencies" section will be kept because we also bump hardhat-node-test-reporter

--- a/.changeset/test4.md
+++ b/.changeset/test4.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/hardhat-vendored": patch
----
-
-Test 4: This will create a bump in hardhat, which won't be removed. Only its "Updated dependencies" title will be cleaned up.

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -6,11 +6,5 @@
     "v-next/hardhat/templates",
     "v-next/config"
   ],
-  "bumps": [
-    {
-      "package": "@nomicfoundation/hardhat-viem",
-      "peer": "hardhat",
-      "reason": "test"
-    }
-  ]
+  "bumps": []
 }


### PR DESCRIPTION
After having validated that #8054 worked correctly using [this commit](https://github.com/NomicFoundation/hardhat/pull/8055/changes/0289978d62cc51de4903f1c18232ea7536f115fe), this PR removes the mock changesets and peer-bump.