### PR TITLE
Add solc 0.8.34 default EVM target (osaka)

### DIFF
--- a/.changeset/add-solc-0834-evm-target.md
+++ b/.changeset/add-solc-0834-evm-target.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add Solidity 0.8.34 to the default EVM targets table (osaka)

--- a/.changeset/add-solc-0834-evm-target.md
+++ b/.changeset/add-solc-0834-evm-target.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Add Solidity 0.8.34 to the default EVM targets table (osaka)
+Add Solidity 0.8.34 to the default EVM targets table (osaka) ([#8105](https://github.com/NomicFoundation/hardhat/pull/8105))

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-info.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-info.ts
@@ -107,6 +107,7 @@ const defaultEvmTargets: { [key: string]: string } = {
   "0.8.31": "osaka",
   "0.8.32": "osaka",
   "0.8.33": "osaka",
+  "0.8.34": "osaka",
 };
 
 export function getEvmVersionFromSolcVersion(


### PR DESCRIPTION
## Summary
Add Solidity 0.8.34 to the `defaultEvmTargets` table in `solc-info.ts`. The default EVM version is `osaka`.

**Before:**
```
Compiled 1 Solidity file with solc 0.8.34 (evm target: Check solc 0.8.34's doc for its default evm version)
```

**After:**
```
Compiled 1 Solidity file with solc 0.8.34 (evm target: osaka)
```