### PR TITLE
linter: forbid type-extensions in test files

### DIFF
--- a/v-next/config/eslint.config.js
+++ b/v-next/config/eslint.config.js
@@ -449,6 +449,14 @@ export function createConfig(
       import: importPlugin,
     },
     rules: {
+      "no-restricted-syntax": [
+        ...noRestrictedSyntaxRules,
+        {
+          selector: "TSModuleDeclaration[declare=true]",
+          message:
+            "Type extensions (declare module) in test files pollute other tests and production code. Use type assertions/casts instead of test-level type extensions.",
+        },
+      ],
       "import/no-extraneous-dependencies": [
         "error",
         {


### PR DESCRIPTION
Type extensions in test files affect/pollute other tests, and with our current config also the source code. This PR adds a linter rule to forbid them.

Note: The second commit is an example of a failure. It will be removed after approval.