### PR TITLE
Add `splitTestsCompilation` solidity setting (5): Minor builtin task updates: `run`, `test`, `console`

### DIFF
--- a/packages/hardhat/src/internal/builtin-plugins/console/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/console/task-action.ts
@@ -42,7 +42,8 @@ const consoleAction: NewTaskActionFunction<ConsoleActionArguments> = async (
     }
 
     if (!noCompile) {
-      await hre.tasks.getTask("build").run({ noTests: true, quiet: true });
+      const noTests = hre.config.solidity.splitTestsCompilation;
+      await hre.tasks.getTask("build").run({ noTests, quiet: true });
     }
 
     return await new Promise<REPLServer>(async (resolve) => {

--- a/packages/hardhat/src/internal/builtin-plugins/run/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/run/task-action.ts
@@ -25,7 +25,8 @@ const runScriptWithHardhat: NewTaskActionFunction<RunActionArguments> = async (
   }
 
   if (!noCompile) {
-    await hre.tasks.getTask("build").run({ quiet: true, noTests: true });
+    const noTests = hre.config.solidity.splitTestsCompilation;
+    await hre.tasks.getTask("build").run({ quiet: true, noTests });
     console.log();
   }
 

--- a/packages/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -64,9 +64,8 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
   const thisTask = hre.tasks.getTask("test");
 
   if (!noCompile) {
-    await hre.tasks.getTask("build").run({
-      noTests: true,
-    });
+    const noTests = hre.config.solidity.splitTestsCompilation;
+    await hre.tasks.getTask("build").run({ noTests });
   }
 
   if (hre.globalOptions.coverage === true) {

--- a/packages/hardhat/test/internal/builtin-plugins/console/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/console/task-action.ts
@@ -14,6 +14,7 @@ import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { exists, remove } from "@nomicfoundation/hardhat-utils/fs";
 import debug from "debug";
 
+import { overrideTask } from "../../../../src/config.js";
 import consoleAction from "../../../../src/internal/builtin-plugins/console/task-action.js";
 import { createHardhatRuntimeEnvironment } from "../../../../src/internal/hre-initialization.js";
 
@@ -149,6 +150,71 @@ describe("console/task-action", function () {
         hre,
       );
       assert.equal(replServer.lastError, undefined);
+    });
+  });
+
+  describe("build invocation", function () {
+    useFixtureProject("run-js-script");
+
+    function buildArgCaptor() {
+      const buildArgs: any[] = [];
+      const buildOverride = overrideTask("build")
+        .setAction(async () => {
+          return {
+            default: (args: any) => {
+              buildArgs.push(args);
+              return { contractRootPaths: [], testRootPaths: [] };
+            },
+          };
+        })
+        .build();
+      return { buildArgs, buildOverride };
+    }
+
+    it("should call build without noTests when splitTestsCompilation is false", async function () {
+      const { buildArgs, buildOverride } = buildArgCaptor();
+      const testHre = await createHardhatRuntimeEnvironment({
+        tasks: [buildOverride],
+      });
+
+      await consoleAction(
+        {
+          commands: [".exit"],
+          history: "",
+          noCompile: false,
+          options,
+        },
+        testHre,
+      );
+
+      assert.equal(buildArgs.length, 1);
+      assert.equal(buildArgs[0].noTests, false);
+      assert.equal(buildArgs[0].quiet, true);
+    });
+
+    it("should call build with noTests when splitTestsCompilation is true", async function () {
+      const { buildArgs, buildOverride } = buildArgCaptor();
+      const testHre = await createHardhatRuntimeEnvironment({
+        solidity: {
+          version: "0.8.28",
+          splitTestsCompilation: true,
+        },
+        tasks: [buildOverride],
+      });
+
+      await consoleAction(
+        {
+          commands: [".exit"],
+          history: "",
+          noCompile: false,
+          options,
+        },
+        testHre,
+      );
+
+      assert.equal(buildArgs.length, 1);
+      assert.equal(buildArgs[0].noTests, true);
+      assert.equal(buildArgs[0].quiet, true);
     });
   });
 

--- a/packages/hardhat/test/internal/builtin-plugins/run/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/run/task-action.ts
@@ -1,5 +1,6 @@
 import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
 
+import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
@@ -9,6 +10,7 @@ import {
   useFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 
+import { overrideTask } from "../../../../src/config.js";
 import runScriptWithHardhat from "../../../../src/internal/builtin-plugins/run/task-action.js";
 import { createHardhatRuntimeEnvironment } from "../../../../src/internal/hre-initialization.js";
 
@@ -93,6 +95,61 @@ describe("run/task-action", function () {
           ),
         );
       });
