### PR TITLE
Add `splitTestsCompilation` solidity setting (4): Bulitin `build` task updates

### DIFF
--- a/SPLIT_TESTS_COMPILATION_SPEC.md
+++ b/SPLIT_TESTS_COMPILATION_SPEC.md
@@ -596,6 +596,9 @@ Rewrite the high-level build task to implement the new unified-mode semantics.
   - split mode preserves the current unused-file error when explicit files fall only in a disabled scope
   - other split-mode regressions for current behavior
 - Run `pnpm test` in `packages/hardhat`
+- **Known failures after Phase 4:** 18 tests fail because two callers still use `build({ files, noContracts: true })`, which is now invalid in unified mode. All 18 originate from:
+  - `solidity-test/task-action.ts` (6 failures) — fixed in Phase 6
+  - `CoverageManagerImplementation` (12 failures) — also fixed in Phase 6, since coverage delegates to the solidity-test runner
 
 ## Phase 5: Other Built-In Task Callers
 

--- a/SPLIT_TESTS_COMPILATION_SPEC.md
+++ b/SPLIT_TESTS_COMPILATION_SPEC.md
@@ -164,7 +164,16 @@ This keeps cache hits fast:
 
 The high-level build task becomes mode-dependent.
 
-When `splitTestsCompilation === false`:
+#### Mode-independent validation
+
+Before branching on `splitTestsCompilation`, the build task validates that explicit files are compatible with `--no-tests` / `--no-contracts`:
+
+- If `--no-contracts` is set and any explicit file is a contract, throw `INCOMPATIBLE_FILES_WITH_BUILD_FLAGS`
+- If `--no-tests` is set and any explicit file is a test, throw `INCOMPATIBLE_FILES_WITH_BUILD_FLAGS`
+
+This validation applies identically in both modes. It uses a new `HardhatError` (`INCOMPATIBLE_FILES_WITH_BUILD_FLAGS`) rather than the old `UNRECOGNIZED_FILES_NOT_COMPILED` or `FILES_WITH_SCOPE_FILTERS_NOT_SUPPORTED` errors.
+
+#### When `splitTestsCompilation === false`
 
 - `build` uses a single compilation pass
 - the pass runs with `scope: "contracts"`
@@ -207,16 +216,25 @@ Behavior by input mode when `splitTestsCompilation === false`:
    - `onCleanUpArtifacts` does not run
    - Any stale artifacts or stale build-info files remain, exactly like any other partial build
 
-5. Explicit `files` cannot be combined with `--no-tests` or `--no-contracts`
+5. Explicit `files` with `--no-tests`
 
-   - If `files.length > 0` and either `--no-tests` or `--no-contracts` is used, the task throws
+   - Compatible contract files build normally as a partial build; test files in the file list would have been caught by the mode-independent validation above
+   - This is a partial build (no cleanup)
+   - The `--no-tests` flag also filters out test roots from the resolved set, so it is meaningful even when explicit files are provided
 
-When `splitTestsCompilation === true`:
+6. Explicit `files` with `--no-contracts`
+
+   - Compatible test files build normally as a partial build; contract files in the file list would have been caught by the mode-independent validation above
+   - This is a partial build (no cleanup)
+   - The `--no-contracts` flag also filters out contract roots from the resolved set, so it is meaningful even when explicit files are provided
+
+#### When `splitTestsCompilation === true`
 
 - current behavior is preserved
 - The task builds contracts and tests in two separate passes
 - `--no-tests` and `--no-contracts` skip a scope exactly as they do today
-- Otherwise, explicit `files` are routed to the matching scope with `getScope()`
+- explicit `files` are routed to the matching scope with `getScope()`
+- explicit `files` can be combined with `--no-tests` or `--no-contracts` when compatible (e.g., contract files with `--no-tests`); incompatible combinations are caught by the mode-independent validation above
 - Scope-specific cleanup remains unchanged
 
 Both modes return:
@@ -552,21 +570,28 @@ Rewrite the high-level build task to implement the new unified-mode semantics.
 ### Changes
 
 1. `packages/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts`
+   - Add mode-independent validation before the `splitTestsCompilation` branch:
+     - if `--no-contracts` and any explicit file is a contract, throw `INCOMPATIBLE_FILES_WITH_BUILD_FLAGS`
+     - if `--no-tests` and any explicit file is a test, throw `INCOMPATIBLE_FILES_WITH_BUILD_FLAGS`
    - Branch on `splitTestsCompilation`
    - Unified mode:
      - full build when no `files` and no scope-skipping flags
      - exact partial build when explicit `files` are provided
+     - explicit `files` can be combined with `--no-tests` or `--no-contracts` when the files are compatible with the flag; the flag still filters the resolved root set
      - synthetic partial build of all contracts for `--no-tests`: call `getRootFilePaths({ scope: "contracts" })` to get all roots, filter to contract roots using `getScope()`, and pass them as `rootFilePaths` to `build()`
      - synthetic partial build of all tests for `--no-contracts`: call `getRootFilePaths({ scope: "contracts" })` to get all roots, filter to test roots using `getScope()`, and pass them as `rootFilePaths` to `build()`
      - all low-level `solidity.build()` and `solidity.cleanupArtifacts()` calls use `scope: "contracts"`, even when the selected roots are all tests
      - the task must never call low-level Solidity build-system APIs with `scope: "tests"` in unified mode
-     - reject `files` combined with `--no-tests` or `--no-contracts`
      - cleanup runs only for the full unified build
    - Split mode:
      - preserve the current two-pass behavior
      - preserve the current explicit-file routing behavior
-     - preserve the current unused-file validation after scope routing
+     - explicit `files` can be combined with `--no-tests` or `--no-contracts` when the files are compatible with the flag; incompatible combinations are caught by the mode-independent validation
    - Return `{ contractRootPaths, testRootPaths }` from the roots actually built, partitioning them with `getScope()`
+
+2. `packages/hardhat-errors/src/descriptors.ts`
+   - Replace `FILES_WITH_SCOPE_FILTERS_NOT_SUPPORTED` with `INCOMPATIBLE_FILES_WITH_BUILD_FLAGS` (same error number 917)
+   - `UNRECOGNIZED_FILES_NOT_COMPILED` (915) is no longer used in build.ts (still used by the solidity-test runner, addressed in Phase 6)
 
 ### Validation
 
@@ -580,11 +605,15 @@ Rewrite the high-level build task to implement the new unified-mode semantics.
   - "includes test artifacts in duplicate-name detection": replace direct `getRootFilePaths` + `build` + `cleanupArtifacts` calls with `hre.tasks.getTask("build").run()`
   - "passes mixed contract and test artifact paths to onCleanUpArtifacts": replace direct `getRootFilePaths` + `build` + `cleanupArtifacts` calls with `hre.tasks.getTask("build").run()` and use an inline plugin to register an `onCleanUpArtifacts` handler that asserts on the received artifact paths
 - Add tests for:
+  - mode-independent: explicit contract files + `--no-contracts` throws `INCOMPATIBLE_FILES_WITH_BUILD_FLAGS`
+  - mode-independent: explicit test files + `--no-tests` throws `INCOMPATIBLE_FILES_WITH_BUILD_FLAGS`
+  - mode-independent: mixed files + `--no-contracts` throws for the contract files
+  - mode-independent: mixed files + `--no-tests` throws for the test files
   - unified full build compiles contracts and tests together
   - unified explicit-file builds compile exactly the provided files
   - unified explicit-file builds still use low-level `scope: "contracts"`
-  - unified explicit `files` + `--no-tests` throws
-  - unified explicit `files` + `--no-contracts` throws
+  - unified explicit contract files + `--no-tests` succeeds (partial build, contracts only)
+  - unified explicit test files + `--no-contracts` succeeds (partial build, tests only)
   - unified `--no-tests` behaves like a partial build over all contracts
   - unified `--no-contracts` behaves like a partial build over all tests
   - unified `--no-contracts` still uses low-level `scope: "contracts"`
@@ -593,16 +622,14 @@ Rewrite the high-level build task to implement the new unified-mode semantics.
   - unified mode partitions returned `contractRootPaths` and `testRootPaths` with `getScope()` from the actual roots built
   - split mode preserves explicit contract-file builds with `--no-tests`
   - split mode preserves explicit test-file builds with `--no-contracts`
-  - split mode preserves the current unused-file error when explicit files fall only in a disabled scope
+  - split mode: explicit test files only (no flags) skips the contracts scope entirely
   - other split-mode regressions for current behavior
 - Run `pnpm test` in `packages/hardhat`
