### PR TITLE
Add `--gas-stats-json` global option for JSON gas stats export

### DIFF
--- a/.changeset/wet-apes-kick.md
+++ b/.changeset/wet-apes-kick.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/hardhat-node-test-runner": minor
+"@nomicfoundation/hardhat-mocha": minor
+"hardhat": minor
+---
+
+Add `--gas-stats-json <path>` global option to write gas usage statistics to a JSON file ([#7990](https://github.com/NomicFoundation/hardhat/issues/7990)).

--- a/.changeset/wet-apes-kick.md
+++ b/.changeset/wet-apes-kick.md
@@ -1,7 +1,7 @@
 ---
-"@nomicfoundation/hardhat-node-test-runner": minor
-"@nomicfoundation/hardhat-mocha": minor
-"@nomicfoundation/hardhat-errors": minor
+"@nomicfoundation/hardhat-node-test-runner": patch
+"@nomicfoundation/hardhat-mocha": patch
+"@nomicfoundation/hardhat-errors": patch
 "hardhat": minor
 ---
 

--- a/.changeset/wet-apes-kick.md
+++ b/.changeset/wet-apes-kick.md
@@ -1,6 +1,7 @@
 ---
 "@nomicfoundation/hardhat-node-test-runner": minor
 "@nomicfoundation/hardhat-mocha": minor
+"@nomicfoundation/hardhat-errors": minor
 "hardhat": minor
 ---
 

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -6,5 +6,16 @@
     "v-next/hardhat/templates",
     "v-next/config"
   ],
-  "bumps": []
+  "bumps": [
+    {
+      "package": "@nomicfoundation/hardhat-mocha",
+      "peer": "hardhat",
+      "reason": "hardhat-mocha now reads hre.globalOptions.gasStatsJson, which is only present in the hardhat version that added the --gas-stats-json global option"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-node-test-runner",
+      "peer": "hardhat",
+      "reason": "hardhat-node-test-runner now reads hre.globalOptions.gasStatsJson, which is only present in the hardhat version that added the --gas-stats-json global option"
+    }
+  ]
 }

--- a/v-next/hardhat-errors/src/descriptors.ts
+++ b/v-next/hardhat-errors/src/descriptors.ts
@@ -855,6 +855,14 @@ Please double check your arguments.`,
 
 Please double check your script's path.`,
       },
