### PR TITLE
Lazy-load Sentry reporter

### DIFF
--- a/.changeset/cool-planets-reflect.md
+++ b/.changeset/cool-planets-reflect.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Improve error reporter

--- a/packages/hardhat/src/cli.ts
+++ b/packages/hardhat/src/cli.ts
@@ -3,7 +3,7 @@
 import { printNodeJsVersionWarningIfNecessary } from "./internal/cli/node-version.js";
 import { setupGlobalUnhandledErrorHandlers } from "./internal/cli/telemetry/error-reporter/global-error-handlers.js";
 
-// We setup the global unhandled errors first
+// We set up the global unhandled errors first
 setupGlobalUnhandledErrorHandlers();
 
 // We enable the sourcemaps before loading main, so that everything except this

--- a/packages/hardhat/src/cli.ts
+++ b/packages/hardhat/src/cli.ts
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
 import { printNodeJsVersionWarningIfNecessary } from "./internal/cli/node-version.js";
+import { setupGlobalUnhandledErrorHandlers } from "./internal/cli/telemetry/error-reporter/global-error-handlers.js";
+
+// We setup the global unhandled errors first
+setupGlobalUnhandledErrorHandlers();
 
 // We enable the sourcemaps before loading main, so that everything except this
 // small file is loaded with sourcemaps enabled.

--- a/packages/hardhat/src/cli.ts
+++ b/packages/hardhat/src/cli.ts
@@ -1,10 +1,6 @@
 #!/usr/bin/env node
 
 import { printNodeJsVersionWarningIfNecessary } from "./internal/cli/node-version.js";
-import { setupGlobalUnhandledErrorHandlers } from "./internal/cli/telemetry/error-reporter/global-error-handlers.js";
-
-// We set up the global unhandled errors first
-setupGlobalUnhandledErrorHandlers();
 
 // We enable the sourcemaps before loading main, so that everything except this
 // small file is loaded with sourcemaps enabled.

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -36,7 +36,7 @@ import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
 import { deepEqual } from "@nomicfoundation/hardhat-utils/lang";
 import debug from "debug";
 
-import { sendErrorTelemetry } from "../../../cli/telemetry/sentry/reporter.js";
+import { sendErrorTelemetry } from "../../../cli/telemetry/error-reporter/reporter.js";
 import { EDR_NETWORK_REVERT_SNAPSHOT_EVENT } from "../../../constants.js";
 import { hardhatChainTypeToEdrChainType } from "../../../edr/chain-type.js";
 import { getGlobalEdrContext } from "../../../edr/context.js";

--- a/packages/hardhat/src/internal/builtin-plugins/node/helpers.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/helpers.ts
@@ -16,7 +16,7 @@ import chalk from "chalk";
 // micro-eth-signer is known to be slow to load, so we lazy load it
 let microEthSigner: typeof MicroEthSignerT | undefined;
 
-import { sendErrorTelemetry } from "../../cli/telemetry/sentry/reporter.js";
+import { sendErrorTelemetry } from "../../cli/telemetry/error-reporter/reporter.js";
 import { isDefaultEdrNetworkHDAccountsConfig } from "../network-manager/edr/edr-provider.js";
 import { normalizeEdrNetworkAccountsConfig } from "../network-manager/edr/utils/convert-to-edr.js";
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -9,7 +9,7 @@ import type { TestResult } from "@nomicfoundation/edr";
 import { bytesToHexString } from "@nomicfoundation/hardhat-utils/hex";
 import chalk from "chalk";
 
-import { sendErrorTelemetry } from "../../cli/telemetry/sentry/reporter.js";
+import { sendErrorTelemetry } from "../../cli/telemetry/error-reporter/reporter.js";
 import { SolidityTestStackTraceGenerationError } from "../network-manager/edr/stack-traces/stack-trace-generation-errors.js";
 import { encodeStackTraceEntry } from "../network-manager/edr/stack-traces/stack-trace-solidity-errors.js";
 import { formatTraces } from "../network-manager/edr/utils/trace-formatters.js";

--- a/packages/hardhat/src/internal/cli/init/init.ts
+++ b/packages/hardhat/src/internal/cli/init/init.ts
@@ -31,7 +31,7 @@ import {
 } from "../../utils/package.js";
 import { BannerManager } from "../banner-manager.js";
 import { sendProjectTypeAnalytics } from "../telemetry/analytics/analytics.js";
