### PR TITLE
Add `splitTestsCompilation` solidity setting (2): Build System core changes

### DIFF
--- a/SPLIT_TESTS_COMPILATION_SPEC.md
+++ b/SPLIT_TESTS_COMPILATION_SPEC.md
@@ -575,6 +575,10 @@ Rewrite the high-level build task to implement the new unified-mode semantics.
 - Run existing scope and cleanup tests:
   - `packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts`
   - `packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts`
+- Update Phase 2 tests that call build-system APIs directly to go through the build task instead:
+  - "skips per-source artifacts.d.ts for test roots in unified contracts-scope builds": replace direct `getRootFilePaths` + `build` calls with `hre.tasks.getTask("build").run()`
+  - "includes test artifacts in duplicate-name detection": replace direct `getRootFilePaths` + `build` + `cleanupArtifacts` calls with `hre.tasks.getTask("build").run()`
+  - "passes mixed contract and test artifact paths to onCleanUpArtifacts": replace direct `getRootFilePaths` + `build` + `cleanupArtifacts` calls with `hre.tasks.getTask("build").run()` and use an inline plugin to register an `onCleanUpArtifacts` handler that asserts on the received artifact paths
 - Add tests for:
   - unified full build compiles contracts and tests together
   - unified explicit-file builds compile exactly the provided files

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -1346,6 +1346,20 @@ Solidity test files must be placed in your test directory, or in your contracts 
         
 Solidity test files must be placed in your test directory, or in your contracts directory and end in .t.sol.`,
       },
+      SPLIT_TESTS_COMPILATION_DISABLED: {
+        number: 916,
+        messageTemplate: `A method of the SolidityBuildSystem was called with \`scope: "tests"\`, but \`splitTestsCompilation\` is disabled in your config.
+
+When \`splitTestsCompilation\` is \`false\`, contracts and tests are compiled together under \`scope: "contracts"\`, so \`scope: "tests"\` is not a valid option.
+
+Set \`solidity.splitTestsCompilation\` to \`true\` in your Hardhat config to enable this build scope.`,
+        websiteTitle: "Split tests compilation is disabled",
+        websiteDescription: `The Solidity build system was called with \`scope: "tests"\`, but \`splitTestsCompilation\` is disabled in your config.
+
+When \`splitTestsCompilation\` is \`false\`, contracts and tests are compiled together under \`scope: "contracts"\`, so \`scope: "tests"\` is not a valid option.
+
+Set \`solidity.splitTestsCompilation\` to \`true\` in your Hardhat config to enable this build scope.`,
+      },
     },
     ARTIFACTS: {
       NOT_FOUND: {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -223,6 +223,15 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     rootFilePaths: string[],
     _options?: BuildOptions,
   ): Promise<CompilationJobCreationError | Map<string, FileBuildResult>> {
+    if (
+      !this.#options.solidityConfig.splitTestsCompilation &&
+      _options?.scope === "tests"
+    ) {
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+      );
+    }
+
     return this.#hooks.runHandlerChain(
       "solidity",
       "build",
@@ -423,6 +432,15 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     rootFilePaths: string[],
     options?: GetCompilationJobsOptions,
   ): Promise<CompilationJobCreationError | GetCompilationJobsResult> {
+    if (
+      !this.#options.solidityConfig.splitTestsCompilation &&
+      options?.scope === "tests"
+    ) {
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+      );
+    }
+
     await this.#downloadConfiguredCompilers(options?.quiet);
 
     const dependencyGraph = await buildDependencyGraph(
@@ -816,6 +834,13 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     options: { scope?: BuildScope } = {},
   ): Promise<EmitArtifactsResult> {
     const scope = options.scope ?? "contracts";
+    const unified = !this.#options.solidityConfig.splitTestsCompilation;
+
+    if (unified && scope === "tests") {
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+      );
+    }
 
     const artifactsPerFile = new Map<string, string[]>();
     const typeFilePaths = new Map<string, string>();
