### PR TITLE
fixes for createServer

### DIFF
--- a/.changeset/cyan-dogs-ask.md
+++ b/.changeset/cyan-dogs-ask.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Updated `network.createServer` signature to type non-generic chainTypes

--- a/.changeset/petite-teams-slide.md
+++ b/.changeset/petite-teams-slide.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-errors": patch
+"hardhat": patch
+---
+
+Added guard against `http` network configs in `network.createServer(...)`

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -1050,6 +1050,14 @@ account, and its parameters are incompatible. You sent both gasPrice and authori
 
 Please double check your transactions' parameters.`,
       },
+      CREATE_SERVER_UNSUPPORTED_NETWORK_TYPE: {
+        number: 724,
+        messageTemplate:
+          'Cannot create a server for network "{networkName}" because it has type "{networkType}". Only "edr-simulated" networks are supported.',
+        websiteTitle: "Unsupported network type for createServer",
+        websiteDescription:
+          "The createServer method only supports 'edr-simulated' networks. HTTP networks cannot be used to create a local JSON-RPC server.",
+      },
     },
     SOLIDITY_TESTS: {
       BUILD_INFO_NOT_FOUND_FOR_CONTRACT: {

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -117,6 +117,8 @@ export class NetworkManagerImplementation implements NetworkManager {
     _hostname?: string,
     port?: number,
   ): Promise<JsonRpcServer> {
+    this.#ensureNetworkOrParamsIsNotHttpNetworkConfig(networkOrParams);
+
     const insideDocker = await exists("/.dockerenv");
     const hostname = _hostname ?? (insideDocker ? "0.0.0.0" : "127.0.0.1");
 
@@ -435,5 +437,28 @@ export class NetworkManagerImplementation implements NetworkManager {
     }
 
     return path;
+  }
+
+  #ensureNetworkOrParamsIsNotHttpNetworkConfig(
+    networkOrParams: NetworkConnectionParams<string> | string,
+  ) {
+    const networkName =
+      typeof networkOrParams === "string"
+        ? networkOrParams
+        : networkOrParams.network ?? this.#defaultNetwork;
+
+    const networkConfig = this.#networkConfigs[networkName];
+
+    if (networkConfig === undefined || networkConfig.type === "edr-simulated") {
+      return;
+    }
+
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.NETWORK.CREATE_SERVER_UNSUPPORTED_NETWORK_TYPE,
+      {
+        networkName,
+        networkType: networkConfig.type,
+      },
+    );
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -113,7 +113,7 @@ export class NetworkManagerImplementation implements NetworkManager {
   public async createServer<
     ChainTypeT extends ChainType | string = DefaultChainType,
   >(
-    networkOrParams: NetworkConnectionParams<ChainTypeT> | string = "default",
+    networkOrParams?: NetworkConnectionParams<ChainTypeT> | string,
     _hostname?: string,
     port?: number,
   ): Promise<JsonRpcServer> {
@@ -440,12 +440,12 @@ export class NetworkManagerImplementation implements NetworkManager {
   }
 
   #ensureNetworkOrParamsIsNotHttpNetworkConfig(
-    networkOrParams: NetworkConnectionParams<string> | string,
+    networkOrParams?: NetworkConnectionParams<string> | string,
   ) {
     const networkName =
       typeof networkOrParams === "string"
         ? networkOrParams
-        : networkOrParams.network ?? this.#defaultNetwork;
+        : networkOrParams?.network ?? this.#defaultNetwork;
 
     const networkConfig = this.#networkConfigs[networkName];
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -110,8 +110,10 @@ export class NetworkManagerImplementation implements NetworkManager {
     return networkConnection as NetworkConnection<ChainTypeT>;
   }
 
-  public async createServer(
-    networkOrParams: NetworkConnectionParams | string = "default",
+  public async createServer<
+    ChainTypeT extends ChainType | string = DefaultChainType,
+  >(
+    networkOrParams: NetworkConnectionParams<ChainTypeT> | string = "default",
     _hostname?: string,
     port?: number,
   ): Promise<JsonRpcServer> {

--- a/v-next/hardhat/src/types/network.ts
+++ b/v-next/hardhat/src/types/network.ts
@@ -62,8 +62,8 @@ export interface NetworkManager {
    *
    * @return A `JsonRpcServer` instance that can be started with {@link JsonRpcServer.listen}.
    */
-  createServer(
-    networkOrParams?: NetworkConnectionParams | string,
+  createServer<ChainTypeT extends ChainType | string = DefaultChainType>(
+    networkOrParams?: NetworkConnectionParams<ChainTypeT> | string,
     hostname?: string,
     port?: number,
   ): Promise<JsonRpcServer>;

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -846,6 +846,22 @@ describe("NetworkManagerImplementation", () => {
   });
 
   describe("createServer", function () {
+    it("should throw an error if the network type is not edr-simulated", async () => {
+      await assertRejectsWithHardhatError(
+        networkManager.createServer("localhost"),
+        HardhatError.ERRORS.CORE.NETWORK.CREATE_SERVER_UNSUPPORTED_NETWORK_TYPE,
+        { networkName: "localhost", networkType: "http" },
+      );
+    });
+
+    it("should throw an error if network parameters specify an http network", async () => {
+      await assertRejectsWithHardhatError(
+        networkManager.createServer({ network: "localhost" }),
+        HardhatError.ERRORS.CORE.NETWORK.CREATE_SERVER_UNSUPPORTED_NETWORK_TYPE,
+        { networkName: "localhost", networkType: "http" },
+      );
+    });
+
     it("connects to a network and returns a JsonRpcServer that wraps around it", async () => {
       const server = await networkManager.createServer(
         "edrNetwork",

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -851,12 +851,34 @@ describe("NetworkManagerImplementation", () => {
         "edrNetwork",
         "127.0.0.1",
       );
+
       const { address, port } = await server.listen();
+
       try {
         const { provider } = await networkManager.connect({
           network: "localhost",
           override: { url: `http://${address}:${port}` },
         });
+        await provider.request({ method: "eth_chainId" });
+      } finally {
+        await server.close();
+      }
+    });
+
+    it("connects to a network based on network parameters and returns a JsonRpcServer that wraps around it", async () => {
+      const server = await networkManager.createServer(
+        { network: "edrNetwork", chainType: "op" },
+        "127.0.0.1",
+      );
+
+      const { address, port } = await server.listen();
+
+      try {
+        const { provider } = await networkManager.connect({
+          network: "localhost",
+          override: { url: `http://${address}:${port}` },
+        });
+
         await provider.request({ method: "eth_chainId" });
       } finally {
         await server.close();


### PR DESCRIPTION
This includes two small changes but touches the type of `network.createServer`.

1. It alters the network parameters type to allow chain types other than `generic`
2. It throws if `createServer` is used against a network config that is not `edr-simulated` (copying the pattern in `npx hardhat node`)

The changes are commit at a time.

## createServer Type

The current type would show an error for the following code:

```ts
import { network } from "hardhat";

const server = await network.createServer(
  {
    network: "edrOp",
    chainType: "op", // <------ error: expected "generic"
  },
  "0.0.0.0",
  8545,
);
```

This PR accepts `op` without a type error. An alternative is to say that `chainType` makes no sense for the `createServer` method and `Omit<>` the property from the `createServer` interface.