### PR TITLE
feat: add fallible methods to artifact manager

### DIFF
--- a/packages/hardhat-ethers/test/helpers/artifact-manager-mock.ts
+++ b/packages/hardhat-ethers/test/helpers/artifact-manager-mock.ts
@@ -49,9 +49,37 @@ export class MockArtifactManager implements ArtifactManager {
     return artifact;
   }
 
+  public async tryToReadArtifact<ContractNameT extends string>(
+    contractNameOrFullyQualifiedName: ContractNameT,
+  ): Promise<GetArtifactByName<ContractNameT> | undefined> {
+    const artifactFileName = this.#artifactsPaths.get(
+      contractNameOrFullyQualifiedName,
+    );
+
+    if (artifactFileName === undefined) {
+      return undefined;
+    }
+
+    const artifact = (await import(`./artifacts/${artifactFileName}.ts`))
+      .CONTRACT;
+
+    return artifact;
+  }
+
   public async getArtifactPath(
     _contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.INTERNAL.NOT_IMPLEMENTED_ERROR,
+      {
+        message: "Not implemented in MockArtifactManager",
+      },
+    );
+  }
+
+  public async tryToGetArtifactPath(
+    contractNameOrFullyQualifiedName: string,
+  ): Promise<string | undefined> {
     throw new HardhatError(
       HardhatError.ERRORS.CORE.INTERNAL.NOT_IMPLEMENTED_ERROR,
       {

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -60,6 +60,22 @@ export class ArtifactManagerImplementation implements ArtifactManager {
     return readJsonFile(artifactPath);
   }
 
+  public async tryToReadArtifact<
+    ContractNameT extends StringWithArtifactContractNamesAutocompletion,
+  >(
+    contractNameOrFullyQualifiedName: ContractNameT,
+  ): Promise<GetArtifactByName<ContractNameT> | undefined> {
+    const artifactPath = await this.tryToGetArtifactPath(
+      contractNameOrFullyQualifiedName,
+    );
+
+    if (artifactPath === undefined) {
+      return undefined;
+    }
+
+    return readJsonFile(artifactPath);
+  }
+
   public async getArtifactPath(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
@@ -78,25 +94,35 @@ export class ArtifactManagerImplementation implements ArtifactManager {
     return artifactPath;
   }
 
+  public async tryToGetArtifactPath(
+    contractNameOrFullyQualifiedName: string,
+  ): Promise<string | undefined> {
+    const fqn = await this.#tryToGetFullyQualifiedName(
+      contractNameOrFullyQualifiedName,
+    );
+
+    if (typeof fqn === "string") {
+      const { fullyQualifiedNameToArtifactPath } = await this.#getFsData();
+
+      const artifactPath = fullyQualifiedNameToArtifactPath.get(fqn);
+      assertHardhatInvariant(
+        artifactPath !== undefined,
+        "Artifact path should be defined",
+      );
+
+      return artifactPath;
+    }
+
+    return undefined;
+  }
+
   public async artifactExists(
     contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
-    try {
-      // This throw if the artifact doesn't exist
-      await this.getArtifactPath(contractNameOrFullyQualifiedName);
-
-      return true;
-    } catch (error) {
-      if (HardhatError.isHardhatError(error)) {
-        if (
-          error.number === HardhatError.ERRORS.CORE.ARTIFACTS.NOT_FOUND.number
-        ) {
-          return false;
-        }
-      }
-
-      throw error;
-    }
+    const artifactPath = await this.tryToGetArtifactPath(
+      contractNameOrFullyQualifiedName,
+    );
+    return artifactPath !== undefined;
   }
 
   public async getBuildInfoId(
@@ -159,6 +185,32 @@ export class ArtifactManagerImplementation implements ArtifactManager {
   async #getFullyQualifiedName(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
+    const fqn = await this.#tryToGetFullyQualifiedName(
+      contractNameOrFullyQualifiedName,
+    );
+
+    if (typeof fqn === "string") {
+      return fqn;
+    }
+
+    const { allFullyQualifiedNames, bareNameToFullyQualifiedNameMap } = fqn;
+
+    this.#throwNotFoundError(
+      contractNameOrFullyQualifiedName,
+      bareNameToFullyQualifiedNameMap.keys(),
+      allFullyQualifiedNames,
+    );
+  }
+
+  async #tryToGetFullyQualifiedName(
+    contractNameOrFullyQualifiedName: string,
+  ): Promise<
+    | string
+    | {
+        allFullyQualifiedNames: ReadonlySet<string>;
+        bareNameToFullyQualifiedNameMap: Map<string, ReadonlySet<string>>;
+      }
+  > {
     const { bareNameToFullyQualifiedNameMap, allFullyQualifiedNames } =
       await this.#getFsData();
 
@@ -167,11 +219,10 @@ export class ArtifactManagerImplementation implements ArtifactManager {
         return contractNameOrFullyQualifiedName;
       }
 
-      this.#throwNotFoundError(
-        contractNameOrFullyQualifiedName,
-        bareNameToFullyQualifiedNameMap.keys(),
+      return {
         allFullyQualifiedNames,
-      );
+        bareNameToFullyQualifiedNameMap,
+      };
     }
 
     const fqns = bareNameToFullyQualifiedNameMap.get(
@@ -179,11 +230,10 @@ export class ArtifactManagerImplementation implements ArtifactManager {
     );
 
     if (fqns === undefined || fqns.size === 0) {
-      this.#throwNotFoundError(
-        contractNameOrFullyQualifiedName,
-        bareNameToFullyQualifiedNameMap.keys(),
+      return {
+        bareNameToFullyQualifiedNameMap,
         allFullyQualifiedNames,
-      );
+      };
     }
 
     if (fqns.size !== 1) {

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -23,11 +23,29 @@ class LazyArtifactManager implements ArtifactManager {
     return artifactManager.readArtifact(contractNameOrFullyQualifiedName);
   }
 
+  public async tryToReadArtifact<
+    ContractNameT extends StringWithArtifactContractNamesAutocompletion,
+  >(
+    contractNameOrFullyQualifiedName: ContractNameT,
+  ): Promise<GetArtifactByName<ContractNameT> | undefined> {
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.tryToReadArtifact(contractNameOrFullyQualifiedName);
+  }
+
   public async getArtifactPath(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
     const artifactManager = await this.#getArtifactManager();
     return artifactManager.getArtifactPath(contractNameOrFullyQualifiedName);
+  }
+
+  public async tryToGetArtifactPath(
+    contractNameOrFullyQualifiedName: string,
+  ): Promise<string | undefined> {
+    const artifactManager = await this.#getArtifactManager();
+    return artifactManager.tryToGetArtifactPath(
+      contractNameOrFullyQualifiedName,
+    );
   }
 
   public async artifactExists(

--- a/packages/hardhat/src/types/artifacts.ts
+++ b/packages/hardhat/src/types/artifacts.ts
@@ -76,6 +76,27 @@ export interface ArtifactManager {
   ): Promise<GetArtifactByName<ContractNameT>>;
 
   /**
+   * Tries to read an artifact, returning `undefined` if it doesn't exist.
+   *
+   * Use this instead of `readArtifact` if you want to avoid constructing an error when the artifact doesn't exist, which can be expensive if it happens often.
+   *
+   * @param contractNameOrFullyQualifiedName The name of the contract.
+   *   It can be a contract bare contract name (e.g. "Token") if it's
+   *   unique in your project, or a fully qualified contract name
+   *   (e.g. "contract/token.sol:Token") otherwise. TypeScript's language server
+   *   autocompletes the names of the contracts that have already been built. If
+   *   your contract name isn't in the list, you can still use it, and/or run
+   *   `hardhat build` to get it in the list.
+   * @throws Throws an error if a non-unique contract name is used,
+   *   indicating which fully qualified names can be used instead.
+   */
+  tryToReadArtifact<
+    ContractNameT extends StringWithArtifactContractNamesAutocompletion,
+  >(
+    contractNameOrFullyQualifiedName: ContractNameT,
+  ): Promise<GetArtifactByName<ContractNameT> | undefined>;
+
+  /**
    * Returns the absolute path to the given artifact.
    *
    * @param contractNameOrFullyQualifiedName The name or fully qualified name
@@ -85,6 +106,20 @@ export interface ArtifactManager {
    * @throws Throws an error if the artifact doesn't exist.
    */
   getArtifactPath(contractNameOrFullyQualifiedName: string): Promise<string>;
+
+  /**
+   * Tries to get the absolute path to the given artifact, returning `undefined` if it doesn't exist.
+   *
+   * Use this instead of `getArtifactPath` if you want to avoid constructing an error when the artifact doesn't exist, which can be expensive if it happens often.
+   *
+   * @param contractNameOrFullyQualifiedName The name or fully qualified name
+   * of the contract.
+   * @throws Throws an error if a non-unique contract name is used,
+   *   indicating which fully qualified names can be used instead.
+   */
+  tryToGetArtifactPath(
+    contractNameOrFullyQualifiedName: string,
+  ): Promise<string | undefined>;
 
   /**
    * Returns true if an artifact exists.

--- a/packages/hardhat/test/test-helpers/mock-artifact-manager.ts
+++ b/packages/hardhat/test/test-helpers/mock-artifact-manager.ts
@@ -40,9 +40,37 @@ export class MockArtifactManager implements ArtifactManager {
     return artifact as GetArtifactByName<ContractNameT>;
   }
 
+  public async tryToReadArtifact<
+    ContractNameT extends StringWithArtifactContractNamesAutocompletion,
+  >(
+    contractNameOrFullyQualifiedName: ContractNameT,
+  ): Promise<GetArtifactByName<ContractNameT> | undefined> {
+    const artifact = this.#artifacts.get(contractNameOrFullyQualifiedName);
+
+    if (artifact === undefined) {
+      return undefined;
+    }
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+    We are asserting that the artifact is of the correct type, which won't be
+    really used during tests. */
+    return artifact as GetArtifactByName<ContractNameT>;
+  }
+
   public async getArtifactPath(
     _contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.INTERNAL.NOT_IMPLEMENTED_ERROR,
+      {
+        message: "Not implemented in MockArtifactManager",
+      },
+    );
+  }
+
+  public async tryToGetArtifactPath(
+    _contractNameOrFullyQualifiedName: string,
+  ): Promise<string | undefined> {
     throw new HardhatError(
       HardhatError.ERRORS.CORE.INTERNAL.NOT_IMPLEMENTED_ERROR,
       {


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

The existing `ArtifactManager` methods always throw, which can be expensive when failures are common, especially if the thrown error is not even used. The new methods avoid throwing and instead return `undefined`.

[The Openzeppelin Contracts](https://github.com/Amxx/openzeppelin-contracts) suffer from this problem, as they have a test suite that auto-generates test vectors for as many artifacts as possible (for more info, see [1](https://github.com/Amxx/openzeppelin-contracts/blob/00780408a72fd41efd3cf1c54addf74d305f037a/test/helpers/storage.js#L36) & [2](https://github.com/Amxx/openzeppelin-contracts/blob/00780408a72fd41efd3cf1c54addf74d305f037a/hardhat/hardhat-oz-contracts-helpers/hook-handlers/hre.ts#L12).

As seen in this profiling run, Hardhat's `editDistance` function takes the 4th largest amount of time. 

<img width="551" height="216" alt="image" src="https://github.com/user-attachments/assets/faf697ec-7548-43a2-8461-2a08dfee4cb0" />

In total, the `#getFullyQualifiedName` function is consuming about 6.3% of the OZ test time:

<img width="589" height="43" alt="image" src="https://github.com/user-attachments/assets/4c9dce16-f8ce-4988-bda0-95465391b213" />

There are several reasons for this becoming a hot path despite being error handling code:
1. OpenZeppelin causes 6006 calls to `#getSimilarStrings` due to missing artifacts
2. `#getSimilarStrings` is called with 764+ names to compare against
3. `editDistance` is called with names ranging in length from 3 to 39.
4. `editDistance` uses Levenshtein algorithm to determine the edit distance. The standard implementation has a time complexity of `O(m×n)`

After optimisation, we're almost spending no time (i.e. <0.1%) on this code path anymore:

<img width="534" height="43" alt="image" src="https://github.com/user-attachments/assets/360a525f-b4dd-494f-a805-eeb9dc97735b" />

The runtime of `npx hardhat test mocha --no-compile` went from 1:31.84 to 1:22.23, a reduction of 9.61s (-10.5%).

The accompanying change in OpenZeppelin Contracts can be found [here](https://github.com/Wodann/openzeppelin-contracts/commit/a0cb3d884555e88e312438fdf143f06776fedb23).

This PR also speeds up the `artifactExists` implementation shipped with Hardhat by not requiring the generation of the (later discarded) error for non-existent artifacts.

# Considerations

- I considered alternatives to the Levenshtein algorithm, like Jaro-Winkler Similarity which has `O(m+n)` time complexity; but given that OpenZeppelin never actually uses the generated error, I thought it would be a better alternative to introduce APIs that signal the possibility of the file not existing.
- An alternative optimisation would be to change the `#throwNotFoundError` to return a cheap intermediate error type that needs to be converted to a full, expensive-to-calculate Hardhat error (with suggestion) at a later time. That intermediate error type would contain the following information:
  ```ts
  {
    allFullyQualifiedNames: ReadonlySet<string>;
    bareNameToFullyQualifiedNameMap: Map<string, ReadonlySet<string>>;
  }
  ```
  Plugins (or users) that directly interface with `ArtifactManager` as a "library API" would then have control over whether to use the error or not. End-user application like Hardhat's CLI would then invoke the error conversion on the intermediate error type.