### PR TITLE
misc: increase max file size in verdaccio for EDR

### DIFF
--- a/scripts/verdaccio/start.ts
+++ b/scripts/verdaccio/start.ts
@@ -98,6 +98,7 @@ packages:
     publish: $authenticated
     unpublish: $authenticated
     proxy: npmjs
+max_body_size: 100mb
 log:
 ${logConfig}
 `;


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This PR increases the maximum file size in verdaccio such that EDR binaries can be published to it.