### PR TITLE
Fix remappings duplication

### DIFF
--- a/.changeset/yellow-cycles-grow.md
+++ b/.changeset/yellow-cycles-grow.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix remappings duplication

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
@@ -205,13 +205,15 @@ export class DependencyGraphImplementation implements DependencyGraph {
   }
 
   public getAllRemappings(): readonly string[] {
-    return this.#dependenciesMap
-      .values()
-      .flatMap((dependencies) =>
-        dependencies.values().flatMap((remappings) => remappings.values()),
-      )
-      .toArray()
-      .sort();
+    return [
+      ...new Set(
+        this.#dependenciesMap
+          .values()
+          .flatMap((dependencies) =>
+            dependencies.values().flatMap((remappings) => remappings.values()),
+          ),
+      ),
+    ].sort();
   }
 
   public toJSON(): DependencyGraphImplementationJson {

--- a/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts-alt/C.sol
+++ b/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts-alt/C.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.31;
+
+library C {
+  function value() internal pure returns (uint256) {
+    return 3;
+  }
+}

--- a/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/A.sol
+++ b/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/A.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.31;
+
+library A {
+  function value() internal pure returns (uint256) {
+    return 1;
+  }
+}

--- a/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/B.sol
+++ b/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/B.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.31;
+
+library B {
+  function value() internal pure returns (uint256) {
+    return 2;
+  }
+}

--- a/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/ImportA.sol
+++ b/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/ImportA.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.31;
+
+import {A} from "@dup/A.sol";
+
+contract ImportA {
+  function value() external pure returns (uint256) {
+    return A.value();
+  }
+}

--- a/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/ImportAB.sol
+++ b/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/ImportAB.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.31;
+
+import {A} from "@dup/A.sol";
+import {B} from "@dup/B.sol";
+
+contract ImportAB {
+  function value() external pure returns (uint256) {
+    return A.value() + B.value();
+  }
+}

--- a/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/ImportB.sol
+++ b/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/ImportB.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.31;
+
+import {B} from "@dup/B.sol";
+
+contract ImportB {
+  function value() external pure returns (uint256) {
+    return B.value();
+  }
+}

--- a/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/ImportC.sol
+++ b/packages/hardhat/test/fixture-projects/no-duplicated-remappings/contracts/ImportC.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.31;
+
+import {C} from "@alt/C.sol";
+
+contract ImportC {
+  function value() external pure returns (uint256) {
+    return C.value();
+  }
+}

--- a/packages/hardhat/test/fixture-projects/no-duplicated-remappings/hardhat.config.ts
+++ b/packages/hardhat/test/fixture-projects/no-duplicated-remappings/hardhat.config.ts
@@ -1,0 +1,9 @@
+import type { HardhatUserConfig } from "../../../src/types/config.js";
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: "0.8.31",
+  },
+};
+
+export default config;

--- a/packages/hardhat/test/fixture-projects/no-duplicated-remappings/package.json
+++ b/packages/hardhat/test/fixture-projects/no-duplicated-remappings/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "hardhat-duplicate-remappings-regression",
+  "private": true,
+  "type": "module"
+}

--- a/packages/hardhat/test/fixture-projects/no-duplicated-remappings/remappings.txt
+++ b/packages/hardhat/test/fixture-projects/no-duplicated-remappings/remappings.txt
@@ -1,0 +1,3 @@
+@dup/=contracts/
+@dup/=contracts/
+@alt/=contracts-alt/

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
@@ -714,7 +714,7 @@ describe("DependencyGraphImplementation", () => {
       assert.deepEqual(mergedGraph.toJSON(), expectedJson);
     });
 
