### PR TITLE
chore: small improvements to our release config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,15 +15,7 @@
     "@nomicfoundation/template-package",
     "template-*"
   ],
-  "fixed": [
-    [
-      "@nomicfoundation/hardhat-ignition",
-      "@nomicfoundation/hardhat-ignition-ethers",
-      "@nomicfoundation/hardhat-ignition-viem",
-      "@nomicfoundation/ignition-core",
-      "@nomicfoundation/ignition-ui"
-    ]
-  ],
+  "fixed": [],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/scripts/lib/packages.ts
+++ b/scripts/lib/packages.ts
@@ -13,7 +13,6 @@ export async function readAllReleasablePackages() {
         "example-project",
         "template-package",
         "hardhat-test-utils",
-        "hardhat-vendored",
       ].includes(file),
   );
 


### PR DESCRIPTION
This PR makes two changes:

1. No longer fix all ignition packages to the same version
2. No longer exclude `hardhat-vendored` from merge queue checks

The first we have discussed before, the second is a cleanup that has been forgotten.
