### PR TITLE
fix/inline config parse on large build inputs

### DIFF
--- a/.changeset/warm-groups-knock.md
+++ b/.changeset/warm-groups-knock.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix inline config reading for large buildinfo files

--- a/cspell.dictionary.txt
+++ b/cspell.dictionary.txt
@@ -91,6 +91,7 @@ onuncaughtexception
 perché
 perché
 popd
+popescuoctavian
 PREVRANDAO
 pushd
 randao

--- a/end-to-end/base-contracts/preinstall.sh
+++ b/end-to-end/base-contracts/preinstall.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+~/.foundry/bin/forge install --no-git \
+		github.com/foundry-rs/forge-std@6853b9ec7df5dc0c213b05ae67785ad4f4baa0ea \
+		github.com/runtimeverification/kontrol-cheatcodes@2c48ae1ab44228c199dca29414c0b4b18a3434e6 \
+		github.com/ethereum-optimism/lib-keccak@3b1e7bbb4cc23e9228097cfebe42aedaf3b8f2b9 \
+		github.com/OpenZeppelin/openzeppelin-contracts@ecd2ca2cd7cac116f7a37d0e474bbb3d7d5e1c4d \
+		github.com/OpenZeppelin/openzeppelin-contracts-upgradeable@0a2cb9a445c365870ed7a8ab461b12acf3e27d63 \
+		github.com/transmissions11/solmate@8f9b23f8838670afda0fd8983f2c41e8037ae6bc \
+		github.com/safe-global/safe-contracts@bf943f80fec5ac647159d26161446ac5d716a294 \
+		github.com/Vectorized/solady@502cc1ea718e6fa73b380635ee0868b0740595f0 \
+		github.com/base/nitro-validator@0f006d2075637dd9640e530c4a7065f5c8bb2132 \
+		github.com/base/op-enclave@a2d5398f04c3a8e4df929d58ee638ba4a037bfec \
+		github.com/risc0/risc0-ethereum@a78ac4a52fe9cfa14120c3b496430f0d42e1d8d3 \
+		github.com/succinctlabs/sp1-contracts@22c4a47cd0a388cb4e25b4f2513954e4275c74ca
+	
+~/.foundry/bin/forge install --no-git \
+    github.com/ethereum-optimism/superchain-registry@84bce73573f130008d84bae6e924163bab589a11
+
+git clone --no-checkout https://github.com/OpenZeppelin/openzeppelin-contracts.git lib/openzeppelin-contracts-v5
+git -C lib/openzeppelin-contracts-v5 checkout dbb6104ce834628e473d2173bbc9d47f81a9eec3
+
+git clone --no-checkout https://github.com/Vectorized/solady.git lib/solady-v0.0.245
+git -C lib/solady-v0.0.245 checkout 8583a6e386b897f3db142a541f86d5953eccd835