-    it("Should deduplicate remappings across edges after merge", () => {
+    it("should deduplicate remappings across edges after merge", () => {
       const root1 = createProjectResolvedFile("root1.sol");
       const root2 = createProjectResolvedFile("root2.sol");
       const dep = createProjectResolvedFile("dep.sol");
@@ -731,7 +731,7 @@ describe("DependencyGraphImplementation", () => {
       assert.deepEqual(mergedGraph.getAllRemappings(), ["r1"]);
     });
 
-    it("Should deduplicate remappings in the same edges after merge", () => {
+    it("should deduplicate remappings in the same edge after merge", () => {
       const root1 = createProjectResolvedFile("root1.sol");
       const dep = createProjectResolvedFile("dep.sol");
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/dependency-graph.ts
@@ -713,5 +713,43 @@ describe("DependencyGraphImplementation", () => {
 
       assert.deepEqual(mergedGraph.toJSON(), expectedJson);
     });
+
+    it("Should deduplicate remappings across edges after merge", () => {
+      const root1 = createProjectResolvedFile("root1.sol");
+      const root2 = createProjectResolvedFile("root2.sol");
+      const dep = createProjectResolvedFile("dep.sol");
+
+      dependencyGraph.addRootFile(root1.inputSourceName, root1);
+      dependencyGraph.addDependency(root1, dep, "r1");
+
+      const otherDependencyGraph = new DependencyGraphImplementation();
+      otherDependencyGraph.addRootFile(root2.inputSourceName, root2);
+      otherDependencyGraph.addDependency(root2, dep, "r1");
+
+      const mergedGraph = dependencyGraph.merge(otherDependencyGraph);
+
+      assert.deepEqual(mergedGraph.getAllRemappings(), ["r1"]);
+    });
+
+    it("Should deduplicate remappings in the same edges after merge", () => {
+      const root1 = createProjectResolvedFile("root1.sol");
+      const dep = createProjectResolvedFile("dep.sol");
+
+      dependencyGraph.addRootFile(root1.inputSourceName, root1);
+      dependencyGraph.addDependency(root1, dep, "r1");
+
+      const otherDependencyGraph = new DependencyGraphImplementation();
+      otherDependencyGraph.addRootFile(root1.inputSourceName, root1);
+      otherDependencyGraph.addDependency(root1, dep, "r1");
+
+      const mergedGraph = dependencyGraph.merge(otherDependencyGraph);
+
+      const dependencies = mergedGraph.getDependencies(root1);
+      assert.equal(dependencies.size, 1);
+
+      const dependency = [...dependencies.values()][0];
+      assert.equal(dependency.file, dep);
+      assert.deepEqual([...dependency.remappings], ["r1"]);
+    });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/regressions/no-duplicated-remappings.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/regressions/no-duplicated-remappings.ts
@@ -1,0 +1,110 @@
+import type { HardhatRuntimeEnvironment } from "../../../../../../src/types/hre.js";
+import type { GetCompilationJobsResult } from "../../../../../../src/types/solidity.js";
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+import { useFixtureProject } from "@nomicfoundation/hardhat-test-utils";
+
+import {
+  createHardhatRuntimeEnvironment,
+  importUserConfig,
+  resolveHardhatConfigPath,
+} from "../../../../../../src/hre.js";
+
+const DUP_REMAPPING = "project/:@dup/=project/contracts/";
+const ALT_REMAPPING = "project/:@alt/=project/contracts-alt/";
+
+async function getCompilationJobs(
+  hre: HardhatRuntimeEnvironment,
+  rootFileNames: string[],
+  options = {},
+) {
+  const allRootFiles = await hre.solidity.getRootFilePaths();
+  const selectedRootFiles = rootFileNames.map((name) => {
+    const match = allRootFiles.find((f) => f.endsWith(`/${name}`));
+    assert.ok(match !== undefined, `Root file not found: ${name}`);
+    return match;
+  });
+
+  const result = await hre.solidity.getCompilationJobs(selectedRootFiles, {
+    force: true,
+    ...options,
+  });
+
+  assert.equal(result.success, true);
+
+  return result;
+}
+
+function getUniqueJobs(compilationJobs: GetCompilationJobsResult) {
+  return [...new Set(compilationJobs.compilationJobsPerFile.values())];
+}
+
+describe("Solidity build system regression tests: no duplicated remappings", () => {
+  useFixtureProject("no-duplicated-remappings");
+  let hre: HardhatRuntimeEnvironment;
+  before(async () => {
+    const configPath = await resolveHardhatConfigPath();
+    const config = await importUserConfig(configPath);
+    hre = await createHardhatRuntimeEnvironment(config, { config: configPath });
+  });
+
+  it("should not duplicate remappings from duplicate remappings.txt entries", async () => {
+    const jobs = getUniqueJobs(await getCompilationJobs(hre, ["ImportA.sol"]));
+
+    assert.equal(jobs.length, 1);
+
+    const solcInput = await jobs[0].getSolcInput();
+    assert.deepEqual(solcInput.settings.remappings, [DUP_REMAPPING]);
+  });
+
+  it("should deduplicate remappings across edges within a single graph", async () => {
+    const jobs = getUniqueJobs(await getCompilationJobs(hre, ["ImportAB.sol"]));
+
+    assert.equal(jobs.length, 1);
+
+    const solcInput = await jobs[0].getSolcInput();
+    assert.deepEqual(solcInput.settings.remappings, [DUP_REMAPPING]);
+  });
+
+  it("should deduplicate remappings when merging graphs", async () => {
+    const jobs = getUniqueJobs(
+      await getCompilationJobs(hre, ["ImportA.sol", "ImportB.sol"]),
+    );
+
+    assert.equal(jobs.length, 1);
+
+    const solcInput = await jobs[0].getSolcInput();
+    assert.deepEqual(solcInput.settings.remappings, [DUP_REMAPPING]);
+  });
+
+  it("should not duplicate remappings in isolated mode", async () => {
+    const jobs = getUniqueJobs(
+      await getCompilationJobs(hre, ["ImportA.sol", "ImportB.sol"], {
+        buildProfile: "production",
+      }),
+    );
+
+    assert.equal(jobs.length, 2);
+
+    for (const job of jobs) {
+      const solcInput = await job.getSolcInput();
+      assert.deepEqual(solcInput.settings.remappings, [DUP_REMAPPING]);
+    }
+  });
+
+  it("should preserve distinct remappings when merging graphs", async () => {
+    const jobs = getUniqueJobs(
+      await getCompilationJobs(hre, ["ImportA.sol", "ImportC.sol"]),
+    );
+
+    assert.equal(jobs.length, 1);
+
+    const solcInput = await jobs[0].getSolcInput();
+    assert.deepEqual(solcInput.settings.remappings, [
+      ALT_REMAPPING,
+      DUP_REMAPPING,
+    ]);
+  });
+});

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/regressions/no-duplicated-remappings.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/regressions/no-duplicated-remappings.ts
@@ -2,6 +2,7 @@ import type { HardhatRuntimeEnvironment } from "../../../../../../src/types/hre.
 import type { GetCompilationJobsResult } from "../../../../../../src/types/solidity.js";
 
 import assert from "node:assert/strict";
+import path from "node:path";
 import { before, describe, it } from "node:test";
 
 import { useFixtureProject } from "@nomicfoundation/hardhat-test-utils";
@@ -22,7 +23,7 @@ async function getCompilationJobs(
 ) {
   const allRootFiles = await hre.solidity.getRootFilePaths();
   const selectedRootFiles = rootFileNames.map((name) => {
-    const match = allRootFiles.find((f) => f.endsWith(`/${name}`));
+    const match = allRootFiles.find((f) => f.endsWith(`${path.sep}${name}`));
     assert.ok(match !== undefined, `Root file not found: ${name}`);
     return match;
   });


### PR DESCRIPTION
There was a bug in the dependency graph, which could lead to remappings being duplicated, this PR fixes it.

Remappings are stored in the edges of the dependency graph, so that we can use only the necessary remappings when building a subgraph of the entire dependency graph. They are stored as a set within each edge, so they can't be duplicated in the same edge, even when merging graphs with the same edge.

The problem was that we weren't deduplicating across edges. For example, if a graph has an edge between `A` and `B` with remapping `r1`, and an edge between `C` and `D` with remapping `r1`, `r1` would be duplicated.

This PR fixes it by doing a cross-edge deduplication in the `getAllRemappings()` method of the graph.

The way this is structured, the first commit add some regression (integration style) tests, and actual unit tests of the functionality. The second commit fixes it, which is tiny.