-- **Known failures after Phase 4:** 18 tests fail because two callers still use `build({ files, noContracts: true })`, which is now invalid in unified mode. All 18 originate from:
-  - `solidity-test/task-action.ts` (6 failures) — fixed in Phase 6
-  - `CoverageManagerImplementation` (12 failures) — also fixed in Phase 6, since coverage delegates to the solidity-test runner
+- **Known failures after Phase 4:** 2 tests fail because the solidity-test runner calls `build({ files: testFiles, noContracts: true })` with a file that `getScope()` classifies as a contract (not in the configured test path). The mode-independent validation catches this as an incompatible combination and throws `INCOMPATIBLE_FILES_WITH_BUILD_FLAGS` (917), but the tests expect the old `UNRECOGNIZED_FILES_NOT_COMPILED` (915). Both originate from `solidity-test/task-action.ts` and are fixed in Phase 6 when the solidity-test runner is updated.
 
 ## Phase 5: Other Built-In Task Callers
 
-Update the built-in tasks that currently call `build({ noTests: true })`.
+Update the built-in tasks that currently call `build({ noTests: true })`. While `build({ noTests: true })` is technically valid after Phase 4 (it produces a partial contracts-only build), these callers need a full unified build with cleanup — not a partial build — so they must drop `noTests` in unified mode.
 
 ### Changes
 
@@ -633,7 +660,7 @@ Update the built-in tasks that currently call `build({ noTests: true })`.
 
 ## Phase 6: Solidity Test Runner
 
-Update the Solidity test runner for unified builds while preserving selected test execution.
+Update the Solidity test runner for unified builds while preserving selected test execution. Note: the solidity-test runner currently uses `build({ files, noContracts: true })`, which is valid after Phase 4 (it produces a partial test-only build). However, in unified mode the runner should perform a full build instead, so this change is still needed for the correct full-build semantics.
 
 ### Changes
 

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -1360,6 +1360,18 @@ When \`splitTestsCompilation\` is \`false\`, contracts and tests are compiled to
 
 Set \`solidity.splitTestsCompilation\` to \`true\` in your Hardhat config to enable this build scope.`,
       },
+      INCOMPATIBLE_FILES_WITH_BUILD_FLAGS: {
+        number: 917,
+        messageTemplate: `Some of the files you are trying to build are incompatible with the \`--no-contracts\` or \`--no-tests\` flag you provided:
+
+{files}
+
+Try re-running without these files, or without the flag.`,
+        websiteTitle: "Incompatible files with build flags",
+        websiteDescription: `You are trying to build a list of files while using \`--no-contracts\` or \`--no-tests\`, but some of those files are incompatible with the flag you provided.
+
+For example, you may be trying to build a test file with \`--no-tests\`, which isn't a valid operation.`,
+      },
     },
     ARTIFACTS: {
       NOT_FOUND: {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
@@ -88,6 +88,7 @@ const buildAction: NewTaskActionFunction<BuildActionArguments> = async (
       );
 
       contractRootPaths.push(...contractBuildResults.contractRootPaths);
+      testRootPaths.push(...contractBuildResults.testRootPaths);
     }
 
     const shouldBuildTests =
@@ -111,6 +112,7 @@ const buildAction: NewTaskActionFunction<BuildActionArguments> = async (
         "The tests scope should build no contract in split test compilation mode",
       );
 
+      contractRootPaths.push(...testBuildResults.contractRootPaths);
       testRootPaths.push(...testBuildResults.testRootPaths);
     }
 
