### PR TITLE
Fix JSON-RPC handler losing revert data for non-ProviderError errors

### DIFF
--- a/.changeset/cuddly-cycles-drum.md
+++ b/.changeset/cuddly-cycles-drum.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed bug to preserve revert data in JSON-RPC responses for non-ProviderErrors ([8061](https://github.com/NomicFoundation/hardhat/pull/8061)).

--- a/v-next/hardhat/src/internal/builtin-plugins/node/json-rpc/handler.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/node/json-rpc/handler.ts
@@ -250,6 +250,12 @@ const _readWsRequest = (msg: string): JsonRpcRequest | JsonRpcRequest[] => {
 };
 
 const _handleError = (error: Error): JsonRpcResponse => {
+  // Extract revert data from the original error before potentially wrapping it.
+  // Non-ProviderError errors (e.g. SolidityError) carry .data and .transactionHash
+  // that would be lost when wrapped in InternalError below.
+  const txHash = extractTxHash(error);
+  const returnData = extractReturnData(error);
+
   // In case of non-hardhat error, treat it as internal and associate the appropriate error code.
   if (!ProviderError.isProviderError(error)) {
     error = new InternalError(undefined, error);
@@ -266,8 +272,8 @@ const _handleError = (error: Error): JsonRpcResponse => {
       message: error.message,
       data: {
         message: error.message,
-        txHash: extractTxHash(error),
-        data: extractReturnData(error),
+        txHash,
+        data: returnData,
       },
     },
   };

--- a/v-next/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts
@@ -64,6 +64,15 @@ describe("JSON-RPC handler", async function () {
       };
       throw err;
     },
+    nonProviderErrorWithRevertData: () => {
+      // Simulates SolidityError: a non-ProviderError with .data and .transactionHash
+      const err = new Error("revert Unauthorized");
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- allow in test
+      (err as any).data = "0xdeadbeef";
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- allow in test
+      (err as any).transactionHash = "0xabc123";
+      throw err;
+    },
   });
   const server = new JsonRpcServerImplementation({
     hostname,
@@ -297,6 +306,29 @@ describe("JSON-RPC handler", async function () {
     );
     assert.equal(rpcRes.error.data.txHash, "0xbeef");
     assert.equal(rpcRes.error.data.data, "0xabad1dea");
+  });
+
+  it("should preserve revert data from non-ProviderError errors", async function () {
+    // Simulates SolidityError which has .data and .transactionHash but is NOT a ProviderError
+    const rpcReq: JsonRpcRequest = {
+      jsonrpc: "2.0",
+      method: "nonProviderErrorWithRevertData",
+      id: 1,
+    };
+
+    const rpcRes = await postRawJsonRpc(hostname, port, JSON.stringify(rpcReq));
+
+    assert.ok(
+      isJsonRpcResponse(rpcRes) && isFailedJsonRpcResponse(rpcRes),
+      "Expected a failed JSON-RPC response",
+    );
+    assert.equal(rpcRes.error.code, InternalError.CODE);
+    assert.ok(
+      isObject(rpcRes.error.data),
+      "Expected error data to be an object",
+    );
+    assert.equal(rpcRes.error.data.txHash, "0xabc123");
+    assert.equal(rpcRes.error.data.data, "0xdeadbeef");
   });
 });
 


### PR DESCRIPTION
# Summary
- Fix JSON-RPC handler losing revert data `(txHash, returnData)` for **non-ProviderError** errors (e.g. SolidityError)
- Add unit test verifying revert data preservation through the JSON-RPC HTTP layer

This bug only affects the Hardhat node (HTTP) because it is exclusive to the JSON-RPC serialization path, whereas in-process EDR passes errors as raw JavaScript objects, bypassing serialization entirely.

# Problem
`_handleError` in `handler.ts` wrapped non-ProviderError errors in InternalError before calling `extractTxHash()` and `extractReturnData()`. Since InternalError doesn't carry .data or .transactionHash, all revert information was lost in the JSON-RPC response.

This broke every revert-checking assertion (.revertedWithCustomError(), .revertedWith(), .revertedWithPanic(), etc.) when running tests against hardhat node over HTTP/WebSocket. In-process EDR tests were unaffected.

# Fix
Move the two extraction calls above the wrapping to preserve the info.