-import { sendErrorTelemetry } from "../telemetry/sentry/reporter.js";
+import { sendErrorTelemetry } from "../telemetry/error-reporter/reporter.js";
 
 import {
   getDevDependenciesInstallationCommand,

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -49,8 +49,7 @@ import { sendTaskAnalytics } from "./telemetry/analytics/analytics.js";
 import {
   sendErrorTelemetry,
   setCliHardhatConfigPath,
-  setupErrorTelemetryIfEnabled,
-} from "./telemetry/sentry/reporter.js";
+} from "./telemetry/error-reporter/reporter.js";
 import { printVersionMessage } from "./version.js";
 
 export interface MainOptions {
@@ -64,7 +63,6 @@ export async function main(
   rawArguments: string[],
   options: MainOptions = {},
 ): Promise<void> {
-  await setupErrorTelemetryIfEnabled();
   const print = options.print ?? console.log;
 
   const log = debug("hardhat:core:cli:main");

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -46,6 +46,7 @@ import { printErrorMessages } from "./error-handler.js";
 import { getGlobalHelpString } from "./help/get-global-help-string.js";
 import { getHelpString } from "./help/get-help-string.js";
 import { sendTaskAnalytics } from "./telemetry/analytics/analytics.js";
+import { setupGlobalUnhandledErrorHandlers } from "./telemetry/error-reporter/global-error-handlers.js";
 import {
   sendErrorTelemetry,
   setCliHardhatConfigPath,
@@ -63,6 +64,9 @@ export async function main(
   rawArguments: string[],
   options: MainOptions = {},
 ): Promise<void> {
+  // We set up the global unhandled errors before running any functionality
+  setupGlobalUnhandledErrorHandlers();
+
   const print = options.print ?? console.log;
 
   const log = debug("hardhat:core:cli:main");

--- a/packages/hardhat/src/internal/cli/node-version.ts
+++ b/packages/hardhat/src/internal/cli/node-version.ts
@@ -1,5 +1,8 @@
 // NOTE: We don't use the `semver` package because it's slow to load, and this
 // is always run during the initialization of the CLI.
+//
+// NOTE: This file shouldn't import any non-builtin dependency, as it's imported
+// before enabling source maps support. TODO: Change chalk to util.styleText
 
 import chalk from "chalk";
 

--- a/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
@@ -18,8 +18,8 @@ function createUnhandledErrorListener(isPromiseRejection: boolean) {
         ? error
         : new Error(
             isObject(error) &&
-              "message" in error &&
-              typeof error.message === "string"
+            "message" in error &&
+            typeof error.message === "string"
               ? error.message
               : "Unknown error",
             { cause: error },

--- a/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
@@ -13,18 +13,25 @@ function createUnhandledErrorListener(isPromiseRejection: boolean) {
   async function listener(error: Error | unknown) {
     log(description, error);
 
-    if (error instanceof Error) {
-      await sendErrorTelemetry(error);
-    } else {
-      const msg =
-        isObject(error) &&
-        "message" in error &&
-        typeof error.message === "string"
-          ? error.message
-          : "Unknown error";
+    const telemetryError =
+      error instanceof Error
+        ? error
+        : new Error(
+            isObject(error) &&
+              "message" in error &&
+              typeof error.message === "string"
+              ? error.message
+              : "Unknown error",
+            { cause: error },
+          );
 
-      const wrappedError = new Error(msg, { cause: error });
-      await sendErrorTelemetry(wrappedError);
+    try {
+      await sendErrorTelemetry(telemetryError);
+    } catch (telemetryErrorReportingError) {
+      log(
+        "Failed to send telemetry for unhandled error",
+        telemetryErrorReportingError,
+      );
     }
 
     console.error();

--- a/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
@@ -10,6 +10,10 @@ function createUnhandledErrorListener(isPromiseRejection: boolean) {
     ? "Unhandled promise rejection"
     : "Uncaught exception";
 
+  const mechanismType = isPromiseRejection
+    ? "onunhandledrejection"
+    : "onuncaughtexception";
+
   async function listener(error: Error | unknown) {
     log(description, error);
 
@@ -26,7 +30,10 @@ function createUnhandledErrorListener(isPromiseRejection: boolean) {
           );
 
     try {
-      await sendErrorTelemetry(telemetryError);
+      await sendErrorTelemetry(telemetryError, {
+        unhandled: true,
+        mechanismType,
+      });
     } catch (telemetryErrorReportingError) {
       log(
         "Failed to send telemetry for unhandled error",

--- a/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
@@ -28,7 +28,7 @@ function createUnhandledErrorListener(isPromiseRejection: boolean) {
 }
 
 /**
- * Setups global error handlers that report unhandled errors and promise
+ * Sets up global error handlers that report unhandled errors and promise
  * rejections if authorized by the user.
  */
 export function setupGlobalUnhandledErrorHandlers(): void {

--- a/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
@@ -1,0 +1,39 @@
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
+import debug from "debug";
+
+import { sendErrorTelemetry } from "./reporter.js";
+
+const log = debug("hardhat:core:telemetry:global-error-handlers");
+
+function createUnhandledErrorListener(isPromiseRejection: boolean) {
+  const description = isPromiseRejection
+    ? "Unhandled promise rejection"
+    : "Uncaught exception";
+
+  async function listener(error: Error | unknown) {
+    log(description, error);
+
+    ensureError(error);
+    await sendErrorTelemetry(error);
+
+    console.error();
+    console.error(`${description}:`);
+    console.error();
+    console.error(error);
+
+    process.exit(1);
+  }
+
+  return listener;
+}
+
+/**
+ * Setups global error handlers that report unhandled errors and promise
+ * rejections if authorized by the user.
+ */
+export function setupGlobalUnhandledErrorHandlers(): void {
+  log("Setting up global unhandled error handlers");
+
+  process.on("uncaughtException", createUnhandledErrorListener(false));
+  process.on("unhandledRejection", createUnhandledErrorListener(true));
+}

--- a/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-reporter/global-error-handlers.ts
@@ -1,4 +1,4 @@
-import { ensureError } from "@nomicfoundation/hardhat-utils/error";
+import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 import debug from "debug";
 
 import { sendErrorTelemetry } from "./reporter.js";
@@ -13,8 +13,19 @@ function createUnhandledErrorListener(isPromiseRejection: boolean) {
   async function listener(error: Error | unknown) {
     log(description, error);
 
-    ensureError(error);
-    await sendErrorTelemetry(error);
+    if (error instanceof Error) {
+      await sendErrorTelemetry(error);
+    } else {
+      const msg =
+        isObject(error) &&
+        "message" in error &&
+        typeof error.message === "string"
+          ? error.message
+          : "Unknown error";
+
+      const wrappedError = new Error(msg, { cause: error });
+      await sendErrorTelemetry(wrappedError);
+    }
 
     console.error();
     console.error(`${description}:`);

--- a/packages/hardhat/src/internal/cli/telemetry/error-reporter/reporter.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-reporter/reporter.ts
@@ -27,7 +27,7 @@ export async function sendErrorTelemetry(error: Error): Promise<void> {
 }
 
 /**
- * Set's the config path used in the Hardhat CLI. This is used for better
+ * Sets the config path used in the Hardhat CLI. This is used for better
  * anonymization of errors.
  */
 export function setCliHardhatConfigPath(configPath: string): void {

--- a/packages/hardhat/src/internal/cli/telemetry/error-reporter/reporter.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-reporter/reporter.ts
@@ -1,8 +1,8 @@
-import type * as SentryReproterT from "../sentry/reporter.js";
+import type * as SentryReporterT from "../sentry/reporter.js";
 
 // Sentry's reporter loads a large number of modules, so we only load it if
 // needed.
-let sentryReporterModule: typeof SentryReproterT | undefined;
+let sentryReporterModule: typeof SentryReporterT | undefined;
 
 // We cache the `setCliHardhatConfigPath` to avoid loading the reporter just
 // for this setting. We load it and set the config path if needed.

--- a/packages/hardhat/src/internal/cli/telemetry/error-reporter/reporter.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-reporter/reporter.ts
@@ -1,0 +1,35 @@
+import type * as SentryReproterT from "../sentry/reporter.js";
+
+// Sentry's reporter loads a large number of modules, so we only load it if
+// needed.
+let sentryReporterModule: typeof SentryReproterT | undefined;
+
+// We cache the `setCliHardhatConfigPath` to avoid loading the reporter just
+// for this setting. We load it and set the config path if needed.
+let cliHardhatConfigPath: string | undefined;
+
+/**
+ * Reports an error if telemetry is authorized by the user.
+ *
+ * While this function is async, it's expected to always complete quickly,
+ * delegating the actual reporting to a subprocess.
+ */
+export async function sendErrorTelemetry(error: Error): Promise<void> {
+  if (sentryReporterModule === undefined) {
+    sentryReporterModule = await import("../sentry/reporter.js");
+  }
+
+  if (cliHardhatConfigPath !== undefined) {
+    sentryReporterModule.setCliHardhatConfigPath(cliHardhatConfigPath);
+  }
+
+  await sentryReporterModule.sendErrorTelemetry(error);
+}
+
+/**
+ * Set's the config path used in the Hardhat CLI. This is used for better
+ * anonymization of errors.
+ */
+export function setCliHardhatConfigPath(configPath: string): void {
+  cliHardhatConfigPath = configPath;
+}

--- a/packages/hardhat/src/internal/cli/telemetry/error-reporter/reporter.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-reporter/reporter.ts
@@ -13,8 +13,22 @@ let cliHardhatConfigPath: string | undefined;
  *
  * While this function is async, it's expected to always complete quickly,
  * delegating the actual reporting to a subprocess.
+ *
+ * @param error - The error to report.
+ * @param hint - Optional metadata describing how the error was captured, used
+ *   to tag the event in Sentry so unhandled crashes can be distinguished from
+ *   errors caught and reported by the CLI.
+ * @param hint.unhandled - Whether the error reached a global handler without
+ *   being caught (e.g. an uncaught exception or unhandled promise rejection).
+ *   Defaults to `false` (i.e. the error was handled).
+ * @param hint.mechanismType - The Sentry mechanism type, used as a tag on the
+ *   event. Common values are `"onuncaughtexception"`, `"onunhandledrejection"`,
+ *   `"instrument"`, and `"generic"`. Defaults to `"generic"`.
  */
-export async function sendErrorTelemetry(error: Error): Promise<void> {
+export async function sendErrorTelemetry(
+  error: Error,
+  hint?: { unhandled?: boolean; mechanismType?: string },
+): Promise<void> {
   if (sentryReporterModule === undefined) {
     sentryReporterModule = await import("../sentry/reporter.js");
   }
@@ -23,7 +37,7 @@ export async function sendErrorTelemetry(error: Error): Promise<void> {
     sentryReporterModule.setCliHardhatConfigPath(cliHardhatConfigPath);
   }
 
-  await sentryReporterModule.sendErrorTelemetry(error);
+  await sentryReporterModule.sendErrorTelemetry(error, hint);
 }
 
 /**

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/init.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/init.ts
@@ -1,10 +1,6 @@
 /* This file is inspired by https://github.com/getsentry/sentry-javascript/blob/9.4.0/packages/node/src/sdk/index.ts */
 
-import type {
-  Client,
-  ServerRuntimeClientOptions,
-  Transport,
-} from "@sentry/core";
+import type { ServerRuntimeClientOptions, Transport } from "@sentry/core";
 
 import os from "node:os";
 import path from "node:path";
@@ -18,14 +14,11 @@ import {
   ServerRuntimeClient,
   stackParserFromStackParserOptions,
 } from "@sentry/core";
-import debug from "debug";
 
 import { GENERIC_SERVER_NAME } from "./constants.js";
 import { nodeContextIntegration } from "./vendor/integrations/context.js";
 import { contextLinesIntegration } from "./vendor/integrations/contextlines.js";
 import { createGetModuleFromFilename } from "./vendor/utils/module.js";
-
-const log = debug("hardhat:core:sentry:init");
 
 interface GlobalCustomSentryReporterOptions {
   /**
@@ -49,12 +42,6 @@ interface GlobalCustomSentryReporterOptions {
    * See the transport module for the different options.
    */
   transport: Transport;
-
-  /**
-   * If `true`, the global unhandled rejection and uncaught exception handlers
-   * will be installed.
-   */
-  installGlobalHandlers?: boolean;
 }
 
 /**
@@ -72,12 +59,9 @@ interface GlobalCustomSentryReporterOptions {
  * The reason that this uses the global instance of sentry (by calling
  * initAndBind), is that using the client directly doesn't work with the linked
  * errors integration.
- *
- * Calling `init` also has an option to set global unhandled rejection and
- * uncaught exception handlers.
  */
 export function init(options: GlobalCustomSentryReporterOptions): void {
-  const client = initAndBind<ServerRuntimeClient, ServerRuntimeClientOptions>(
+  initAndBind<ServerRuntimeClient, ServerRuntimeClientOptions>(
     ServerRuntimeClient,
     {
       dsn: options.dsn,
@@ -113,48 +97,4 @@ export function init(options: GlobalCustomSentryReporterOptions): void {
       ),
     },
   );
-
-  setupGlobalUnhandledErrorHandlers(client);
-}
-
-function createUnhandledErrorListener(
-  client: Client,
-  isPromiseRejection: boolean,
-) {
-  const description = isPromiseRejection
-    ? "Unhandled promise rejection"
-    : "Uncaught exception";
-
-  async function listener(error: Error | unknown) {
-    log(description, error);
-
-    client.captureException(error, {
-      captureContext: {
-        level: "fatal",
-      },
-      mechanism: {
-        handled: false,
-        type: "onuncaughtexception",
-      },
-    });
-
-    await client.flush(100);
-    await client.close(100);
-
-    console.error();
-    console.error(`${description}:`);
-    console.error();
-    console.error(error);
-
-    process.exit(1);
-  }
-
-  return listener;
-}
-
-function setupGlobalUnhandledErrorHandlers(client: Client) {
-  log("Setting up global unhandled error handlers");
-
-  process.on("uncaughtException", createUnhandledErrorListener(client, false));
-  process.on("unhandledRejection", createUnhandledErrorListener(client, true));
 }

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
@@ -23,9 +23,12 @@ export const SENTRY_DSN =
  * @deprecated Use packages/hardhat/src/internal/cli/telemetry/error-reporter/reporter.ts
  *   instead.
  */
-export async function sendErrorTelemetry(error: Error): Promise<boolean> {
+export async function sendErrorTelemetry(
+  error: Error,
+  hint?: { unhandled?: boolean; mechanismType?: string },
+): Promise<boolean> {
   const instance = await Reporter.getInstance();
-  return instance.reportErrorViaSubprocess(error);
+  return instance.reportErrorViaSubprocess(error, hint);
 }
 
 export function setCliHardhatConfigPath(configPath: string): void {
@@ -103,7 +106,10 @@ class Reporter {
     this.#instance = undefined;
   }
 
-  public async reportErrorViaSubprocess(error: Error): Promise<boolean> {
+  public async reportErrorViaSubprocess(
+    error: Error,
+    hint?: { unhandled?: boolean; mechanismType?: string },
+  ): Promise<boolean> {
     if (!(await this.#shouldBeReported(error))) {
       log("Error not send: this type of error should not be reported");
       return false;
@@ -113,7 +119,17 @@ class Reporter {
 
     log("Capturing exception");
 
-    captureException(error);
+    captureException(
+      error,
+      hint !== undefined
+        ? {
+            mechanism: {
+              type: hint.mechanismType ?? "generic",
+              handled: hint.unhandled !== true,
+            },
+          }
+        : undefined,
+    );
     await flush();
 
     return true;

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
@@ -111,11 +111,12 @@ class Reporter {
       return false;
     }
 
-    const { captureException } = await import("@sentry/core");
+    const { captureException, flush } = await import("@sentry/core");
 
     log("Capturing exception");
 
     captureException(error);
+    await flush();
 
     return true;
   }

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
@@ -57,9 +57,7 @@ class Reporter {
     this.#hardhatConfigPath = configPath;
   }
 
-  public static async getInstance(
-    shouldSetupErrorHandlers = false,
-  ): Promise<Reporter> {
+  public static async getInstance(): Promise<Reporter> {
     if (this.#instance !== undefined) {
       return this.#instance;
     }
@@ -94,7 +92,6 @@ class Reporter {
       ),
       release,
       environment,
-      installGlobalHandlers: shouldSetupErrorHandlers,
     });
 
     setExtra("nodeVersion", process.version);

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
@@ -19,12 +19,10 @@ const log = debug("hardhat:cli:telemetry:sentry:reporter");
 export const SENTRY_DSN =
   "https://572b03708e298427cc72fc26dac1e8b2@o385026.ingest.us.sentry.io/4508780138856448"; // PROD
 
-// TODO: This could be done in a more elegant way, but for now, we just
-// initialize the entire reporter so that it sets the global error handlers.
-export async function setupErrorTelemetryIfEnabled(): Promise<void> {
-  await Reporter.getInstance(true);
-}
-
+/**
+ * @deprecated Use packages/hardhat/src/internal/cli/telemetry/error-reporter/reporter.ts
+ *   instead.
+ */
 export async function sendErrorTelemetry(error: Error): Promise<boolean> {
   const instance = await Reporter.getInstance();
   return instance.reportErrorViaSubprocess(error);


### PR DESCRIPTION
This PR introduces the minimum amount of changes to fix https://github.com/NomicFoundation/hardhat/issues/8163

It introduces a new `error-reporter` module, that lazy-loads the existing Sentry one only when needed.

It replaces the global error handlers with new ones that use the new module. This has the added benefit that the unhandled errors/promise rejection now go through the same reporting path, which includes filtering out the errors that shouldn't be reported. Previously we were reporting every unhandled error.