@@ -189,15 +191,24 @@ async function runSolidityBuild({
 
   throwIfSolidityBuildFailed(solidity, results);
 
+  // We use the result keys in case a hook added or removed root files
+  const builtRootPaths = [...results.keys()];
+
   if (isFullBuild) {
-    // We use the result keys in case a hook added more root files
-    const builtRootPaths = [...results.keys()];
     await solidity.cleanupArtifacts(builtRootPaths, {
       scope,
     });
   }
 
-  return { contractRootPaths, testRootPaths };
+  const preBuildRoots = new Set([...contractRootPaths, ...testRootPaths]);
+  if (
+    builtRootPaths.length === preBuildRoots.size &&
+    builtRootPaths.every((p) => preBuildRoots.has(p))
+  ) {
+    return { contractRootPaths, testRootPaths };
+  }
+
+  return partitionRootPathsByScope(solidity, builtRootPaths);
 }
 
 /**

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
@@ -1,8 +1,13 @@
-import type { HardhatRuntimeEnvironment } from "../../../../types/hre.js";
-import type { BuildScope } from "../../../../types/solidity.js";
+import type {
+  BuildScope,
+  SolidityBuildSystem,
+} from "../../../../types/solidity.js";
 import type { NewTaskActionFunction } from "../../../../types/tasks.js";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import {
+  assertHardhatInvariant,
+  HardhatError,
+} from "@nomicfoundation/hardhat-errors";
 import { resolveFromRoot } from "@nomicfoundation/hardhat-utils/path";
 
 import { throwIfSolidityBuildFailed } from "../build-results.js";
@@ -17,110 +22,382 @@ interface BuildActionArguments {
   noContracts: boolean;
 }
 
+interface BuildActionResult {
+  contractRootPaths: string[];
+  testRootPaths: string[];
+}
+
 const buildAction: NewTaskActionFunction<BuildActionArguments> = async (
   args: BuildActionArguments,
   hre,
-) => {
-  let contractRootPaths: string[] = [];
-  let testRootPaths: string[] = [];
-  const allUsedFiles: string[] = [];
+): Promise<BuildActionResult> => {
+  const buildProfile =
+    hre.globalOptions.buildProfile ?? args.defaultBuildProfile;
 
-  if (args.noContracts === false) {
-    const { rootPaths, usedFiles } = await buildForScope(
-      "contracts",
-      args,
-      hre,
+  const files = normalizedRootPaths(args.files);
+
+  const partitionedFiles = await partitionRootPathsByScope(hre.solidity, files);
+
+  if (args.noContracts && partitionedFiles.contractRootPaths.length > 0) {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.SOLIDITY.INCOMPATIBLE_FILES_WITH_BUILD_FLAGS,
+      {
+        files: partitionedFiles.contractRootPaths
+          .sort()
+          .map((f) => `- ${f}`)
+          .join("\n"),
+      },
     );
-
-    contractRootPaths = rootPaths;
-    allUsedFiles.push(...usedFiles);
   }
 
-  if (args.noTests === false) {
-    const { rootPaths, usedFiles } = await buildForScope("tests", args, hre);
-
-    testRootPaths = rootPaths;
-    allUsedFiles.push(...usedFiles);
+  if (args.noTests && partitionedFiles.testRootPaths.length > 0) {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.SOLIDITY.INCOMPATIBLE_FILES_WITH_BUILD_FLAGS,
+      {
+        files: partitionedFiles.testRootPaths
+          .sort()
+          .map((f) => `- ${f}`)
+          .join("\n"),
+      },
+    );
   }
 
-  // If there's an unused file we fail
-  if (args.files.length !== 0) {
-    const files = new Set(args.files);
-    const usedFiles = new Set(allUsedFiles);
-    const unusedFiles = files.difference(usedFiles);
+  if (hre.config.solidity.splitTestsCompilation) {
+    const contractRootPaths = [];
+    const testRootPaths = [];
 
-    if (unusedFiles.size > 0) {
-      const list = [...unusedFiles]
-        .sort()
-        .map((f) => `- ${f}`)
-        .join("\n");
+    const shouldBuildContracts =
+      !args.noContracts &&
+      (files.length === 0 || partitionedFiles.contractRootPaths.length > 0);
 
-      throw new HardhatError(
-        HardhatError.ERRORS.CORE.SOLIDITY.UNRECOGNIZED_FILES_NOT_COMPILED,
-        { files: list },
+    if (shouldBuildContracts) {
+      const contractBuildResults = await runSolidityBuild({
+        buildProfile,
+        files: partitionedFiles.contractRootPaths,
+        force: args.force,
+        isUnifiedModeOrScope: "contracts",
+        noContracts: args.noContracts,
+        noTests: args.noTests,
+        quiet: args.quiet,
+        solidity: hre.solidity,
+      });
+
+      assertHardhatInvariant(
+        contractBuildResults.testRootPaths.length === 0,
+        "The contracts scope should build no test in split test compilation mode",
       );
+
+      contractRootPaths.push(...contractBuildResults.contractRootPaths);
+    }
+
+    const shouldBuildTests =
+      !args.noTests &&
+      (files.length === 0 || partitionedFiles.testRootPaths.length > 0);
+
+    if (shouldBuildTests) {
+      const testBuildResults = await runSolidityBuild({
+        buildProfile,
+        files: partitionedFiles.testRootPaths,
+        force: args.force,
+        isUnifiedModeOrScope: "tests",
+        noContracts: args.noContracts,
+        noTests: args.noTests,
+        quiet: args.quiet,
+        solidity: hre.solidity,
+      });
+
+      assertHardhatInvariant(
+        testBuildResults.contractRootPaths.length === 0,
+        "The tests scope should build no contract in split test compilation mode",
+      );
+
+      testRootPaths.push(...testBuildResults.testRootPaths);
+    }
+
+    return { contractRootPaths, testRootPaths };
+  }
+
+  return runSolidityBuild({
+    buildProfile,
+    files,
+    force: args.force,
+    isUnifiedModeOrScope: true,
+    noContracts: args.noContracts,
+    noTests: args.noTests,
+    quiet: args.quiet,
+    solidity: hre.solidity,
+  });
+};
+
+/**
+ * Runs a solidity build for a scope/unified mode.
+ *
+ * Note: The files array should be pre-classified by scope if using split
+ * compilation. i.e. it should only include files of the scope being used.
+ */
+async function runSolidityBuild({
+  buildProfile,
+  files,
+  force,
+  isUnifiedModeOrScope,
+  noContracts,
+  noTests,
+  quiet,
+  solidity,
+}: {
+  buildProfile: string;
+  files: string[];
+  force: boolean;
+  isUnifiedModeOrScope: true | BuildScope;
+  noContracts: boolean;
+  noTests: boolean;
+  quiet: boolean;
+  solidity: SolidityBuildSystem;
+}): Promise<{ contractRootPaths: string[]; testRootPaths: string[] }> {
+  const scope =
+    isUnifiedModeOrScope === true ? "contracts" : isUnifiedModeOrScope;
+
+  const { isFullBuild, contractRootPaths, testRootPaths } =
+    await getRootsToBuild({
+      solidity,
+      isUnifiedModeOrScope,
+      files,
+      noTests,
+      noContracts,
+    });
+
+  // If there's nothing to build and this isn't a full build, we exit early.
+  // Full builds with no roots still need to run cleanup to remove stale
+  // artifacts.
+  if (
+    !isFullBuild &&
+    contractRootPaths.length === 0 &&
+    testRootPaths.length === 0
+  ) {
+    return { contractRootPaths, testRootPaths };
+  }
+
+  const results = await solidity.build(
+    [...contractRootPaths, ...testRootPaths],
+    {
+      force,
+      buildProfile,
+      quiet,
+      scope,
+    },
+  );
+
+  throwIfSolidityBuildFailed(solidity, results);
+
+  if (isFullBuild) {
+    // We use the result keys in case a hook added more root files
+    const builtRootPaths = [...results.keys()];
+    await solidity.cleanupArtifacts(builtRootPaths, {
+      scope,
+    });
+  }
+
+  return { contractRootPaths, testRootPaths };
+}
+
+/**
+ * Returns the files to build, classified by testRootPaths and
+ * contractRootPaths, and a boolean indicating if this represents a full build
+ * for the scope/unified build.
+ *
+ * Note: The files array should be pre-classified by scope if using split
+ * compilation. i.e. it should only include files of the scope being used.
+ */
+async function getRootsToBuild({
+  solidity,
+  isUnifiedModeOrScope,
+  files,
+  noTests,
+  noContracts,
+}: {
+  solidity: SolidityBuildSystem;
+  isUnifiedModeOrScope: true | BuildScope;
+  files: string[];
+  noTests: boolean;
+  noContracts: boolean;
+}): Promise<{
+  testRootPaths: string[];
+  contractRootPaths: string[];
+  isFullBuild: boolean;
+}> {
+  if (isUnifiedModeOrScope === true) {
+    return getRootsToBuildInUnifiedMode({
+      files,
+      noContracts,
+      noTests,
+      solidity,
+    });
+  }
+
+  return getRootsToBuildForScope({
+    files,
+    scope: isUnifiedModeOrScope,
+    solidity,
+  });
+}
+
+/**
+ * Returns the root files to build in unified mode. While they are returned
+ * classified as contractRootPaths and testRootPaths, they are expected to be
+ * build together. It also returns a boolean indicating if this represents a
+ * full unified build.
+ *
+ * Note: The files array should be normalized already.
+ * @returns
+ */
+async function getRootsToBuildInUnifiedMode({
+  files,
+  noContracts,
+  noTests,
+  solidity,
+}: {
+  files: string[];
+  noContracts: boolean;
+  noTests: boolean;
+  solidity: SolidityBuildSystem;
+}): Promise<{
+  testRootPaths: string[];
+  contractRootPaths: string[];
+  isFullBuild: boolean;
+}> {
+  const isFullBuild = files.length === 0 && !noTests && !noContracts;
+
+  let rootFilePaths: string[];
+
+  if (isFullBuild) {
+    // In this mode, "contracts" also returns the tests
+    rootFilePaths = await solidity.getRootFilePaths({
+      scope: "contracts",
+    });
+  } else {
+    const allRoots =
+      files.length > 0
+        ? files
+        : await solidity.getRootFilePaths({
+            scope: "contracts",
+          });
+
+    rootFilePaths = [];
+    for (const root of allRoots) {
+      if (isNpmRootPath(root)) {
+        // npm files are considered contract files, so we skip them if
+        // --no-contracts
+        if (!noContracts) {
+          rootFilePaths.push(root);
+        }
+
+        continue;
+      }
+
+      const scope = await solidity.getScope(root);
+
+      if (noTests && scope === "tests") {
+        continue;
+      }
+
+      if (noContracts && scope === "contracts") {
+        continue;
+      }
+
+      rootFilePaths.push(root);
+    }
+  }
+
+  const partitionedRootPaths = await partitionRootPathsByScope(
+    solidity,
+    rootFilePaths,
+  );
+
+  return {
+    isFullBuild,
+    ...partitionedRootPaths,
+  };
+}
+
+/**
+ * Returns the root files to build for a certain scope, and a boolean indicating
+ * if it's a full build for that scope.
+ *
+ * Note: The files array should be pre-classified by scope if using split
+ * compilation. i.e. it should only include files of the scope being used.
+ *
+ * Note: One of the returned arrays is always empty, depending on the scope
+ * being used.
+ */
+async function getRootsToBuildForScope({
+  files,
+  scope,
+  solidity,
+}: {
+  files: string[];
+  scope: BuildScope;
+  solidity: SolidityBuildSystem;
+}): Promise<{
+  isFullBuild: boolean;
+  contractRootPaths: string[];
+  testRootPaths: string[];
+}> {
+  const isFullBuild = files.length === 0;
+
+  const rootPaths = isFullBuild
+    ? await solidity.getRootFilePaths({ scope })
+    : files; // This is safe because the files have already been partitioned by scope
+
+  if (scope === "contracts") {
+    return { isFullBuild, contractRootPaths: rootPaths, testRootPaths: [] };
+  }
+
+  return { isFullBuild, contractRootPaths: [], testRootPaths: rootPaths };
+}
+
+/**
+ * Partitions root paths by scope, as returned by `solidity.getScope(rootPath)`.
+ */
+async function partitionRootPathsByScope(
+  solidity: SolidityBuildSystem,
+  rootPaths: string[],
+): Promise<{ contractRootPaths: string[]; testRootPaths: string[] }> {
+  const contractRootPaths: string[] = [];
+  const testRootPaths: string[] = [];
+
+  for (const rootPath of rootPaths) {
+    if (isNpmRootPath(rootPath)) {
+      contractRootPaths.push(rootPath);
+      continue;
+    }
+
+    const scope = await solidity.getScope(rootPath);
+    if (scope === "tests") {
+      testRootPaths.push(rootPath);
+    } else {
+      contractRootPaths.push(rootPath);
     }
   }
 
   return { contractRootPaths, testRootPaths };
-};
+}
 
