### PR TITLE
Error reporting cleanup PR #1

### DIFF
--- a/.changeset/async-improvements-hardhat-ethers-chai-matchers.md
+++ b/.changeset/async-improvements-hardhat-ethers-chai-matchers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-ethers.md
+++ b/.changeset/async-improvements-hardhat-ethers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-foundry.md
+++ b/.changeset/async-improvements-hardhat-foundry.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-foundry": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-ignition-ethers.md
+++ b/.changeset/async-improvements-hardhat-ignition-ethers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition-ethers": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-ignition-viem.md
+++ b/.changeset/async-improvements-hardhat-ignition-viem.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition-viem": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-ignition.md
+++ b/.changeset/async-improvements-hardhat-ignition.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-keystore.md
+++ b/.changeset/async-improvements-hardhat-keystore.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-keystore": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-ledger.md
+++ b/.changeset/async-improvements-hardhat-ledger.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ledger": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-mocha.md
+++ b/.changeset/async-improvements-hardhat-mocha.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-mocha": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-network-helpers.md
+++ b/.changeset/async-improvements-hardhat-network-helpers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-node-test-reporter.md
+++ b/.changeset/async-improvements-hardhat-node-test-reporter.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-reporter": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-node-test-runner.md
+++ b/.changeset/async-improvements-hardhat-node-test-runner.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-runner": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-solx.md
+++ b/.changeset/async-improvements-hardhat-solx.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-solx": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-test-utils.md
+++ b/.changeset/async-improvements-hardhat-test-utils.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-test-utils": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-typechain.md
+++ b/.changeset/async-improvements-hardhat-typechain.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-typechain": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-utils.md
+++ b/.changeset/async-improvements-hardhat-utils.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-verify.md
+++ b/.changeset/async-improvements-hardhat-verify.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-viem-assertions.md
+++ b/.changeset/async-improvements-hardhat-viem-assertions.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat-viem.md
+++ b/.changeset/async-improvements-hardhat-viem.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-hardhat.md
+++ b/.changeset/async-improvements-hardhat.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/async-improvements-ignition-core.md
+++ b/.changeset/async-improvements-ignition-core.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/ignition-core": patch
+---
+
+Improve async handling to get better error reports

--- a/.changeset/proud-clocks-love.md
+++ b/.changeset/proud-clocks-love.md
@@ -1,0 +1,8 @@
+---
+"hardhat": patch
+"@nomicfoundation/hardhat-ignition": patch
+"@nomicfoundation/hardhat-verify": patch
+"@nomicfoundation/hardhat-errors": patch
+---
+
+Don't report HardhatErrors that aren't bugs

