### PR TITLE
Fix ARM CI failures by refreshing apt package index

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -49,4 +49,6 @@ runs:
     - name: Install Linux system dependencies
       if: runner.os == 'Linux'
       shell: bash
-      run: sudo apt-get install -y libusb-1.0-0-dev libudev-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libusb-1.0-0-dev libudev-dev

--- a/.github/workflows/v-next-ci.yml
+++ b/.github/workflows/v-next-ci.yml
@@ -109,6 +109,7 @@ jobs:
           COMMON_FILTERS: |
             [
               ".github/workflows/v-next-ci.yml",
+              ".github/actions/setup-env/**",
               "config-v-next/**",
               "pnpm-lock.yaml"
             ]


### PR DESCRIPTION
The ubuntu-24.04-arm runners have a stale apt index referencing a superseded libudev-dev version that 404s. Adding `apt-get update` before install ensures the current package version is resolved.

Also added `".github/actions/setup-env/**",` to the common filters, so v-next CI actually runs when you change the setup environment.

