### PR TITLE
Improve use ephemeral fixture project

### DIFF
--- a/v-next/hardhat-errors/.gitignore
+++ b/v-next/hardhat-errors/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-errors/package.json
+++ b/v-next/hardhat-errors/package.json
@@ -33,7 +33,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-ethers-chai-matchers/.gitignore
+++ b/v-next/hardhat-ethers-chai-matchers/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-ethers-chai-matchers/package.json
+++ b/v-next/hardhat-ethers-chai-matchers/package.json
@@ -35,7 +35,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-ethers/.gitignore
+++ b/v-next/hardhat-ethers/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-foundry/.gitignore
+++ b/v-next/hardhat-foundry/.gitignore
@@ -10,3 +10,6 @@
 # test coverage output
 coverage
 
+
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-foundry/package.json
+++ b/v-next/hardhat-foundry/package.json
@@ -35,7 +35,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-ignition-ethers/.gitignore
+++ b/v-next/hardhat-ignition-ethers/.gitignore
@@ -145,3 +145,6 @@ package-lock.json
 
 artifacts
 cache
+
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-ignition-ethers/package.json
+++ b/v-next/hardhat-ignition-ethers/package.json
@@ -33,7 +33,7 @@
     "test": "node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:coverage": "c8 --reporter html --reporter text --all --exclude test --exclude \"src/**/{types,type-extensions}.ts\" --src src node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
-    "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo ./test/fixture-projects/**/deployments ./test/fixture-projects/**/artifacts ./test/fixture-projects/**/cache",
+    "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo ./test/fixture-projects/**/deployments ./test/fixture-projects/**/artifacts ./test/fixture-projects/**/cache ./test/fixture-projects/*-tmp-*-*-*-*-*",
     "prepack": "pnpm build",
     "pretest": "pnpm build",
     "pretest:only": "pnpm build"

--- a/v-next/hardhat-ignition-viem/.gitignore
+++ b/v-next/hardhat-ignition-viem/.gitignore
@@ -145,3 +145,6 @@ package-lock.json
 
 artifacts
 cache
+
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-ignition-viem/package.json
+++ b/v-next/hardhat-ignition-viem/package.json
@@ -34,7 +34,7 @@
     "test": "node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:only": "node --import tsx/esm --test --test-only --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
     "test:coverage": "c8 --reporter html --reporter text --all --exclude test --exclude \"src/**/{types,type-extensions}.ts\" --src src node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter \"test/*.ts\" \"test/!(fixture-projects|helpers)/**/*.ts\"",
-    "clean": "rimraf .nyc_output coverage dist artifacts cache tsconfig.tsbuildinfo ./test/fixture-projects/**/deployments ./test/fixture-projects/**/artifacts ./test/fixture-projects/**/cache ./test/fixture-projects/tmp",
+    "clean": "rimraf .nyc_output coverage dist artifacts cache tsconfig.tsbuildinfo ./test/fixture-projects/**/deployments ./test/fixture-projects/**/artifacts ./test/fixture-projects/**/cache ./test/fixture-projects/*-tmp-*-*-*-*-*",
     "prepack": "pnpm build",
     "test-build": "tsc --build tsconfig.json && node ./scripts/compile-test-fixture-project.js create2 && node ./scripts/compile-test-fixture-project.js minimal && tsc --build tsconfig.test.json",
     "pretest": "pnpm test-build",

--- a/v-next/hardhat-ignition/.gitignore
+++ b/v-next/hardhat-ignition/.gitignore
@@ -142,3 +142,6 @@ dist
 
 # npm lockfile since we use pnpm now
 package-lock.json
+
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-ignition/package.json
+++ b/v-next/hardhat-ignition/package.json
@@ -49,7 +49,7 @@
     "test:build": "tsc --project ./test/",
     "prepack": "pnpm build",
     "build": "tsc --build .",
-    "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo ./test/fixture-projects/**/deployments ./test/fixture-projects/**/artifacts ./test/fixture-projects/**/cache"
+    "clean": "rimraf .nyc_output coverage dist tsconfig.tsbuildinfo ./test/fixture-projects/**/deployments ./test/fixture-projects/**/artifacts ./test/fixture-projects/**/cache ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-keystore/.gitignore
+++ b/v-next/hardhat-keystore/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-keystore/package.json
+++ b/v-next/hardhat-keystore/package.json
@@ -31,7 +31,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-ledger/.gitignore
+++ b/v-next/hardhat-ledger/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-ledger/package.json
+++ b/v-next/hardhat-ledger/package.json
@@ -34,7 +34,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-mocha/.gitignore
+++ b/v-next/hardhat-mocha/.gitignore
@@ -10,7 +10,7 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/
 /test/fixture-projects/*/artifacts
 /test/fixture-projects/*/cache