--- a/packages/config/eslint.config.js
+++ b/packages/config/eslint.config.js
@@ -321,6 +321,7 @@ export function createConfig(
     "no-new-wrappers": "error",
     "no-only-tests/no-only-tests": "error",
     "no-return-await": "off",
+    "@typescript-eslint/promise-function-async": "error",
     "@typescript-eslint/return-await": ["error", "always"],
     "no-sequences": "error",
     "no-sparse-arrays": "error",

--- a/packages/config/eslint.config.js
+++ b/packages/config/eslint.config.js
@@ -321,7 +321,7 @@ export function createConfig(
     "no-new-wrappers": "error",
     "no-only-tests/no-only-tests": "error",
     "no-return-await": "off",
-    "@typescript-eslint/return-await": "error",
+    "@typescript-eslint/return-await": ["error", "always"],
     "no-sequences": "error",
     "no-sparse-arrays": "error",
     "no-template-curly-in-string": "error",

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -356,7 +356,6 @@ You can learn how to use Hardhat by reading the [Getting Started guide](/getting
       },
       DUPLICATED_PLUGIN_ID: {
         number: 2,
-        shouldBeReported: true,
         messageTemplate:
           'Duplicated plugin id "{id}" found. Did you install multiple versions of the same plugin?',
         websiteTitle: "Duplicated plugin id",
@@ -1501,7 +1500,6 @@ Please use the fully qualified name of the contract to disambiguate it.`,
       },
       UNKNOWN_TRANSACTION_TYPE: {
         number: 10110,
-        shouldBeReported: true,
         messageTemplate: `Unknown transaction type: "{type}"`,
         websiteTitle:
           "Hardhat Ignition was unable to display an unknown transaction type",
@@ -1530,7 +1528,6 @@ Please use the fully qualified name of the contract to disambiguate it.`,
       },
       VISUALIZATION_TEMPLATE_DIR_NOT_FOUND: {
         number: 10114,
-        shouldBeReported: true,
         messageTemplate: `Unable to find template directory: "{templateDir}"`,
         websiteTitle: "Visualization template directory not found",
         websiteDescription: "Visualization template directory not found",
@@ -2845,7 +2842,6 @@ Please check the returned message for details.`,
       CONTRACT_VERIFICATION_UNEXPECTED_RESPONSE: {
         number: 80025,
         messageTemplate: `The block explorer API returned an unexpected message: "{message}". Please report this issue to the Hardhat team.`,
-        shouldBeReported: true,
         websiteTitle: "Unexpected API response during contract verification",
         websiteDescription: `The block explorer API returned a message that doesn't match the expected format. This may indicate a change in the API or an issue with the request.
 

--- a/packages/hardhat-ethers-chai-matchers/src/index.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/index.ts
@@ -5,7 +5,7 @@ import "./type-extensions.js";
 const hardhatChaiMatchersPlugin: HardhatPlugin = {
   id: "hardhat-ethers-chai-matchers",
   hookHandlers: {
-    network: () => import("./internal/hook-handlers/network.js"),
+    network: async () => await import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ethers-chai-matchers",
   dependencies: () => [import("@nomicfoundation/hardhat-ethers")],

--- a/packages/hardhat-ethers-chai-matchers/src/internal/hook-handlers/network.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/hook-handlers/network.ts
@@ -16,7 +16,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         isInitialized = true;
       }
 
-      return next(context);
+      return await next(context);
     },
   };
 

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/changeEtherBalances.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/changeEtherBalances.ts
@@ -162,7 +162,7 @@ async function getTxFees(
   txResponse: TransactionResponse,
   options?: BalanceChangeOptions,
 ): Promise<bigint[]> {
-  return Promise.all(
+  return await Promise.all(
     accounts.map(async (account) => {
       if (
         options?.includeFee !== true &&

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/changeTokenBalance.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/changeTokenBalance.ts
@@ -122,8 +122,9 @@ export function supportChangeTokenBalance(
       validateInput(this._obj, token, accounts, balanceChanges);
 
       const balanceChangesPromise = Promise.all(
-        accounts.map((account) =>
-          getBalanceChange(ethers, subject, token, account),
+        accounts.map(
+          async (account) =>
+            await getBalanceChange(ethers, subject, token, account),
         ),
       );
       const addressesPromise = Promise.all(accounts.map(getAddressOf));

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
@@ -130,7 +130,7 @@ export function supportEmit(
         chaiUtils.flag(this, "contract", contract);
       };
 
-      const derivedPromise = promise.then(() => {
+      const derivedPromise = promise.then(async () => {
         // abort if the assertion chain was aborted, for example because
         // a `.not` was combined with a `.withArgs`
         if (chaiUtils.flag(this, ASSERTION_ABORTED) === true) {
@@ -141,15 +141,16 @@ export function supportEmit(
           chaiAssert.fail("contract.runner.provider shouldn't be null");
         }
 
-        return waitForPendingTransaction(tx, contract.runner.provider).then(
-          (receipt) => {
-            assertIsNotNull(
-              receipt,
-              "Transaction's receipt cannot be fetched from the network",
-            );
-            return onSuccess(receipt);
-          },
-        );
+        return await waitForPendingTransaction(
+          tx,
+          contract.runner.provider,
+        ).then((receipt) => {
+          assertIsNotNull(
+            receipt,
+            "Transaction's receipt cannot be fetched from the network",
+          );
+          return onSuccess(receipt);
+        });
       });
 
       chaiUtils.flag(this, EMIT_CALLED, true);

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
@@ -44,11 +44,11 @@ async function waitForPendingTransaction(
     // string, it might not be a real tx hash. Do a one-shot check to
     // avoid polling forever.
     if (isBytes32String(hash)) {
-      return provider.getTransactionReceipt(hash);
+      return await provider.getTransactionReceipt(hash);
     }
   }
 
-  return provider.waitForTransaction(hash);
+  return await provider.waitForTransaction(hash);
 }
 
 export function supportEmit(

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
@@ -146,7 +146,7 @@ export function supportRevert(
 }
 
 async function waitForTransactionReceipt(ethers: HardhatEthers, hash: string) {
-  return ethers.provider.waitForTransaction(hash);
+  return await ethers.provider.waitForTransaction(hash);
 }
 
 function isTransactionResponse(x: unknown): x is { hash: string } {

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/withArgs.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/withArgs.ts
@@ -67,9 +67,9 @@ export function supportWithArgs(
     const resolveArgument = (arg: any) =>
       isAddressable(arg) ? arg.getAddress() : arg;
 
-    const onSuccess = (resolvedExpectedArgs: any[]) => {
+    const onSuccess = async (resolvedExpectedArgs: any[]) => {
       if (emitCalled) {
-        return emitWithArgs(
+        return await emitWithArgs(
           this,
           Assertion,
           chaiUtils,
@@ -77,7 +77,7 @@ export function supportWithArgs(
           onSuccess,
         );
       } else {
-        return revertedWithCustomErrorWithArgs(
+        return await revertedWithCustomErrorWithArgs(
           this,
           Assertion,
           chaiUtils,
@@ -88,7 +88,7 @@ export function supportWithArgs(
     };
 
     const promise = (this.then === undefined ? Promise.resolve() : this)
-      .then(() => Promise.all(expectedArgs.map(resolveArgument)))
+      .then(async () => await Promise.all(expectedArgs.map(resolveArgument)))
       .then(onSuccess);
 
     this.then = promise.then.bind(promise);

--- a/packages/hardhat-ethers-chai-matchers/src/internal/utils/account.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/utils/account.ts
@@ -12,7 +12,7 @@ export async function getAddressOf(
   }
 
   if (isAddressable(account)) {
-    return account.getAddress();
+    return await account.getAddress();
   }
 
   chaiAssert.fail(`Expected string or addressable, but got "${account}"`);

--- a/packages/hardhat-ethers-chai-matchers/src/internal/utils/balance.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/utils/balance.ts
@@ -12,10 +12,12 @@ export interface BalanceChangeOptions {
   includeFee?: boolean;
 }
 
-export function getAddresses(
+export async function getAddresses(
   accounts: Array<Addressable | string>,
 ): Promise<string[]> {
-  return Promise.all(accounts.map((account) => getAddressOf(account)));
+  return await Promise.all(
+    accounts.map(async (account) => await getAddressOf(account)),
+  );
 }
 
 export async function getBalances(

--- a/packages/hardhat-ethers-chai-matchers/src/internal/utils/balance.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/utils/balance.ts
@@ -23,7 +23,7 @@ export async function getBalances(
   accounts: Array<Addressable | string>,
   blockNumber: number,
 ): Promise<bigint[]> {
-  return Promise.all(
+  return await Promise.all(
     accounts.map(async (account) => {
       const address = await getAddressOf(account);
 

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
@@ -317,7 +317,7 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
       describe("Change balance, one contract", () => {
         it("should pass when expected balance change is passed as int and is equal to an actual", async () => {
           await expect(async () =>
-            sender.sendTransaction({
+            await sender.sendTransaction({
               to: contract,
               value: 200,
             }),
@@ -326,7 +326,7 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
         it("should pass when calling function that returns half the sent ether", async () => {
           await expect(async () =>
-            contract.returnHalf({ value: 200 }),
+            await contract.returnHalf({ value: 200 }),
           ).to.changeEtherBalance(ethers, sender, -100);
         });
       });
@@ -449,7 +449,7 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
       describe("Change balance, one contract", () => {
         it("should pass when expected balance change is passed as int and is equal to an actual", async () => {
           await expect(async () =>
-            sender.sendTransaction({
+            await sender.sendTransaction({
               to: contract,
               maxFeePerGas: 2,
               maxPriorityFeePerGas: 1,
@@ -478,7 +478,7 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
         it("should pass when calling function that returns half the sent ether", async () => {
           await expect(async () =>
-            contract.returnHalf({
+            await contract.returnHalf({
               value: 200,
               maxFeePerGas: 2,
               maxPriorityFeePerGas: 1,

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
@@ -66,11 +66,12 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
     describe("Transaction Callback (legacy tx)", () => {
       describe("Change balance, one account", () => {
         it("should pass when expected balance change is passed as string and is equal to an actual", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, sender, "-200");
         });
 
@@ -90,12 +91,13 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
           await provider.request({ method: "evm_setAutomine", params: [true] });
 
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                value: 200,
-                gasLimit: 30_000,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  value: 200,
+                  gasLimit: 30_000,
+                }),
             ).to.changeEtherBalance(ethers, sender, -200, {
               includeFee: true,
             }),
@@ -105,29 +107,32 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
         });
 
         it("should pass when given an address as a string", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, sender.address, "-200");
         });
 
         it("should pass when given a native bigint", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, sender, -200n);
         });
 
         it("should pass when given a predicate", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.changeEtherBalance(
             ethers,
             sender,
@@ -136,33 +141,36 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
         });
 
         it("should pass when expected balance change is passed as int and is equal to an actual", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, receiver, 200);
         });
 
         it("should take into account transaction fee", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              gasPrice: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                gasPrice: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, sender, -(txGasFees + 200), {
             includeFee: true,
           });
         });
 
         it("should take into account transaction fee when given a predicate", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              gasPrice: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                gasPrice: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalance(
             ethers,
             sender,
@@ -174,33 +182,36 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
         });
 
         it("should ignore fee if receiver's wallet is being checked and includeFee was set", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              gasPrice: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                gasPrice: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, receiver, 200, {
             includeFee: true,
           });
         });
 
         it("should take into account transaction fee by default", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              gasPrice: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                gasPrice: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, sender, -200);
         });
 
         it("should pass on negative case when expected balance does not satisfy the predicate", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.not.changeEtherBalance(
             ethers,
             receiver,
@@ -210,12 +221,13 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
         it("should throw when fee was not calculated correctly", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                gasPrice: 1,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  gasPrice: 1,
+                  value: 200,
+                }),
             ).to.changeEtherBalance(ethers, sender, -200, {
               includeFee: true,
             }),
@@ -229,11 +241,12 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
         it("should throw when expected balance change value was different from an actual", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  value: 200,
+                }),
             ).to.changeEtherBalance(ethers, sender, "-500"),
           ).to.be.eventually.rejectedWith(
             AssertionError,
@@ -243,11 +256,12 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
         it("should throw when actual balance change value does not satisfy the predicate", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  value: 200,
+                }),
             ).to.changeEtherBalance(
               ethers,
               sender,
@@ -261,11 +275,12 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
         it("should throw in negative case when expected balance change value was equal to an actual", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  value: 200,
+                }),
             ).to.not.changeEtherBalance(ethers, sender, "-200"),
           ).to.be.eventually.rejectedWith(
             AssertionError,
@@ -275,11 +290,12 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
         it("should throw in negative case when expected balance change value satisfies the predicate", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  value: 200,
+                }),
             ).to.not.changeEtherBalance(
               ethers,
               sender,
@@ -292,19 +308,21 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
         });
 
         it("should pass when given zero value tx", async () => {
-          await expect(() =>
-            sender.sendTransaction({ to: receiver.address, value: 0 }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({ to: receiver.address, value: 0 }),
           ).to.changeEtherBalance(ethers, sender, 0);
         });
 
         it("shouldn't run the transaction twice", async () => {
           const receiverBalanceBefore: bigint =
             await ethers.provider.getBalance(receiver);
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, sender, -200);
           const receiverBalanceAfter: bigint =
             await ethers.provider.getBalance(receiver);
@@ -316,17 +334,18 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
       describe("Change balance, one contract", () => {
         it("should pass when expected balance change is passed as int and is equal to an actual", async () => {
-          await expect(async () =>
-            await sender.sendTransaction({
-              to: contract,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: contract,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, contract, 200);
         });
 
         it("should pass when calling function that returns half the sent ether", async () => {
-          await expect(async () =>
-            await contract.returnHalf({ value: 200 }),
+          await expect(
+            async () => await contract.returnHalf({ value: 200 }),
           ).to.changeEtherBalance(ethers, sender, -100);
         });
       });
@@ -335,73 +354,79 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
     describe("Transaction Callback (1559 tx)", () => {
       describe("Change balance, one account", () => {
         it("should pass when expected balance change is passed as string and is equal to an actual", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              maxFeePerGas: 2,
-              maxPriorityFeePerGas: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                maxFeePerGas: 2,
+                maxPriorityFeePerGas: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, sender, "-200");
         });
 
         it("should pass when expected balance change is passed as int and is equal to an actual", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              maxFeePerGas: 2,
-              maxPriorityFeePerGas: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                maxFeePerGas: 2,
+                maxPriorityFeePerGas: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, receiver, 200);
         });
 
         it("should take into account transaction fee", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              maxFeePerGas: 2,
-              maxPriorityFeePerGas: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                maxFeePerGas: 2,
+                maxPriorityFeePerGas: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, sender, -(txGasFees + 200), {
             includeFee: true,
           });
         });
 
         it("should ignore fee if receiver's wallet is being checked and includeFee was set", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              maxFeePerGas: 2,
-              maxPriorityFeePerGas: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                maxFeePerGas: 2,
+                maxPriorityFeePerGas: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, receiver, 200, {
             includeFee: true,
           });
         });
 
         it("should take into account transaction fee by default", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              maxFeePerGas: 2,
-              maxPriorityFeePerGas: 1,
-              value: 200,
-            }),
-          ).to.changeEtherBalance(ethers, sender, -200);
-        });
-
-        it("should throw when fee was not calculated correctly", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
+            async () =>
+              await sender.sendTransaction({
                 to: receiver.address,
                 maxFeePerGas: 2,
                 maxPriorityFeePerGas: 1,
                 value: 200,
               }),
+          ).to.changeEtherBalance(ethers, sender, -200);
+        });
+
+        it("should throw when fee was not calculated correctly", async () => {
+          await expect(
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  maxFeePerGas: 2,
+                  maxPriorityFeePerGas: 1,
+                  value: 200,
+                }),
             ).to.changeEtherBalance(ethers, sender, -200, {
               includeFee: true,
             }),
@@ -415,13 +440,14 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
         it("should throw when expected balance change value was different from an actual", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                maxFeePerGas: 2,
-                maxPriorityFeePerGas: 1,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  maxFeePerGas: 2,
+                  maxPriorityFeePerGas: 1,
+                  value: 200,
+                }),
             ).to.changeEtherBalance(ethers, sender, "-500"),
           ).to.be.eventually.rejectedWith(
             AssertionError,
@@ -431,13 +457,14 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
         it("should throw in negative case when expected balance change value was equal to an actual", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                maxFeePerGas: 2,
-                maxPriorityFeePerGas: 1,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  maxFeePerGas: 2,
+                  maxPriorityFeePerGas: 1,
+                  value: 200,
+                }),
             ).to.not.changeEtherBalance(ethers, sender, "-200"),
           ).to.be.eventually.rejectedWith(
             AssertionError,
@@ -448,13 +475,14 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
       describe("Change balance, one contract", () => {
         it("should pass when expected balance change is passed as int and is equal to an actual", async () => {
-          await expect(async () =>
-            await sender.sendTransaction({
-              to: contract,
-              maxFeePerGas: 2,
-              maxPriorityFeePerGas: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: contract,
+                maxFeePerGas: 2,
+                maxPriorityFeePerGas: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, contract, 200);
         });
 
@@ -466,23 +494,21 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
             value: 200,
           };
           const gas: bigint = await ethers.provider.estimateGas(tx);
-          await expect(() => sender.sendTransaction(tx)).to.changeEtherBalance(
-            ethers,
-            sender,
-            -(gas + 200n),
-            {
-              includeFee: true,
-            },
-          );
+          await expect(
+            async () => await sender.sendTransaction(tx),
+          ).to.changeEtherBalance(ethers, sender, -(gas + 200n), {
+            includeFee: true,
+          });
         });
 
         it("should pass when calling function that returns half the sent ether", async () => {
-          await expect(async () =>
-            await contract.returnHalf({
-              value: 200,
-              maxFeePerGas: 2,
-              maxPriorityFeePerGas: 1,
-            }),
+          await expect(
+            async () =>
+              await contract.returnHalf({
+                value: 200,
+                maxFeePerGas: 2,
+                maxPriorityFeePerGas: 1,
+              }),
           ).to.changeEtherBalance(ethers, sender, -100);
         });
       });
@@ -491,13 +517,14 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
         const receiverBalanceBefore: bigint =
           await ethers.provider.getBalance(receiver);
 
-        await expect(() =>
-          sender.sendTransaction({
-            to: receiver.address,
-            maxFeePerGas: 2,
-            maxPriorityFeePerGas: 1,
-            value: 200,
-          }),
+        await expect(
+          async () =>
+            await sender.sendTransaction({
+              to: receiver.address,
+              maxFeePerGas: 2,
+              maxPriorityFeePerGas: 1,
+              value: 200,
+            }),
         ).to.changeEtherBalance(ethers, sender, -200);
 
         const receiverBalanceAfter: bigint =
@@ -621,8 +648,8 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
         it("should throw if chained to another non-chainable method", () => {
           assertThrows(
-            () =>
-              expect(
+            async () =>
+              await expect(
                 sender.sendTransaction({
                   to: receiver.address,
                   value: 200,
@@ -644,11 +671,12 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
       // smoke test for stack traces
       it("includes test file", async () => {
         try {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, sender, -100);
         } catch (e) {
           expect(util.inspect(e)).to.include(

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
@@ -11,7 +11,7 @@ import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
 import {
-  assertThrows,
+  assertRejects,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { expect, AssertionError } from "chai";
@@ -646,8 +646,8 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
           );
         });
 
-        it("should throw if chained to another non-chainable method", () => {
-          assertThrows(
+        it("should throw if chained to another non-chainable method", async () => {
+          await assertRejects(
             async () =>
               await expect(
                 sender.sendTransaction({

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalances.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalances.ts
@@ -66,19 +66,21 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
     describe("Transaction Callback", () => {
       describe("Change balances, one account, one contract", () => {
         it("should pass when all expected balance changes are equal to actual values", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: contract,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: contract,
+                value: 200,
+              }),
           ).to.changeEtherBalances(ethers, [sender, contract], [-200, 200]);
         });
       });
 
       describe("Change balances, contract forwards ether sent", () => {
         it("should pass when contract function forwards all tx ether", async () => {
-          await expect(() =>
-            contract.transferTo(receiver.address, { value: 200 }),
+          await expect(
+            async () =>
+              await contract.transferTo(receiver.address, { value: 200 }),
           ).to.changeEtherBalances(
             ethers,
             [sender, contract, receiver],
@@ -89,22 +91,24 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
 
       describe("Change balance, multiple accounts", () => {
         it("should pass when all expected balance changes are equal to actual values", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              gasPrice: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                gasPrice: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalances(ethers, [sender, receiver], ["-200", 200]);
         });
 
         it("should pass when given addresses as strings", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              gasPrice: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                gasPrice: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalances(
             ethers,
             [sender.address, receiver.address],
@@ -113,22 +117,24 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
         });
 
         it("should pass when given native BigInt", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              gasPrice: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                gasPrice: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalances(ethers, [sender, receiver], [-200n, 200n]);
         });
 
         it("should pass when given a predicate", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              gasPrice: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                gasPrice: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalances(
             ethers,
             [sender, receiver],
@@ -139,12 +145,13 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
 
         it("should fail when the predicate returns false", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                gasPrice: 1,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  gasPrice: 1,
+                  value: 200,
+                }),
             ).to.changeEtherBalances(
               ethers,
               [sender, receiver],
@@ -159,12 +166,13 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
 
         it("should fail when the predicate returns true and the assertion is negated", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                gasPrice: 1,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  gasPrice: 1,
+                  value: 200,
+                }),
             ).to.not.changeEtherBalances(
               ethers,
               [sender, receiver],
@@ -178,12 +186,13 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
         });
 
         it("should take into account transaction fee (legacy tx)", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              gasPrice: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                gasPrice: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalances(
             ethers,
             [sender, receiver, contract],
@@ -193,13 +202,14 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
         });
 
         it("should take into account transaction fee (1559 tx)", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              maxFeePerGas: 1,
-              maxPriorityFeePerGas: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                maxFeePerGas: 1,
+                maxPriorityFeePerGas: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalances(
             ethers,
             [sender, receiver, contract],
@@ -209,28 +219,34 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
         });
 
         it("should pass when given a single address", async () => {
-          await expect(() =>
-            sender.sendTransaction({ to: receiver.address, value: 200 }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.changeEtherBalances(ethers, [sender], [-200]);
         });
 
         it("should pass when negated and numbers don't match", async () => {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              gasPrice: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                gasPrice: 1,
+                value: 200,
+              }),
           ).to.not.changeEtherBalances(
             ethers,
             [sender, receiver],
             [-(txGasFees + 201), 200],
           );
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.not.changeEtherBalances(
             ethers,
             [sender, receiver],
@@ -243,24 +259,26 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
 
         it("should throw when expected balance change value was different from an actual for any wallet", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                gasPrice: 1,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  gasPrice: 1,
+                  value: 200,
+                }),
             ).to.changeEtherBalances(ethers, [sender, receiver], [-200, 201]),
           ).to.be.eventually.rejectedWith(
             AssertionError,
             `Expected the ether balance of ${receiver.address} (the 2nd address in the list) to change by 201 wei, but it changed by 200 wei`,
           );
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                gasPrice: 1,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  gasPrice: 1,
+                  value: 200,
+                }),
             ).to.changeEtherBalances(ethers, [sender, receiver], [-201, 200]),
           ).to.be.eventually.rejectedWith(
             AssertionError,
@@ -270,12 +288,13 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
 
         it("should throw in negative case when expected balance changes value were equal to an actual", async () => {
           await expect(
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver.address,
-                gasPrice: 1,
-                value: 200,
-              }),
+            expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver.address,
+                  gasPrice: 1,
+                  value: 200,
+                }),
             ).to.not.changeEtherBalances(
               ethers,
               [sender, receiver],
@@ -288,26 +307,28 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
         });
 
         it("arrays have different length", async () => {
-          expect(() =>
-            expect(
-              sender.sendTransaction({
-                to: receiver.address,
-                gasPrice: 1,
-                value: 200,
-              }),
-            ).to.changeEtherBalances(ethers, [sender], ["-200", 200]),
+          expect(
+            async () =>
+              await expect(
+                sender.sendTransaction({
+                  to: receiver.address,
+                  gasPrice: 1,
+                  value: 200,
+                }),
+              ).to.changeEtherBalances(ethers, [sender], ["-200", 200]),
           ).to.throw(
             Error,
             "The number of accounts (1) is different than the number of expected balance changes (2)",
           );
-          expect(() =>
-            expect(
-              sender.sendTransaction({
-                to: receiver.address,
-                gasPrice: 1,
-                value: 200,
-              }),
-            ).to.changeEtherBalances(ethers, [sender, receiver], ["-200"]),
+          expect(
+            async () =>
+              await expect(
+                sender.sendTransaction({
+                  to: receiver.address,
+                  gasPrice: 1,
+                  value: 200,
+                }),
+              ).to.changeEtherBalances(ethers, [sender, receiver], ["-200"]),
           ).to.throw(
             Error,
             "The number of accounts (2) is different than the number of expected balance changes (1)",
@@ -319,12 +340,13 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
         const receiverBalanceBefore =
           await ethers.provider.getBalance(receiver);
 
-        await expect(() =>
-          sender.sendTransaction({
-            to: receiver.address,
-            gasPrice: 1,
-            value: 200,
-          }),
+        await expect(
+          async () =>
+            await sender.sendTransaction({
+              to: receiver.address,
+              gasPrice: 1,
+              value: 200,
+            }),
         ).to.changeEtherBalances(ethers, [sender, receiver], [-200, 200]);
 
         const receiverBalanceAfter = await ethers.provider.getBalance(receiver);
@@ -349,8 +371,8 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
 
       it("should throw if chained to another non-chainable method", () => {
         assertThrows(
-          () =>
-            expect(
+          async () =>
+            await expect(
               sender.sendTransaction({
                 to: contract,
                 value: 200,
@@ -491,11 +513,12 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
       // smoke test for stack traces
       it("includes test file", async () => {
         try {
-          await expect(() =>
-            sender.sendTransaction({
-              to: receiver.address,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: receiver.address,
+                value: 200,
+              }),
           ).to.changeEtherBalances(ethers, [sender, receiver], [-100, 100]);
         } catch (e) {
           expect(util.inspect(e)).to.include(

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalances.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalances.ts
@@ -11,7 +11,7 @@ import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
 import {
-  assertThrows,
+  assertRejects,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { expect, AssertionError } from "chai";
@@ -307,7 +307,7 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
         });
 
         it("arrays have different length", async () => {
-          expect(
+          await assertRejects(
             async () =>
               await expect(
                 sender.sendTransaction({
@@ -316,11 +316,12 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
                   value: 200,
                 }),
               ).to.changeEtherBalances(ethers, [sender], ["-200", 200]),
-          ).to.throw(
-            Error,
-            "The number of accounts (1) is different than the number of expected balance changes (2)",
+            (e) =>
+              e.message.includes(
+                "The number of accounts (1) is different than the number of expected balance changes (2)",
+              ),
           );
-          expect(
+          await assertRejects(
             async () =>
               await expect(
                 sender.sendTransaction({
@@ -329,9 +330,10 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
                   value: 200,
                 }),
               ).to.changeEtherBalances(ethers, [sender, receiver], ["-200"]),
-          ).to.throw(
-            Error,
-            "The number of accounts (2) is different than the number of expected balance changes (1)",
+            (e) =>
+              e.message.includes(
+                "The number of accounts (2) is different than the number of expected balance changes (1)",
+              ),
           );
         });
       });
@@ -369,8 +371,8 @@ describe("INTEGRATION: changeEtherBalances matcher", { timeout: 60000 }, () => {
         });
       });
 
-      it("should throw if chained to another non-chainable method", () => {
-        assertThrows(
+      it("should throw if chained to another non-chainable method", async () => {
+        await assertRejects(
           async () =>
             await expect(
               sender.sendTransaction({

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/changeTokenBalance.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/changeTokenBalance.ts
@@ -17,7 +17,7 @@ import { afterEach, before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
 import {
-  assertThrows,
+  assertRejects,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { AssertionError, expect } from "chai";
@@ -653,8 +653,8 @@ describe(
             );
           });
 
-          it("changeTokenBalance: Should throw if chained to another non-chainable method", () => {
-            assertThrows(
+          it("changeTokenBalance: Should throw if chained to another non-chainable method", async () => {
+            await assertRejects(
               async () =>
                 await expect(contract.emitWithoutArgs())
                   .to.emit(contract, "WithoutArgs")
@@ -667,8 +667,8 @@ describe(
             );
           });
 
-          it("changeTokenBalances: should throw if chained to another non-chainable method", () => {
-            assertThrows(
+          it("changeTokenBalances: should throw if chained to another non-chainable method", async () => {
+            await assertRejects(
               async () =>
                 await expect(matchers.revertWithCustomErrorWithInt(1))
                   .to.be.revert(ethers)
@@ -691,7 +691,7 @@ describe(
       describe("validation errors", () => {
         describe(CHANGE_TOKEN_BALANCE_MATCHER, () => {
           it("token is not specified", async () => {
-            assertThrows(
+            await assertRejects(
               async () =>
                 await expect(
                   mockToken.transfer(receiver.address, 50),
@@ -705,7 +705,7 @@ describe(
             );
 
             // if an address is used (receiver.address)
-            assertThrows(
+            await assertRejects(
               async () =>
                 await expect(
                   mockToken.transfer(receiver.address, 50),
@@ -723,14 +723,15 @@ describe(
             const NotAToken = await ethers.getContractFactory("NotAToken");
             const notAToken = await NotAToken.deploy();
 
-            expect(
+            await assertRejects(
               async () =>
                 await expect(
                   mockToken.transfer(receiver.address, 50),
                 ).to.changeTokenBalance(ethers, notAToken, sender, -50),
-            ).to.throw(
-              Error,
-              "The given contract instance is not an ERC20 token",
+              (e) =>
+                e.message.includes(
+                  "The given contract instance is not an ERC20 token",
+                ),
             );
           });
 
@@ -775,7 +776,7 @@ describe(
 
         describe(CHANGE_TOKEN_BALANCES_MATCHER, () => {
           it("token is not specified", async () => {
-            assertThrows(
+            await assertRejects(
               async () =>
                 await expect(
                   mockToken.transfer(receiver.address, 50),
@@ -793,7 +794,7 @@ describe(
             const NotAToken = await ethers.getContractFactory("NotAToken");
             const notAToken = await NotAToken.deploy();
 
-            expect(
+            await assertRejects(
               async () =>
                 await expect(
                   mockToken.transfer(receiver.address, 50),
@@ -803,13 +804,14 @@ describe(
                   [sender, receiver],
                   [-50, 50],
                 ),
-            ).to.throw(
-              Error,
-              "The given contract instance is not an ERC20 token",
+              (e) =>
+                e.message.includes(
+                  "The given contract instance is not an ERC20 token",
+                ),
             );
           });
           it("arrays have different length", async () => {
-            expect(
+            await assertRejects(
               async () =>
                 await expect(
                   mockToken.transfer(receiver.address, 50),
@@ -819,12 +821,13 @@ describe(
                   [sender],
                   [-50, 50],
                 ),
-            ).to.throw(
-              Error,
-              "The number of accounts (1) is different than the number of expected balance changes (2)",
+              (e) =>
+                e.message.includes(
+                  "The number of accounts (1) is different than the number of expected balance changes (2)",
+                ),
             );
 
-            expect(
+            await assertRejects(
               async () =>
                 await expect(
                   mockToken.transfer(receiver.address, 50),
@@ -834,14 +837,15 @@ describe(
                   [sender, receiver],
                   [-50],
                 ),
-            ).to.throw(
-              Error,
-              "The number of accounts (2) is different than the number of expected balance changes (1)",
+              (e) =>
+                e.message.includes(
+                  "The number of accounts (2) is different than the number of expected balance changes (1)",
+                ),
             );
           });
 
           it("arrays have different length, subject is a rejected promise", async () => {
-            expect(
+            await assertRejects(
               async () =>
                 await expect(
                   matchers.revertsWithoutReason(),
@@ -851,9 +855,10 @@ describe(
                   [sender],
                   [-50, 50],
                 ),
-            ).to.throw(
-              Error,
-              "The number of accounts (1) is different than the number of expected balance changes (2)",
+              (e) =>
+                e.message.includes(
+                  "The number of accounts (1) is different than the number of expected balance changes (2)",
+                ),
             );
           });
 

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/changeTokenBalance.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/changeTokenBalance.ts
@@ -111,7 +111,7 @@ describe(
         it("with a function that returns a promise of a TxResponse", async () => {
           await runAllAsserts(
             ethers,
-            () => sender.sendTransaction({ to: receiver.address }),
+            async () => await sender.sendTransaction({ to: receiver.address }),
             mockToken,
             [sender, receiver],
             [0, 0],
@@ -136,8 +136,8 @@ describe(
             sender.sendTransaction({ to: receiver.address }),
           ).to.changeTokenBalance(ethers, mockToken, sender.address, 0);
 
-          await expect(() =>
-            sender.sendTransaction({ to: receiver.address }),
+          await expect(
+            async () => await sender.sendTransaction({ to: receiver.address }),
           ).to.changeTokenBalances(
             ethers,
             mockToken,
@@ -146,8 +146,8 @@ describe(
           );
 
           // mixing signers and addresses
-          await expect(() =>
-            sender.sendTransaction({ to: receiver.address }),
+          await expect(
+            async () => await sender.sendTransaction({ to: receiver.address }),
           ).to.changeTokenBalances(
             ethers,
             mockToken,
@@ -170,8 +170,8 @@ describe(
             (diff: bigint) => diff > 0n,
           );
 
-          await expect(() =>
-            sender.sendTransaction({ to: receiver.address }),
+          await expect(
+            async () => await sender.sendTransaction({ to: receiver.address }),
           ).to.not.changeTokenBalances(
             ethers,
             mockToken,
@@ -179,8 +179,8 @@ describe(
             [0, 1],
           );
 
-          await expect(() =>
-            sender.sendTransaction({ to: receiver.address }),
+          await expect(
+            async () => await sender.sendTransaction({ to: receiver.address }),
           ).to.not.changeTokenBalances(
             ethers,
             mockToken,
@@ -188,8 +188,8 @@ describe(
             [1, 0],
           );
 
-          await expect(() =>
-            sender.sendTransaction({ to: receiver.address }),
+          await expect(
+            async () => await sender.sendTransaction({ to: receiver.address }),
           ).to.not.changeTokenBalances(
             ethers,
             mockToken,
@@ -309,8 +309,8 @@ describe(
 
       describe("Transaction Callback", () => {
         it("should pass when given predicate", async () => {
-          await expect(() =>
-            mockToken.transfer(receiver.address, 75),
+          await expect(
+            async () => await mockToken.transfer(receiver.address, 75),
           ).to.changeTokenBalances(
             ethers,
             mockToken,
@@ -387,7 +387,7 @@ describe(
         it("with a function that returns a promise of a TxResponse", async () => {
           await runAllAsserts(
             ethers,
-            () => mockToken.transfer(receiver.address, 200),
+            async () => await mockToken.transfer(receiver.address, 200),
             mockToken,
             [sender, receiver],
             [-200, 200],
@@ -410,8 +410,8 @@ describe(
             receiver.address,
           );
 
-          await expect(() =>
-            mockToken.transfer(receiver.address, 50),
+          await expect(
+            async () => await mockToken.transfer(receiver.address, 50),
           ).to.changeTokenBalance(ethers, mockToken, receiver, 50);
 
           const receiverBalanceChange =
@@ -426,8 +426,8 @@ describe(
             receiver.address,
           );
 
-          await expect(() =>
-            mockToken.transfer(receiver.address, 50),
+          await expect(
+            async () => await mockToken.transfer(receiver.address, 50),
           ).to.changeTokenBalances(
             ethers,
             mockToken,
@@ -655,8 +655,8 @@ describe(
 
           it("changeTokenBalance: Should throw if chained to another non-chainable method", () => {
             assertThrows(
-              () =>
-                expect(contract.emitWithoutArgs())
+              async () =>
+                await expect(contract.emitWithoutArgs())
                   .to.emit(contract, "WithoutArgs")
                   .and.to.changeTokenBalance(ethers, mockToken, receiver, 0),
               (e) =>
@@ -669,8 +669,8 @@ describe(
 
           it("changeTokenBalances: should throw if chained to another non-chainable method", () => {
             assertThrows(
-              () =>
-                expect(matchers.revertWithCustomErrorWithInt(1))
+              async () =>
+                await expect(matchers.revertWithCustomErrorWithInt(1))
                   .to.be.revert(ethers)
                   .and.to.changeTokenBalances(
                     ethers,
@@ -692,8 +692,8 @@ describe(
         describe(CHANGE_TOKEN_BALANCE_MATCHER, () => {
           it("token is not specified", async () => {
             assertThrows(
-              () =>
-                expect(
+              async () =>
+                await expect(
                   mockToken.transfer(receiver.address, 50),
                   // @ts-expect-error -- force error scenario: token should be specified
                 ).to.changeTokenBalance(ethers, receiver, 50),
@@ -706,8 +706,8 @@ describe(
 
             // if an address is used (receiver.address)
             assertThrows(
-              () =>
-                expect(
+              async () =>
+                await expect(
                   mockToken.transfer(receiver.address, 50),
                   // @ts-expect-error -- force error scenario: token should be specified
                 ).to.changeTokenBalance(ethers, receiver.address, 50),
@@ -723,10 +723,11 @@ describe(
             const NotAToken = await ethers.getContractFactory("NotAToken");
             const notAToken = await NotAToken.deploy();
 
-            expect(() =>
-              expect(
-                mockToken.transfer(receiver.address, 50),
-              ).to.changeTokenBalance(ethers, notAToken, sender, -50),
+            expect(
+              async () =>
+                await expect(
+                  mockToken.transfer(receiver.address, 50),
+                ).to.changeTokenBalance(ethers, notAToken, sender, -50),
             ).to.throw(
               Error,
               "The given contract instance is not an ERC20 token",
@@ -775,8 +776,8 @@ describe(
         describe(CHANGE_TOKEN_BALANCES_MATCHER, () => {
           it("token is not specified", async () => {
             assertThrows(
-              () =>
-                expect(
+              async () =>
+                await expect(
                   mockToken.transfer(receiver.address, 50),
                   // @ts-expect-error -- force error scenario: token should be specified
                 ).to.changeTokenBalances(ethers, [sender, receiver], [-50, 50]),
@@ -792,39 +793,47 @@ describe(
             const NotAToken = await ethers.getContractFactory("NotAToken");
             const notAToken = await NotAToken.deploy();
 
-            expect(() =>
-              expect(
-                mockToken.transfer(receiver.address, 50),
-              ).to.changeTokenBalances(
-                ethers,
-                notAToken,
-                [sender, receiver],
-                [-50, 50],
-              ),
+            expect(
+              async () =>
+                await expect(
+                  mockToken.transfer(receiver.address, 50),
+                ).to.changeTokenBalances(
+                  ethers,
+                  notAToken,
+                  [sender, receiver],
+                  [-50, 50],
+                ),
             ).to.throw(
               Error,
               "The given contract instance is not an ERC20 token",
             );
           });
           it("arrays have different length", async () => {
-            expect(() =>
-              expect(
-                mockToken.transfer(receiver.address, 50),
-              ).to.changeTokenBalances(ethers, mockToken, [sender], [-50, 50]),
+            expect(
+              async () =>
+                await expect(
+                  mockToken.transfer(receiver.address, 50),
+                ).to.changeTokenBalances(
+                  ethers,
+                  mockToken,
+                  [sender],
+                  [-50, 50],
+                ),
             ).to.throw(
               Error,
               "The number of accounts (1) is different than the number of expected balance changes (2)",
             );
 
-            expect(() =>
-              expect(
-                mockToken.transfer(receiver.address, 50),
-              ).to.changeTokenBalances(
-                ethers,
-                mockToken,
-                [sender, receiver],
-                [-50],
-              ),
+            expect(
+              async () =>
+                await expect(
+                  mockToken.transfer(receiver.address, 50),
+                ).to.changeTokenBalances(
+                  ethers,
+                  mockToken,
+                  [sender, receiver],
+                  [-50],
+                ),
             ).to.throw(
               Error,
               "The number of accounts (2) is different than the number of expected balance changes (1)",
@@ -832,13 +841,16 @@ describe(
           });
 
           it("arrays have different length, subject is a rejected promise", async () => {
-            expect(() =>
-              expect(matchers.revertsWithoutReason()).to.changeTokenBalances(
-                ethers,
-                mockToken,
-                [sender],
-                [-50, 50],
-              ),
+            expect(
+              async () =>
+                await expect(
+                  matchers.revertsWithoutReason(),
+                ).to.changeTokenBalances(
+                  ethers,
+                  mockToken,
+                  [sender],
+                  [-50, 50],
+                ),
             ).to.throw(
               Error,
               "The number of accounts (1) is different than the number of expected balance changes (2)",

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/events.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/events.ts
@@ -81,9 +81,13 @@ describe(".to.emit (contract events)", { timeout: 60000 }, () => {
 
     it("should fail when matcher is called with too many arguments", async () => {
       await assertRejects(
-        () =>
+        async () =>
           // @ts-expect-error -- force error scenario: emit should not be called with more than two arguments
-          expect(contract.emitUint(1)).not.to.emit(contract, "WithoutArgs", 1),
+          await expect(contract.emitUint(1)).not.to.emit(
+            contract,
+            "WithoutArgs",
+            1,
+          ),
         (e) =>
           e.message.includes(
             "The .emit matcher expects two arguments: the contract and the event name. Arguments should be asserted with the .withArgs helper.",
@@ -116,18 +120,20 @@ describe(".to.emit (contract events)", { timeout: 60000 }, () => {
 
     describe(".withArgs", () => {
       it("should fail when used with .not.", async () => {
-        expect(() =>
-          expect(contract.emitUint(1))
-            .not.to.emit(contract, "WithUintArg")
-            .withArgs(1),
+        expect(
+          async () =>
+            await expect(contract.emitUint(1))
+              .not.to.emit(contract, "WithUintArg")
+              .withArgs(1),
         ).to.throw(Error, "Do not combine .not. with .withArgs()");
       });
 
       it("should fail when used with .not, subject is a rejected promise", async () => {
-        expect(() =>
-          expect(matchers.revertsWithoutReason())
-            .not.to.emit(contract, "WithUintArg")
-            .withArgs(1),
+        expect(
+          async () =>
+            await expect(matchers.revertsWithoutReason())
+              .not.to.emit(contract, "WithUintArg")
+              .withArgs(1),
         ).to.throw(Error, "Do not combine .not. with .withArgs()");
       });
 
@@ -899,7 +905,7 @@ describe(".to.emit (contract events)", { timeout: 60000 }, () => {
 
     it("With an invalid transaction hash string", async () => {
       await assertRejects(
-        () => expect("0x123").to.emit(contract, "WithoutArgs"),
+        async () => await expect("0x123").to.emit(contract, "WithoutArgs"),
         (e) =>
           e.message.includes(
             'Expected a valid transaction hash, but got "0x123"',

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/events.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/events.ts
@@ -82,10 +82,10 @@ describe(".to.emit (contract events)", { timeout: 60000 }, () => {
     it("should fail when matcher is called with too many arguments", async () => {
       await assertRejects(
         async () =>
-          // @ts-expect-error -- force error scenario: emit should not be called with more than two arguments
           await expect(contract.emitUint(1)).not.to.emit(
             contract,
             "WithoutArgs",
+            // @ts-expect-error -- force error scenario: emit should not be called with more than two arguments
             1,
           ),
         (e) =>

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/events.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/events.ts
@@ -120,21 +120,23 @@ describe(".to.emit (contract events)", { timeout: 60000 }, () => {
 
     describe(".withArgs", () => {
       it("should fail when used with .not.", async () => {
-        expect(
+        await assertRejects(
           async () =>
             await expect(contract.emitUint(1))
               .not.to.emit(contract, "WithUintArg")
               .withArgs(1),
-        ).to.throw(Error, "Do not combine .not. with .withArgs()");
+          (e) => e.message.includes("Do not combine .not. with .withArgs()"),
+        );
       });
 
       it("should fail when used with .not, subject is a rejected promise", async () => {
-        expect(
+        await assertRejects(
           async () =>
             await expect(matchers.revertsWithoutReason())
               .not.to.emit(contract, "WithUintArg")
               .withArgs(1),
-        ).to.throw(Error, "Do not combine .not. with .withArgs()");
+          (e) => e.message.includes("Do not combine .not. with .withArgs()"),
+        );
       });
 
       it("should fail if withArgs is called on its own", async () => {

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
@@ -50,7 +50,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
 
     // helpers
     const expectAssertionError = async (x: Promise<void>, message: string) => {
-      return expect(x).to.be.eventually.rejectedWith(AssertionError, message);
+      return await expect(x).to.be.eventually.rejectedWith(AssertionError, message);
     };
 
     describe("with a string as its subject", () => {

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
@@ -50,7 +50,10 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
 
     // helpers
     const expectAssertionError = async (x: Promise<void>, message: string) => {
-      return await expect(x).to.be.eventually.rejectedWith(AssertionError, message);
+      return await expect(x).to.be.eventually.rejectedWith(
+        AssertionError,
+        message,
+      );
     };
 
     describe("with a string as its subject", () => {
@@ -80,7 +83,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
 
       it("invalid string", async () => {
         await assertRejects(
-          () => expect("0x123").to.be.revert(ethers),
+          async () => await expect("0x123").to.be.revert(ethers),
           (e) =>
             e.message.includes(
               'Expected a valid transaction hash, but got "0x123"',
@@ -89,7 +92,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
         );
 
         await assertRejects(
-          () => expect("0x123").to.not.be.revert(ethers),
+          async () => await expect("0x123").to.not.be.revert(ethers),
           (e) =>
             e.message.includes(
               'Expected a valid transaction hash, but got "0x123"',
@@ -122,7 +125,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
 
       it("promise of an invalid string", async () => {
         await assertRejects(
-          () => expect(Promise.resolve("0x123")).to.be.revert(ethers),
+          async () =>
+            await expect(Promise.resolve("0x123")).to.be.revert(ethers),
           (e) =>
             e.message.includes(
               'Expected a valid transaction hash, but got "0x123"',
@@ -131,7 +135,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
         );
 
         await assertRejects(
-          () => expect(Promise.resolve("0x123")).to.not.be.revert(ethers),
+          async () =>
+            await expect(Promise.resolve("0x123")).to.not.be.revert(ethers),
           (e) =>
             e.message.includes(
               'Expected a valid transaction hash, but got "0x123"',
@@ -192,8 +197,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
 
       it("reverted: should throw if chained to another non-chainable method", () => {
         assertThrows(
-          () =>
-            expect(matchers.revertsWith("bar"))
+          async () =>
+            await expect(matchers.revertsWith("bar"))
               .to.be.revertedWith("bar")
               .and.to.be.revert(ethers),
           (e) =>
@@ -206,8 +211,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
 
       it("revertedWith: should throw if chained to another non-chainable method", () => {
         assertThrows(
-          () =>
-            expect(matchers.revertWithCustomErrorWithInt(1))
+          async () =>
+            await expect(matchers.revertWithCustomErrorWithInt(1))
               .to.be.revertedWithCustomError(matchers, "CustomErrorWithInt")
               .and.to.be.revertedWith("an error message"),
           (e) =>
@@ -220,8 +225,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
 
       it("revertedWithCustomError: should throw if chained to another non-chainable method", () => {
         assertThrows(
-          () =>
-            expect(matchers.revertsWithoutReason())
+          async () =>
+            await expect(matchers.revertsWithoutReason())
               .to.be.revertedWithoutReason(ethers)
               .and.to.be.revertedWithCustomError(matchers, "SomeCustomError"),
           (e) =>
@@ -234,8 +239,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
 
       it("revertedWithoutReason: should throw if chained to another non-chainable method", () => {
         assertThrows(
-          () =>
-            expect(matchers.panicAssert())
+          async () =>
+            await expect(matchers.panicAssert())
               .to.be.revertedWithPanic()
               .and.to.be.revertedWithoutReason(ethers),
           (e) =>
@@ -250,12 +255,13 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
         const [sender, receiver] = await ethers.getSigners();
 
         assertThrows(
-          () =>
-            expect(() =>
-              sender.sendTransaction({
-                to: receiver,
-                value: 200,
-              }),
+          async () =>
+            await expect(
+              async () =>
+                await sender.sendTransaction({
+                  to: receiver,
+                  value: 200,
+                }),
             )
               .to.changeEtherBalance(ethers, sender, "-200")
               .and.to.be.revertedWithPanic(),
@@ -320,7 +326,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
           matchers,
           method: "succeeds",
           args: [],
-          successfulAssert: (x) => expect(x).to.not.be.revert(ethers),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revert(ethers),
         });
       });
 
@@ -329,7 +336,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
           matchers,
           method: "succeeds",
           args: [],
-          failedAssert: (x) => expect(x).to.be.revert(ethers),
+          failedAssert: async (x) => await expect(x).to.be.revert(ethers),
           failedAssertReason: "Expected transaction to be reverted",
         });
       });
@@ -341,7 +348,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWithoutReason",
           args: [],
-          successfulAssert: (x) => expect(x).to.be.revert(ethers),
+          successfulAssert: async (x) => await expect(x).to.be.revert(ethers),
         });
       });
 
@@ -350,7 +357,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWithoutReason",
           args: [],
-          failedAssert: (x) => expect(x).not.to.be.revert(ethers),
+          failedAssert: async (x) => await expect(x).not.to.be.revert(ethers),
           failedAssertReason: "Expected transaction NOT to be reverted",
         });
       });
@@ -362,7 +369,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          successfulAssert: (x) => expect(x).to.be.revert(ethers),
+          successfulAssert: async (x) => await expect(x).to.be.revert(ethers),
         });
       });
 
@@ -371,7 +378,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          failedAssert: (x) => expect(x).not.to.be.revert(ethers),
+          failedAssert: async (x) => await expect(x).not.to.be.revert(ethers),
           failedAssertReason:
             "Expected transaction NOT to be reverted, but it reverted with reason 'some reason'",
         });
@@ -384,7 +391,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
           matchers,
           method: "panicAssert",
           args: [],
-          successfulAssert: (x) => expect(x).to.be.revert(ethers),
+          successfulAssert: async (x) => await expect(x).to.be.revert(ethers),
         });
       });
 
@@ -393,7 +400,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
           matchers,
           method: "panicAssert",
           args: [],
-          failedAssert: (x) => expect(x).not.to.be.revert(ethers),
+          failedAssert: async (x) => await expect(x).not.to.be.revert(ethers),
           failedAssertReason:
             "Expected transaction NOT to be reverted, but it reverted with panic code 0x1 (Assertion error)",
         });
@@ -406,7 +413,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
           matchers,
           method: "revertWithSomeCustomError",
           args: [],
-          successfulAssert: (x) => expect(x).to.be.revert(ethers),
+          successfulAssert: async (x) => await expect(x).to.be.revert(ethers),
         });
       });
 
@@ -415,7 +422,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
           matchers,
           method: "revertWithSomeCustomError",
           args: [],
-          failedAssert: (x) => expect(x).not.to.be.revert(ethers),
+          failedAssert: async (x) => await expect(x).not.to.be.revert(ethers),
           failedAssertReason: "Expected transaction NOT to be reverted",
         });
       });

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
@@ -8,7 +8,6 @@ import util from "node:util";
 
 import {
   assertRejects,
-  assertThrows,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { AssertionError, expect } from "chai";
@@ -195,8 +194,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
         );
       });
 
-      it("reverted: should throw if chained to another non-chainable method", () => {
-        assertThrows(
+      it("reverted: should throw if chained to another non-chainable method", async () => {
+        await assertRejects(
           async () =>
             await expect(matchers.revertsWith("bar"))
               .to.be.revertedWith("bar")
@@ -209,8 +208,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
         );
       });
 
-      it("revertedWith: should throw if chained to another non-chainable method", () => {
-        assertThrows(
+      it("revertedWith: should throw if chained to another non-chainable method", async () => {
+        await assertRejects(
           async () =>
             await expect(matchers.revertWithCustomErrorWithInt(1))
               .to.be.revertedWithCustomError(matchers, "CustomErrorWithInt")
@@ -223,8 +222,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
         );
       });
 
-      it("revertedWithCustomError: should throw if chained to another non-chainable method", () => {
-        assertThrows(
+      it("revertedWithCustomError: should throw if chained to another non-chainable method", async () => {
+        await assertRejects(
           async () =>
             await expect(matchers.revertsWithoutReason())
               .to.be.revertedWithoutReason(ethers)
@@ -237,8 +236,8 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
         );
       });
 
-      it("revertedWithoutReason: should throw if chained to another non-chainable method", () => {
-        assertThrows(
+      it("revertedWithoutReason: should throw if chained to another non-chainable method", async () => {
+        await assertRejects(
           async () =>
             await expect(matchers.panicAssert())
               .to.be.revertedWithPanic()
@@ -254,7 +253,7 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
       it("revertedWithPanic: should throw if chained to another non-chainable method", async () => {
         const [sender, receiver] = await ethers.getSigners();
 
-        assertThrows(
+        await assertRejects(
           async () =>
             await expect(
               async () =>

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWith.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWith.ts
@@ -51,8 +51,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "succeeds",
-          successfulAssert: (x) =>
-            expect(x).not.to.be.revertedWith("some reason"),
+          successfulAssert: async (x) =>
+            await expect(x).not.to.be.revertedWith("some reason"),
         });
       });
 
@@ -60,7 +60,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "succeeds",
-          failedAssert: (x) => expect(x).to.be.revertedWith("some reason"),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWith("some reason"),
           failedAssertReason:
             "Expected transaction to be reverted with reason 'some reason', but it didn't revert",
         });
@@ -72,8 +73,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "revertsWithoutReason",
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWith("some reason"),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWith("some reason"),
         });
       });
 
@@ -81,7 +82,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertsWithoutReason",
-          failedAssert: (x) => expect(x).to.be.revertedWith("some reason"),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWith("some reason"),
           failedAssertReason:
             "Expected transaction to be reverted with reason 'some reason', but it reverted without a reason",
         });
@@ -94,21 +96,22 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          successfulAssert: (x) => expect(x).to.be.revertedWith("some reason"),
+          successfulAssert: async (x) =>
+            await expect(x).to.be.revertedWith("some reason"),
         });
         await runSuccessfulAsserts({
           matchers,
           method: "revertsWith",
           args: ["regular expression reason"],
-          successfulAssert: (x) =>
-            expect(x).to.be.revertedWith(/regular .* reason/),
+          successfulAssert: async (x) =>
+            await expect(x).to.be.revertedWith(/regular .* reason/),
         });
         await runSuccessfulAsserts({
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWith("another reason"),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWith("another reason"),
         });
       });
 
@@ -117,7 +120,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          failedAssert: (x) => expect(x).to.not.be.revertedWith("some reason"),
+          failedAssert: async (x) =>
+            await expect(x).to.not.be.revertedWith("some reason"),
           failedAssertReason:
             "Expected transaction NOT to be reverted with reason 'some reason', but it was",
         });
@@ -128,7 +132,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["another reason"],
-          failedAssert: (x) => expect(x).to.be.revertedWith("some reason"),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWith("some reason"),
           failedAssertReason:
             "Expected transaction to be reverted with reason 'some reason', but it reverted with reason 'another reason'",
         });
@@ -139,8 +144,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["another regular expression reason"],
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWith(/some regular .* reason/),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWith(/some regular .* reason/),
           failedAssertReason:
             "Expected transaction to be reverted with reason 'some regular .* reason', but it reverted with reason 'another regular expression reason'",
         });
@@ -152,8 +157,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "panicAssert",
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWith("some reason"),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWith("some reason"),
         });
       });
 
@@ -161,7 +166,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "panicAssert",
-          failedAssert: (x) => expect(x).to.be.revertedWith("some reason"),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWith("some reason"),
           failedAssertReason:
             "Expected transaction to be reverted with reason 'some reason', but it reverted with panic code 0x1 (Assertion error)",
         });
@@ -173,8 +179,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "revertWithSomeCustomError",
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWith("some reason"),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWith("some reason"),
         });
       });
 
@@ -182,7 +188,8 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertWithSomeCustomError",
-          failedAssert: (x) => expect(x).to.be.revertedWith("some reason"),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWith("some reason"),
           failedAssertReason:
             "Expected transaction to be reverted with reason 'some reason', but it reverted with a custom error",
         });
@@ -201,7 +208,7 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
 
         assertThrows(
           // @ts-expect-error -- force error scenario: reason should be a string or a regular expression
-          () => expect(hash).to.be.revertedWith(10),
+          async () => await expect(hash).to.be.revertedWith(10),
           (e) =>
             e.message.includes(
               "Expected the revert reason to be a string or a regular expression",
@@ -215,7 +222,7 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
 
         assertThrows(
           // @ts-expect-error -- force error scenario: reason should be a string or a regular expression
-          () => expect(tx).to.be.revertedWith(10),
+          async () => await expect(tx).to.be.revertedWith(10),
           (e) =>
             e.message.includes(
               "Expected the revert reason to be a string or a regular expression",

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWith.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWith.ts
@@ -7,7 +7,7 @@ import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
 import {
-  assertThrows,
+  assertRejects,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { AssertionError, expect } from "chai";
@@ -206,7 +206,7 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
       it("non-string as expectation", async () => {
         const { hash } = await mineSuccessfulTransaction(provider, ethers);
 
-        assertThrows(
+        await assertRejects(
           // @ts-expect-error -- force error scenario: reason should be a string or a regular expression
           async () => await expect(hash).to.be.revertedWith(10),
           (e) =>
@@ -220,7 +220,7 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
       it("non-string as expectation, subject is a rejected promise", async () => {
         const tx = matchers.revertsWithoutReason();
 
-        assertThrows(
+        await assertRejects(
           // @ts-expect-error -- force error scenario: reason should be a string or a regular expression
           async () => await expect(tx).to.be.revertedWith(10),
           (e) =>

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithCustomError.ts
@@ -7,7 +7,7 @@ import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
 import {
-  assertThrows,
+  assertRejects,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { AssertionError, expect } from "chai";
@@ -381,12 +381,13 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
       });
 
       it("should fail when used with .not.", async () => {
-        expect(
+        await assertRejects(
           async () =>
             await expect(matchers.revertWithSomeCustomError())
               .to.not.be.revertedWithCustomError(matchers, "SomeCustomError")
               .withArgs(1),
-        ).to.throw(Error, "Do not combine .not. with .withArgs()");
+          (e) => e.message.includes("Do not combine .not. with .withArgs()"),
+        );
       });
 
       it("should fail if withArgs is called on its own", async () => {
@@ -459,7 +460,7 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
       it("non-string as expectation", async () => {
         const { hash } = await mineSuccessfulTransaction(provider, ethers);
 
-        assertThrows(
+        await assertRejects(
           // @ts-expect-error -- force error scenario: reason should be a string or a regular expression
           async () => await expect(hash).to.be.revertedWith(10),
           (e) =>
@@ -471,7 +472,7 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
       });
 
       it("the contract is not specified", async () => {
-        assertThrows(
+        await assertRejects(
           async () =>
             await expect(
               matchers.revertWithSomeCustomError(),
@@ -486,7 +487,7 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
       });
 
       it("the contract doesn't have a custom error with that name", async () => {
-        assertThrows(
+        await assertRejects(
           async () =>
             await expect(
               matchers.revertWithSomeCustomError(),
@@ -524,7 +525,7 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
       });
 
       it("extra arguments", async () => {
-        assertThrows(
+        await assertRejects(
           async () =>
             await expect(
               matchers.revertWithSomeCustomError(),

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithCustomError.ts
@@ -55,8 +55,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "succeeds",
-          successfulAssert: (x) =>
-            expect(x).not.to.be.revertedWithCustomError(
+          successfulAssert: async (x) =>
+            await expect(x).not.to.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -67,8 +67,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "succeeds",
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithCustomError(
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -83,8 +83,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "revertsWithoutReason",
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWithCustomError(
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -95,8 +95,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertsWithoutReason",
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithCustomError(
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -112,8 +112,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWithCustomError(
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -125,8 +125,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithCustomError(
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -141,8 +141,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "panicAssert",
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWithCustomError(
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -153,8 +153,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "panicAssert",
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithCustomError(
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -169,8 +169,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "revertWithSomeCustomError",
-          successfulAssert: (x) =>
-            expect(x).to.be.revertedWithCustomError(
+          successfulAssert: async (x) =>
+            await expect(x).to.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -179,8 +179,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "revertWithAnotherCustomError",
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWithCustomError(
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -191,8 +191,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertWithSomeCustomError",
-          failedAssert: (x) =>
-            expect(x).to.not.be.revertedWithCustomError(
+          failedAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -205,8 +205,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertWithAnotherCustomError",
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithCustomError(
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -219,8 +219,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertWithAnotherContractCustomError",
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithCustomError(
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithCustomError(
               matchers,
               "SomeCustomError",
             ),
@@ -381,10 +381,11 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
       });
 
       it("should fail when used with .not.", async () => {
-        expect(() =>
-          expect(matchers.revertWithSomeCustomError())
-            .to.not.be.revertedWithCustomError(matchers, "SomeCustomError")
-            .withArgs(1),
+        expect(
+          async () =>
+            await expect(matchers.revertWithSomeCustomError())
+              .to.not.be.revertedWithCustomError(matchers, "SomeCustomError")
+              .withArgs(1),
         ).to.throw(Error, "Do not combine .not. with .withArgs()");
       });
 
@@ -460,7 +461,7 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
 
         assertThrows(
           // @ts-expect-error -- force error scenario: reason should be a string or a regular expression
-          () => expect(hash).to.be.revertedWith(10),
+          async () => await expect(hash).to.be.revertedWith(10),
           (e) =>
             e.message.includes(
               "Expected the revert reason to be a string or a regular expression",
@@ -471,8 +472,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
 
       it("the contract is not specified", async () => {
         assertThrows(
-          () =>
-            expect(
+          async () =>
+            await expect(
               matchers.revertWithSomeCustomError(),
               // @ts-expect-error -- force error scenario: contract should be specified
             ).to.be.revertedWithCustomError("SomeCustomError"),
@@ -486,8 +487,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
 
       it("the contract doesn't have a custom error with that name", async () => {
         assertThrows(
-          () =>
-            expect(
+          async () =>
+            await expect(
               matchers.revertWithSomeCustomError(),
             ).to.be.revertedWithCustomError(matchers, "SomeCustomErrorTwo"),
           (e) =>
@@ -524,8 +525,8 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
 
       it("extra arguments", async () => {
         assertThrows(
-          () =>
-            expect(
+          async () =>
+            await expect(
               matchers.revertWithSomeCustomError(),
             ).to.be.revertedWithCustomError(
               matchers,

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithPanic.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithPanic.ts
@@ -7,7 +7,7 @@ import { before, beforeEach, describe, it } from "node:test";
 import util from "node:util";
 
 import {
-  assertThrows,
+  assertRejects,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { AssertionError, expect } from "chai";
@@ -302,7 +302,7 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
       it("non-number as expectation", async () => {
         const { hash } = await mineSuccessfulTransaction(provider, ethers);
 
-        assertThrows(
+        await assertRejects(
           async () => await expect(hash).to.be.revertedWithPanic("invalid"),
           (e) =>
             e.message.includes(
@@ -315,7 +315,7 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
       it("non-number as expectation, subject is a rejected promise", async () => {
         const tx = matchers.revertsWithoutReason();
 
-        assertThrows(
+        await assertRejects(
           async () => await expect(tx).to.be.revertedWithPanic("invalid"),
           (e) =>
             e.message.includes(

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithPanic.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithPanic.ts
@@ -52,13 +52,16 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "succeeds",
-          successfulAssert: (x) => expect(x).not.to.be.revertedWithPanic(),
+          successfulAssert: async (x) =>
+            await expect(x).not.to.be.revertedWithPanic(),
         });
         await runSuccessfulAsserts({
           matchers,
           method: "succeeds",
-          successfulAssert: (x) =>
-            expect(x).not.to.be.revertedWithPanic(PANIC_CODES.ASSERTION_ERROR),
+          successfulAssert: async (x) =>
+            await expect(x).not.to.be.revertedWithPanic(
+              PANIC_CODES.ASSERTION_ERROR,
+            ),
         });
       });
 
@@ -66,15 +69,17 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "succeeds",
-          failedAssert: (x) => expect(x).to.be.revertedWithPanic(),
+          failedAssert: async (x) => await expect(x).to.be.revertedWithPanic(),
           failedAssertReason:
             "Expected transaction to be reverted with some panic code, but it didn't revert",
         });
         await runFailedAsserts({
           matchers,
           method: "succeeds",
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithPanic(PANIC_CODES.ASSERTION_ERROR),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithPanic(
+              PANIC_CODES.ASSERTION_ERROR,
+            ),
           failedAssertReason:
             "Expected transaction to be reverted with panic code 0x1 (Assertion error), but it didn't revert",
         });
@@ -86,14 +91,17 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "revertsWithoutReason",
-          successfulAssert: (x) => expect(x).to.not.be.revertedWithPanic(),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithPanic(),
         });
 
         await runSuccessfulAsserts({
           matchers,
           method: "revertsWithoutReason",
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWithPanic(PANIC_CODES.ASSERTION_ERROR),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithPanic(
+              PANIC_CODES.ASSERTION_ERROR,
+            ),
         });
       });
 
@@ -101,7 +109,7 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertsWithoutReason",
-          failedAssert: (x) => expect(x).to.be.revertedWithPanic(),
+          failedAssert: async (x) => await expect(x).to.be.revertedWithPanic(),
           failedAssertReason:
             "Expected transaction to be reverted with some panic code, but it reverted without a reason",
         });
@@ -109,8 +117,10 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertsWithoutReason",
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithPanic(PANIC_CODES.ASSERTION_ERROR),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithPanic(
+              PANIC_CODES.ASSERTION_ERROR,
+            ),
           failedAssertReason:
             "Expected transaction to be reverted with panic code 0x1 (Assertion error), but it reverted without a reason",
         });
@@ -123,14 +133,17 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          successfulAssert: (x) => expect(x).to.not.be.revertedWithPanic(),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithPanic(),
         });
         await runSuccessfulAsserts({
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWithPanic(PANIC_CODES.ASSERTION_ERROR),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithPanic(
+              PANIC_CODES.ASSERTION_ERROR,
+            ),
         });
       });
 
@@ -139,7 +152,7 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          failedAssert: (x) => expect(x).to.be.revertedWithPanic(),
+          failedAssert: async (x) => await expect(x).to.be.revertedWithPanic(),
           failedAssertReason:
             "Expected transaction to be reverted with some panic code, but it reverted with reason 'some reason'",
         });
@@ -147,8 +160,10 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithPanic(PANIC_CODES.ASSERTION_ERROR),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithPanic(
+              PANIC_CODES.ASSERTION_ERROR,
+            ),
           failedAssertReason:
             "Expected transaction to be reverted with panic code 0x1 (Assertion error), but it reverted with reason 'some reason'",
         });
@@ -160,13 +175,16 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "panicAssert",
-          successfulAssert: (x) => expect(x).to.be.revertedWithPanic(),
+          successfulAssert: async (x) =>
+            await expect(x).to.be.revertedWithPanic(),
         });
         await runSuccessfulAsserts({
           matchers,
           method: "panicAssert",
-          successfulAssert: (x) =>
-            expect(x).to.be.revertedWithPanic(PANIC_CODES.ASSERTION_ERROR),
+          successfulAssert: async (x) =>
+            await expect(x).to.be.revertedWithPanic(
+              PANIC_CODES.ASSERTION_ERROR,
+            ),
         });
       });
 
@@ -174,7 +192,8 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "panicAssert",
-          failedAssert: (x) => expect(x).to.not.be.revertedWithPanic(),
+          failedAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithPanic(),
           failedAssertReason:
             "Expected transaction NOT to be reverted with some panic code, but it reverted with panic code 0x1 (Assertion error)",
         });
@@ -182,8 +201,10 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "panicAssert",
-          failedAssert: (x) =>
-            expect(x).to.not.be.revertedWithPanic(PANIC_CODES.ASSERTION_ERROR),
+          failedAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithPanic(
+              PANIC_CODES.ASSERTION_ERROR,
+            ),
           failedAssertReason:
             "Expected transaction NOT to be reverted with panic code 0x1 (Assertion error), but it was",
         });
@@ -191,8 +212,10 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "panicAssert",
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithPanic(PANIC_CODES.ARITHMETIC_OVERFLOW),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithPanic(
+              PANIC_CODES.ARITHMETIC_OVERFLOW,
+            ),
           failedAssertReason:
             "Expected transaction to be reverted with panic code 0x11 (Arithmetic operation overflowed outside of an unchecked block), but it reverted with panic code 0x1 (Assertion error)",
         });
@@ -204,14 +227,17 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "revertWithSomeCustomError",
-          successfulAssert: (x) => expect(x).to.not.be.revertedWithPanic(),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithPanic(),
         });
 
         await runSuccessfulAsserts({
           matchers,
           method: "revertWithSomeCustomError",
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWithPanic(PANIC_CODES.ASSERTION_ERROR),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithPanic(
+              PANIC_CODES.ASSERTION_ERROR,
+            ),
         });
       });
 
@@ -219,7 +245,7 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertWithSomeCustomError",
-          failedAssert: (x) => expect(x).to.be.revertedWithPanic(),
+          failedAssert: async (x) => await expect(x).to.be.revertedWithPanic(),
           failedAssertReason:
             "Expected transaction to be reverted with some panic code, but it reverted with a custom error",
         });
@@ -227,8 +253,10 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertWithSomeCustomError",
-          failedAssert: (x) =>
-            expect(x).to.be.revertedWithPanic(PANIC_CODES.ASSERTION_ERROR),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithPanic(
+              PANIC_CODES.ASSERTION_ERROR,
+            ),
           failedAssertReason:
             "Expected transaction to be reverted with panic code 0x1 (Assertion error), but it reverted with a custom error",
         });
@@ -240,7 +268,8 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "succeeds",
-          successfulAssert: (x) => expect(x).not.to.be.revertedWithPanic(1),
+          successfulAssert: async (x) =>
+            await expect(x).not.to.be.revertedWithPanic(1),
         });
       });
 
@@ -248,7 +277,8 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "succeeds",
-          successfulAssert: (x) => expect(x).not.to.be.revertedWithPanic(1n),
+          successfulAssert: async (x) =>
+            await expect(x).not.to.be.revertedWithPanic(1n),
         });
       });
 
@@ -256,7 +286,8 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "succeeds",
-          successfulAssert: (x) => expect(x).not.to.be.revertedWithPanic("1"),
+          successfulAssert: async (x) =>
+            await expect(x).not.to.be.revertedWithPanic("1"),
         });
       });
     });
@@ -272,7 +303,7 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         const { hash } = await mineSuccessfulTransaction(provider, ethers);
 
         assertThrows(
-          () => expect(hash).to.be.revertedWithPanic("invalid"),
+          async () => await expect(hash).to.be.revertedWithPanic("invalid"),
           (e) =>
             e.message.includes(
               'Expected the given panic code to be a number-like value, but got "invalid"',
@@ -285,7 +316,7 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
         const tx = matchers.revertsWithoutReason();
 
         assertThrows(
-          () => expect(tx).to.be.revertedWithPanic("invalid"),
+          async () => await expect(tx).to.be.revertedWithPanic("invalid"),
           (e) =>
             e.message.includes(
               'Expected the given panic code to be a number-like value, but got "invalid"',

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithoutReason.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithoutReason.ts
@@ -46,8 +46,8 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "succeeds",
-          successfulAssert: (x) =>
-            expect(x).not.to.be.revertedWithoutReason(ethers),
+          successfulAssert: async (x) =>
+            await expect(x).not.to.be.revertedWithoutReason(ethers),
         });
       });
 
@@ -55,7 +55,8 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "succeeds",
-          failedAssert: (x) => expect(x).to.be.revertedWithoutReason(ethers),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithoutReason(ethers),
           failedAssertReason:
             "Expected transaction to be reverted without a reason, but it didn't revert",
         });
@@ -68,8 +69,8 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWithoutReason",
           args: [],
-          successfulAssert: (x) =>
-            expect(x).to.be.revertedWithoutReason(ethers),
+          successfulAssert: async (x) =>
+            await expect(x).to.be.revertedWithoutReason(ethers),
         });
       });
 
@@ -78,8 +79,8 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWithoutReason",
           args: [],
-          failedAssert: (x) =>
-            expect(x).to.not.be.revertedWithoutReason(ethers),
+          failedAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithoutReason(ethers),
           failedAssertReason:
             "Expected transaction NOT to be reverted without a reason, but it was",
         });
@@ -92,8 +93,8 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWithoutReason(ethers),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithoutReason(ethers),
         });
       });
 
@@ -102,7 +103,8 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
           matchers,
           method: "revertsWith",
           args: ["some reason"],
-          failedAssert: (x) => expect(x).to.be.revertedWithoutReason(ethers),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithoutReason(ethers),
           failedAssertReason:
             "Expected transaction to be reverted without a reason, but it reverted with reason 'some reason'",
         });
@@ -114,8 +116,8 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "panicAssert",
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWithoutReason(ethers),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithoutReason(ethers),
         });
       });
 
@@ -123,7 +125,8 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "panicAssert",
-          failedAssert: (x) => expect(x).to.be.revertedWithoutReason(ethers),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithoutReason(ethers),
           failedAssertReason:
             "Expected transaction to be reverted without a reason, but it reverted with panic code 0x1 (Assertion error)",
         });
@@ -135,8 +138,8 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
         await runSuccessfulAsserts({
           matchers,
           method: "revertWithSomeCustomError",
-          successfulAssert: (x) =>
-            expect(x).to.not.be.revertedWithoutReason(ethers),
+          successfulAssert: async (x) =>
+            await expect(x).to.not.be.revertedWithoutReason(ethers),
         });
       });
 
@@ -144,7 +147,8 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
         await runFailedAsserts({
           matchers,
           method: "revertWithSomeCustomError",
-          failedAssert: (x) => expect(x).to.be.revertedWithoutReason(ethers),
+          failedAssert: async (x) =>
+            await expect(x).to.be.revertedWithoutReason(ethers),
           failedAssertReason:
             "Expected transaction to be reverted without a reason, but it reverted with a custom error",
         });

--- a/packages/hardhat-ethers-chai-matchers/test/multi-network-connections.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/multi-network-connections.ts
@@ -66,11 +66,12 @@ describe("handle multiple connections", () => {
       let nonceSender = await sender.getNonce();
       let nonceSender2 = await sender2.getNonce();
 
-      await expect(() =>
-        sender.sendTransaction({
-          to: receiver.address,
-          value: 200,
-        }),
+      await expect(
+        async () =>
+          await sender.sendTransaction({
+            to: receiver.address,
+            value: 200,
+          }),
       ).to.changeEtherBalance(ethers, sender, "-200");
 
       // Only the sender nonce should be changed
@@ -81,11 +82,12 @@ describe("handle multiple connections", () => {
       nonceSender = await sender.getNonce();
       nonceSender2 = await sender2.getNonce();
 
-      await expect(() =>
-        sender2.sendTransaction({
-          to: receiver2.address,
-          value: 200,
-        }),
+      await expect(
+        async () =>
+          await sender2.sendTransaction({
+            to: receiver2.address,
+            value: 200,
+          }),
       ).to.changeEtherBalance(ethers2, sender2, "-200");
 
       // Only the sender2 nonce should be changed

--- a/packages/hardhat-ethers/src/index.ts
+++ b/packages/hardhat-ethers/src/index.ts
@@ -5,7 +5,7 @@ import type { HardhatPlugin } from "hardhat/types/plugins";
 const hardhatEthersPlugin: HardhatPlugin = {
   id: "hardhat-ethers",
   hookHandlers: {
-    network: () => import("./internal/hook-handlers/network.js"),
+    network: async () => await import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ethers",
 };

--- a/packages/hardhat-ethers/src/internal/ethers-utils/ethers-utils.ts
+++ b/packages/hardhat-ethers/src/internal/ethers-utils/ethers-utils.ts
@@ -112,7 +112,7 @@ export async function resolveProperties<T>(value: {
   const keys = Object.keys(value);
   const results = await Promise.all(
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this code is a verbatim copy of ethers
-    keys.map((k) => Promise.resolve(value[k as keyof T])),
+    keys.map(async (k) => await Promise.resolve(value[k as keyof T])),
   );
 
   return results.reduce(

--- a/packages/hardhat-ethers/src/internal/hardhat-ethers-provider/hardhat-ethers-provider.ts
+++ b/packages/hardhat-ethers/src/internal/hardhat-ethers-provider/hardhat-ethers-provider.ts
@@ -482,68 +482,70 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
 
     const pollingInterval = (await this.#isHardhatNetwork()) ? 50 : 500;
 
-    return await new Promise<ethers.TransactionReceipt | null>((resolve, reject) => {
-      let cancelled = false;
-      let timeoutTimer: NodeJS.Timeout | undefined;
-      let pollingTimeout: NodeJS.Timeout | undefined;
+    return await new Promise<ethers.TransactionReceipt | null>(
+      (resolve, reject) => {
+        let cancelled = false;
+        let timeoutTimer: NodeJS.Timeout | undefined;
+        let pollingTimeout: NodeJS.Timeout | undefined;
 
-      if (timeout !== undefined && timeout > 0) {
-        timeoutTimer = setTimeout(() => {
-          cancelled = true;
+        if (timeout !== undefined && timeout > 0) {
+          timeoutTimer = setTimeout(() => {
+            cancelled = true;
 
-          clearTimeout(pollingTimeout);
+            clearTimeout(pollingTimeout);
 
-          resolve(null);
-        }, timeout);
-      }
-
-      const poll = async () => {
-        if (cancelled) {
-          return;
+            resolve(null);
+          }, timeout);
         }
 
-        try {
-          const receipt = await this.getTransactionReceipt(hash);
+        const poll = async () => {
+          if (cancelled) {
+            return;
+          }
 
-          // Wait for the required confirmation depth before resolving,
-          // so callers relying on confirmations for reorg safety aren't
-          // given a receipt that could still be reverted.
-          if (receipt !== null && receipt.blockNumber !== null) {
-            const latestBlockNumber = await this.getBlockNumber();
-            const confirmations = latestBlockNumber - receipt.blockNumber + 1;
+          try {
+            const receipt = await this.getTransactionReceipt(hash);
 
-            if (confirmations >= resolvedConfirms) {
-              cancelled = true;
+            // Wait for the required confirmation depth before resolving,
+            // so callers relying on confirmations for reorg safety aren't
+            // given a receipt that could still be reverted.
+            if (receipt !== null && receipt.blockNumber !== null) {
+              const latestBlockNumber = await this.getBlockNumber();
+              const confirmations = latestBlockNumber - receipt.blockNumber + 1;
 
-              if (timeoutTimer !== undefined) {
-                clearTimeout(timeoutTimer);
+              if (confirmations >= resolvedConfirms) {
+                cancelled = true;
+
+                if (timeoutTimer !== undefined) {
+                  clearTimeout(timeoutTimer);
+                }
+
+                clearTimeout(pollingTimeout);
+                resolve(receipt);
+
+                return;
               }
-
-              clearTimeout(pollingTimeout);
-              resolve(receipt);
-
-              return;
             }
+
+            clearTimeout(pollingTimeout);
+
+            pollingTimeout = setTimeout(poll, pollingInterval);
+          } catch (e) {
+            ensureError(e);
+
+            cancelled = true;
+
+            if (timeoutTimer !== undefined) {
+              clearTimeout(timeoutTimer);
+            }
+
+            reject(e);
           }
+        };
 
-          clearTimeout(pollingTimeout);
-
-          pollingTimeout = setTimeout(poll, pollingInterval);
-        } catch (e) {
-          ensureError(e);
-
-          cancelled = true;
-
-          if (timeoutTimer !== undefined) {
-            clearTimeout(timeoutTimer);
-          }
-
-          reject(e);
-        }
-      };
-
-      void poll();
-    });
+        void poll();
+      },
+    );
   }
 
   public async waitForBlock(

--- a/packages/hardhat-ethers/src/internal/hardhat-ethers-provider/hardhat-ethers-provider.ts
+++ b/packages/hardhat-ethers/src/internal/hardhat-ethers-provider/hardhat-ethers-provider.ts
@@ -116,7 +116,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
   public destroy(): void {}
 
   public async send(method: string, params?: any[]): Promise<any> {
-    return this.#hardhatProvider.request({
+    return await this.#hardhatProvider.request({
       method,
       params,
     });
@@ -143,7 +143,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
           },
         );
       }
-      return HardhatEthersSigner.create(
+      return await HardhatEthersSigner.create(
         this,
         this.#networkName,
         this.#networkConfig,
@@ -152,7 +152,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
     }
 
     if (typeof address === "string") {
-      return HardhatEthersSigner.create(
+      return await HardhatEthersSigner.create(
         this,
         this.#networkName,
         this.#networkConfig,
@@ -477,12 +477,12 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
     const resolvedConfirms = confirms ?? DEFAULT_TRANSACTION_CONFIRMS;
 
     if (resolvedConfirms === 0) {
-      return this.getTransactionReceipt(hash);
+      return await this.getTransactionReceipt(hash);
     }
 
     const pollingInterval = (await this.#isHardhatNetwork()) ? 50 : 500;
 
-    return new Promise<ethers.TransactionReceipt | null>((resolve, reject) => {
+    return await new Promise<ethers.TransactionReceipt | null>((resolve, reject) => {
       let cancelled = false;
       let timeoutTimer: NodeJS.Timeout | undefined;
       let pollingTimeout: NodeJS.Timeout | undefined;
@@ -741,14 +741,14 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
     event: ProviderEvent,
     listener: Listener,
   ): Promise<this> {
-    return this.on(event, listener);
+    return await this.on(event, listener);
   }
 
   public async removeListener(
     event: ProviderEvent,
     listener: Listener,
   ): Promise<this> {
-    return this.off(event, listener);
+    return await this.off(event, listener);
   }
 
   public toJSON() {
@@ -883,7 +883,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
     includeTransactions: boolean,
   ): Promise<any> {
     if (isHexString(block, 32)) {
-      return this.#hardhatProvider.request({
+      return await this.#hardhatProvider.request({
         method: "eth_getBlockByHash",
         params: [block, includeTransactions],
       });
@@ -894,7 +894,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
       blockTag = await blockTag;
     }
 
-    return this.#hardhatProvider.request({
+    return await this.#hardhatProvider.request({
       method: "eth_getBlockByNumber",
       params: [blockTag, includeTransactions],
     });

--- a/packages/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
+++ b/packages/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
@@ -104,7 +104,7 @@ export class HardhatHelpers {
     if (typeof nameOrAbi === "string") {
       const artifact = await this.#artifactManager.readArtifact(nameOrAbi);
 
-      return this.getContractFactoryFromArtifact<A, I>(
+      return await this.getContractFactoryFromArtifact<A, I>(
         artifact,
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- bytecodeOrFactoryOptions overlaps with one of the following types
         bytecodeOrFactoryOptions as EthersT.Signer | FactoryOptions | undefined,
@@ -117,7 +117,7 @@ export class HardhatHelpers {
       "bytecode should be a string",
     );
 
-    return this.#getContractFactoryByAbiAndBytecode(
+    return await this.#getContractFactoryByAbiAndBytecode(
       nameOrAbi,
       bytecodeOrFactoryOptions,
       signer,
@@ -159,7 +159,7 @@ export class HardhatHelpers {
       libraries,
     );
 
-    return this.#getContractFactoryByAbiAndBytecode(
+    return await this.#getContractFactoryByAbiAndBytecode(
       artifact.abi,
       linkedBytecode,
       signer,
@@ -174,7 +174,7 @@ export class HardhatHelpers {
     if (typeof nameOrAbi === "string") {
       const artifact = await this.#artifactManager.readArtifact(nameOrAbi);
 
-      return this.getContractAtFromArtifact(artifact, address, signer);
+      return await this.getContractAtFromArtifact(artifact, address, signer);
     }
 
     if (signer === undefined) {
@@ -266,14 +266,14 @@ export class HardhatHelpers {
     }
 
     const factory = await this.getContractFactory(name, signerOrOptions);
-    return factory.deploy(...args, overrides);
+    return await factory.deploy(...args, overrides);
   }
 
   public async getImpersonatedSigner(
     address: string,
   ): Promise<HardhatEthersSigner> {
     await this.#provider.send("hardhat_impersonateAccount", [address]);
-    return this.getSigner(address);
+    return await this.getSigner(address);
   }
 
   #isArtifact(artifact: any): artifact is Artifact {

--- a/packages/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
+++ b/packages/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
@@ -63,7 +63,7 @@ export class HardhatHelpers {
     }
 
     const signersWithAddress = await Promise.all(
-      accounts.map((account) => this.getSigner(account)),
+      accounts.map(async (account) => await this.getSigner(account)),
     );
 
     return signersWithAddress;

--- a/packages/hardhat-ethers/src/internal/signers/deep-copy.ts
+++ b/packages/hardhat-ethers/src/internal/signers/deep-copy.ts
@@ -34,7 +34,7 @@ export async function deepCopy<T = any>(value: T): Promise<T> {
   }
 
   if (Array.isArray(value)) {
-    return deepClone(value);
+    return await deepClone(value);
   }
 
   if (isObject(value)) {

--- a/packages/hardhat-ethers/src/internal/signers/derive-private-key.ts
+++ b/packages/hardhat-ethers/src/internal/signers/derive-private-key.ts
@@ -22,7 +22,7 @@ export async function derivePrivateKeys(
   const mnemonic = await accounts.mnemonic.get();
   const passphrase = await accounts.passphrase.get();
 
-  return derivePrivateKeysImpl(
+  return await derivePrivateKeysImpl(
     mnemonic,
     accounts.path,
     accounts.initialIndex,

--- a/packages/hardhat-ethers/src/internal/signers/populate.ts
+++ b/packages/hardhat-ethers/src/internal/signers/populate.ts
@@ -35,5 +35,5 @@ export async function populate(
     pop.from = signer.getAddress();
   }
 
-  return resolveProperties(pop);
+  return await resolveProperties(pop);
 }

--- a/packages/hardhat-ethers/src/internal/signers/signers.ts
+++ b/packages/hardhat-ethers/src/internal/signers/signers.ts
@@ -112,7 +112,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
 
     const wallet = new Wallet(privateKey, this.provider);
 
-    return wallet.authorize(auth);
+    return await wallet.authorize(auth);
   }
 
   public async populateAuthorization(
@@ -149,11 +149,11 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
   }
 
   public async estimateGas(tx: TransactionRequest): Promise<bigint> {
-    return this.provider.estimateGas(await this.populateCall(tx));
+    return await this.provider.estimateGas(await this.populateCall(tx));
   }
 
   public async call(tx: TransactionRequest): Promise<string> {
-    return this.provider.call(await this.populateCall(tx));
+    return await this.provider.call(await this.populateCall(tx));
   }
 
   public resolveName(name: string): Promise<string | null> {
@@ -186,7 +186,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
     // for a response, and we need the actual transaction, so we poll
     // for it; it should show up very quickly
 
-    return new Promise((resolve) => {
+    return await new Promise((resolve) => {
       const timeouts = [1000, 100];
       const checkTx = async () => {
         // Try getting the transaction
@@ -234,7 +234,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
       },
     );
 
-    return this.provider.send("eth_signTypedData_v4", [
+    return await this.provider.send("eth_signTypedData_v4", [
       this.address.toLowerCase(),
       JSON.stringify(
         TypedDataEncoder.getPayload(populated.domain, types, populated.value),
@@ -315,7 +315,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
 
     const hexTx = getRpcTransaction(resolvedTx);
 
-    return this.provider.send("eth_sendTransaction", [hexTx]);
+    return await this.provider.send("eth_sendTransaction", [hexTx]);
   }
 
   async #getPrivateKey(): Promise<string | undefined> {
@@ -341,21 +341,21 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
       }
 
       if (Array.isArray(accounts)) {
-        return Promise.all(accounts.map((acc) => acc.get()));
+        return await Promise.all(accounts.map((acc) => acc.get()));
       }
 
       if ("mnemonic" in accounts) {
-        return derivePrivateKeys(accounts);
+        return await derivePrivateKeys(accounts);
       }
     }
 
     if (type === "edr-simulated") {
       if (Array.isArray(accounts)) {
-        return Promise.all(accounts.map((acc) => acc.privateKey.get()));
+        return await Promise.all(accounts.map((acc) => acc.privateKey.get()));
       }
 
       if ("mnemonic" in accounts) {
-        return derivePrivateKeys(accounts);
+        return await derivePrivateKeys(accounts);
       }
     }
 

--- a/packages/hardhat-ethers/src/internal/signers/signers.ts
+++ b/packages/hardhat-ethers/src/internal/signers/signers.ts
@@ -132,20 +132,20 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
     return auth;
   }
 
-  public getNonce(blockTag?: BlockTag | undefined): Promise<number> {
-    return this.provider.getTransactionCount(this.address, blockTag);
+  public async getNonce(blockTag?: BlockTag | undefined): Promise<number> {
+    return await this.provider.getTransactionCount(this.address, blockTag);
   }
 
-  public populateCall(
+  public async populateCall(
     tx: TransactionRequest,
   ): Promise<ethers.TransactionLike<string>> {
-    return populate(this, tx);
+    return await populate(this, tx);
   }
 
-  public populateTransaction(
+  public async populateTransaction(
     tx: TransactionRequest,
   ): Promise<ethers.TransactionLike<string>> {
-    return this.populateCall(tx);
+    return await this.populateCall(tx);
   }
 
   public async estimateGas(tx: TransactionRequest): Promise<bigint> {
@@ -156,8 +156,8 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
     return await this.provider.call(await this.populateCall(tx));
   }
 
-  public resolveName(name: string): Promise<string | null> {
-    return this.provider.resolveName(name);
+  public async resolveName(name: string): Promise<string | null> {
+    return await this.provider.resolveName(name);
   }
 
   public async signTransaction(_tx: TransactionRequest): Promise<string> {
@@ -208,10 +208,10 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
     });
   }
 
-  public signMessage(message: string | Uint8Array): Promise<string> {
+  public async signMessage(message: string | Uint8Array): Promise<string> {
     const resolvedMessage =
       typeof message === "string" ? toUtf8Bytes(message) : message;
-    return this.provider.send("personal_sign", [
+    return await this.provider.send("personal_sign", [
       hexlify(resolvedMessage),
       this.address.toLowerCase(),
     ]);
@@ -341,7 +341,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
       }
 
       if (Array.isArray(accounts)) {
-        return await Promise.all(accounts.map((acc) => acc.get()));
+        return await Promise.all(accounts.map(async (acc) => await acc.get()));
       }
 
       if ("mnemonic" in accounts) {
@@ -351,7 +351,9 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
 
     if (type === "edr-simulated") {
       if (Array.isArray(accounts)) {
-        return await Promise.all(accounts.map((acc) => acc.privateKey.get()));
+        return await Promise.all(
+          accounts.map(async (acc) => await acc.privateKey.get()),
+        );
       }
 
       if ("mnemonic" in accounts) {

--- a/packages/hardhat-ethers/test/contracts.ts
+++ b/packages/hardhat-ethers/test/contracts.ts
@@ -116,9 +116,9 @@ describe("contracts", () => {
     const contract = await factory.deploy();
 
     let listener: any;
-    const eventPromise = new Promise((resolve) => {
+    const eventPromise = new Promise(async (resolve) => {
       listener = resolve;
-      return contract.on("Inc", resolve);
+      return await contract.on("Inc", resolve);
     });
 
     await contract.inc();
@@ -139,8 +139,8 @@ describe("contracts", () => {
 
     const contract = await factory.deploy();
 
-    const eventPromise = new Promise((resolve) => {
-      return contract.once("Inc", resolve);
+    const eventPromise = new Promise(async (resolve) => {
+      return await contract.once("Inc", resolve);
     });
 
     await contract.inc();
@@ -162,9 +162,9 @@ describe("contracts", () => {
     const contractEvent = contract.getEvent("Inc");
 
     let listener: any;
-    const eventPromise = new Promise((resolve) => {
+    const eventPromise = new Promise(async (resolve) => {
       listener = resolve;
-      return contract.on(contractEvent, resolve);
+      return await contract.on(contractEvent, resolve);
     });
 
     await contract.inc();
@@ -186,9 +186,9 @@ describe("contracts", () => {
     const contract = await factory.deploy();
 
     let listener: any;
-    const eventPromise = new Promise((resolve) => {
+    const eventPromise = new Promise(async (resolve) => {
       listener = resolve;
-      return contract.on("IncBy", resolve);
+      return await contract.on("IncBy", resolve);
     });
 
     await contract.incBy();
@@ -211,12 +211,12 @@ describe("contracts", () => {
 
     let listener: any;
     let listenerTriggered = false;
-    const eventPromise = new Promise<void>((resolve) => {
+    const eventPromise = new Promise<void>(async (resolve) => {
       listener = () => {
         listenerTriggered = true;
         resolve();
       };
-      return contract.on("IncBy", listener);
+      return await contract.on("IncBy", listener);
     });
 
     // call a function that doesn't trigger IncBy
@@ -243,15 +243,15 @@ describe("contracts", () => {
     const contract = await factory.deploy();
 
     let listenerInc: any;
-    const incEventPromise = new Promise<void>((resolve) => {
+    const incEventPromise = new Promise<void>(async (resolve) => {
       listenerInc = resolve;
-      return contract.on("Inc", listenerInc);
+      return await contract.on("Inc", listenerInc);
     });
 
     let listenerAnotherEvent: any;
-    const anotherEventPromise = new Promise<void>((resolve) => {
+    const anotherEventPromise = new Promise<void>(async (resolve) => {
       listenerAnotherEvent = resolve;
-      return contract.on("AnotherEvent", listenerAnotherEvent);
+      return await contract.on("AnotherEvent", listenerAnotherEvent);
     });
 
     // call a function that doesn't trigger IncBy
@@ -276,14 +276,14 @@ describe("contracts", () => {
 
     let listenerInc: any;
     let timesCalled = 0;
-    const incEventPromise = new Promise<void>((resolve) => {
+    const incEventPromise = new Promise<void>(async (resolve) => {
       listenerInc = () => {
         timesCalled++;
         if (timesCalled === 2) {
           resolve();
         }
       };
-      return contract.on("Inc", listenerInc);
+      return await contract.on("Inc", listenerInc);
     });
 
     await contract.incTwice();

--- a/packages/hardhat-ethers/test/helpers/helpers.ts
+++ b/packages/hardhat-ethers/test/helpers/helpers.ts
@@ -96,7 +96,7 @@ export function assertIsSigner(
 }
 
 export async function sleep(timeout: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, timeout));
+  return await new Promise((resolve) => setTimeout(resolve, timeout));
 }
 
 export async function tryUntil(f: () => any): Promise<void> {

--- a/packages/hardhat-ethers/test/plugin-functionalities.ts
+++ b/packages/hardhat-ethers/test/plugin-functionalities.ts
@@ -107,7 +107,7 @@ describe("Ethers plugin", () => {
             if (method === "eth_accounts") {
               throw new Error("the method has been deprecated: eth_accounts");
             }
-            return originalSend.call(this, method, params);
+            return await originalSend.call(this, method, params);
           };
 
           const sigs = await ethers.getSigners();

--- a/packages/hardhat-foundry/src/index.ts
+++ b/packages/hardhat-foundry/src/index.ts
@@ -3,7 +3,7 @@ import type { HardhatPlugin } from "hardhat/types/plugins";
 const hardhatFoundry: HardhatPlugin = {
   id: "@nomicfoundation/hardhat-foundry",
   hookHandlers: {
-    solidity: () => import("./internal/hook-handlers/solidity.js"),
+    solidity: async () => await import("./internal/hook-handlers/solidity.js"),
   },
 };
 

--- a/packages/hardhat-foundry/src/internal/foundry/forge.ts
+++ b/packages/hardhat-foundry/src/internal/foundry/forge.ts
@@ -43,7 +43,7 @@ export function resetExecMock(): void {
  */
 export async function hasFoundryConfig(packagePath: string): Promise<boolean> {
   const foundryTomlPath = path.join(packagePath, "foundry.toml");
-  return exists(foundryTomlPath);
+  return await exists(foundryTomlPath);
 }
 
 /**

--- a/packages/hardhat-foundry/test/integration/solidity-hook.ts
+++ b/packages/hardhat-foundry/test/integration/solidity-hook.ts
@@ -111,7 +111,7 @@ describe("hardhat-foundry integration", () => {
       const filePath = "./contracts/Main.sol".replace(/\//g, path.sep);
 
       await assertRejectsWithHardhatError(
-        () => hre.tasks.getTask("build").run({ quiet: true }),
+        async () => await hre.tasks.getTask("build").run({ quiet: true }),
         HardhatError.ERRORS.CORE.SOLIDITY.IMPORT_RESOLUTION_ERROR,
         {
           filePath,

--- a/packages/hardhat-ignition-ethers/src/index.ts
+++ b/packages/hardhat-ignition-ethers/src/index.ts
@@ -9,7 +9,7 @@ const hardhatIgnitionEthersPlugin: HardhatPlugin = {
     import("@nomicfoundation/hardhat-ethers"),
   ],
   hookHandlers: {
-    network: () => import("./internal/hook-handlers/network.js"),
+    network: async () => await import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ignition-ethers",
 };

--- a/packages/hardhat-ignition-ethers/src/internal/ethers-ignition-helper.ts
+++ b/packages/hardhat-ignition-ethers/src/internal/ethers-ignition-helper.ts
@@ -308,7 +308,7 @@ export class EthersIgnitionHelperImpl<ChainTypeT extends ChainType | string>
     );
 
     if ("artifact" in future) {
-      return connection.ethers.getContractAt(
+      return await connection.ethers.getContractAt(
         // The abi meets the abi spec and we assume we can convert to
         // an acceptable Ethers abi
         future.artifact.abi,
@@ -316,7 +316,7 @@ export class EthersIgnitionHelperImpl<ChainTypeT extends ChainType | string>
       );
     }
 
-    return connection.ethers.getContractAt(
+    return await connection.ethers.getContractAt(
       future.contractName,
       deployedContract.address,
     );

--- a/packages/hardhat-ignition-ethers/test/deploy-with-ethers-result.ts
+++ b/packages/hardhat-ignition-ethers/test/deploy-with-ethers-result.ts
@@ -137,8 +137,8 @@ describe("deploy with ethers result", () => {
       });
 
       await assertRejectsWithHardhatError(
-        () => {
-          return connection.ignition.deploy(badModuleDefinition);
+        async () => {
+          return await connection.ignition.deploy(badModuleDefinition);
         },
         HardhatError.ERRORS.CORE.ARTIFACTS.NOT_FOUND,
         {

--- a/packages/hardhat-ignition-ethers/test/ignition-helper-exclusivity.ts
+++ b/packages/hardhat-ignition-ethers/test/ignition-helper-exclusivity.ts
@@ -50,7 +50,7 @@ describe("ignition helper mutual exclusivity", () => {
           plugins: [fakeHardhatIgnitionViemPlugin, hardhatIgnitionEthersPlugin],
         });
 
-        return hre.network.create();
+        return await hre.network.create();
       },
       HardhatError.ERRORS.IGNITION.INTERNAL
         .ONLY_ONE_IGNITION_EXTENSION_PLUGIN_ALLOWED,

--- a/packages/hardhat-ignition-viem/src/index.ts
+++ b/packages/hardhat-ignition-viem/src/index.ts
@@ -9,7 +9,7 @@ const hardhatIgnitionViemPlugin: HardhatPlugin = {
     import("@nomicfoundation/hardhat-viem"),
   ],
   hookHandlers: {
-    network: () => import("./internal/hook-handlers/network.js"),
+    network: async () => await import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ignition-viem",
 };

--- a/packages/hardhat-ignition-viem/src/internal/viem-ignition-helper.ts
+++ b/packages/hardhat-ignition-viem/src/internal/viem-ignition-helper.ts
@@ -340,7 +340,7 @@ export class ViemIgnitionHelperImpl<ChainTypeT extends ChainType | string>
     }
   }
 
-  #convertHardhatContractToViemContract(
+  async #convertHardhatContractToViemContract(
     connection: NetworkConnection<ChainTypeT>,
     future:
       | NamedArtifactContractDeploymentFuture<string>
@@ -348,7 +348,7 @@ export class ViemIgnitionHelperImpl<ChainTypeT extends ChainType | string>
       | NamedArtifactContractAtFuture<string>,
     deployedContract: { address: string },
   ): Promise<GetContractReturnType> {
-    return connection.viem.getContractAt(
+    return await connection.viem.getContractAt(
       future.contractName,
       ViemIgnitionHelperImpl.#ensureAddressFormat(deployedContract.address),
     );

--- a/packages/hardhat-ignition-viem/src/internal/viem-ignition-helper.ts
+++ b/packages/hardhat-ignition-viem/src/internal/viem-ignition-helper.ts
@@ -308,7 +308,7 @@ export class ViemIgnitionHelperImpl<ChainTypeT extends ChainType | string>
       `Expected contract future but got ${future.id} with type ${future.type} instead`,
     );
 
-    return this.#convertContractFutureToViemContract(
+    return await this.#convertContractFutureToViemContract(
       connection,
       future,
       deployedContract,
@@ -324,7 +324,7 @@ export class ViemIgnitionHelperImpl<ChainTypeT extends ChainType | string>
       case FutureType.NAMED_ARTIFACT_CONTRACT_DEPLOYMENT:
       case FutureType.NAMED_ARTIFACT_LIBRARY_DEPLOYMENT:
       case FutureType.NAMED_ARTIFACT_CONTRACT_AT:
-        return this.#convertHardhatContractToViemContract(
+        return await this.#convertHardhatContractToViemContract(
           connection,
           future,
           deployedContract,
@@ -332,7 +332,7 @@ export class ViemIgnitionHelperImpl<ChainTypeT extends ChainType | string>
       case FutureType.CONTRACT_DEPLOYMENT:
       case FutureType.LIBRARY_DEPLOYMENT:
       case FutureType.CONTRACT_AT:
-        return this.#convertArtifactToViemContract(
+        return await this.#convertArtifactToViemContract(
           connection,
           future,
           deployedContract,

--- a/packages/hardhat-ignition-viem/test/ignition-helper-exclusivity.ts
+++ b/packages/hardhat-ignition-viem/test/ignition-helper-exclusivity.ts
@@ -50,7 +50,7 @@ describe("ignition helper mutual exclusivity", () => {
           plugins: [fakeHardhatIgnitionEthersPlugin, hardhatIgnitionViemPlugin],
         });
 
-        return hre.network.create();
+        return await hre.network.create();
       },
       HardhatError.ERRORS.IGNITION.INTERNAL
         .ONLY_ONE_IGNITION_EXTENSION_PLUGIN_ALLOWED,

--- a/packages/hardhat-ignition-viem/test/viem-results.ts
+++ b/packages/hardhat-ignition-viem/test/viem-results.ts
@@ -116,8 +116,8 @@ describe("viem results", () => {
       });
 
       await assertRejectsWithHardhatError(
-        () => {
-          return connection.ignition.deploy(badModuleDefinition);
+        async () => {
+          return await connection.ignition.deploy(badModuleDefinition);
         },
         HardhatError.ERRORS.CORE.ARTIFACTS.NOT_FOUND,
         {

--- a/packages/hardhat-ignition/src/helpers/hardhat-artifact-resolver.ts
+++ b/packages/hardhat-ignition/src/helpers/hardhat-artifact-resolver.ts
@@ -34,7 +34,7 @@ export class HardhatArtifactResolver implements ArtifactResolver {
     return await readJsonFile<BuildInfo>(buildInfoPath);
   }
 
-  public loadArtifact(contractName: string): Promise<Artifact> {
-    return this.#artifactManager.readArtifact(contractName);
+  public async loadArtifact(contractName: string): Promise<Artifact> {
+    return await this.#artifactManager.readArtifact(contractName);
   }
 }

--- a/packages/hardhat-ignition/src/helpers/hardhat-artifact-resolver.ts
+++ b/packages/hardhat-ignition/src/helpers/hardhat-artifact-resolver.ts
@@ -31,7 +31,7 @@ export class HardhatArtifactResolver implements ArtifactResolver {
       return undefined;
     }
 
-    return readJsonFile<BuildInfo>(buildInfoPath);
+    return await readJsonFile<BuildInfo>(buildInfoPath);
   }
 
   public loadArtifact(contractName: string): Promise<Artifact> {

--- a/packages/hardhat-ignition/src/index.ts
+++ b/packages/hardhat-ignition/src/index.ts
@@ -11,7 +11,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
   id: PLUGIN_ID,
   npmPackage: "@nomicfoundation/hardhat-ignition",
   hookHandlers: {
-    config: () => import("./internal/hook-handlers/config.js"),
+    config: async () => await import("./internal/hook-handlers/config.js"),
   },
   dependencies: () => [import("@nomicfoundation/hardhat-verify")],
   tasks: [
@@ -63,7 +63,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         description:
           "Write deployment information to disk when deploying to the in-memory network",
       })
-      .setAction(() => import("./internal/tasks/deploy.js"))
+      .setAction(async () => await import("./internal/tasks/deploy.js"))
       .build(),
     task(["ignition", "status"], "Show the current status of a deployment")
       .addPositionalArgument({
@@ -71,10 +71,10 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "The id of the deployment to show",
       })
-      .setAction(() => import("./internal/tasks/status.js"))
+      .setAction(async () => await import("./internal/tasks/status.js"))
       .build(),
     task(["ignition", "deployments"], "List all deployment IDs")
-      .setAction(() => import("./internal/tasks/deployments.js"))
+      .setAction(async () => await import("./internal/tasks/deployments.js"))
       .build(),
     task(
       ["ignition", "transactions"],
@@ -85,7 +85,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "The id of the deployment to show transactions for",
       })
-      .setAction(() => import("./internal/tasks/transactions.js"))
+      .setAction(async () => await import("./internal/tasks/transactions.js"))
       .build(),
     task(["ignition", "wipe"], "Reset a deployment's future to allow rerunning")
       .addPositionalArgument({
@@ -98,7 +98,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "The id of the future to wipe",
       })
-      .setAction(() => import("./internal/tasks/wipe.js"))
+      .setAction(async () => await import("./internal/tasks/wipe.js"))
       .build(),
     task(["ignition", "visualize"], "Visualize a module as an HTML report")
       .addPositionalArgument({
@@ -110,7 +110,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         name: "noOpen",
         description: "Disables opening report in browser",
       })
-      .setAction(() => import("./internal/tasks/visualize.js"))
+      .setAction(async () => await import("./internal/tasks/visualize.js"))
       .build(),
 
     task(
@@ -126,7 +126,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         name: "force",
         description: "Force verification",
       })
-      .setAction(() => import("./internal/tasks/verify.js"))
+      .setAction(async () => await import("./internal/tasks/verify.js"))
       .build(),
     task(
       ["ignition", "track-tx"],
@@ -142,7 +142,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "The id of the deployment to add the tx to",
       })
-      .setAction(() => import("./internal/tasks/track-tx.js"))
+      .setAction(async () => await import("./internal/tasks/track-tx.js"))
       .build(),
     task(
       ["ignition", "migrate"],
@@ -153,7 +153,7 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "The id of the deployment to migrate",
       })
-      .setAction(() => import("./internal/tasks/migrate.js"))
+      .setAction(async () => await import("./internal/tasks/migrate.js"))
       .build(),
   ],
 };

--- a/packages/hardhat-ignition/src/internal/tasks/deploy.ts
+++ b/packages/hardhat-ignition/src/internal/tasks/deploy.ts
@@ -273,7 +273,7 @@ async function resolveParametersFromModuleName(
   const configFilename = `${moduleName}.config.json`;
 
   return files.includes(configFilename)
-    ? readDeploymentParameters(path.resolve(ignitionPath, configFilename))
+    ? await readDeploymentParameters(path.resolve(ignitionPath, configFilename))
     : undefined;
 }
 
@@ -282,7 +282,7 @@ async function resolveParametersFromFileName(
 ): Promise<DeploymentParameters> {
   const filepath = path.resolve(process.cwd(), fileName);
 
-  return readDeploymentParameters(filepath);
+  return await readDeploymentParameters(filepath);
 }
 
 async function resolveParametersString(

--- a/packages/hardhat-ignition/test/deploy/build-profile.ts
+++ b/packages/hardhat-ignition/test/deploy/build-profile.ts
@@ -32,7 +32,7 @@ describe("build profile", function () {
               default: async (args, _hre, runSuper) => {
                 defaultBuildProfile = args.defaultBuildProfile;
 
-                return runSuper(args);
+                return await runSuper(args);
               },
             }))
             .build(),

--- a/packages/hardhat-ignition/test/test-helpers/mine-block.ts
+++ b/packages/hardhat-ignition/test/test-helpers/mine-block.ts
@@ -3,5 +3,5 @@ import type { NetworkConnection } from "hardhat/types/network";
 export async function mineBlock(
   connection: NetworkConnection<string>,
 ): Promise<any> {
-  return connection.provider.request({ method: "evm_mine", params: [] });
+  return await connection.provider.request({ method: "evm_mine", params: [] });
 }

--- a/packages/hardhat-ignition/test/test-helpers/sleep.ts
+++ b/packages/hardhat-ignition/test/test-helpers/sleep.ts
@@ -1,2 +1,2 @@
-export const sleep = (timeout: number): Promise<void> =>
-  new Promise((res) => setTimeout(res, timeout));
+export const sleep = async (timeout: number): Promise<void> =>
+  await new Promise((res) => setTimeout(res, timeout));

--- a/packages/hardhat-ignition/test/test-helpers/test-ignition-helper.ts
+++ b/packages/hardhat-ignition/test/test-helpers/test-ignition-helper.ts
@@ -127,7 +127,7 @@ export class TestIgnitionHelper {
       transport: custom(this._connection.provider),
     });
 
-    return this._toViemContracts(
+    return await this._toViemContracts(
       this._hre,
       ignitionModule,
       result,

--- a/packages/hardhat-ignition/test/test-helpers/use-ignition-project.ts
+++ b/packages/hardhat-ignition/test/test-helpers/use-ignition-project.ts
@@ -323,7 +323,7 @@ export class TestChainHelper {
       );
     }
 
-    return mineBlock(this._connection);
+    return await mineBlock(this._connection);
   }
 
   public async clearMempool(pendingTxToAwait: number = 0): Promise<void> {
@@ -335,11 +335,11 @@ export class TestChainHelper {
       );
     }
 
-    return clearPendingTransactionsFromMemoryPool(this._connection);
+    return await clearPendingTransactionsFromMemoryPool(this._connection);
   }
 
   public async setNextBlockBaseFeePerGas(fee: bigint): Promise<void> {
-    return this._connection.networkHelpers.setNextBlockBaseFeePerGas(fee);
+    return await this._connection.networkHelpers.setNextBlockBaseFeePerGas(fee);
   }
 
   /**
@@ -366,7 +366,7 @@ class ProxyProvider extends EventEmitter implements EthereumProvider {
       throw new Error("Killing deploy process");
     }
 
-    return this.#provider.request(requestArguments);
+    return await this.#provider.request(requestArguments);
   }
 
   public async close(): Promise<void> {
@@ -375,7 +375,7 @@ class ProxyProvider extends EventEmitter implements EthereumProvider {
       throw new Error("Killing deploy process");
     }
 
-    return this.#provider.close();
+    return await this.#provider.close();
   }
 
   public async send(method: string, params?: unknown[]): Promise<any> {
@@ -384,7 +384,7 @@ class ProxyProvider extends EventEmitter implements EthereumProvider {
       throw new Error("Killing deploy process");
     }
 
-    return this.#provider.send(method, params);
+    return await this.#provider.send(method, params);
   }
 
   public async sendAsync(jsonRpcRequest: any, callback: any): Promise<any> {

--- a/packages/hardhat-ignition/test/test-helpers/use-ignition-project.ts
+++ b/packages/hardhat-ignition/test/test-helpers/use-ignition-project.ts
@@ -2,6 +2,7 @@ import type {
   DeployConfig,
   IgnitionModule,
 } from "@nomicfoundation/ignition-core";
+import type {} from "mocha";
 import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
 import type { NetworkConnection } from "hardhat/types/network";
 import type {
@@ -28,7 +29,6 @@ import { waitForPendingTxs } from "./wait-for-pending-txs.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-import "mocha";
 declare module "mocha" {
   interface Context {
     hre: HardhatRuntimeEnvironment;

--- a/packages/hardhat-ignition/test/test-helpers/use-ignition-project.ts
+++ b/packages/hardhat-ignition/test/test-helpers/use-ignition-project.ts
@@ -28,6 +28,7 @@ import { waitForPendingTxs } from "./wait-for-pending-txs.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+import "mocha";
 declare module "mocha" {
   interface Context {
     hre: HardhatRuntimeEnvironment;
@@ -197,11 +198,11 @@ export function useFileIgnitionProject(
 
     await ensureDir(deploymentDir);
 
-    this.runControlledDeploy = (
+    this.runControlledDeploy = async (
       ignitionModule: IgnitionModule,
       chainUpdates: (c: TestChainHelper) => Promise<void> = async () => {},
     ) => {
-      return runDeploy(
+      return await runDeploy(
         deploymentDir,
         ignitionModule,
         { hre, connection, config: testConfig },
@@ -236,7 +237,7 @@ async function runDeploy(
     config?: Partial<DeployConfig>;
   },
   chainUpdates: (c: TestChainHelper) => Promise<void> = async () => {},
-): Promise<ReturnType<TestIgnitionHelper["deploy"]>> {
+): ReturnType<TestIgnitionHelper["deploy"]> {
   const { ignitionHelper, kill: killFn } = setupIgnitionHelperRiggedToThrow(
     hre,
     connection,

--- a/packages/hardhat-ignition/test/test-helpers/wait-for-pending-txs.ts
+++ b/packages/hardhat-ignition/test/test-helpers/wait-for-pending-txs.ts
@@ -1,7 +1,7 @@
 import type { NetworkConnection } from "hardhat/types/network";
 
-const sleep = (timeout: number) =>
-  new Promise((res) => setTimeout(res, timeout));
+const sleep = async (timeout: number) =>
+  await new Promise((res) => setTimeout(res, timeout));
 
 /**
  * Wait until there are at least `expectedCount` transactions in the mempool

--- a/packages/hardhat-keystore/src/index.ts
+++ b/packages/hardhat-keystore/src/index.ts
@@ -10,9 +10,9 @@ import { PLUGIN_ID } from "./internal/constants.js";
 const hardhatKeystorePlugin: HardhatPlugin = {
   id: PLUGIN_ID,
   hookHandlers: {
-    config: () => import("./internal/hook-handlers/config.js"),
-    configurationVariables: () =>
-      import("./internal/hook-handlers/configuration-variables.js"),
+    config: async () => await import("./internal/hook-handlers/config.js"),
+    configurationVariables: async () =>
+      await import("./internal/hook-handlers/configuration-variables.js"),
   },
   tasks: [
     emptyTask("keystore", "Store keys in an encrypted storage").build(),
@@ -35,7 +35,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         description:
           "Use the development keystore instead of the production one",
       })
-      .setAction(() => import("./internal/tasks/set.js"))
+      .setAction(async () => await import("./internal/tasks/set.js"))
       .build(),
 
     task(["keystore", "get"], "Get a value given a key")
@@ -49,7 +49,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         type: ArgumentType.STRING,
         description: "Specify the key to retrieve the value for",
       })
-      .setAction(() => import("./internal/tasks/get.js"))
+      .setAction(async () => await import("./internal/tasks/get.js"))
       .build(),
 
     task(["keystore", "list"], "List all keys in the keystore")
@@ -58,7 +58,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         description:
           "Use the development keystore instead of the production one",
       })
-      .setAction(() => import("./internal/tasks/list.js"))
+      .setAction(async () => await import("./internal/tasks/list.js"))
       .build(),
 
     task(["keystore", "delete"], "Delete a key from the keystore")
@@ -77,7 +77,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         description:
           "Force to not throw an error if the key does not exist during deletion.",
       })
-      .setAction(() => import("./internal/tasks/delete.js"))
+      .setAction(async () => await import("./internal/tasks/delete.js"))
       .build(),
 
     task(["keystore", "rename"], "Rename a key in the keystore")
@@ -100,7 +100,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         name: "force",
         description: "Force overwrite if the new key already exists.",
       })
-      .setAction(() => import("./internal/tasks/rename.js"))
+      .setAction(async () => await import("./internal/tasks/rename.js"))
       .build(),
 
     task(["keystore", "path"], "Display the path where the keystore is stored")
@@ -109,7 +109,7 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         description:
           "Use the development keystore instead of the production one",
       })
-      .setAction(() => import("./internal/tasks/path.js"))
+      .setAction(async () => await import("./internal/tasks/path.js"))
       .build(),
 
     task(
@@ -121,7 +121,9 @@ const hardhatKeystorePlugin: HardhatPlugin = {
         description:
           "Use the development keystore instead of the production one",
       })
-      .setAction(() => import("./internal/tasks/change-password.js"))
+      .setAction(
+        async () => await import("./internal/tasks/change-password.js"),
+      )
       .build(),
   ],
   npmPackage: "@nomicfoundation/hardhat-keystore",

--- a/packages/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
+++ b/packages/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
@@ -29,7 +29,7 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
       // If we are in CI, the keystore should not be used
       // or even initialized
       if (isCi()) {
-        return next(context, variable);
+        return await next(context, variable);
       }
 
       // First try to get the value from the development keystore
@@ -58,7 +58,7 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
         return value;
       }
 
-      return next(context, variable);
+      return await next(context, variable);
     },
   };
 
@@ -112,7 +112,7 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
       return undefined;
     }
 
-    return keystore.readValue(variable.name, masterKey);
+    return await keystore.readValue(variable.name, masterKey);
   }
 
   return handlers;

--- a/packages/hardhat-keystore/src/internal/keystores/password.ts
+++ b/packages/hardhat-keystore/src/internal/keystores/password.ts
@@ -24,8 +24,10 @@ export function getPasswordHandlers(
 } {
   if (isDevKeystore) {
     return {
-      setUpPassword: () => setUpPasswordForDevKeystore(devPasswordFilePath),
-      askPassword: () => askPasswordForDevKeystore(devPasswordFilePath),
+      setUpPassword: async () =>
+        await setUpPasswordForDevKeystore(devPasswordFilePath),
+      askPassword: async () =>
+        await askPasswordForDevKeystore(devPasswordFilePath),
       setNewPassword: () => {
         throw new HardhatError(
           HardhatError.ERRORS.HARDHAT_KEYSTORE.GENERAL.CANNOT_CHANGED_PASSWORD_FOR_DEV_KEYSTORE,
@@ -35,9 +37,11 @@ export function getPasswordHandlers(
   }
 
   return {
-    setUpPassword: () => setUpPassword(requestSecretInput, consoleLog),
-    askPassword: () => askPassword(requestSecretInput),
-    setNewPassword: () => setNewPassword(requestSecretInput, consoleLog),
+    setUpPassword: async () =>
+      await setUpPassword(requestSecretInput, consoleLog),
+    askPassword: async () => await askPassword(requestSecretInput),
+    setNewPassword: async () =>
+      await setNewPassword(requestSecretInput, consoleLog),
   };
 }
 
@@ -78,7 +82,10 @@ export async function setNewPassword(
 export async function askPassword(
   requestSecretInput: KeystoreRequestSecretInput,
 ): Promise<string> {
-  return await requestSecretInput(PLUGIN_ID, UserDisplayMessages.enterPasswordMsg());
+  return await requestSecretInput(
+    PLUGIN_ID,
+    UserDisplayMessages.enterPasswordMsg(),
+  );
 }
 
 export async function askPasswordForDevKeystore(

--- a/packages/hardhat-keystore/src/internal/keystores/password.ts
+++ b/packages/hardhat-keystore/src/internal/keystores/password.ts
@@ -51,7 +51,7 @@ export async function setUpPassword(
   consoleLog(UserDisplayMessages.passwordRequirementsMessage());
   consoleLog("");
 
-  return createPassword(requestSecretInput, consoleLog);
+  return await createPassword(requestSecretInput, consoleLog);
 }
 
 export async function setUpPasswordForDevKeystore(
@@ -72,19 +72,19 @@ export async function setNewPassword(
   consoleLog(UserDisplayMessages.passwordRequirementsMessage());
   consoleLog("");
 
-  return createPassword(requestSecretInput, consoleLog);
+  return await createPassword(requestSecretInput, consoleLog);
 }
 
 export async function askPassword(
   requestSecretInput: KeystoreRequestSecretInput,
 ): Promise<string> {
-  return requestSecretInput(PLUGIN_ID, UserDisplayMessages.enterPasswordMsg());
+  return await requestSecretInput(PLUGIN_ID, UserDisplayMessages.enterPasswordMsg());
 }
 
 export async function askPasswordForDevKeystore(
   devPasswordFilePath: string,
 ): Promise<string> {
-  return readUtf8File(devPasswordFilePath);
+  return await readUtf8File(devPasswordFilePath);
 }
 
 async function createPassword(

--- a/packages/hardhat-keystore/src/internal/loaders/file-manager.ts
+++ b/packages/hardhat-keystore/src/internal/loaders/file-manager.ts
@@ -20,7 +20,7 @@ export class FileManagerImpl implements FileManager {
     // First write to a temporary file, then move it to minimize the risk of file corruption
     const tmpPath = `${absolutePathToFile}.tmp`;
     await writeJsonFile(tmpPath, keystoreFile);
-    return move(tmpPath, absolutePathToFile);
+    return await move(tmpPath, absolutePathToFile);
   }
 
   public readJsonFile(absolutePathToFile: string): Promise<EncryptedKeystore> {

--- a/packages/hardhat-keystore/src/internal/loaders/file-manager.ts
+++ b/packages/hardhat-keystore/src/internal/loaders/file-manager.ts
@@ -9,8 +9,8 @@ import {
 } from "@nomicfoundation/hardhat-utils/fs";
 
 export class FileManagerImpl implements FileManager {
-  public fileExists(absolutePath: string): Promise<boolean> {
-    return exists(absolutePath);
+  public async fileExists(absolutePath: string): Promise<boolean> {
+    return await exists(absolutePath);
   }
 
   public async writeJsonFile(
@@ -23,7 +23,9 @@ export class FileManagerImpl implements FileManager {
     return await move(tmpPath, absolutePathToFile);
   }
 
-  public readJsonFile(absolutePathToFile: string): Promise<EncryptedKeystore> {
-    return readJsonFile(absolutePathToFile);
+  public async readJsonFile(
+    absolutePathToFile: string,
+  ): Promise<EncryptedKeystore> {
+    return await readJsonFile(absolutePathToFile);
   }
 }

--- a/packages/hardhat-keystore/src/internal/loaders/keystore-file-loader.ts
+++ b/packages/hardhat-keystore/src/internal/loaders/keystore-file-loader.ts
@@ -36,7 +36,7 @@ export class KeystoreFileLoader implements KeystoreLoader {
       return true;
     }
 
-    return this.#fileManager.fileExists(this.#keystoreFilePath);
+    return await this.#fileManager.fileExists(this.#keystoreFilePath);
   }
 
   public async loadKeystore(): Promise<Keystore> {

--- a/packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts
+++ b/packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts
@@ -307,8 +307,8 @@ describe("hook-handlers - configuration variables - fetchValue", () => {
 
       it("should throw an error if the keystore is executed in test mode and the key is not in the development keystore", async () => {
         await assertRejectsWithHardhatError(
-          () =>
-            hre.hooks.runHandlerChain(
+          async () =>
+            await hre.hooks.runHandlerChain(
               "configurationVariables",
               "fetchValue",
               [exampleConfigurationVariable3],
@@ -327,8 +327,8 @@ describe("hook-handlers - configuration variables - fetchValue", () => {
         await remove(configurationVariableDevKeystoreFilePath);
 
         await assertRejectsWithHardhatError(
-          () =>
-            hre.hooks.runHandlerChain(
+          async () =>
+            await hre.hooks.runHandlerChain(
               "configurationVariables",
               "fetchValue",
               [exampleConfigurationVariable3],

--- a/packages/hardhat-keystore/test/integration/tasks.ts
+++ b/packages/hardhat-keystore/test/integration/tasks.ts
@@ -120,23 +120,26 @@ describe("integration tests for the keystore tasks", () => {
 
       it("should display the value on a `npx hardhat keystore get`", async () => {
         await _assertConsoleOutputMatchesFor(
-          () =>
-            hre.tasks.getTask(["keystore", "get"]).run({ dev, key: "myKey1" }),
+          async () =>
+            await hre.tasks
+              .getTask(["keystore", "get"])
+              .run({ dev, key: "myKey1" }),
           "myValue1\n",
         );
       });
 
       it("should display the list of keys on `npx hardhat keystore list`", async () => {
         await _assertConsoleOutputMatchesFor(
-          () => hre.tasks.getTask(["keystore", "list"]).run({ dev }),
+          async () =>
+            await hre.tasks.getTask(["keystore", "list"]).run({ dev }),
           `Keys in the ${getKeystoreType(dev)} keystore:\nmyKey1\nmyKey2\n\n`,
         );
       });
 
       it("should display the delete the key on `npx hardhat keystore delete myKey1`", async () => {
         await _assertConsoleOutputMatchesFor(
-          () =>
-            hre.tasks
+          async () =>
+            await hre.tasks
               .getTask(["keystore", "delete"])
               .run({ dev, key: "myKey1" }),
           `Key "myKey1" deleted from the ${getKeystoreType(dev)} keystore\n`,
@@ -145,8 +148,8 @@ describe("integration tests for the keystore tasks", () => {
 
       it("should set a value on a `npx hardhat keystore set`", async () => {
         await _assertConsoleOutputMatchesFor(
-          () =>
-            hre.tasks
+          async () =>
+            await hre.tasks
               .getTask(["keystore", "set"])
               .run({ dev, key: "myNewKey" }),
           `Key "myNewKey" set in the ${getKeystoreType(dev)} keystore\n`,
@@ -155,7 +158,8 @@ describe("integration tests for the keystore tasks", () => {
 
       it("should show the keystore path", async () => {
         await _assertConsoleOutputMatchesFor(
-          () => hre.tasks.getTask(["keystore", "path"]).run({ dev }),
+          async () =>
+            await hre.tasks.getTask(["keystore", "path"]).run({ dev }),
           `${keystoreFilePath}\n`,
         );
       });
@@ -165,8 +169,10 @@ describe("integration tests for the keystore tasks", () => {
         { skip: !dev },
         async () => {
           await assertRejectsWithHardhatError(
-            () =>
-              hre.tasks.getTask(["keystore", "change-password"]).run({ dev }),
+            async () =>
+              await hre.tasks
+                .getTask(["keystore", "change-password"])
+                .run({ dev }),
             HardhatError.ERRORS.HARDHAT_KEYSTORE.GENERAL
               .CANNOT_CHANGED_PASSWORD_FOR_DEV_KEYSTORE,
             {},
@@ -194,7 +200,8 @@ describe("integration tests for the keystore tasks", () => {
         });
 
         await _assertConsoleOutputMatchesFor(
-          () => tmpHre.tasks.getTask(["keystore", "change-password"]).run(),
+          async () =>
+            await tmpHre.tasks.getTask(["keystore", "change-password"]).run(),
           "Unlock the production keystore using your current password before proceeding with the password change.\n" +
             "Change your password.\n" +
             "The password must have at least 8 characters.\n" +
@@ -216,16 +223,18 @@ describe("integration tests for the keystore tasks", () => {
 
         // Check that the keystore with the new password is working as expected
         await _assertConsoleOutputMatchesFor(
-          () =>
-            tmpHre.tasks.getTask(["keystore", "get"]).run({ key: "myKey1" }),
+          async () =>
+            await tmpHre.tasks
+              .getTask(["keystore", "get"])
+              .run({ key: "myKey1" }),
           "myValue1\n",
         );
       });
 
       it("should rename a key on `npx hardhat keystore rename myKey1 renamedKey`", async () => {
         await _assertConsoleOutputMatchesFor(
-          () =>
-            hre.tasks
+          async () =>
+            await hre.tasks
               .getTask(["keystore", "rename"])
               .run({ dev, oldKey: "myKey1", newKey: "renamedKey" }),
           `Key "myKey1" renamed to "renamedKey" in the ${getKeystoreType(dev)} keystore\n`,

--- a/packages/hardhat-ledger/src/index.ts
+++ b/packages/hardhat-ledger/src/index.ts
@@ -7,8 +7,8 @@ import { PLUGIN_NAME } from "./internal/plugin-name.js";
 const hardhatLedgerPlugin: HardhatPlugin = {
   id: PLUGIN_NAME,
   hookHandlers: {
-    config: () => import("./internal/hook-handlers/config.js"),
-    network: () => import("./internal/hook-handlers/network.js"),
+    config: async () => await import("./internal/hook-handlers/config.js"),
+    network: async () => await import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ledger",
 };

--- a/packages/hardhat-ledger/src/internal/handler.ts
+++ b/packages/hardhat-ledger/src/internal/handler.ts
@@ -218,13 +218,13 @@ export class LedgerHandler {
 
         const path = await this.#derivePath(address);
 
-        const signature = await this.#withConfirmation(() => {
+        const signature = await this.#withConfirmation(async () => {
           assertHardhatInvariant(
             this.#eth !== undefined,
             "Ledger handler should have initialized the eth instance",
           );
 
-          return this.#eth.signPersonalMessage(
+          return await this.#eth.signPersonalMessage(
             path,
             bytesToHexString(data).replace("0x", ""),
           );
@@ -626,13 +626,13 @@ export class LedgerHandler {
 
         const path = await this.#derivePath(address);
 
-        const signature = await this.#withConfirmation(() => {
+        const signature = await this.#withConfirmation(async () => {
           assertHardhatInvariant(
             this.#eth !== undefined,
             "Ledger handler should have initialized the eth instance",
           );
 
-          return this.#eth.signPersonalMessage(
+          return await this.#eth.signPersonalMessage(
             path,
             bytesToHexString(data).replace("0x", ""),
           );
@@ -700,7 +700,11 @@ export class LedgerHandler {
       try {
         return await this.#eth.signEIP712Message(path, typedMessage);
       } catch (_error) {
-        return await this.#eth.signEIP712HashedMessage(path, domainHash, structHash);
+        return await this.#eth.signEIP712HashedMessage(
+          path,
+          domainHash,
+          structHash,
+        );
       }
     });
 
@@ -788,13 +792,13 @@ export class LedgerHandler {
 
     const resolution = await ledgerService.resolveTransaction(txToSign, {}, {});
 
-    const signature = await this.#withConfirmation(() => {
+    const signature = await this.#withConfirmation(async () => {
       assertHardhatInvariant(
         this.#eth !== undefined,
         "Ledger handler should have initialized the eth instance",
       );
 
-      return this.#eth.signTransaction(path, txToSign, resolution);
+      return await this.#eth.signTransaction(path, txToSign, resolution);
     });
 
     const signedTx = new microEthSigner.Transaction(unsignedTx.type, {

--- a/packages/hardhat-ledger/src/internal/handler.ts
+++ b/packages/hardhat-ledger/src/internal/handler.ts
@@ -230,7 +230,7 @@ export class LedgerHandler {
           );
         });
 
-        return this.#toRpcSig(signature);
+        return await this.#toRpcSig(signature);
       }
     }
   }
@@ -292,7 +292,7 @@ export class LedgerHandler {
           );
           await this.#delayBeforeRetry(delay);
 
-          return this.init(retryAttempts + 1);
+          return await this.init(retryAttempts + 1);
         }
 
         // Give up - either not a retryable error or exhausted retries
@@ -375,7 +375,7 @@ export class LedgerHandler {
         await this.#resetConnection();
         await this.init();
 
-        return this.#derivePath(addressToFindAsBuffer, {
+        return await this.#derivePath(addressToFindAsBuffer, {
           ...retryState,
           reconnection: retryState.reconnection + 1,
         });
@@ -394,7 +394,7 @@ export class LedgerHandler {
           LedgerHandler.DEVICE_NOT_READY_RETRY_DELAY_SECONDS,
         );
 
-        return this.#derivePath(addressToFindAsBuffer, {
+        return await this.#derivePath(addressToFindAsBuffer, {
           ...retryState,
           deviceNotReady: retryState.deviceNotReady + 1,
         });
@@ -541,7 +541,7 @@ export class LedgerHandler {
         await this.#resetConnection();
         await this.init();
 
-        return this.#withConfirmation(func, {
+        return await this.#withConfirmation(func, {
           ...retryState,
           reconnection: retryState.reconnection + 1,
         });
@@ -560,7 +560,7 @@ export class LedgerHandler {
           LedgerHandler.DEVICE_NOT_READY_RETRY_DELAY_SECONDS,
         );
 
-        return this.#withConfirmation(func, {
+        return await this.#withConfirmation(func, {
           ...retryState,
           deviceNotReady: retryState.deviceNotReady + 1,
         });
@@ -638,7 +638,7 @@ export class LedgerHandler {
           );
         });
 
-        return this.#toRpcSig(signature);
+        return await this.#toRpcSig(signature);
       }
     }
   }
@@ -700,11 +700,11 @@ export class LedgerHandler {
       try {
         return await this.#eth.signEIP712Message(path, typedMessage);
       } catch (_error) {
-        return this.#eth.signEIP712HashedMessage(path, domainHash, structHash);
+        return await this.#eth.signEIP712HashedMessage(path, domainHash, structHash);
       }
     });
 
-    return this.#toRpcSig(signature);
+    return await this.#toRpcSig(signature);
   }
 
   async #ethSendTransaction(params: any[]): Promise<{

--- a/packages/hardhat-ledger/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-ledger/src/internal/hook-handlers/config.ts
@@ -6,7 +6,7 @@ import { validateLedgerUserConfig } from "../config/validate-ledger-user-config.
 export default async (): Promise<Partial<ConfigHooks>> => {
   const handlers: Partial<ConfigHooks> = {
     validateUserConfig: async (userConfig) =>
-      validateLedgerUserConfig(userConfig),
+      await validateLedgerUserConfig(userConfig),
     resolveUserConfig: async (
       userConfig,
       resolveConfigurationVariable,

--- a/packages/hardhat-ledger/src/internal/hook-handlers/network.ts
+++ b/packages/hardhat-ledger/src/internal/hook-handlers/network.ts
@@ -39,7 +39,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
       ) {
         // Allow these methods to pass through untouched.
         // The ledger handler calls them directly, so intercepting them here would lead to infinite recursion.
-        return next(context, networkConnection, jsonRpcRequest);
+        return await next(context, networkConnection, jsonRpcRequest);
       }
 
       const ledgerHandler = await initializationMutex.exclusiveRun(async () => {
@@ -104,7 +104,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         return newRequestOrResponse;
       }
 
-      return next(context, networkConnection, newRequestOrResponse);
+      return await next(context, networkConnection, newRequestOrResponse);
     },
 
     async closeConnection<ChainTypeT extends ChainType | string>(
@@ -119,7 +119,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         ledgerHandlerPerConnection.delete(networkConnection);
       }
 
-      return next(context, networkConnection);
+      return await next(context, networkConnection);
     },
   };
 

--- a/packages/hardhat-ledger/test/helpers/ethereum-provider-mock.ts
+++ b/packages/hardhat-ledger/test/helpers/ethereum-provider-mock.ts
@@ -73,8 +73,8 @@ export class EthereumMockedProvider
     return ret;
   }
 
-  public send(_method: string, _params?: unknown[]): Promise<unknown> {
-    return Promise.resolve(null);
+  public async send(_method: string, _params?: unknown[]): Promise<unknown> {
+    return await Promise.resolve(null);
   }
 
   public sendAsync(

--- a/packages/hardhat-ledger/test/internal/handler.ts
+++ b/packages/hardhat-ledger/test/internal/handler.ts
@@ -305,7 +305,7 @@ describe("LedgerHandler", () => {
           if (createCallCount <= 2) {
             throw new TransportError("No Ledger device found", "NoDeviceFound");
           }
-          return originalCreate(...args);
+          return await originalCreate(...args);
         };
 
         ledgerHandler = new LedgerHandler(

--- a/packages/hardhat-ledger/test/internal/handler.ts
+++ b/packages/hardhat-ledger/test/internal/handler.ts
@@ -221,7 +221,7 @@ describe("LedgerHandler", () => {
       );
 
       await assertRejectsWithHardhatError(
-        () => ledgerHandler.init(),
+        async () => await ledgerHandler.init(),
         HardhatError.ERRORS.HARDHAT_LEDGER.GENERAL.CONNECTION_ERROR,
         {
           error,
@@ -254,7 +254,7 @@ describe("LedgerHandler", () => {
       );
 
       await assertRejectsWithHardhatError(
-        () => ledgerHandler.init(),
+        async () => await ledgerHandler.init(),
         HardhatError.ERRORS.HARDHAT_LEDGER.GENERAL.CONNECTION_ERROR,
         {
           error,
@@ -378,7 +378,7 @@ describe("LedgerHandler", () => {
         mockedDisplayInfo.clear();
 
         await assertRejectsWithHardhatError(
-          () => ledgerHandler.init(),
+          async () => await ledgerHandler.init(),
           HardhatError.ERRORS.HARDHAT_LEDGER.GENERAL.CONNECTION_ERROR,
           {
             error: transportError,
@@ -1138,7 +1138,7 @@ describe("LedgerHandler", () => {
         );
 
         await assertRejectsWithHardhatError(
-          () => ledgerHandler.handle(request),
+          async () => await ledgerHandler.handle(request),
           HardhatError.ERRORS.HARDHAT_LEDGER.GENERAL.ERROR_WHILE_DERIVING_PATH,
           {
             path: "m/44'/60'/0'/0/0",
@@ -1172,7 +1172,7 @@ describe("LedgerHandler", () => {
         );
 
         await assertRejectsWithHardhatError(
-          () => ledgerHandler.handle(request),
+          async () => await ledgerHandler.handle(request),
           HardhatError.ERRORS.HARDHAT_LEDGER.GENERAL
             .CANNOT_FIND_VALID_DERIVATION_PATH,
           {
@@ -1279,7 +1279,7 @@ describe("LedgerHandler", () => {
         ]);
 
         await assertRejects(
-          () => ledgerHandler.handle(request),
+          async () => await ledgerHandler.handle(request),
           (error) => error instanceof DisconnectedDevice,
           "Expected DisconnectedDevice error after exhausted retries",
         );
@@ -1641,7 +1641,7 @@ describe("LedgerHandler", () => {
         ]);
 
         await assertRejectsWithHardhatError(
-          () => ledgerHandler.handle(request),
+          async () => await ledgerHandler.handle(request),
           HardhatError.ERRORS.HARDHAT_LEDGER.GENERAL.LOCKED_DEVICE,
           {},
         );
@@ -1932,7 +1932,7 @@ describe("LedgerHandler", () => {
         ]);
 
         await assertRejectsWithHardhatError(
-          () => ledgerHandler.handle(request),
+          async () => await ledgerHandler.handle(request),
           HardhatError.ERRORS.HARDHAT_LEDGER.GENERAL.LOCKED_DEVICE,
           {},
         );

--- a/packages/hardhat-ledger/test/mocked-network-plugin.ts
+++ b/packages/hardhat-ledger/test/mocked-network-plugin.ts
@@ -32,7 +32,7 @@ const mockedNetworkPlugin: HardhatPlugin = {
             };
           }
 
-          return next(context, networkConnection, jsonRpcRequest);
+          return await next(context, networkConnection, jsonRpcRequest);
         },
       }),
     }),

--- a/packages/hardhat-mocha/src/hookHandlers/test.ts
+++ b/packages/hardhat-mocha/src/hookHandlers/test.ts
@@ -26,7 +26,7 @@ export default async (): Promise<Partial<TestHooks>> => {
         return "mocha";
       }
 
-      return next(context, filePath);
+      return await next(context, filePath);
     },
   };
 

--- a/packages/hardhat-mocha/src/index.ts
+++ b/packages/hardhat-mocha/src/index.ts
@@ -28,12 +28,12 @@ const hardhatPlugin: HardhatPlugin = {
         name: "noCompile",
         description: "Don't compile the project before running the tests",
       })
-      .setAction(() => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   hookHandlers: {
-    config: () => import("./hookHandlers/config.js"),
-    test: () => import("./hookHandlers/test.js"),
+    config: async () => await import("./hookHandlers/config.js"),
+    test: async () => await import("./hookHandlers/test.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-mocha",
 };

--- a/packages/hardhat-mocha/src/task-action.ts
+++ b/packages/hardhat-mocha/src/task-action.ts
@@ -57,7 +57,7 @@ async function getTestFiles(
     return testFilesAbsolutePaths;
   }
 
-  return getAllFilesMatching(
+  return await getAllFilesMatching(
     config.paths.tests.mocha,
     (f) => isJavascriptFile(f) || isTypescriptFile(f),
   );

--- a/packages/hardhat-network-helpers/src/index.ts
+++ b/packages/hardhat-network-helpers/src/index.ts
@@ -5,7 +5,7 @@ import type { HardhatPlugin } from "hardhat/types/plugins";
 const hardhatNetworkHelpersPlugin: HardhatPlugin = {
   id: "hardhat-network-helpers",
   hookHandlers: {
-    network: () => import("./internal/hook-handlers/network.js"),
+    network: async () => await import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-network-helpers",
 };

--- a/packages/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
+++ b/packages/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
@@ -64,7 +64,7 @@ export class NetworkHelpers<ChainTypeT extends ChainType | string>
 
   public async dropTransaction(txHash: string): Promise<boolean> {
     await this.throwIfNotDevelopmentNetwork();
-    return dropTransaction(this.#provider, txHash);
+    return await dropTransaction(this.#provider, txHash);
   }
 
   public async getStorageAt(
@@ -73,12 +73,12 @@ export class NetworkHelpers<ChainTypeT extends ChainType | string>
     block: NumberLike | BlockTag = "latest",
   ): Promise<string> {
     await this.throwIfNotDevelopmentNetwork();
-    return getStorageAt(this.#provider, address, index, block);
+    return await getStorageAt(this.#provider, address, index, block);
   }
 
   public async impersonateAccount(address: string): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return impersonateAccount(this.#provider, address);
+    return await impersonateAccount(this.#provider, address);
   }
 
   public async loadFixture<T>(fixture: Fixture<T, ChainTypeT>): Promise<T> {
@@ -101,49 +101,49 @@ export class NetworkHelpers<ChainTypeT extends ChainType | string>
     options: { interval?: NumberLike } = { interval: 1 },
   ): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return mine(this.#provider, blocks, options);
+    return await mine(this.#provider, blocks, options);
   }
 
   public async mineUpTo(blockNumber: NumberLike): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return mineUpTo(this.#provider, blockNumber, this.time);
+    return await mineUpTo(this.#provider, blockNumber, this.time);
   }
 
   public async setBalance(address: string, balance: NumberLike): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setBalance(this.#provider, address, balance);
+    return await setBalance(this.#provider, address, balance);
   }
 
   public async setBlockGasLimit(blockGasLimit: NumberLike): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setBlockGasLimit(this.#provider, blockGasLimit);
+    return await setBlockGasLimit(this.#provider, blockGasLimit);
   }
 
   public async setCode(address: string, code: string): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setCode(this.#provider, address, code);
+    return await setCode(this.#provider, address, code);
   }
 
   public async setCoinbase(address: string): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setCoinbase(this.#provider, address);
+    return await setCoinbase(this.#provider, address);
   }
 
   public async setNextBlockBaseFeePerGas(
     baseFeePerGas: NumberLike,
   ): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setNextBlockBaseFeePerGas(this.#provider, baseFeePerGas);
+    return await setNextBlockBaseFeePerGas(this.#provider, baseFeePerGas);
   }
 
   public async setNonce(address: string, nonce: NumberLike): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setNonce(this.#provider, address, nonce);
+    return await setNonce(this.#provider, address, nonce);
   }
 
   public async setPrevRandao(prevRandao: NumberLike): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setPrevRandao(this.#provider, prevRandao);
+    return await setPrevRandao(this.#provider, prevRandao);
   }
 
   public async setStorageAt(
@@ -152,17 +152,17 @@ export class NetworkHelpers<ChainTypeT extends ChainType | string>
     value: NumberLike,
   ): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setStorageAt(this.#provider, address, index, value);
+    return await setStorageAt(this.#provider, address, index, value);
   }
 
   public async stopImpersonatingAccount(address: string): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return stopImpersonatingAccount(this.#provider, address);
+    return await stopImpersonatingAccount(this.#provider, address);
   }
 
   public async takeSnapshot(): Promise<SnapshotRestorer> {
     await this.throwIfNotDevelopmentNetwork();
-    return takeSnapshot(this.#provider);
+    return await takeSnapshot(this.#provider);
   }
 
   public async throwIfNotDevelopmentNetwork(): Promise<void> {

--- a/packages/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase.ts
+++ b/packages/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase.ts
@@ -20,5 +20,5 @@ export async function increase<ChainTypeT extends ChainType | string>(
 
   await networkHelpers.mine();
 
-  return networkHelpers.time.latest();
+  return await networkHelpers.time.latest();
 }

--- a/packages/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
+++ b/packages/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
@@ -32,12 +32,12 @@ export class Time<ChainTypeT extends ChainType | string> implements TimeI {
 
   public async increase(amountInSeconds: NumberLike): Promise<number> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return increase(this.#provider, this.#networkHelpers, amountInSeconds);
+    return await increase(this.#provider, this.#networkHelpers, amountInSeconds);
   }
 
   public async increaseTo(timestamp: NumberLike | Date): Promise<void> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return increaseTo(
+    return await increaseTo(
       this.#provider,
       this.#networkHelpers,
       timestamp,
@@ -47,18 +47,18 @@ export class Time<ChainTypeT extends ChainType | string> implements TimeI {
 
   public async latest(): Promise<number> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return latest(this.#provider);
+    return await latest(this.#provider);
   }
 
   public async latestBlock(): Promise<number> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return latestBlock(this.#provider);
+    return await latestBlock(this.#provider);
   }
 
   public async setNextBlockTimestamp(
     timestamp: NumberLike | Date,
   ): Promise<void> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return setNextBlockTimestamp(this.#provider, timestamp, this.duration);
+    return await setNextBlockTimestamp(this.#provider, timestamp, this.duration);
   }
 }

--- a/packages/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
+++ b/packages/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
@@ -32,7 +32,11 @@ export class Time<ChainTypeT extends ChainType | string> implements TimeI {
 
   public async increase(amountInSeconds: NumberLike): Promise<number> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return await increase(this.#provider, this.#networkHelpers, amountInSeconds);
+    return await increase(
+      this.#provider,
+      this.#networkHelpers,
+      amountInSeconds,
+    );
   }
 
   public async increaseTo(timestamp: NumberLike | Date): Promise<void> {
@@ -59,6 +63,10 @@ export class Time<ChainTypeT extends ChainType | string> implements TimeI {
     timestamp: NumberLike | Date,
   ): Promise<void> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return await setNextBlockTimestamp(this.#provider, timestamp, this.duration);
+    return await setNextBlockTimestamp(
+      this.#provider,
+      timestamp,
+      this.duration,
+    );
   }
 }

--- a/packages/hardhat-network-helpers/test/assertions.ts
+++ b/packages/hardhat-network-helpers/test/assertions.ts
@@ -72,7 +72,9 @@ describe("assertions", () => {
     it("should throw if the address is not a valid checksum address", async () => {
       await assertRejectsWithHardhatError(
         async () =>
-          await assertValidAddress("0xCF5609B003B2776699EEA1233F7C82D5695CC9AA"),
+          await assertValidAddress(
+            "0xCF5609B003B2776699EEA1233F7C82D5695CC9AA",
+          ),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_CHECKSUM_ADDRESS,
         {
           value: "0xCF5609B003B2776699EEA1233F7C82D5695CC9AA",

--- a/packages/hardhat-network-helpers/test/assertions.ts
+++ b/packages/hardhat-network-helpers/test/assertions.ts
@@ -61,7 +61,7 @@ describe("assertions", () => {
   describe("assertValidAddress", () => {
     it("should throw if the address is not a valid address", async () => {
       await assertRejectsWithHardhatError(
-        async () => assertValidAddress("0xZZZZ"),
+        async () => await assertValidAddress("0xZZZZ"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
         {
           value: "0xZZZZ",
@@ -72,7 +72,7 @@ describe("assertions", () => {
     it("should throw if the address is not a valid checksum address", async () => {
       await assertRejectsWithHardhatError(
         async () =>
-          assertValidAddress("0xCF5609B003B2776699EEA1233F7C82D5695CC9AA"),
+          await assertValidAddress("0xCF5609B003B2776699EEA1233F7C82D5695CC9AA"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_CHECKSUM_ADDRESS,
         {
           value: "0xCF5609B003B2776699EEA1233F7C82D5695CC9AA",

--- a/packages/hardhat-network-helpers/test/helpers/mocked-web3-client-version.ts
+++ b/packages/hardhat-network-helpers/test/helpers/mocked-web3-client-version.ts
@@ -24,7 +24,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         };
       }
 
-      return next(context, networkConnection, jsonRpcRequest);
+      return await next(context, networkConnection, jsonRpcRequest);
     },
   };
 

--- a/packages/hardhat-network-helpers/test/index.ts
+++ b/packages/hardhat-network-helpers/test/index.ts
@@ -67,7 +67,8 @@ describe("hardhat-network-helpers plugin initialization", () => {
             // enabling the simulation of a non-test network.
             id: "mocked-web3-client-version",
             hookHandlers: {
-              network: () => import("./helpers/mocked-web3-client-version.js"),
+              network: async () =>
+                await import("./helpers/mocked-web3-client-version.js"),
             },
           },
         ],
@@ -80,7 +81,7 @@ describe("hardhat-network-helpers plugin initialization", () => {
 
     it("should throw when using a method from the network-helpers class", async () => {
       await assertRejectsWithHardhatError(
-        () => networkHelpers.takeSnapshot(),
+        async () => await networkHelpers.takeSnapshot(),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
           .CAN_ONLY_BE_USED_WITH_HARDHAT_NETWORK_VERSIONED,
         {
@@ -92,7 +93,7 @@ describe("hardhat-network-helpers plugin initialization", () => {
 
     it("should throw when using a method from the time class", async () => {
       await assertRejectsWithHardhatError(
-        () => networkHelpers.time.latest(),
+        async () => await networkHelpers.time.latest(),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
           .CAN_ONLY_BE_USED_WITH_HARDHAT_NETWORK_VERSIONED,
         {

--- a/packages/hardhat-network-helpers/test/network-helpers/drop-transaction.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/drop-transaction.ts
@@ -103,7 +103,7 @@ describe("network-helpers - dropTransaction", () => {
 
   it(`should throw because the transaction hash is invalid`, async function () {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.dropTransaction("0xaaa"),
+      async () => await networkHelpers.dropTransaction("0xaaa"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_TX_HASH,
       {
         value: "0xaaa",

--- a/packages/hardhat-network-helpers/test/network-helpers/get-storage-at.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/get-storage-at.ts
@@ -68,7 +68,7 @@ describe("network-helpers - getStorageAt", () => {
 
   it("should throw because the address is not valid", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.getStorageAt("0xaa", "0x1", "0xbeef"),
+      async () => await networkHelpers.getStorageAt("0xaa", "0x1", "0xbeef"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       {
         value: "0xaa",

--- a/packages/hardhat-network-helpers/test/network-helpers/impersonate-account.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/impersonate-account.ts
@@ -59,7 +59,7 @@ describe("network-helpers - impersonateAccount", () => {
 
   it("should throw because the address is not valid", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setBalance("0xaa", 1),
+      async () => await networkHelpers.setBalance("0xaa", 1),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       {
         value: "0xaa",

--- a/packages/hardhat-network-helpers/test/network-helpers/load-fixture.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/load-fixture.ts
@@ -162,7 +162,7 @@ describe("network-helpers - loadFixture", () => {
 
   it("should throw when an anonymous regular function is used", async function () {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.loadFixture(async function () {}),
+      async () => await networkHelpers.loadFixture(async function () {}),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .FIXTURE_ANONYMOUS_FUNCTION_ERROR,
       {},
@@ -171,7 +171,7 @@ describe("network-helpers - loadFixture", () => {
 
   it("should throw when an anonymous arrow function is used", async function () {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.loadFixture(async () => {}),
+      async () => await networkHelpers.loadFixture(async () => {}),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .FIXTURE_ANONYMOUS_FUNCTION_ERROR,
       {},

--- a/packages/hardhat-network-helpers/test/network-helpers/mine-up-to.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/mine-up-to.ts
@@ -31,7 +31,7 @@ describe("network-helpers - mineUpTo", () => {
     const initialHeight = await networkHelpers.time.latestBlock();
 
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.mineUpTo(initialHeight),
+      async () => await networkHelpers.mineUpTo(initialHeight),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .BLOCK_NUMBER_SMALLER_THAN_CURRENT,
       {

--- a/packages/hardhat-network-helpers/test/network-helpers/mine.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/mine.ts
@@ -104,7 +104,7 @@ describe("network-helpers - mine", () => {
 
   it("should throw because the string is not 0x-prefixed", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.mine("3"),
+      async () => await networkHelpers.mine("3"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .ONLY_ALLOW_0X_PREFIXED_STRINGS,
       {},
@@ -137,7 +137,7 @@ describe("network-helpers - mine", () => {
   it("should throw because the string is not 0x-prefixed", async () => {
     await assertRejectsWithHardhatError(
       async () =>
-        networkHelpers.mine(100, {
+        await networkHelpers.mine(100, {
           interval: "3",
         }),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL

--- a/packages/hardhat-network-helpers/test/network-helpers/set-balance.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-balance.ts
@@ -44,7 +44,7 @@ describe("network-helpers - setBalance", () => {
 
   it("should throw because the address is invalid", async function () {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setBalance("0xCF", 1),
+      async () => await networkHelpers.setBalance("0xCF", 1),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       {
         value: "0xCF",

--- a/packages/hardhat-network-helpers/test/network-helpers/set-block-gas-limit.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-block-gas-limit.ts
@@ -66,7 +66,7 @@ describe("network-helpers - setBlockGasLimit", () => {
 
     it("should not accept strings that are not 0x-prefixed", async () => {
       await assertRejectsWithHardhatError(
-        async () => networkHelpers.setBlockGasLimit("3"),
+        async () => await networkHelpers.setBlockGasLimit("3"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
           .ONLY_ALLOW_0X_PREFIXED_STRINGS,
         {},

--- a/packages/hardhat-network-helpers/test/network-helpers/set-code.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-code.ts
@@ -44,7 +44,7 @@ describe("network-helpers - setCode", () => {
   describe("accepted parameter types for code", () => {
     it("should not accept strings that are not 0x-prefixed", async () => {
       await assertRejectsWithHardhatError(
-        async () => networkHelpers.setCode(recipient, "a1a2a3"),
+        async () => await networkHelpers.setCode(recipient, "a1a2a3"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_HEX_STRING,
         { value: "a1a2a3" },
       );
@@ -52,7 +52,7 @@ describe("network-helpers - setCode", () => {
 
     it("should not accept invalid addresses", async () => {
       await assertRejectsWithHardhatError(
-        async () => networkHelpers.setCode("0x123", "0xaaa"),
+        async () => await networkHelpers.setCode("0x123", "0xaaa"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
         {
           value: "0x123",

--- a/packages/hardhat-network-helpers/test/network-helpers/set-coinbase.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-coinbase.ts
@@ -46,7 +46,7 @@ describe("network-helpers - setCoinbase", () => {
 
   it(`should throw because the address is invalid`, async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setCoinbase("0x123"),
+      async () => await networkHelpers.setCoinbase("0x123"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       { value: "0x123" },
     );

--- a/packages/hardhat-network-helpers/test/network-helpers/set-next-block-base-fee-per-gas.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-next-block-base-fee-per-gas.ts
@@ -66,7 +66,7 @@ describe("network-helpers - setNextBlockBaseFeePerGas", () => {
 
     it("should throw because the the string is not 0x-prefixed", async () => {
       await assertRejectsWithHardhatError(
-        async () => networkHelpers.setNextBlockBaseFeePerGas("3"),
+        async () => await networkHelpers.setNextBlockBaseFeePerGas("3"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
           .ONLY_ALLOW_0X_PREFIXED_STRINGS,
         {},

--- a/packages/hardhat-network-helpers/test/network-helpers/set-nonce.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-nonce.ts
@@ -91,7 +91,7 @@ describe("network-helpers - setNonce", () => {
 
   it("should throw because the address is invalid", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setNonce("0xCF", 1),
+      async () => await networkHelpers.setNonce("0xCF", 1),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       {
         value: "0xCF",
@@ -101,7 +101,7 @@ describe("network-helpers - setNonce", () => {
 
   it("should throw because the nonce is invalid", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setNonce(account, "CF"),
+      async () => await networkHelpers.setNonce(account, "CF"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .ONLY_ALLOW_0X_PREFIXED_STRINGS,
       {},

--- a/packages/hardhat-network-helpers/test/network-helpers/set-prevrandao.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-prevrandao.ts
@@ -63,7 +63,7 @@ describe("network-helpers - setPrevRandao", () => {
 
     it("should not accept strings that are not 0x-prefixed", async () => {
       await assertRejectsWithHardhatError(
-        async () => networkHelpers.setPrevRandao("3"),
+        async () => await networkHelpers.setPrevRandao("3"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
           .ONLY_ALLOW_0X_PREFIXED_STRINGS,
         {},

--- a/packages/hardhat-network-helpers/test/network-helpers/set-storage-at.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-storage-at.ts
@@ -51,7 +51,7 @@ describe("network-helpers - setStorageAt", () => {
 
   it("should throw because the address is not valid", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setStorageAt("0xaa", "0x1", "0xbeef"),
+      async () => await networkHelpers.setStorageAt("0xaa", "0x1", "0xbeef"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       {
         value: "0xaa",

--- a/packages/hardhat-network-helpers/test/network-helpers/take-snapshot.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/take-snapshot.ts
@@ -55,7 +55,7 @@ describe("network-helpers - takeSnapshot", () => {
     await snapshot1.restore();
 
     await assertRejectsWithHardhatError(
-      async () => snapshot2.restore(),
+      async () => await snapshot2.restore(),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_SNAPSHOT,
       {},
     );

--- a/packages/hardhat-network-helpers/test/time/increase-to.ts
+++ b/packages/hardhat-network-helpers/test/time/increase-to.ts
@@ -36,14 +36,14 @@ describe("time - increaseTo", () => {
     const initialTimestamp = await time.latest();
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () => time.increaseTo(initialTimestamp));
+    await assert.rejects(async () => await time.increaseTo(initialTimestamp));
   });
 
   it("should throw if given a timestamp that is less than the current block timestamp", async () => {
     const initialTimestamp = await time.latest();
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () => time.increaseTo(initialTimestamp - 1));
+    await assert.rejects(async () => await time.increaseTo(initialTimestamp - 1));
   });
 
   describe("accepted parameter types for timestamp", () => {

--- a/packages/hardhat-network-helpers/test/time/increase-to.ts
+++ b/packages/hardhat-network-helpers/test/time/increase-to.ts
@@ -43,7 +43,9 @@ describe("time - increaseTo", () => {
     const initialTimestamp = await time.latest();
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () => await time.increaseTo(initialTimestamp - 1));
+    await assert.rejects(
+      async () => await time.increaseTo(initialTimestamp - 1),
+    );
   });
 
   describe("accepted parameter types for timestamp", () => {

--- a/packages/hardhat-network-helpers/test/time/increase.ts
+++ b/packages/hardhat-network-helpers/test/time/increase.ts
@@ -34,12 +34,12 @@ describe("time - increase", () => {
 
   it("should throw if given zero number of seconds", async () => {
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () => time.increase(0));
+    await assert.rejects(async () => await time.increase(0));
   });
 
   it("should throw if given a negative number of seconds", async () => {
     await assertRejectsWithHardhatError(
-      async () => time.increase(-1),
+      async () => await time.increase(-1),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .CANNOT_CONVERT_NEGATIVE_NUMBER_TO_RPC_QUANTITY,
       {

--- a/packages/hardhat-network-helpers/test/time/set-next-block-timestamp.ts
+++ b/packages/hardhat-network-helpers/test/time/set-next-block-timestamp.ts
@@ -59,7 +59,7 @@ describe("time - setNextBlockTimestamp", () => {
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
     await assert.rejects(async () =>
-      time.setNextBlockTimestamp(initialTimestamp),
+      await time.setNextBlockTimestamp(initialTimestamp),
     );
   });
 
@@ -68,7 +68,7 @@ describe("time - setNextBlockTimestamp", () => {
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
     await assert.rejects(async () =>
-      time.setNextBlockTimestamp(initialTimestamp - 1),
+      await time.setNextBlockTimestamp(initialTimestamp - 1),
     );
   });
 

--- a/packages/hardhat-network-helpers/test/time/set-next-block-timestamp.ts
+++ b/packages/hardhat-network-helpers/test/time/set-next-block-timestamp.ts
@@ -58,8 +58,8 @@ describe("time - setNextBlockTimestamp", () => {
     const initialTimestamp = await time.latest();
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () =>
-      await time.setNextBlockTimestamp(initialTimestamp),
+    await assert.rejects(
+      async () => await time.setNextBlockTimestamp(initialTimestamp),
     );
   });
 
@@ -67,8 +67,8 @@ describe("time - setNextBlockTimestamp", () => {
     const initialTimestamp = await time.latest();
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () =>
-      await time.setNextBlockTimestamp(initialTimestamp - 1),
+    await assert.rejects(
+      async () => await time.setNextBlockTimestamp(initialTimestamp - 1),
     );
   });
 

--- a/packages/hardhat-node-test-reporter/integration-tests/fixture-tests/errors-test/test.ts
+++ b/packages/hardhat-node-test-reporter/integration-tests/fixture-tests/errors-test/test.ts
@@ -10,7 +10,7 @@ test("aggregate error in top level test", async () => {
   );
   const promise2 = Promise.reject(new Error("Promise 2 failed"));
 
-  return Promise.any([promise1, promise2]);
+  return await Promise.any([promise1, promise2]);
 });
 
 // TODO: We're commenting out this test case because https://nodejs.org/en/blog/release/v22.16.0

--- a/packages/hardhat-node-test-runner/src/hookHandlers/test.ts
+++ b/packages/hardhat-node-test-runner/src/hookHandlers/test.ts
@@ -26,7 +26,7 @@ export default async (): Promise<Partial<TestHooks>> => {
         return "nodejs";
       }
 
-      return next(context, filePath);
+      return await next(context, filePath);
     },
   };
 

--- a/packages/hardhat-node-test-runner/src/index.ts
+++ b/packages/hardhat-node-test-runner/src/index.ts
@@ -36,12 +36,12 @@ const hardhatPlugin: HardhatPlugin = {
         defaultValue: 0,
         hidden: true,
       })
-      .setAction(() => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   hookHandlers: {
-    config: () => import("./hookHandlers/config.js"),
-    test: () => import("./hookHandlers/test.js"),
+    config: async () => await import("./hookHandlers/config.js"),
+    test: async () => await import("./hookHandlers/test.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-node-test-runner",
 };

--- a/packages/hardhat-node-test-runner/src/task-action.ts
+++ b/packages/hardhat-node-test-runner/src/task-action.ts
@@ -46,7 +46,7 @@ async function getTestFiles(
     return testFiles;
   }
 
-  return getAllFilesMatching(
+  return await getAllFilesMatching(
     config.paths.tests.nodejs,
     (f) => isJavascriptFile(f) || isTypescriptFile(f),
   );

--- a/packages/hardhat-solx/src/index.ts
+++ b/packages/hardhat-solx/src/index.ts
@@ -6,8 +6,8 @@ const hardhatSolxPlugin: HardhatPlugin = {
   id: "hardhat-solx",
   npmPackage: "@nomicfoundation/hardhat-solx",
   hookHandlers: {
-    config: () => import("./internal/hook-handlers/config.js"),
-    solidity: () => import("./internal/hook-handlers/solidity.js"),
+    config: async () => await import("./internal/hook-handlers/config.js"),
+    solidity: async () => await import("./internal/hook-handlers/solidity.js"),
   },
 };
 

--- a/packages/hardhat-solx/src/internal/hook-handlers/solidity.ts
+++ b/packages/hardhat-solx/src/internal/hook-handlers/solidity.ts
@@ -85,7 +85,7 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
 
   getCompiler: async (context, compilerConfig, next) => {
     if (compilerConfig.type !== SOLX_COMPILER_TYPE) {
-      return next(context, compilerConfig);
+      return await next(context, compilerConfig);
     }
 
     // Honor custom path — skip version lookup and download

--- a/packages/hardhat-solx/src/internal/solx-compiler.ts
+++ b/packages/hardhat-solx/src/internal/solx-compiler.ts
@@ -41,6 +41,6 @@ export class SolxCompiler implements Compiler {
       },
     };
 
-    return this.#spawnCompile(this.compilerPath, args, modifiedInput);
+    return await this.#spawnCompile(this.compilerPath, args, modifiedInput);
   }
 }

--- a/packages/hardhat-solx/test/integration.ts
+++ b/packages/hardhat-solx/test/integration.ts
@@ -14,7 +14,7 @@ describe("hardhat-solx integration", () => {
   async function createHre() {
     const configPath = await resolveHardhatConfigPath();
     const userConfig = await importUserConfig(configPath);
-    return createHardhatRuntimeEnvironment(userConfig);
+    return await createHardhatRuntimeEnvironment(userConfig);
   }
 
   it("resolves plugin config through the HRE", async () => {

--- a/packages/hardhat-test-utils/src/fixture-projects.ts
+++ b/packages/hardhat-test-utils/src/fixture-projects.ts
@@ -82,5 +82,5 @@ async function getFixtureProjectPath(
     throw new Error(`Fixture project ${projectName} doesn't exist`);
   }
 
-  return getRealPath(projectPath);
+  return await getRealPath(projectPath);
 }

--- a/packages/hardhat-test-utils/test/hardhat-error.ts
+++ b/packages/hardhat-test-utils/test/hardhat-error.ts
@@ -161,7 +161,7 @@ describe("HardhatError helpers", () => {
   describe("assertRejectsWithHardhatError", () => {
     it("should throw if the function doesn't return a promise that rejects", async () => {
       await assert.rejects(async () =>
-        assertRejectsWithHardhatError(
+        await assertRejectsWithHardhatError(
           async () => {},
           HardhatError.ERRORS.CORE.TASK_DEFINITIONS.INVALID_ACTION,
           { task: "bar" },
@@ -171,7 +171,7 @@ describe("HardhatError helpers", () => {
 
     it("should throw the promise that rejects", async () => {
       await assert.rejects(async () =>
-        assertRejectsWithHardhatError(
+        await assertRejectsWithHardhatError(
           Promise.resolve(1),
           HardhatError.ERRORS.CORE.TASK_DEFINITIONS.INVALID_ACTION,
           { task: "bar" },

--- a/packages/hardhat-test-utils/test/hardhat-error.ts
+++ b/packages/hardhat-test-utils/test/hardhat-error.ts
@@ -160,50 +160,54 @@ describe("HardhatError helpers", () => {
 
   describe("assertRejectsWithHardhatError", () => {
     it("should throw if the function doesn't return a promise that rejects", async () => {
-      await assert.rejects(async () =>
-        await assertRejectsWithHardhatError(
-          async () => {},
-          HardhatError.ERRORS.CORE.TASK_DEFINITIONS.INVALID_ACTION,
-          { task: "bar" },
-        ),
+      await assert.rejects(
+        async () =>
+          await assertRejectsWithHardhatError(
+            async () => {},
+            HardhatError.ERRORS.CORE.TASK_DEFINITIONS.INVALID_ACTION,
+            { task: "bar" },
+          ),
       );
     });
 
     it("should throw the promise that rejects", async () => {
-      await assert.rejects(async () =>
-        await assertRejectsWithHardhatError(
-          Promise.resolve(1),
-          HardhatError.ERRORS.CORE.TASK_DEFINITIONS.INVALID_ACTION,
-          { task: "bar" },
-        ),
+      await assert.rejects(
+        async () =>
+          await assertRejectsWithHardhatError(
+            Promise.resolve(1),
+            HardhatError.ERRORS.CORE.TASK_DEFINITIONS.INVALID_ACTION,
+            { task: "bar" },
+          ),
       );
     });
 
     it("asserts the error of the rejection", async () => {
-      await assert.rejects(() =>
-        assertRejectsWithHardhatError(
-          async () => {
-            throw new HardhatError(
-              HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
-              { option: "foo", task: "bar" },
-            );
-          },
-          HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
-          { option: "foo2", task: "bar" },
-        ),
+      await assert.rejects(
+        async () =>
+          await assertRejectsWithHardhatError(
+            async () => {
+              throw new HardhatError(
+                HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+                { option: "foo", task: "bar" },
+              );
+            },
+            HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+            { option: "foo2", task: "bar" },
+          ),
       );
 
-      await assert.rejects(() =>
-        assertRejectsWithHardhatError(
-          Promise.reject(
-            new HardhatError(
-              HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
-              { option: "foo", task: "bar" },
+      await assert.rejects(
+        async () =>
+          await assertRejectsWithHardhatError(
+            Promise.reject(
+              new HardhatError(
+                HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+                { option: "foo", task: "bar" },
+              ),
             ),
+            HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
+            { option: "foo2", task: "bar" },
           ),
-          HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_TASK_OPTION,
-          { option: "foo2", task: "bar" },
-        ),
       );
 
       await assertRejectsWithHardhatError(

--- a/packages/hardhat-typechain/src/index.ts
+++ b/packages/hardhat-typechain/src/index.ts
@@ -6,9 +6,9 @@ import { globalFlag } from "hardhat/config";
 const hardhatTypechain: HardhatPlugin = {
   id: "hardhat-typechain",
   hookHandlers: {
-    config: () => import("./internal/hook-handlers/config.js"),
-    solidity: () => import("./internal/hook-handlers/solidity.js"),
-    clean: () => import("./internal/hook-handlers/clean.js"),
+    config: async () => await import("./internal/hook-handlers/config.js"),
+    solidity: async () => await import("./internal/hook-handlers/solidity.js"),
+    clean: async () => await import("./internal/hook-handlers/clean.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-typechain",
   dependencies: () => [import("@nomicfoundation/hardhat-ethers")],

--- a/packages/hardhat-typechain/test/index.ts
+++ b/packages/hardhat-typechain/test/index.ts
@@ -336,8 +336,8 @@ describe("hardhat-typechain", () => {
       await hre.tasks.getTask("clean").run();
 
       // Build should throw due to compilation error
-      await assertRejects(async () =>
-        await hre.tasks.getTask("build").run({ quiet: true }),
+      await assertRejects(
+        async () => await hre.tasks.getTask("build").run({ quiet: true }),
       );
 
       // Types should NOT be generated

--- a/packages/hardhat-typechain/test/index.ts
+++ b/packages/hardhat-typechain/test/index.ts
@@ -337,7 +337,7 @@ describe("hardhat-typechain", () => {
 
       // Build should throw due to compilation error
       await assertRejects(async () =>
-        hre.tasks.getTask("build").run({ quiet: true }),
+        await hre.tasks.getTask("build").run({ quiet: true }),
       );
 
       // Types should NOT be generated

--- a/packages/hardhat-utils/src/eth.ts
+++ b/packages/hardhat-utils/src/eth.ts
@@ -24,7 +24,7 @@ export function isAddress(value: unknown): value is PrefixedHexString {
  * @returns True if the value is an Ethereum address with a valid checksum, false otherwise.
  */
 export async function isValidChecksumAddress(value: unknown): Promise<boolean> {
-  return isAddress(value) && isValidChecksum(value);
+  return await (isAddress(value) && isValidChecksum(value));
 }
 
 /**
@@ -55,7 +55,7 @@ export function toEvmWord(value: bigint | number): PrefixedHexString {
  */
 export async function generateHashBytes(): Promise<Uint8Array> {
   const hashGenerator = await getHashGenerator();
-  return hashGenerator.next();
+  return await hashGenerator.next();
 }
 
 /**

--- a/packages/hardhat-utils/src/eth.ts
+++ b/packages/hardhat-utils/src/eth.ts
@@ -24,7 +24,10 @@ export function isAddress(value: unknown): value is PrefixedHexString {
  * @returns True if the value is an Ethereum address with a valid checksum, false otherwise.
  */
 export async function isValidChecksumAddress(value: unknown): Promise<boolean> {
-  return await (isAddress(value) && isValidChecksum(value));
+  if (!isAddress(value)) {
+    return false;
+  }
+  return await isValidChecksum(value);
 }
 
 /**

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -69,7 +69,7 @@ export async function getAllFilesMatching(
           directoryFilter === undefined ||
           (await directoryFilter(absolutePathToFile))
         ) {
-          return getAllFilesMatching(
+          return await getAllFilesMatching(
             absolutePathToFile,
             matches,
             directoryFilter,
@@ -120,7 +120,7 @@ export async function getAllDirectoriesMatching(
         return absolutePathToFile;
       }
 
-      return getAllDirectoriesMatching(absolutePathToFile, matches);
+      return await getAllDirectoriesMatching(absolutePathToFile, matches);
     }),
   );
 

--- a/packages/hardhat-utils/src/package.ts
+++ b/packages/hardhat-utils/src/package.ts
@@ -158,7 +158,7 @@ export async function findDependencyPackageJson(
     const packageJsonPath = path.join(lookupPath, ...pathToTest);
 
     if (await exists(packageJsonPath)) {
-      return getRealPath(packageJsonPath);
+      return await getRealPath(packageJsonPath);
     }
   }
 }

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -615,7 +615,7 @@ export class AsyncMutex {
       };
     }
 
-    return new Promise<() => Promise<void>>((resolve) => {
+    return await new Promise<() => Promise<void>>((resolve) => {
       this.#queue.push(() => {
         resolve(this.#acquire());
       });

--- a/packages/hardhat-utils/test/subprocess.ts
+++ b/packages/hardhat-utils/test/subprocess.ts
@@ -143,7 +143,9 @@ describe("subprocess", () => {
 
     await assert.rejects(
       async () =>
-        await spawnDetachedSubProcess(pathToSubprocessFile, [], { env1: "env1" }),
+        await spawnDetachedSubProcess(pathToSubprocessFile, [], {
+          env1: "env1",
+        }),
       new SubprocessFileNotFoundError(pathToSubprocessFile),
     );
   });
@@ -153,7 +155,9 @@ describe("subprocess", () => {
 
     await assert.rejects(
       async () =>
-        await spawnDetachedSubProcess(pathToSubprocessFile, [], { env1: "env1" }),
+        await spawnDetachedSubProcess(pathToSubprocessFile, [], {
+          env1: "env1",
+        }),
       new SubprocessPathIsDirectoryError(pathToSubprocessFile),
     );
   });

--- a/packages/hardhat-utils/test/subprocess.ts
+++ b/packages/hardhat-utils/test/subprocess.ts
@@ -27,7 +27,7 @@ async function checkIfSubprocessWasExecuted() {
   // within a specified number of attempts, an error is thrown, indicating a failure in subprocess execution.
   const MAX_COUNTER = 20;
 
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     let counter = 0;
 
     const intervalId = setInterval(async () => {
@@ -143,7 +143,7 @@ describe("subprocess", () => {
 
     await assert.rejects(
       async () =>
-        spawnDetachedSubProcess(pathToSubprocessFile, [], { env1: "env1" }),
+        await spawnDetachedSubProcess(pathToSubprocessFile, [], { env1: "env1" }),
       new SubprocessFileNotFoundError(pathToSubprocessFile),
     );
   });
@@ -153,7 +153,7 @@ describe("subprocess", () => {
 
     await assert.rejects(
       async () =>
-        spawnDetachedSubProcess(pathToSubprocessFile, [], { env1: "env1" }),
+        await spawnDetachedSubProcess(pathToSubprocessFile, [], { env1: "env1" }),
       new SubprocessPathIsDirectoryError(pathToSubprocessFile),
     );
   });

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -9,8 +9,8 @@ import verifySourcifyTask from "./internal/tasks/verify/sourcify/index.js";
 const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-verify",
   hookHandlers: {
-    config: () => import("./internal/hook-handlers/config.js"),
-    network: () => import("./internal/hook-handlers/network.js"),
+    config: async () => await import("./internal/hook-handlers/config.js"),
+    network: async () => await import("./internal/hook-handlers/network.js"),
   },
   tasks: [
     verifyTask,

--- a/packages/hardhat-verify/src/internal/blockscout.ts
+++ b/packages/hardhat-verify/src/internal/blockscout.ts
@@ -415,7 +415,7 @@ export class Blockscout implements VerificationProvider {
     if (blockscoutResponse.isPending()) {
       await sleep(this.pollingIntervalMs);
 
-      return this.pollVerificationStatus(guid, contractAddress, contractName);
+      return await this.pollVerificationStatus(guid, contractAddress, contractName);
     }
 
     if (blockscoutResponse.isAlreadyVerified()) {

--- a/packages/hardhat-verify/src/internal/blockscout.ts
+++ b/packages/hardhat-verify/src/internal/blockscout.ts
@@ -415,7 +415,11 @@ export class Blockscout implements VerificationProvider {
     if (blockscoutResponse.isPending()) {
       await sleep(this.pollingIntervalMs);
 
-      return await this.pollVerificationStatus(guid, contractAddress, contractName);
+      return await this.pollVerificationStatus(
+        guid,
+        contractAddress,
+        contractName,
+      );
     }
 
     if (blockscoutResponse.isAlreadyVerified()) {

--- a/packages/hardhat-verify/src/internal/bytecode.ts
+++ b/packages/hardhat-verify/src/internal/bytecode.ts
@@ -67,7 +67,7 @@ export class Bytecode {
       );
     }
 
-    return Bytecode.#parse(deployedBytecode);
+    return await Bytecode.#parse(deployedBytecode);
   }
 
   public hasVersionRange(): boolean {

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -58,9 +58,9 @@ export class ContractInformationResolver {
     deployedBytecode: Bytecode,
   ): Promise<ContractInformation> {
     if (contract !== undefined) {
-      return this.#resolveByFqn(contract, deployedBytecode);
+      return await this.#resolveByFqn(contract, deployedBytecode);
     } else {
-      return this.#resolveByBytecodeLookup(deployedBytecode);
+      return await this.#resolveByBytecodeLookup(deployedBytecode);
     }
   }
 

--- a/packages/hardhat-verify/src/internal/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/etherscan.ts
@@ -429,7 +429,11 @@ export class Etherscan implements VerificationProvider {
     if (etherscanResponse.isPending()) {
       await sleep(this.pollingIntervalMs);
 
-      return await this.pollVerificationStatus(guid, contractAddress, contractName);
+      return await this.pollVerificationStatus(
+        guid,
+        contractAddress,
+        contractName,
+      );
     }
 
     if (etherscanResponse.isAlreadyVerified()) {

--- a/packages/hardhat-verify/src/internal/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/etherscan.ts
@@ -429,7 +429,7 @@ export class Etherscan implements VerificationProvider {
     if (etherscanResponse.isPending()) {
       await sleep(this.pollingIntervalMs);
 
-      return this.pollVerificationStatus(guid, contractAddress, contractName);
+      return await this.pollVerificationStatus(guid, contractAddress, contractName);
     }
 
     if (etherscanResponse.isAlreadyVerified()) {
@@ -661,12 +661,12 @@ export class LazyEtherscanImpl implements LazyEtherscan {
 
   public async isVerified(address: string): Promise<boolean> {
     const etherscan = await this.#getEtherscan();
-    return etherscan.isVerified(address);
+    return await etherscan.isVerified(address);
   }
 
   public async verify(args: EtherscanVerifyArgs): Promise<string> {
     const etherscan = await this.#getEtherscan();
-    return etherscan.verify(args);
+    return await etherscan.verify(args);
   }
 
   public async pollVerificationStatus(
@@ -675,7 +675,7 @@ export class LazyEtherscanImpl implements LazyEtherscan {
     contractName: string,
   ): Promise<{ success: boolean; message: string }> {
     const etherscan = await this.#getEtherscan();
-    return etherscan.pollVerificationStatus(
+    return await etherscan.pollVerificationStatus(
       guid,
       contractAddress,
       contractName,
@@ -687,6 +687,6 @@ export class LazyEtherscanImpl implements LazyEtherscan {
     options?: EtherscanCustomApiCallOptions,
   ): Promise<EtherscanResponseBody> {
     const etherscan = await this.#getEtherscan();
-    return etherscan.customApiCall(params, options);
+    return await etherscan.customApiCall(params, options);
   }
 }

--- a/packages/hardhat-verify/src/internal/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/sourcify.ts
@@ -303,7 +303,7 @@ export class Sourcify implements VerificationProvider {
     if (verificationStatus.isPending()) {
       await sleep(this.pollingIntervalMs);
 
-      return this.pollVerificationStatus(guid, contractAddress, contractName);
+      return await this.pollVerificationStatus(guid, contractAddress, contractName);
     }
 
     if (verificationStatus.isAlreadyVerified()) {

--- a/packages/hardhat-verify/src/internal/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/sourcify.ts
@@ -303,7 +303,11 @@ export class Sourcify implements VerificationProvider {
     if (verificationStatus.isPending()) {
       await sleep(this.pollingIntervalMs);
 
-      return await this.pollVerificationStatus(guid, contractAddress, contractName);
+      return await this.pollVerificationStatus(
+        guid,
+        contractAddress,
+        contractName,
+      );
     }
 
     if (verificationStatus.isAlreadyVerified()) {

--- a/packages/hardhat-verify/src/internal/tasks/verify/blockscout/index.ts
+++ b/packages/hardhat-verify/src/internal/tasks/verify/blockscout/index.ts
@@ -7,7 +7,7 @@ import { extendWithVerificationArgs } from "../utils.js";
 const verifyBlockscoutTask: NewTaskDefinition = extendWithVerificationArgs(
   task(["verify", "blockscout"], "Verify a contract on Blockscout"),
 )
-  .setAction(() => import("./task-action.js"))
+  .setAction(async () => await import("./task-action.js"))
   .build();
 
 export default verifyBlockscoutTask;

--- a/packages/hardhat-verify/src/internal/tasks/verify/etherscan/index.ts
+++ b/packages/hardhat-verify/src/internal/tasks/verify/etherscan/index.ts
@@ -7,7 +7,7 @@ import { extendWithVerificationArgs } from "../utils.js";
 const verifyEtherscanTask: NewTaskDefinition = extendWithVerificationArgs(
   task(["verify", "etherscan"], "Verify a contract on Etherscan"),
 )
-  .setAction(() => import("./task-action.js"))
+  .setAction(async () => await import("./task-action.js"))
   .build();
 
 export default verifyEtherscanTask;

--- a/packages/hardhat-verify/src/internal/tasks/verify/index.ts
+++ b/packages/hardhat-verify/src/internal/tasks/verify/index.ts
@@ -9,7 +9,7 @@ const verifyTask: NewTaskDefinition = extendWithSourcifyArgs(
     task("verify", "Verify a contract on all supported explorers"),
   ),
 )
-  .setAction(() => import("./task-action.js"))
+  .setAction(async () => await import("./task-action.js"))
   .build();
 
 export default verifyTask;

--- a/packages/hardhat-verify/src/internal/tasks/verify/sourcify/index.ts
+++ b/packages/hardhat-verify/src/internal/tasks/verify/sourcify/index.ts
@@ -13,7 +13,7 @@ const verifySourcifyTask: NewTaskDefinition = extendWithSourcifyArgs(
   ),
   false,
 )
-  .setAction(() => import("./task-action.js"))
+  .setAction(async () => await import("./task-action.js"))
   .build();
 
 export default verifySourcifyTask;

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -359,7 +359,7 @@ export async function createVerificationProviderInstance({
     dispatcher,
   });
 
-  return ProviderClass.create(createOptions);
+  return await ProviderClass.create(createOptions);
 }
 
 async function attemptVerification(

--- a/packages/hardhat-verify/src/verify.ts
+++ b/packages/hardhat-verify/src/verify.ts
@@ -9,5 +9,5 @@ export async function verifyContract(
   verifyContractArgs: VerifyContractArgs,
   hre: HardhatRuntimeEnvironment,
 ): Promise<boolean> {
-  return verify(verifyContractArgs, hre);
+  return await verify(verifyContractArgs, hre);
 }

--- a/packages/hardhat-verify/test/tasks/verify/task-action.ts
+++ b/packages/hardhat-verify/test/tasks/verify/task-action.ts
@@ -61,7 +61,7 @@ describe("verify/task-action", () => {
     });
 
     it("should set process.exitCode to 0 when verification is successful", async () => {
-      const verifyContract = async () => Promise.resolve(true);
+      const verifyContract = async () => await Promise.resolve(true);
 
       await internalVerifyAction(
         {
@@ -100,7 +100,7 @@ describe("verify/task-action", () => {
       }) => {
         if (provider === "etherscan") {
           console.log("Verification successful for Etherscan");
-          return Promise.resolve(true);
+          return await Promise.resolve(true);
         }
         throw new Error(`Verification failed for provider: ${provider}`);
       };
@@ -166,7 +166,7 @@ describe("verify/task-action", () => {
           constructorArgs: [],
         },
         localHre,
-        async () => Promise.resolve(true),
+        async () => await Promise.resolve(true),
       );
 
       assert.equal(process.exitCode, 0);

--- a/packages/hardhat-verify/test/utils.ts
+++ b/packages/hardhat-verify/test/utils.ts
@@ -38,10 +38,10 @@ export class MockEthereumProvider
     throw new Error("Method not supported");
   }
 
-  public close(): Promise<void> {
+  public async close(): Promise<void> {
     throw new Error("Method not implemented.");
   }
-  public send(): Promise<any> {
+  public async send(): Promise<any> {
     throw new Error("Method not implemented.");
   }
   public sendAsync(): void {

--- a/packages/hardhat-viem-assertions/src/index.ts
+++ b/packages/hardhat-viem-assertions/src/index.ts
@@ -6,7 +6,7 @@ const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-viem-assertions",
   dependencies: () => [import("@nomicfoundation/hardhat-viem")],
   hookHandlers: {
-    network: () => import("./internal/hook-handlers/network.js"),
+    network: async () => await import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-viem-assertions",
 };

--- a/packages/hardhat-viem-assertions/src/internal/assertions/balances-have-changed.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/balances-have-changed.ts
@@ -33,11 +33,12 @@ export async function balancesHaveChanged<
   const blockNrAfterTx = receipt.blockNumber;
 
   const beforeBalances = await Promise.all(
-    changes.map(({ address }) =>
-      publicClient.getBalance({
-        address,
-        blockNumber: blockNrAfterTx - 1n,
-      }),
+    changes.map(
+      async ({ address }) =>
+        await publicClient.getBalance({
+          address,
+          blockNumber: blockNrAfterTx - 1n,
+        }),
     ),
   );
 

--- a/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
+++ b/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
@@ -38,7 +38,7 @@ export class HardhatViemAssertionsImpl<
       amount: bigint;
     }>,
   ): Promise<void> {
-    return balancesHaveChanged(this.#viem, resolvedTxHash, changes);
+    return await balancesHaveChanged(this.#viem, resolvedTxHash, changes);
   }
 
   public async emit<
@@ -49,7 +49,7 @@ export class HardhatViemAssertionsImpl<
     contract: ContractReturnType<ContractName>,
     eventName: EventName,
   ): Promise<void> {
-    return emit(this.#viem, contractFn, contract, eventName);
+    return await emit(this.#viem, contractFn, contract, eventName);
   }
 
   public async emitWithArgs<
@@ -61,20 +61,20 @@ export class HardhatViemAssertionsImpl<
     eventName: EventName,
     args: any[],
   ): Promise<void> {
-    return emitWithArgs(this.#viem, contractFn, contract, eventName, args);
+    return await emitWithArgs(this.#viem, contractFn, contract, eventName, args);
   }
 
   public async revert(
     contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
   ): Promise<void> {
-    return revert(contractFn);
+    return await revert(contractFn);
   }
 
   public async revertWith(
     contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
     expectedRevertReason: string,
   ): Promise<void> {
-    return revertWith(contractFn, expectedRevertReason);
+    return await revertWith(contractFn, expectedRevertReason);
   }
 
   public async revertWithCustomError<ContractName extends keyof ContractAbis>(
@@ -82,7 +82,7 @@ export class HardhatViemAssertionsImpl<
     contract: ContractReturnType<ContractName>,
     customErrorName: string,
   ): Promise<void> {
-    return revertWithCustomError(contractFn, contract, customErrorName);
+    return await revertWithCustomError(contractFn, contract, customErrorName);
   }
 
   public async revertWithCustomErrorWithArgs<
@@ -93,7 +93,7 @@ export class HardhatViemAssertionsImpl<
     customErrorName: string,
     args: any[],
   ): Promise<void> {
-    return revertWithCustomErrorWithArgs(
+    return await revertWithCustomErrorWithArgs(
       contractFn,
       contract,
       customErrorName,

--- a/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
+++ b/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
@@ -61,7 +61,13 @@ export class HardhatViemAssertionsImpl<
     eventName: EventName,
     args: any[],
   ): Promise<void> {
-    return await emitWithArgs(this.#viem, contractFn, contract, eventName, args);
+    return await emitWithArgs(
+      this.#viem,
+      contractFn,
+      contract,
+      eventName,
+      args,
+    );
   }
 
   public async revert(

--- a/packages/hardhat-viem/src/index.ts
+++ b/packages/hardhat-viem/src/index.ts
@@ -5,7 +5,7 @@ import "./type-extensions.js";
 const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-viem",
   hookHandlers: {
-    network: () => import("./internal/hook-handlers/network.js"),
+    network: async () => await import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-viem",
 };

--- a/packages/hardhat-viem/src/internal/clients.ts
+++ b/packages/hardhat-viem/src/internal/clients.ts
@@ -143,7 +143,7 @@ export async function getDefaultWalletClient<
     );
   }
 
-  return getWalletClient(
+  return await getWalletClient(
     provider,
     chainType,
     chainDescriptors,

--- a/packages/hardhat-viem/src/internal/initialization.ts
+++ b/packages/hardhat-viem/src/internal/initialization.ts
@@ -24,8 +24,8 @@ export function initializeViem<ChainTypeT extends ChainType | string>(
   networkName: string,
 ): HardhatViemHelpers<ChainTypeT> {
   return {
-    getPublicClient: (publicClientConfig) =>
-      getPublicClient(
+    getPublicClient: async (publicClientConfig) =>
+      await getPublicClient(
         provider,
         chainType,
         chainDescriptors,
@@ -33,8 +33,8 @@ export function initializeViem<ChainTypeT extends ChainType | string>(
         publicClientConfig,
       ),
 
-    getWalletClients: (walletClientConfig) =>
-      getWalletClients(
+    getWalletClients: async (walletClientConfig) =>
+      await getWalletClients(
         provider,
         chainType,
         chainDescriptors,
@@ -42,8 +42,8 @@ export function initializeViem<ChainTypeT extends ChainType | string>(
         walletClientConfig,
       ),
 
-    getWalletClient: (address, walletClientConfig) =>
-      getWalletClient(
+    getWalletClient: async (address, walletClientConfig) =>
+      await getWalletClient(
         provider,
         chainType,
         chainDescriptors,
@@ -52,8 +52,8 @@ export function initializeViem<ChainTypeT extends ChainType | string>(
         walletClientConfig,
       ),
 
-    getTestClient: (testClientConfig) =>
-      getTestClient(
+    getTestClient: async (testClientConfig) =>
+      await getTestClient(
         provider,
         chainType,
         chainDescriptors,
@@ -61,8 +61,12 @@ export function initializeViem<ChainTypeT extends ChainType | string>(
         testClientConfig,
       ),
 
-    deployContract: (contractName, constructorArgs, deployContractConfig) =>
-      deployContract(
+    deployContract: async (
+      contractName,
+      constructorArgs,
+      deployContractConfig,
+    ) =>
+      await deployContract(
         provider,
         artifactManager,
         chainDescriptors,
@@ -72,12 +76,12 @@ export function initializeViem<ChainTypeT extends ChainType | string>(
         deployContractConfig,
       ),
 
-    sendDeploymentTransaction: (
+    sendDeploymentTransaction: async (
       contractName,
       constructorArgs,
       sendDeploymentTransactionConfig,
     ) =>
-      sendDeploymentTransaction(
+      await sendDeploymentTransaction(
         provider,
         artifactManager,
         chainDescriptors,
@@ -87,8 +91,8 @@ export function initializeViem<ChainTypeT extends ChainType | string>(
         sendDeploymentTransactionConfig,
       ),
 
-    getContractAt: (contractName, address, getContractAtConfig) =>
-      getContractAt(
+    getContractAt: async (contractName, address, getContractAtConfig) =>
+      await getContractAt(
         provider,
         artifactManager,
         chainDescriptors,

--- a/packages/hardhat-viem/test/contracts.ts
+++ b/packages/hardhat-viem/test/contracts.ts
@@ -267,7 +267,7 @@ describe("contracts", () => {
               result: [],
             };
           }
-          return next(context, netConn, jsonRpcRequest);
+          return await next(context, netConn, jsonRpcRequest);
         };
         const networkHooks: Partial<NetworkHooks> = {
           onRequest,

--- a/packages/hardhat-viem/test/utils.ts
+++ b/packages/hardhat-viem/test/utils.ts
@@ -24,10 +24,10 @@ export class MockEthereumProvider
     throw new Error("Method not supported");
   }
 
-  public close(): Promise<void> {
+  public async close(): Promise<void> {
     throw new Error("Method not implemented.");
   }
-  public send(): Promise<any> {
+  public async send(): Promise<any> {
     throw new Error("Method not implemented.");
   }
   public sendAsync(): void {

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -57,7 +57,7 @@ export class ArtifactManagerImplementation implements ArtifactManager {
       contractNameOrFullyQualifiedName,
     );
 
-    return readJsonFile(artifactPath);
+    return await readJsonFile(artifactPath);
   }
 
   public async getArtifactPath(

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -45,7 +45,8 @@ export class ArtifactManagerImplementation implements ArtifactManager {
 
   constructor(artifactsPath: string, readFsData?: () => Promise<FsData>) {
     this.#artifactsPath = artifactsPath;
-    this.#readFsData = readFsData ?? (() => this.#readFsDataFromFileSystem());
+    this.#readFsData =
+      readFsData ?? (async () => await this.#readFsDataFromFileSystem());
   }
 
   public async readArtifact<

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -20,62 +20,62 @@ class LazyArtifactManager implements ArtifactManager {
     contractNameOrFullyQualifiedName: ContractNameT,
   ): Promise<GetArtifactByName<ContractNameT>> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.readArtifact(contractNameOrFullyQualifiedName);
+    return await artifactManager.readArtifact(contractNameOrFullyQualifiedName);
   }
 
   public async getArtifactPath(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getArtifactPath(contractNameOrFullyQualifiedName);
+    return await artifactManager.getArtifactPath(contractNameOrFullyQualifiedName);
   }
 
   public async artifactExists(
     contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.artifactExists(contractNameOrFullyQualifiedName);
+    return await artifactManager.artifactExists(contractNameOrFullyQualifiedName);
   }
 
   public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getAllFullyQualifiedNames();
+    return await artifactManager.getAllFullyQualifiedNames();
   }
 
   public async getAllArtifactPaths(): Promise<ReadonlySet<string>> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getAllArtifactPaths();
+    return await artifactManager.getAllArtifactPaths();
   }
 
   public async getBuildInfoId(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string | undefined> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getBuildInfoId(contractNameOrFullyQualifiedName);
+    return await artifactManager.getBuildInfoId(contractNameOrFullyQualifiedName);
   }
 
   public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getAllBuildInfoIds();
+    return await artifactManager.getAllBuildInfoIds();
   }
 
   public async getBuildInfoPath(
     buildInfoId: string,
   ): Promise<string | undefined> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getBuildInfoPath(buildInfoId);
+    return await artifactManager.getBuildInfoPath(buildInfoId);
   }
 
   public async getBuildInfoOutputPath(
     buildInfoId: string,
   ): Promise<string | undefined> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getBuildInfoOutputPath(buildInfoId);
+    return await artifactManager.getBuildInfoOutputPath(buildInfoId);
   }
 
   public async clearCache(): Promise<void> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.clearCache();
+    return await artifactManager.clearCache();
   }
 
   async #getArtifactManager(): Promise<ArtifactManager> {

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -27,14 +27,18 @@ class LazyArtifactManager implements ArtifactManager {
     contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
     const artifactManager = await this.#getArtifactManager();
-    return await artifactManager.getArtifactPath(contractNameOrFullyQualifiedName);
+    return await artifactManager.getArtifactPath(
+      contractNameOrFullyQualifiedName,
+    );
   }
 
   public async artifactExists(
     contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
     const artifactManager = await this.#getArtifactManager();
-    return await artifactManager.artifactExists(contractNameOrFullyQualifiedName);
+    return await artifactManager.artifactExists(
+      contractNameOrFullyQualifiedName,
+    );
   }
 
   public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
@@ -51,7 +55,9 @@ class LazyArtifactManager implements ArtifactManager {
     contractNameOrFullyQualifiedName: string,
   ): Promise<string | undefined> {
     const artifactManager = await this.#getArtifactManager();
-    return await artifactManager.getBuildInfoId(contractNameOrFullyQualifiedName);
+    return await artifactManager.getBuildInfoId(
+      contractNameOrFullyQualifiedName,
+    );
   }
 
   public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/index.ts
@@ -4,7 +4,7 @@ import "./type-extensions.js";
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:artifacts",
   hookHandlers: {
-    hre: () => import("./hook-handlers/hre.js"),
+    hre: async () => await import("./hook-handlers/hre.js"),
   },
   npmPackage: "hardhat",
 };

--- a/packages/hardhat/src/internal/builtin-plugins/clean/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/clean/index.ts
@@ -12,7 +12,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "global",
         description: "Clear the global cache",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   npmPackage: "hardhat",

--- a/packages/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -20,7 +20,7 @@ const hardhatPlugin: HardhatPlugin = {
         description: "Commands to run when the console starts",
         defaultValue: [],
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../solidity/index.js")],

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/solidity.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/solidity.ts
@@ -94,7 +94,7 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
         );
       }
     } else {
-      return next(context, sourceName, fsPath, fileContent, solcVersion);
+      return await next(context, sourceName, fsPath, fileContent, solcVersion);
     }
   },
   preprocessSolcInputBeforeBuilding: async (context, solcInput, next) => {
@@ -121,6 +121,6 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
       solcInput.sources[COVERAGE_LIBRARY_PATH] = { content };
     }
 
-    return next(context, solcInput);
+    return await next(context, solcInput);
   },
 });

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/index.ts
@@ -14,10 +14,10 @@ const hardhatPlugin: HardhatPlugin = {
     }),
   ],
   hookHandlers: {
-    clean: () => import("./hook-handlers/clean.js"),
-    hre: () => import("./hook-handlers/hre.js"),
-    solidity: () => import("./hook-handlers/solidity.js"),
-    test: () => import("./hook-handlers/test.js"),
+    clean: async () => await import("./hook-handlers/clean.js"),
+    hre: async () => await import("./hook-handlers/hre.js"),
+    solidity: async () => await import("./hook-handlers/solidity.js"),
+    test: async () => await import("./hook-handlers/test.js"),
   },
   npmPackage: "hardhat",
 };

--- a/packages/hardhat/src/internal/builtin-plugins/flatten/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/flatten/index.ts
@@ -14,7 +14,7 @@ const hardhatPlugin: HardhatPlugin = {
         description: "An optional list of files to flatten",
         type: ArgumentType.FILE,
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
 };

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
@@ -22,7 +22,7 @@ const hardhatPlugin: HardhatPlugin = {
         default: async (args, _hre, runSuper) => {
           // We don't need to do anything here, as the test task will forward
           // the arguments to its subtasks.
-          return runSuper(args);
+          return await runSuper(args);
         },
       }))
       .build(),
@@ -35,7 +35,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "snapshotCheck",
         description: "Check the snapshots match the stored values",
       })
-      .setAction(async () => import("./tasks/solidity-test/task-action.js"))
+      .setAction(async () => await import("./tasks/solidity-test/task-action.js"))
       .build(),
   ],
   globalOptions: [

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
@@ -35,7 +35,9 @@ const hardhatPlugin: HardhatPlugin = {
         name: "snapshotCheck",
         description: "Check the snapshots match the stored values",
       })
-      .setAction(async () => await import("./tasks/solidity-test/task-action.js"))
+      .setAction(
+        async () => await import("./tasks/solidity-test/task-action.js"),
+      )
       .build(),
   ],
   globalOptions: [
@@ -53,8 +55,8 @@ const hardhatPlugin: HardhatPlugin = {
     }),
   ],
   hookHandlers: {
-    hre: () => import("./hook-handlers/hre.js"),
-    test: () => import("./hook-handlers/test.js"),
+    hre: async () => await import("./hook-handlers/hre.js"),
+    test: async () => await import("./hook-handlers/test.js"),
   },
   dependencies: () => [
     import("../test/index.js"),

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/base-provider.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/base-provider.ts
@@ -20,11 +20,11 @@ export abstract class BaseProvider
   ): Promise<SuccessfulJsonRpcResponse["result"]>;
   public abstract close(): Promise<void>;
 
-  public send(
+  public async send(
     method: string,
     params?: unknown[],
   ): Promise<SuccessfulJsonRpcResponse["result"]> {
-    return this.request({ method, params });
+    return await this.request({ method, params });
   }
 
   public sendAsync(

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -87,7 +87,7 @@ export const DEFAULT_EDR_NETWORK_HD_ACCOUNTS_CONFIG_PARAMS: EdrNetworkDefaultHDA
 export async function isDefaultEdrNetworkHDAccountsConfig(
   accounts: EdrNetworkHDAccountsConfig,
 ): Promise<boolean> {
-  return deepEqual(
+  return await deepEqual(
     {
       ...accounts,
       mnemonic: await accounts.mnemonic.get(),
@@ -325,7 +325,7 @@ export class EdrProvider extends BaseProvider {
         typeof jsonRpcResponse.result === "string",
         "Invalid client version response",
       );
-      return clientVersion(jsonRpcResponse.result);
+      return await clientVersion(jsonRpcResponse.result);
     } else {
       return jsonRpcResponse.result;
     }
@@ -496,7 +496,7 @@ export class EdrProvider extends BaseProvider {
       throw new UnknownError(error.message, error);
     }
 
-    return this.#handleEdrResponse(
+    return await this.#handleEdrResponse(
       edrResponse,
       request.method,
       Array.isArray(request.params) ? request.params : undefined,

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/genesis-state.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/genesis-state.ts
@@ -79,7 +79,7 @@ export async function getGenesisStateAndOwnedAccounts(
     return cached;
   }
 
-  return genesisStateAndAccountsCacheMutex.exclusiveRun(async () => {
+  return await genesisStateAndAccountsCacheMutex.exclusiveRun(async () => {
     // We need to check again inside the mutex callback in case another async
     // operation initialized it while we were waiting to acquire the mutex
     const cachedAfterWaiting = genesisStateAndAccountsCache

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -281,7 +281,7 @@ export async function hardhatAccountsToEdrOwnedAccounts(
     balance: account.balance,
   }));
 
-  return Promise.all(accountPromises);
+  return await Promise.all(accountPromises);
 }
 
 export async function normalizeEdrNetworkAccountsConfig(

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/hre.ts
@@ -17,7 +17,7 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
           networkManager = await createNetworkManager(hre, context);
         }
 
-        return networkManager.create(networkConnectionParams);
+        return await networkManager.create(networkConnectionParams);
       },
 
       async connect(networkConnectionParams) {
@@ -25,7 +25,7 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
           networkManager = await createNetworkManager(hre, context);
         }
 
-        return networkManager.connect(networkConnectionParams);
+        return await networkManager.connect(networkConnectionParams);
       },
 
       async getOrCreate(networkOrParams) {
@@ -33,7 +33,7 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
           networkManager = await createNetworkManager(hre, context);
         }
 
-        return networkManager.getOrCreate(networkOrParams);
+        return await networkManager.getOrCreate(networkOrParams);
       },
 
       async createServer(...params) {
@@ -41,7 +41,7 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
           networkManager = await createNetworkManager(hre, context);
         }
 
-        return networkManager.createServer(...params);
+        return await networkManager.createServer(...params);
       },
     };
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -78,7 +78,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         updatedRequest = newRequestOrResponse;
       }
 
-      return next(context, networkConnection, updatedRequest);
+      return await next(context, networkConnection, updatedRequest);
     },
 
     async closeConnection<ChainTypeT extends ChainType | string>(
@@ -93,7 +93,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         requestHandlersPerConnection.delete(networkConnection);
       }
 
-      return next(context, networkConnection);
+      return await next(context, networkConnection);
     },
   };
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -224,7 +224,7 @@ export class HttpProvider extends BaseProvider {
           retryCount,
         );
         if (this.#shouldRetryRequest(retryAfterSeconds, retryCount)) {
-          return this.#retry(jsonRpcRequest, retryAfterSeconds, retryCount);
+          return await this.#retry(jsonRpcRequest, retryAfterSeconds, retryCount);
         }
 
         // eslint-disable-next-line no-restricted-syntax -- allow throwing ProviderError
@@ -269,7 +269,7 @@ export class HttpProvider extends BaseProvider {
     retryCount: number,
   ) {
     await sleep(retryAfterSeconds);
-    return this.#fetchJsonRpcResponse(request, retryCount + 1);
+    return await this.#fetchJsonRpcResponse(request, retryCount + 1);
   }
 }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -136,7 +136,7 @@ export class HttpProvider extends BaseProvider {
     if (this.#jsonRpcRequestWrapper !== undefined) {
       jsonRpcResponse = await this.#jsonRpcRequestWrapper(
         jsonRpcRequest,
-        (request) => this.#fetchJsonRpcResponse(request),
+        async (request) => await this.#fetchJsonRpcResponse(request),
       );
     } else {
       jsonRpcResponse = await this.#fetchJsonRpcResponse(jsonRpcRequest);
@@ -224,7 +224,11 @@ export class HttpProvider extends BaseProvider {
           retryCount,
         );
         if (this.#shouldRetryRequest(retryAfterSeconds, retryCount)) {
-          return await this.#retry(jsonRpcRequest, retryAfterSeconds, retryCount);
+          return await this.#retry(
+            jsonRpcRequest,
+            retryAfterSeconds,
+            retryCount,
+          );
         }
 
         // eslint-disable-next-line no-restricted-syntax -- allow throwing ProviderError

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/index.ts
@@ -11,9 +11,9 @@ import "./type-extensions/hre.js";
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:network-manager",
   hookHandlers: {
-    config: () => import("./hook-handlers/config.js"),
-    hre: () => import("./hook-handlers/hre.js"),
-    network: () => import("./hook-handlers/network.js"),
+    config: async () => await import("./hook-handlers/config.js"),
+    hre: async () => await import("./hook-handlers/hre.js"),
+    network: async () => await import("./hook-handlers/network.js"),
   },
   globalOptions: [
     globalOption({

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -116,7 +116,11 @@ export class NetworkManagerImplementation implements NetworkManager {
       "newConnection",
       [],
       async (_context) =>
-        await this.#initializeNetworkConnection(networkName, chainType, override),
+        await this.#initializeNetworkConnection(
+          networkName,
+          chainType,
+          override,
+        ),
     );
 
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -252,11 +256,11 @@ export class NetworkManagerImplementation implements NetworkManager {
     const createProvider = async (
       networkConnection: NetworkConnectionImplementation<ChainTypeT>,
     ): Promise<EthereumProvider> => {
-      const jsonRpcRequestWrapper: JsonRpcRequestWrapperFunction = (
+      const jsonRpcRequestWrapper: JsonRpcRequestWrapperFunction = async (
         request,
         defaultBehavior,
       ) =>
-        hookManager.runHandlerChain(
+        await hookManager.runHandlerChain(
           "network",
           "onRequest",
           [networkConnection, request],

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -116,7 +116,7 @@ export class NetworkManagerImplementation implements NetworkManager {
       "newConnection",
       [],
       async (_context) =>
-        this.#initializeNetworkConnection(networkName, chainType, override),
+        await this.#initializeNetworkConnection(networkName, chainType, override),
     );
 
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -131,7 +131,7 @@ export class NetworkManagerImplementation implements NetworkManager {
   ): Promise<NetworkConnection<ChainTypeT>> {
     this.#connectCalled = true;
 
-    return this.create(networkOrParams);
+    return await this.create(networkOrParams);
   }
 
   public async getOrCreate<
@@ -170,7 +170,7 @@ export class NetworkManagerImplementation implements NetworkManager {
       return cached as NetworkConnection<ChainTypeT>;
     }
 
-    return this.#getOrCreateMutex.exclusiveRun(async () => {
+    return await this.#getOrCreateMutex.exclusiveRun(async () => {
       // Double-check after acquiring the mutex — another call may have
       // populated the cache while we were waiting.
       const cachedAfterWaiting = this.#getOrCreateCache
@@ -260,7 +260,7 @@ export class NetworkManagerImplementation implements NetworkManager {
           "network",
           "onRequest",
           [networkConnection, request],
-          async (_context, _connection, req) => defaultBehavior(req),
+          async (_context, _connection, req) => await defaultBehavior(req),
         );
 
       if (resolvedNetworkConfig.type === "edr-simulated") {
@@ -351,7 +351,7 @@ export class NetworkManagerImplementation implements NetworkManager {
 
         const includeCallTraces = verbosityToIncludeTraces(this.#verbosity);
 
-        return EdrProvider.create({
+        return await EdrProvider.create({
           chainDescriptors: this.#chainDescriptors,
           // The resolvedNetworkConfig can have its chainType set to `undefined`
           // so we default to the default chain type here.
@@ -375,7 +375,7 @@ export class NetworkManagerImplementation implements NetworkManager {
         });
       }
 
-      return HttpProvider.create({
+      return await HttpProvider.create({
         url: await resolvedNetworkConfig.url.getUrl(),
         networkName: resolvedNetworkName,
         extraHeaders: resolvedNetworkConfig.httpHeaders,
@@ -384,7 +384,7 @@ export class NetworkManagerImplementation implements NetworkManager {
       });
     };
 
-    return NetworkConnectionImplementation.create(
+    return await NetworkConnectionImplementation.create(
       this.#nextConnectionId++,
       resolvedNetworkName,
       resolvedChainType,

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers-array.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers-array.ts
@@ -90,7 +90,7 @@ export async function createHandlersArray<
 
     if (Array.isArray(accounts)) {
       const resolvedAccounts = await Promise.all(
-        accounts.map((acc) => acc.getHexString()),
+        accounts.map(async (acc) => await acc.getHexString()),
       );
 
       requestHandlers.push(

--- a/packages/hardhat/src/internal/builtin-plugins/node/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/index.ts
@@ -46,7 +46,7 @@ const hardhatPlugin: HardhatPlugin = {
         type: ArgumentType.INT,
         defaultValue: -1,
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../network-manager/index.js")],

--- a/packages/hardhat/src/internal/builtin-plugins/node/json-rpc/handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/json-rpc/handler.ts
@@ -9,6 +9,7 @@ import type WebSocket from "ws";
 
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
+import debug from "debug";
 
 import {
   isJsonRpcRequest,
@@ -22,6 +23,8 @@ import {
   ProviderError,
 } from "../../network-manager/provider-errors.js";
 import { REVERT_ERROR_CODE } from "../../network-manager/revert-error-code.js";
+
+const log = debug("hardhat:node:json-rpc");
 
 export class JsonRpcHandler {
   readonly #provider: EthereumProvider;
@@ -123,11 +126,18 @@ export class JsonRpcHandler {
 
       // Clear any active subscriptions for the closed websocket connection.
       isClosed = true;
-      subscriptions.forEach(async (subscriptionId) => {
-        await this.#provider.request({
-          method: "eth_unsubscribe",
-          params: [subscriptionId],
-        });
+      Promise.all(
+        subscriptions.map(async (subscriptionId) => {
+          await this.#provider.request({
+            method: "eth_unsubscribe",
+            params: [subscriptionId],
+          });
+        }),
+      ).catch((error: unknown) => {
+        log(
+          "Failed to request eth_unsubscribe when websocket is closed",
+          error,
+        );
       });
     });
   };

--- a/packages/hardhat/src/internal/builtin-plugins/node/json-rpc/handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/json-rpc/handler.ts
@@ -53,8 +53,8 @@ export class JsonRpcHandler {
     // the following code block could be safely removed.
     if (Array.isArray(jsonHttpRequest)) {
       const responses = await Promise.all(
-        jsonHttpRequest.map((singleReq: unknown) =>
-          this.#handleRequest(singleReq),
+        jsonHttpRequest.map(
+          async (singleReq: unknown) => await this.#handleRequest(singleReq),
         ),
       );
 
@@ -104,7 +104,9 @@ export class JsonRpcHandler {
 
         rpcResp = Array.isArray(rpcReq)
           ? await Promise.all(
-              rpcReq.map((req) => this.#handleWsRequest(req, subscriptions)),
+              rpcReq.map(
+                async (req) => await this.#handleWsRequest(req, subscriptions),
+              ),
             )
           : await this.#handleWsRequest(rpcReq, subscriptions);
       } catch (error) {

--- a/packages/hardhat/src/internal/builtin-plugins/node/json-rpc/server.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/json-rpc/server.ts
@@ -37,8 +37,8 @@ export class JsonRpcServerImplementation implements JsonRpcServer {
     this.#wsServer.on("connection", handler.handleWs);
   }
 
-  public listen = (): Promise<{ address: string; port: number }> => {
-    return new Promise((resolve) => {
+  public listen = async (): Promise<{ address: string; port: number }> => {
+    return await new Promise((resolve) => {
       log(`Starting JSON-RPC server on port ${this.#config.port}`);
       this.#httpServer.listen(this.#config.port, this.#config.hostname, () => {
         // We get the address and port directly from the server in order to handle random port allocation with `0`.

--- a/packages/hardhat/src/internal/builtin-plugins/run/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/run/index.ts
@@ -14,7 +14,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "noCompile",
         description: "Do not compile the project before running the script",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../solidity/index.js")],

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts
@@ -31,7 +31,7 @@ export async function getBuildInfosAndOutputs(
 ): Promise<BuildInfoAndOutput[]> {
   const buildInfoIds = await artifactManager.getAllBuildInfoIds();
 
-  return Promise.all(
+  return await Promise.all(
     Array.from(buildInfoIds).map(async (buildInfoId) => {
       const buildInfoPath = await artifactManager.getBuildInfoPath(buildInfoId);
       const buildInfoOutputPath =
@@ -76,7 +76,7 @@ export async function buildEdrArtifactsWithMetadata(
 
   const artifacts = await Promise.all(
     Array.from(fullyQualifiedNames).map(async (fullyQualifiedName) => {
-      return artifactManager.readArtifact(fullyQualifiedName);
+      return await artifactManager.readArtifact(fullyQualifiedName);
     }),
   );
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/hook-handlers/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/hook-handlers/config.ts
@@ -19,7 +19,7 @@ export default async (): Promise<Partial<ConfigHooks>> => {
         resolveConfigurationVariable,
       );
 
-      return resolveSolidityTestUserConfig(
+      return await resolveSolidityTestUserConfig(
         userConfig,
         resolvedConfig,
         resolveConfigurationVariable,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/hook-handlers/test.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/hook-handlers/test.ts
@@ -15,7 +15,7 @@ export default async (): Promise<Partial<TestHooks>> => {
         return "solidity";
       }
 
-      return next(context, filePath);
+      return await next(context, filePath);
     },
   };
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -9,8 +9,8 @@ import "./type-extensions.js";
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:solidity-tests",
   hookHandlers: {
-    config: () => import("./hook-handlers/config.js"),
-    test: () => import("./hook-handlers/test.js"),
+    config: async () => await import("./hook-handlers/config.js"),
+    test: async () => await import("./hook-handlers/test.js"),
   },
   tasks: [
     task(["test", "solidity"], "Run the Solidity tests")

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -42,7 +42,7 @@ const hardhatPlugin: HardhatPlugin = {
         defaultValue: 0,
         hidden: true,
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -201,7 +201,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
               f.endsWith(".sol"),
             ),
             ...this.#options.soliditySourcesPaths.map(async (dir) => {
-              return getAllFilesMatching(dir, (f) => f.endsWith(".t.sol"));
+              return await getAllFilesMatching(dir, (f) => f.endsWith(".t.sol"));
             }),
           ])
         ).flat(1);
@@ -223,12 +223,12 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     rootFilePaths: string[],
     _options?: BuildOptions,
   ): Promise<CompilationJobCreationError | Map<string, FileBuildResult>> {
-    return this.#hooks.runHandlerChain(
+    return await this.#hooks.runHandlerChain(
       "solidity",
       "build",
       [rootFilePaths, _options],
       async (_context, nextRootFilePaths, nextOptions) =>
-        this.#build(nextRootFilePaths, nextOptions),
+        await this.#build(nextRootFilePaths, nextOptions),
     );
   }
 
@@ -277,7 +277,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       // internally in each compilation job
       await Promise.all(
         runnableCompilationJobs.map(async (runnableCompilationJob) =>
-          runnableCompilationJob.getBuildId(),
+          await runnableCompilationJob.getBuildId(),
         ),
       );
 
@@ -505,7 +505,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
           "getCompiler",
           [compilerConfig],
           async (_context, cfg) =>
-            getSolcCompilerForConfig(cfg, buildProfile.preferWasm),
+            await getSolcCompilerForConfig(cfg, buildProfile.preferWasm),
         );
         longVersion = compiler.longVersion;
         longVersionMap.set(compilerConfig.version, longVersion);
@@ -751,7 +751,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       "getCompiler",
       [runnableCompilationJob.solcConfig],
       async (_context, cfg) =>
-        getSolcCompilerForConfig(cfg, buildProfile.preferWasm),
+        await getSolcCompilerForConfig(cfg, buildProfile.preferWasm),
     );
 
     log(
@@ -770,7 +770,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       "invokeSolc",
       [compiler, input, runnableCompilationJob.solcConfig],
       async (_context, nextCompiler, nextSolcInput) => {
-        return nextCompiler.compile(nextSolcInput);
+        return await nextCompiler.compile(nextSolcInput);
       },
     );
 
@@ -1092,7 +1092,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       preferWasm: false,
     });
 
-    return compiler.compile(buildInfo.input);
+    return await compiler.compile(buildInfo.input);
   }
 
   async #downloadConfiguredCompilers(quiet = false): Promise<void> {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -179,11 +179,12 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       case "contracts":
         const localFilesToCompile = (
           await Promise.all(
-            this.#options.soliditySourcesPaths.map((dir) =>
-              getAllFilesMatching(
-                dir,
-                (f) => f.endsWith(".sol") && !f.endsWith(".t.sol"),
-              ),
+            this.#options.soliditySourcesPaths.map(
+              async (dir) =>
+                await getAllFilesMatching(
+                  dir,
+                  (f) => f.endsWith(".sol") && !f.endsWith(".t.sol"),
+                ),
             ),
           )
         ).flat(1);
@@ -201,7 +202,9 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
               f.endsWith(".sol"),
             ),
             ...this.#options.soliditySourcesPaths.map(async (dir) => {
-              return await getAllFilesMatching(dir, (f) => f.endsWith(".t.sol"));
+              return await getAllFilesMatching(dir, (f) =>
+                f.endsWith(".t.sol"),
+              );
             }),
           ])
         ).flat(1);
@@ -276,8 +279,9 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       // NOTE: We precompute the build ids in parallel here, which are cached
       // internally in each compilation job
       await Promise.all(
-        runnableCompilationJobs.map(async (runnableCompilationJob) =>
-          await runnableCompilationJob.getBuildId(),
+        runnableCompilationJobs.map(
+          async (runnableCompilationJob) =>
+            await runnableCompilationJob.getBuildId(),
         ),
       );
 
@@ -362,8 +366,9 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
         );
 
         const errors = await Promise.all(
-          (result.compilerOutput.errors ?? []).map((error) =>
-            this.remapCompilerError(result.compilationJob, error, true),
+          (result.compilerOutput.errors ?? []).map(
+            async (error) =>
+              await this.remapCompilerError(result.compilationJob, error, true),
           ),
         );
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job.ts
@@ -92,7 +92,7 @@ export class CompilationJobImplementation implements CompilationJob {
         // instrument the project file content when coverage feature is enabled.
         // We pass some additional data via the chain - i.e. the input source name and solc
         // version - but we expect any handlers to pass them on as-is without modification.
-        return this.#hooks.runHandlerChain(
+        return await this.#hooks.runHandlerChain(
           "solidity",
           "preprocessProjectFileBeforeBuilding",
           [file.inputSourceName, file.fsPath, file.content.text, solcVersion],

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -195,7 +195,7 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
 
     const downloadPath = this.#getCompilerBinaryPathFromBuild(build);
 
-    return exists(downloadPath);
+    return await exists(downloadPath);
   }
 
   public async downloadCompiler(version: string): Promise<boolean> {
@@ -208,7 +208,7 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
       path.join(this.#compilersDir, `compiler-download-${version}`),
     );
 
-    return mutex.use(async () => {
+    return await mutex.use(async () => {
       const isCompilerDownloaded = await this.isCompilerDownloaded(version);
 
       if (isCompilerDownloaded === true) {
@@ -240,7 +240,7 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
         }
       }
 
-      return this.#postProcessCompilerDownload(build, downloadPath);
+      return await this.#postProcessCompilerDownload(build, downloadPath);
     });
   }
 
@@ -295,7 +295,7 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
   }
 
   async #readCompilerList(listPath: string): Promise<CompilerList> {
-    return readJsonFile(listPath);
+    return await readJsonFile(listPath);
   }
 
   #getCompilerDownloadPathFromBuild(build: CompilerBuild): string {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/index.ts
@@ -124,10 +124,10 @@ export async function getCompiler(
 ): Promise<Compiler> {
   if (compilerPath !== undefined) {
     // If a compiler path is provided, it means the user is using a custom compiler
-    return getCompilerFromPath(version, compilerPath);
+    return await getCompilerFromPath(version, compilerPath);
   } else {
     // Otherwise we get or download the compiler for the specific version
-    return getCompilerFromVersion(version, { preferWasm });
+    return await getCompilerFromVersion(version, { preferWasm });
   }
 }
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/solcjs-runner.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/solcjs-runner.ts
@@ -6,7 +6,7 @@ async function readStream(
 ): Promise<string> {
   stream.setEncoding(encoding);
 
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     let data = "";
 
     stream.on("data", (chunk) => (data += chunk.toString(encoding)));

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph-building.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph-building.ts
@@ -22,13 +22,13 @@ export async function buildDependencyGraph(
   hookManager: HookManager,
 ): Promise<DependencyGraphImplementation> {
   // Create the wrapper function that captures the hook manager
-  const remappingsReader: RemappingsReaderFunction = (
+  const remappingsReader: RemappingsReaderFunction = async (
     packageName,
     packageVersion,
     packagePath,
     defaultBehavior,
   ) =>
-    hookManager.runHandlerChain(
+    await hookManager.runHandlerChain(
       "solidity",
       "readNpmPackageRemappings",
       [packageName, packageVersion, packagePath],

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph-building.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph-building.ts
@@ -33,7 +33,7 @@ export async function buildDependencyGraph(
       "readNpmPackageRemappings",
       [packageName, packageVersion, packagePath],
       async (_context, name, version, path) =>
-        defaultBehavior(name, version, path),
+        await defaultBehavior(name, version, path),
     );
 
   const resolver = await ResolverImplementation.create(

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/read-source-file.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/read-source-file.ts
@@ -6,11 +6,11 @@ export function readSourceFileFactory(
   hooks: HookManager,
 ): (absPath: string) => Promise<string> {
   return async (factoryAbsPath: string) => {
-    return hooks.runHandlerChain(
+    return await hooks.runHandlerChain(
       "solidity",
       "readSourceFile",
       [factoryAbsPath],
-      async (_context, absPath) => readUtf8File(absPath),
+      async (_context, absPath) => await readUtf8File(absPath),
     );
   };
 }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -133,8 +133,8 @@ export class ResolverImplementation implements Resolver {
   public async resolveProjectFile(
     absoluteFilePath: string,
   ): Promise<Result<ProjectResolvedFile, ProjectRootResolutionError>> {
-    return this.#mutex.exclusiveRun(async () => {
-      return this.#resolveProjectFile(absoluteFilePath);
+    return await this.#mutex.exclusiveRun(async () => {
+      return await this.#resolveProjectFile(absoluteFilePath);
     });
   }
 
@@ -146,8 +146,8 @@ export class ResolverImplementation implements Resolver {
       NpmRootResolutionError
     >
   > {
-    return this.#mutex.exclusiveRun(async () => {
-      return this.#resolveNpmDependencyFileAsRoot(npmModule);
+    return await this.#mutex.exclusiveRun(async () => {
+      return await this.#resolveNpmDependencyFileAsRoot(npmModule);
     });
   }
 
@@ -160,8 +160,8 @@ export class ResolverImplementation implements Resolver {
       ImportResolutionError
     >
   > {
-    return this.#mutex.exclusiveRun(async () =>
-      this.#resolveImport(from, importPath),
+    return await this.#mutex.exclusiveRun(async () =>
+      await this.#resolveImport(from, importPath),
     );
   }
 
@@ -495,7 +495,7 @@ export class ResolverImplementation implements Resolver {
         };
       }
 
-      return this.#resolveRelativeImport({
+      return await this.#resolveRelativeImport({
         from,
         importPath,
         directImport,
@@ -504,7 +504,7 @@ export class ResolverImplementation implements Resolver {
       if (bestUserRemapping !== undefined) {
         // If the import isn't relative, and there's a user remapping, we
         // prioritize that.
-        return this.#resolveUserRemappedImport({
+        return await this.#resolveUserRemappedImport({
           from,
           importPath,
           directImport,
@@ -576,7 +576,7 @@ export class ResolverImplementation implements Resolver {
 
     const relativeFsPath = sourceNamePathToFsPath(relativeSourceNamePath);
 
-    return this.#commonImportResolution({
+    return await this.#commonImportResolution({
       from,
       importPath,
       npmPackage: from.package,
@@ -639,7 +639,7 @@ export class ResolverImplementation implements Resolver {
 
     const relativeFsPath = sourceNamePathToFsPath(relativeSourceNamePath);
 
-    return this.#commonImportResolution({
+    return await this.#commonImportResolution({
       from,
       importPath,
       npmPackage: targetNpmPackage,
@@ -796,7 +796,7 @@ export class ResolverImplementation implements Resolver {
     const relativePath = resolvedSubpath ?? subpath;
     const relativeFsPathWithinPackage = sourceNamePathToFsPath(relativePath);
 
-    return this.#commonImportResolution({
+    return await this.#commonImportResolution({
       from,
       importPath,
       npmPackage: dependency,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -160,8 +160,8 @@ export class ResolverImplementation implements Resolver {
       ImportResolutionError
     >
   > {
-    return await this.#mutex.exclusiveRun(async () =>
-      await this.#resolveImport(from, importPath),
+    return await this.#mutex.exclusiveRun(
+      async () => await this.#resolveImport(from, importPath),
     );
   }
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
@@ -457,7 +457,7 @@ export class RemappedNpmPackagesGraphImplementation
       npmPackage.version,
       npmPackage.rootFsPath,
       async (_packageName, _packageVersion, packagePath) =>
-        this.#defaultReadPackageRemappings(packagePath),
+        await this.#defaultReadPackageRemappings(packagePath),
     );
 
     return this.#parseAndDeduplicateRemappings(npmPackage, allRemappings);

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
@@ -146,12 +146,12 @@ export class RemappedNpmPackagesGraphImplementation
 
   public static async create(
     projectRootPath: string,
-    remappingsReader: RemappingsReaderFunction = (
+    remappingsReader: RemappingsReaderFunction = async (
       packageName,
       packageVersion,
       packagePath,
       defaultBehavior,
-    ) => defaultBehavior(packageName, packageVersion, packagePath),
+    ) => await defaultBehavior(packageName, packageVersion, packagePath),
   ): Promise<RemappedNpmPackagesGraphImplementation> {
     const projectPackageJson = await readJsonFile<PackageJson>(
       path.join(projectRootPath, "package.json"),

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/config.ts
@@ -20,7 +20,7 @@ export default async (): Promise<Partial<ConfigHooks>> => {
         resolveConfigurationVariable,
       );
 
-      return resolveSolidityUserConfig(userConfig, resolvedConfig);
+      return await resolveSolidityUserConfig(userConfig, resolvedConfig);
     },
     validateResolvedConfig: async (resolvedConfig) =>
       validateSolidityConfig(resolvedConfig),

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
@@ -38,12 +38,12 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options: { scope?: BuildScope } = {},
   ): Promise<string[]> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.getRootFilePaths(options);
+    return await buildSystem.getRootFilePaths(options);
   }
 
   public async getScope(fsPath: string): Promise<BuildScope> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.getScope(fsPath);
+    return await buildSystem.getScope(fsPath);
   }
 
   public isSuccessfulBuildResult(
@@ -59,7 +59,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options?: BuildOptions,
   ): Promise<CompilationJobCreationError | Map<string, FileBuildResult>> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.build(rootFiles, options);
+    return await buildSystem.build(rootFiles, options);
   }
 
   public async getCompilationJobs(
@@ -67,7 +67,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options?: GetCompilationJobsOptions,
   ): Promise<CompilationJobCreationError | GetCompilationJobsResult> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.getCompilationJobs(rootFiles, options);
+    return await buildSystem.getCompilationJobs(rootFiles, options);
   }
 
   public async runCompilationJob(
@@ -75,7 +75,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options?: RunCompilationJobOptions,
   ): Promise<RunCompilationJobResult> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.runCompilationJob(compilationJob, options);
+    return await buildSystem.runCompilationJob(compilationJob, options);
   }
 
   public async remapCompilerError(
@@ -84,7 +84,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     shouldShortenPaths?: boolean,
   ): Promise<CompilerOutputError> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.remapCompilerError(
+    return await buildSystem.remapCompilerError(
       compilationJob,
       error,
       shouldShortenPaths,
@@ -97,7 +97,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options: { scope?: BuildScope } = {},
   ): Promise<EmitArtifactsResult> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.emitArtifacts(compilationJob, compilerOutput, options);
+    return await buildSystem.emitArtifacts(compilationJob, compilerOutput, options);
   }
 
   public async cleanupArtifacts(
@@ -105,7 +105,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options: { scope?: BuildScope } = {},
   ): Promise<void> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.cleanupArtifacts(rootFilePaths, options);
+    return await buildSystem.cleanupArtifacts(rootFilePaths, options);
   }
 
   public async compileBuildInfo(
@@ -113,12 +113,12 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options?: CompileBuildInfoOptions,
   ): Promise<CompilerOutput> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.compileBuildInfo(buildInfo, options);
+    return await buildSystem.compileBuildInfo(buildInfo, options);
   }
 
   public async getArtifactsDirectory(scope: BuildScope): Promise<string> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.getArtifactsDirectory(scope);
+    return await buildSystem.getArtifactsDirectory(scope);
   }
 
   async #getBuildSystem(): Promise<SolidityBuildSystem> {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
@@ -97,7 +97,11 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options: { scope?: BuildScope } = {},
   ): Promise<EmitArtifactsResult> {
     const buildSystem = await this.#getBuildSystem();
-    return await buildSystem.emitArtifacts(compilationJob, compilerOutput, options);
+    return await buildSystem.emitArtifacts(
+      compilationJob,
+      compilerOutput,
+      options,
+    );
   }
 
   public async cleanupArtifacts(

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/index.ts
@@ -32,7 +32,7 @@ const buildTask = task("build", "Build project")
     name: "noContracts",
     description: "Skip solidity contracts compilation",
   })
-  .setAction(async () => import("./tasks/build.js"))
+  .setAction(async () => await import("./tasks/build.js"))
   .build();
 
 const hardhatPlugin: HardhatPlugin = {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/index.ts
@@ -39,9 +39,9 @@ const hardhatPlugin: HardhatPlugin = {
   id: "builtin:solidity",
   dependencies: () => [import("../artifacts/index.js")],
   hookHandlers: {
-    config: () => import("./hook-handlers/config.js"),
-    hre: () => import("./hook-handlers/hre.js"),
-    solidity: () => import("./hook-handlers/solidity.js"),
+    config: async () => await import("./hook-handlers/config.js"),
+    hre: async () => await import("./hook-handlers/hre.js"),
+    solidity: async () => await import("./hook-handlers/solidity.js"),
   },
   tasks: [
     {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/solidity-hooks.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/solidity-hooks.ts
@@ -46,7 +46,7 @@ export async function getSolcCompilerForConfig(
   compilerConfig: SolidityCompilerConfig,
   buildProfilePreferWasm: boolean,
 ): Promise<Compiler> {
-  return getCompiler(compilerConfig.version, {
+  return await getCompiler(compilerConfig.version, {
     preferWasm: resolvePreferWasm(compilerConfig, buildProfilePreferWasm),
     compilerPath: compilerConfig.path,
   });

--- a/packages/hardhat/src/internal/builtin-plugins/telemetry/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/telemetry/index.ts
@@ -14,7 +14,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "disable",
         description: "Disable telemetry",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   npmPackage: "hardhat",

--- a/packages/hardhat/src/internal/builtin-plugins/test/hook-handlers/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/hook-handlers/config.ts
@@ -14,7 +14,7 @@ export default async (): Promise<Partial<ConfigHooks>> => {
         resolveConfigurationVariable,
       );
 
-      return resolveTestUserConfig(userConfig, resolvedConfig);
+      return await resolveTestUserConfig(userConfig, resolvedConfig);
     },
   };
 

--- a/packages/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -8,7 +8,7 @@ import "./type-extensions.js";
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:test",
   hookHandlers: {
-    config: () => import("./hook-handlers/config.js"),
+    config: async () => await import("./hook-handlers/config.js"),
   },
   tasks: [
     task("test", "Run all tests")

--- a/packages/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -32,7 +32,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "noCompile",
         description: "Do not compile the project before running the tests",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../solidity/index.js")],

--- a/packages/hardhat/src/internal/cli/telemetry/analytics/analytics.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/analytics/analytics.ts
@@ -60,7 +60,7 @@ export async function sendTaskAnalytics(taskId: string[]): Promise<boolean> {
     },
   };
 
-  return sendAnalytics(taskAnalyticsEvent);
+  return await sendAnalytics(taskAnalyticsEvent);
 }
 
 export async function sendProjectTypeAnalytics(
@@ -75,7 +75,7 @@ export async function sendProjectTypeAnalytics(
     },
   };
 
-  return sendAnalytics(initAnalyticsEvent);
+  return await sendAnalytics(initAnalyticsEvent);
 }
 
 // Return a boolean for testing purposes to confirm whether analytics were sent based on the consent value and not in CI environments

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/anonymizer.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/anonymizer.ts
@@ -359,7 +359,7 @@ export class Anonymizer {
   async #anonymizeFrames(frames: StackFrame[]): Promise<StackFrame[]> {
     const anonymizedFrames = await Promise.all(
       frames.map(async (frame) => {
-        return this.#anonymizeFrame(frame);
+        return await this.#anonymizeFrame(frame);
       }),
     );
     return anonymizedFrames;

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/anonymizer.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/anonymizer.ts
@@ -323,7 +323,9 @@ export class Anonymizer {
 
   async #anonymizeExceptions(exceptions: Exception[]): Promise<Exception[]> {
     const anonymizedExceptions = await Promise.all(
-      exceptions.map((exception) => this.#anonymizeException(exception)),
+      exceptions.map(
+        async (exception) => await this.#anonymizeException(exception),
+      ),
     );
     return anonymizedExceptions;
   }

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
@@ -27,7 +27,7 @@ export async function setupErrorTelemetryIfEnabled(): Promise<void> {
 
 export async function sendErrorTelemetry(error: Error): Promise<boolean> {
   const instance = await Reporter.getInstance();
-  return instance.reportErrorViaSubprocess(error);
+  return await instance.reportErrorViaSubprocess(error);
 }
 
 export function setCliHardhatConfigPath(configPath: string): void {

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/transport.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/transport.ts
@@ -35,7 +35,7 @@ export function createDetachedProcessTransport(
   getConfigPath: () => string | undefined,
 ): Transport {
   return {
-    send: (envelope) => {
+    send: async (envelope) => {
       const verbose = log.enabled;
 
       // **Synchronously** spawn a detached subprocess here
@@ -75,10 +75,10 @@ export function createDetachedProcessTransport(
 
       subprocess.unref();
 
-      return Promise.resolve({ statusCode: 200 });
+      return await Promise.resolve({ statusCode: 200 });
     },
-    flush: (_timeout) => {
-      return Promise.resolve(true);
+    flush: async (_timeout) => {
+      return await Promise.resolve(true);
     },
   };
 }

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/transport.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/transport.ts
@@ -139,7 +139,7 @@ export async function sendEnvelopeToSentryBackend(
   dsn: string,
   envelope: Envelope,
 ): Promise<TransportMakeRequestResponse> {
-  return sendSerializedEnvelopeToSentryBackend(
+  return await sendSerializedEnvelopeToSentryBackend(
     dsn,
     serializeEnvelope(envelope),
   );

--- a/packages/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
@@ -35,7 +35,7 @@ export async function isTelemetryAllowed(
     return process.env.HARDHAT_TEST_TELEMETRY_ENABLED === "true" ? true : false;
   }
 
-  return isTelemetryEnabled(telemetryConfigFilePath);
+  return await isTelemetryEnabled(telemetryConfigFilePath);
 }
 
 /**

--- a/packages/hardhat/src/internal/config-loading.ts
+++ b/packages/hardhat/src/internal/config-loading.ts
@@ -34,15 +34,15 @@ export async function resolveHardhatConfigPath(
   userProvidedPath?: string,
 ): Promise<string> {
   if (userProvidedPath !== undefined) {
-    return normalizeConfigPath(userProvidedPath);
+    return await normalizeConfigPath(userProvidedPath);
   }
 
   if (process.env.HARDHAT_CONFIG !== undefined) {
     log("Using config file path from the HARDHAT_CONFIG env var");
-    return normalizeConfigPath(process.env.HARDHAT_CONFIG);
+    return await normalizeConfigPath(process.env.HARDHAT_CONFIG);
   }
 
-  return findClosestHardhatConfig();
+  return await findClosestHardhatConfig();
 }
 
 /**

--- a/packages/hardhat/src/internal/core/configuration-variables.ts
+++ b/packages/hardhat/src/internal/core/configuration-variables.ts
@@ -118,24 +118,25 @@ export class LazyResolvedConfigurationVariable extends BaseResolvedConfiguration
     const mutex = LazyResolvedConfigurationVariable.#mutexes.get(this.#hooks);
     assertHardhatInvariant(mutex !== undefined, "Mutex must be defined");
 
-    return await mutex.exclusiveRun(async () =>
-      await this.#hooks.runHandlerChain(
-        "configurationVariables",
-        "fetchValue",
-        [this.#variable],
-        async (_context, v) => {
-          const value = process.env[v.name];
+    return await mutex.exclusiveRun(
+      async () =>
+        await this.#hooks.runHandlerChain(
+          "configurationVariables",
+          "fetchValue",
+          [this.#variable],
+          async (_context, v) => {
+            const value = process.env[v.name];
 
-          if (typeof value !== "string") {
-            throw new HardhatError(
-              HardhatError.ERRORS.CORE.GENERAL.ENV_VAR_NOT_FOUND,
-              { name: v.name },
-            );
-          }
+            if (typeof value !== "string") {
+              throw new HardhatError(
+                HardhatError.ERRORS.CORE.GENERAL.ENV_VAR_NOT_FOUND,
+                { name: v.name },
+              );
+            }
 
-          return value;
-        },
-      ),
+            return value;
+          },
+        ),
     );
   }
 }

--- a/packages/hardhat/src/internal/core/configuration-variables.ts
+++ b/packages/hardhat/src/internal/core/configuration-variables.ts
@@ -118,8 +118,8 @@ export class LazyResolvedConfigurationVariable extends BaseResolvedConfiguration
     const mutex = LazyResolvedConfigurationVariable.#mutexes.get(this.#hooks);
     assertHardhatInvariant(mutex !== undefined, "Mutex must be defined");
 
-    return mutex.exclusiveRun(async () =>
-      this.#hooks.runHandlerChain(
+    return await mutex.exclusiveRun(async () =>
+      await this.#hooks.runHandlerChain(
         "configurationVariables",
         "fetchValue",
         [this.#variable],

--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -124,7 +124,7 @@ export class HookManagerImplementation implements HookManager {
       return result;
     };
 
-    return next(...handlerParams);
+    return await next(...handlerParams);
   }
 
   public async runSequentialHandlers<
@@ -192,7 +192,7 @@ export class HookManagerImplementation implements HookManager {
       handlerParams = params;
     }
 
-    return Promise.all(
+    return await Promise.all(
       handlers.map((handler) => (handler as any)(...handlerParams)),
     );
   }
@@ -277,7 +277,7 @@ export class HookManagerImplementation implements HookManager {
     const categories: Array<
       Partial<HardhatHooks[HookCategoryNameT]> | undefined
     > = await this.#mutex.exclusiveRun(async () => {
-      return Promise.all(
+      return await Promise.all(
         this.#pluginsInReverseOrder.map(async (plugin) => {
           const existingCategory = this.#staticHookHandlerCategories
             .get(plugin.id)

--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -193,7 +193,7 @@ export class HookManagerImplementation implements HookManager {
     }
 
     return await Promise.all(
-      handlers.map((handler) => (handler as any)(...handlerParams)),
+      handlers.map(async (handler) => await (handler as any)(...handlerParams)),
     );
   }
 

--- a/packages/hardhat/src/internal/core/hre.ts
+++ b/packages/hardhat/src/internal/core/hre.ts
@@ -193,7 +193,9 @@ export class HardhatRuntimeEnvironmentImplementation
 export async function resolveProjectRoot(
   absolutePathWithinProject: string | undefined,
 ): Promise<string> {
-  return await findClosestPackageRoot(absolutePathWithinProject ?? process.cwd());
+  return await findClosestPackageRoot(
+    absolutePathWithinProject ?? process.cwd(),
+  );
 }
 
 /**

--- a/packages/hardhat/src/internal/core/hre.ts
+++ b/packages/hardhat/src/internal/core/hre.ts
@@ -193,7 +193,7 @@ export class HardhatRuntimeEnvironmentImplementation
 export async function resolveProjectRoot(
   absolutePathWithinProject: string | undefined,
 ): Promise<string> {
-  return findClosestPackageRoot(absolutePathWithinProject ?? process.cwd());
+  return await findClosestPackageRoot(absolutePathWithinProject ?? process.cwd());
 }
 
 /**
@@ -292,7 +292,7 @@ async function runUserConfigExtensions(
   hooks: HookManager,
   config: HardhatUserConfig,
 ): Promise<HardhatUserConfig> {
-  return hooks.runHandlerChain(
+  return await hooks.runHandlerChain(
     "config",
     "extendUserConfig",
     [config],
@@ -320,7 +320,7 @@ async function resolveUserConfig(
     paths: resolvePaths(projectRoot, configPath, config.paths),
   } as HardhatConfig;
 
-  return hooks.runHandlerChain(
+  return await hooks.runHandlerChain(
     "config",
     "resolveUserConfig",
     [config, (variable) => resolveConfigurationVariable(hooks, variable)],

--- a/packages/hardhat/src/internal/core/plugins/resolve-plugin-list.ts
+++ b/packages/hardhat/src/internal/core/plugins/resolve-plugin-list.ts
@@ -12,7 +12,7 @@ export async function resolvePluginList(
   projectRoot: string,
   userConfigPluginList: HardhatPlugin[] = [],
 ): Promise<HardhatPlugin[]> {
-  return reverseTopologicalSort(projectRoot, userConfigPluginList);
+  return await reverseTopologicalSort(projectRoot, userConfigPluginList);
 }
 
 /**

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -185,12 +185,12 @@ export class ResolvedTask implements Task {
         nextTaskArguments,
         this.#hre,
         async (newTaskArguments: TaskArguments) => {
-          return next(newTaskArguments, currentIndex - 1);
+          return await next(newTaskArguments, currentIndex - 1);
         },
       );
     };
 
-    return next(validatedTaskArguments);
+    return await next(validatedTaskArguments);
   }
 
   /**

--- a/packages/hardhat/src/internal/core/user-interruptions.ts
+++ b/packages/hardhat/src/internal/core/user-interruptions.ts
@@ -21,8 +21,8 @@ export class UserInterruptionManagerImplementation
     interruptor: string,
     message: string,
   ): Promise<void> {
-    return this.#mutex.exclusiveRun(async () => {
-      return this.#hooks.runHandlerChain(
+    return await this.#mutex.exclusiveRun(async () => {
+      return await this.#hooks.runHandlerChain(
         "userInterruptions",
         "displayMessage",
         [interruptor, message],
@@ -35,8 +35,8 @@ export class UserInterruptionManagerImplementation
     interruptor: string,
     inputDescription: string,
   ): Promise<string> {
-    return this.#mutex.exclusiveRun(async () => {
-      return this.#hooks.runHandlerChain(
+    return await this.#mutex.exclusiveRun(async () => {
+      return await this.#hooks.runHandlerChain(
         "userInterruptions",
         "requestInput",
         [interruptor, inputDescription],
@@ -49,8 +49,8 @@ export class UserInterruptionManagerImplementation
     interruptor: string,
     inputDescription: string,
   ): Promise<string> {
-    return this.#mutex.exclusiveRun(async () => {
-      return this.#hooks.runHandlerChain(
+    return await this.#mutex.exclusiveRun(async () => {
+      return await this.#hooks.runHandlerChain(
         "userInterruptions",
         "requestSecretInput",
         [interruptor, inputDescription],
@@ -62,7 +62,7 @@ export class UserInterruptionManagerImplementation
   public async uninterrupted<ReturnT>(
     f: () => ReturnT,
   ): Promise<Awaited<ReturnT>> {
-    return this.#mutex.exclusiveRun(f);
+    return await this.#mutex.exclusiveRun(f);
   }
 }
 
@@ -84,7 +84,7 @@ async function defaultRequestInput(
     output: process.stdout,
   });
 
-  return new Promise<string>((resolve) => {
+  return await new Promise<string>((resolve) => {
     rl.question(
       chalk.blue(`[${interruptor}]`) + ` ${inputDescription}: `,
       (answer) => {
@@ -138,7 +138,7 @@ async function defaultRequestSecretInput(
     }
   };
 
-  return new Promise<string>((resolve) => {
+  return await new Promise<string>((resolve) => {
     rl.question(
       chalk.blue(`[${interruptor}]`) + ` ${inputDescription}: `,
       (answer) => {

--- a/packages/hardhat/src/internal/hre-initialization.ts
+++ b/packages/hardhat/src/internal/hre-initialization.ts
@@ -65,7 +65,7 @@ export async function createHardhatRuntimeEnvironment(
     unsafeOptions.globalOptionDefinitions = globalOptionDefinitions;
   }
 
-  return HardhatRuntimeEnvironmentImplementation.create(
+  return await HardhatRuntimeEnvironmentImplementation.create(
     config,
     userProvidedGlobalOptions,
     resolvedProjectRoot,

--- a/packages/hardhat/src/internal/utils/package.ts
+++ b/packages/hardhat/src/internal/utils/package.ts
@@ -63,10 +63,10 @@ export async function getLatestHardhatVersion(): Promise<string> {
 
   const latestHardhat = await getRequest(
     `https://registry.npmjs.org/${packageName}/latest`,
-  ).then(({ body }) => {
+  ).then(async ({ body }) => {
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     -- Cast to PackageJson because that's what we expect from the registry */
-    return body.json() as Promise<PackageJson>;
+    return await (body.json() as Promise<PackageJson>);
   });
 
   cachedLatestHardhatVersion = latestHardhat.version;

--- a/packages/hardhat/test/internal/builtin-plugins/flatten/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/flatten/task-action.ts
@@ -50,7 +50,7 @@ async function assertFlattenedFilesResult(flattened: string) {
 }
 
 async function createHRE() {
-  return createHardhatRuntimeEnvironment({}, {}, process.cwd());
+  return await createHardhatRuntimeEnvironment({}, {}, process.cwd());
 }
 
 describe("flatten/task-action", () => {

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -59,8 +59,15 @@ describe("network hook handler", () => {
     const concurrentCalls = 10;
 
     const results = await Promise.all(
-      Array.from({ length: concurrentCalls }, (_, i) =>
-        handlers.onRequest(context, connection, createRequestWithId(i), next),
+      Array.from(
+        { length: concurrentCalls },
+        async (_, i) =>
+          await handlers.onRequest(
+            context,
+            connection,
+            createRequestWithId(i),
+            next,
+          ),
       ),
     );
 

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
@@ -480,7 +480,7 @@ describe("http-provider", () => {
             result: expectedChainId,
           };
         } else {
-          return fetch(request);
+          return await fetch(request);
         }
       };
 

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -682,7 +682,7 @@ describe("NetworkManagerImplementation", () => {
         const networkHooks: Partial<NetworkHooks> = {
           newConnection: async (context, next) => {
             hookCalled = true;
-            return next(context);
+            return await next(context);
           },
         };
 
@@ -891,7 +891,7 @@ describe("NetworkManagerImplementation", () => {
             const handlers: Partial<ConfigHooks> = {
               resolveUserConfig: async (userConfig, rCV, next) => {
                 resolveUserConfigCallCount++;
-                return next(userConfig, rCV);
+                return await next(userConfig, rCV);
               },
             };
             return handlers;
@@ -1238,7 +1238,7 @@ describe("NetworkManagerImplementation", () => {
         next,
       ) => {
         hookCalled = true;
-        return next(context, networkConnection, jsonRpcRequest);
+        return await next(context, networkConnection, jsonRpcRequest);
       };
       const networkHooks: Partial<NetworkHooks> = {
         onRequest,

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/ethereum-mocked-provider.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/ethereum-mocked-provider.ts
@@ -64,8 +64,8 @@ export class EthereumMockedProvider
     return ret;
   }
 
-  public send(_method: string, _params?: unknown[]): Promise<unknown> {
-    return Promise.resolve(null);
+  public async send(_method: string, _params?: unknown[]): Promise<unknown> {
+    return await Promise.resolve(null);
   }
 
   public sendAsync(

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
@@ -233,7 +233,7 @@ describe("LocalAccountsHandler", () => {
         ]);
 
         await assertRejectsWithHardhatError(
-          () => localAccountsHandler.handle(jsonRpcRequest),
+          async () => await localAccountsHandler.handle(jsonRpcRequest),
           HardhatError.ERRORS.CORE.NETWORK.NOT_LOCAL_ACCOUNT,
           {
             account: "0x000006d4548a3ac17d72b372ae1e416bf65b8ead",
@@ -378,7 +378,7 @@ describe("LocalAccountsHandler", () => {
         ]);
 
         await assertRejectsWithHardhatError(
-          () => localAccountsHandler.handle(jsonRpcRequest),
+          async () => await localAccountsHandler.handle(jsonRpcRequest),
           HardhatError.ERRORS.CORE.NETWORK
             .ETHSIGN_TYPED_DATA_V4_INVALID_DATA_PARAM,
           {},
@@ -391,7 +391,7 @@ describe("LocalAccountsHandler", () => {
         ]);
 
         await assertRejectsWithHardhatError(
-          () => localAccountsHandler.handle(jsonRpcRequest),
+          async () => await localAccountsHandler.handle(jsonRpcRequest),
           HardhatError.ERRORS.CORE.NETWORK.ETHSIGN_MISSING_DATA_PARAM,
           {},
         );
@@ -508,7 +508,7 @@ describe("LocalAccountsHandler", () => {
           ]);
 
           await assertRejectsWithHardhatError(
-            () => localAccountsHandler.handle(jsonRpcRequest),
+            async () => await localAccountsHandler.handle(jsonRpcRequest),
             HardhatError.ERRORS.CORE.NETWORK
               .DATA_FIELD_CANNOT_BE_NULL_WITH_NULL_ADDRESS,
             {},
@@ -694,7 +694,7 @@ describe("LocalAccountsHandler", () => {
       ]);
 
       await assertRejectsWithHardhatError(
-        () => localAccountsHandler.handle(jsonRpcRequest),
+        async () => await localAccountsHandler.handle(jsonRpcRequest),
         HardhatError.ERRORS.CORE.NETWORK
           .DATA_FIELD_CANNOT_BE_NULL_WITH_NULL_ADDRESS,
         {},
@@ -724,7 +724,7 @@ describe("LocalAccountsHandler", () => {
       ]);
 
       await assertRejectsWithHardhatError(
-        () => localAccountsHandler.handle(jsonRpcRequest),
+        async () => await localAccountsHandler.handle(jsonRpcRequest),
         HardhatError.ERRORS.CORE.NETWORK.INCOMPATIBLE_EIP7702_FIELDS,
         {},
       );
@@ -861,7 +861,7 @@ describe("LocalAccountsHandler", () => {
       ]);
 
       await assertRejectsWithHardhatError(
-        () => localAccountsHandler.handle(jsonRpcRequest),
+        async () => await localAccountsHandler.handle(jsonRpcRequest),
         HardhatError.ERRORS.CORE.NETWORK.MISSING_TX_PARAM_TO_SIGN_LOCALLY,
         { param: "gas" },
       );
@@ -878,7 +878,7 @@ describe("LocalAccountsHandler", () => {
       ]);
 
       await assertRejectsWithHardhatError(
-        () => localAccountsHandler.handle(jsonRpcRequest),
+        async () => await localAccountsHandler.handle(jsonRpcRequest),
         HardhatError.ERRORS.CORE.NETWORK.MISSING_FEE_PRICE_FIELDS,
         {},
       );
@@ -908,13 +908,13 @@ describe("LocalAccountsHandler", () => {
       ]);
 
       await assertRejectsWithHardhatError(
-        () => localAccountsHandler.handle(jsonRpcRequest1),
+        async () => await localAccountsHandler.handle(jsonRpcRequest1),
         HardhatError.ERRORS.CORE.NETWORK.INCOMPATIBLE_FEE_PRICE_FIELDS,
         {},
       );
 
       await assertRejectsWithHardhatError(
-        () => localAccountsHandler.handle(jsonRpcRequest2),
+        async () => await localAccountsHandler.handle(jsonRpcRequest2),
         HardhatError.ERRORS.CORE.NETWORK.INCOMPATIBLE_FEE_PRICE_FIELDS,
         {},
       );
@@ -942,13 +942,13 @@ describe("LocalAccountsHandler", () => {
       ]);
 
       await assertRejectsWithHardhatError(
-        () => localAccountsHandler.handle(jsonRpcRequest1),
+        async () => await localAccountsHandler.handle(jsonRpcRequest1),
         HardhatError.ERRORS.CORE.NETWORK.MISSING_TX_PARAM_TO_SIGN_LOCALLY,
         { param: "maxPriorityFeePerGas" },
       );
 
       await assertRejectsWithHardhatError(
-        () => localAccountsHandler.handle(jsonRpcRequest2),
+        async () => await localAccountsHandler.handle(jsonRpcRequest2),
         HardhatError.ERRORS.CORE.NETWORK.MISSING_TX_PARAM_TO_SIGN_LOCALLY,
         { param: "maxFeePerGas" },
       );
@@ -967,7 +967,7 @@ describe("LocalAccountsHandler", () => {
       ]);
 
       await assertRejectsWithHardhatError(
-        () => localAccountsHandler.handle(jsonRpcRequest),
+        async () => await localAccountsHandler.handle(jsonRpcRequest),
         HardhatError.ERRORS.CORE.NETWORK.NOT_LOCAL_ACCOUNT,
         { account: "0x000006d4548a3ac17d72b372ae1e416bf65b8ead" },
       );

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/chain-id/chain-id-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/chain-id/chain-id-handler.ts
@@ -101,6 +101,8 @@ describe("ChainIdValidatorHandler", () => {
       1,
     );
 
-    await assertRejects(() => chainIdValidatorHandler.handle(jsonRpcRequest));
+    await assertRejects(
+      async () => await chainIdValidatorHandler.handle(jsonRpcRequest),
+    );
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts
@@ -378,7 +378,7 @@ async function postRawJsonRpc(
   port: number,
   rawBody: string,
 ): Promise<unknown> {
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     const req = http.request(
       {
         hostname,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -75,7 +75,12 @@ async function _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
     builtinPlugin,
   ]);
 
-  return await createHardhatRuntimeEnvironment(config, {}, resolvedProjectRoot, {
-    resolvedPlugins,
-  });
+  return await createHardhatRuntimeEnvironment(
+    config,
+    {},
+    resolvedProjectRoot,
+    {
+      resolvedPlugins,
+    },
+  );
 }

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -75,7 +75,7 @@ async function _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
     builtinPlugin,
   ]);
 
-  return createHardhatRuntimeEnvironment(config, {}, resolvedProjectRoot, {
+  return await createHardhatRuntimeEnvironment(config, {}, resolvedProjectRoot, {
     resolvedPlugins,
   });
 }

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -78,8 +78,8 @@ describe("solidity-test/task-action", function () {
     it("should throw if a file is provided but is not considered a test", async () => {
       hre = await createHardhatRuntimeEnvironment(hardhatConfigPartialTests);
       await assertRejectsWithHardhatError(
-        () =>
-          hre.tasks.getTask(["test", "solidity"]).run({
+        async () =>
+          await hre.tasks.getTask(["test", "solidity"]).run({
             noCompile: true,
             testFiles: ["./test/not-in-test-path.t.sol"],
           }),
@@ -107,8 +107,8 @@ describe("solidity-test/task-action", function () {
     it("should throw if a file is provided but is not considered a test", async () => {
       hre = await createHardhatRuntimeEnvironment(hardhatConfigPartialTests);
       await assertRejectsWithHardhatError(
-        () =>
-          hre.tasks.getTask(["test"]).run({
+        async () =>
+          await hre.tasks.getTask(["test"]).run({
             noCompile: true,
             testFiles: ["./test/not-in-test-path.t.sol"],
           }),
@@ -255,10 +255,10 @@ describe("solidity-test/task-action", function () {
             overrideTask("build")
               .setAction(async () => {
                 return {
-                  default: (args, _hre, runSuper) => {
+                  default: async (args, _hre, runSuper) => {
                     buildArgs.push(args);
 
-                    return runSuper(args);
+                    return await runSuper(args);
                   },
                 };
               })

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job.ts
@@ -301,7 +301,7 @@ describe("CompilationJobImplementation", () => {
             next,
           ) => {
             solcInput.sources.test = { content: "test" };
-            return next(context, solcInput);
+            return await next(context, solcInput);
           },
         });
         assert.notEqual(
@@ -327,7 +327,7 @@ describe("CompilationJobImplementation", () => {
             solcVersion,
             next,
           ) => {
-            return next(context, inputSourceName, fsPath, "test", solcVersion);
+            return await next(context, inputSourceName, fsPath, "test", solcVersion);
           },
         });
         assert.notEqual(
@@ -667,7 +667,7 @@ describe("CompilationJobImplementation", () => {
             next,
           ) => {
             solcInput.sources.test = { content };
-            return next(context, solcInput);
+            return await next(context, solcInput);
           },
         });
       });
@@ -707,7 +707,7 @@ describe("CompilationJobImplementation", () => {
             solcVersion,
             next,
           ) => {
-            return next(
+            return await next(
               context,
               name ?? inputSourceName,
               path ?? fsPath,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job.ts
@@ -327,7 +327,13 @@ describe("CompilationJobImplementation", () => {
             solcVersion,
             next,
           ) => {
-            return await next(context, inputSourceName, fsPath, "test", solcVersion);
+            return await next(
+              context,
+              inputSourceName,
+              fsPath,
+              "test",
+              solcVersion,
+            );
           },
         });
         assert.notEqual(

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -39,7 +39,7 @@ describe(
 
       it("should throw when version is bad", async function () {
         await assertRejectsWithHardhatError(
-          () => wasmDownloader.isCompilerDownloaded("0.5.0a"),
+          async () => await wasmDownloader.isCompilerDownloaded("0.5.0a"),
           HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
           {
             version: "0.5.0a",
@@ -79,7 +79,7 @@ describe(
 
       it("should throw when version is bad", async function () {
         await assertRejectsWithHardhatError(
-          () => downloader.isCompilerDownloaded("0.5.0a"),
+          async () => await downloader.isCompilerDownloaded("0.5.0a"),
           HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
           {
             version: "0.5.0a",
@@ -123,7 +123,7 @@ describe(
         );
 
         await assertRejectsWithHardhatError(
-          () => downloader.downloadCompiler("asd"),
+          async () => await downloader.downloadCompiler("asd"),
           HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
           {
             version: "asd",
@@ -131,7 +131,7 @@ describe(
         );
 
         await assertRejectsWithHardhatError(
-          () => downloader.downloadCompiler("100.0.0"),
+          async () => await downloader.downloadCompiler("100.0.0"),
           HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
           {
             version: "100.0.0",
@@ -149,7 +149,8 @@ describe(
         );
 
         await assertRejectsWithHardhatError(
-          () => mockDownloader.updateCompilerListIfNeeded(new Set(["0.5.0"])),
+          async () =>
+            await mockDownloader.updateCompilerListIfNeeded(new Set(["0.5.0"])),
           HardhatError.ERRORS.CORE.SOLIDITY.VERSION_LIST_DOWNLOAD_FAILED,
           {},
         );
@@ -161,10 +162,10 @@ describe(
         const mockDownloader = new CompilerDownloader(
           CompilerPlatform.WASM,
           process.cwd(),
-          (url, destination, requestOptions, dispatcherOptions) => {
+          async (url, destination, requestOptions, dispatcherOptions) => {
             if (!hasDownloadedOnce) {
               hasDownloadedOnce = true;
-              return download(
+              return await download(
                 url,
                 destination,
                 requestOptions,
@@ -179,7 +180,7 @@ describe(
         await mockDownloader.updateCompilerListIfNeeded(new Set(["0.5.0"]));
 
         await assertRejectsWithHardhatError(
-          () => mockDownloader.downloadCompiler("0.5.0"),
+          async () => await mockDownloader.downloadCompiler("0.5.0"),
           HardhatError.ERRORS.CORE.SOLIDITY.DOWNLOAD_FAILED,
           {
             remoteVersion: "0.5.0+commit.1d4f565a",
@@ -198,9 +199,9 @@ describe(
         const mockDownloader = new CompilerDownloader(
           CompilerPlatform.WASM,
           process.cwd(),
-          (url, destination, requestOptions, dispatcherOptions) => {
+          async (url, destination, requestOptions, dispatcherOptions) => {
             downloads++;
-            return download(
+            return await download(
               url,
               destination,
               requestOptions,
@@ -256,7 +257,7 @@ describe(
         await mockDownloader.updateCompilerListIfNeeded(new Set(["0.5.0"]));
 
         await assertRejectsWithHardhatError(
-          () => mockDownloader.downloadCompiler("0.5.0"),
+          async () => await mockDownloader.downloadCompiler("0.5.0"),
           HardhatError.ERRORS.CORE.SOLIDITY.INVALID_DOWNLOAD,
           {
             remoteVersion: "0.5.0+commit.1d4f565a",
@@ -293,9 +294,9 @@ describe(
           const mockDownloader = new CompilerDownloader(
             CompilerPlatform.WASM,
             process.cwd(),
-            (url, destination, requestOptions, dispatcherOptions) => {
+            async (url, destination, requestOptions, dispatcherOptions) => {
               downloads++;
-              return download(
+              return await download(
                 url,
                 destination,
                 requestOptions,
@@ -329,9 +330,9 @@ describe(
           const mockDownloader = new CompilerDownloader(
             CompilerPlatform.WASM,
             process.cwd(),
-            (url, destination, requestOptions, dispatcherOptions) => {
+            async (url, destination, requestOptions, dispatcherOptions) => {
               downloads++;
-              return download(
+              return await download(
                 url,
                 destination,
                 requestOptions,
@@ -377,7 +378,7 @@ describe(
         await downloader.updateCompilerListIfNeeded(new Set([]));
 
         await assertRejectsWithHardhatError(
-          () => downloader.getCompiler("0.5.0"),
+          async () => await downloader.getCompiler("0.5.0"),
           HardhatError.ERRORS.CORE.INTERNAL.ASSERTION_ERROR,
           {
             message: "Trying to get a compiler 0.5.0 before it was downloaded",
@@ -393,7 +394,7 @@ describe(
         await downloader.downloadCompiler("0.5.0");
 
         await assertRejectsWithHardhatError(
-          () => downloader.getCompiler("0.5.1"),
+          async () => await downloader.getCompiler("0.5.1"),
           HardhatError.ERRORS.CORE.INTERNAL.ASSERTION_ERROR,
           {
             message: "Trying to get a compiler 0.5.1 before it was downloaded",
@@ -450,7 +451,7 @@ describe(
             ? "0.5.0"
             : "0.5.0+commit.1d4f565a";
         await assertRejectsWithHardhatError(
-          () => mockDownloader.downloadCompiler("0.5.0"),
+          async () => await mockDownloader.downloadCompiler("0.5.0"),
           HardhatError.ERRORS.CORE.SOLIDITY.INVALID_DOWNLOAD,
           {
             remoteVersion,
@@ -580,7 +581,7 @@ describe(
           await downloader.updateCompilerListIfNeeded(new Set(["0.8.28"]));
 
           await assertRejectsWithHardhatError(
-            () => downloader.isCompilerDownloaded("0.4.24"),
+            async () => await downloader.isCompilerDownloaded("0.4.24"),
             HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
             { version: "0.4.24" },
           );
@@ -590,7 +591,7 @@ describe(
           await downloader.updateCompilerListIfNeeded(new Set(["0.8.28"]));
 
           await assertRejectsWithHardhatError(
-            () => downloader.downloadCompiler("0.4.24"),
+            async () => await downloader.downloadCompiler("0.4.24"),
             HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
             { version: "0.4.24" },
           );
@@ -600,7 +601,7 @@ describe(
           await downloader.updateCompilerListIfNeeded(new Set(["0.8.28"]));
 
           await assertRejectsWithHardhatError(
-            () => downloader.getCompiler("0.4.24"),
+            async () => await downloader.getCompiler("0.4.24"),
             HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
             { version: "0.4.24" },
           );

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -230,7 +230,7 @@ describe(
           process.cwd(),
           async (url, destination, requestOptions, dispatcherOptions) => {
             if (stopMocking) {
-              return download(
+              return await download(
                 url,
                 destination,
                 requestOptions,
@@ -240,7 +240,7 @@ describe(
 
             if (!hasDownloadedOnce) {
               hasDownloadedOnce = true;
-              return download(
+              return await download(
                 url,
                 destination,
                 requestOptions,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/tool-versions.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/tool-versions.ts
@@ -30,7 +30,7 @@ async function readBuildInfo(
   const buildInfoPath = await hre.artifacts.getBuildInfoPath(buildInfoId);
   assert.ok(buildInfoPath !== undefined, "Expected build info path to exist");
 
-  return readJsonFile<SolidityBuildInfo>(buildInfoPath);
+  return await readJsonFile<SolidityBuildInfo>(buildInfoPath);
 }
 
 describe(

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/helpers.ts
@@ -17,7 +17,7 @@ import { createHardhatRuntimeEnvironment } from "../../../../../../src/internal/
 export async function getHRE(
   project: TestProject,
 ): Promise<HardhatRuntimeEnvironment> {
-  return createHardhatRuntimeEnvironment(
+  return await createHardhatRuntimeEnvironment(
     {
       solidity: {
         profiles: {
@@ -103,7 +103,7 @@ export class TestProjectWrapper {
       .filter((filePath) => !filePath.endsWith(".output.json"))
       .map((basename) => path.join(this.buildInfosBasePath(), basename));
 
-    return Promise.all(
+    return await Promise.all(
       filePaths.map(async (filePath) => {
         const modificationTime = await this.getModificationTime(filePath);
         const buildId = path.basename(filePath).replace(".json", "");
@@ -132,7 +132,7 @@ export class TestProjectWrapper {
       .filter((filePath) => filePath.endsWith(".output.json"))
       .map((basename) => path.join(this.buildInfosBasePath(), basename));
 
-    return Promise.all(
+    return await Promise.all(
       filePaths.map(async (filePath) => ({
         path: filePath,
         modificationTime: await this.getModificationTime(filePath),
@@ -146,7 +146,7 @@ export class TestProjectWrapper {
   }
 
   public async getArtifactFolders(): Promise<string[]> {
-    return readdir(this.artifactsBasePath());
+    return await readdir(this.artifactsBasePath());
   }
 
   public async getArtifacts(): Promise<Record<string, FileDetail[]>> {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/helpers.ts
@@ -122,7 +122,7 @@ export async function useTestProjectTemplate(
       return hre;
     },
     [Symbol.asyncDispose]: async () => {
-      return project.clean();
+      return await project.clean();
     },
   };
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
@@ -2051,7 +2051,7 @@ d/=../node_modules/d/`,
         defaultBehavior,
       ) => {
         hookCalls.push({ name, version, path: packagePath });
-        return defaultBehavior(name, version, packagePath);
+        return await defaultBehavior(name, version, packagePath);
       };
 
       const graph = await RemappedNpmPackagesGraphImplementation.create(
@@ -2121,7 +2121,7 @@ d/=../node_modules/d/`,
         defaultBehavior,
       ) => {
         hookCalls.push({ name, version, path: packagePath });
-        return defaultBehavior(name, version, packagePath);
+        return await defaultBehavior(name, version, packagePath);
       };
 
       const graph = await RemappedNpmPackagesGraphImplementation.create(

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
@@ -248,7 +248,7 @@ describe("solidity - hooks", () => {
                     // Filter to only first file
                     modifiedRootFilePaths = rootFilePaths.slice(0, 1);
 
-                    return next(context, modifiedRootFilePaths, {
+                    return await next(context, modifiedRootFilePaths, {
                       ...options,
                       force: true,
                     });
@@ -542,7 +542,7 @@ describe("solidity - hooks", () => {
                   capturedConfig = compilerConfig;
 
                   // Fall through to the default handler (solc)
-                  return next(context, compilerConfig);
+                  return await next(context, compilerConfig);
                 },
               };
 
@@ -608,7 +608,7 @@ describe("solidity - hooks", () => {
                   if ((compilerConfig.type as string) === "custom") {
                     return customCompiler;
                   }
-                  return next(_context, compilerConfig);
+                  return await next(_context, compilerConfig);
                 },
               };
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
@@ -63,7 +63,7 @@ contract AddedByHook {}`,
                     );
 
                     // Add extra file to the build
-                    return next(
+                    return await next(
                       context,
                       [...rootFilePaths, extraFile],
                       options,
@@ -190,7 +190,7 @@ contract Filter {}`,
                     const filteredPaths = rootFilePaths.filter(
                       (p) => !p.includes("Filter"),
                     );
-                    return next(context, filteredPaths, options);
+                    return await next(context, filteredPaths, options);
                   },
                 };
 

--- a/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
@@ -305,7 +305,7 @@ describe("test/task-action", function () {
             default: async () => ({
               registerFileForTestRunner: async (context, filePath, next) => {
                 if (filePath === "runner-a-test.ts") return "runner-a";
-                return next(context, filePath);
+                return await next(context, filePath);
               },
             }),
           }),

--- a/packages/hardhat/test/internal/cli/init/init.ts
+++ b/packages/hardhat/test/internal/cli/init/init.ts
@@ -56,7 +56,7 @@ describe("getWorkspace", () => {
       await writeUtf8File(filePath, "some content");
 
       await assertRejectsWithHardhatError(
-        async () => getWorkspace(filePath),
+        async () => await getWorkspace(filePath),
         HardhatError.ERRORS.CORE.GENERAL.WORKSPACE_MUST_BE_A_DIRECTORY,
         {
           workspace: path.resolve(filePath),
@@ -69,7 +69,7 @@ describe("getWorkspace", () => {
     await ensureDir("hardhat-project");
     await writeUtf8File("hardhat.config.ts", "");
     await assertRejectsWithHardhatError(
-      async () => getWorkspace("hardhat-project"),
+      async () => await getWorkspace("hardhat-project"),
       HardhatError.ERRORS.CORE.GENERAL.HARDHAT_PROJECT_ALREADY_CREATED,
       {
         hardhatProjectRootPath: path.join(process.cwd(), "hardhat.config.ts"),
@@ -82,7 +82,7 @@ describe("getWorkspace", () => {
 describe("getTemplate", () => {
   it("should throw if the provided template does not exist", async () => {
     await assertRejectsWithHardhatError(
-      async () => getTemplate("hardhat-3", "non-existent-template"),
+      async () => await getTemplate("hardhat-3", "non-existent-template"),
       HardhatError.ERRORS.CORE.GENERAL.TEMPLATE_NOT_FOUND,
       {
         template: "non-existent-template",
@@ -145,7 +145,7 @@ describe("validatePackageJson", () => {
 
     await assertRejectsWithHardhatError(
       async () =>
-        validatePackageJson(
+        await validatePackageJson(
           process.cwd(),
           {
             name: "package-name",

--- a/packages/hardhat/test/internal/cli/init/prompt.ts
+++ b/packages/hardhat/test/internal/cli/init/prompt.ts
@@ -14,7 +14,7 @@ describe("promptForWorkspace", () => {
   it("should fail if the user is not in an interactive shell", async () => {
     if (!process.stdout.isTTY) {
       await assertRejectsWithHardhatError(
-        async () => promptForWorkspace(),
+        async () => await promptForWorkspace(),
         HardhatError.ERRORS.CORE.GENERAL.NOT_IN_INTERACTIVE_SHELL,
         {},
       );
@@ -26,7 +26,7 @@ describe("promptForTemplate", () => {
   it("should fail if the user is not in an interactive shell", async () => {
     if (!process.stdout.isTTY) {
       await assertRejectsWithHardhatError(
-        async () => promptForTemplate([]),
+        async () => await promptForTemplate([]),
         HardhatError.ERRORS.CORE.GENERAL.NOT_IN_INTERACTIVE_SHELL,
         {},
       );
@@ -38,7 +38,7 @@ describe("promptForForce", () => {
   it("should fail if the user is not in an interactive shell", async () => {
     if (!process.stdout.isTTY) {
       await assertRejectsWithHardhatError(
-        async () => promptForForce([]),
+        async () => await promptForForce([]),
         HardhatError.ERRORS.CORE.GENERAL.NOT_IN_INTERACTIVE_SHELL,
         {},
       );
@@ -50,7 +50,7 @@ describe("promptForInstall", () => {
   it("should fail if the user is not in an interactive shell", async () => {
     if (!process.stdout.isTTY) {
       await assertRejectsWithHardhatError(
-        async () => promptForInstall("foo"),
+        async () => await promptForInstall("foo"),
         HardhatError.ERRORS.CORE.GENERAL.NOT_IN_INTERACTIVE_SHELL,
         {},
       );

--- a/packages/hardhat/test/internal/cli/main.ts
+++ b/packages/hardhat/test/internal/cli/main.ts
@@ -218,7 +218,7 @@ describe("main", function () {
         const command = "npx hardhat task-default-3 nonExistingTask";
 
         await assertRejectsWithHardhatError(
-          () => runMain(command),
+          async () => await runMain(command),
           HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_SUBTASK,
           {
             task: "task-default-3",
@@ -235,7 +235,7 @@ describe("main", function () {
         const command = "npx hardhat test-task --opt <value>";
 
         await assertRejectsWithHardhatError(
-          () => runMain(command),
+          async () => await runMain(command),
           HardhatError.ERRORS.CORE.ARGUMENTS.NO_HIDDEN_OPTION_CLI,
           {
             option: "--opt",
@@ -247,7 +247,7 @@ describe("main", function () {
         const command = "npx hardhat test-task --flag";
 
         await assertRejectsWithHardhatError(
-          () => runMain(command),
+          async () => await runMain(command),
           HardhatError.ERRORS.CORE.ARGUMENTS.NO_HIDDEN_OPTION_CLI,
           {
             option: "--flag",
@@ -328,7 +328,7 @@ Usage: hardhat [GLOBAL OPTIONS] empty-task <SUBTASK> [SUBTASK OPTIONS] [--] [SUB
           const command = "npx hardhat task-default-3 nonExistingTask --help";
 
           await assertRejectsWithHardhatError(
-            () => runMain(command),
+            async () => await runMain(command),
             HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_SUBTASK,
             {
               task: "task-default-3",
@@ -533,7 +533,8 @@ GLOBAL OPTIONS:
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
       await assertRejectsWithHardhatError(
-        async () => await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
+        async () =>
+          await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.CORE.ARGUMENTS.CANNOT_COMBINE_INIT_AND_CONFIG_PATH,
         {},
       );
@@ -546,7 +547,8 @@ GLOBAL OPTIONS:
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
       await assertRejectsWithHardhatError(
-        async () => await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
+        async () =>
+          await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.CORE.ARGUMENTS.DUPLICATED_NAME,
         {
           name: "--config",
@@ -561,7 +563,8 @@ GLOBAL OPTIONS:
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
       await assertRejectsWithHardhatError(
-        async () => await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
+        async () =>
+          await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_CONFIG_FILE,
         {},
       );

--- a/packages/hardhat/test/internal/cli/main.ts
+++ b/packages/hardhat/test/internal/cli/main.ts
@@ -533,7 +533,7 @@ GLOBAL OPTIONS:
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
       await assertRejectsWithHardhatError(
-        async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
+        async () => await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.CORE.ARGUMENTS.CANNOT_COMBINE_INIT_AND_CONFIG_PATH,
         {},
       );
@@ -546,7 +546,7 @@ GLOBAL OPTIONS:
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
       await assertRejectsWithHardhatError(
-        async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
+        async () => await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.CORE.ARGUMENTS.DUPLICATED_NAME,
         {
           name: "--config",
@@ -561,7 +561,7 @@ GLOBAL OPTIONS:
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
       await assertRejectsWithHardhatError(
-        async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
+        async () => await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_CONFIG_FILE,
         {},
       );

--- a/packages/hardhat/test/internal/cli/telemetry/helpers.ts
+++ b/packages/hardhat/test/internal/cli/telemetry/helpers.ts
@@ -26,7 +26,7 @@ export async function checkIfSubprocessWasExecuted(
   // within a specified number of attempts, an error is thrown, indicating a failure in subprocess execution.
   const MAX_COUNTER = 100;
 
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     let counter = 0;
 
     const intervalId = setInterval(async () => {

--- a/packages/hardhat/test/internal/core/config-validation.ts
+++ b/packages/hardhat/test/internal/core/config-validation.ts
@@ -1943,7 +1943,7 @@ describe("resolved config validation", function () {
     const resolvedPlugins = await resolvePluginList(resolvedProjectRoot, [
       plugin,
     ]);
-    return createHardhatRuntimeEnvironment(config, {}, resolvedProjectRoot, {
+    return await createHardhatRuntimeEnvironment(config, {}, resolvedProjectRoot, {
       resolvedPlugins,
     });
   }

--- a/packages/hardhat/test/internal/core/config-validation.ts
+++ b/packages/hardhat/test/internal/core/config-validation.ts
@@ -1943,9 +1943,14 @@ describe("resolved config validation", function () {
     const resolvedPlugins = await resolvePluginList(resolvedProjectRoot, [
       plugin,
     ]);
-    return await createHardhatRuntimeEnvironment(config, {}, resolvedProjectRoot, {
-      resolvedPlugins,
-    });
+    return await createHardhatRuntimeEnvironment(
+      config,
+      {},
+      resolvedProjectRoot,
+      {
+        resolvedPlugins,
+      },
+    );
   }
 
   it("should throw INVALID_RESOLVED_CONFIG when validateResolvedConfig returns errors", async function () {

--- a/packages/hardhat/test/internal/core/hook-manager.ts
+++ b/packages/hardhat/test/internal/core/hook-manager.ts
@@ -408,7 +408,8 @@ describe("HookManager", () => {
         const examplePlugin: HardhatPlugin = {
           id: "example",
           hookHandlers: {
-            config: () => import("./fixture-plugins/config-plugin.js"),
+            config: async () =>
+              await import("./fixture-plugins/config-plugin.js"),
           },
         };
 
@@ -440,7 +441,7 @@ describe("HookManager", () => {
         const examplePlugin: HardhatPlugin = {
           id: "example",
           hookHandlers: {
-            config: () => import(nonExistentImport),
+            config: async () => await import(nonExistentImport),
           },
           npmPackage: null,
         };

--- a/packages/hardhat/test/internal/core/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/packages/hardhat/test/internal/core/plugins/detect-plugin-npm-dependency-problems.ts
@@ -67,7 +67,7 @@ describe("Plugins - detect npm dependency problems", () => {
 
       await assertRejectsWithHardhatError(
         async () =>
-          detectPluginNpmDependencyProblems(
+          await detectPluginNpmDependencyProblems(
             nonInstalledPackageProjectFixture,
             plugin,
             originalError,
@@ -87,7 +87,7 @@ describe("Plugins - detect npm dependency problems", () => {
 
       await assertRejectsWithHardhatError(
         async () =>
-          detectPluginNpmDependencyProblems(
+          await detectPluginNpmDependencyProblems(
             nonInstalledPackageProjectFixture,
             {
               ...pluginWithNpmPackageUndefined,
@@ -159,7 +159,7 @@ describe("Plugins - detect npm dependency problems", () => {
 
       await assertRejectsWithHardhatError(
         async () =>
-          detectPluginNpmDependencyProblems(
+          await detectPluginNpmDependencyProblems(
             peerDepWithWrongVersionFixture,
             plugin,
             originalError,

--- a/packages/hardhat/test/internal/core/plugins/resolve-plugin-list.ts
+++ b/packages/hardhat/test/internal/core/plugins/resolve-plugin-list.ts
@@ -201,7 +201,7 @@ describe("Plugins - resolve plugin list", () => {
     const copy = { id: "dup" };
 
     await assertRejectsWithHardhatError(
-      async () => resolvePluginList(installedPackageFixture, [a, copy]),
+      async () => await resolvePluginList(installedPackageFixture, [a, copy]),
       HardhatError.ERRORS.CORE.GENERAL.DUPLICATED_PLUGIN_ID,
       {
         id: "dup",
@@ -218,7 +218,7 @@ describe("Plugins - resolve plugin list", () => {
       };
 
       await assertRejectsWithHardhatError(
-        async () => resolvePluginList(installedPackageFixture, [plugin]),
+        async () => await resolvePluginList(installedPackageFixture, [plugin]),
         HardhatError.ERRORS.CORE.PLUGINS.PLUGIN_DEPENDENCY_FAILED_LOAD,
         { pluginId: plugin.id },
       );
@@ -236,7 +236,7 @@ describe("Plugins - resolve plugin list", () => {
       };
 
       await assertRejectsWithHardhatError(
-        async () => resolvePluginList(notInstalledPackageFixture, [plugin]),
+        async () => await resolvePluginList(notInstalledPackageFixture, [plugin]),
         HardhatError.ERRORS.CORE.PLUGINS.PLUGIN_NOT_INSTALLED,
         {
           pluginId: "example",

--- a/packages/hardhat/test/internal/core/plugins/resolve-plugin-list.ts
+++ b/packages/hardhat/test/internal/core/plugins/resolve-plugin-list.ts
@@ -236,7 +236,8 @@ describe("Plugins - resolve plugin list", () => {
       };
 
       await assertRejectsWithHardhatError(
-        async () => await resolvePluginList(notInstalledPackageFixture, [plugin]),
+        async () =>
+          await resolvePluginList(notInstalledPackageFixture, [plugin]),
         HardhatError.ERRORS.CORE.PLUGINS.PLUGIN_NOT_INSTALLED,
         {
           pluginId: "example",
@@ -271,7 +272,7 @@ describe("Plugins - resolve plugin list - conditional dependencies", () => {
     conditionalDependencies: [
       {
         condition: () => [mod(B)],
-        plugin: () => mod(D),
+        plugin: async () => await mod(D),
       },
     ],
   };
@@ -281,7 +282,7 @@ describe("Plugins - resolve plugin list - conditional dependencies", () => {
     conditionalDependencies: [
       {
         condition: () => [mod(E), mod(G)],
-        plugin: () => mod(F),
+        plugin: async () => await mod(F),
       },
     ],
   };
@@ -309,7 +310,7 @@ describe("Plugins - resolve plugin list - conditional dependencies", () => {
     conditionalDependencies: [
       {
         condition: () => [mod(D)],
-        plugin: () => mod(G),
+        plugin: async () => await mod(G),
       },
     ],
   };
@@ -319,7 +320,7 @@ describe("Plugins - resolve plugin list - conditional dependencies", () => {
     conditionalDependencies: [
       {
         condition: () => [import(`${"nonexistant"}`)],
-        plugin: () => mod(G),
+        plugin: async () => await mod(G),
       },
     ],
   };
@@ -333,7 +334,7 @@ describe("Plugins - resolve plugin list - conditional dependencies", () => {
     conditionalDependencies: [
       {
         condition: () => [mod(G)],
-        plugin: () => mod(F),
+        plugin: async () => await mod(F),
       },
     ],
   };
@@ -343,7 +344,7 @@ describe("Plugins - resolve plugin list - conditional dependencies", () => {
     conditionalDependencies: [
       {
         condition: () => [mod(B)],
-        plugin: () => mod(G),
+        plugin: async () => await mod(G),
       },
     ],
   };
@@ -353,11 +354,11 @@ describe("Plugins - resolve plugin list - conditional dependencies", () => {
     conditionalDependencies: [
       {
         condition: () => [mod(G)],
-        plugin: () => mod(C),
+        plugin: async () => await mod(C),
       },
       {
         condition: () => [mod(B)],
-        plugin: () => mod(F),
+        plugin: async () => await mod(F),
       },
     ],
   };
@@ -367,15 +368,15 @@ describe("Plugins - resolve plugin list - conditional dependencies", () => {
     conditionalDependencies: [
       {
         condition: () => [mod(G)],
-        plugin: () => mod(L),
+        plugin: async () => await mod(L),
       },
       {
         condition: () => [mod(L)],
-        plugin: () => mod(M),
+        plugin: async () => await mod(M),
       },
       {
         condition: () => [mod(M)],
-        plugin: () => mod(F),
+        plugin: async () => await mod(F),
       },
     ],
   };
@@ -385,7 +386,7 @@ describe("Plugins - resolve plugin list - conditional dependencies", () => {
     conditionalDependencies: [
       {
         condition: () => [mod(B)],
-        plugin: () => mod(G),
+        plugin: async () => await mod(G),
       },
     ],
   };
@@ -395,7 +396,7 @@ describe("Plugins - resolve plugin list - conditional dependencies", () => {
     conditionalDependencies: [
       {
         condition: () => [mod(B)],
-        plugin: () => mod(G),
+        plugin: async () => await mod(G),
       },
     ],
   };

--- a/packages/hardhat/test/internal/core/tasks/builders.ts
+++ b/packages/hardhat/test/internal/core/tasks/builders.ts
@@ -167,8 +167,8 @@ describe("Task builders", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
         const taskActionUrl = "./path/to/task-action.js";
 
-        const action: LazyActionObject<NewTaskActionFunction> = () =>
-          import(taskActionUrl);
+        const action: LazyActionObject<NewTaskActionFunction> = async () =>
+          await import(taskActionUrl);
 
         const taskDefinition = builder.setAction(action).build();
 
@@ -1213,8 +1213,8 @@ describe("Task builders", () => {
         );
         const taskActionUrl = "./path/to/task-action.js";
 
-        const action: LazyActionObject<NewTaskActionFunction> = () =>
-          import(taskActionUrl);
+        const action: LazyActionObject<NewTaskActionFunction> = async () =>
+          await import(taskActionUrl);
 
         const taskDefinition = builder.setAction(action).build();
 

--- a/packages/hardhat/test/internal/core/tasks/task-manager.ts
+++ b/packages/hardhat/test/internal/core/tasks/task-manager.ts
@@ -1920,7 +1920,7 @@ describe("TaskManagerImplementation", () => {
                   .build(),
                 new TaskOverrideDefinitionBuilderImplementation("task1")
                   .addOption({ name: "arg1", defaultValue: "default" })
-                  .setAction(() => import(actionUrl))
+                  .setAction(async () => await import(actionUrl))
                   .build(),
               ],
             },
@@ -1945,11 +1945,11 @@ describe("TaskManagerImplementation", () => {
               id: "plugin1",
               tasks: [
                 new NewTaskDefinitionBuilderImplementation("task1")
-                  .setAction(() => import(invalidUrl))
+                  .setAction(async () => await import(invalidUrl))
                   .build(),
                 new TaskOverrideDefinitionBuilderImplementation("task1")
                   .addOption({ name: "arg1", defaultValue: "default" })
-                  .setAction(() => import(validActionUrl))
+                  .setAction(async () => await import(validActionUrl))
                   .build(),
               ],
             },
@@ -2471,7 +2471,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(() => import(invalidUrl))
+                    .setAction(async () => await import(invalidUrl))
                     .build(),
                 ],
                 npmPackage: null,
@@ -2509,7 +2509,9 @@ describe("TaskManagerImplementation", () => {
                 npmPackage: "non-installed-package",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(() => import(nonInstalledPackageActionUrl))
+                    .setAction(
+                      async () => await import(nonInstalledPackageActionUrl),
+                    )
                     .build(),
                 ],
               },
@@ -2545,7 +2547,9 @@ describe("TaskManagerImplementation", () => {
                 npmPackage: "non-installed-package",
                 tasks: [
                   new TaskOverrideDefinitionBuilderImplementation("task1")
-                    .setAction(() => import(nonInstalledPackageActionUrl))
+                    .setAction(
+                      async () => await import(nonInstalledPackageActionUrl),
+                    )
                     .build(),
                 ],
               },
@@ -2573,7 +2577,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(() => import(actionUrl))
+                    .setAction(async () => await import(actionUrl))
                     .build(),
                 ],
               },
@@ -2603,7 +2607,7 @@ describe("TaskManagerImplementation", () => {
                 id: "plugin1",
                 tasks: [
                   new NewTaskDefinitionBuilderImplementation("task1")
-                    .setAction(() => import(actionUrl))
+                    .setAction(async () => await import(actionUrl))
                     .build(),
                 ],
               },

--- a/packages/hardhat/test/internal/example-mock-artifacts-plugin-using-test.ts
+++ b/packages/hardhat/test/internal/example-mock-artifacts-plugin-using-test.ts
@@ -29,8 +29,8 @@ describe("createMockHardhatRuntimeEnvironment", () => {
       tasks: [
         task("hello-artifact-using-world", "Test artifact loading")
           .setAction(async () => ({
-            default: (_args, hre) => {
-              return hre.artifacts.readArtifact("MyContract");
+            default: async (_args, hre) => {
+              return await hre.artifacts.readArtifact("MyContract");
             },
           }))
           .build(),

--- a/packages/hardhat/test/test-helpers/create-mock-hardhat-runtime-environment.ts
+++ b/packages/hardhat/test/test-helpers/create-mock-hardhat-runtime-environment.ts
@@ -19,12 +19,12 @@ export async function createMockHardhatRuntimeEnvironment(
 ): Promise<HardhatRuntimeEnvironment & { artifacts: MockArtifactManager }> {
   /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
   We know that the mockArtifactPlugin sets `hre.artifacts` to `MockArtifactManager */
-  return createHardhatRuntimeEnvironment(
+  return await (createHardhatRuntimeEnvironment(
     { ...config, plugins: [mockArtifactsPlugin, ...(config.plugins ?? [])] },
     userProvidedGlobalOptions,
     projectRoot,
     unsafeOptions,
-  ) as Promise<HardhatRuntimeEnvironment & { artifacts: MockArtifactManager }>;
+  ) as Promise<HardhatRuntimeEnvironment & { artifacts: MockArtifactManager }>);
 }
 
 const mockArtifactsPlugin: HardhatPlugin = {

--- a/packages/hardhat/test/utils.ts
+++ b/packages/hardhat/test/utils.ts
@@ -29,11 +29,11 @@ export class MockEthereumProvider
     throw new Error("Method not supported");
   }
 
-  public close(): Promise<void> {
-    return Promise.resolve();
+  public async close(): Promise<void> {
+    return await Promise.resolve();
   }
 
-  public send(): Promise<any> {
+  public async send(): Promise<any> {
     throw new Error("Method not implemented.");
   }
   public sendAsync(): void {

--- a/packages/ignition-core/src/deploy.ts
+++ b/packages/ignition-core/src/deploy.ts
@@ -149,7 +149,7 @@ export async function deploy<
     executionEventListener,
   );
 
-  return deployer.deploy(
+  return await deployer.deploy(
     ignitionModule,
     deploymentParameters,
     accounts,

--- a/packages/ignition-core/src/internal/deployment-loader/ephemeral-deployment-loader.ts
+++ b/packages/ignition-core/src/internal/deployment-loader/ephemeral-deployment-loader.ts
@@ -99,7 +99,7 @@ export class EphemeralDeploymentLoader implements DeploymentLoader {
           `Unable to load artifact, underlying resolver returned undefined for ${saved.contractName}`,
         );
 
-        return fileArtifact;
+        return await fileArtifact;
       }
     }
   }

--- a/packages/ignition-core/src/internal/deployment-loader/file-deployment-loader.ts
+++ b/packages/ignition-core/src/internal/deployment-loader/file-deployment-loader.ts
@@ -66,14 +66,14 @@ export class FileDeploymentLoader implements DeploymentLoader {
     return this._journal.read();
   }
 
-  public storeNamedArtifact(
+  public async storeNamedArtifact(
     futureId: string,
     _contractName: string,
     artifact: Artifact,
   ): Promise<void> {
     // For a file deployment we don't differentiate between
     // named contracts (from HH) and anonymous contracts passed in by the user
-    return this.storeUserProvidedArtifact(futureId, artifact);
+    return await this.storeUserProvidedArtifact(futureId, artifact);
   }
 
   public async storeUserProvidedArtifact(

--- a/packages/ignition-core/src/internal/execution/future-processor/future-processor.ts
+++ b/packages/ignition-core/src/internal/execution/future-processor/future-processor.ts
@@ -183,7 +183,7 @@ export class FutureProcessor {
   ): Promise<JournalMessage | undefined> {
     switch (nextAction) {
       case NextAction.RUN_STRATEGY:
-        return runStrategy(exState, this._executionStrategy);
+        return await runStrategy(exState, this._executionStrategy);
 
       case NextAction.SEND_TRANSACTION:
         assertIgnitionInvariant(
@@ -191,7 +191,7 @@ export class FutureProcessor {
           `Unexpected transaction request in StaticCallExecutionState ${exState.id}`,
         );
 
-        return sendTransaction(
+        return await sendTransaction(
           exState,
           this._executionStrategy,
           this._jsonRpcClient,
@@ -201,7 +201,7 @@ export class FutureProcessor {
         );
 
       case NextAction.QUERY_STATIC_CALL:
-        return queryStaticCall(exState, this._jsonRpcClient);
+        return await queryStaticCall(exState, this._jsonRpcClient);
 
       case NextAction.MONITOR_ONCHAIN_INTERACTION:
         assertIgnitionInvariant(
@@ -209,7 +209,7 @@ export class FutureProcessor {
           `Unexpected transaction request in StaticCallExecutionState ${exState.id}`,
         );
 
-        return monitorOnchainInteraction({
+        return await monitorOnchainInteraction({
           exState,
           jsonRpcClient: this._jsonRpcClient,
           transactionTrackingTimer: this._transactionTrackingTimer,

--- a/packages/ignition-core/src/internal/execution/future-processor/handlers/monitor-onchain-interaction.ts
+++ b/packages/ignition-core/src/internal/execution/future-processor/handlers/monitor-onchain-interaction.ts
@@ -186,8 +186,8 @@ async function _getTransactionWithRetry(
     );
 
     const transactions = await Promise.all(
-      params.onchainInteraction.transactions.map((tx) =>
-        params.jsonRpcClient.getTransaction(tx.hash),
+      params.onchainInteraction.transactions.map(
+        async (tx) => await params.jsonRpcClient.getTransaction(tx.hash),
       ),
     );
 

--- a/packages/ignition-core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
+++ b/packages/ignition-core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
@@ -38,7 +38,7 @@ export async function runStaticCall(
   client: JsonRpcClient,
   staticCall: StaticCall,
 ): Promise<RawStaticCallResult> {
-  return client.call(
+  return await client.call(
     {
       from: staticCall.from,
       to: staticCall.to,

--- a/packages/ignition-core/src/internal/execution/future-processor/helpers/replay-strategy.ts
+++ b/packages/ignition-core/src/internal/execution/future-processor/helpers/replay-strategy.ts
@@ -184,22 +184,22 @@ export async function replayStrategy(
 > {
   switch (executionState.type) {
     case ExecutionSateType.DEPLOYMENT_EXECUTION_STATE:
-      return replayExecutionStrategyWithOnchainInteractions(
+      return await replayExecutionStrategyWithOnchainInteractions(
         executionState,
         strategy,
       );
     case ExecutionSateType.CALL_EXECUTION_STATE:
-      return replayExecutionStrategyWithOnchainInteractions(
+      return await replayExecutionStrategyWithOnchainInteractions(
         executionState,
         strategy,
       );
     case ExecutionSateType.SEND_DATA_EXECUTION_STATE:
-      return replayExecutionStrategyWithOnchainInteractions(
+      return await replayExecutionStrategyWithOnchainInteractions(
         executionState,
         strategy,
       );
     case ExecutionSateType.STATIC_CALL_EXECUTION_STATE:
-      return replayStaticCallExecutionStrategy(executionState, strategy);
+      return await replayStaticCallExecutionStrategy(executionState, strategy);
   }
 }
 

--- a/packages/ignition-core/src/internal/execution/future-processor/helpers/save-artifacts-for-future.ts
+++ b/packages/ignition-core/src/internal/execution/future-processor/helpers/save-artifacts-for-future.ts
@@ -18,14 +18,14 @@ export async function saveArtifactsForFuture(
     case FutureType.NAMED_ARTIFACT_CONTRACT_DEPLOYMENT:
     case FutureType.NAMED_ARTIFACT_LIBRARY_DEPLOYMENT:
     case FutureType.NAMED_ARTIFACT_CONTRACT_AT:
-      return _storeArtifactAndBuildInfoAgainstDeployment(future, {
+      return await _storeArtifactAndBuildInfoAgainstDeployment(future, {
         artifactResolver,
         deploymentLoader,
       });
     case FutureType.CONTRACT_DEPLOYMENT:
     case FutureType.LIBRARY_DEPLOYMENT:
     case FutureType.CONTRACT_AT:
-      return deploymentLoader.storeUserProvidedArtifact(
+      return await deploymentLoader.storeUserProvidedArtifact(
         future.id,
         future.artifact,
       );

--- a/packages/ignition-core/src/internal/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/ignition-core/src/internal/execution/nonce-management/get-nonce-sync-messages.ts
@@ -135,7 +135,7 @@ export async function getNonceSyncMessages(
       networkInteractionId,
     } of pendingIgnitionTransactions) {
       const fetchedTransactions = await Promise.all(
-        transactions.map((tx) => jsonRpcClient.getTransaction(tx)),
+        transactions.map(async (tx) => await jsonRpcClient.getTransaction(tx)),
       );
 
       // If at least one transaction for the future is still in the mempool,

--- a/packages/ignition-core/src/internal/reconciliation/reconcile-future-specific-reconciliations.ts
+++ b/packages/ignition-core/src/internal/reconciliation/reconcile-future-specific-reconciliations.ts
@@ -35,25 +35,25 @@ export async function reconcileFutureSpecificReconciliations(
 ): Promise<ReconciliationFutureResult> {
   switch (future.type) {
     case FutureType.NAMED_ARTIFACT_CONTRACT_DEPLOYMENT:
-      return reconcileNamedContractDeployment(
+      return await reconcileNamedContractDeployment(
         future,
         executionState as DeploymentExecutionState,
         context,
       );
     case FutureType.CONTRACT_DEPLOYMENT:
-      return reconcileArtifactContractDeployment(
+      return await reconcileArtifactContractDeployment(
         future,
         executionState as DeploymentExecutionState,
         context,
       );
     case FutureType.NAMED_ARTIFACT_LIBRARY_DEPLOYMENT:
-      return reconcileNamedLibraryDeployment(
+      return await reconcileNamedLibraryDeployment(
         future,
         executionState as DeploymentExecutionState,
         context,
       );
     case FutureType.LIBRARY_DEPLOYMENT:
-      return reconcileArtifactLibraryDeployment(
+      return await reconcileArtifactLibraryDeployment(
         future,
         executionState as DeploymentExecutionState,
         context,
@@ -77,13 +77,13 @@ export async function reconcileFutureSpecificReconciliations(
         context,
       );
     case FutureType.NAMED_ARTIFACT_CONTRACT_AT:
-      return reconcileNamedContractAt(
+      return await reconcileNamedContractAt(
         future,
         executionState as ContractAtExecutionState,
         context,
       );
     case FutureType.CONTRACT_AT: {
-      return reconcileArtifactContractAt(
+      return await reconcileArtifactContractAt(
         future,
         executionState as ContractAtExecutionState,
         context,

--- a/packages/ignition-core/src/internal/validation/validate.ts
+++ b/packages/ignition-core/src/internal/validation/validate.ts
@@ -63,77 +63,77 @@ async function _validateFuture(
 ): Promise<string[]> {
   switch (future.type) {
     case FutureType.CONTRACT_DEPLOYMENT:
-      return validateArtifactContractDeployment(
+      return await validateArtifactContractDeployment(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.LIBRARY_DEPLOYMENT:
-      return validateArtifactLibraryDeployment(
+      return await validateArtifactLibraryDeployment(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.CONTRACT_AT:
-      return validateArtifactContractAt(
+      return await validateArtifactContractAt(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.NAMED_ARTIFACT_CONTRACT_DEPLOYMENT:
-      return validateNamedContractDeployment(
+      return await validateNamedContractDeployment(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.NAMED_ARTIFACT_LIBRARY_DEPLOYMENT:
-      return validateNamedLibraryDeployment(
+      return await validateNamedLibraryDeployment(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.NAMED_ARTIFACT_CONTRACT_AT:
-      return validateNamedContractAt(
+      return await validateNamedContractAt(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.CONTRACT_CALL:
-      return validateNamedContractCall(
+      return await validateNamedContractCall(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.STATIC_CALL:
-      return validateNamedStaticCall(
+      return await validateNamedStaticCall(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.ENCODE_FUNCTION_CALL:
-      return validateNamedEncodeFunctionCall(
+      return await validateNamedEncodeFunctionCall(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.READ_EVENT_ARGUMENT:
-      return validateReadEventArgument(
+      return await validateReadEventArgument(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.SEND_DATA:
-      return validateSendData(
+      return await validateSendData(
         future,
         artifactLoader,
         deploymentParameters,

--- a/packages/ignition-core/src/internal/wiper.ts
+++ b/packages/ignition-core/src/internal/wiper.ts
@@ -53,7 +53,7 @@ export class Wiper {
       futureId,
     };
 
-    return applyNewMessage(
+    return await applyNewMessage(
       wipeMessage,
       deploymentState,
       this._deploymentLoader,

--- a/packages/ignition-core/src/list-deployments.ts
+++ b/packages/ignition-core/src/list-deployments.ts
@@ -14,5 +14,5 @@ export async function listDeployments(
     return [];
   }
 
-  return readdir(deploymentDir);
+  return await readdir(deploymentDir);
 }

--- a/packages/ignition-core/src/track-transaction.ts
+++ b/packages/ignition-core/src/track-transaction.ts
@@ -158,7 +158,7 @@ export async function trackTransaction(
           // case 2: the user sent a different transaction that replaced ours
           // so we check their transaction for the required number of confirmations
           else {
-            return checkConfirmations(
+            return await checkConfirmations(
               exState,
               networkInteraction,
               transaction,
@@ -181,7 +181,7 @@ export async function trackTransaction(
 
           // case 4: the user sent a different transaction that replaced ours
           // so we check their transaction for the required number of confirmations
-          return checkConfirmations(
+          return await checkConfirmations(
             exState,
             networkInteraction,
             transaction,


### PR DESCRIPTION
This is the first PR to tackle https://github.com/NomicFoundation/hardhat/issues/8041

It is not complete, but as it changes some linter rules, the sooner we get to merge it, the better.

It has these commits:

1. https://github.com/NomicFoundation/hardhat/commit/dafc4d3d81f75ffb7d0ed0fa14e20e74dc48f449: Remove `shouldBeReported` flags from error descriptors that shouldn't have it.
2. https://github.com/NomicFoundation/hardhat/commit/81730fa139615aa24bb702d229ae0c7bcd8a0420: Enable an eslint rule to force us to always use `return await promise` instead of `return promise`.
3. An autofix of the rule described above.
4. https://github.com/NomicFoundation/hardhat/commit/026b8cc07e4d7bc172afd3f8bc013694f1af93f7: Enable an eslint rule that forces every function that returns a promise to be `async`.
5. An autofix of the rule described above.
6. A fix for an unhandled promise.
7. Changests 
8. Small linter fixes

The reason the eslint rules are added is that v8, and hence Node, reports better error stacks if you await the promises and use async functions instead of sync functions that return promises. It doesn't skip the stack frames like that. It's not perfect, because things like `setTimeout()`/`.then()`/etc can still confuse it, but it's a big improvement. Some info here: https://v8.dev/docs/stack-trace-api#async-stack-traces

This may seem random with respect to the error reporting error, but it's important to be able to properly classify what should and should not be reported to sentry.