+    });
+  });
+
+  describe("build invocation", function () {
+    useFixtureProject("run-js-script");
+
+    function buildArgCaptor() {
+      const buildArgs: any[] = [];
+      const buildOverride = overrideTask("build")
+        .setAction(async () => {
+          return {
+            default: (args: any) => {
+              buildArgs.push(args);
+              return { contractRootPaths: [], testRootPaths: [] };
+            },
+          };
+        })
+        .build();
+      return { buildArgs, buildOverride };
+    }
+
+    it("should call build without noTests when splitTestsCompilation is false", async function () {
+      const { buildArgs, buildOverride } = buildArgCaptor();
+      const testHre = await createHardhatRuntimeEnvironment({
+        tasks: [buildOverride],
+      });
+
+      await runScriptWithHardhat(
+        { script: "./scripts/success.js", noCompile: false },
+        testHre,
+      );
+
+      assert.equal(buildArgs.length, 1);
+      assert.equal(buildArgs[0].noTests, false);
+      assert.equal(buildArgs[0].quiet, true);
+    });
+
+    it("should call build with noTests when splitTestsCompilation is true", async function () {
+      const { buildArgs, buildOverride } = buildArgCaptor();
+      const testHre = await createHardhatRuntimeEnvironment({
+        solidity: {
+          version: "0.8.28",
+          splitTestsCompilation: true,
+        },
+        tasks: [buildOverride],
+      });
+
+      await runScriptWithHardhat(
+        { script: "./scripts/success.js", noCompile: false },
+        testHre,
+      );
+
+      assert.equal(buildArgs.length, 1);
+      assert.equal(buildArgs[0].noTests, true);
+      assert.equal(buildArgs[0].quiet, true);
     });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
@@ -1,3 +1,4 @@
+import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
 import type { HardhatPlugin } from "../../../../src/types/plugins.js";
 
 import assert from "node:assert/strict";
@@ -290,6 +291,68 @@ describe("test/task-action", function () {
       const result = await hre.tasks.getTask("test").run({ noCompile: true });
 
       assert.deepEqual(result, { success: true, value: undefined });
+    });
+  });
+
+  describe("build invocation", function () {
+    function buildArgCaptor() {
+      const buildArgs: any[] = [];
+      const buildOverride = overrideTask("build")
+        .setAction(async () => {
+          return {
+            default: (args: any) => {
+              buildArgs.push(args);
+              return { contractRootPaths: [], testRootPaths: [] };
+            },
+          };
+        })
+        .build();
+      return { buildArgs, buildOverride };
+    }
+
+    async function createTestHre(
+      buildOverride: ReturnType<typeof buildArgCaptor>["buildOverride"],
+      splitTestsCompilation: boolean,
+    ): Promise<HardhatRuntimeEnvironment> {
+      return createHardhatRuntimeEnvironment({
+        ...(splitTestsCompilation
+          ? {
+              solidity: {
+                version: "0.8.28",
+                splitTestsCompilation: true,
+              },
+            }
+          : {}),
+        tasks: [
+          solidityNoOp,
+          buildOverride,
+          mockRunner("runner-a", () =>
+            successfulResult({
+              summary: { passed: 1, failed: 0, skipped: 0, todo: 0 },
+            }),
+          ),
+        ],
+      });
+    }
+
+    it("should call build without noTests when splitTestsCompilation is false", async () => {
+      const { buildArgs, buildOverride } = buildArgCaptor();
+      const hre = await createTestHre(buildOverride, false);
+
+      await hre.tasks.getTask("test").run({ noCompile: false });
+
+      assert.equal(buildArgs.length, 1);
+      assert.equal(buildArgs[0].noTests, false);
+    });
+
+    it("should call build with noTests when splitTestsCompilation is true", async () => {
+      const { buildArgs, buildOverride } = buildArgCaptor();
+      const hre = await createTestHre(buildOverride, true);
+
+      await hre.tasks.getTask("test").run({ noCompile: false });
+
+      assert.equal(buildArgs.length, 1);
+      assert.equal(buildArgs[0].noTests, true);
     });
   });
 


### PR DESCRIPTION
Pretty straightforward PR updating some builtin tasks.

Some errors in external plugins and solidity tests related things are expected.