--- a/end-to-end/base-contracts/scenario.json
+++ b/end-to-end/base-contracts/scenario.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
+  "description": "Base contracts main branch (Foundry Solidity test suite)",
+  "tags": ["external-repo"],
+  "repo": "popescuoctavian/base-contracts",
+  "commit": "8f365822e412f90a57b80ba6571815bb1152fe79",
+  "packageManager": "pnpm",
+  "submodules": true,
+  "preinstall": "./preinstall.sh",
+  "defaultCommand": "pnpm hardhat test solidity"
+}

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts
@@ -9,6 +9,7 @@ import { readBinaryFile } from "@nomicfoundation/hardhat-utils/fs";
 
 export interface BuildInfoAndOutput extends EdrBuildInfoAndOutput {
   buildInfoId: string;
+  buildInfoOutputPath: string;
 }
 
 export interface EdrArtifactWithMetadata {
@@ -58,6 +59,7 @@ export async function getBuildInfosAndOutputs(
         buildInfoId,
         buildInfo,
         output,
+        buildInfoOutputPath,
       };
     }),
   );

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -10,7 +10,7 @@ import {
   HardhatError,
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
-import { bytesToUtf8String } from "@nomicfoundation/hardhat-utils/bytes";
+import { readJsonFileAsStream } from "@nomicfoundation/hardhat-utils/fs";
 
 import { getFullyQualifiedName } from "../../../../utils/contract-names.js";
 
@@ -48,11 +48,11 @@ interface CollectedOverrides {
  * in the solc AST. It only extracts them from the build info where each
  * test artifact's file was compiled as a root file.
  */
-export function getTestFunctionOverrides(
+export async function getTestFunctionOverrides(
   testSuiteArtifacts: EdrArtifactWithMetadata[],
   buildInfosAndOutputs: BuildInfoAndOutput[],
-): TestFunctionOverride[] {
-  const allRawOverrides = collectRawOverrides(
+): Promise<TestFunctionOverride[]> {
+  const allRawOverrides = await collectRawOverrides(
     testSuiteArtifacts,
     buildInfosAndOutputs,
   );
@@ -62,10 +62,10 @@ export function getTestFunctionOverrides(
   return buildTestFunctionOverrides(allRawOverrides);
 }
 
-function collectRawOverrides(
+async function collectRawOverrides(
   testSuiteArtifacts: EdrArtifactWithMetadata[],
   buildInfosAndOutputs: BuildInfoAndOutput[],
-): CollectedOverrides {
+): Promise<CollectedOverrides> {
   const overrides: RawInlineOverride[] = [];
   const methodIdentifiersByContract = new Map<string, Record<string, string>>();
 
@@ -153,8 +153,8 @@ function collectRawOverrides(
       continue;
     }
 
-    const buildInfoOutput: SolidityBuildInfoOutput = JSON.parse(
-      bytesToUtf8String(buildInfoAndOutput.output),
+    const buildInfoOutput = await readJsonFileAsStream<SolidityBuildInfoOutput>(
+      buildInfoAndOutput.buildInfoOutputPath,
     );
 
     for (const [

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -169,7 +169,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     }
   }
 
-  const testFunctionOverrides = getTestFunctionOverrides(
+  const testFunctionOverrides = await getTestFunctionOverrides(
     testSuiteArtifacts,
     allBuildInfosAndOutputs,
   );

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import {
   getFunctionFqn,
@@ -14,7 +14,7 @@ import { makeBuildInfo, makeTestSuiteArtifact } from "./mocks.js";
 
 describe("inline-config", () => {
   describe("getTestFunctionOverrides", () => {
-    it("should return empty array when no build infos contain inline config", () => {
+    it("should return empty array when no build infos contain inline config", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "// just a comment\ncontract MyTest {}",
@@ -26,10 +26,10 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      assert.deepEqual(getTestFunctionOverrides(artifacts, [bi]), []);
+      assert.deepEqual(await getTestFunctionOverrides(artifacts, [bi]), []);
     });
 
-    it("should deduplicate when same source appears in multiple build infos", () => {
+    it("should deduplicate when same source appears in multiple build infos", async () => {
       const bi1 = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10",
@@ -61,11 +61,11 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      const overrides = getTestFunctionOverrides(artifacts, [bi1, bi2]);
+      const overrides = await getTestFunctionOverrides(artifacts, [bi1, bi2]);
       assert.equal(overrides.length, 1);
     });
 
-    it("should produce correct ArtifactId with solcVersion", () => {
+    it("should produce correct ArtifactId with solcVersion", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10",
@@ -85,7 +85,7 @@ describe("inline-config", () => {
       const artifacts = [
         makeTestSuiteArtifact("test/MyTest.sol", "MyTest", "0.8.20"),
       ];
-      const overrides = getTestFunctionOverrides(artifacts, [bi]);
+      const overrides = await getTestFunctionOverrides(artifacts, [bi]);
       assert.deepEqual(overrides[0].identifier.contractArtifact, {
         name: "MyTest",
         source: "test/MyTest.sol",
@@ -93,7 +93,7 @@ describe("inline-config", () => {
       });
     });
 
-    it("should throw UNRESOLVED_SELECTOR when function has no ABI entry", () => {
+    it("should throw UNRESOLVED_SELECTOR when function has no ABI entry", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10",
@@ -110,8 +110,8 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      assertThrowsHardhatError(
-        () => getTestFunctionOverrides(artifacts, [bi]),
+      await assertRejectsWithHardhatError(
+        async () => getTestFunctionOverrides(artifacts, [bi]),
         HardhatError.ERRORS.CORE.SOLIDITY_TESTS
           .INLINE_CONFIG_UNRESOLVED_SELECTOR,
         {
@@ -124,7 +124,7 @@ describe("inline-config", () => {
       );
     });
 
-    it("should process a basic end-to-end case", () => {
+    it("should process a basic end-to-end case", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 50",
@@ -141,13 +141,13 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      const overrides = getTestFunctionOverrides(artifacts, [bi]);
+      const overrides = await getTestFunctionOverrides(artifacts, [bi]);
       assert.equal(overrides.length, 1);
       assert.equal(overrides[0].identifier.functionSelector, "0xaabbccdd");
       assert.deepEqual(overrides[0].config, { fuzz: { runs: 50 } });
     });
 
-    it("should merge overrides from mixed hardhat-config: and forge-config: prefixes", () => {
+    it("should merge overrides from mixed hardhat-config: and forge-config: prefixes", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10\n/// forge-config: fuzz.max-test-rejects = 500",
@@ -165,14 +165,14 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      const overrides = getTestFunctionOverrides(artifacts, [bi]);
+      const overrides = await getTestFunctionOverrides(artifacts, [bi]);
       assert.equal(overrides.length, 1);
       assert.deepEqual(overrides[0].config, {
         fuzz: { runs: 10, maxTestRejects: 500 },
       });
     });
 
-    it("should throw BUILD_INFO_NOT_FOUND when artifact references missing build info", () => {
+    it("should throw BUILD_INFO_NOT_FOUND when artifact references missing build info", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10",
@@ -192,8 +192,8 @@ describe("inline-config", () => {
       );
 
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      assertThrowsHardhatError(
-        () => getTestFunctionOverrides(artifacts, [bi]),
+      await assertRejectsWithHardhatError(
+        async () => getTestFunctionOverrides(artifacts, [bi]),
         HardhatError.ERRORS.CORE.SOLIDITY_TESTS
           .BUILD_INFO_NOT_FOUND_FOR_CONTRACT,
         {
@@ -202,7 +202,7 @@ describe("inline-config", () => {
       );
     });
 
-    it("should produce separate overrides for overloaded functions", () => {
+    it("should produce separate overrides for overloaded functions", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10\n/// hardhat-config: fuzz.runs = 20",
@@ -228,7 +228,7 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      const result = getTestFunctionOverrides(artifacts, [bi]);
+      const result = await getTestFunctionOverrides(artifacts, [bi]);
       assert.equal(result.length, 2);
 
       const selectors = result.map((r) => r.identifier.functionSelector).sort();
@@ -241,7 +241,7 @@ describe("inline-config", () => {
       assert.deepEqual(bySelector.get("0x11223344"), { fuzz: { runs: 20 } });
     });
 
-    it("should not duplicate overrides when same source is a root in multiple build infos", () => {
+    it("should not duplicate overrides when same source is a root in multiple build infos", async () => {
       const bi1 = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10",
@@ -280,12 +280,12 @@ describe("inline-config", () => {
       const artifacts = [
         makeTestSuiteArtifact("test/MyTest.sol", "MyTest", "0.8.23", "bi-1"),
       ];
-      const overrides = getTestFunctionOverrides(artifacts, [bi1, bi2]);
+      const overrides = await getTestFunctionOverrides(artifacts, [bi1, bi2]);
       assert.equal(overrides.length, 1);
       assert.deepEqual(overrides[0].config, { fuzz: { runs: 10 } });
     });
 
-    it("should handle multiple contracts in a single source file", () => {
+    it("should handle multiple contracts in a single source file", async () => {
       const bi = makeBuildInfo(
         "test/Multi.sol",
         "/// hardhat-config: fuzz.runs = 10\n/// hardhat-config: fuzz.runs = 20",
@@ -314,7 +314,7 @@ describe("inline-config", () => {
         makeTestSuiteArtifact("test/Multi.sol", "ContractA"),
         makeTestSuiteArtifact("test/Multi.sol", "ContractB"),
       ];
-      const result = getTestFunctionOverrides(artifacts, [bi]);
+      const result = await getTestFunctionOverrides(artifacts, [bi]);
       assert.equal(result.length, 2);
 
       const bySelector = new Map(

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/mocks.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/mocks.ts
@@ -1,6 +1,11 @@
 import type { EdrArtifactWithMetadata } from "../../../../../src/internal/builtin-plugins/solidity-test/edr-artifacts.js";
 import type { RawInlineOverride } from "../../../../../src/internal/builtin-plugins/solidity-test/inline-config/index.js";
 
+import { randomUUID } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { utf8StringToBytes } from "@nomicfoundation/hardhat-utils/bytes";
 
 export function makeRawOverride(
@@ -57,7 +62,12 @@ export function makeBuildInfo(
   >,
   solcVersion = "0.8.23",
   buildInfoId = "test-build-info-id",
-): { buildInfo: Uint8Array; output: Uint8Array; buildInfoId: string } {
+): {
+  buildInfo: Uint8Array;
+  output: Uint8Array;
+  buildInfoId: string;
+  buildInfoOutputPath: string;
+} {
   const buildInfoJson = {
     _format: "hh3-sol-build-info-1",
     id: "test-build-info",
@@ -121,9 +131,14 @@ export function makeBuildInfo(
     },
   };
 
+  const outputJsonString = JSON.stringify(outputJson);
+  const buildInfoOutputPath = join(tmpdir(), `${randomUUID()}.json`);
+  writeFileSync(buildInfoOutputPath, outputJsonString);
+
   return {
     buildInfo: utf8StringToBytes(JSON.stringify(buildInfoJson)),
-    output: utf8StringToBytes(JSON.stringify(outputJson)),
+    output: utf8StringToBytes(outputJsonString),
     buildInfoId,
+    buildInfoOutputPath,
   };
 }

--- a/scripts/end-to-end/schema/scenario-schema.test.ts
+++ b/scripts/end-to-end/schema/scenario-schema.test.ts
@@ -60,6 +60,19 @@ describe("isScenarioDefinition", () => {
     assert.equal(isScenarioDefinition(value), true);
   });
 
+  it("accepts pnpm as a package manager", () => {
+    const value = {
+      description: "Base contracts with pnpm",
+      repo: "popescuoctavian/base-contracts",
+      commit: "abc123",
+      packageManager: "pnpm",
+      defaultCommand: "pnpm exec hardhat test solidity",
+      tags: ["external-repo"],
+    };
+
+    assert.equal(isScenarioDefinition(value), true);
+  });
+
   it("accepts a scenario with disabled: true", () => {
     const value = {
       description: "A disabled scenario",
@@ -131,7 +144,7 @@ describe("isScenarioDefinition", () => {
       isScenarioDefinition({
         repo: "org/repo",
         commit: "abc",
-        packageManager: "pnpm",
+        packageManager: "pip",
         tags: [],
         description: "a scenario",
         defaultCommand: "npx hardhat test",

--- a/scripts/end-to-end/schema/scenario-schema.ts
+++ b/scripts/end-to-end/schema/scenario-schema.ts
@@ -15,6 +15,7 @@ export function isScenarioDefinition(
     typeof obj.commit === "string" &&
     (obj.packageManager === "npm" ||
       obj.packageManager === "bun" ||
+      obj.packageManager === "pnpm" ||
       obj.packageManager === "yarn") &&
     typeof obj.defaultCommand === "string" &&
     Array.isArray(obj.tags) &&

--- a/scripts/end-to-end/schema/scenario.schema.json
+++ b/scripts/end-to-end/schema/scenario.schema.json
@@ -28,7 +28,7 @@
     },
     "packageManager": {
       "type": "string",
-      "enum": ["npm", "bun", "yarn"],
+      "enum": ["npm", "bun", "pnpm", "yarn"],
       "description": "Package manager used by the repo"
     },
     "defaultCommand": {

--- a/scripts/end-to-end/types.ts
+++ b/scripts/end-to-end/types.ts
@@ -9,7 +9,7 @@ export interface ScenarioDefinition {
   description: string;
   repo: string;
   commit: string;
-  packageManager: "npm" | "bun" | "yarn";
+  packageManager: "npm" | "bun" | "pnpm" | "yarn";
   defaultCommand: string;
   preinstall?: string;
   install?: string;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,3 +18,7 @@ sudo apt install -y hyperfine
 
 # Make sure bun is available at the cli
 npm install -g bun
+
+# Install forge
+curl -L https://foundry.paradigm.xyz | bash
+~/.foundry/bin/foundryup


### PR DESCRIPTION
This PR reproduces the issue of inline config parsing failing on large enough build infos.

To run and end to end test that reproduces the failure based on our fork of base contracts (https://github.com/popescuoctavian/base-contracts/tree/migrate-to-HH3), then:

```shell
# Ensure foundry is installed - the devcontainer now sets it up
pnpm e2e exec --scenario ./end-to-end/base-contracts
```

This will, eventually generate this output:

```shell
# ... lots of setup and compilation taking a long time

An unexpected error occurred:

Error: Cannot create a string longer than 0x1fffffe8 characters
    at TextDecoder.decode (node:internal/encoding:494:28)
    at bytesToUtf8String (/tmp/end-to-end/base-contracts/node_modules/.pnpm/@nomicfoundation+hardhat-utils@4.0.2/node_modules/@nomicfoundation/hardhat-utils/src/bytes.ts:59:28)
    at collectRawOverrides (/tmp/end-to-end/base-contracts/node_modules/.pnpm/hardhat@3.3.0/node_modules/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts:157:7)
    at getTestFunctionOverrides (/tmp/end-to-end/base-contracts/node_modules/.pnpm/hardhat@3.3.0/node_modules/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts:55:27)
    at runSolidityTests (/tmp/end-to-end/base-contracts/node_modules/.pnpm/hardhat@3.3.0/node_modules/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts:172:33)
    at async runSolidityTests (/tmp/end-to-end/base-contracts/node_modules/.pnpm/hardhat@3.3.0/node_modules/hardhat/src/internal/builtin-plugins/gas-analytics/tasks/solidity-test/task-action.ts:43:5)
    at async Promise.all (index 0)
    at async main (/tmp/end-to-end/base-contracts/node_modules/.pnpm/hardhat@3.3.0/node_modules/hardhat/src/internal/cli/main.ts:221:26)
    at async file:///tmp/end-to-end/base-contracts/node_modules/.pnpm/hardhat@3.3.0/node_modules/hardhat/dist/src/cli.js:21:1 {
  code: 'ERR_STRING_TOO_LONG'
}

If you think this is a bug in Hardhat, please report it here: https://hardhat.org/report-bug
[e2e] Error: Command failed: pnpm hardhat test solidity
 ELIFECYCLE  Command failed with exit code 1.
```

## Approach

First this PR replicates the issue with an end to end scenario by:

* supporting pnpm to our end to end test scenarios
* adding foundry to the devcontainer setup
* adding a `./end-to-end/base-contracts` scenario pointing at our fork where we found the issue (i.e. `popescuoctavian/base-contracts`)

Second this PR demonstrates one approach to the fix, implemented by Claude:

> The inline config parser crashed with ERR_STRING_TOO_LONG on large codebases (e.g. base/contracts) because collectRawOverrides converted the entire build info output (~898MB) from Uint8Array to a JS string via bytesToUtf8String before passing it to JSON.parse, exceeding Node's ~512MB string limit. This PR replaces that with readJsonFileAsStream from hardhat-utils, which already exists and uses @streamparser/json-node to stream-parse the JSON from disk without ever creating a single large string. The BuildInfoAndOutput type is extended with buildInfoOutputPath to thread the file path through to the parser, and getTestFunctionOverrides becomes async accordingly.

This does resolve the immediate error from `JSON.parse` at the cost of a second read from the build info file.

```
pnpm version-for-release
pnpm e2e clean --scenario ./end-to-end/base-contracts
pnpm e2e exec --scenario ./end-to-end/base-contracts

# ... lots of setup, cloning, installing, compiling but eventually ...

[e2e] === Running: pnpm hardhat test solidity ===

Running Solidity tests

Error HHE807: Invalid inline config key "default.isolate" in project/test/L2/CrossL2Inbox.t.sol:CrossL2Inbox_ValidateMessage_Test#testFuzz_validateMessage_succeeds. Valid keys are: fuzz.runs, fuzz.maxTestRejects, fuzz.showLogs, fuzz.timeout, invariant.runs, invariant.depth, invariant.failOnRevert, invariant.callOverride, invariant.timeout, allowInternalExpectRevert

For more info go to https://hardhat.org/HHE807 or run Hardhat with --show-stack-traces
[e2e] Error: Command failed: pnpm hardhat test solidity --no-compile
 ELIFECYCLE  Command failed with exit code 1.
```

Fixes #8117.