+      INVALID_FILE_PATH: {
+        number: 601,
+        messageTemplate: `The path "{path}" is a directory. A file path was expected.`,
+        websiteTitle: "Invalid file path",
+        websiteDescription: `A file path was expected, but a directory was provided.
+
+Please specify a valid file path.`,
+      },
     },
     NETWORK: {
       INVALID_URL: {

--- a/v-next/hardhat-mocha/src/task-action.ts
+++ b/v-next/hardhat-mocha/src/task-action.ts
@@ -123,7 +123,8 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
     if (
       hre.globalOptions.coverage === true ||
-      hre.globalOptions.gasStats === true
+      hre.globalOptions.gasStats === true ||
+      hre.globalOptions.gasStatsJson !== undefined
     ) {
       const testWorkerDone = new URL(
         import.meta.resolve("@nomicfoundation/hardhat-mocha/test-worker-done"),

--- a/v-next/hardhat-node-test-runner/src/task-action.ts
+++ b/v-next/hardhat-node-test-runner/src/task-action.ts
@@ -95,7 +95,8 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
   if (
     hre.globalOptions.coverage === true ||
-    hre.globalOptions.gasStats === true
+    hre.globalOptions.gasStats === true ||
+    hre.globalOptions.gasStatsJson !== undefined
   ) {
     const testWorkerDone = new URL(
       import.meta.resolve(

--- a/v-next/hardhat-utils/src/env.ts
+++ b/v-next/hardhat-utils/src/env.ts
@@ -7,7 +7,7 @@ import { camelToSnakeCase } from "./string.js";
  * with each option adhering to its definition in the globalOptionDefinitions.
  */
 export function setGlobalOptionsAsEnvVariables<
-  T extends Record<keyof T, string | boolean>,
+  T extends Record<keyof T, string | boolean | undefined>,
 >(globalOptions: T): void {
   for (const [name, value] of Object.entries(globalOptions)) {
     const envName = getEnvVariableNameFromGlobalOption(name);

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -1,4 +1,10 @@
-import type { GasAnalyticsManager, GasMeasurement } from "./types.js";
+import type {
+  ContractGasStatsJson,
+  GasAnalyticsManager,
+  GasMeasurement,
+  GasStatsJson,
+  GasStatsJsonEntry,
+} from "./types.js";
 import type { TableItem } from "@nomicfoundation/hardhat-utils/format";
 
 import crypto from "node:crypto";
@@ -15,6 +21,8 @@ import {
 import { findDuplicates } from "@nomicfoundation/hardhat-utils/lang";
 import chalk from "chalk";
 import debug from "debug";
+
+import { parseFullyQualifiedName } from "../../../utils/contract-names.js";
 
 const gasStatsLog = debug(
   "hardhat:core:gas-analytics:gas-analytics-manager:gas-stats",
@@ -92,6 +100,26 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
     console.log(report);
     console.log();
     gasStatsLog("Printed markdown report");
+  }
+
+  public async writeGasStatsJson(
+    outputPath: string,
+    ...ids: string[]
+  ): Promise<void> {
+    if (!this.#reportEnabled) {
+      return;
+    }
+
+    await this._loadGasMeasurements(...ids);
+
+    const gasStatsByContract = this._calculateGasStats();
+
+    const resolvedPath = path.resolve(outputPath);
+    await ensureDir(path.dirname(resolvedPath));
+
+    const json = this._generateGasStatsJson(gasStatsByContract);
+    await writeJsonFile(resolvedPath, json);
+    gasStatsLog("Written gas stats JSON to", resolvedPath);
   }
 
   public enableReport(): void {
@@ -304,6 +332,46 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
     }
 
     return formatTable(rows);
+  }
+
+  /**
+   * @private exposed for testing purposes only
+   */
+  public _generateGasStatsJson(
+    gasStatsByContract: GasStatsByContract,
+  ): GasStatsJson {
+    const sortedContracts = [...gasStatsByContract.entries()]
+      .map(([internalFqn, stats]) => ({
+        userFqn: getUserFqn(internalFqn),
+        stats,
+      }))
+      .sort((a, b) => a.userFqn.localeCompare(b.userFqn));
+
+    const contracts: Record<string, ContractGasStatsJson> = {};
+
+    for (const { userFqn, stats } of sortedContracts) {
+      const { sourceName, contractName } = parseFullyQualifiedName(userFqn);
+
+      const deployment: GasStatsJsonEntry | null =
+        stats.deployment !== undefined ? { ...stats.deployment } : null;
+
+      let functions: Record<string, GasStatsJsonEntry> | null = null;
+      if (stats.functions.size > 0) {
+        functions = {};
+        // Sort functions by removing trailing ) and comparing alphabetically.
+        // This ensures that overloaded functions with fewer params come first
+        // (e.g., foo(uint256) comes before foo(uint256,uint256)). In other
+        // scenarios, removing the trailing ) has no effect on the order.
+        const sortedFunctions = [...stats.functions.entries()].sort(
+          ([a], [b]) => a.split(")")[0].localeCompare(b.split(")")[0]),
+        );
+        functions = Object.fromEntries(sortedFunctions);
+      }
+
+      contracts[userFqn] = { sourceName, contractName, deployment, functions };
+    }
+
+    return { contracts };
   }
 }
 

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -10,10 +10,13 @@ import type { TableItem } from "@nomicfoundation/hardhat-utils/format";
 import crypto from "node:crypto";
 import path from "node:path";
 
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { formatTable } from "@nomicfoundation/hardhat-utils/format";
 import {
   ensureDir,
+  exists,
   getAllFilesMatching,
+  isDirectory,
   readJsonFile,
   remove,
   writeJsonFile,
@@ -115,6 +118,12 @@ export class GasAnalyticsManagerImplementation implements GasAnalyticsManager {
     const gasStatsByContract = this._calculateGasStats();
 
     const resolvedPath = path.resolve(outputPath);
+    if ((await exists(resolvedPath)) && (await isDirectory(resolvedPath))) {
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.BUILTIN_TASKS.INVALID_FILE_PATH,
+        { path: outputPath },
+      );
+    }
     await ensureDir(path.dirname(resolvedPath));
 
     const json = this._generateGasStatsJson(gasStatsByContract);

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/hre.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/hre.ts
@@ -5,7 +5,10 @@ import { setGasAnalyticsManager } from "../helpers.js";
 
 export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
   created: async (context, hre) => {
-    if (context.globalOptions.gasStats) {
+    if (
+      context.globalOptions.gasStats ||
+      context.globalOptions.gasStatsJson !== undefined
+    ) {
       const gasAnalyticsManager = new GasAnalyticsManagerImplementation(
         hre.config.paths.cache,
       );

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/test.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/hook-handlers/test.ts
@@ -19,11 +19,18 @@ export default async (): Promise<Partial<TestHooks>> => ({
   },
 });
 
+function isGasStatsEnabled(context: HookContext): boolean {
+  return (
+    context.globalOptions.gasStats === true ||
+    context.globalOptions.gasStatsJson !== undefined
+  );
+}
+
 export async function testRunStart(
   context: HookContext,
   id: string,
 ): Promise<void> {
-  if (context.globalOptions.gasStats === true) {
+  if (isGasStatsEnabled(context)) {
     await getGasAnalyticsManager(context).clearGasMeasurements(id);
   }
 }
@@ -32,7 +39,7 @@ export async function testWorkerDone(
   context: HookContext,
   id: string,
 ): Promise<void> {
-  if (context.globalOptions.gasStats === true) {
+  if (isGasStatsEnabled(context)) {
     await getGasAnalyticsManager(context).saveGasMeasurements(id);
   }
 }
@@ -43,5 +50,11 @@ export async function testRunDone(
 ): Promise<void> {
   if (context.globalOptions.gasStats === true) {
     await getGasAnalyticsManager(context).reportGasStats(id);
+  }
+  if (context.globalOptions.gasStatsJson !== undefined) {
+    await getGasAnalyticsManager(context).writeGasStatsJson(
+      context.globalOptions.gasStatsJson,
+      id,
+    );
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
@@ -48,7 +48,7 @@ const hardhatPlugin: HardhatPlugin = {
       name: "gasStatsJson",
       description:
         "Write gas usage statistics to a JSON file at the specified path",
-      type: ArgumentType.STRING_WITHOUT_DEFAULT,
+      type: ArgumentType.FILE_WITHOUT_DEFAULT,
       defaultValue: undefined,
     }),
   ],

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
@@ -1,6 +1,7 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
-import { globalFlag, overrideTask } from "../../core/config.js";
+import { ArgumentType } from "../../../types/arguments.js";
+import { globalFlag, globalOption, overrideTask } from "../../core/config.js";
 
 import "./type-extensions.js";
 
@@ -42,6 +43,13 @@ const hardhatPlugin: HardhatPlugin = {
       name: "gasStats",
       description:
         "Collects and displays gas usage statistics for all function calls during tests",
+    }),
+    globalOption({
+      name: "gasStatsJson",
+      description:
+        "Write gas usage statistics to a JSON file at the specified path",
+      type: ArgumentType.STRING_WITHOUT_DEFAULT,
+      defaultValue: undefined,
     }),
   ],
   hookHandlers: {

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/type-extensions.ts
@@ -2,6 +2,6 @@ import "../../../types/global-options.js";
 declare module "../../../types/global-options.js" {
   export interface GlobalOptions {
     gasStats: boolean;
-    gasStatsJson: string;
+    gasStatsJson: string | undefined;
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/type-extensions.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/type-extensions.ts
@@ -2,5 +2,6 @@ import "../../../types/global-options.js";
 declare module "../../../types/global-options.js" {
   export interface GlobalOptions {
     gasStats: boolean;
+    gasStatsJson: string;
   }
 }

--- a/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/types.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/gas-analytics/types.ts
@@ -1,3 +1,36 @@
+/**
+ * Gas statistics for a single function call or deployment (min/max/avg/median/count).
+ */
+export interface GasStatsJsonEntry {
+  min: number;
+  max: number;
+  avg: number;
+  median: number;
+  count: number;
+}
+
+/**
+ * Gas statistics for a single contract in the JSON output.
+ * `deployment` is null when the contract was never deployed during the test run
+ * (e.g. deployed by a factory or via forking). `functions` is null when the
+ * contract was deployed but no functions were called.
+ */
+export interface ContractGasStatsJson {
+  sourceName: string;
+  contractName: string;
+  deployment: GasStatsJsonEntry | null;
+  functions: Record<string, GasStatsJsonEntry> | null;
+}
+
+/**
+ * Top-level JSON output shape produced by `--gas-stats-json`.
+ * Contract keys are user-friendly FQNs (e.g. `contracts/Foo.sol:Foo`),
+ * sorted alphabetically.
+ */
+export interface GasStatsJson {
+  contracts: Record<string, ContractGasStatsJson>;
+}
+
 interface BaseGasMeasurement {
   contractFqn: string;
   gas: number;
@@ -21,6 +54,7 @@ export interface GasAnalyticsManager {
   clearGasMeasurements(id: string): Promise<void>;
   saveGasMeasurements(id: string): Promise<void>;
   reportGasStats(...ids: string[]): Promise<void>;
+  writeGasStatsJson(outputPath: string, ...ids: string[]): Promise<void>;
 
   enableReport(): void;
   disableReport(): void;

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -169,7 +169,9 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
       verbosity,
       observability: observabilityConfig,
       testPattern: grep,
-      generateGasReport: hre.globalOptions.gasStats,
+      generateGasReport:
+        hre.globalOptions.gasStats ||
+        hre.globalOptions.gasStatsJson !== undefined,
     });
   const tracingConfig: TracingConfigWithBuffers = {
     buildInfos,

--- a/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -74,7 +74,10 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
     getCoverageManager(hre).disableReport();
   }
 
-  if (hre.globalOptions.gasStats === true) {
+  if (
+    hre.globalOptions.gasStats === true ||
+    hre.globalOptions.gasStatsJson !== undefined
+  ) {
     getGasAnalyticsManager(hre).disableReport();
   }
 
@@ -235,11 +238,24 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
     console.log();
   }
 
-  if (hre.globalOptions.gasStats === true) {
+  if (
+    hre.globalOptions.gasStats === true ||
+    hre.globalOptions.gasStatsJson !== undefined
+  ) {
     const gasAnalytics = getGasAnalyticsManager(hre);
     gasAnalytics.enableReport();
-    await gasAnalytics.reportGasStats(...ranSubtaskIds);
-    console.log();
+
+    if (hre.globalOptions.gasStats === true) {
+      await gasAnalytics.reportGasStats(...ranSubtaskIds);
+      console.log();
+    }
+
+    if (hre.globalOptions.gasStatsJson !== undefined) {
+      await gasAnalytics.writeGasStatsJson(
+        hre.globalOptions.gasStatsJson,
+        ...ranSubtaskIds,
+      );
+    }
   }
 
   if (hasFailures) {

--- a/v-next/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -1,4 +1,7 @@
-import type { GasMeasurement } from "../../../../src/internal/builtin-plugins/gas-analytics/types.js";
+import type {
+  GasMeasurement,
+  GasStatsJson,
+} from "../../../../src/internal/builtin-plugins/gas-analytics/types.js";
 
 import assert from "node:assert/strict";
 import path from "node:path";
@@ -20,6 +23,7 @@ import {
   getFunctionName,
   GasAnalyticsManagerImplementation,
 } from "../../../../src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.js";
+import { getFullyQualifiedName } from "../../../../src/utils/contract-names.js";
 
 describe("gas-analytics-manager", () => {
   disableConsole();
@@ -1092,6 +1096,358 @@ describe("gas-analytics-manager", () => {
           mintUint256Line < mintBytesLine,
           "mint(uint256) should come before mint(uint256,bytes)",
         );
+      });
+    });
+
+    describe("_generateGasStatsJson", () => {
+      it("should return empty contracts object when no measurements", () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const result = manager._generateGasStatsJson(new Map());
+        assert.deepEqual(result, { contracts: {} });
+      });
+
+      it("should include both deployment and functions stats", () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        const stats = manager._calculateGasStats();
+        const result = manager._generateGasStatsJson(stats);
+
+        const contract =
+          result.contracts["contracts/MyContract.sol:MyContract"];
+        assert.ok(contract !== undefined, "contract entry should exist");
+        assert.equal(contract.sourceName, "contracts/MyContract.sol");
+        assert.equal(contract.contractName, "MyContract");
+        assert.deepEqual(contract.deployment, {
+          min: 500000,
+          max: 500000,
+          avg: 500000,
+          median: 500000,
+          count: 1,
+        });
+        assert.ok(contract.functions !== null, "functions should not be null");
+        assert.deepEqual(contract.functions.transfer, {
+          min: 25000,
+          max: 25000,
+          avg: 25000,
+          median: 25000,
+          count: 1,
+        });
+      });
+
+      it("should set deployment to null when contract has only function calls", () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/Token.sol:Token",
+          functionSig: "balanceOf(address)",
+          gas: 15000,
+        });
+        const stats = manager._calculateGasStats();
+        const result = manager._generateGasStatsJson(stats);
+
+        const contract = result.contracts["contracts/Token.sol:Token"];
+        assert.ok(contract !== undefined, "contract entry should exist");
+        assert.equal(contract.deployment, null);
+        assert.ok(contract.functions !== null, "functions should not be null");
+      });
+
+      it("should set functions to null when contract has only deployments", () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/Factory.sol:Factory",
+          gas: 300000,
+          size: 1024,
+        });
+        const stats = manager._calculateGasStats();
+        const result = manager._generateGasStatsJson(stats);
+
+        const contract = result.contracts["contracts/Factory.sol:Factory"];
+        assert.ok(contract !== undefined, "contract entry should exist");
+        assert.ok(
+          contract.deployment !== null,
+          "deployment should not be null",
+        );
+        assert.equal(contract.functions, null);
+      });
+
+      it("should sort contracts alphabetically by user-friendly FQN", () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/ZContract.sol:ZContract",
+          gas: 100000,
+          size: 512,
+        });
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/AContract.sol:AContract",
+          gas: 200000,
+          size: 512,
+        });
+        const stats = manager._calculateGasStats();
+        const result = manager._generateGasStatsJson(stats);
+
+        const keys = Object.keys(result.contracts);
+        assert.equal(keys[0], "contracts/AContract.sol:AContract");
+        assert.equal(keys[1], "contracts/ZContract.sol:ZContract");
+      });
+
+      it("should sort functions alphabetically within a contract", () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/Token.sol:Token",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/Token.sol:Token",
+          functionSig: "approve(address,uint256)",
+          gas: 46000,
+        });
+        const stats = manager._calculateGasStats();
+        const result = manager._generateGasStatsJson(stats);
+
+        const tokenContract = result.contracts["contracts/Token.sol:Token"];
+        assert.ok(tokenContract !== undefined, "token contract should exist");
+        assert.ok(
+          tokenContract.functions !== null,
+          "functions should not be null",
+        );
+        const fns = Object.keys(tokenContract.functions);
+        assert.equal(fns[0], "approve");
+        assert.equal(fns[1], "transfer");
+      });
+
+      it("should use full signatures as keys for overloaded functions", () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/Token.sol:Token",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/Token.sol:Token",
+          functionSig: "transfer(address,uint256,bytes)",
+          gas: 35000,
+        });
+        const stats = manager._calculateGasStats();
+        const result = manager._generateGasStatsJson(stats);
+
+        const overloadedContract =
+          result.contracts["contracts/Token.sol:Token"];
+        assert.ok(overloadedContract !== undefined, "contract should exist");
+        assert.ok(
+          overloadedContract.functions !== null,
+          "functions should not be null",
+        );
+        assert.ok(
+          "transfer(address,uint256)" in overloadedContract.functions,
+          "overloaded function should use full signature",
+        );
+        assert.ok(
+          "transfer(address,uint256,bytes)" in overloadedContract.functions,
+          "overloaded function should use full signature",
+        );
+      });
+
+      it("should strip project/ prefix from contract keys via getUserFqn", () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 100000,
+          size: 512,
+        });
+        const stats = manager._calculateGasStats();
+        const result = manager._generateGasStatsJson(stats);
+
+        assert.ok(
+          "contracts/MyContract.sol:MyContract" in result.contracts,
+          "key should not have project/ prefix",
+        );
+        assert.ok(
+          !("project/contracts/MyContract.sol:MyContract" in result.contracts),
+          "key with project/ prefix should not exist",
+        );
+      });
+
+      it("should strip npm package version from contract keys", () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn:
+            "npm/@openzeppelin/contracts@5.0.0/token/ERC20/ERC20.sol:ERC20",
+          functionSig: "approve(address,uint256)",
+          gas: 46200,
+        });
+        const stats = manager._calculateGasStats();
+        const result = manager._generateGasStatsJson(stats);
+
+        const key = "@openzeppelin/contracts/token/ERC20/ERC20.sol:ERC20";
+        assert.ok(key in result.contracts, "key should not have npm version");
+        const erc20Contract = result.contracts[key];
+        assert.ok(erc20Contract !== undefined, "ERC20 contract should exist");
+        assert.equal(
+          erc20Contract.sourceName,
+          "@openzeppelin/contracts/token/ERC20/ERC20.sol",
+        );
+        assert.equal(erc20Contract.contractName, "ERC20");
+      });
+
+      it("should match artifact format — FQN key equals getFullyQualifiedName(sourceName, contractName)", () => {
+        const sourceName = "contracts/MyToken.sol";
+        const contractName = "MyToken";
+        const internalFqn = `project/${sourceName}:${contractName}`;
+
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: internalFqn,
+          gas: 250000,
+          size: 1024,
+        });
+        const stats = manager._calculateGasStats();
+        const result = manager._generateGasStatsJson(stats);
+
+        const expectedKey = getFullyQualifiedName(sourceName, contractName);
+        const contract = result.contracts[expectedKey];
+
+        assert.ok(
+          contract !== undefined,
+          `contract should exist at key ${expectedKey}`,
+        );
+        assert.equal(contract.sourceName, sourceName);
+        assert.equal(contract.contractName, contractName);
+      });
+    });
+
+    describe("writeGasStatsJson", () => {
+      afterEach(async () => {
+        await emptyDir(tmpDir);
+      });
+
+      it("should write JSON file at the specified path", async () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        await manager.saveGasMeasurements("test-id");
+
+        const outputPath = path.join(tmpDir, "gas-output.json");
+        await manager.writeGasStatsJson(outputPath, "test-id");
+
+        const json = await readJsonFile<GasStatsJson>(outputPath);
+        assert.ok(
+          "contracts/MyContract.sol:MyContract" in json.contracts,
+          "output should contain the contract",
+        );
+        const writtenContract =
+          json.contracts["contracts/MyContract.sol:MyContract"];
+        assert.ok(
+          writtenContract !== undefined,
+          "contract should exist in output",
+        );
+        assert.ok(
+          writtenContract.functions !== null,
+          "functions should not be null",
+        );
+        assert.deepEqual(writtenContract.functions.transfer, {
+          min: 25000,
+          max: 25000,
+          avg: 25000,
+          median: 25000,
+          count: 1,
+        });
+      });
+
+      it("should create parent directories if they do not exist", async () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "deployment",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          gas: 500000,
+          size: 2048,
+        });
+        await manager.saveGasMeasurements("test-id");
+
+        const outputPath = path.join(
+          tmpDir,
+          "nested",
+          "deep",
+          "gas-output.json",
+        );
+        await manager.writeGasStatsJson(outputPath, "test-id");
+
+        const json = await readJsonFile<GasStatsJson>(outputPath);
+        assert.ok(
+          "contracts/MyContract.sol:MyContract" in json.contracts,
+          "written JSON should contain the contract",
+        );
+      });
+
+      it("should resolve a relative path against process.cwd()", async () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        await manager.saveGasMeasurements("test-id");
+
+        const originalCwd = process.cwd();
+        process.chdir(tmpDir);
+        try {
+          await manager.writeGasStatsJson("relative-output.json", "test-id");
+        } finally {
+          process.chdir(originalCwd);
+        }
+
+        const expectedPath = path.join(tmpDir, "relative-output.json");
+        const json = await readJsonFile<GasStatsJson>(expectedPath);
+        assert.ok(
+          "contracts/MyContract.sol:MyContract" in json.contracts,
+          "output should contain the contract",
+        );
+      });
+
+      it("should not write file when report is disabled", async () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        manager.addGasMeasurement({
+          type: "function",
+          contractFqn: "project/contracts/MyContract.sol:MyContract",
+          functionSig: "transfer(address,uint256)",
+          gas: 25000,
+        });
+        await manager.saveGasMeasurements("test-id");
+
+        manager.disableReport();
+        const outputPath = path.join(tmpDir, "should-not-exist.json");
+        await manager.writeGasStatsJson(outputPath, "test-id");
+
+        const files = await getAllFilesMatching(tmpDir, (f) =>
+          f.endsWith("should-not-exist.json"),
+        );
+        assert.equal(files.length, 0, "file should not have been written");
       });
     });
   });

