### PR TITLE
perf: avoid mutex if hook categories have been initialized

### DIFF
--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -18,9 +18,27 @@ import { AsyncMutex } from "@nomicfoundation/hardhat-utils/synchronization";
 
 import { detectPluginNpmDependencyProblems } from "./plugins/detect-plugin-npm-dependency-problems.js";
 
-export class HookManagerImplementation implements HookManager {
-  readonly #mutex: AsyncMutex = new AsyncMutex();
+class StaticHookHandlers {
+  public readonly mutex: AsyncMutex = new AsyncMutex();
 
+  #categories: Map<
+    keyof HardhatHooks,
+    Partial<HardhatHooks[keyof HardhatHooks]>
+  > = new Map();
+
+  public get(hookCategoryName: keyof HardhatHooks) {
+    return this.#categories.get(hookCategoryName);
+  }
+
+  public set(
+    hookCategoryName: keyof HardhatHooks,
+    hookCategory: Partial<HardhatHooks[keyof HardhatHooks]>,
+  ) {
+    this.#categories.set(hookCategoryName, hookCategory);
+  }
+}
+
+export class HookManagerImplementation implements HookManager {
   readonly #projectRoot: string;
 
   readonly #pluginsInReverseOrder: HardhatPlugin[];
@@ -34,10 +52,8 @@ export class HookManagerImplementation implements HookManager {
   /**
    * The initialized handler categories for each plugin.
    */
-  readonly #staticHookHandlerCategories: Map<
-    string,
-    Map<keyof HardhatHooks, Partial<HardhatHooks[keyof HardhatHooks]>>
-  > = new Map();
+  readonly #staticHookHandlerCategories: Map<string, StaticHookHandlers> =
+    new Map();
 
   /**
    * A map of the dynamically registered handler categories.
@@ -220,12 +236,10 @@ export class HookManagerImplementation implements HookManager {
     hookCategoryName: HookCategoryNameT,
     hookName: HookNameT,
   ): Promise<Array<HardhatHooks[HookCategoryNameT][HookNameT]>> {
-    const pluginHooks = await this.#getPluginHooks(hookCategoryName, hookName);
-
-    const dynamicHooks = await this.#getDynamicHooks(
-      hookCategoryName,
-      hookName,
-    );
+    const [pluginHooks, dynamicHooks] = await Promise.all([
+      this.#getPluginHooks(hookCategoryName, hookName),
+      this.#getDynamicHooks(hookCategoryName, hookName),
+    ]);
 
     return [...dynamicHooks, ...pluginHooks];
   }
@@ -276,22 +290,37 @@ export class HookManagerImplementation implements HookManager {
   ): Promise<Array<HardhatHooks[HookCategoryNameT][HookNameT]>> {
     const categories: Array<
       Partial<HardhatHooks[HookCategoryNameT]> | undefined
-    > = await this.#mutex.exclusiveRun(async () => {
-      return Promise.all(
-        this.#pluginsInReverseOrder.map(async (plugin) => {
-          const existingCategory = this.#staticHookHandlerCategories
-            .get(plugin.id)
-            ?.get(hookCategoryName);
+    > = await Promise.all(
+      this.#pluginsInReverseOrder.map(async (plugin) => {
+        let staticPluginHandlers = this.#staticHookHandlerCategories.get(
+          plugin.id,
+        );
 
+        if (staticPluginHandlers === undefined) {
+          staticPluginHandlers = new StaticHookHandlers();
+          this.#staticHookHandlerCategories.set(
+            plugin.id,
+            staticPluginHandlers,
+          );
+        }
+
+        const existingCategory = staticPluginHandlers.get(hookCategoryName);
+        if (existingCategory !== undefined) {
+          return existingCategory as Partial<HardhatHooks[HookCategoryNameT]>;
+        }
+
+        const hookHandlerCategoryFactory =
+          plugin.hookHandlers?.[hookCategoryName];
+
+        if (hookHandlerCategoryFactory === undefined) {
+          return undefined;
+        }
+
+        return staticPluginHandlers.mutex.exclusiveRun(async () => {
+          // Recheck whether another execution of this function has already initialized the category while we were waiting for the lock, to avoid initializing it multiple times.
+          const existingCategory = staticPluginHandlers.get(hookCategoryName);
           if (existingCategory !== undefined) {
             return existingCategory as Partial<HardhatHooks[HookCategoryNameT]>;
-          }
-
-          const hookHandlerCategoryFactory =
-            plugin.hookHandlers?.[hookCategoryName];
-
-          if (hookHandlerCategoryFactory === undefined) {
-            return;
           }
 
           let factory;
@@ -321,19 +350,12 @@ export class HookManagerImplementation implements HookManager {
             `Plugin ${plugin.id} doesn't export a valid factory for category ${hookCategoryName}, it didn't return an object`,
           );
 
-          if (!this.#staticHookHandlerCategories.has(plugin.id)) {
-            this.#staticHookHandlerCategories.set(plugin.id, new Map());
-          }
-
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Defined right above
-          this.#staticHookHandlerCategories
-            .get(plugin.id)!
-            .set(hookCategoryName, hookCategory);
+          staticPluginHandlers.set(hookCategoryName, hookCategory);
 
           return hookCategory;
-        }),
-      );
-    });
+        });
+      }),
+    );
 
     return categories.flatMap((category) => {
       const handler = category?.[hookName];


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

After prior optimisations, the OpenZeppelin contracts (OZC) repo is spending a significant time inside `HookManagerImplementation::#getPluginHooks`, its call to `exclusiveRun`, and idling (i.e. waiting for `Promise`s to be resolved) during this time.

<img width="604" height="757" alt="image" src="https://github.com/user-attachments/assets/a42d1cd5-580b-4d4e-ad23-7f3aea7a3b34" />

Originally, we locked an `AsyncMutex` before asynchronously retrieving and potentially constructing hooks per category.

To reduce the time spent inside `exclusiveRun`, I attempted an optimisation that checks whether the requested category has already been cached, before locking the `AsyncMutex` and performing an `exclusiveRun` (also called a double-check pattern).

Since multiple `Promise`s can now be trying to acquire the `AsyncMutex` at the same time, this required a second step to avoid lock contention. Since each `Promise` is only interested in modifying a unique cached entry, I instead introduced an `AsyncMutex` per category.

For the OZC repo, this reduced the runtime of `npx hardhat test mocha --no-compile` from 1:31.84 to 1:27.49, a reduction of -4.35s (-4.7%).

Optimisations are reaching a point where the required changes are becoming larger and gains smaller. It's unclear whether the gain for OZC due to these changes would translate to a similar gain (or maybe even loss) in performance for small(er) Hardhat projects.

To that end, I'd recommend implementing benchmarks for multiple HH3 repos before deciding to merge this PR (or not).