### PR TITLE
Cache genesis state

### DIFF
--- a/.changeset/cyan-clowns-type.md
+++ b/.changeset/cyan-clowns-type.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Optimize the initilization of EDR Network Connections by caching their genesis state.
+Optimize the initialization of EDR Network Connections by caching their genesis state.

--- a/.changeset/cyan-clowns-type.md
+++ b/.changeset/cyan-clowns-type.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Optimize the initilization of EDR Network Connections by caching their genesis state.

--- a/.changeset/every-islands-relate.md
+++ b/.changeset/every-islands-relate.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix a bug where `network.connect()` re-resolved the config when not needed.

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -21,17 +21,10 @@ import type {
   Provider,
   ProviderConfig,
   TracingConfigWithBuffers,
-  AccountOverride,
   GasReportConfig,
 } from "@nomicfoundation/edr";
 
-import {
-  opGenesisState,
-  opHardforkFromString,
-  l1GenesisState,
-  l1HardforkFromString,
-  ContractDecoder,
-} from "@nomicfoundation/edr";
+import { ContractDecoder } from "@nomicfoundation/edr";
 import {
   assertHardhatInvariant,
   HardhatError,
@@ -41,14 +34,9 @@ import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
 import { deepEqual } from "@nomicfoundation/hardhat-utils/lang";
 import debug from "debug";
-import { hexToBytes } from "ethereum-cryptography/utils";
-import { addr } from "micro-eth-signer";
 
 import { sendErrorTelemetry } from "../../../cli/telemetry/sentry/reporter.js";
-import {
-  EDR_NETWORK_REVERT_SNAPSHOT_EVENT,
-  OPTIMISM_CHAIN_TYPE,
-} from "../../../constants.js";
+import { EDR_NETWORK_REVERT_SNAPSHOT_EVENT } from "../../../constants.js";
 import { hardhatChainTypeToEdrChainType } from "../../../edr/chain-type.js";
 import { getGlobalEdrContext } from "../../../edr/context.js";
 import { DEFAULT_HD_ACCOUNTS_CONFIG_PARAMS } from "../accounts/constants.js";
@@ -60,6 +48,7 @@ import {
   UnknownError,
 } from "../provider-errors.js";
 
+import { getGenesisStateAndOwnedAccounts } from "./genesis-state.js";
 import { EdrProviderStackTraceGenerationError } from "./stack-traces/stack-trace-generation-errors.js";
 import { createSolidityErrorWithStackTrace } from "./stack-traces/stack-trace-solidity-errors.js";
 import { isEdrProviderErrorData } from "./type-validation.js";
@@ -69,7 +58,6 @@ import {
   hardhatMiningIntervalToEdrMiningInterval,
   hardhatMempoolOrderToEdrMineOrdering,
   hardhatHardforkToEdrSpecId,
-  hardhatAccountsToEdrOwnedAccounts,
   hardhatForkingConfigToEdrForkConfig,
 } from "./utils/convert-to-edr.js";
 import { printLine, replaceLastLine } from "./utils/logger.js";
@@ -440,42 +428,12 @@ export async function getProviderConfig(
     networkConfig.chainType,
   );
 
-  const ownedAccounts = await hardhatAccountsToEdrOwnedAccounts(
+  const { genesisState, ownedAccounts } = await getGenesisStateAndOwnedAccounts(
     networkConfig.accounts,
+    networkConfig.forking,
+    networkConfig.chainType,
+    specId,
   );
-
-  const genesisState: Map<Uint8Array, AccountOverride> = new Map(
-    ownedAccounts.map(({ secretKey, balance }) => {
-      const address = hexToBytes(addr.fromPrivateKey(secretKey));
-      const accountOverride: AccountOverride = {
-        address,
-        balance: BigInt(balance),
-        code: new Uint8Array(), // Empty account code, removing potential delegation code when forking
-      };
-
-      return [address, accountOverride];
-    }),
-  );
-
-  const chainGenesisState =
-    networkConfig.forking !== undefined
-      ? [] // TODO: Add support for overriding remote fork state when the local fork is different
-      : networkConfig.chainType === OPTIMISM_CHAIN_TYPE
-        ? opGenesisState(opHardforkFromString(specId))
-        : l1GenesisState(l1HardforkFromString(specId));
-
-  for (const account of chainGenesisState) {
-    const existingOverride = genesisState.get(account.address);
-    if (existingOverride !== undefined) {
-      // Favor the genesis state specified by the user
-      account.balance = account.balance ?? existingOverride.balance;
-      account.nonce = account.nonce ?? existingOverride.nonce;
-      account.code = account.code ?? existingOverride.code;
-      account.storage = account.storage ?? existingOverride.storage;
-    } else {
-      genesisState.set(account.address, account);
-    }
-  }
 
   return {
     allowBlocksWithSameTimestamp: networkConfig.allowBlocksWithSameTimestamp,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/genesis-state.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/genesis-state.ts
@@ -30,6 +30,12 @@ const noForkingConfigCacheMarkerObject = {};
  * in practice this should rarely happen, except when using network config
  * overrides that generate the same config. These cases should be the minority
  * within a test suite.
+ *
+ * Note: the main reason that we don't use the entire NetworkConfig as cache
+ * key is that EDR initialization path recreates the NetworkConfig object to
+ * override some properties like `allowUnlimitedContractSize`, leading to a
+ * different NetworkConfig reference, despite keeping the references of most
+ * of its properties (including the accounts and forking config) the same.
  */
 const genesisStateAndAccountsCache: WeakMap<
   EdrNetworkAccountsConfig,

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/genesis-state.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/genesis-state.ts
@@ -1,0 +1,147 @@
+import type {
+  EdrNetworkAccountsConfig,
+  EdrNetworkForkingConfig,
+} from "../../../../types/config.js";
+import type { ChainType } from "../../../../types/network.js";
+
+import {
+  l1GenesisState,
+  l1HardforkFromString,
+  opGenesisState,
+  opHardforkFromString,
+  type AccountOverride,
+} from "@nomicfoundation/edr";
+import { hexToBytes } from "ethereum-cryptography/utils";
+import { addr } from "micro-eth-signer/address";
+
+import { OPTIMISM_CHAIN_TYPE } from "../../../constants.js";
+
+import { hardhatAccountsToEdrOwnedAccounts } from "./utils/convert-to-edr.js";
+
+const noForkingConfigCacheMarkerObject = {};
+
+/**
+ * We cache the genesis state and owned accounts because computing them can be
+ * expensive, especially when run multiple times for the same configuration
+ * (e.g. when creating many EDR connections to the same network config).
+ *
+ * We use mostly references as cache keys, which means that we can miss some
+ * cache hits if an equivalent config is used with a different reference, but
+ * in practice this should rarely happen, except when using network config
+ * overrides that generate the same config. These cases should be the minority
+ * within a test suite.
+ */
+const genesisStateAndAccountsCache: WeakMap<
+  EdrNetworkAccountsConfig,
+  WeakMap<
+    EdrNetworkForkingConfig | typeof noForkingConfigCacheMarkerObject,
+    Map<
+      ChainType,
+      Map<
+        string,
+        {
+          genesisState: Map<Uint8Array, AccountOverride>;
+          ownedAccounts: Array<{ secretKey: string; balance: bigint }>;
+        }
+      >
+    >
+  >
+> = new WeakMap();
+
+export async function getGenesisStateAndOwnedAccounts(
+  accountsConfig: EdrNetworkAccountsConfig,
+  forkingConfig: EdrNetworkForkingConfig | undefined,
+  chainType: ChainType,
+  specId: string,
+): Promise<{
+  genesisState: Map<Uint8Array, AccountOverride>;
+  ownedAccounts: Array<{ secretKey: string; balance: bigint }>;
+}> {
+  const cached = genesisStateAndAccountsCache
+    .get(accountsConfig)
+    ?.get(forkingConfig ?? noForkingConfigCacheMarkerObject)
+    ?.get(chainType)
+    ?.get(specId);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const result = await createGenesisStateAndOwnedAccounts(
+    accountsConfig,
+    forkingConfig,
+    chainType,
+    specId,
+  );
+
+  let secondLevelCacheMap = genesisStateAndAccountsCache.get(accountsConfig);
+  if (secondLevelCacheMap === undefined) {
+    secondLevelCacheMap = new WeakMap();
+    genesisStateAndAccountsCache.set(accountsConfig, secondLevelCacheMap);
+  }
+
+  const forkingConfigCacheKey =
+    forkingConfig ?? noForkingConfigCacheMarkerObject;
+  let thirdLevelCacheMap = secondLevelCacheMap.get(forkingConfigCacheKey);
+  if (thirdLevelCacheMap === undefined) {
+    thirdLevelCacheMap = new Map();
+    secondLevelCacheMap.set(forkingConfigCacheKey, thirdLevelCacheMap);
+  }
+
+  let fourthLevelCacheMap = thirdLevelCacheMap.get(chainType);
+  if (fourthLevelCacheMap === undefined) {
+    fourthLevelCacheMap = new Map();
+    thirdLevelCacheMap.set(chainType, fourthLevelCacheMap);
+  }
+
+  fourthLevelCacheMap.set(specId, result);
+
+  return result;
+}
+
+async function createGenesisStateAndOwnedAccounts(
+  accountsConfig: EdrNetworkAccountsConfig,
+  forkingConfig: EdrNetworkForkingConfig | undefined,
+  chainType: ChainType,
+  specId: string,
+): Promise<{
+  genesisState: Map<Uint8Array, AccountOverride>;
+  ownedAccounts: Array<{ secretKey: string; balance: bigint }>;
+}> {
+  const ownedAccounts = await hardhatAccountsToEdrOwnedAccounts(accountsConfig);
+
+  const genesisState: Map<Uint8Array, AccountOverride> = new Map(
+    ownedAccounts.map(({ secretKey, balance }) => {
+      const address = hexToBytes(addr.fromPrivateKey(secretKey));
+      const accountOverride: AccountOverride = {
+        address,
+        balance: BigInt(balance),
+        code: new Uint8Array(), // Empty account code, removing potential delegation code when forking
+      };
+
+      return [address, accountOverride];
+    }),
+  );
+
+  const chainGenesisState =
+    forkingConfig !== undefined
+      ? [] // TODO: Add support for overriding remote fork state when the local fork is different
+      : chainType === OPTIMISM_CHAIN_TYPE
+        ? opGenesisState(opHardforkFromString(specId))
+        : l1GenesisState(l1HardforkFromString(specId));
+
+  for (const account of chainGenesisState) {
+    const existingOverride = genesisState.get(account.address);
+    if (existingOverride !== undefined) {
+      // Favor the genesis state specified by the user
+      account.balance = account.balance ?? existingOverride.balance;
+      account.nonce = account.nonce ?? existingOverride.nonce;
+      account.code = account.code ?? existingOverride.code;
+      account.storage = account.storage ?? existingOverride.storage;
+    } else {
+      genesisState.set(account.address, account);
+    }
+  }
+
+  return { genesisState, ownedAccounts };
+}

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/genesis-state.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/edr/genesis-state.ts
@@ -11,6 +11,7 @@ import {
   opHardforkFromString,
   type AccountOverride,
 } from "@nomicfoundation/edr";
+import { AsyncMutex } from "@nomicfoundation/hardhat-utils/synchronization";
 import { hexToBytes } from "ethereum-cryptography/utils";
 import { addr } from "micro-eth-signer/address";
 
@@ -54,6 +55,8 @@ const genesisStateAndAccountsCache: WeakMap<
   >
 > = new WeakMap();
 
+const genesisStateAndAccountsCacheMutex = new AsyncMutex();
+
 export async function getGenesisStateAndOwnedAccounts(
   accountsConfig: EdrNetworkAccountsConfig,
   forkingConfig: EdrNetworkForkingConfig | undefined,
@@ -73,36 +76,50 @@ export async function getGenesisStateAndOwnedAccounts(
     return cached;
   }
 
-  const result = await createGenesisStateAndOwnedAccounts(
-    accountsConfig,
-    forkingConfig,
-    chainType,
-    specId,
-  );
+  return genesisStateAndAccountsCacheMutex.exclusiveRun(async () => {
+    // We need to check again inside the mutex callback in case another async
+    // operation initialized it while we were waiting to acquire the mutex
+    const cachedAfterWaiting = genesisStateAndAccountsCache
+      .get(accountsConfig)
+      ?.get(forkingConfig ?? noForkingConfigCacheMarkerObject)
+      ?.get(chainType)
+      ?.get(specId);
 
-  let secondLevelCacheMap = genesisStateAndAccountsCache.get(accountsConfig);
-  if (secondLevelCacheMap === undefined) {
-    secondLevelCacheMap = new WeakMap();
-    genesisStateAndAccountsCache.set(accountsConfig, secondLevelCacheMap);
-  }
+    if (cachedAfterWaiting !== undefined) {
+      return cachedAfterWaiting;
+    }
 
-  const forkingConfigCacheKey =
-    forkingConfig ?? noForkingConfigCacheMarkerObject;
-  let thirdLevelCacheMap = secondLevelCacheMap.get(forkingConfigCacheKey);
-  if (thirdLevelCacheMap === undefined) {
-    thirdLevelCacheMap = new Map();
-    secondLevelCacheMap.set(forkingConfigCacheKey, thirdLevelCacheMap);
-  }
+    const result = await createGenesisStateAndOwnedAccounts(
+      accountsConfig,
+      forkingConfig,
+      chainType,
+      specId,
+    );
 
-  let fourthLevelCacheMap = thirdLevelCacheMap.get(chainType);
-  if (fourthLevelCacheMap === undefined) {
-    fourthLevelCacheMap = new Map();
-    thirdLevelCacheMap.set(chainType, fourthLevelCacheMap);
-  }
+    let secondLevelCacheMap = genesisStateAndAccountsCache.get(accountsConfig);
+    if (secondLevelCacheMap === undefined) {
+      secondLevelCacheMap = new WeakMap();
+      genesisStateAndAccountsCache.set(accountsConfig, secondLevelCacheMap);
+    }
 
-  fourthLevelCacheMap.set(specId, result);
+    const forkingConfigCacheKey =
+      forkingConfig ?? noForkingConfigCacheMarkerObject;
+    let thirdLevelCacheMap = secondLevelCacheMap.get(forkingConfigCacheKey);
+    if (thirdLevelCacheMap === undefined) {
+      thirdLevelCacheMap = new Map();
+      secondLevelCacheMap.set(forkingConfigCacheKey, thirdLevelCacheMap);
+    }
 
-  return result;
+    let fourthLevelCacheMap = thirdLevelCacheMap.get(chainType);
+    if (fourthLevelCacheMap === undefined) {
+      fourthLevelCacheMap = new Map();
+      thirdLevelCacheMap.set(chainType, fourthLevelCacheMap);
+    }
+
+    fourthLevelCacheMap.set(specId, result);
+
+    return result;
+  });
 }
 
 async function createGenesisStateAndOwnedAccounts(

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -332,15 +332,30 @@ export class NetworkManagerImplementation implements NetworkManager {
    */
   async #resolveNetworkConfig<ChainTypeT extends ChainType | string>(
     resolvedNetworkName: string,
-    networkConfigOverride: NetworkConfigOverride | undefined = {},
+    networkConfigOverride: NetworkConfigOverride = {},
     resolvedChainType: ChainTypeT,
   ): Promise<NetworkConfig> {
     const existingNetworkConfig = this.#networkConfigs[resolvedNetworkName];
-    if (
-      Object.keys(networkConfigOverride).length === 0 &&
-      resolvedChainType === existingNetworkConfig.chainType
-    ) {
+
+    const hasNoOverrides = Object.keys(networkConfigOverride).length === 0;
+    const isChainTypeUnchanged =
+      resolvedChainType === existingNetworkConfig.chainType;
+    const isChainTypeDefault =
+      existingNetworkConfig.chainType === undefined &&
+      resolvedChainType === this.#defaultChainType;
+
+    if (hasNoOverrides && isChainTypeUnchanged) {
       return existingNetworkConfig;
+    }
+
+    if (hasNoOverrides && isChainTypeDefault) {
+      return {
+        ...existingNetworkConfig,
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+          TypeScript can't follow this case, but we are just providing the
+          default */
+        chainType: resolvedChainType as ChainType,
+      };
     }
 
     if (

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/edr/genesis-state.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/edr/genesis-state.ts
@@ -39,7 +39,7 @@ describe("getGenesisStateAndOwnedAccounts", () => {
     assert.equal(result1, result2);
   });
 
-  it("should return different results (by reference) if any of the parameters change, even the change is only by reference (same values)", async () => {
+  it("should return different results (by reference) if any of the parameters change, even if the change is only by reference (same values)", async () => {
     const result1 = await getGenesisStateAndOwnedAccounts(
       accounts,
       undefined,

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/edr/genesis-state.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/edr/genesis-state.ts
@@ -1,0 +1,68 @@
+import type { EdrNetworkAccountsConfig } from "../../../../../src/types/config.js";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { CANCUN, LONDON } from "@nomicfoundation/edr";
+
+import { getGenesisStateAndOwnedAccounts } from "../../../../../src/internal/builtin-plugins/network-manager/edr/genesis-state.js";
+import { L1_CHAIN_TYPE } from "../../../../../src/internal/constants.js";
+import { FixedValueConfigurationVariable } from "../../../../../src/internal/core/configuration-variables.js";
+
+describe("getGenesisStateAndOwnedAccounts", () => {
+  const accounts: EdrNetworkAccountsConfig = {
+    mnemonic: new FixedValueConfigurationVariable(
+      "test test test test test test test test test test test junk",
+    ),
+    accountsBalance: 10000000000000000000000n,
+    count: 2,
+    initialIndex: 0,
+    passphrase: new FixedValueConfigurationVariable(""),
+    path: "m/44'/60'/0'/0",
+  };
+
+  it("should return cached result for same config references", async () => {
+    const result1 = await getGenesisStateAndOwnedAccounts(
+      accounts,
+      undefined,
+      L1_CHAIN_TYPE,
+      CANCUN,
+    );
+
+    const result2 = await getGenesisStateAndOwnedAccounts(
+      accounts,
+      undefined,
+      L1_CHAIN_TYPE,
+      CANCUN,
+    );
+
+    assert.equal(result1, result2);
+  });
+
+  it("should return different results (by reference) if any of the parameters change, even the change is only by reference (same values)", async () => {
+    const result1 = await getGenesisStateAndOwnedAccounts(
+      accounts,
+      undefined,
+      L1_CHAIN_TYPE,
+      CANCUN,
+    );
+
+    const result2 = await getGenesisStateAndOwnedAccounts(
+      accounts,
+      undefined,
+      L1_CHAIN_TYPE,
+      LONDON,
+    );
+
+    const result3 = await getGenesisStateAndOwnedAccounts(
+      { ...accounts },
+      undefined,
+      L1_CHAIN_TYPE,
+      LONDON,
+    );
+
+    assert.notEqual(result1, result2);
+    assert.notEqual(result2, result3);
+    assert.notEqual(result3, result1);
+  });
+});

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -160,6 +160,38 @@ describe("NetworkManagerImplementation", () => {
       });
     });
 
+    it("should return the same networkConfig field references for two connect() calls without overrides", async () => {
+      const conn1 = await networkManager.connect();
+      const conn2 = await networkManager.connect();
+
+      assert.equal(conn1.networkConfig.type, conn2.networkConfig.type);
+
+      for (const key of Object.keys(conn1.networkConfig)) {
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+          we know the type of the network config object. It may have discrepancies
+          between the two connections, but we the assertion above ensures that. */
+        const networkConfigKey = key as keyof NetworkConfig;
+        assert.equal(
+          conn1.networkConfig[networkConfigKey],
+          conn2.networkConfig[networkConfigKey],
+          `The networkConfig field ${key} should have the same reference in both connections`,
+        );
+      }
+    });
+
+    it("should return the same networkConfig reference for two connect() calls that have the chaintype defined in the config", async () => {
+      const conn1 = await networkManager.connect({
+        network: "edrNetwork",
+        chainType: OPTIMISM_CHAIN_TYPE,
+      });
+      const conn2 = await networkManager.connect({
+        network: "edrNetwork",
+        chainType: OPTIMISM_CHAIN_TYPE,
+      });
+
+      assert.equal(conn1.networkConfig, conn2.networkConfig);
+    });
+
     it("should connect to the specified network and default chain type if none are provided and the network doesn't have a chain type", async () => {
       const networkConnection = await networkManager.connect({
         network: "customNetwork",
@@ -843,6 +875,65 @@ describe("NetworkManagerImplementation", () => {
       assertPluginPropertiesCopied(networkConnection.networkConfig, {
         pluginAddedProperties: ["my-value"],
       });
+    });
+  });
+
+  describe("connect should not re-resolve config when no overrides are provided", () => {
+    let resolveUserConfigCallCount: number;
+
+    const resolutionCountingPlugin: HardhatPlugin = {
+      id: "resolution-counting-plugin",
+      hookHandlers: {
+        config: async () => ({
+          default: async () => {
+            const handlers: Partial<ConfigHooks> = {
+              resolveUserConfig: async (userConfig, rCV, next) => {
+                resolveUserConfigCallCount++;
+                return next(userConfig, rCV);
+              },
+            };
+            return handlers;
+          },
+        }),
+      },
+    };
+
+    beforeEach(async () => {
+      resolveUserConfigCallCount = 0;
+      hre = await createHardhatRuntimeEnvironment({
+        plugins: [resolutionCountingPlugin],
+      });
+
+      networkManager = new NetworkManagerImplementation(
+        "localhost",
+        GENERIC_CHAIN_TYPE,
+        hre.config.networks,
+        hre.hooks,
+        hre.artifacts,
+        { networks: {} },
+        hre.config.chainDescriptors,
+        hre.globalOptions.config,
+        hre.config.paths.root,
+      );
+    });
+
+    it("should not call resolveUserConfig when connecting without overrides", async () => {
+      await networkManager.connect();
+      await networkManager.connect();
+      // Note: this is 1 and not 0 because there's the HRE creation's config
+      // resolution
+      assert.equal(resolveUserConfigCallCount, 1);
+    });
+
+    it("should call resolveUserConfig when connecting with overrides", async () => {
+      await networkManager.connect({
+        network: "localhost",
+        override: { timeout: 5000 },
+      });
+
+      // Note: this is 2 and not 1 because there's the HRE creation's config
+      // resolution
+      assert.equal(resolveUserConfigCallCount, 2);
     });
   });
 

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -179,7 +179,7 @@ describe("NetworkManagerImplementation", () => {
       }
     });
 
-    it("should return the same networkConfig reference for two connect() calls that have the chaintype defined in the config", async () => {
+    it("should return the same networkConfig reference for two connect() calls that have the chain type defined in the config", async () => {
       const conn1 = await networkManager.connect({
         network: "edrNetwork",
         chainType: OPTIMISM_CHAIN_TYPE,

--- a/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -169,7 +169,7 @@ describe("NetworkManagerImplementation", () => {
       for (const key of Object.keys(conn1.networkConfig)) {
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
           we know the type of the network config object. It may have discrepancies
-          between the two connections, but we the assertion above ensures that. */
+          between the two connections, but the assertion above ensures that this is safe. */
         const networkConfigKey = key as keyof NetworkConfig;
         assert.equal(
           conn1.networkConfig[networkConfigKey],

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
@@ -52,7 +52,7 @@ function createTypeRegistrationMockPlugin(types: string[]): HardhatPlugin {
               userConfig,
               resolveConfigurationVariable,
             );
-             
+
             resolved.solidity.registeredCompilerTypes.push(...(types as any[]));
             return resolved;
           },
@@ -68,7 +68,6 @@ describe("solidity - hooks", () => {
 
     const expectedSolidityVersion = "0.8.23";
 
-     
     const fakeOutput: CompilerOutput = {} as any;
 
     let hre: HardhatRuntimeEnvironment;
@@ -82,7 +81,6 @@ describe("solidity - hooks", () => {
       passedSolcInput = undefined;
       returnedSolcOutput = undefined;
 
-       
       const fakeCompiler: Compiler = {
         compile: () => {
           return fakeOutput;
@@ -574,7 +572,6 @@ describe("solidity - hooks", () => {
     });
 
     it("should allow plugins to return a custom compiler", async () => {
-       
       const fakeOutput: CompilerOutput = {
         contracts: {},
         sources: {},
@@ -583,7 +580,6 @@ describe("solidity - hooks", () => {
 
       let customCompilerUsed = false;
 
-       
       const customCompiler: Compiler = {
         version: "0.8.23",
         longVersion: "0.8.23+custom",
@@ -609,7 +605,6 @@ describe("solidity - hooks", () => {
                     nextCompilerConfig: SolidityCompilerConfig,
                   ) => Promise<Compiler>,
                 ) => {
-                   
                   if ((compilerConfig.type as string) === "custom") {
                     return customCompiler;
                   }
@@ -629,7 +624,6 @@ describe("solidity - hooks", () => {
           createTypeRegistrationMockPlugin(["custom"]),
         ],
         solidity: {
-           
           compilers: [{ type: "custom" as any, version: "0.8.23" }],
         },
       });

--- a/v-next/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
+++ b/v-next/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
@@ -52,7 +52,7 @@ function createTypeRegistrationMockPlugin(types: string[]): HardhatPlugin {
               userConfig,
               resolveConfigurationVariable,
             );
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test registers unregistered types
+             
             resolved.solidity.registeredCompilerTypes.push(...(types as any[]));
             return resolved;
           },
@@ -68,7 +68,7 @@ describe("solidity - hooks", () => {
 
     const expectedSolidityVersion = "0.8.23";
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentional fake for test
+     
     const fakeOutput: CompilerOutput = {} as any;
 
     let hre: HardhatRuntimeEnvironment;
@@ -82,7 +82,7 @@ describe("solidity - hooks", () => {
       passedSolcInput = undefined;
       returnedSolcOutput = undefined;
 
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentional mocking of compiler
+       
       const fakeCompiler: Compiler = {
         compile: () => {
           return fakeOutput;
@@ -574,7 +574,7 @@ describe("solidity - hooks", () => {
     });
 
     it("should allow plugins to return a custom compiler", async () => {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentional fake for test
+       
       const fakeOutput: CompilerOutput = {
         contracts: {},
         sources: {},
@@ -583,7 +583,7 @@ describe("solidity - hooks", () => {
 
       let customCompilerUsed = false;
 
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentional mocking of compiler
+       
       const customCompiler: Compiler = {
         version: "0.8.23",
         longVersion: "0.8.23+custom",
@@ -609,7 +609,7 @@ describe("solidity - hooks", () => {
                     nextCompilerConfig: SolidityCompilerConfig,
                   ) => Promise<Compiler>,
                 ) => {
-                  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test uses unregistered type
+                   
                   if ((compilerConfig.type as string) === "custom") {
                     return customCompiler;
                   }
@@ -629,7 +629,7 @@ describe("solidity - hooks", () => {
           createTypeRegistrationMockPlugin(["custom"]),
         ],
         solidity: {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- test uses unregistered compiler type
+           
           compilers: [{ type: "custom" as any, version: "0.8.23" }],
         },
       });


### PR DESCRIPTION
This PR caches the creation of the genesis state of EDR providers, and fixes a bug in `network.connect()` which was triggering the re-resolution of the config unnecessarily. The bug was preventing the cache from working.