--- a/v-next/hardhat-mocha/package.json
+++ b/v-next/hardhat-mocha/package.json
@@ -32,7 +32,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-network-helpers/.gitignore
+++ b/v-next/hardhat-network-helpers/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-network-helpers/package.json
+++ b/v-next/hardhat-network-helpers/package.json
@@ -34,7 +34,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-node-test-reporter/.gitignore
+++ b/v-next/hardhat-node-test-reporter/.gitignore
@@ -10,7 +10,7 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/
 
 /integration-tests/fixture-tests/*/result.actual.txt

--- a/v-next/hardhat-node-test-reporter/package.json
+++ b/v-next/hardhat-node-test-reporter/package.json
@@ -34,7 +34,7 @@
     "pretest:integration": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-node-test-runner/.gitignore
+++ b/v-next/hardhat-node-test-runner/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-node-test-runner/package.json
+++ b/v-next/hardhat-node-test-runner/package.json
@@ -32,7 +32,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-test-utils/.gitignore
+++ b/v-next/hardhat-test-utils/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-test-utils/package.json
+++ b/v-next/hardhat-test-utils/package.json
@@ -27,7 +27,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-test-utils/src/fixture-projects.ts
+++ b/v-next/hardhat-test-utils/src/fixture-projects.ts
@@ -41,7 +41,7 @@ export function useFixtureProject(
  */
 export function useEphemeralFixtureProject(projectName: string): void {
   const basePath = path.join(process.cwd(), "test", "fixture-projects");
-  const tmpProjectPath = path.join("tmp", randomUUID());
+  const tmpProjectPath = `${projectName}-tmp-${randomUUID()}`;
 
   before(() => {
     cpSync(

--- a/v-next/hardhat-toolbox-mocha-ethers/.gitignore
+++ b/v-next/hardhat-toolbox-mocha-ethers/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-toolbox-mocha-ethers/package.json
+++ b/v-next/hardhat-toolbox-mocha-ethers/package.json
@@ -34,7 +34,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-toolbox-viem/.gitignore
+++ b/v-next/hardhat-toolbox-viem/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-toolbox-viem/package.json
+++ b/v-next/hardhat-toolbox-viem/package.json
@@ -34,7 +34,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-typechain/.gitignore
+++ b/v-next/hardhat-typechain/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-typechain/package.json
+++ b/v-next/hardhat-typechain/package.json
@@ -35,7 +35,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-utils/.gitignore
+++ b/v-next/hardhat-utils/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-utils/package.json
+++ b/v-next/hardhat-utils/package.json
@@ -56,7 +56,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-vendored/.gitignore
+++ b/v-next/hardhat-vendored/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-vendored/package.json
+++ b/v-next/hardhat-vendored/package.json
@@ -31,7 +31,7 @@
     "build": "tsc --build .",
     "postbuild": "node dist/src/copy-assets.js",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-verify/.gitignore
+++ b/v-next/hardhat-verify/.gitignore
@@ -10,8 +10,8 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/
 
 # generated files in the fixture projects
 /test/fixture-projects/**/artifacts/

--- a/v-next/hardhat-verify/package.json
+++ b/v-next/hardhat-verify/package.json
@@ -38,7 +38,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-viem-assertions/.gitignore
+++ b/v-next/hardhat-viem-assertions/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-viem-assertions/package.json
+++ b/v-next/hardhat-viem-assertions/package.json
@@ -37,7 +37,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-viem/.gitignore
+++ b/v-next/hardhat-viem/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-viem/package.json
+++ b/v-next/hardhat-viem/package.json
@@ -35,7 +35,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat-zod-utils/.gitignore
+++ b/v-next/hardhat-zod-utils/.gitignore
@@ -10,5 +10,5 @@
 # test coverage output
 coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat-zod-utils/package.json
+++ b/v-next/hardhat-zod-utils/package.json
@@ -33,7 +33,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",

--- a/v-next/hardhat/.gitignore
+++ b/v-next/hardhat/.gitignore
@@ -13,5 +13,5 @@ coverage
 !test/internal/builtin-plugins/coverage
 !test/fixture-projects/coverage
 
-# all the tmp folders in the fixture projects
-/test/fixture-projects/tmp/
+# ephemeral fixture project copies (useEphemeralFixtureProject)
+/test/fixture-projects/*-tmp-*-*-*-*-*/

--- a/v-next/hardhat/package.json
+++ b/v-next/hardhat/package.json
@@ -64,7 +64,7 @@
     "pretest:only": "pnpm build",
     "build": "tsc --build .",
     "prepublishOnly": "pnpm build",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist ./test/fixture-projects/*-tmp-*-*-*-*-*"
   },
   "files": [
     "dist/src/",


### PR DESCRIPTION
The previous version used a folder `tmp` under `fixture-projects`, this shifted the files of a project one folder deeper in the nesting structure such that relative imports in the `hardhat.config.ts` could fail e.g.

```ts
import myPlugin from "../../src/index.js"
```

Instead a copied fixture project is created directly under `./fixture-projects`, so at the same level as the original project but with a name:

```
<projectName>-tmp-<UUID>
```

The ephemeral fixture project is deleted at the end of the test but .gitinore and `pnpm clean` have been updated to deal with any missed due to failures.

## Review

> [!NOTE]
> **The first commit contains the util test change**, the second the .gitignore and pnpm clean changes.