-async function buildForScope(
-  scope: BuildScope,
-  { force, files, quiet, defaultBuildProfile }: BuildActionArguments,
-  { solidity, globalOptions }: HardhatRuntimeEnvironment,
-) {
-  const usedFiles = [];
-
-  // If no specific files are passed, it means a full compilation, i.e. all source files
-  const isFullCompilation = files.length === 0;
-
-  const rootPaths = [];
-
-  if (isFullCompilation) {
-    rootPaths.push(...(await solidity.getRootFilePaths({ scope })));
-  } else {
-    for (const file of files) {
-      if (isNpmRootPath(file)) {
-        rootPaths.push(file);
-      }
-
-      const rootPath = resolveFromRoot(process.cwd(), file);
-
-      if ((await solidity.getScope(rootPath)) !== scope) {
-        continue;
-      }
-
-      usedFiles.push(file);
-      rootPaths.push(rootPath);
+/**
+ * Normalizes the received root paths.
+ *
+ * If a file is an npm root path or absolute file path, it's returned as is.
+ * If it's a relative path it's resolved from the CWD.
+ */
+function normalizedRootPaths(files: string[]): string[] {
+  const normalizedPaths = files.map((f) => {
+    if (isNpmRootPath(f)) {
+      return f;
     }
 
-    // If a file list has been passed but none match this scope, we don't run the build
-    if (rootPaths.length === 0) {
-      return { rootPaths, usedFiles };
-    }
-  }
-
-  const buildProfile = globalOptions.buildProfile ?? defaultBuildProfile;
-
-  const results = await solidity.build(rootPaths, {
-    force,
-    buildProfile,
-    quiet,
-    scope,
+    return resolveFromRoot(process.cwd(), f);
   });
 
-  throwIfSolidityBuildFailed(solidity, results);
-
-  // If we recompiled the entire project we cleanup the artifacts
-  if (isFullCompilation) {
-    // Use the root files from the build results, which may include
-    // additional files added by plugins hooking into solidity#build
-    const builtRootPaths = [...results.keys()];
-    await solidity.cleanupArtifacts(builtRootPaths, { scope });
-  }
-
-  return { rootPaths, usedFiles };
+  return normalizedPaths;
 }
 
 export default buildAction;

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
@@ -1,3 +1,15 @@
+import type {
+  HookContext,
+  SolidityHooks,
+} from "../../../../../../src/types/hooks.js";
+import type { HardhatPlugin } from "../../../../../../src/types/plugins.js";
+import type {
+  BuildOptions,
+  BuildScope,
+  CompilationJobCreationError,
+  FileBuildResult,
+} from "../../../../../../src/types/solidity/build-system.js";
+
 import assert from "node:assert/strict";
 import path from "node:path";
 import { describe, it } from "node:test";
@@ -11,6 +23,48 @@ import {
 } from "@nomicfoundation/hardhat-utils/fs";
 
 import { useTestProjectTemplate } from "../resolver/helpers.js";
+
+/**
+ * Creates a plugin that installs a `solidity.build` hook adding `extraFile`
+ * to the root file paths. If `onlyForScope` is provided, the file is only
+ * added when the build is invoked for that scope.
+ */
+function makeBuildHookAddingPlugin(
+  extraFile: string,
+  onlyForScope?: BuildScope,
+): HardhatPlugin {
+  return {
+    id: "test-build-hook-adding-plugin",
+    hookHandlers: {
+      solidity: async () => ({
+        default: async () => {
+          const handlers: Partial<SolidityHooks> = {
+            build: async (
+              context: HookContext,
+              rootFilePaths: string[],
+              options: BuildOptions | undefined,
+              next: (
+                nextContext: HookContext,
+                nextRootFilePaths: string[],
+                nextOptions: BuildOptions | undefined,
+              ) => Promise<
+                CompilationJobCreationError | Map<string, FileBuildResult>
+              >,
+            ) => {
+              const shouldAdd =
+                onlyForScope === undefined || options?.scope === onlyForScope;
+              const nextRoots = shouldAdd
+                ? [...rootFilePaths, extraFile]
+                : rootFilePaths;
+              return next(context, nextRoots, options);
+            },
+          };
+          return handlers;
+        },
+      }),
+    },
+  };
+}
 
 const basicProjectTemplate = {
   name: "test",
@@ -155,6 +209,38 @@ describe("build system - build task - behavior on build scope", function () {
         assert.equal(await exists(testBuildInfoPath), false);
         assert.equal(await exists(contractArtifactPath), false);
         assert.equal(await exists(testArtifactPath), false);
+      });
+
+      it("includes a hook-added contract root in the returned contractRootPaths", async () => {
+        await using project = await useTestProjectTemplate({
+          ...basicProjectTemplate,
+          name: "test-split-hook-adds-contract",
+          files: {
+            ...basicProjectTemplate.files,
+            "extra/AddedByHook.sol": `// SPDX-License-Identifier: UNLICENSED
+              pragma solidity ^0.8.0;
+              contract AddedByHook {}`,
+          },
+        });
+        const extraFile = path.join(project.path, "extra/AddedByHook.sol");
+        const hre = await project.getHRE({
+          ...solidityCompilationConfig,
+          plugins: [makeBuildHookAddingPlugin(extraFile, "contracts")],
+        });
+
+        const result: {
+          contractRootPaths: string[];
+          testRootPaths: string[];
+        } = await hre.tasks.getTask("build").run();
+
+        assert.ok(
+          result.contractRootPaths.some((r) => r === extraFile),
+          "Expected hook-added AddedByHook.sol in contractRootPaths",
+        );
+        assert.ok(
+          !result.testRootPaths.some((r) => r === extraFile),
+          "Did not expect hook-added contract in testRootPaths",
+        );
       });
     });
 
@@ -652,6 +738,38 @@ describe("build system - splitTestsCompilation: false - build task", function ()
       assert.ok(
         result.testRootPaths.some((r) => r.endsWith("OtherFooTest.sol")),
         "Expected OtherFooTest.sol in testRootPaths",
+      );
+    });
+
+    it("includes a hook-added contract root in the returned contractRootPaths", async () => {
+      await using project = await useTestProjectTemplate({
+        ...basicProjectTemplate,
+        name: "test-unified-hook-adds-contract",
+        files: {
+          ...basicProjectTemplate.files,
+          "extra/AddedByHook.sol": `// SPDX-License-Identifier: UNLICENSED
+            pragma solidity ^0.8.0;
+            contract AddedByHook {}`,
+        },
+      });
+      const extraFile = path.join(project.path, "extra/AddedByHook.sol");
+      const hre = await project.getHRE({
+        ...unifiedTestsCompilationConfig,
+        plugins: [makeBuildHookAddingPlugin(extraFile)],
+      });
+
+      const result: {
+        contractRootPaths: string[];
+        testRootPaths: string[];
+      } = await hre.tasks.getTask("build").run();
+
+      assert.ok(
+        result.contractRootPaths.some((r) => r === extraFile),
+        "Expected hook-added AddedByHook.sol in contractRootPaths",
+      );
+      assert.ok(
+        !result.testRootPaths.some((r) => r === extraFile),
+        "Did not expect hook-added contract in testRootPaths",
       );
     });
   });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
@@ -6,9 +6,7 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 import {
   exists,
-  getAllFilesMatching,
   readJsonFile,
-  readUtf8File,
   writeUtf8File,
 } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -411,88 +409,169 @@ describe("build system - build task - behavior on build scope", function () {
       assert.equal(await exists(testBuildInfoPath), false);
       assert.equal(await exists(testArtifactPath), false);
     });
+  });
 
