### PR TITLE
refactor: conditionally avoid network handlers

### DIFF
--- a/.changeset/cuddly-insects-invent.md
+++ b/.changeset/cuddly-insects-invent.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Improved network handler performance through additional metadata to allow early skipping ([#8103](https://github.com/NomicFoundation/hardhat/pull/8103))

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -65,6 +65,10 @@ export default async (): Promise<Partial<NetworkHooks>> => {
       let updatedRequest = jsonRpcRequest;
 
       for (const handler of requestHandlers) {
+        if (!handler.isSupportedMethod(updatedRequest)) {
+          continue;
+        }
+
         const newRequestOrResponse = await handler.handle(updatedRequest);
 
         if (isJsonRpcResponse(newRequestOrResponse)) {

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/hd-wallet-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/hd-wallet-handler.ts
@@ -27,6 +27,7 @@ export class HDWalletHandler extends LocalAccountsHandler {
 
     return new HDWalletHandler(provider, privateKeys);
   }
+
   private constructor(provider: EthereumProvider, privateKeys: string[]) {
     super(provider, privateKeys);
   }

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
@@ -39,6 +39,15 @@ import { ChainId } from "../chain-id/chain-id.js";
 
 const EXTRA_ENTROPY = false;
 export class LocalAccountsHandler extends ChainId implements RequestHandler {
+  readonly #methods: ReadonlySet<string> = new Set([
+    "eth_accounts",
+    "eth_requestAccounts",
+    "eth_sign",
+    "personal_sign",
+    "eth_signTypedData_v4",
+    "eth_sendTransaction",
+  ]);
+
   readonly #localAccountsHexPrivateKeys: string[];
 
   #addressToPrivateKey: Map<string, Uint8Array> | undefined;
@@ -51,6 +60,27 @@ export class LocalAccountsHandler extends ChainId implements RequestHandler {
     super(provider);
 
     this.#localAccountsHexPrivateKeys = localAccountsHexPrivateKeys;
+  }
+
+  public isSupportedMethod(jsonRpcRequest: JsonRpcRequest): boolean {
+    return this.#methods.has(jsonRpcRequest.method);
+  }
+
+  public async handle(
+    jsonRpcRequest: JsonRpcRequest,
+  ): Promise<JsonRpcRequest | JsonRpcResponse> {
+    if (!this.isSupportedMethod(jsonRpcRequest)) {
+      return jsonRpcRequest;
+    }
+
+    const response = await this.#resolveRequest(jsonRpcRequest);
+    if (response !== null) {
+      return response;
+    }
+
+    await this.#modifyRequest(jsonRpcRequest);
+
+    return jsonRpcRequest;
   }
 
   async #getAddressesAndPrivateKeysMap(): Promise<{
@@ -73,19 +103,6 @@ export class LocalAccountsHandler extends ChainId implements RequestHandler {
       addresses: this.#addresses,
       addressToPrivateKey: this.#addressToPrivateKey,
     };
-  }
-
-  public async handle(
-    jsonRpcRequest: JsonRpcRequest,
-  ): Promise<JsonRpcRequest | JsonRpcResponse> {
-    const response = await this.#resolveRequest(jsonRpcRequest);
-    if (response !== null) {
-      return response;
-    }
-
-    await this.#modifyRequest(jsonRpcRequest);
-
-    return jsonRpcRequest;
   }
 
   async #resolveRequest(

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/sender.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/sender.ts
@@ -17,35 +17,43 @@ import { getRequestParams } from "../../../json-rpc.js";
  * The class also provides a mechanism to retrieve the sender account, which must be implemented by subclasses.
  */
 export abstract class SenderHandler implements RequestHandler {
+  readonly #methods: ReadonlySet<string> = new Set([
+    "eth_sendTransaction",
+    "eth_call",
+    "eth_estimateGas",
+  ]);
+
   protected readonly provider: EthereumProvider;
 
   constructor(provider: EthereumProvider) {
     this.provider = provider;
   }
 
+  public isSupportedMethod(jsonRpcRequest: JsonRpcRequest): boolean {
+    return this.#methods.has(jsonRpcRequest.method);
+  }
+
   public async handle(
     jsonRpcRequest: JsonRpcRequest,
   ): Promise<JsonRpcRequest | JsonRpcResponse> {
+    if (!this.isSupportedMethod(jsonRpcRequest)) {
+      return jsonRpcRequest;
+    }
+
     const method = jsonRpcRequest.method;
     const params = getRequestParams(jsonRpcRequest);
 
-    if (
-      method === "eth_sendTransaction" ||
-      method === "eth_call" ||
-      method === "eth_estimateGas"
-    ) {
-      const [tx] = params;
+    const [tx] = params;
 
-      if (isObject(tx) && tx.from === undefined) {
-        const senderAccount = await this.getSender();
+    if (isObject(tx) && tx.from === undefined) {
+      const senderAccount = await this.getSender();
 
-        if (senderAccount !== undefined) {
-          tx.from = senderAccount;
-        } else if (method === "eth_sendTransaction") {
-          throw new HardhatError(
-            HardhatError.ERRORS.CORE.NETWORK.NO_REMOTE_ACCOUNT_AVAILABLE,
-          );
-        }
+      if (senderAccount !== undefined) {
+        tx.from = senderAccount;
+      } else if (method === "eth_sendTransaction") {
+        throw new HardhatError(
+          HardhatError.ERRORS.CORE.NETWORK.NO_REMOTE_ACCOUNT_AVAILABLE,
+        );
       }
     }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/chain-id/chain-id-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/chain-id/chain-id-handler.ts
@@ -25,17 +25,25 @@ export class ChainIdValidatorHandler extends ChainId implements RequestHandler {
     this.#expectedChainId = expectedChainId;
   }
 
-  public async handle(
-    jsonRpcRequest: JsonRpcRequest,
-  ): Promise<JsonRpcRequest | JsonRpcResponse> {
+  public isSupportedMethod(jsonRpcRequest: JsonRpcRequest): boolean {
+    if (this.#alreadyValidated) {
+      return false;
+    }
+
     if (
       jsonRpcRequest.method === "eth_chainId" ||
       jsonRpcRequest.method === "net_version"
     ) {
-      return jsonRpcRequest;
+      return false;
     }
 
-    if (this.#alreadyValidated) {
+    return true;
+  }
+
+  public async handle(
+    jsonRpcRequest: JsonRpcRequest,
+  ): Promise<JsonRpcRequest | JsonRpcResponse> {
+    if (!this.isSupportedMethod(jsonRpcRequest)) {
       return jsonRpcRequest;
     }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts
@@ -25,6 +25,8 @@ export class AutomaticGasHandler
   extends MultipliedGasEstimation
   implements RequestHandler
 {
+  readonly #methods: ReadonlySet<string> = new Set(["eth_sendTransaction"]);
+
   constructor(
     provider: EthereumProvider,
     gasMultiplier: number = DEFAULT_GAS_MULTIPLIER,
@@ -32,10 +34,14 @@ export class AutomaticGasHandler
     super(provider, gasMultiplier);
   }
 
+  public isSupportedMethod(jsonRpcRequest: JsonRpcRequest): boolean {
+    return this.#methods.has(jsonRpcRequest.method);
+  }
+
   public async handle(
     jsonRpcRequest: JsonRpcRequest,
   ): Promise<JsonRpcRequest | JsonRpcResponse> {
-    if (jsonRpcRequest.method !== "eth_sendTransaction") {
+    if (!this.isSupportedMethod(jsonRpcRequest)) {
       return jsonRpcRequest;
     }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts
@@ -19,6 +19,8 @@ import { getRequestParams } from "../../../json-rpc.js";
  * It ensures that gas prices are set correctly.
  */
 export class AutomaticGasPriceHandler implements RequestHandler {
+  readonly #methods: ReadonlySet<string> = new Set(["eth_sendTransaction"]);
+
   readonly #provider: EthereumProvider;
 
   // We pay the max base fee that can be required if the next
@@ -36,10 +38,14 @@ export class AutomaticGasPriceHandler implements RequestHandler {
   #nodeHasFeeHistory?: boolean;
   #nodeSupportsEIP1559?: boolean;
 
+  public isSupportedMethod(jsonRpcRequest: JsonRpcRequest): boolean {
+    return this.#methods.has(jsonRpcRequest.method);
+  }
+
   public async handle(
     jsonRpcRequest: JsonRpcRequest,
   ): Promise<JsonRpcRequest | JsonRpcResponse> {
-    if (jsonRpcRequest.method !== "eth_sendTransaction") {
+    if (!this.isSupportedMethod(jsonRpcRequest)) {
       return jsonRpcRequest;
     }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
@@ -14,16 +14,22 @@ import { getRequestParams } from "../../../json-rpc.js";
  * For `eth_sendTransaction` requests, it sets the gas field with the value provided via the class constructor, if it hasn't been specified already.
  */
 export class FixedGasHandler implements RequestHandler {
+  readonly #methods: ReadonlySet<string> = new Set(["eth_sendTransaction"]);
+
   readonly #gas: PrefixedHexString;
 
   constructor(gas: PrefixedHexString) {
     this.#gas = gas;
   }
 
+  public isSupportedMethod(jsonRpcRequest: JsonRpcRequest): boolean {
+    return this.#methods.has(jsonRpcRequest.method);
+  }
+
   public async handle(
     jsonRpcRequest: JsonRpcRequest,
   ): Promise<JsonRpcRequest | JsonRpcResponse> {
-    if (jsonRpcRequest.method !== "eth_sendTransaction") {
+    if (!this.isSupportedMethod(jsonRpcRequest)) {
       return jsonRpcRequest;
     }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts
@@ -14,16 +14,22 @@ import { getRequestParams } from "../../../json-rpc.js";
  * For `eth_sendTransaction` requests, it sets the gasPrice field with the value provided via the class constructor, if it hasn't been specified already.
  */
 export class FixedGasPriceHandler implements RequestHandler {
+  readonly #methods: ReadonlySet<string> = new Set(["eth_sendTransaction"]);
+
   readonly #gasPrice: PrefixedHexString;
 
   constructor(gasPrice: PrefixedHexString) {
     this.#gasPrice = gasPrice;
   }
 
+  public isSupportedMethod(jsonRpcRequest: JsonRpcRequest): boolean {
+    return this.#methods.has(jsonRpcRequest.method);
+  }
+
   public async handle(
     jsonRpcRequest: JsonRpcRequest,
   ): Promise<JsonRpcRequest | JsonRpcResponse> {
-    if (jsonRpcRequest.method !== "eth_sendTransaction") {
+    if (!this.isSupportedMethod(jsonRpcRequest)) {
       return jsonRpcRequest;
     }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/types.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/types.ts
@@ -14,6 +14,16 @@ import type {
  *
  */
 export interface RequestHandler {
+  /**
+   * A guard to ensure the request is supported by the handler.
+   * If the handler does not support the request, then it can be safely
+   * skipped.
+   *
+   * @param jsonRpcRequest - The JSON-RPC request to check.
+   * @returns true if the method will be processed by the handler, false otherwise.
+   */
+  isSupportedMethod(jsonRpcRequest: JsonRpcRequest): boolean;
+
   handle(
     jsonRpcRequest: JsonRpcRequest,
   ): Promise<JsonRpcRequest | JsonRpcResponse>;


### PR DESCRIPTION
Add metadata to each subhandler in `onRequest` specifying which which RPC Methods are used. The handler will be skipped if the request's method does not match.

The goal here is avoid a cycle of async/awaits, instead we do sync checks.

The check is rerun within the handler as a guard and to force an engineer modifying the handler to consider the supported list. This justifies the no additional tests.

Resolves #8047
