### PR TITLE
perf: avoid `await import` for code that's guaranteed to execute

### DIFF
--- a/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
+++ b/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
@@ -4,7 +4,7 @@ import type {
   Libraries,
 } from "../../types.js";
 import type { HardhatEthersProvider } from "../hardhat-ethers-provider/hardhat-ethers-provider.js";
-import type { HardhatEthersSigner } from "../signers/signers.js";
+import { HardhatEthersSigner } from "../signers/signers.js";
 import type { ethers as EthersT } from "ethers";
 import type {
   Abi,
@@ -68,11 +68,7 @@ export class HardhatHelpers {
   }
 
   public async getSigner(address: string): Promise<HardhatEthersSigner> {
-    const { HardhatEthersSigner: SignerWithAddressImpl } = await import(
-      "../signers/signers.js"
-    );
-
-    const signerWithAddress = await SignerWithAddressImpl.create(
+    const signerWithAddress = await HardhatEthersSigner.create(
       this.#provider,
       this.#networkName,
       this.#networkConfig,

--- a/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
+++ b/v-next/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
@@ -4,7 +4,6 @@ import type {
   Libraries,
 } from "../../types.js";
 import type { HardhatEthersProvider } from "../hardhat-ethers-provider/hardhat-ethers-provider.js";
-import { HardhatEthersSigner } from "../signers/signers.js";
 import type { ethers as EthersT } from "ethers";
 import type {
   Abi,
@@ -18,6 +17,8 @@ import {
   assertHardhatInvariant,
   HardhatError,
 } from "@nomicfoundation/hardhat-errors";
+
+import { HardhatEthersSigner } from "../signers/signers.js";
 
 interface Link {
   sourceName: string;

--- a/v-next/hardhat-utils/src/internal/lang.ts
+++ b/v-next/hardhat-utils/src/internal/lang.ts
@@ -1,15 +1,10 @@
-import type rfdcT from "rfdc";
+import rfdc from "rfdc";
 
 import { isObject } from "../lang.js";
 
-let clone: ReturnType<typeof rfdcT> | null = null;
-export async function getDeepCloneFunction(): Promise<<T>(input: T) => T> {
-  const { default: rfdc } = await import("rfdc");
+const clone = rfdc();
 
-  if (clone === null) {
-    clone = rfdc();
-  }
-
+export function getDeepCloneFunction(): <T>(input: T) => T {
   return clone;
 }
 

--- a/v-next/hardhat-utils/src/lang.ts
+++ b/v-next/hardhat-utils/src/lang.ts
@@ -10,10 +10,8 @@ import {
  * @param value The value to clone.
  * @returns The deep clone of the provided value.
  */
-export async function deepClone<T>(value: T): Promise<T> {
-  const _deepClone = await getDeepCloneFunction();
-
-  return _deepClone<T>(value);
+export function deepClone<T>(value: T): T {
+  return getDeepCloneFunction()<T>(value);
 }
 
 /**

--- a/v-next/hardhat-utils/test/lang.ts
+++ b/v-next/hardhat-utils/test/lang.ts
@@ -17,7 +17,7 @@ describe("lang", () => {
   describe("deepClone", () => {
     it("Should clone an object", async () => {
       const obj = { a: 1, b: 2, c: { d: 3 } };
-      const clonedObj = await deepClone(obj);
+      const clonedObj = deepClone(obj);
 
       assert.deepEqual(clonedObj, obj);
       assert.notEqual(clonedObj, obj);
@@ -27,7 +27,7 @@ describe("lang", () => {
 
     it("Should clone an array", async () => {
       const arr = [1, 2, [3]];
-      const clonedArr = await deepClone(arr);
+      const clonedArr = deepClone(arr);
 
       assert.deepEqual(clonedArr, arr);
       assert.notEqual(clonedArr, arr);
@@ -37,7 +37,7 @@ describe("lang", () => {
 
     it("Should clone a string", async () => {
       const str = "hello";
-      const clonedStr = await deepClone(str);
+      const clonedStr = deepClone(str);
 
       assert.equal(clonedStr, str);
       expectTypeOf(clonedStr).toBeString();
@@ -45,7 +45,7 @@ describe("lang", () => {
 
     it("Should clone a number", async () => {
       const num = 42;
-      const clonedNum = await deepClone(num);
+      const clonedNum = deepClone(num);
 
       assert.equal(clonedNum, num);
       expectTypeOf(clonedNum).toBeNumber();
@@ -53,7 +53,7 @@ describe("lang", () => {
 
     it("Should clone null", async () => {
       const n = null;
-      const clonedN = await deepClone(n);
+      const clonedN = deepClone(n);
 
       assert.equal(clonedN, n);
       expectTypeOf(clonedN).toBeNull();
@@ -61,7 +61,7 @@ describe("lang", () => {
 
     it("Should clone undefined", async () => {
       const u = undefined;
-      const clonedU = await deepClone(u);
+      const clonedU = deepClone(u);
 
       assert.equal(clonedU, u);
       expectTypeOf(clonedU).toBeUndefined();
@@ -69,7 +69,7 @@ describe("lang", () => {
 
     it("Should reference a function", async () => {
       const fn = () => {};
-      const clonedFn = await deepClone(fn);
+      const clonedFn = deepClone(fn);
 
       assert.equal(clonedFn, fn);
       expectTypeOf(clonedFn).toEqualTypeOf<typeof fn>();
@@ -77,7 +77,7 @@ describe("lang", () => {
 
     it("Should clone a Date", async () => {
       const date = new Date();
-      const clonedDate = await deepClone(date);
+      const clonedDate = deepClone(date);
 
       assert.deepEqual(clonedDate, date);
       assert.notEqual(clonedDate, date);
@@ -89,7 +89,7 @@ describe("lang", () => {
         ["a", 1],
         ["b", 2],
       ]);
-      const clonedMap = await deepClone(map);
+      const clonedMap = deepClone(map);
 
       assert.deepEqual(clonedMap, map);
       assert.notEqual(clonedMap, map);
@@ -98,7 +98,7 @@ describe("lang", () => {
 
     it("Should clone a Set", async () => {
       const set = new Set([1, 2]);
-      const clonedSet = await deepClone(set);
+      const clonedSet = deepClone(set);
 
       assert.deepEqual(clonedSet, set);
       assert.notEqual(clonedSet, set);
@@ -107,7 +107,7 @@ describe("lang", () => {
 
     it("Should clone a Buffer", async () => {
       const buffer = Buffer.from("test");
-      const clonedBuffer = await deepClone(buffer);
+      const clonedBuffer = deepClone(buffer);
 
       const expected: { [key: number]: number } = {};
       for (let i = 0; i < buffer.length; i++) {
@@ -124,7 +124,7 @@ describe("lang", () => {
         return arguments;
       }
       const args = testFunc(1, "2", false);
-      const clonedArgs = await deepClone(args);
+      const clonedArgs = deepClone(args);
 
       assert.deepEqual(clonedArgs, { "0": 1, "1": "2", "2": false });
       expectTypeOf(clonedArgs).toHaveProperty("0").toBeNumber();

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/config-resolution.ts
@@ -224,7 +224,7 @@ export function resolveCoinbase(
 export async function resolveChainDescriptors(
   chainDescriptors: ChainDescriptorsUserConfig | undefined,
 ): Promise<ChainDescriptorsConfig> {
-  const resolvedChainDescriptors: ChainDescriptorsConfig = await deepClone(
+  const resolvedChainDescriptors: ChainDescriptorsConfig = deepClone(
     DEFAULT_CHAIN_DESCRIPTORS,
   );
 

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -7,6 +7,7 @@ import type {
   JsonRpcRequest,
   JsonRpcResponse,
 } from "../../../../types/providers.js";
+import { createHandlersArray } from "../request-handlers/handlers-array.js";
 import type { RequestHandler } from "../request-handlers/types.js";
 
 import { AsyncMutex } from "@nomicfoundation/hardhat-utils/synchronization";
@@ -37,10 +38,6 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         nextJsonRpcRequest: JsonRpcRequest,
       ) => Promise<JsonRpcResponse>,
     ) {
-      const { createHandlersArray } = await import(
-        "../request-handlers/handlers-array.js"
-      );
-
       const requestHandlers = await initializationMutex.exclusiveRun(
         async () => {
           let handlersPerConnection =

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -7,12 +7,12 @@ import type {
   JsonRpcRequest,
   JsonRpcResponse,
 } from "../../../../types/providers.js";
-import { createHandlersArray } from "../request-handlers/handlers-array.js";
 import type { RequestHandler } from "../request-handlers/types.js";
 
 import { AsyncMutex } from "@nomicfoundation/hardhat-utils/synchronization";
 
 import { isJsonRpcResponse } from "../json-rpc.js";
+import { createHandlersArray } from "../request-handlers/handlers-array.js";
 
 export default async (): Promise<Partial<NetworkHooks>> => {
   // This map is essential for managing multiple network connections in Hardhat V3.

--- a/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job.ts
@@ -130,7 +130,7 @@ export class CompilationJobImplementation implements CompilationJob {
     // from other files (e.g. new Foo()), and it won't output its bytecode if
     // it's not asked for. This would prevent EDR from doing any runtime
     // analysis.
-    const outputSelection = await deepClone(settings.outputSelection ?? {});
+    const outputSelection = deepClone(settings.outputSelection ?? {});
     outputSelection["*"] ??= {};
     outputSelection["*"][""] ??= [];
     outputSelection["*"]["*"] ??= [];


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Performance optimisations for Hardhat 3 by moving hot code `await import`s that are guaranteed to be run to be synchronous.

In the OpenZeppelin contracts repo, this reduced the Mocha test suite runtime from 284.57s to 136.92s (-51.9%).
