### PR TITLE
`HookManager` optimizations

### DIFF
--- a/.changeset/cyan-hairs-explode.md
+++ b/.changeset/cyan-hairs-explode.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Optimize the `HookManager` and the `coverage` plugin

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
@@ -126,11 +126,11 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
   }
 
   async #getBuildSystem(): Promise<SolidityBuildSystem> {
-    const { SolidityBuildSystemImplementation } = await import(
-      "../build-system/build-system.js"
-    );
-
     if (this.#buildSystem === undefined) {
+      const { SolidityBuildSystemImplementation } = await import(
+        "../build-system/build-system.js"
+      );
+
       this.#buildSystem = new SolidityBuildSystemImplementation(
         this.#hooks,
         this.#options,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
@@ -21,7 +21,14 @@ import type {
   CompilerOutputError,
 } from "../../../../types/solidity/compiler-io.js";
 import type { SolidityBuildInfo } from "../../../../types/solidity.js";
-import type { SolidityBuildSystemOptions } from "../build-system/build-system.js";
+import type {
+  SolidityBuildSystemOptions,
+  SolidityBuildSystemImplementation as SolidityBuildSystemImplementationT,
+} from "../build-system/build-system.js";
+
+let SolidityBuildSystemImplementation:
+  | typeof SolidityBuildSystemImplementationT
+  | undefined;
 
 class LazySolidityBuildSystem implements SolidityBuildSystem {
   readonly #hooks: HookManager;
@@ -126,11 +133,13 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
   }
 
   async #getBuildSystem(): Promise<SolidityBuildSystem> {
-    if (this.#buildSystem === undefined) {
-      const { SolidityBuildSystemImplementation } = await import(
-        "../build-system/build-system.js"
-      );
+    if (SolidityBuildSystemImplementation === undefined) {
+      const buildSystemModule = await import("../build-system/build-system.js");
+      SolidityBuildSystemImplementation =
+        buildSystemModule.SolidityBuildSystemImplementation;
+    }
 
+    if (this.#buildSystem === undefined) {
       this.#buildSystem = new SolidityBuildSystemImplementation(
         this.#hooks,
         this.#options,

--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -370,7 +370,7 @@ export class HookManagerImplementation implements HookManager {
       hookName,
     );
 
-    const sequential = chained.slice().reverse();
+    const sequential = chained.toReversed();
 
     handlersByName.set(hookName as string, sequential);
 

--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -193,7 +193,7 @@ export class HookManagerImplementation implements HookManager {
     // handlerParams and the `next` closure, and call the default implementation
     // directly.
     if (handlers.length === 0) {
-      return defaultImplementation(...handlerParams) as any;
+      return (await defaultImplementation(...handlerParams)) as any;
     }
 
     const numberOfHandlers = handlers.length;

--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -96,6 +96,10 @@ export class HookManagerImplementation implements HookManager {
       for (const hookCategoryName of Object.keys(plugin.hookHandlers) as Array<
         keyof HardhatHooks
       >) {
+        if (plugin.hookHandlers[hookCategoryName] === undefined) {
+          continue;
+        }
+
         let pluginsForCategory =
           this.#pluginsByHookCategory.get(hookCategoryName);
 

--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -23,35 +23,90 @@ export class HookManagerImplementation implements HookManager {
 
   readonly #projectRoot: string;
 
-  readonly #pluginsInReverseOrder: HardhatPlugin[];
-
   /**
+   * The context passed to hook handlers, except to the `config` ones, to break
+   * a circular dependency between the config and the hook handler.
+   *
    * Initially `undefined` to be able to run the config hooks during
    * initialization.
    */
   #context: HookContext | undefined;
 
   /**
-   * The initialized handler categories for each plugin.
+   * Plugins that provide hook handlers for each category, in reverse order.
+   *
+   * Precomputed from the plugin list at construction.
    */
-  readonly #staticHookHandlerCategories: Map<
-    string,
-    Map<keyof HardhatHooks, Partial<HardhatHooks[keyof HardhatHooks]>>
+  readonly #pluginsByHookCategory: Map<keyof HardhatHooks, HardhatPlugin[]> =
+    new Map();
+
+  /**
+   * Cached resolved category objects per hook category in reverse plugin
+   * order.
+   *
+   * Only written by #getStaticHookHandlerCategories, which uses a mutex to
+   * ensure that every Hook Category Factory is run once per HookManager
+   * instance.
+   */
+  readonly #resolvedStaticCategories: Map<
+    keyof HardhatHooks,
+    Array<Partial<HardhatHooks[keyof HardhatHooks]>>
   > = new Map();
 
   /**
    * A map of the dynamically registered handler categories.
    *
    * Each array is a list of categories, in reverse order of registration.
+   *
+   * Written by registerHandlers and unregisterHandlers.
    */
   readonly #dynamicHookHandlerCategories: Map<
     keyof HardhatHooks,
     Array<Partial<HardhatHooks[keyof HardhatHooks]>>
   > = new Map();
 
+  /**
+   * Cached combined (dynamic + static) handlers per (category, hook name) in
+   * chained running order.
+   *
+   * Only written by #getHandlersInChainedRunningOrder, and invalidated
+   * per-category on dynamic handlers register/unregister.
+   */
+  readonly #chainedHandlers: Map<keyof HardhatHooks, Map<string, any[]>> =
+    new Map();
+
+  /**
+   * Cached combined handlers per (category, hook name) in sequential running
+   * order (reverse of chained).
+   *
+   * Only written by #getHandlersInSequentialRunningOrder, and invalidated
+   * per-category on dynamic handlers register/unregister.
+   */
+  readonly #sequentialHandlers: Map<keyof HardhatHooks, Map<string, any[]>> =
+    new Map();
+
   constructor(projectRoot: string, plugins: HardhatPlugin[]) {
     this.#projectRoot = projectRoot;
-    this.#pluginsInReverseOrder = plugins.toReversed();
+
+    for (const plugin of plugins.toReversed()) {
+      if (plugin.hookHandlers === undefined) {
+        continue;
+      }
+
+      for (const hookCategoryName of Object.keys(plugin.hookHandlers) as Array<
+        keyof HardhatHooks
+      >) {
+        let pluginsForCategory =
+          this.#pluginsByHookCategory.get(hookCategoryName);
+
+        if (pluginsForCategory === undefined) {
+          pluginsForCategory = [];
+          this.#pluginsByHookCategory.set(hookCategoryName, pluginsForCategory);
+        }
+
+        pluginsForCategory.push(plugin);
+      }
+    }
   }
 
   public setContext(context: HookContext): void {
@@ -69,6 +124,8 @@ export class HookManagerImplementation implements HookManager {
     }
 
     categories.unshift(hookHandlerCategory);
+
+    this.#invalidateResolvedHandlersCache(hookCategoryName);
   }
 
   public unregisterHandlers<HookCategoryNameT extends keyof HardhatHooks>(
@@ -84,6 +141,8 @@ export class HookManagerImplementation implements HookManager {
       hookCategoryName,
       categories.filter((c) => c !== hookHandlerCategory),
     );
+
+    this.#invalidateResolvedHandlersCache(hookCategoryName);
   }
 
   public async runHandlerChain<
@@ -96,10 +155,33 @@ export class HookManagerImplementation implements HookManager {
     params: InitialChainedHookParams<HookCategoryNameT, HookT>,
     defaultImplementation: LastParameter<HookT>,
   ): Promise<Awaited<Return<HardhatHooks[HookCategoryNameT][HookNameT]>>> {
-    const handlers = await this.#getHandlersInChainedRunningOrder(
-      hookCategoryName,
-      hookName,
-    );
+    // Synchronous fast path for already cached handlers
+    const cachedHandlers = this.#chainedHandlers
+      .get(hookCategoryName)
+      ?.get(hookName as string);
+
+    const handlers =
+      cachedHandlers ??
+      (await this.#getHandlersInChainedRunningOrder(
+        hookCategoryName,
+        hookName,
+      ));
+
+    // Fast path for the common case of no registered handlers: skip building
+    // handlerParams and the `next` closure, and call the default implementation
+    // directly.
+    if (handlers.length === 0) {
+      if (hookCategoryName !== "config") {
+        assertHardhatInvariant(
+          this.#context !== undefined,
+          "Context must be set before running non-config hooks",
+        );
+
+        return defaultImplementation(this.#context, ...params) as any;
+      }
+
+      return defaultImplementation(...(params as any)) as any;
+    }
 
     let handlerParams: Parameters<typeof defaultImplementation>;
     if (hookCategoryName !== "config") {
@@ -220,14 +302,48 @@ export class HookManagerImplementation implements HookManager {
     hookCategoryName: HookCategoryNameT,
     hookName: HookNameT,
   ): Promise<Array<HardhatHooks[HookCategoryNameT][HookNameT]>> {
-    const pluginHooks = await this.#getPluginHooks(hookCategoryName, hookName);
+    let handlersByName = this.#chainedHandlers.get(hookCategoryName);
+    if (handlersByName === undefined) {
+      handlersByName = new Map();
+      this.#chainedHandlers.set(hookCategoryName, handlersByName);
+    }
 
-    const dynamicHooks = await this.#getDynamicHooks(
+    const cached = handlersByName.get(hookName as string);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const staticCategories =
+      await this.#getStaticHookHandlerCategories(hookCategoryName);
+
+    // IMPORTANT NOTE: Accessing the dynamic hook handlers MUST happen
+    // after awaiting the static ones. See
+    // #invalidateResolvedHandlersCache for more info.
+    const dynamicCategories = this.#dynamicHookHandlerCategories.get(
       hookCategoryName,
-      hookName,
-    );
+    ) as Array<Partial<HardhatHooks[HookCategoryNameT]>> | undefined;
 
-    return [...dynamicHooks, ...pluginHooks];
+    const handlers: Array<HardhatHooks[HookCategoryNameT][HookNameT]> = [];
+
+    if (dynamicCategories !== undefined) {
+      for (const category of dynamicCategories) {
+        const handler = category[hookName];
+        if (handler !== undefined) {
+          handlers.push(handler as HardhatHooks[HookCategoryNameT][HookNameT]);
+        }
+      }
+    }
+
+    for (const category of staticCategories) {
+      const handler = category[hookName];
+      if (handler !== undefined) {
+        handlers.push(handler as HardhatHooks[HookCategoryNameT][HookNameT]);
+      }
+    }
+
+    handlersByName.set(hookName as string, handlers);
+
+    return handlers;
   }
 
   async #getHandlersInSequentialRunningOrder<
@@ -237,62 +353,70 @@ export class HookManagerImplementation implements HookManager {
     hookCategoryName: HookCategoryNameT,
     hookName: HookNameT,
   ): Promise<Array<HardhatHooks[HookCategoryNameT][HookNameT]>> {
-    const handlersInChainedOrder = await this.#getHandlersInChainedRunningOrder(
+    let handlersByName = this.#sequentialHandlers.get(hookCategoryName);
+    if (handlersByName === undefined) {
+      handlersByName = new Map();
+      this.#sequentialHandlers.set(hookCategoryName, handlersByName);
+    }
+
+    const cached = handlersByName.get(hookName as string);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const chained = await this.#getHandlersInChainedRunningOrder(
       hookCategoryName,
       hookName,
     );
 
-    return handlersInChainedOrder.reverse();
+    const sequential = chained.slice().reverse();
+
+    handlersByName.set(hookName as string, sequential);
+
+    return sequential;
   }
 
-  async #getDynamicHooks<
+  async #getStaticHookHandlerCategories<
     HookCategoryNameT extends keyof HardhatHooks,
-    HookNameT extends keyof HardhatHooks[HookCategoryNameT],
   >(
     hookCategoryName: HookCategoryNameT,
-    hookName: HookNameT,
-  ): Promise<Array<HardhatHooks[HookCategoryNameT][HookNameT]>> {
-    const categories = this.#dynamicHookHandlerCategories.get(
-      hookCategoryName,
-    ) as Array<Partial<HardhatHooks[HookCategoryNameT]>> | undefined;
+  ): Promise<Array<Partial<HardhatHooks[HookCategoryNameT]>>> {
+    const cached = this.#resolvedStaticCategories.get(hookCategoryName) as
+      | Array<Partial<HardhatHooks[HookCategoryNameT]>>
+      | undefined;
 
-    if (categories === undefined) {
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const plugins = this.#pluginsByHookCategory.get(hookCategoryName);
+
+    // We don't need to get the mutex to resolve this case, as it will always
+    // be an empty array, and won't execute any factory.
+    if (plugins === undefined) {
+      this.#resolvedStaticCategories.set(hookCategoryName, []);
       return [];
     }
 
-    return categories.flatMap((hookCategory) => {
-      return (hookCategory[hookName] ?? []) as Array<
-        HardhatHooks[HookCategoryNameT][HookNameT]
-      >;
-    });
-  }
+    return await this.#mutex.exclusiveRun(async () => {
+      // Re-check under the mutex in case another caller just populated it.
+      const recheck = this.#resolvedStaticCategories.get(hookCategoryName) as
+        | Array<Partial<HardhatHooks[HookCategoryNameT]>>
+        | undefined;
 
-  async #getPluginHooks<
-    HookCategoryNameT extends keyof HardhatHooks,
-    HookNameT extends keyof HardhatHooks[HookCategoryNameT],
-  >(
-    hookCategoryName: HookCategoryNameT,
-    hookName: HookNameT,
-  ): Promise<Array<HardhatHooks[HookCategoryNameT][HookNameT]>> {
-    const categories: Array<
-      Partial<HardhatHooks[HookCategoryNameT]> | undefined
-    > = await this.#mutex.exclusiveRun(async () => {
-      return await Promise.all(
-        this.#pluginsInReverseOrder.map(async (plugin) => {
-          const existingCategory = this.#staticHookHandlerCategories
-            .get(plugin.id)
-            ?.get(hookCategoryName);
+      if (recheck !== undefined) {
+        return recheck;
+      }
 
-          if (existingCategory !== undefined) {
-            return existingCategory as Partial<HardhatHooks[HookCategoryNameT]>;
-          }
-
+      const resolved = await Promise.all(
+        plugins.map(async (plugin) => {
           const hookHandlerCategoryFactory =
             plugin.hookHandlers?.[hookCategoryName];
 
-          if (hookHandlerCategoryFactory === undefined) {
-            return;
-          }
+          assertHardhatInvariant(
+            hookHandlerCategoryFactory !== undefined,
+            "#pluginsByHookCategory only contains plugins with this hook category",
+          );
 
           let factory;
           try {
@@ -321,27 +445,53 @@ export class HookManagerImplementation implements HookManager {
             `Plugin ${plugin.id} doesn't export a valid factory for category ${hookCategoryName}, it didn't return an object`,
           );
 
-          if (!this.#staticHookHandlerCategories.has(plugin.id)) {
-            this.#staticHookHandlerCategories.set(plugin.id, new Map());
-          }
-
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Defined right above
-          this.#staticHookHandlerCategories
-            .get(plugin.id)!
-            .set(hookCategoryName, hookCategory);
-
           return hookCategory;
         }),
       );
-    });
 
-    return categories.flatMap((category) => {
-      const handler = category?.[hookName];
-      if (handler === undefined) {
-        return [];
-      }
+      this.#resolvedStaticCategories.set(hookCategoryName, resolved);
 
-      return handler as HardhatHooks[HookCategoryNameT][HookNameT];
+      return resolved;
     });
+  }
+
+  #invalidateResolvedHandlersCache<
+    HookCategoryNameT extends keyof HardhatHooks,
+  >(hookCategoryName: HookCategoryNameT) {
+    // Invalidation deletes the outer entry rather than clearing the inner
+    // map. This matters under concurrency.
+    //
+    // A reader of #getHandlersInChainedRunningOrder (or its sequential
+    // sibling) captures a reference to the inner map before awaiting the
+    // static categories, and writes its computed array back after the
+    // await. If invalidation runs during that await, deleting the outer
+    // entry leaves the reader's inner map orphaned: its write lands in a
+    // map no longer reachable from #chainedHandlers/#sequentialHandlers,
+    // so it cannot poison the shared cache. The next reader sees
+    // `undefined`, installs a fresh inner map, and rebuilds from the
+    // current dynamic state.
+    //
+    // Two distinct properties make this safe, guaranteed by two different
+    // things:
+    //
+    //   1. The in-flight reader's own return value is correct. This is
+    //      because #getHandlersInChainedRunningOrder reads
+    //      #dynamicHookHandlerCategories *after* awaiting the static
+    //      categories. Any invalidation that happened during the await is
+    //      visible to the reader when it resumes, so the array it builds
+    //      reflects the current dynamic state.
+    //
+    //   2. The shared cache never holds a stale array. This is guaranteed
+    //      by the orphaning-by-delete described above: a reader that
+    //      started before the invalidation can only write into an
+    //      unreachable inner map.
+    //
+    // Property 1 depends on the ordering of the dynamic handlers read relative
+    // to the await. If that read ever moved *before* the await, a reader
+    // could build a stale array and return it to its caller — the cache
+    // would still be protected by property 2, but the reader's caller
+    // would see the stale result.
+    this.#chainedHandlers.delete(hookCategoryName);
+    this.#sequentialHandlers.delete(hookCategoryName);
   }
 }

--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -404,50 +404,63 @@ export class HookManagerImplementation implements HookManager {
       }
 
       const resolved = await Promise.all(
-        plugins.map(async (plugin) => {
-          const hookHandlerCategoryFactory =
-            plugin.hookHandlers?.[hookCategoryName];
-
-          assertHardhatInvariant(
-            hookHandlerCategoryFactory !== undefined,
-            "#pluginsByHookCategory only contains plugins with this hook category",
-          );
-
-          let factory;
-          try {
-            factory = (await hookHandlerCategoryFactory()).default;
-          } catch (error) {
-            ensureError(error);
-
-            await detectPluginNpmDependencyProblems(
-              this.#projectRoot,
-              plugin,
-              error,
-            );
-
-            throw error;
-          }
-
-          assertHardhatInvariant(
-            typeof factory === "function",
-            `Plugin ${plugin.id} doesn't export a hook factory for category ${hookCategoryName}`,
-          );
-
-          const hookCategory = await factory();
-
-          assertHardhatInvariant(
-            hookCategory !== null && typeof hookCategory === "object",
-            `Plugin ${plugin.id} doesn't export a valid factory for category ${hookCategoryName}, it didn't return an object`,
-          );
-
-          return hookCategory;
-        }),
+        plugins.map(
+          async (plugin) =>
+            await this.#getPluginStaticHookCategory(plugin, hookCategoryName),
+        ),
       );
 
       this.#resolvedStaticCategories.set(hookCategoryName, resolved);
 
       return resolved;
     });
+  }
+
+  /**
+   * Returns the hook category object for a plugin that has the hook category
+   * defined.
+   *
+   * @param plugin A plugin that MUST have the given hook category defined.
+   * @param hookCategoryName The name of the hook category.
+   * @returns The hook category object.
+   */
+  async #getPluginStaticHookCategory<
+    HookCategoryNameT extends keyof HardhatHooks,
+  >(
+    plugin: HardhatPlugin,
+    hookCategoryName: HookCategoryNameT,
+  ): Promise<Partial<HardhatHooks[HookCategoryNameT]>> {
+    const hookHandlerCategoryFactory = plugin.hookHandlers?.[hookCategoryName];
+
+    assertHardhatInvariant(
+      hookHandlerCategoryFactory !== undefined,
+      "#pluginsByHookCategory only contains plugins with this hook category",
+    );
+
+    let factory;
+    try {
+      factory = (await hookHandlerCategoryFactory()).default;
+    } catch (error) {
+      ensureError(error);
+
+      await detectPluginNpmDependencyProblems(this.#projectRoot, plugin, error);
+
+      throw error;
+    }
+
+    assertHardhatInvariant(
+      typeof factory === "function",
+      `Plugin ${plugin.id} doesn't export a hook factory for category ${hookCategoryName}`,
+    );
+
+    const hookCategory = await factory();
+
+    assertHardhatInvariant(
+      hookCategory !== null && typeof hookCategory === "object",
+      `Plugin ${plugin.id} doesn't export a valid factory for category ${hookCategoryName}, it didn't return an object`,
+    );
+
+    return hookCategory;
   }
 
   #invalidateResolvedHandlersCache<

--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -159,7 +159,13 @@ export class HookManagerImplementation implements HookManager {
     params: InitialChainedHookParams<HookCategoryNameT, HookT>,
     defaultImplementation: LastParameter<HookT>,
   ): Promise<Awaited<Return<HardhatHooks[HookCategoryNameT][HookNameT]>>> {
-    // Synchronous fast path for already cached handlers
+    // Synchronous fast path for already cached handlers. This duplicates
+    // the check inside #getHandlersInChainedRunningOrder on purpose:
+    // calling that async method introduces a microtask tick even on a
+    // cache hit, whereas a direct Map lookup stays on the current tick.
+    // That tick matters here because runHandlerChain is on every hook's
+    // hot path, and this path pairs with the empty-handlers shortcut
+    // below to dispatch straight to defaultImplementation with no awaits.
     const cachedHandlers = this.#chainedHandlers
       .get(hookCategoryName)
       ?.get(hookName as string);

--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -171,22 +171,6 @@ export class HookManagerImplementation implements HookManager {
         hookName,
       ));
 
-    // Fast path for the common case of no registered handlers: skip building
-    // handlerParams and the `next` closure, and call the default implementation
-    // directly.
-    if (handlers.length === 0) {
-      if (hookCategoryName !== "config") {
-        assertHardhatInvariant(
-          this.#context !== undefined,
-          "Context must be set before running non-config hooks",
-        );
-
-        return defaultImplementation(this.#context, ...params) as any;
-      }
-
-      return defaultImplementation(...(params as any)) as any;
-    }
-
     let handlerParams: Parameters<typeof defaultImplementation>;
     if (hookCategoryName !== "config") {
       assertHardhatInvariant(
@@ -197,6 +181,13 @@ export class HookManagerImplementation implements HookManager {
       handlerParams = [this.#context, ...params] as any;
     } else {
       handlerParams = params as any;
+    }
+
+    // Fast path for the common case of no registered handlers: skip building
+    // handlerParams and the `next` closure, and call the default implementation
+    // directly.
+    if (handlers.length === 0) {
+      return defaultImplementation(...handlerParams) as any;
     }
 
     const numberOfHandlers = handlers.length;

--- a/packages/hardhat/test/internal/core/hook-manager.ts
+++ b/packages/hardhat/test/internal/core/hook-manager.ts
@@ -1093,7 +1093,7 @@ describe("HookManager", () => {
                   extendUserConfig: async (
                     config: HardhatUserConfig,
                     next: (c: HardhatUserConfig) => Promise<HardhatUserConfig>,
-                  ) => next(config),
+                  ) => await next(config),
                   validateUserConfig: async (): Promise<
                     HardhatUserConfigValidationError[]
                   > => [],

--- a/packages/hardhat/test/internal/core/hook-manager.ts
+++ b/packages/hardhat/test/internal/core/hook-manager.ts
@@ -1075,4 +1075,299 @@ describe("HookManager", () => {
       });
     });
   });
+
+  describe("caching", () => {
+    it("Should invoke each plugin's hook-category factory at most once per HookManager, across multiple hook names and run methods", async () => {
+      let categoryFactoryCalls = 0;
+      let defaultFactoryCalls = 0;
+
+      const plugin: HardhatPlugin = {
+        id: "counter",
+        hookHandlers: {
+          config: async () => {
+            categoryFactoryCalls++;
+            return {
+              default: async () => {
+                defaultFactoryCalls++;
+                return {
+                  extendUserConfig: async (
+                    config: HardhatUserConfig,
+                    next: (c: HardhatUserConfig) => Promise<HardhatUserConfig>,
+                  ) => next(config),
+                  validateUserConfig: async (): Promise<
+                    HardhatUserConfigValidationError[]
+                  > => [],
+                };
+              },
+            };
+          },
+        },
+      };
+
+      const manager = new HookManagerImplementation(projectRoot, [plugin]);
+
+      // Exercise multiple hook names within the same category via different
+      // run methods. None of these should re-invoke the factory.
+      for (let i = 0; i < 3; i++) {
+        await manager.runHandlerChain(
+          "config",
+          "extendUserConfig",
+          [{}],
+          async (c) => c,
+        );
+        await manager.runSequentialHandlers("config", "validateUserConfig", [
+          {},
+        ]);
+        await manager.runParallelHandlers("config", "validateUserConfig", [{}]);
+        await manager.hasHandlers("config", "extendUserConfig");
+      }
+
+      assert.equal(categoryFactoryCalls, 1);
+      assert.equal(defaultFactoryCalls, 1);
+    });
+
+    it("Should include a newly registered dynamic handler on the next call", async () => {
+      const manager = new HookManagerImplementation(projectRoot, []);
+
+      const beforeRegister = await manager.runSequentialHandlers(
+        "config",
+        "validateUserConfig",
+        [{}],
+      );
+      assert.deepEqual(beforeRegister, []);
+
+      manager.registerHandlers("config", {
+        validateUserConfig: async (): Promise<
+          HardhatUserConfigValidationError[]
+        > => [{ path: [], message: "added" }],
+      });
+
+      const afterRegister = await manager.runSequentialHandlers(
+        "config",
+        "validateUserConfig",
+        [{}],
+      );
+      assert.deepEqual(afterRegister, [[{ path: [], message: "added" }]]);
+    });
+
+    it("Should stop returning a handler after it is unregistered", async () => {
+      const manager = new HookManagerImplementation(projectRoot, []);
+
+      const handlerCategory = {
+        validateUserConfig: async (): Promise<
+          HardhatUserConfigValidationError[]
+        > => [{ path: [], message: "x" }],
+      };
+
+      manager.registerHandlers("config", handlerCategory);
+      const withHandler = await manager.runSequentialHandlers(
+        "config",
+        "validateUserConfig",
+        [{}],
+      );
+      assert.equal(withHandler.length, 1);
+
+      manager.unregisterHandlers("config", handlerCategory);
+      const withoutHandler = await manager.runSequentialHandlers(
+        "config",
+        "validateUserConfig",
+        [{}],
+      );
+      assert.deepEqual(withoutHandler, []);
+    });
+
+    it("Should reflect dynamic registration and unregister in hasHandlers", async () => {
+      const manager = new HookManagerImplementation(projectRoot, []);
+
+      assert.equal(
+        await manager.hasHandlers("config", "validateUserConfig"),
+        false,
+      );
+
+      const handlerCategory = {
+        validateUserConfig: async (): Promise<
+          HardhatUserConfigValidationError[]
+        > => [],
+      };
+
+      manager.registerHandlers("config", handlerCategory);
+      assert.equal(
+        await manager.hasHandlers("config", "validateUserConfig"),
+        true,
+      );
+
+      manager.unregisterHandlers("config", handlerCategory);
+      assert.equal(
+        await manager.hasHandlers("config", "validateUserConfig"),
+        false,
+      );
+    });
+
+    it("Should build an empty result for a category provided by no plugin and no dynamic registration", async () => {
+      const manager = new HookManagerImplementation(projectRoot, []);
+
+      assert.equal(
+        await manager.hasHandlers("config", "validateUserConfig"),
+        false,
+      );
+
+      const sequential = await manager.runSequentialHandlers(
+        "config",
+        "validateUserConfig",
+        [{}],
+      );
+      assert.deepEqual(sequential, []);
+
+      const parallel = await manager.runParallelHandlers(
+        "config",
+        "validateUserConfig",
+        [{}],
+      );
+      assert.deepEqual(parallel, []);
+
+      const chain = await manager.runHandlerChain(
+        "config",
+        "extendUserConfig",
+        [{}],
+        async (c) => c,
+      );
+      assert.deepEqual(chain, {});
+    });
+
+    // These tests exercise what happens when registerHandlers runs while a
+    // handler chain is already in flight. The interesting interleavings all
+    // require the in-flight chain to be *suspended* at a specific point
+    // (inside a handler, or inside the plugin's category factory) at the
+    // moment the register happens — otherwise Node's single-threaded,
+    // run-to-completion semantics collapse the interleaving and the test
+    // exercises nothing.
+    //
+    // To make this deterministic, each test uses two hand-built promises:
+    //
+    //   - A "started" promise, resolved by the handler/factory at the moment
+    //     it begins executing. The test awaits this to know the suspension
+    //     point has been reached before it triggers the race.
+    //   - A "gate" promise that the handler/factory awaits. The test holds
+    //     the resolver and releases it after performing the racing action
+    //     (e.g. registerHandlers). That lets the suspended code resume and
+    //     lets the chain finish.
+    //
+    // Concretely: the test starts the run (which returns a promise but does
+    // not yet resolve), awaits "started" so it knows execution has reached
+    // the suspension point, calls registerHandlers, then resolves the gate,
+    // then awaits the original run promise. The assertions then check what
+    // the in-flight call saw vs. what a subsequent call sees.
+    describe("Race conditions related tests", () => {
+      it("Should not affect an in-flight handler chain when a new handler is registered mid-execution", async () => {
+        let signalStarted!: () => void;
+        const started = new Promise<void>((resolve) => {
+          signalStarted = resolve;
+        });
+
+        let unblock!: () => void;
+        const gate = new Promise<void>((resolve) => {
+          unblock = resolve;
+        });
+
+        const manager = new HookManagerImplementation(projectRoot, []);
+
+        manager.registerHandlers("config", {
+          validateUserConfig: async () => {
+            signalStarted();
+            await gate;
+            return [{ path: [], message: "original" }];
+          },
+        });
+
+        const runPromise = manager.runSequentialHandlers(
+          "config",
+          "validateUserConfig",
+          [{}],
+        );
+
+        // Wait until the in-flight handler has started executing.
+        await started;
+
+        // Register an additional handler while the chain is running.
+        manager.registerHandlers("config", {
+          validateUserConfig: async (): Promise<
+            HardhatUserConfigValidationError[]
+          > => [{ path: [], message: "added-midway" }],
+        });
+
+        unblock();
+        const result = await runPromise;
+
+        // The in-flight call saw a frozen handler list at the time of
+        // resolution, so the "added-midway" handler must not appear.
+        assert.deepEqual(result, [[{ path: [], message: "original" }]]);
+
+        // But a subsequent call picks up the new handler.
+        const next = await manager.runSequentialHandlers(
+          "config",
+          "validateUserConfig",
+          [{}],
+        );
+        assert.equal(next.length, 2);
+      });
+
+      it("Should include a handler registered while the static categories are still resolving", async () => {
+        let signalFactoryEntered!: () => void;
+        const factoryEntered = new Promise<void>((resolve) => {
+          signalFactoryEntered = resolve;
+        });
+
+        let unblockFactory!: () => void;
+        const factoryGate = new Promise<void>((resolve) => {
+          unblockFactory = resolve;
+        });
+
+        const slowPlugin: HardhatPlugin = {
+          id: "slow-factory",
+          hookHandlers: {
+            config: async () => {
+              signalFactoryEntered();
+              await factoryGate;
+              return {
+                default: async () => ({
+                  validateUserConfig: async (): Promise<
+                    HardhatUserConfigValidationError[]
+                  > => [{ path: [], message: "from-static" }],
+                }),
+              };
+            },
+          },
+        };
+
+        const manager = new HookManagerImplementation(projectRoot, [
+          slowPlugin,
+        ]);
+
+        const runPromise = manager.runSequentialHandlers(
+          "config",
+          "validateUserConfig",
+          [{}],
+        );
+
+        // Wait until the factory is suspended, so the subsequent register
+        // happens while the chain is still resolving static categories.
+        await factoryEntered;
+
+        manager.registerHandlers("config", {
+          validateUserConfig: async (): Promise<
+            HardhatUserConfigValidationError[]
+          > => [{ path: [], message: "from-dynamic" }],
+        });
+
+        unblockFactory();
+        const result = await runPromise;
+
+        // The in-flight call must observe the dynamic registration that
+        // happened during the static-categories await, because the dynamic
+        // map is read after that await. Both handlers should be present.
+        const messages = result.flat().map((e) => e.message);
+        assert.deepEqual(messages.sort(), ["from-dynamic", "from-static"]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR extends @Wodann's finding and his PR #8106 to cache more aggressively in the `HookManager`.

Given the amount of caching that this PR adds, analyzing its concurrent behavior can be trickier than before. Luckily Claude came up with a testing pattern that's great, and easy to understand. It uses different promises to run a specific concurrent scenario, and test the results.

This PR also adds a 1-line change optimization that I found while testing it.

PS: I rebased this PR on top of #8179 to be able to continue making progress, but this is effectively independent.