-    describe("When user provided files' scopes can't be recognized", async () => {
-      it("Should throw if a test file isn't recognized", async () => {
-        await using project =
-          await useTestProjectTemplate(basicProjectTemplate);
-        const hre = await project.getHRE(solidityCompilationConfig);
+  describe("explicit files with compatible scope flags", function () {
+    it("builds contract files with --no-tests", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(solidityCompilationConfig);
+      process.chdir(project.path);
 
-        const previousCwd = process.cwd();
-        process.chdir(project.path);
+      await hre.tasks
+        .getTask("build")
+        .run({ files: ["contracts/Foo.sol"], noTests: true });
 
-        try {
-          await assertRejectsWithHardhatError(
-            hre.tasks
-              .getTask("build")
-              .run({ noTests: true, files: ["contracts/Foo.t.sol"] }),
-            HardhatError.ERRORS.CORE.SOLIDITY.UNRECOGNIZED_FILES_NOT_COMPILED,
-            { files: "- contracts/Foo.t.sol" },
-          );
+      const contractsArtifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+      await readJsonFile(
+        path.join(contractsArtifactsPath, "contracts", "Foo.sol", "Foo.json"),
+      );
+    });
 
-          await assertRejectsWithHardhatError(
-            hre.tasks
-              .getTask("build")
-              .run({ noTests: true, files: ["test/OtherFooTest.sol"] }),
-            HardhatError.ERRORS.CORE.SOLIDITY.UNRECOGNIZED_FILES_NOT_COMPILED,
-            { files: "- test/OtherFooTest.sol" },
-          );
-        } catch {
-          process.chdir(previousCwd);
-        }
-      });
+    it("builds test files with --no-contracts", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(solidityCompilationConfig);
+      process.chdir(project.path);
 
-      it("Should throw if a contract isn't recognized", async () => {
-        await using project =
-          await useTestProjectTemplate(basicProjectTemplate);
-        const hre = await project.getHRE(solidityCompilationConfig);
+      await hre.tasks
+        .getTask("build")
+        .run({ files: ["contracts/Foo.t.sol"], noContracts: true });
 
-        const previousCwd = process.cwd();
-        process.chdir(project.path);
+      const testsArtifactsPath =
+        await hre.solidity.getArtifactsDirectory("tests");
+      await readJsonFile(
+        path.join(testsArtifactsPath, "contracts", "Foo.t.sol", "FooTest.json"),
+      );
+    });
+  });
 
-        try {
-          await assertRejectsWithHardhatError(
-            hre.tasks
-              .getTask("build")
-              .run({ noContracts: true, files: ["contracts/Foo.sol"] }),
-            HardhatError.ERRORS.CORE.SOLIDITY.UNRECOGNIZED_FILES_NOT_COMPILED,
-            { files: "- contracts/Foo.sol" },
-          );
-        } catch {
-          process.chdir(previousCwd);
-        }
-      });
+  describe("explicit files in one scope without flags", function () {
+    it("skips the contracts scope when only test files are passed", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(solidityCompilationConfig);
+      process.chdir(project.path);
 
-      it("Should throw if neither is recognized", async () => {
-        await using project =
-          await useTestProjectTemplate(basicProjectTemplate);
-        const hre = await project.getHRE(solidityCompilationConfig);
+      await hre.tasks
+        .getTask("build")
+        .run({ files: ["test/OtherFooTest.sol"] });
 
-        const previousCwd = process.cwd();
-        process.chdir(project.path);
+      const testsArtifactsPath =
+        await hre.solidity.getArtifactsDirectory("tests");
 
-        try {
-          await assertRejectsWithHardhatError(
-            hre.tasks.getTask("build").run({
-              noContracts: true,
-              noTests: true,
-              files: ["contracts/Foo.sol", "contracts/Foo.t.sol"],
-            }),
-            HardhatError.ERRORS.CORE.SOLIDITY.UNRECOGNIZED_FILES_NOT_COMPILED,
-            {
-              files: `- contracts/Foo.sol
-- contracts/Foo.t.sol`,
-            },
-          );
-        } catch {
-          process.chdir(previousCwd);
-        }
-      });
+      // Test artifact should exist
+      await readJsonFile(
+        path.join(
+          testsArtifactsPath,
+          "test",
+          "OtherFooTest.sol",
+          "OtherFooTest.json",
+        ),
+      );
+
+      // Contract artifacts should NOT exist (contracts scope was skipped)
+      const contractsArtifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+      assert.equal(
+        await exists(
+          path.join(contractsArtifactsPath, "contracts", "Foo.sol", "Foo.json"),
+        ),
+        false,
+        "Contract artifact should not exist when only test files were passed",
+      );
     });
   });
 });
 
