### PR TITLE
Add `from` config tests and rename gas-config tests to network-config

### DIFF
--- a/packages/hardhat-ethers/src/internal/signers/signers.ts
+++ b/packages/hardhat-ethers/src/internal/signers/signers.ts
@@ -252,7 +252,10 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
 
     const promises: Array<Promise<void>> = [];
 
-    // Make sure the from matches the sender
+    // Mirror stock ethers: ENS-resolve `from` and assert it matches the
+    // signer. Hardhat can be pointed at mainnet/testnets via --network, where
+    // ENS works and users expect ethers-compatible `from` handling. Don't
+    // "simplify" this by letting the node handle the mismatch.
     if (resolvedTx.from !== null && resolvedTx.from !== undefined) {
       const _from = resolvedTx.from;
       promises.push(

--- a/packages/hardhat-ethers/test/network-config.ts
+++ b/packages/hardhat-ethers/test/network-config.ts
@@ -254,6 +254,26 @@ function defineNetworkConfigTests(initEthers: () => Promise<InitResult>) {
     });
   });
 
+  describe("from config", () => {
+    let ethers: HardhatEthers;
+
+    before(async () => {
+      ({ ethers } = await initEthers());
+    });
+
+    it("default signer sends from its own address", async () => {
+      const [firstSigner, secondSigner] = await ethers.getSigners();
+      const tx = await firstSigner.sendTransaction({ to: secondSigner });
+      assert.equal(tx.from, firstSigner.address);
+    });
+
+    it("non-first signer sends from its own address", async () => {
+      const [firstSigner, secondSigner] = await ethers.getSigners();
+      const tx = await secondSigner.sendTransaction({ to: firstSigner });
+      assert.equal(tx.from, secondSigner.address);
+    });
+  });
+
   describe("non-interference with explicit gas-related calls", () => {
     let ethers: HardhatEthers;
     let provider: EthereumProvider;

--- a/packages/hardhat-ethers/test/network-config.ts
+++ b/packages/hardhat-ethers/test/network-config.ts
@@ -272,6 +272,28 @@ function defineNetworkConfigTests(initEthers: () => Promise<InitResult>) {
       const tx = await secondSigner.sendTransaction({ to: firstSigner });
       assert.equal(tx.from, secondSigner.address);
     });
+
+    it("respects explicit from matching the signer", async () => {
+      const [firstSigner, secondSigner] = await ethers.getSigners();
+      const tx = await firstSigner.sendTransaction({
+        to: secondSigner,
+        from: firstSigner.address,
+      });
+      assert.equal(tx.from, firstSigner.address);
+    });
+
+    it("throws when explicit from doesn't match the signer", async () => {
+      const [firstSigner, secondSigner] = await ethers.getSigners();
+
+      // eslint-disable-next-line no-restricted-syntax -- it tests a non Hardhat error
+      await assert.rejects(
+        firstSigner.sendTransaction({
+          to: firstSigner,
+          from: secondSigner.address,
+        }),
+        /from address mismatch/,
+      );
+    });
   });
 
   describe("non-interference with explicit gas-related calls", () => {

--- a/packages/hardhat-ethers/test/network-config.ts
+++ b/packages/hardhat-ethers/test/network-config.ts
@@ -16,9 +16,9 @@ interface InitResult {
   networkConfig: NetworkConfig;
 }
 
-describe("gas config behavior", () => {
+describe("network config behavior", () => {
   describe("in-process hardhat network", () => {
-    defineGasConfigTests(() => initializeTestEthers(ARTIFACTS));
+    defineNetworkConfigTests(() => initializeTestEthers(ARTIFACTS));
   });
 
   describe("local http node", () => {
@@ -34,7 +34,7 @@ describe("gas config behavior", () => {
       await server.close();
     });
 
-    defineGasConfigTests(() =>
+    defineNetworkConfigTests(() =>
       initializeTestEthers(ARTIFACTS, {
         networks: {
           localhost: { type: "http", url: `http://${address}:${port}` },
@@ -44,7 +44,7 @@ describe("gas config behavior", () => {
   });
 });
 
-function defineGasConfigTests(initEthers: () => Promise<InitResult>) {
+function defineNetworkConfigTests(initEthers: () => Promise<InitResult>) {
   describe("gas: auto (default)", () => {
     let ethers: HardhatEthers;
 

--- a/packages/hardhat-viem/test/network-config.ts
+++ b/packages/hardhat-viem/test/network-config.ts
@@ -367,6 +367,36 @@ function defineNetworkConfigTests(initViem: () => Promise<InitResult>) {
     });
   });
 
+  describe("from config", () => {
+    let viem: HardhatViemHelpers;
+
+    before(async () => {
+      ({ viem } = await initViem());
+    });
+
+    it("default wallet client sends from its own address", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [firstClient, secondClient] = await viem.getWalletClients();
+      const hash = await firstClient.sendTransaction({
+        to: secondClient.account.address,
+        value: 0n,
+      });
+      const tx = await publicClient.getTransaction({ hash });
+      assert.equal(tx.from.toLowerCase(), firstClient.account.address.toLowerCase());
+    });
+
+    it("non-first wallet client sends from its own address", async () => {
+      const publicClient = await viem.getPublicClient();
+      const [firstClient, secondClient] = await viem.getWalletClients();
+      const hash = await secondClient.sendTransaction({
+        to: firstClient.account.address,
+        value: 0n,
+      });
+      const tx = await publicClient.getTransaction({ hash });
+      assert.equal(tx.from.toLowerCase(), secondClient.account.address.toLowerCase());
+    });
+  });
+
   describe("non-interference with RPC calls", () => {
     let viem: HardhatViemHelpers;
     let provider: EthereumProvider;

--- a/packages/hardhat-viem/test/network-config.ts
+++ b/packages/hardhat-viem/test/network-config.ts
@@ -19,7 +19,7 @@ interface InitResult {
   networkConfig: NetworkConfig;
 }
 
-describe("gas config behavior", () => {
+describe("network config behavior", () => {
   useEphemeralFixtureProject("default-ts-project");
 
   let hre: HardhatRuntimeEnvironment;
@@ -35,7 +35,7 @@ describe("gas config behavior", () => {
   });
 
   describe("in-process hardhat network", () => {
-    defineGasConfigTests(async () => {
+    defineNetworkConfigTests(async () => {
       const conn = await hre.network.create();
       return {
         viem: conn.viem,
@@ -59,7 +59,7 @@ describe("gas config behavior", () => {
       await server.close();
     });
 
-    defineGasConfigTests(async () => {
+    defineNetworkConfigTests(async () => {
       const conn = await hre.network.create({
         network: "localhost",
         override: { url: `http://${address}:${port}` },
@@ -73,7 +73,7 @@ describe("gas config behavior", () => {
   });
 });
 
-function defineGasConfigTests(initViem: () => Promise<InitResult>) {
+function defineNetworkConfigTests(initViem: () => Promise<InitResult>) {
   describe("gas: auto (default)", () => {
     let viem: HardhatViemHelpers;
 

--- a/packages/hardhat-viem/test/network-config.ts
+++ b/packages/hardhat-viem/test/network-config.ts
@@ -382,7 +382,10 @@ function defineNetworkConfigTests(initViem: () => Promise<InitResult>) {
         value: 0n,
       });
       const tx = await publicClient.getTransaction({ hash });
-      assert.equal(tx.from.toLowerCase(), firstClient.account.address.toLowerCase());
+      assert.equal(
+        tx.from.toLowerCase(),
+        firstClient.account.address.toLowerCase(),
+      );
     });
 
     it("non-first wallet client sends from its own address", async () => {
@@ -393,7 +396,10 @@ function defineNetworkConfigTests(initViem: () => Promise<InitResult>) {
         value: 0n,
       });
       const tx = await publicClient.getTransaction({ hash });
-      assert.equal(tx.from.toLowerCase(), secondClient.account.address.toLowerCase());
+      assert.equal(
+        tx.from.toLowerCase(),
+        secondClient.account.address.toLowerCase(),
+      );
     });
   });
 


### PR DESCRIPTION
Adds test coverage for the `from` field in `HardhatEthersSigner.sendTransaction` and viem's `walletClient.sendTransaction`, and renames the `gas-config` test files to `network-config` in both the `hardhat-ethers` and `hardhat-viem` plugins now that they cover more than just gas configuration.

**hardhat-ethers** — new `from config` describe block covering:
- default signer sends from its own address
- non-first signer sends from its own address
- explicit `from` matching the signer is respected
- explicit `from` mismatching the signer throws `"from address mismatch"` (existing pre-PR behavior from `#sendUncheckedTransaction`)

**hardhat-viem** — new `from config` describe block covering:
- default wallet client sends from its own address
- non-first wallet client sends from its own address

No behavior changes — tests only.
