### PR TITLE
Fix gas config resolution in ethers plugin and add tests

### DIFF
--- a/.changeset/wild-spiders-grab.md
+++ b/.changeset/wild-spiders-grab.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Fix gas config fields (gas, gasMultiplier, gasPrice) not being applied when sending transactions through the HardhatEthersSigner

--- a/packages/hardhat-ethers/src/internal/signers/signers.ts
+++ b/packages/hardhat-ethers/src/internal/signers/signers.ts
@@ -42,7 +42,6 @@ type SignerAccounts =
     };
 
 export class HardhatEthersSigner implements HardhatEthersSignerI {
-  readonly #gasLimit: bigint | undefined;
   readonly #signerAccounts: SignerAccounts;
   #cachedPrivateKey: string | undefined;
 
@@ -60,29 +59,21 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
     this.networkName = networkName;
     this.networkConfig = networkConfig;
 
-    let gasLimit: bigint | undefined;
-
-    if (networkConfig.gas !== "auto") {
-      gasLimit = networkConfig.gas;
-    }
-
     const signerAccounts: SignerAccounts =
       networkConfig.type === "http"
         ? { type: "http", accounts: networkConfig.accounts }
         : { type: "edr-simulated", accounts: networkConfig.accounts };
 
-    return new HardhatEthersSigner(address, provider, signerAccounts, gasLimit);
+    return new HardhatEthersSigner(address, provider, signerAccounts);
   }
 
   private constructor(
     address: string,
     provider: ethers.JsonRpcProvider | HardhatEthersProvider,
     signerAccounts: SignerAccounts,
-    gasLimit?: bigint | undefined,
   ) {
     this.address = getAddress(address);
     this.provider = provider;
-    this.#gasLimit = gasLimit;
 
     this.#signerAccounts = signerAccounts;
   }
@@ -94,7 +85,6 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
       this.address,
       provider,
       this.#signerAccounts,
-      this.#gasLimit,
     );
   }
 
@@ -281,21 +271,6 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
       );
     } else {
       resolvedTx.from = this.address;
-    }
-
-    if (resolvedTx.gasLimit === null || resolvedTx.gasLimit === undefined) {
-      if (this.#gasLimit !== undefined) {
-        resolvedTx.gasLimit = this.#gasLimit;
-      } else {
-        promises.push(
-          (async () => {
-            resolvedTx.gasLimit = await this.provider.estimateGas({
-              ...resolvedTx,
-              from: this.address,
-            });
-          })(),
-        );
-      }
     }
 
     // The address may be an ENS name or Addressable

--- a/packages/hardhat-ethers/test/gas-config.ts
+++ b/packages/hardhat-ethers/test/gas-config.ts
@@ -254,7 +254,7 @@ function defineGasConfigTests(initEthers: () => Promise<InitResult>) {
     });
   });
 