--- a/v-next/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -7,7 +7,11 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { afterEach, before, describe, it } from "node:test";
 
-import { disableConsole } from "@nomicfoundation/hardhat-test-utils";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import {
+  assertRejectsWithHardhatError,
+  disableConsole,
+} from "@nomicfoundation/hardhat-test-utils";
 import {
   emptyDir,
   getAllFilesMatching,
@@ -1340,6 +1344,15 @@ describe("gas-analytics-manager", () => {
     describe("writeGasStatsJson", () => {
       afterEach(async () => {
         await emptyDir(tmpDir);
+      });
+
+      it("should throw if outputPath is a directory", async () => {
+        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        await assertRejectsWithHardhatError(
+          manager.writeGasStatsJson(tmpDir, "test-id"),
+          HardhatError.ERRORS.CORE.BUILTIN_TASKS.INVALID_FILE_PATH,
+          { path: tmpDir },
+        );
       });
 
       it("should write JSON file at the specified path", async () => {

--- a/v-next/hardhat/test/internal/cli/main.ts
+++ b/v-next/hardhat/test/internal/cli/main.ts
@@ -290,6 +290,7 @@ GLOBAL OPTIONS:
   --config                 A Hardhat config file
   --coverage               Enables code coverage
   --gas-stats              Collects and displays gas usage statistics for all function calls during tests
+  --gas-stats-json         Write gas usage statistics to a JSON file at the specified path
   --help, -h               Show this message, or a task's help if its name is provided
   --init                   Initializes a Hardhat project
   --network                The network to connect to
@@ -363,6 +364,7 @@ GLOBAL OPTIONS:
   --config                 A Hardhat config file
   --coverage               Enables code coverage
   --gas-stats              Collects and displays gas usage statistics for all function calls during tests
+  --gas-stats-json         Write gas usage statistics to a JSON file at the specified path
   --help, -h               Show this message, or a task's help if its name is provided
   --init                   Initializes a Hardhat project
   --network                The network to connect to
@@ -403,6 +405,7 @@ GLOBAL OPTIONS:
   --config                 A Hardhat config file
   --coverage               Enables code coverage
   --gas-stats              Collects and displays gas usage statistics for all function calls during tests
+  --gas-stats-json         Write gas usage statistics to a JSON file at the specified path
   --help, -h               Show this message, or a task's help if its name is provided
   --init                   Initializes a Hardhat project
   --network                The network to connect to

--- a/v-next/hardhat/test/internal/hre-initialization.ts
+++ b/v-next/hardhat/test/internal/hre-initialization.ts
@@ -248,6 +248,7 @@ describe("HRE initialization", () => {
           config: configPath,
           coverage: false,
           gasStats: false,
+          gasStatsJson: undefined,
           help: false,
           init: false,
           showStackTraces: false,


### PR DESCRIPTION
This PR adds a new `--gas-stats-json <path>` global option that writes gas usage statistics to a JSON file at the specified path. It works independently of `--gas-stats` (terminal table output), so either or both flags can be used together.

Docs: https://github.com/NomicFoundation/hardhat-website/pull/238

Closes #7990.