### PR TITLE
remove network request deepClone

### DIFF
--- a/.changeset/huge-parrots-watch.md
+++ b/.changeset/huge-parrots-watch.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Improved performance of the network stack by removing a clone of the http request ([#8046](https://github.com/NomicFoundation/hardhat/issues/8046))

--- a/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/v-next/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -9,7 +9,6 @@ import type {
 } from "../../../../types/providers.js";
 import type { RequestHandler } from "../request-handlers/types.js";
 
-import { deepClone } from "@nomicfoundation/hardhat-utils/lang";
 import { AsyncMutex } from "@nomicfoundation/hardhat-utils/synchronization";
 
 import { isJsonRpcResponse } from "../json-rpc.js";
@@ -61,21 +60,22 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         },
       );
 
-      // We clone the request to avoid interfering with other hook handlers that
-      // might be using the original request.
-      let request = await deepClone(jsonRpcRequest);
+      // We previously cloned here, but the performance impact is significant.
+      // TODO: ensure the passed in request is not mutated by adapting the
+      // handlers being applied here. See https://github.com/NomicFoundation/hardhat/issues/8090
+      let updatedRequest = jsonRpcRequest;
 
       for (const handler of requestHandlers) {
-        const newRequestOrResponse = await handler.handle(request);
+        const newRequestOrResponse = await handler.handle(updatedRequest);
 
         if (isJsonRpcResponse(newRequestOrResponse)) {
           return newRequestOrResponse;
         }
 
-        request = newRequestOrResponse;
+        updatedRequest = newRequestOrResponse;
       }
 
-      return next(context, networkConnection, request);
+      return next(context, networkConnection, updatedRequest);
     },
 
     async closeConnection<ChainTypeT extends ChainType | string>(


### PR DESCRIPTION
As part of the `onRequest` hook handler to apply the request mutating sub-handlers we applied a defesive deepClone, to ensure the passed in request was not mutated.

The `deepClone` is a performance bottleneck we have opted to remove.

For the moment, we will accept that the passed in request is updated in place. We have a follow up task to alter the subhandlers to transform rather than mutate, see https://github.com/NomicFoundation/hardhat/issues/8090

Resolves #8046

## Peer bumps reasoning

We are changing the ownership pattern here for requests within the `onRequest` hook. However, we have analyzed the downstream plugins and none are affected in the Nomic or community plugin list.