-  describe("non-interference with RPC calls", () => {
+  describe("non-interference with explicit gas-related calls", () => {
     let ethers: HardhatEthers;
     let provider: EthereumProvider;
 

--- a/packages/hardhat-ethers/test/gas-config.ts
+++ b/packages/hardhat-ethers/test/gas-config.ts
@@ -1,159 +1,286 @@
-// This test suite generates different gas configuration
-// combinations and runs some common tests for all of them.
-
 import type { HardhatEthers } from "../src/types.js";
 import type { NetworkConfig } from "hardhat/types/config";
+import type { JsonRpcServer } from "hardhat/types/network";
+import type { EthereumProvider } from "hardhat/types/providers";
 
 import assert from "node:assert/strict";
-import { before, describe, it } from "node:test";
+import { after, before, describe, it } from "node:test";
 
-import { initializeTestEthers } from "./helpers/helpers.js";
+import { initializeTestEthers, spawnTestRpcServer } from "./helpers/helpers.js";
 
-type GasLimitValue = "default" | "auto" | bigint;
-type ConnectedNetwork = "default" | "localhost";
+const ARTIFACTS = [{ artifactName: "Example", fileName: "gas-config" }];
 
-interface Combination {
-  hardhatGasLimit: GasLimitValue;
-  localhostGasLimit: GasLimitValue;
-  connectedNetwork: ConnectedNetwork;
-}
-
-function generateCombinations(): Combination[] {
-  const result: Combination[] = [];
-
-  const hardhatGasLimitValues: GasLimitValue[] = [
-    // TODO: enable when V3 is ready: when blockGasLimit is implemented
-    // "default",
-    "auto",
-    1_000_000n,
-  ];
-  const localhostGasLimitValues: GasLimitValue[] = [
-    // TODO: enable when V3 is ready: when blockGasLimit is implemented
-    // "default",
-    "auto",
-    1_000_000n,
-  ];
-
-  const connectedNetworkValues: ConnectedNetwork[] = ["default", "localhost"];
-
-  for (const hardhatGasLimit of hardhatGasLimitValues) {
-    for (const localhostGasLimit of localhostGasLimitValues) {
-      for (const connectedNetwork of connectedNetworkValues) {
-        result.push({
-          hardhatGasLimit,
-          localhostGasLimit,
-          connectedNetwork,
-        });
-      }
-    }
-  }
-
-  return result;
+interface InitResult {
+  ethers: HardhatEthers;
+  provider: EthereumProvider;
+  networkConfig: NetworkConfig;
 }
 
 describe("gas config behavior", () => {
-  let ethers: HardhatEthers;
-  let networkConfig: NetworkConfig;
+  describe("in-process hardhat network", () => {
+    defineGasConfigTests(() => initializeTestEthers(ARTIFACTS));
+  });
 
-  for (const {
-    hardhatGasLimit,
-    localhostGasLimit,
-    connectedNetwork,
-  } of generateCombinations()) {
-    describe(`hardhat gas limit: ${hardhatGasLimit} | localhostGasLimit: ${localhostGasLimit} | connectedNetwork: ${connectedNetwork}`, () => {
+  describe("local http node", () => {
+    let server: JsonRpcServer;
+    let port: number;
+    let address: string;
+
+    before(async () => {
+      ({ server, port, address } = await spawnTestRpcServer());
+    });
+
+    after(async () => {
+      await server.close();
+    });
+
+    defineGasConfigTests(() =>
+      initializeTestEthers(ARTIFACTS, {
+        networks: {
+          localhost: { type: "http", url: `http://${address}:${port}` },
+        },
+      }),
+    );
+  });
+});
+
+function defineGasConfigTests(initEthers: () => Promise<InitResult>) {
+  describe("gas: auto (default)", () => {
+    let ethers: HardhatEthers;
+
+    before(async () => {
+      ({ ethers } = await initEthers());
+    });
+
+    it("plain transaction uses estimated gas", async () => {
+      const [signer] = await ethers.getSigners();
+      const estimate = await signer.estimateGas({ to: signer });
+      const tx = await signer.sendTransaction({ to: signer });
+
+      assert.equal(tx.gasLimit, estimate);
+    });
+
+    it("contract deployment uses estimated gas", async () => {
+      const [signer] = await ethers.getSigners();
+      const factory = await ethers.getContractFactory("Example");
+      const deployTx = await factory.getDeployTransaction();
+      const estimate = await signer.estimateGas(deployTx);
+
+      const example = await ethers.deployContract("Example");
+      const deploymentTx = example.deploymentTransaction();
+
+      assert.equal(deploymentTx?.gasLimit, estimate);
+    });
+
+    it("contract call uses estimated gas", async () => {
+      const [signer] = await ethers.getSigners();
+      const example = await ethers.deployContract("Example");
+      const estimate = await signer.estimateGas({
+        to: example,
+        data: example.interface.encodeFunctionData("f"),
+      });
+      const tx = await example.f();
+
+      assert.equal(tx.gasLimit, estimate);
+    });
+
+    it("explicit gasLimit overrides auto estimation", async () => {
+      const [signer] = await ethers.getSigners();
+      const tx = await signer.sendTransaction({
+        to: signer,
+        gasLimit: 500_000,
+      });
+
+      assert.equal(tx.gasLimit, 500_000n);
+    });
+  });
+
+  describe("gas: fixed value", () => {
+    let ethers: HardhatEthers;
+    let networkConfig: NetworkConfig;
+
+    before(async () => {
+      ({ ethers, networkConfig } = await initEthers());
+      networkConfig.gas = 1_000_000n;
+    });
+
+    it("plain transaction uses fixed gas", async () => {
+      const [signer] = await ethers.getSigners();
+      const tx = await signer.sendTransaction({ to: signer });
+
+      assert.equal(tx.gasLimit, 1_000_000n);
+    });
+
+    it("contract deployment uses fixed gas", async () => {
+      const example = await ethers.deployContract("Example");
+      const deploymentTx = example.deploymentTransaction();
+
+      assert.equal(deploymentTx?.gasLimit, 1_000_000n);
+    });
+
+    it("contract call uses fixed gas", async () => {
+      const example = await ethers.deployContract("Example");
+      const tx = await example.f();
+
+      assert.equal(tx.gasLimit, 1_000_000n);
+    });
+
+    it("explicit gasLimit overrides fixed config", async () => {
+      const [signer] = await ethers.getSigners();
+      const tx = await signer.sendTransaction({
+        to: signer,
+        gasLimit: 500_000,
+      });
+
+      assert.equal(tx.gasLimit, 500_000n);
+    });
+  });
+
+  describe("gasMultiplier", () => {
+    const GAS_MULTIPLIER = 1.5;
+    let ethers: HardhatEthers;
+    let networkConfig: NetworkConfig;
+
+    before(async () => {
+      ({ ethers, networkConfig } = await initEthers());
+      networkConfig.gasMultiplier = GAS_MULTIPLIER;
+    });
+
+    it("plain transaction gas is multiplied", async () => {
+      const [signer] = await ethers.getSigners();
+      const estimate = await signer.estimateGas({ to: signer });
+      const tx = await signer.sendTransaction({ to: signer });
+
+      const expected = BigInt(Math.floor(Number(estimate) * GAS_MULTIPLIER));
+      assert.equal(tx.gasLimit, expected);
+    });
+
+    it("contract deployment gas is multiplied", async () => {
+      const [signer] = await ethers.getSigners();
+      const factory = await ethers.getContractFactory("Example");
+      const deployTx = await factory.getDeployTransaction();
+      const estimate = await signer.estimateGas(deployTx);
+
+      const example = await ethers.deployContract("Example");
+      const deploymentTx = example.deploymentTransaction();
+
+      const expected = BigInt(Math.floor(Number(estimate) * GAS_MULTIPLIER));
+      assert.equal(deploymentTx?.gasLimit, expected);
+    });
+
+    it("contract call gas is multiplied", async () => {
+      const [signer] = await ethers.getSigners();
+      const example = await ethers.deployContract("Example");
+      const estimate = await signer.estimateGas({
+        to: example,
+        data: example.interface.encodeFunctionData("f"),
+      });
+      const tx = await example.f();
+
+      const expected = BigInt(Math.floor(Number(estimate) * GAS_MULTIPLIER));
+      assert.equal(tx.gasLimit, expected);
+    });
+
+    it("explicit gasLimit is not multiplied", async () => {
+      const [signer] = await ethers.getSigners();
+      const tx = await signer.sendTransaction({
+        to: signer,
+        gasLimit: 500_000,
+      });
+
+      assert.equal(tx.gasLimit, 500_000n);
+    });
+  });
+
+  describe("gasPrice config", () => {
+    describe("auto gasPrice (default)", () => {
+      let ethers: HardhatEthers;
+
       before(async () => {
-        ({ ethers, networkConfig } = await initializeTestEthers([
-          { artifactName: "Example", fileName: "gas-config" },
-        ]));
-
-        if (hardhatGasLimit !== "default" && connectedNetwork === "default") {
-          networkConfig.gas = hardhatGasLimit;
-        }
-
-        if (
-          localhostGasLimit !== "default" &&
-          connectedNetwork === "localhost"
-        ) {
-          networkConfig.gas = localhostGasLimit;
-        }
+        ({ ethers } = await initEthers());
       });
 
-      // for some combinations there will be a default gas limit that is used
-      // when no explicit gas limit is set by the user; in those cases, we
-      // assert that the tx indeed uses that gas limit; if not, then
-      // the result of an estimateGas call should be used
-      let defaultGasLimit: bigint | undefined;
-      if (
-        (connectedNetwork === "default" && hardhatGasLimit === 1_000_000n) ||
-        (connectedNetwork === "localhost" && localhostGasLimit === 1_000_000n)
-      ) {
-        defaultGasLimit = 1_000_000n;
-      } else if (
-        (connectedNetwork === "default" && hardhatGasLimit === "default") ||
-        (connectedNetwork === "localhost" && localhostGasLimit === "default")
-      ) {
-        // expect the block gas limit to be used as the default gas limit
-        defaultGasLimit = 60_000_000n;
-      }
-
-      it("plain transaction, default gas limit", async () => {
-        const expectedGasLimit = defaultGasLimit ?? 21_001n;
-
+      it("EIP-1559 fields are populated", async () => {
         const [signer] = await ethers.getSigners();
-        const tx = await signer.sendTransaction({
-          to: signer,
-        });
+        const tx = await signer.sendTransaction({ to: signer });
 
-        assert.equal(tx.gasLimit, expectedGasLimit);
-      });
-
-      it("plain transaction, explicit gas limit", async () => {
-        const [signer] = await ethers.getSigners();
-
-        const tx = await signer.sendTransaction({
-          to: signer,
-          gasLimit: 500_000,
-        });
-
-        assert.equal(tx.gasLimit, 500_000n);
-      });
-
-      it("contract deployment, default gas limit", async () => {
-        const expectedGasLimit = defaultGasLimit ?? 76_985n;
-
-        const example: any = await ethers.deployContract("Example");
-        const deploymentTx = await example.deploymentTransaction();
-
-        assert.equal(deploymentTx.gasLimit, expectedGasLimit);
-      });
-
-      it("contract deployment, explicit gas limit", async () => {
-        const Example: any = await ethers.getContractFactory("Example");
-        const example = await Example.deploy({
-          gasLimit: 500_000,
-        });
-        const deploymentTx = await example.deploymentTransaction();
-
-        assert.equal(deploymentTx.gasLimit, 500_000n);
-      });
-
-      it("contract call, default gas limit", async () => {
-        const expectedGasLimit = defaultGasLimit ?? 21_186n;
-
-        const example: any = await ethers.deployContract("Example");
-        const tx = await example.f();
-
-        assert.equal(tx.gasLimit, expectedGasLimit);
-      });
-
-      it("contract call, explicit gas limit", async () => {
-        const example: any = await ethers.deployContract("Example");
-        const tx = await example.f({
-          gasLimit: 500_000,
-        });
-
-        assert.equal(tx.gasLimit, 500_000n);
+        assert.equal(tx.type, 2);
+        assert.notEqual(tx.maxFeePerGas, null);
+        assert.notEqual(tx.maxPriorityFeePerGas, null);
       });
     });
-  }
-});
+
+    describe("fixed gasPrice", () => {
+      let ethers: HardhatEthers;
+      let networkConfig: NetworkConfig;
+      const FIXED_GAS_PRICE = 10_000_000_000n; // 10 gwei
+
+      before(async () => {
+        ({ ethers, networkConfig } = await initEthers());
+        networkConfig.gasPrice = FIXED_GAS_PRICE;
+      });
+
+      it("legacy gasPrice is used", async () => {
+        const [signer] = await ethers.getSigners();
+        const tx = await signer.sendTransaction({ to: signer });
+
+        assert.equal(tx.type, 0);
+        assert.equal(tx.gasPrice, FIXED_GAS_PRICE);
+      });
+
+      it("explicit gasPrice overrides config", async () => {
+        const [signer] = await ethers.getSigners();
+        const userGasPrice = 20_000_000_000n;
+        const tx = await signer.sendTransaction({
+          to: signer,
+          gasPrice: userGasPrice,
+        });
+
+        assert.equal(tx.gasPrice, userGasPrice);
+      });
+
+      it("explicit maxFeePerGas overrides config", async () => {
+        const [signer] = await ethers.getSigners();
+        const tx = await signer.sendTransaction({
+          to: signer,
+          maxFeePerGas: 20_000_000_000n,
+          maxPriorityFeePerGas: 1_000_000_000n,
+        });
+
+        assert.equal(tx.type, 2);
+        assert.equal(tx.maxFeePerGas, 20_000_000_000n);
+        assert.equal(tx.maxPriorityFeePerGas, 1_000_000_000n);
+      });
+    });
+  });
+
+  describe("non-interference with RPC calls", () => {
+    let ethers: HardhatEthers;
+    let provider: EthereumProvider;
+
+    before(async () => {
+      let networkConfig: NetworkConfig;
+      ({ ethers, provider, networkConfig } = await initEthers());
+      networkConfig.gas = 1_000_000n;
+      networkConfig.gasPrice = 10_000_000_000n;
+    });
+
+    it("estimateGas returns real estimate, not fixed config value", async () => {
+      const [signer] = await ethers.getSigners();
+      const estimate = await signer.estimateGas({ to: signer });
+
+      assert.notEqual(estimate, 1_000_000n);
+      assert.ok(estimate > 0n, "estimate should be greater than 0");
+    });
+
+    it("eth_gasPrice returns real gas price, not fixed config value", async () => {
+      const gasPrice = await provider.request({
+        method: "eth_gasPrice",
+      });
+
+      assert.ok(typeof gasPrice === "string", "gasPrice should be a string");
+      assert.ok(BigInt(gasPrice) > 0n, "gasPrice should be greater than 0");
+      assert.notEqual(BigInt(gasPrice), 10_000_000_000n);
+    });
+  });
+}

--- a/packages/hardhat-viem/test/gas-config.ts
+++ b/packages/hardhat-viem/test/gas-config.ts
@@ -1,0 +1,405 @@
+import type { HardhatViemHelpers } from "../src/types.js";
+import type { NetworkConfig } from "hardhat/types/config";
+import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
+import type { JsonRpcServer } from "hardhat/types/network";
+import type { EthereumProvider } from "hardhat/types/providers";
+
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+
+import { useFixtureProject } from "@nomicfoundation/hardhat-test-utils";
+import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+import { encodeFunctionData } from "viem";
+
+import HardhatViem from "../src/index.js";
+
+interface InitResult {
+  viem: HardhatViemHelpers;
+  provider: EthereumProvider;
+  networkConfig: NetworkConfig;
+}
+
+describe("gas config behavior", () => {
+  useFixtureProject("default-ts-project");
+
+  let hre: HardhatRuntimeEnvironment;
+
+  before(async () => {
+    hre = await createHardhatRuntimeEnvironment({
+      plugins: [HardhatViem],
+      networks: {
+        localhost: { type: "http", url: "http://127.0.0.1:0" },
+      },
+    });
+    await hre.tasks.getTask("build").run({});
+  });
+
+  describe("in-process hardhat network", () => {
+    defineGasConfigTests(async () => {
+      const conn = await hre.network.create();
+      return {
+        viem: conn.viem,
+        provider: conn.provider,
+        networkConfig: conn.networkConfig,
+      };
+    });
+  });
+
+  describe("local http node", () => {
+    let server: JsonRpcServer;
+    let address: string;
+    let port: number;
+
+    before(async () => {
+      server = await hre.network.createServer();
+      ({ address, port } = await server.listen());
+    });
+
+    after(async () => {
+      await server.close();
+    });
+
+    defineGasConfigTests(async () => {
+      const conn = await hre.network.create({
+        network: "localhost",
+        override: { url: `http://${address}:${port}` },
+      });
+      return {
+        viem: conn.viem,
+        provider: conn.provider,
+        networkConfig: conn.networkConfig,
+      };
+    });
+  });
+});
+
+function defineGasConfigTests(initViem: () => Promise<InitResult>) {
+  describe("gas: auto (default)", () => {
+    let viem: HardhatViemHelpers;
+
+    before(async () => {
+      ({ viem } = await initViem());
+    });
+
+    it("plain transaction uses estimated gas", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+
+      const estimate = await publicClient.estimateGas({
+        account: walletClient.account.address,
+        to: walletClient.account.address,
+        value: 0n,
+      });
+      const hash = await walletClient.sendTransaction({
+        to: walletClient.account.address,
+        value: 0n,
+      });
+      const tx = await publicClient.getTransaction({ hash });
+
+      assert.equal(tx.gas, estimate);
+    });
+
+    it("contract deployment uses estimated gas", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+
+      const { deploymentTransaction } = await viem.sendDeploymentTransaction(
+        "WithoutConstructorArgs",
+      );
+      const estimate = await publicClient.estimateGas({
+        account: walletClient.account.address,
+        data: deploymentTransaction.input,
+      });
+
+      assert.equal(deploymentTransaction.gas, estimate);
+    });
+
+    it("contract call uses estimated gas", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+      const contract = await viem.deployContract("WithoutConstructorArgs");
+
+      const estimate = await publicClient.estimateGas({
+        account: walletClient.account.address,
+        to: contract.address,
+        data: encodeFunctionData({
+          abi: contract.abi,
+          functionName: "setData",
+          args: [50n],
+        }),
+      });
+      const hash = await contract.write.setData([50n]);
+      const tx = await publicClient.getTransaction({ hash });
+
+      assert.equal(tx.gas, estimate);
+    });
+
+    it("explicit gas overrides auto estimation", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+
+      const hash = await walletClient.sendTransaction({
+        to: walletClient.account.address,
+        value: 0n,
+        gas: 500_000n,
+      });
+      const tx = await publicClient.getTransaction({ hash });
+
+      assert.equal(tx.gas, 500_000n);
+    });
+  });
+
+  describe("gas: fixed value", () => {
+    let viem: HardhatViemHelpers;
+    let networkConfig: NetworkConfig;
+
+    before(async () => {
+      ({ viem, networkConfig } = await initViem());
+      networkConfig.gas = 1_000_000n;
+    });
+
+    it("plain transaction uses fixed gas", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+
+      const hash = await walletClient.sendTransaction({
+        to: walletClient.account.address,
+        value: 0n,
+      });
+      const tx = await publicClient.getTransaction({ hash });
+
+      assert.equal(tx.gas, 1_000_000n);
+    });
+
+    it("contract deployment uses fixed gas", async () => {
+      const { deploymentTransaction } = await viem.sendDeploymentTransaction(
+        "WithoutConstructorArgs",
+      );
+
+      assert.equal(deploymentTransaction.gas, 1_000_000n);
+    });
+
+    it("contract call uses fixed gas", async () => {
+      const publicClient = await viem.getPublicClient();
+      const contract = await viem.deployContract("WithoutConstructorArgs");
+
+      const hash = await contract.write.setData([50n]);
+      const tx = await publicClient.getTransaction({ hash });
+
+      assert.equal(tx.gas, 1_000_000n);
+    });
+
+    it("explicit gas overrides fixed config", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+
+      const hash = await walletClient.sendTransaction({
+        to: walletClient.account.address,
+        value: 0n,
+        gas: 500_000n,
+      });
+      const tx = await publicClient.getTransaction({ hash });
+
+      assert.equal(tx.gas, 500_000n);
+    });
+  });
+
+  describe("gasMultiplier", () => {
+    const GAS_MULTIPLIER = 1.5;
+    let viem: HardhatViemHelpers;
+    let networkConfig: NetworkConfig;
+
+    before(async () => {
+      ({ viem, networkConfig } = await initViem());
+      networkConfig.gasMultiplier = GAS_MULTIPLIER;
+    });
+
+    it("plain transaction gas is multiplied", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+
+      const estimate = await publicClient.estimateGas({
+        account: walletClient.account.address,
+        to: walletClient.account.address,
+        value: 0n,
+      });
+      const hash = await walletClient.sendTransaction({
+        to: walletClient.account.address,
+        value: 0n,
+      });
+      const tx = await publicClient.getTransaction({ hash });
+
+      const expected = BigInt(Math.floor(Number(estimate) * GAS_MULTIPLIER));
+      assert.equal(tx.gas, expected);
+    });
+
+    it("contract deployment gas is multiplied", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+
+      const { deploymentTransaction } = await viem.sendDeploymentTransaction(
+        "WithoutConstructorArgs",
+      );
+      const estimate = await publicClient.estimateGas({
+        account: walletClient.account.address,
+        data: deploymentTransaction.input,
+      });
+
+      const expected = BigInt(Math.floor(Number(estimate) * GAS_MULTIPLIER));
+      assert.equal(deploymentTransaction.gas, expected);
+    });
+
+    it("contract call gas is multiplied", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+      const contract = await viem.deployContract("WithoutConstructorArgs");
+
+      const estimate = await publicClient.estimateGas({
+        account: walletClient.account.address,
+        to: contract.address,
+        data: encodeFunctionData({
+          abi: contract.abi,
+          functionName: "setData",
+          args: [50n],
+        }),
+      });
+      const hash = await contract.write.setData([50n]);
+      const tx = await publicClient.getTransaction({ hash });
+
+      const expected = BigInt(Math.floor(Number(estimate) * GAS_MULTIPLIER));
+      assert.equal(tx.gas, expected);
+    });
+
+    it("explicit gas is not multiplied", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+
+      const hash = await walletClient.sendTransaction({
+        to: walletClient.account.address,
+        value: 0n,
+        gas: 500_000n,
+      });
+      const tx = await publicClient.getTransaction({ hash });
+
+      assert.equal(tx.gas, 500_000n);
+    });
+  });
+
+  describe("gasPrice config", () => {
+    describe("auto gasPrice (default)", () => {
+      let viem: HardhatViemHelpers;
+
+      before(async () => {
+        ({ viem } = await initViem());
+      });
+
+      it("EIP-1559 fields are populated", async () => {
+        const publicClient = await viem.getPublicClient();
+        const [walletClient] = await viem.getWalletClients();
+
+        const hash = await walletClient.sendTransaction({
+          to: walletClient.account.address,
+          value: 0n,
+        });
+        const tx = await publicClient.getTransaction({ hash });
+
+        assert.equal(tx.type, "eip1559");
+        assert.notEqual(tx.maxFeePerGas, null);
+        assert.notEqual(tx.maxPriorityFeePerGas, null);
+      });
+    });
+
+    describe("fixed gasPrice", () => {
+      let viem: HardhatViemHelpers;
+      let networkConfig: NetworkConfig;
+      const FIXED_GAS_PRICE = 10_000_000_000n; // 10 gwei
+
+      before(async () => {
+        ({ viem, networkConfig } = await initViem());
+        networkConfig.gasPrice = FIXED_GAS_PRICE;
+      });
+
+      it("legacy gasPrice is used", async () => {
+        const publicClient = await viem.getPublicClient();
+        const [walletClient] = await viem.getWalletClients();
+
+        const hash = await walletClient.sendTransaction({
+          to: walletClient.account.address,
+          value: 0n,
+        });
+        const tx = await publicClient.getTransaction({ hash });
+
+        assert.equal(tx.type, "legacy");
+        assert.equal(tx.gasPrice, FIXED_GAS_PRICE);
+      });
+
+      it("explicit gasPrice overrides config", async () => {
+        const publicClient = await viem.getPublicClient();
+        const [walletClient] = await viem.getWalletClients();
+        const userGasPrice = 20_000_000_000n;
+
+        const hash = await walletClient.sendTransaction({
+          to: walletClient.account.address,
+          value: 0n,
+          gasPrice: userGasPrice,
+        });
+        const tx = await publicClient.getTransaction({ hash });
+
+        assert.equal(tx.gasPrice, userGasPrice);
+      });
+
+      it("explicit maxFeePerGas overrides config", async () => {
+        const publicClient = await viem.getPublicClient();
+        const [walletClient] = await viem.getWalletClients();
+
+        const hash = await walletClient.sendTransaction({
+          to: walletClient.account.address,
+          value: 0n,
+          maxFeePerGas: 20_000_000_000n,
+          maxPriorityFeePerGas: 1_000_000_000n,
+        });
+        const tx = await publicClient.getTransaction({ hash });
+
+        assert.equal(tx.type, "eip1559");
+        assert.equal(tx.maxFeePerGas, 20_000_000_000n);
+        assert.equal(tx.maxPriorityFeePerGas, 1_000_000_000n);
+      });
+    });
+  });
+
+  describe("non-interference with RPC calls", () => {
+    let viem: HardhatViemHelpers;
+    let provider: EthereumProvider;
+
+    before(async () => {
+      let networkConfig: NetworkConfig;
+      ({ viem, provider, networkConfig } = await initViem());
+      networkConfig.gas = 1_000_000n;
+      networkConfig.gasPrice = 10_000_000_000n;
+    });
+
+    it("estimateGas returns real estimate, not fixed config value", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [walletClient] = await viem.getWalletClients();
+
+      const estimate = await publicClient.estimateGas({
+        account: walletClient.account.address,
+        to: walletClient.account.address,
+        value: 0n,
+      });
+
+      assert.notEqual(estimate, 1_000_000n);
+      assert.ok(estimate > 0n, "estimate should be greater than 0");
+    });
+
+    it("eth_gasPrice returns real gas price, not fixed config value", async () => {
+      const gasPrice = await provider.request({
+        method: "eth_gasPrice",
+      });
+
+      assert.ok(typeof gasPrice === "string", "gasPrice should be a string");
+      assert.ok(BigInt(gasPrice) > 0n, "gasPrice should be greater than 0");
+      assert.notEqual(BigInt(gasPrice), 10_000_000_000n);
+    });
+  });
+}