-describe("build system - splitTestsCompilation: false", function () {
+describe("build system - mode-independent file+flag validation", function () {
+  // These tests use the default config (splitTestsCompilation: false)
+  // because the validation applies identically in both modes.
+  it("throws when test files are passed with --no-tests", async () => {
+    await using project = await useTestProjectTemplate(basicProjectTemplate);
+    const hre = await project.getHRE();
+    process.chdir(project.path);
+
+    await assertRejectsWithHardhatError(
+      hre.tasks
+        .getTask("build")
+        .run({ noTests: true, files: ["test/OtherFooTest.sol"] }),
+      HardhatError.ERRORS.CORE.SOLIDITY.INCOMPATIBLE_FILES_WITH_BUILD_FLAGS,
+      {
+        files: `- ${path.resolve(project.path, "test/OtherFooTest.sol")}`,
+      },
+    );
+  });
+
+  it("throws when contract files are passed with --no-contracts", async () => {
+    await using project = await useTestProjectTemplate(basicProjectTemplate);
+    const hre = await project.getHRE();
+    process.chdir(project.path);
+
+    await assertRejectsWithHardhatError(
+      hre.tasks
+        .getTask("build")
+        .run({ noContracts: true, files: ["contracts/Foo.sol"] }),
+      HardhatError.ERRORS.CORE.SOLIDITY.INCOMPATIBLE_FILES_WITH_BUILD_FLAGS,
+      {
+        files: `- ${path.resolve(project.path, "contracts/Foo.sol")}`,
+      },
+    );
+  });
+
+  it("throws for the test file when mixed files are passed with --no-tests", async () => {
+    await using project = await useTestProjectTemplate(basicProjectTemplate);
+    const hre = await project.getHRE();
+    process.chdir(project.path);
+
+    await assertRejectsWithHardhatError(
+      hre.tasks.getTask("build").run({
+        noTests: true,
+        files: ["contracts/Foo.sol", "test/OtherFooTest.sol"],
+      }),
+      HardhatError.ERRORS.CORE.SOLIDITY.INCOMPATIBLE_FILES_WITH_BUILD_FLAGS,
+      {
+        files: `- ${path.resolve(project.path, "test/OtherFooTest.sol")}`,
+      },
+    );
+  });
+
+  it("throws for the contract file when mixed files are passed with --no-contracts", async () => {
+    await using project = await useTestProjectTemplate(basicProjectTemplate);
+    const hre = await project.getHRE();
+    process.chdir(project.path);
+
+    await assertRejectsWithHardhatError(
+      hre.tasks.getTask("build").run({
+        noContracts: true,
+        files: ["contracts/Foo.sol", "test/OtherFooTest.sol"],
+      }),
+      HardhatError.ERRORS.CORE.SOLIDITY.INCOMPATIBLE_FILES_WITH_BUILD_FLAGS,
+      {
+        files: `- ${path.resolve(project.path, "contracts/Foo.sol")}`,
+      },
+    );
+  });
+
+  it("throws for the first conflict when both flags are set", async () => {
+    await using project = await useTestProjectTemplate(basicProjectTemplate);
+    const hre = await project.getHRE();
+    process.chdir(project.path);
+
+    // noContracts is checked first, so only the contract file appears in the error
+    await assertRejectsWithHardhatError(
+      hre.tasks.getTask("build").run({
+        noContracts: true,
+        noTests: true,
+        files: ["contracts/Foo.sol", "contracts/Foo.t.sol"],
+      }),
+      HardhatError.ERRORS.CORE.SOLIDITY.INCOMPATIBLE_FILES_WITH_BUILD_FLAGS,
+      {
+        files: `- ${path.resolve(project.path, "contracts/Foo.sol")}`,
+      },
+    );
+  });
+});
+
+describe("build system - splitTestsCompilation: false - build task", function () {
   const unifiedTestsCompilationConfig = {
     solidity: {
       version: "0.8.28",
@@ -500,271 +579,316 @@ describe("build system - splitTestsCompilation: false", function () {
     },
   };
 
-  describe("getRootFilePaths", function () {
-    it("returns contract, test, and npm roots for scope 'contracts'", async () => {
+  describe("full build", function () {
+    it("compiles contracts and tests together", async () => {
       await using project = await useTestProjectTemplate(basicProjectTemplate);
       const hre = await project.getHRE(unifiedTestsCompilationConfig);
 
-      const roots = await hre.solidity.getRootFilePaths({
-        scope: "contracts",
-      });
-
-      // Should contain the contract file
-      assert.ok(
-        roots.some((r) => r.endsWith("Foo.sol") && !r.endsWith(".t.sol")),
-        "Expected contract root Foo.sol in unified roots",
-      );
-      // Should contain the .t.sol test file
-      assert.ok(
-        roots.some((r) => r.endsWith("Foo.t.sol")),
-        "Expected test root Foo.t.sol in unified roots",
-      );
-      // Should contain the test directory test file
-      assert.ok(
-        roots.some((r) => r.endsWith("OtherFooTest.sol")),
-        "Expected test root OtherFooTest.sol in unified roots",
-      );
-    });
-
-    it("throws for scope 'tests'", async () => {
-      await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE(unifiedTestsCompilationConfig);
-
-      await assertRejectsWithHardhatError(
-        hre.solidity.getRootFilePaths({ scope: "tests" }),
-        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
-        {},
-      );
-    });
-  });
-
-  describe("getArtifactsDirectory", function () {
-    it("returns the main artifacts dir for scope 'tests'", async () => {
-      await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE(unifiedTestsCompilationConfig);
-
-      const contractsDir =
-        await hre.solidity.getArtifactsDirectory("contracts");
-      const testsDir = await hre.solidity.getArtifactsDirectory("tests");
-
-      assert.equal(contractsDir, testsDir);
-    });
-  });
-
-  describe("low-level scope:'tests' rejection", function () {
-    it("build() throws for scope 'tests'", async () => {
-      await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE(unifiedTestsCompilationConfig);
-
-      await assertRejectsWithHardhatError(
-        hre.solidity.build([], { scope: "tests" }),
-        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
-        {},
-      );
-    });
-
-    it("getCompilationJobs() throws for scope 'tests'", async () => {
-      await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE(unifiedTestsCompilationConfig);
-
-      await assertRejectsWithHardhatError(
-        hre.solidity.getCompilationJobs([], { scope: "tests" }),
-        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
-        {},
-      );
-    });
-
-    it("emitArtifacts() throws for scope 'tests'", async () => {
-      await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE(unifiedTestsCompilationConfig);
-
-      // We need a real compilation job to call emitArtifacts.
-      // Build first so we can get a compilation job.
-      const roots = await hre.solidity.getRootFilePaths({
-        scope: "contracts",
-      });
-      const contractRoots = roots.filter(
-        (r) =>
-          !r.endsWith(".t.sol") && !r.includes(path.sep + "test" + path.sep),
-      );
-      const result = await hre.solidity.getCompilationJobs(contractRoots, {
-        scope: "contracts",
-      });
-
-      assert.ok(result.success, "Expected compilation jobs to succeed");
-
-      const firstJob = [...result.compilationJobsPerFile.values()][0];
-      const runResult = await hre.solidity.runCompilationJob(firstJob);
-
-      await assertRejectsWithHardhatError(
-        hre.solidity.emitArtifacts(firstJob, runResult.output, {
-          scope: "tests",
-        }),
-        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
-        {},
-      );
-    });
-
-    it("cleanupArtifacts() throws for scope 'tests'", async () => {
-      await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE(unifiedTestsCompilationConfig);
-
-      await assertRejectsWithHardhatError(
-        hre.solidity.cleanupArtifacts([], { scope: "tests" }),
-        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
-        {},
-      );
-    });
-  });
-
-  describe("emitArtifacts - type declarations", function () {
-    it("skips per-source artifacts.d.ts for test roots in unified contracts-scope builds", async () => {
-      await using project = await useTestProjectTemplate(basicProjectTemplate);
-      const hre = await project.getHRE(unifiedTestsCompilationConfig);
-
-      // Build directly using the build-system APIs (the build task is
-      // not updated until Phase 4).
-      const roots = await hre.solidity.getRootFilePaths({
-        scope: "contracts",
-      });
-      const buildResult = await hre.solidity.build(roots, {
-        scope: "contracts",
-      });
-
-      assert.ok(
-        hre.solidity.isSuccessfulBuildResult(buildResult),
-        "Expected build to succeed",
-      );
+      await hre.tasks.getTask("build").run();
 
       const artifactsPath =
         await hre.solidity.getArtifactsDirectory("contracts");
 
-      // Contract root should have artifacts.d.ts
-      assert.equal(
-        await exists(
-          path.join(artifactsPath, "contracts", "Foo.sol", "artifacts.d.ts"),
+      // Contract artifact
+      await readJsonFile(
+        path.join(artifactsPath, "contracts", "Foo.sol", "Foo.json"),
+      );
+      // Test artifacts in main artifacts dir
+      await readJsonFile(
+        path.join(artifactsPath, "contracts", "Foo.t.sol", "FooTest.json"),
+      );
+      await readJsonFile(
+        path.join(
+          artifactsPath,
+          "test",
+          "OtherFooTest.sol",
+          "OtherFooTest.json",
         ),
-        true,
-      );
-
-      // Test roots should NOT have artifacts.d.ts
-      assert.equal(
-        await exists(
-          path.join(artifactsPath, "contracts", "Foo.t.sol", "artifacts.d.ts"),
-        ),
-        false,
-      );
-      assert.equal(
-        await exists(
-          path.join(
-            artifactsPath,
-            "test",
-            "OtherFooTest.sol",
-            "artifacts.d.ts",
-          ),
-        ),
-        false,
-      );
-    });
-  });
-
-  describe("unified cleanup", function () {
-    it("includes test artifacts in duplicate-name detection", async () => {
-      const duplicateNameTemplate = {
-        name: "test",
-        version: "1.0.0",
-        files: {
-          "contracts/Foo.sol": `// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.0;\ncontract Foo {}`,
-          "test/Foo.sol": `// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.0;\ncontract Foo {}`,
-        },
-      };
-
-      await using project = await useTestProjectTemplate(duplicateNameTemplate);
-      const hre = await project.getHRE(unifiedTestsCompilationConfig);
-
-      // Build directly using the build-system APIs (the build task is
-      // not updated until Phase 4).
-      const roots = await hre.solidity.getRootFilePaths({
-        scope: "contracts",
-      });
-      const buildResult = await hre.solidity.build(roots, {
-        scope: "contracts",
-      });
-
-      assert.ok(
-        hre.solidity.isSuccessfulBuildResult(buildResult),
-        "Expected build to succeed",
-      );
-
-      await hre.solidity.cleanupArtifacts([...buildResult.keys()], {
-        scope: "contracts",
-      });
-
-      const artifactsPath =
-        await hre.solidity.getArtifactsDirectory("contracts");
-
-      // The top-level artifacts.d.ts should exist and contain the duplicate
-      const topLevelDts = path.join(artifactsPath, "artifacts.d.ts");
-      assert.equal(await exists(topLevelDts), true);
-      const dtsContent = await readUtf8File(topLevelDts);
-      assert.ok(
-        dtsContent.includes('"Foo"'),
-        "Expected top-level artifacts.d.ts to include the duplicated contract name Foo from both test and contract artifacts",
       );
     });
 
-    it("passes mixed contract and test artifact paths to onCleanUpArtifacts", async () => {
+    it("runs cleanup on the main artifacts directory", async () => {
       await using project = await useTestProjectTemplate(basicProjectTemplate);
       const hre = await project.getHRE(unifiedTestsCompilationConfig);
 
-      // Build directly using the build-system APIs (the build task is
-      // not updated until Phase 4).
-      const roots = await hre.solidity.getRootFilePaths({
-        scope: "contracts",
-      });
-      const buildResult = await hre.solidity.build(roots, {
-        scope: "contracts",
-      });
-
-      assert.ok(
-        hre.solidity.isSuccessfulBuildResult(buildResult),
-        "Expected build to succeed",
-      );
-
-      // This is run directly here, so this isn't testing much now, but will be
-      // better tested in Phase 4
-      await hre.solidity.cleanupArtifacts([...buildResult.keys()], {
-        scope: "contracts",
-      });
-
       const artifactsPath =
         await hre.solidity.getArtifactsDirectory("contracts");
 
-      // All artifacts should be in the main artifacts directory
-      const buildInfoDir = path.join(artifactsPath, "build-info");
-      const artifactPaths = await getAllFilesMatching(
+      // Create a stale artifact
+      const staleArtifactPath = path.join(
         artifactsPath,
-        (p) =>
-          p.endsWith(".json") &&
-          p.indexOf(path.sep, artifactsPath.length + path.sep.length) !== -1,
-        (dir) => dir !== buildInfoDir,
+        "contracts",
+        "Stale.sol",
+        "Stale.json",
+      );
+      await writeUtf8File(staleArtifactPath, "");
+      assert.equal(await exists(staleArtifactPath), true);
+
+      await hre.tasks.getTask("build").run();
+
+      // Stale artifact should be cleaned up
+      assert.equal(await exists(staleArtifactPath), false);
+    });
+
+    it("partitions returned contractRootPaths and testRootPaths with getScope()", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      const result: {
+        contractRootPaths: string[];
+        testRootPaths: string[];
+      } = await hre.tasks.getTask("build").run();
+
+      assert.ok(
+        result.contractRootPaths.some(
+          (r) => r.endsWith("Foo.sol") && !r.endsWith(".t.sol"),
+        ),
+        "Expected Foo.sol in contractRootPaths",
+      );
+      assert.ok(
+        result.testRootPaths.some((r) => r.endsWith("Foo.t.sol")),
+        "Expected Foo.t.sol in testRootPaths",
+      );
+      assert.ok(
+        result.testRootPaths.some((r) => r.endsWith("OtherFooTest.sol")),
+        "Expected OtherFooTest.sol in testRootPaths",
+      );
+    });
+  });
+
+  describe("explicit files", function () {
+    it("compiles exactly the provided files", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+      process.chdir(project.path);
+
+      await hre.tasks.getTask("build").run({ files: ["contracts/Foo.sol"] });
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // Only Foo.sol should have been compiled
+      await readJsonFile(
+        path.join(artifactsPath, "contracts", "Foo.sol", "Foo.json"),
+      );
+    });
+
+    it("uses the main artifacts dir for explicit files", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+      process.chdir(project.path);
+
+      // Compile a test file explicitly — it should still go through
+      // scope: "contracts" at the low level
+      await hre.tasks
+        .getTask("build")
+        .run({ files: ["test/OtherFooTest.sol"] });
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // The test artifact should be in the main artifacts directory
+      await readJsonFile(
+        path.join(
+          artifactsPath,
+          "test",
+          "OtherFooTest.sol",
+          "OtherFooTest.json",
+        ),
+      );
+    });
+
+    it("does not run cleanup for explicit-file builds", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      // First do a full build
+      await hre.tasks.getTask("build").run();
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // Create a stale artifact
+      const staleArtifactPath = path.join(
+        artifactsPath,
+        "contracts",
+        "Stale.sol",
+        "Stale.json",
+      );
+      await writeUtf8File(staleArtifactPath, "");
+
+      process.chdir(project.path);
+
+      // Partial build with explicit files
+      await hre.tasks.getTask("build").run({ files: ["contracts/Foo.sol"] });
+
+      // Stale artifact should NOT be cleaned up
+      assert.equal(await exists(staleArtifactPath), true);
+    });
+
+    it("builds contract files with --no-tests", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+      process.chdir(project.path);
+
+      await hre.tasks
+        .getTask("build")
+        .run({ files: ["contracts/Foo.sol"], noTests: true });
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // Contract artifact should exist
+      await readJsonFile(
+        path.join(artifactsPath, "contracts", "Foo.sol", "Foo.json"),
+      );
+    });
+
+    it("builds test files with --no-contracts", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+      process.chdir(project.path);
+
+      await hre.tasks
+        .getTask("build")
+        .run({ files: ["contracts/Foo.t.sol"], noContracts: true });
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // Test artifact should be in the main artifacts directory
+      await readJsonFile(
+        path.join(artifactsPath, "contracts", "Foo.t.sol", "FooTest.json"),
+      );
+    });
+  });
+
+  describe("--no-tests", function () {
+    it("behaves like a partial build over all contracts", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      await hre.tasks.getTask("build").run({ noTests: true });
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // Contract artifact should exist
+      await readJsonFile(
+        path.join(artifactsPath, "contracts", "Foo.sol", "Foo.json"),
       );
 
-      // Should include both contract and test artifacts
+      // Test artifacts should also exist because they're dependencies,
+      // but the test roots themselves weren't included as roots
+      const noTestsResult: {
+        contractRootPaths: string[];
+        testRootPaths: string[];
+      } = await hre.tasks.getTask("build").run({ noTests: true });
       assert.ok(
-        artifactPaths.some(
-          (p) => p.includes("Foo.sol") && !p.includes(".t.sol"),
+        noTestsResult.contractRootPaths.length > 0,
+        "Expected contractRootPaths to contain entries",
+      );
+      assert.equal(
+        noTestsResult.testRootPaths.length,
+        0,
+        "Expected testRootPaths to be empty for --no-tests",
+      );
+    });
+
+    it("does not run cleanup", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      // First do a full build
+      await hre.tasks.getTask("build").run();
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // Create a stale artifact
+      const staleArtifactPath = path.join(
+        artifactsPath,
+        "contracts",
+        "Stale.sol",
+        "Stale.json",
+      );
+      await writeUtf8File(staleArtifactPath, "");
+
+      await hre.tasks.getTask("build").run({ noTests: true });
+
+      // Stale artifact should NOT be cleaned up (partial build)
+      assert.equal(await exists(staleArtifactPath), true);
+    });
+  });
+
+  describe("--no-contracts", function () {
+    it("behaves like a partial build over all tests", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      const noContractsResult: {
+        contractRootPaths: string[];
+        testRootPaths: string[];
+      } = await hre.tasks.getTask("build").run({ noContracts: true });
+
+      assert.equal(
+        noContractsResult.contractRootPaths.length,
+        0,
+        "Expected contractRootPaths to be empty for --no-contracts",
+      );
+      assert.ok(
+        noContractsResult.testRootPaths.length > 0,
+        "Expected testRootPaths to contain entries",
+      );
+    });
+
+    it("still uses low-level scope 'contracts'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      // --no-contracts builds only test roots but uses scope: "contracts"
+      await hre.tasks.getTask("build").run({ noContracts: true });
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // Test artifacts should be in the main artifacts directory
+      await readJsonFile(
+        path.join(artifactsPath, "contracts", "Foo.t.sol", "FooTest.json"),
+      );
+      await readJsonFile(
+        path.join(
+          artifactsPath,
+          "test",
+          "OtherFooTest.sol",
+          "OtherFooTest.json",
         ),
-        "Expected contract artifact Foo.json in unified artifacts",
       );
-      assert.ok(
-        artifactPaths.some((p) => p.includes("Foo.t.sol")),
-        "Expected test artifact FooTest.json in unified artifacts",
+    });
+
+    it("does not run cleanup", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      // First do a full build
+      await hre.tasks.getTask("build").run();
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // Create a stale artifact
+      const staleArtifactPath = path.join(
+        artifactsPath,
+        "contracts",
+        "Stale.sol",
+        "Stale.json",
       );
-      assert.ok(
-        artifactPaths.some((p) => p.includes("OtherFooTest.sol")),
-        "Expected test artifact OtherFooTest.json in unified artifacts",
-      );
+      await writeUtf8File(staleArtifactPath, "");
+
+      await hre.tasks.getTask("build").run({ noContracts: true });
+
+      // Stale artifact should NOT be cleaned up (partial build)
+      assert.equal(await exists(staleArtifactPath), true);
     });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/unified-build-system.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/unified-build-system.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
+import { exists } from "@nomicfoundation/hardhat-utils/fs";
+
+import { useTestProjectTemplate } from "../resolver/helpers.js";
+
+const basicProjectTemplate = {
+  name: "test",
+  version: "1.0.0",
+  files: {
+    "contracts/Foo.sol": `// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract Foo {
+    uint256 x;
+}`,
+    "contracts/Foo.t.sol": `// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "./Foo.sol";
+
+contract FooTest {
+    Foo foo;
+
+    constructor() {
+        foo = new Foo();
+    }
+
+    function test_Assertion() public view {
+        assert(address(foo) != address(0));
+    }
+}`,
+    "test/OtherFooTest.sol": `// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "../contracts/Foo.sol";
+
+contract OtherFooTest {
+    Foo foo;
+
+    constructor() {
+        foo = new Foo();
+    }
+
+    function test_Assertion() public view {
+        assert(address(foo) != address(0));
+    }
+}`,
+  },
+};
+
+const unifiedTestsCompilationConfig = {
+  solidity: {
+    version: "0.8.28",
+    splitTestsCompilation: false,
+  },
+};
+
+describe("build system - splitTestsCompilation: false - build system API", function () {
+  describe("getRootFilePaths", function () {
+    it("returns contract, test, and npm roots for scope 'contracts'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      const roots = await hre.solidity.getRootFilePaths({
+        scope: "contracts",
+      });
+
+      // Should contain the contract file
+      assert.ok(
+        roots.some((r) => r.endsWith("Foo.sol") && !r.endsWith(".t.sol")),
+        "Expected contract root Foo.sol in unified roots",
+      );
+      // Should contain the .t.sol test file
+      assert.ok(
+        roots.some((r) => r.endsWith("Foo.t.sol")),
+        "Expected test root Foo.t.sol in unified roots",
+      );
+      // Should contain the test directory test file
+      assert.ok(
+        roots.some((r) => r.endsWith("OtherFooTest.sol")),
+        "Expected test root OtherFooTest.sol in unified roots",
+      );
+    });
+
+    it("throws for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      await assertRejectsWithHardhatError(
+        hre.solidity.getRootFilePaths({ scope: "tests" }),
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+        {},
+      );
+    });
+  });
+
+  describe("getArtifactsDirectory", function () {
+    it("returns the main artifacts dir for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      const contractsDir =
+        await hre.solidity.getArtifactsDirectory("contracts");
+      const testsDir = await hre.solidity.getArtifactsDirectory("tests");
+
+      assert.equal(contractsDir, testsDir);
+    });
+  });
+
+  describe("low-level scope:'tests' rejection", function () {
+    it("build() throws for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      await assertRejectsWithHardhatError(
+        hre.solidity.build([], { scope: "tests" }),
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+        {},
+      );
+    });
+
+    it("getCompilationJobs() throws for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      await assertRejectsWithHardhatError(
+        hre.solidity.getCompilationJobs([], { scope: "tests" }),
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+        {},
+      );
+    });
+
+    it("emitArtifacts() throws for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      // We need a real compilation job to call emitArtifacts.
+      // Build first so we can get a compilation job.
+      const roots = await hre.solidity.getRootFilePaths({
+        scope: "contracts",
+      });
+      const contractRoots = roots.filter(
+        (r) => !r.endsWith(".t.sol") && !r.includes("/test/"),
+      );
+      const result = await hre.solidity.getCompilationJobs(contractRoots, {
+        scope: "contracts",
+      });
+
+      assert.ok(result.success, "Expected compilation jobs to succeed");
+
+      const firstJob = [...result.compilationJobsPerFile.values()][0];
+      const runResult = await hre.solidity.runCompilationJob(firstJob);
+
+      await assertRejectsWithHardhatError(
+        hre.solidity.emitArtifacts(firstJob, runResult.output, {
+          scope: "tests",
+        }),
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+        {},
+      );
+    });
+
+    it("cleanupArtifacts() throws for scope 'tests'", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      await assertRejectsWithHardhatError(
+        hre.solidity.cleanupArtifacts([], { scope: "tests" }),
+        HardhatError.ERRORS.CORE.SOLIDITY.SPLIT_TESTS_COMPILATION_DISABLED,
+        {},
+      );
+    });
+  });
+
+  describe("emitArtifacts - type declarations", function () {
+    it("skips per-source artifacts.d.ts for test roots in unified contracts-scope builds", async () => {
+      await using project = await useTestProjectTemplate(basicProjectTemplate);
+      const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+      await hre.tasks.getTask("build").run();
+
+      const artifactsPath =
+        await hre.solidity.getArtifactsDirectory("contracts");
+
+      // Contract root should have artifacts.d.ts
+      assert.equal(
+        await exists(
+          path.join(artifactsPath, "contracts", "Foo.sol", "artifacts.d.ts"),
+        ),
+        true,
+      );
+
+      // Test roots should NOT have artifacts.d.ts
+      assert.equal(
+        await exists(
+          path.join(artifactsPath, "contracts", "Foo.t.sol", "artifacts.d.ts"),
+        ),
+        false,
+      );
+      assert.equal(
+        await exists(
+          path.join(
+            artifactsPath,
+            "test",
+            "OtherFooTest.sol",
+            "artifacts.d.ts",
+          ),
+        ),
+        false,
+      );
+    });
+  });
+});

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/unified-build-system.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/unified-build-system.ts
@@ -145,7 +145,8 @@ describe("build system - splitTestsCompilation: false - build system API", funct
         scope: "contracts",
       });
       const contractRoots = roots.filter(
-        (r) => !r.endsWith(".t.sol") && !r.includes("/test/"),
+        (r) =>
+          !r.endsWith(".t.sol") && !r.includes(path.sep + "test" + path.sep),
       );
       const result = await hre.solidity.getCompilationJobs(contractRoots, {
         scope: "contracts",

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
@@ -89,7 +89,7 @@ contract AddedByHook {}`,
         // Run full build
         await hre.tasks.getTask("build").run({
           force: true,
-          noTests: true,
+
           quiet: true,
         });
 
@@ -145,7 +145,7 @@ contract Filter {}`,
 
         await hreNoFilter.tasks.getTask("build").run({
           force: true,
-          noTests: true,
+
           quiet: true,
         });
 
@@ -212,7 +212,7 @@ contract Filter {}`,
         // Run full build with filtering
         await hreWithFilter.tasks.getTask("build").run({
           force: true,
-          noTests: true,
+
           quiet: true,
         });
 
@@ -260,7 +260,7 @@ contract Third {}`,
         // Run full build
         await hre.tasks.getTask("build").run({
           force: true,
-          noTests: true,
+
           quiet: true,
         });
 
@@ -306,7 +306,7 @@ contract Two {}`,
 
         await hre.tasks.getTask("build").run({
           force: true,
-          noTests: true,
+
           quiet: true,
         });
 
@@ -326,7 +326,7 @@ contract Two {}`,
         // Run partial build with only One.sol
         await hre.tasks.getTask("build").run({
           force: true,
-          noTests: true,
+
           quiet: true,
           files: [path.join(project.path, "contracts/One.sol")],
         });
@@ -370,7 +370,7 @@ contract ToDelete {}`,
 
         await hre.tasks.getTask("build").run({
           force: true,
-          noTests: true,
+
           quiet: true,
         });
 
@@ -401,7 +401,7 @@ contract ToDelete {}`,
         // Rebuild
         await hre.tasks.getTask("build").run({
           force: true,
-          noTests: true,
+
           quiet: true,
         });
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
@@ -13,7 +13,11 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { describe, it } from "node:test";
 
-import { exists, remove } from "@nomicfoundation/hardhat-utils/fs";
+import {
+  exists,
+  readUtf8File,
+  remove,
+} from "@nomicfoundation/hardhat-utils/fs";
 
 import { createHardhatRuntimeEnvironment } from "../../../../../src/hre.js";
 import { useTestProjectTemplate } from "../build-system/resolver/helpers.js";
@@ -416,5 +420,146 @@ contract ToDelete {}`,
         );
       });
     });
+  });
+});
+
+const unifiedCleanupProjectTemplate = {
+  name: "test",
+  version: "1.0.0",
+  files: {
+    "contracts/Foo.sol": `// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract Foo {
+    uint256 x;
+}`,
+    "contracts/Foo.t.sol": `// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "./Foo.sol";
+
+contract FooTest {
+    Foo foo;
+
+    constructor() {
+        foo = new Foo();
+    }
+
+    function test_Assertion() public view {
+        assert(address(foo) != address(0));
+    }
+}`,
+    "test/OtherFooTest.sol": `// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "../contracts/Foo.sol";
+
+contract OtherFooTest {
+    Foo foo;
+
+    constructor() {
+        foo = new Foo();
+    }
+
+    function test_Assertion() public view {
+        assert(address(foo) != address(0));
+    }
+}`,
+  },
+};
+
+const unifiedTestsCompilationConfig = {
+  solidity: {
+    version: "0.8.28",
+    splitTestsCompilation: false,
+  },
+};
+
+describe("build task - unified mode cleanup", () => {
+  it("includes test artifacts in duplicate-name detection", async () => {
+    const duplicateNameTemplate = {
+      name: "test",
+      version: "1.0.0",
+      files: {
+        "contracts/Foo.sol": `// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.0;\ncontract Foo {}`,
+        "test/Foo.sol": `// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.0;\ncontract Foo {}`,
+      },
+    };
+
+    await using project = await useTestProjectTemplate(duplicateNameTemplate);
+    const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+    await hre.tasks.getTask("build").run();
+
+    const artifactsPath = await hre.solidity.getArtifactsDirectory("contracts");
+
+    // The top-level artifacts.d.ts should exist and contain the duplicate
+    const topLevelDts = path.join(artifactsPath, "artifacts.d.ts");
+    assert.equal(await exists(topLevelDts), true);
+    const dtsContent = await readUtf8File(topLevelDts);
+    assert.ok(
+      dtsContent.includes('"Foo"'),
+      "Expected top-level artifacts.d.ts to include the duplicated contract name Foo from both test and contract artifacts",
+    );
+  });
+
+  it("passes mixed contract and test artifact paths to onCleanUpArtifacts", async () => {
+    await using project = await useTestProjectTemplate(
+      unifiedCleanupProjectTemplate,
+    );
+
+    const receivedArtifactPaths: string[] = [];
+
+    const hookCapturingPlugin: HardhatPlugin = {
+      id: "test-capture-cleanup-hook",
+      hookHandlers: {
+        solidity: async () => ({
+          default: async () => {
+            const handlers: Partial<SolidityHooks> = {
+              onCleanUpArtifacts: async (
+                _context: HookContext,
+                artifactPaths: string[],
+                next: (
+                  nextContext: HookContext,
+                  nextArtifactPaths: string[],
+                ) => Promise<void>,
+              ) => {
+                receivedArtifactPaths.push(...artifactPaths);
+                return next(_context, artifactPaths);
+              },
+            };
+
+            return handlers;
+          },
+        }),
+      },
+    };
+
+    const hre = await createHardhatRuntimeEnvironment(
+      {
+        plugins: [hookCapturingPlugin],
+        ...unifiedTestsCompilationConfig,
+      },
+      {},
+      project.path,
+    );
+
+    await hre.tasks.getTask("build").run();
+
+    // Should include both contract and test artifacts
+    assert.ok(
+      receivedArtifactPaths.some(
+        (p) => p.includes("Foo.sol") && !p.includes(".t.sol"),
+      ),
+      "Expected contract artifact path in onCleanUpArtifacts",
+    );
+    assert.ok(
+      receivedArtifactPaths.some((p) => p.includes("Foo.t.sol")),
+      "Expected test artifact path (Foo.t.sol) in onCleanUpArtifacts",
+    );
+    assert.ok(
+      receivedArtifactPaths.some((p) => p.includes("OtherFooTest.sol")),
+      "Expected test artifact path (OtherFooTest.sol) in onCleanUpArtifacts",
+    );
   });
 });


### PR DESCRIPTION
This PR updates the builtin `build` task so that it works with and without the `splitTestsCompilation`. This is one of the most product-complex PRs of this series.

Some test failures are expected, as the `test solidity` task hasn't been updated.