@@ -972,9 +997,18 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     rootFilePaths: string[],
     options: { scope?: BuildScope } = {},
   ): Promise<void> {
-    log(`Cleaning up artifacts`);
-
     const scope = options.scope ?? "contracts";
+
+    if (
+      !this.#options.solidityConfig.splitTestsCompilation &&
+      scope === "tests"
+    ) {
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+      );
+    }
+
+    log(`Cleaning up artifacts`);
     const artifactsDirectory = await this.getArtifactsDirectory(scope);
 
     const userSourceNames = rootFilePaths.map((rootFilePath) => {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -174,10 +174,11 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     options: { scope?: BuildScope } = {},
   ): Promise<string[]> {
     const scope = options.scope ?? "contracts";
+    const unified = !this.#options.solidityConfig.splitTestsCompilation;
 
     switch (scope) {
-      case "contracts":
-        const localFilesToCompile = (
+      case "contracts": {
+        const localContractFiles = (
           await Promise.all(
             this.#options.soliditySourcesPaths.map((dir) =>
               getAllFilesMatching(
@@ -193,8 +194,36 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
             npmModuleToNpmRootPath,
           );
 
-        return [...localFilesToCompile, ...npmFilesToBuild];
-      case "tests":
+        if (!unified) {
+          return [...localContractFiles, ...npmFilesToBuild];
+        }
+
+        // In unified mode, contracts scope returns all roots: contracts,
+        // tests, and npm files.
+        const testFiles = (
+          await Promise.all([
+            getAllFilesMatching(this.#options.solidityTestsPath, (f) =>
+              f.endsWith(".sol"),
+            ),
+            ...this.#options.soliditySourcesPaths.map(async (dir) => {
+              return getAllFilesMatching(dir, (f) => f.endsWith(".t.sol"));
+            }),
+          ])
+        ).flat(1);
+
+        // Remove duplicates in case there is an intersection between
+        // the tests.solidity paths and the sources paths
+        return Array.from(
+          new Set([...localContractFiles, ...npmFilesToBuild, ...testFiles]),
+        );
+      }
+      case "tests": {
+        if (unified) {
+          throw new HardhatError(
+            HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+          );
+        }
+
         let rootFilePaths = (
           await Promise.all([
             getAllFilesMatching(this.#options.solidityTestsPath, (f) =>
@@ -210,6 +239,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
         // the tests.solidity paths and the sources paths
         rootFilePaths = Array.from(new Set(rootFilePaths));
         return rootFilePaths;
+      }
     }
   }
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -922,8 +922,12 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
 
       artifactsPerFile.set(formatRootPath(userSourceName, root), paths);
 
-      // Write the type declaration file, only for contracts
-      if (scope === "contracts") {
+      const isTestRoot = unified
+        ? (await this.getScope(root.fsPath)) === "tests"
+        : false;
+
+      // Write the type declaration file for contract roots only.
+      if (scope === "contracts" && !isTestRoot) {
         const artifactsDeclarationFilePath = path.join(
           fileFolder,
           "artifacts.d.ts",

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1022,6 +1022,12 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
   }
 
   public async getArtifactsDirectory(scope: BuildScope): Promise<string> {
+    // In unified mode, both scopes point to the main artifacts directory
+    // because contract and test artifacts live together.
+    if (!this.#options.solidityConfig.splitTestsCompilation) {
+      return this.#options.artifactsPath;
+    }
+
     return scope === "contracts"
       ? this.#options.artifactsPath
       : path.join(this.#options.cachePath, "test-artifacts");

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -376,7 +376,6 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
               compilationResult,
               emitArtifactsResult,
               buildProfile.isolated,
-              options.scope,
             );
           }),
         );
@@ -1229,7 +1228,6 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     result: CompilationResult,
     emitArtifactsResult: EmitArtifactsResult,
     isolated: boolean,
-    scope: BuildScope,
   ): Promise<void> {
     for (const [userSourceName, root] of result.compilationJob.dependencyGraph
       .getRoots()
@@ -1251,12 +1249,6 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       );
 
       const typeFilePath = emitArtifactsResult.typeFilePaths.get(rootFilePath);
-
-      // Type declaration file is not generated for solidity tests
-      assertHardhatInvariant(
-        scope === "tests" || typeFilePath !== undefined,
-        `No type file found on map for contract ${rootFilePath}`,
-      );
 
       const jobHash = await individualJob.getBuildId();
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -161,9 +161,11 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       return "tests";
     }
 
-    for (const sourcesPath of this.#options.soliditySourcesPaths) {
-      if (fsPath.startsWith(sourcesPath) && fsPath.endsWith(".t.sol")) {
-        return "tests";
+    if (fsPath.endsWith(".t.sol")) {
+      for (const sourcesPath of this.#options.soliditySourcesPaths) {
+        if (fsPath.startsWith(sourcesPath)) {
+          return "tests";
+        }
       }
     }
 

--- a/packages/hardhat/src/types/solidity/build-system.ts
+++ b/packages/hardhat/src/types/solidity/build-system.ts
@@ -43,7 +43,13 @@ export interface BuildOptions {
   quiet?: boolean;
 
   /**
-   * Whether to compile contracts or tests. Defaults to contracts
+   * Whether to compile contracts or tests. Defaults to contracts.
+   *
+   * When `solidity.splitTestsCompilation` is `false` (the default), only
+   * `"contracts"` is accepted.
+   *
+   * When `solidity.splitTestsCompilation` is `true`, both scopes are valid
+   * and produce separate compilation passes.
    */
   scope?: BuildScope;
 }
@@ -272,6 +278,16 @@ export interface SolidityBuildSystem {
    * The root files are either absolute paths or
    * `npm:<package-name>/<file-path>` URIs.
    *
+   * When `solidity.splitTestsCompilation` is `false`, contracts and tests are
+   * compiled together and `scope: "contracts"` returns every build root:
+   * contract roots, test roots, and `npmFilesToBuild` roots.
+   *
+   * Calling this method with `scope: "tests"` in this mode is a logic error and
+   * throws a `HardhatError`.
+   *
+   * When `solidity.splitTestsCompilation` is `true`, `scope: "contracts"`
+   * returns only contract roots and `scope: "tests"` returns only test roots.
+   *
    * @returns An array of root file paths.
    */
   getRootFilePaths(options?: { scope?: BuildScope }): Promise<string[]>;
@@ -283,6 +299,15 @@ export interface SolidityBuildSystem {
 
   /**
    * Builds the provided files, generating their compilation artifacts.
+   *
+   * When `solidity.splitTestsCompilation` is `false`, this method rejects
+   * `scope: "tests"` as a logic error and throws a `HardhatError`
+   *
+   * In this mode, callers must use `scope: "contracts"` and contracts and tests
+   * are built together, emitting their artifacts into the same directory.
+   *
+   * When `solidity.splitTestsCompilation` is `true`, both scopes are valid
+   * and are built into separate artifact directories.
    *
    * @param rootFilePaths The files to build, which can be either absolute paths
    * or `npm:<package-name>/<file-path>` URIs.
@@ -312,6 +337,9 @@ export interface SolidityBuildSystem {
    * Note that if `options.mergeCompilationJobs` is true, the same instance of
    * can be returned for multiple files, so you should deduplicate the results
    * before using them.
+   *
+   * When `solidity.splitTestsCompilation` is `false`, this method rejects
+   * `scope: "tests"` as a logic error and throws a `HardhatError`.
    *
    * @param rootFilePaths The files to analyze, which can be either absolute
    * paths or `npm:<package-name>/<file-path>` URIs.
@@ -358,6 +386,13 @@ export interface SolidityBuildSystem {
   /**
    * Emits the artifacts of the given compilation job.
    *
+   * When `solidity.splitTestsCompilation` is `false`, this method rejects
+   * `scope: "tests"` as a logic error and throws a `HardhatError`
+   *
+   * Artifacts for both contracts and tests are emitted under the main artifacts
+   * directory when built with `scope: "contracts"` and `splitTestsCompilation`
+   * `false`.
+   *
    * @param compilationJob The compilation job to emit the artifacts of.
    * @param compilerOutput The result of running the compilation job.
    * @returns A map from user source name to the absolute paths of the
@@ -379,7 +414,25 @@ export interface SolidityBuildSystem {
    * This method should only be used after a complete build has succeeded, as
    * it relies on the build system to have generated all the necessary artifact
    * files.
-
+   *
+   * When `solidity.splitTestsCompilation` is `false`, this method rejects
+   * `scope: "tests"` as a logic error and throws a `HardhatError`. Cleanup in
+   * this mode operates on the main artifacts directory using `scope:
+   * "contracts"`.
+   *
+   * What is considered a complete build changes according to
+   * `splitTestsCompilation`:
+   *  - When it's `true`
+   *    - A full "contracts" build is run when `--no-contracts` isn't used, and
+   *      no explicit contract `files` are provided (i.e. you can still provide
+   *      explicit test `files`).
+   *    - A full "tests" build is run when `--no-tests` isn't used, and no
+   *      explicit test files `files` are provided (i.e. you can still provide
+   *      explicit contract `files`)
+   *  - When it's `false`
+   *    - A full build is when `files`, `--no-contracts`, nor `--no-tests` are
+   *      used.
+   *
    * @param rootFilePaths All the root files of the project.
    */
   cleanupArtifacts(
@@ -405,7 +458,17 @@ export interface SolidityBuildSystem {
   ): Promise<CompilerOutput>;
 
   /**
-   * Gets the artifacts directory for a given target (contracts/tests)
+   * Gets the artifacts directory for a given target (contracts/tests).
+   *
+   * When `solidity.splitTestsCompilation` is `false`, both scopes return the
+   * main artifacts directory, because contracts and tests share it.
+   *
+   * Unlike the other scope-aware methods, this one does not throw on that mode,
+   * as it's a read-only method that can be helpful for plugins.
+   *
+   * When `solidity.splitTestsCompilation` is `true`, `scope: "contracts"`
+   * returns the main artifacts directory and `scope: "tests"` returns a
+   * separate test-artifacts directory under the cache path.
    */
   getArtifactsDirectory(scope: BuildScope): Promise<string>;
 }

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
@@ -6,7 +6,9 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 import {
   exists,
+  getAllFilesMatching,
   readJsonFile,
+  readUtf8File,
   writeUtf8File,
 } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -53,6 +55,13 @@ const basicProjectTemplate = {
         }
       }
     `,
+  },
+};
+
+const solidityCompilationConfig = {
+  solidity: {
+    version: "0.8.28",
+    splitTestsCompilation: true,
   },
 };
 
@@ -479,6 +488,282 @@ describe("build system - build task - behavior on build scope", function () {
           process.chdir(previousCwd);
         }
       });
+    });
+  });
+});
+
+describe("build system - splitTestsCompilation: false", function () {
+  const unifiedTestsCompilationConfig = {
+    solidity: {
+      version: "0.8.28",
+      splitTestsCompilation: false,
+    },
+  };
+
+  describe("getRootFilePaths", function () {
+    it("returns contract, test, and npm roots for scope 'contracts'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      const roots = await hre.solidity.getRootFilePaths({
+        scope: "contracts",
+      });
+
+      // Should contain the contract file
+      assert.ok(
+        roots.some((r) => r.endsWith("Foo.sol") && !r.endsWith(".t.sol")),
+        "Expected contract root Foo.sol in unified roots",
+      );
+      // Should contain the .t.sol test file
+      assert.ok(
+        roots.some((r) => r.endsWith("Foo.t.sol")),
+        "Expected test root Foo.t.sol in unified roots",
+      );
+      // Should contain the test directory test file
+      assert.ok(
+        roots.some((r) => r.endsWith("OtherFooTest.sol")),
+        "Expected test root OtherFooTest.sol in unified roots",
+      );
+    });
+
+    it("throws for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      await assertRejectsWithHardhatError(
+        hre.solidity.getRootFilePaths({ scope: "tests" }),
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+        {},
+      );
+    });
+  });
+
+  describe("getArtifactsDirectory", function () {
+    it("returns the main artifacts dir for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      const contractsDir =
+        await hre.solidity.getArtifactsDirectory("contracts");
+      const testsDir = await hre.solidity.getArtifactsDirectory("tests");
+
+      assert.equal(contractsDir, testsDir);
+    });
+  });
+
+  describe("low-level scope:'tests' rejection", function () {
+    it("build() throws for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      await assertRejectsWithHardhatError(
+        hre.solidity.build([], { scope: "tests" }),
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+        {},
+      );
+    });
+
+    it("getCompilationJobs() throws for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      await assertRejectsWithHardhatError(
+        hre.solidity.getCompilationJobs([], { scope: "tests" }),
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+        {},
+      );
+    });
+
+    it("emitArtifacts() throws for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      // We need a real compilation job to call emitArtifacts.
+      // Build first so we can get a compilation job.
+      const roots = await hre.solidity.getRootFilePaths({
+        scope: "contracts",
+      });
+      const contractRoots = roots.filter(
+        (r) => !r.endsWith(".t.sol") && !r.includes("/test/"),
+      );
+      const result = await hre.solidity.getCompilationJobs(contractRoots, {
+        scope: "contracts",
+      });
+
+      assert.ok(result.success, "Expected compilation jobs to succeed");
+
+      const firstJob = [...result.compilationJobsPerFile.values()][0];
+      const runResult = await hre.solidity.runCompilationJob(firstJob);
+
+      await assertRejectsWithHardhatError(
+        hre.solidity.emitArtifacts(firstJob, runResult.output, {
+          scope: "tests",
+        }),
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+        {},
+      );
+    });
+
+    it("cleanupArtifacts() throws for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      await assertRejectsWithHardhatError(
+        hre.solidity.cleanupArtifacts([], { scope: "tests" }),
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+        {},
+      );
+    });
+  });
+
+  describe("emitArtifacts - type declarations", function () {
+    it("skips per-source artifacts.d.ts for test roots in unified contracts-scope builds", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      // Build directly using the build-system APIs (the build task is
+      // not updated until Phase 4).
+      const roots = await hre.solidity.getRootFilePaths({
+        scope: "contracts",
+      });
+      const buildResult = await hre.solidity.build(roots, {
+        scope: "contracts",
+      });
+
+      assert.ok(
+        hre.solidity.isSuccessfulBuildResult(buildResult),
+        "Expected build to succeed",
+      );
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // Contract root should have artifacts.d.ts
+      assert.equal(
+        await exists(
+          path.join(artifactsPath, "contracts", "Foo.sol", "artifacts.d.ts"),
+        ),
+        true,
+      );
+
+      // Test roots should NOT have artifacts.d.ts
+      assert.equal(
+        await exists(
+          path.join(artifactsPath, "contracts", "Foo.t.sol", "artifacts.d.ts"),
+        ),
+        false,
+      );
+      assert.equal(
+        await exists(
+          path.join(
+            artifactsPath,
+            "test",
+            "OtherFooTest.sol",
+            "artifacts.d.ts",
+          ),
+        ),
+        false,
+      );
+    });
+  });
+
+  describe("unified cleanup", function () {
+    it("includes test artifacts in duplicate-name detection", async () => {
+      const duplicateNameTemplate = {
+        name: "test",
+        version: "1.0.0",
+        files: {
+          "contracts/Foo.sol": `// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.0;\ncontract Foo {}`,
+          "test/Foo.sol": `// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.0;\ncontract Foo {}`,
+        },
+      };
+
+      await using project = await useTestProjectTemplate(duplicateNameTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      // Build directly using the build-system APIs (the build task is
+      // not updated until Phase 4).
+      const roots = await hre.solidity.getRootFilePaths({
+        scope: "contracts",
+      });
+      const buildResult = await hre.solidity.build(roots, {
+        scope: "contracts",
+      });
+
+      assert.ok(
+        hre.solidity.isSuccessfulBuildResult(buildResult),
+        "Expected build to succeed",
+      );
+
+      await hre.solidity.cleanupArtifacts([...buildResult.keys()], {
+        scope: "contracts",
+      });
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // The top-level artifacts.d.ts should exist and contain the duplicate
+      const topLevelDts = path.join(artifactsPath, "artifacts.d.ts");
+      assert.equal(await exists(topLevelDts), true);
+      const dtsContent = await readUtf8File(topLevelDts);
+      assert.ok(
+        dtsContent.includes('"Foo"'),
+        "Expected top-level artifacts.d.ts to include the duplicated contract name Foo from both test and contract artifacts",
+      );
+    });
+
+    it("passes mixed contract and test artifact paths to onCleanUpArtifacts", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      // Build directly using the build-system APIs (the build task is
+      // not updated until Phase 4).
+      const roots = await hre.solidity.getRootFilePaths({
+        scope: "contracts",
+      });
+      const buildResult = await hre.solidity.build(roots, {
+        scope: "contracts",
+      });
+
+      assert.ok(
+        hre.solidity.isSuccessfulBuildResult(buildResult),
+        "Expected build to succeed",
+      );
+
+      // This is run directly here, so this isn't testing much now, but will be
+      // better tested in Phase 4
+      await hre.solidity.cleanupArtifacts([...buildResult.keys()], {
+        scope: "contracts",
+      });
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // All artifacts should be in the main artifacts directory
+      const buildInfoDir = path.join(artifactsPath, "build-info");
+      const artifactPaths = await getAllFilesMatching(
+        artifactsPath,
+        (p) =>
+          p.endsWith(".json") &&
+          p.indexOf(path.sep, artifactsPath.length + path.sep.length) !== -1,
+        (dir) => dir !== buildInfoDir,
+      );
+
+      // Should include both contract and test artifacts
+      assert.ok(
+        artifactPaths.some(
+          (p) => p.includes("Foo.sol") && !p.includes(".t.sol"),
+        ),
+        "Expected contract artifact Foo.json in unified artifacts",
+      );
+      assert.ok(
+        artifactPaths.some((p) => p.includes("Foo.t.sol")),
+        "Expected test artifact FooTest.json in unified artifacts",
+      );
+      assert.ok(
+        artifactPaths.some((p) => p.includes("OtherFooTest.sol")),
+        "Expected test artifact OtherFooTest.json in unified artifacts",
+      );
     });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
@@ -584,7 +584,8 @@ describe("build system - splitTestsCompilation: false", function () {
         scope: "contracts",
       });
       const contractRoots = roots.filter(
-        (r) => !r.endsWith(".t.sol") && !r.includes("/test/"),
+        (r) =>
+          !r.endsWith(".t.sol") && !r.includes(path.sep + "test" + path.sep),
       );
       const result = await hre.solidity.getCompilationJobs(contractRoots, {
         scope: "contracts",

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
@@ -62,7 +62,7 @@ describe("build system - build task - behavior on build scope", function () {
       it("compiles and generates artifacts for all contracts and tests", async () => {
         await using project =
           await useTestProjectTemplate(basicProjectTemplate);
-        const hre = await project.getHRE();
+        const hre = await project.getHRE(solidityCompilationConfig);
 
         await hre.tasks.getTask("build").run();
 
@@ -97,7 +97,7 @@ describe("build system - build task - behavior on build scope", function () {
       it("performs cleanup on both contracts and tests artifacts and build infos", async () => {
         await using project =
           await useTestProjectTemplate(basicProjectTemplate);
-        const hre = await project.getHRE();
+        const hre = await project.getHRE(solidityCompilationConfig);
 
         // Create test build info and artifact file that should be cleaned up
         const contractsArtifactsPath =
@@ -155,7 +155,7 @@ describe("build system - build task - behavior on build scope", function () {
       it("identifies when a file is a contract", async () => {
         await using project =
           await useTestProjectTemplate(basicProjectTemplate);
-        const hre = await project.getHRE();
+        const hre = await project.getHRE(solidityCompilationConfig);
         process.chdir(project.path);
 
         await hre.tasks.getTask("build").run({ files: ["contracts/Foo.sol"] });
@@ -171,7 +171,7 @@ describe("build system - build task - behavior on build scope", function () {
       it("identifies when a file is a test", async () => {
         await using project =
           await useTestProjectTemplate(basicProjectTemplate);
-        const hre = await project.getHRE();
+        const hre = await project.getHRE(solidityCompilationConfig);
         process.chdir(project.path);
 
         await hre.tasks
@@ -205,7 +205,7 @@ describe("build system - build task - behavior on build scope", function () {
   describe("compiling with the --no-test flag", function () {
     it("compiles and generates artifacts for contracts, but not tests", async () => {
       await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE();
+      const hre = await project.getHRE(solidityCompilationConfig);
 
       await hre.tasks.getTask("build").run({ noTests: true });
 
@@ -249,7 +249,7 @@ describe("build system - build task - behavior on build scope", function () {
 
     it("performs cleanup on contract artifacts, but not tests", async () => {
       await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE();
+      const hre = await project.getHRE(solidityCompilationConfig);
 
       // Create test build info and artifact file that should be cleaned up
       const contractsArtifactsPath =
@@ -306,7 +306,7 @@ describe("build system - build task - behavior on build scope", function () {
   describe("compiling with the --no-contracts flag", function () {
     it("compiles and generates artifacts for tests, but not contracts", async () => {
       await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE();
+      const hre = await project.getHRE(solidityCompilationConfig);
 
       await hre.tasks.getTask("build").run({ noContracts: true });
 
@@ -350,7 +350,7 @@ describe("build system - build task - behavior on build scope", function () {
 
     it("performs cleanup on tests artifacts, but not contracts", async () => {
       await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE();
+      const hre = await project.getHRE(solidityCompilationConfig);
 
       // Create test build info and artifact file that should be cleaned up
       const contractsArtifactsPath =
@@ -407,7 +407,7 @@ describe("build system - build task - behavior on build scope", function () {
       it("Should throw if a test file isn't recognized", async () => {
         await using project =
           await useTestProjectTemplate(basicProjectTemplate);
-        const hre = await project.getHRE();
+        const hre = await project.getHRE(solidityCompilationConfig);
 
         const previousCwd = process.cwd();
         process.chdir(project.path);
@@ -436,7 +436,7 @@ describe("build system - build task - behavior on build scope", function () {
       it("Should throw if a contract isn't recognized", async () => {
         await using project =
           await useTestProjectTemplate(basicProjectTemplate);
-        const hre = await project.getHRE();
+        const hre = await project.getHRE(solidityCompilationConfig);
 
         const previousCwd = process.cwd();
         process.chdir(project.path);
@@ -457,7 +457,7 @@ describe("build system - build task - behavior on build scope", function () {
       it("Should throw if neither is recognized", async () => {
         await using project =
           await useTestProjectTemplate(basicProjectTemplate);
-        const hre = await project.getHRE();
+        const hre = await project.getHRE(solidityCompilationConfig);
 
         const previousCwd = process.cwd();
         process.chdir(project.path);


### PR DESCRIPTION
This PR changes how the build system treats the new setting, but it's intentionally incomplete to make reviewing it simpler.

Many test failures are expected, as this PR doesn't update: the `build` tasks, the `test solidity` task, nor the cache system.