--- a/packages/hardhat-viem/test/gas-config.ts
+++ b/packages/hardhat-viem/test/gas-config.ts
@@ -7,7 +7,7 @@ import type { EthereumProvider } from "hardhat/types/providers";
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 
-import { useFixtureProject } from "@nomicfoundation/hardhat-test-utils";
+import { useEphemeralFixtureProject } from "@nomicfoundation/hardhat-test-utils";
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 import { encodeFunctionData } from "viem";
 
@@ -20,7 +20,7 @@ interface InitResult {
 }
 
 describe("gas config behavior", () => {
-  useFixtureProject("default-ts-project");
+  useEphemeralFixtureProject("default-ts-project");
 
   let hre: HardhatRuntimeEnvironment;
 


### PR DESCRIPTION
The `HardhatEthersSigner` was resolving `gasLimit` before sending the RPC request, bypassing the core request handlers. This meant `gasMultiplier` was silently ignored for ethers users.

 - Remove `gasLimit` resolution from `HardhatEthersSigner`, delegating it to the handler chain
 - Add gas config tests for both `hardhat-ethers` and `hardhat-viem` (gas auto/fixed, gasMultiplier, gasPrice, non-interference with RPC calls)
 - Improve gas configuration docs in the `hardhat-website` repo ([Link](https://github.com/NomicFoundation/hardhat-website/pull/256))

Closes https://github.com/NomicFoundation/hardhat/issues/8042