### PR TITLE
Always `return await`

### DIFF
--- a/.changeset/return-await-hardhat-ethers-chai-matchers.md
+++ b/.changeset/return-await-hardhat-ethers-chai-matchers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-ethers.md
+++ b/.changeset/return-await-hardhat-ethers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-foundry.md
+++ b/.changeset/return-await-hardhat-foundry.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-foundry": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-ignition-ethers.md
+++ b/.changeset/return-await-hardhat-ignition-ethers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition-ethers": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-ignition-viem.md
+++ b/.changeset/return-await-hardhat-ignition-viem.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition-viem": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-ignition.md
+++ b/.changeset/return-await-hardhat-ignition.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-keystore.md
+++ b/.changeset/return-await-hardhat-keystore.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-keystore": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-ledger.md
+++ b/.changeset/return-await-hardhat-ledger.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ledger": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-mocha.md
+++ b/.changeset/return-await-hardhat-mocha.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-mocha": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-network-helpers.md
+++ b/.changeset/return-await-hardhat-network-helpers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-node-test-reporter.md
+++ b/.changeset/return-await-hardhat-node-test-reporter.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-reporter": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-node-test-runner.md
+++ b/.changeset/return-await-hardhat-node-test-runner.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-runner": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-solx.md
+++ b/.changeset/return-await-hardhat-solx.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-solx": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-test-utils.md
+++ b/.changeset/return-await-hardhat-test-utils.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-test-utils": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-typechain.md
+++ b/.changeset/return-await-hardhat-typechain.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-typechain": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-utils.md
+++ b/.changeset/return-await-hardhat-utils.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-verify.md
+++ b/.changeset/return-await-hardhat-verify.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-viem-assertions.md
+++ b/.changeset/return-await-hardhat-viem-assertions.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat-viem.md
+++ b/.changeset/return-await-hardhat-viem.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-hardhat.md
+++ b/.changeset/return-await-hardhat.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Await all returned promises for better debuggability

--- a/.changeset/return-await-ignition-core.md
+++ b/.changeset/return-await-ignition-core.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/ignition-core": patch
+---
+
+Await all returned promises for better debuggability

--- a/packages/config/eslint.config.js
+++ b/packages/config/eslint.config.js
@@ -321,7 +321,7 @@ export function createConfig(
     "no-new-wrappers": "error",
     "no-only-tests/no-only-tests": "error",
     "no-return-await": "off",
-    "@typescript-eslint/return-await": "error",
+    "@typescript-eslint/return-await": ["error", "always"],
     "no-sequences": "error",
     "no-sparse-arrays": "error",
     "no-template-curly-in-string": "error",

--- a/packages/hardhat-ethers-chai-matchers/src/internal/hook-handlers/network.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/hook-handlers/network.ts
@@ -16,7 +16,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         isInitialized = true;
       }
 
-      return next(context);
+      return await next(context);
     },
   };
 

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/changeEtherBalances.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/changeEtherBalances.ts
@@ -162,7 +162,7 @@ async function getTxFees(
   txResponse: TransactionResponse,
   options?: BalanceChangeOptions,
 ): Promise<bigint[]> {
-  return Promise.all(
+  return await Promise.all(
     accounts.map(async (account) => {
       if (
         options?.includeFee !== true &&

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/emit.ts
@@ -44,11 +44,11 @@ async function waitForPendingTransaction(
     // string, it might not be a real tx hash. Do a one-shot check to
     // avoid polling forever.
     if (isBytes32String(hash)) {
-      return provider.getTransactionReceipt(hash);
+      return await provider.getTransactionReceipt(hash);
     }
   }
 
-  return provider.waitForTransaction(hash);
+  return await provider.waitForTransaction(hash);
 }
 
 export function supportEmit(

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
@@ -146,7 +146,7 @@ export function supportRevert(
 }
 
 async function waitForTransactionReceipt(ethers: HardhatEthers, hash: string) {
-  return ethers.provider.waitForTransaction(hash);
+  return await ethers.provider.waitForTransaction(hash);
 }
 
 function isTransactionResponse(x: unknown): x is { hash: string } {

--- a/packages/hardhat-ethers-chai-matchers/src/internal/utils/account.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/utils/account.ts
@@ -12,7 +12,7 @@ export async function getAddressOf(
   }
 
   if (isAddressable(account)) {
-    return account.getAddress();
+    return await account.getAddress();
   }
 
   chaiAssert.fail(`Expected string or addressable, but got "${account}"`);

--- a/packages/hardhat-ethers-chai-matchers/src/internal/utils/balance.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/utils/balance.ts
@@ -23,7 +23,7 @@ export async function getBalances(
   accounts: Array<Addressable | string>,
   blockNumber: number,
 ): Promise<bigint[]> {
-  return Promise.all(
+  return await Promise.all(
     accounts.map(async (account) => {
       const address = await getAddressOf(account);
 

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/changeEtherBalance.ts
@@ -316,17 +316,18 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
       describe("Change balance, one contract", () => {
         it("should pass when expected balance change is passed as int and is equal to an actual", async () => {
-          await expect(async () =>
-            sender.sendTransaction({
-              to: contract,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: contract,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, contract, 200);
         });
 
         it("should pass when calling function that returns half the sent ether", async () => {
-          await expect(async () =>
-            contract.returnHalf({ value: 200 }),
+          await expect(
+            async () => await contract.returnHalf({ value: 200 }),
           ).to.changeEtherBalance(ethers, sender, -100);
         });
       });
@@ -448,13 +449,14 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
 
       describe("Change balance, one contract", () => {
         it("should pass when expected balance change is passed as int and is equal to an actual", async () => {
-          await expect(async () =>
-            sender.sendTransaction({
-              to: contract,
-              maxFeePerGas: 2,
-              maxPriorityFeePerGas: 1,
-              value: 200,
-            }),
+          await expect(
+            async () =>
+              await sender.sendTransaction({
+                to: contract,
+                maxFeePerGas: 2,
+                maxPriorityFeePerGas: 1,
+                value: 200,
+              }),
           ).to.changeEtherBalance(ethers, contract, 200);
         });
 
@@ -477,12 +479,13 @@ describe("INTEGRATION: changeEtherBalance matcher", { timeout: 60000 }, () => {
         });
 
         it("should pass when calling function that returns half the sent ether", async () => {
-          await expect(async () =>
-            contract.returnHalf({
-              value: 200,
-              maxFeePerGas: 2,
-              maxPriorityFeePerGas: 1,
-            }),
+          await expect(
+            async () =>
+              await contract.returnHalf({
+                value: 200,
+                maxFeePerGas: 2,
+                maxPriorityFeePerGas: 1,
+              }),
           ).to.changeEtherBalance(ethers, sender, -100);
         });
       });

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
@@ -50,7 +50,10 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
 
     // helpers
     const expectAssertionError = async (x: Promise<void>, message: string) => {
-      return expect(x).to.be.eventually.rejectedWith(AssertionError, message);
+      return await expect(x).to.be.eventually.rejectedWith(
+        AssertionError,
+        message,
+      );
     };
 
     describe("with a string as its subject", () => {

--- a/packages/hardhat-ethers/src/internal/hardhat-ethers-provider/hardhat-ethers-provider.ts
+++ b/packages/hardhat-ethers/src/internal/hardhat-ethers-provider/hardhat-ethers-provider.ts
@@ -116,7 +116,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
   public destroy(): void {}
 
   public async send(method: string, params?: any[]): Promise<any> {
-    return this.#hardhatProvider.request({
+    return await this.#hardhatProvider.request({
       method,
       params,
     });
@@ -143,7 +143,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
           },
         );
       }
-      return HardhatEthersSigner.create(
+      return await HardhatEthersSigner.create(
         this,
         this.#networkName,
         this.#networkConfig,
@@ -152,7 +152,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
     }
 
     if (typeof address === "string") {
-      return HardhatEthersSigner.create(
+      return await HardhatEthersSigner.create(
         this,
         this.#networkName,
         this.#networkConfig,
@@ -477,73 +477,75 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
     const resolvedConfirms = confirms ?? DEFAULT_TRANSACTION_CONFIRMS;
 
     if (resolvedConfirms === 0) {
-      return this.getTransactionReceipt(hash);
+      return await this.getTransactionReceipt(hash);
     }
 
     const pollingInterval = (await this.#isHardhatNetwork()) ? 50 : 500;
 
-    return new Promise<ethers.TransactionReceipt | null>((resolve, reject) => {
-      let cancelled = false;
-      let timeoutTimer: NodeJS.Timeout | undefined;
-      let pollingTimeout: NodeJS.Timeout | undefined;
+    return await new Promise<ethers.TransactionReceipt | null>(
+      (resolve, reject) => {
+        let cancelled = false;
+        let timeoutTimer: NodeJS.Timeout | undefined;
+        let pollingTimeout: NodeJS.Timeout | undefined;
 
-      if (timeout !== undefined && timeout > 0) {
-        timeoutTimer = setTimeout(() => {
-          cancelled = true;
+        if (timeout !== undefined && timeout > 0) {
+          timeoutTimer = setTimeout(() => {
+            cancelled = true;
 
-          clearTimeout(pollingTimeout);
+            clearTimeout(pollingTimeout);
 
-          resolve(null);
-        }, timeout);
-      }
-
-      const poll = async () => {
-        if (cancelled) {
-          return;
+            resolve(null);
+          }, timeout);
         }
 
-        try {
-          const receipt = await this.getTransactionReceipt(hash);
+        const poll = async () => {
+          if (cancelled) {
+            return;
+          }
 
-          // Wait for the required confirmation depth before resolving,
-          // so callers relying on confirmations for reorg safety aren't
-          // given a receipt that could still be reverted.
-          if (receipt !== null && receipt.blockNumber !== null) {
-            const latestBlockNumber = await this.getBlockNumber();
-            const confirmations = latestBlockNumber - receipt.blockNumber + 1;
+          try {
+            const receipt = await this.getTransactionReceipt(hash);
 
-            if (confirmations >= resolvedConfirms) {
-              cancelled = true;
+            // Wait for the required confirmation depth before resolving,
+            // so callers relying on confirmations for reorg safety aren't
+            // given a receipt that could still be reverted.
+            if (receipt !== null && receipt.blockNumber !== null) {
+              const latestBlockNumber = await this.getBlockNumber();
+              const confirmations = latestBlockNumber - receipt.blockNumber + 1;
 
-              if (timeoutTimer !== undefined) {
-                clearTimeout(timeoutTimer);
+              if (confirmations >= resolvedConfirms) {
+                cancelled = true;
+
+                if (timeoutTimer !== undefined) {
+                  clearTimeout(timeoutTimer);
+                }
+
+                clearTimeout(pollingTimeout);
+                resolve(receipt);
+
+                return;
               }
-
-              clearTimeout(pollingTimeout);
-              resolve(receipt);
-
-              return;
             }
+
+            clearTimeout(pollingTimeout);
+
+            pollingTimeout = setTimeout(poll, pollingInterval);
+          } catch (e) {
+            ensureError(e);
+
+            cancelled = true;
+
+            if (timeoutTimer !== undefined) {
+              clearTimeout(timeoutTimer);
+            }
+
+            reject(e);
           }
+        };
 
-          clearTimeout(pollingTimeout);
-
-          pollingTimeout = setTimeout(poll, pollingInterval);
-        } catch (e) {
-          ensureError(e);
-
-          cancelled = true;
-
-          if (timeoutTimer !== undefined) {
-            clearTimeout(timeoutTimer);
-          }
-
-          reject(e);
-        }
-      };
-
-      void poll();
-    });
+        void poll();
+      },
+    );
   }
 
   public async waitForBlock(
@@ -741,14 +743,14 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
     event: ProviderEvent,
     listener: Listener,
   ): Promise<this> {
-    return this.on(event, listener);
+    return await this.on(event, listener);
   }
 
   public async removeListener(
     event: ProviderEvent,
     listener: Listener,
   ): Promise<this> {
-    return this.off(event, listener);
+    return await this.off(event, listener);
   }
 
   public toJSON() {
@@ -883,7 +885,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
     includeTransactions: boolean,
   ): Promise<any> {
     if (isHexString(block, 32)) {
-      return this.#hardhatProvider.request({
+      return await this.#hardhatProvider.request({
         method: "eth_getBlockByHash",
         params: [block, includeTransactions],
       });
@@ -894,7 +896,7 @@ export class HardhatEthersProvider implements HardhatEthersProviderI {
       blockTag = await blockTag;
     }
 
-    return this.#hardhatProvider.request({
+    return await this.#hardhatProvider.request({
       method: "eth_getBlockByNumber",
       params: [blockTag, includeTransactions],
     });

--- a/packages/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
+++ b/packages/hardhat-ethers/src/internal/hardhat-helpers/hardhat-helpers.ts
@@ -104,7 +104,7 @@ export class HardhatHelpers {
     if (typeof nameOrAbi === "string") {
       const artifact = await this.#artifactManager.readArtifact(nameOrAbi);
 
-      return this.getContractFactoryFromArtifact<A, I>(
+      return await this.getContractFactoryFromArtifact<A, I>(
         artifact,
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- bytecodeOrFactoryOptions overlaps with one of the following types
         bytecodeOrFactoryOptions as EthersT.Signer | FactoryOptions | undefined,
@@ -117,7 +117,7 @@ export class HardhatHelpers {
       "bytecode should be a string",
     );
 
-    return this.#getContractFactoryByAbiAndBytecode(
+    return await this.#getContractFactoryByAbiAndBytecode(
       nameOrAbi,
       bytecodeOrFactoryOptions,
       signer,
@@ -159,7 +159,7 @@ export class HardhatHelpers {
       libraries,
     );
 
-    return this.#getContractFactoryByAbiAndBytecode(
+    return await this.#getContractFactoryByAbiAndBytecode(
       artifact.abi,
       linkedBytecode,
       signer,
@@ -174,7 +174,7 @@ export class HardhatHelpers {
     if (typeof nameOrAbi === "string") {
       const artifact = await this.#artifactManager.readArtifact(nameOrAbi);
 
-      return this.getContractAtFromArtifact(artifact, address, signer);
+      return await this.getContractAtFromArtifact(artifact, address, signer);
     }
 
     if (signer === undefined) {
@@ -266,14 +266,14 @@ export class HardhatHelpers {
     }
 
     const factory = await this.getContractFactory(name, signerOrOptions);
-    return factory.deploy(...args, overrides);
+    return await factory.deploy(...args, overrides);
   }
 
   public async getImpersonatedSigner(
     address: string,
   ): Promise<HardhatEthersSigner> {
     await this.#provider.send("hardhat_impersonateAccount", [address]);
-    return this.getSigner(address);
+    return await this.getSigner(address);
   }
 
   #isArtifact(artifact: any): artifact is Artifact {

--- a/packages/hardhat-ethers/src/internal/signers/deep-copy.ts
+++ b/packages/hardhat-ethers/src/internal/signers/deep-copy.ts
@@ -34,7 +34,7 @@ export async function deepCopy<T = any>(value: T): Promise<T> {
   }
 
   if (Array.isArray(value)) {
-    return deepClone(value);
+    return await deepClone(value);
   }
 
   if (isObject(value)) {

--- a/packages/hardhat-ethers/src/internal/signers/derive-private-key.ts
+++ b/packages/hardhat-ethers/src/internal/signers/derive-private-key.ts
@@ -22,7 +22,7 @@ export async function derivePrivateKeys(
   const mnemonic = await accounts.mnemonic.get();
   const passphrase = await accounts.passphrase.get();
 
-  return derivePrivateKeysImpl(
+  return await derivePrivateKeysImpl(
     mnemonic,
     accounts.path,
     accounts.initialIndex,

--- a/packages/hardhat-ethers/src/internal/signers/populate.ts
+++ b/packages/hardhat-ethers/src/internal/signers/populate.ts
@@ -35,5 +35,5 @@ export async function populate(
     pop.from = signer.getAddress();
   }
 
-  return resolveProperties(pop);
+  return await resolveProperties(pop);
 }

--- a/packages/hardhat-ethers/src/internal/signers/signers.ts
+++ b/packages/hardhat-ethers/src/internal/signers/signers.ts
@@ -102,7 +102,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
 
     const wallet = new Wallet(privateKey, this.provider);
 
-    return wallet.authorize(auth);
+    return await wallet.authorize(auth);
   }
 
   public async populateAuthorization(
@@ -139,11 +139,11 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
   }
 
   public async estimateGas(tx: TransactionRequest): Promise<bigint> {
-    return this.provider.estimateGas(await this.populateCall(tx));
+    return await this.provider.estimateGas(await this.populateCall(tx));
   }
 
   public async call(tx: TransactionRequest): Promise<string> {
-    return this.provider.call(await this.populateCall(tx));
+    return await this.provider.call(await this.populateCall(tx));
   }
 
   public resolveName(name: string): Promise<string | null> {
@@ -176,7 +176,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
     // for a response, and we need the actual transaction, so we poll
     // for it; it should show up very quickly
 
-    return new Promise((resolve) => {
+    return await new Promise((resolve) => {
       const timeouts = [1000, 100];
       const checkTx = async () => {
         // Try getting the transaction
@@ -224,7 +224,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
       },
     );
 
-    return this.provider.send("eth_signTypedData_v4", [
+    return await this.provider.send("eth_signTypedData_v4", [
       this.address.toLowerCase(),
       JSON.stringify(
         TypedDataEncoder.getPayload(populated.domain, types, populated.value),
@@ -290,7 +290,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
 
     const hexTx = getRpcTransaction(resolvedTx);
 
-    return this.provider.send("eth_sendTransaction", [hexTx]);
+    return await this.provider.send("eth_sendTransaction", [hexTx]);
   }
 
   async #getPrivateKey(): Promise<string | undefined> {
@@ -316,21 +316,21 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
       }
 
       if (Array.isArray(accounts)) {
-        return Promise.all(accounts.map((acc) => acc.get()));
+        return await Promise.all(accounts.map((acc) => acc.get()));
       }
 
       if ("mnemonic" in accounts) {
-        return derivePrivateKeys(accounts);
+        return await derivePrivateKeys(accounts);
       }
     }
 
     if (type === "edr-simulated") {
       if (Array.isArray(accounts)) {
-        return Promise.all(accounts.map((acc) => acc.privateKey.get()));
+        return await Promise.all(accounts.map((acc) => acc.privateKey.get()));
       }
 
       if ("mnemonic" in accounts) {
-        return derivePrivateKeys(accounts);
+        return await derivePrivateKeys(accounts);
       }
     }
 

--- a/packages/hardhat-ethers/test/helpers/helpers.ts
+++ b/packages/hardhat-ethers/test/helpers/helpers.ts
@@ -96,7 +96,7 @@ export function assertIsSigner(
 }
 
 export async function sleep(timeout: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, timeout));
+  return await new Promise((resolve) => setTimeout(resolve, timeout));
 }
 
 export async function tryUntil(f: () => any): Promise<void> {

--- a/packages/hardhat-ethers/test/plugin-functionalities.ts
+++ b/packages/hardhat-ethers/test/plugin-functionalities.ts
@@ -107,7 +107,7 @@ describe("Ethers plugin", () => {
             if (method === "eth_accounts") {
               throw new Error("the method has been deprecated: eth_accounts");
             }
-            return originalSend.call(this, method, params);
+            return await originalSend.call(this, method, params);
           };
 
           const sigs = await ethers.getSigners();

--- a/packages/hardhat-foundry/src/internal/foundry/forge.ts
+++ b/packages/hardhat-foundry/src/internal/foundry/forge.ts
@@ -43,7 +43,7 @@ export function resetExecMock(): void {
  */
 export async function hasFoundryConfig(packagePath: string): Promise<boolean> {
   const foundryTomlPath = path.join(packagePath, "foundry.toml");
-  return exists(foundryTomlPath);
+  return await exists(foundryTomlPath);
 }
 
 /**

--- a/packages/hardhat-ignition-ethers/src/internal/ethers-ignition-helper.ts
+++ b/packages/hardhat-ignition-ethers/src/internal/ethers-ignition-helper.ts
@@ -308,7 +308,7 @@ export class EthersIgnitionHelperImpl<ChainTypeT extends ChainType | string>
     );
 
     if ("artifact" in future) {
-      return connection.ethers.getContractAt(
+      return await connection.ethers.getContractAt(
         // The abi meets the abi spec and we assume we can convert to
         // an acceptable Ethers abi
         future.artifact.abi,
@@ -316,7 +316,7 @@ export class EthersIgnitionHelperImpl<ChainTypeT extends ChainType | string>
       );
     }
 
-    return connection.ethers.getContractAt(
+    return await connection.ethers.getContractAt(
       future.contractName,
       deployedContract.address,
     );

--- a/packages/hardhat-ignition-ethers/test/ignition-helper-exclusivity.ts
+++ b/packages/hardhat-ignition-ethers/test/ignition-helper-exclusivity.ts
@@ -50,7 +50,7 @@ describe("ignition helper mutual exclusivity", () => {
           plugins: [fakeHardhatIgnitionViemPlugin, hardhatIgnitionEthersPlugin],
         });
 
-        return hre.network.create();
+        return await hre.network.create();
       },
       HardhatError.ERRORS.IGNITION.INTERNAL
         .ONLY_ONE_IGNITION_EXTENSION_PLUGIN_ALLOWED,

--- a/packages/hardhat-ignition-viem/src/internal/viem-ignition-helper.ts
+++ b/packages/hardhat-ignition-viem/src/internal/viem-ignition-helper.ts
@@ -308,7 +308,7 @@ export class ViemIgnitionHelperImpl<ChainTypeT extends ChainType | string>
       `Expected contract future but got ${future.id} with type ${future.type} instead`,
     );
 
-    return this.#convertContractFutureToViemContract(
+    return await this.#convertContractFutureToViemContract(
       connection,
       future,
       deployedContract,
@@ -324,7 +324,7 @@ export class ViemIgnitionHelperImpl<ChainTypeT extends ChainType | string>
       case FutureType.NAMED_ARTIFACT_CONTRACT_DEPLOYMENT:
       case FutureType.NAMED_ARTIFACT_LIBRARY_DEPLOYMENT:
       case FutureType.NAMED_ARTIFACT_CONTRACT_AT:
-        return this.#convertHardhatContractToViemContract(
+        return await this.#convertHardhatContractToViemContract(
           connection,
           future,
           deployedContract,
@@ -332,7 +332,7 @@ export class ViemIgnitionHelperImpl<ChainTypeT extends ChainType | string>
       case FutureType.CONTRACT_DEPLOYMENT:
       case FutureType.LIBRARY_DEPLOYMENT:
       case FutureType.CONTRACT_AT:
-        return this.#convertArtifactToViemContract(
+        return await this.#convertArtifactToViemContract(
           connection,
           future,
           deployedContract,

--- a/packages/hardhat-ignition-viem/test/ignition-helper-exclusivity.ts
+++ b/packages/hardhat-ignition-viem/test/ignition-helper-exclusivity.ts
@@ -50,7 +50,7 @@ describe("ignition helper mutual exclusivity", () => {
           plugins: [fakeHardhatIgnitionEthersPlugin, hardhatIgnitionViemPlugin],
         });
 
-        return hre.network.create();
+        return await hre.network.create();
       },
       HardhatError.ERRORS.IGNITION.INTERNAL
         .ONLY_ONE_IGNITION_EXTENSION_PLUGIN_ALLOWED,

--- a/packages/hardhat-ignition/src/helpers/hardhat-artifact-resolver.ts
+++ b/packages/hardhat-ignition/src/helpers/hardhat-artifact-resolver.ts
@@ -31,7 +31,7 @@ export class HardhatArtifactResolver implements ArtifactResolver {
       return undefined;
     }
 
-    return readJsonFile<BuildInfo>(buildInfoPath);
+    return await readJsonFile<BuildInfo>(buildInfoPath);
   }
 
   public loadArtifact(contractName: string): Promise<Artifact> {

--- a/packages/hardhat-ignition/src/internal/tasks/deploy.ts
+++ b/packages/hardhat-ignition/src/internal/tasks/deploy.ts
@@ -274,7 +274,7 @@ async function resolveParametersFromModuleName(
   const configFilename = `${moduleName}.config.json`;
 
   return files.includes(configFilename)
-    ? readDeploymentParameters(path.resolve(ignitionPath, configFilename))
+    ? await readDeploymentParameters(path.resolve(ignitionPath, configFilename))
     : undefined;
 }
 
@@ -283,7 +283,7 @@ async function resolveParametersFromFileName(
 ): Promise<DeploymentParameters> {
   const filepath = path.resolve(process.cwd(), fileName);
 
-  return readDeploymentParameters(filepath);
+  return await readDeploymentParameters(filepath);
 }
 
 async function resolveParametersString(

--- a/packages/hardhat-ignition/test/deploy/build-invocation.ts
+++ b/packages/hardhat-ignition/test/deploy/build-invocation.ts
@@ -14,7 +14,7 @@ describe("deploy - build invocation", function () {
       .setAction(async () => ({
         default: async (args: any, _hre, runSuper) => {
           buildArgs.push(args);
-          return runSuper(args);
+          return await runSuper(args);
         },
       }))
       .build();

--- a/packages/hardhat-ignition/test/deploy/build-profile.ts
+++ b/packages/hardhat-ignition/test/deploy/build-profile.ts
@@ -32,7 +32,7 @@ describe("build profile", function () {
               default: async (args, _hre, runSuper) => {
                 defaultBuildProfile = args.defaultBuildProfile;
 
-                return runSuper(args);
+                return await runSuper(args);
               },
             }))
             .build(),

--- a/packages/hardhat-ignition/test/test-helpers/mine-block.ts
+++ b/packages/hardhat-ignition/test/test-helpers/mine-block.ts
@@ -3,5 +3,5 @@ import type { NetworkConnection } from "hardhat/types/network";
 export async function mineBlock(
   connection: NetworkConnection<string>,
 ): Promise<any> {
-  return connection.provider.request({ method: "evm_mine", params: [] });
+  return await connection.provider.request({ method: "evm_mine", params: [] });
 }

--- a/packages/hardhat-ignition/test/test-helpers/test-ignition-helper.ts
+++ b/packages/hardhat-ignition/test/test-helpers/test-ignition-helper.ts
@@ -127,7 +127,7 @@ export class TestIgnitionHelper {
       transport: custom(this._connection.provider),
     });
 
-    return this._toViemContracts(
+    return await this._toViemContracts(
       this._hre,
       ignitionModule,
       result,

--- a/packages/hardhat-ignition/test/test-helpers/use-ignition-project.ts
+++ b/packages/hardhat-ignition/test/test-helpers/use-ignition-project.ts
@@ -323,7 +323,7 @@ export class TestChainHelper {
       );
     }
 
-    return mineBlock(this._connection);
+    return await mineBlock(this._connection);
   }
 
   public async clearMempool(pendingTxToAwait: number = 0): Promise<void> {
@@ -335,11 +335,11 @@ export class TestChainHelper {
       );
     }
 
-    return clearPendingTransactionsFromMemoryPool(this._connection);
+    return await clearPendingTransactionsFromMemoryPool(this._connection);
   }
 
   public async setNextBlockBaseFeePerGas(fee: bigint): Promise<void> {
-    return this._connection.networkHelpers.setNextBlockBaseFeePerGas(fee);
+    return await this._connection.networkHelpers.setNextBlockBaseFeePerGas(fee);
   }
 
   /**
@@ -366,7 +366,7 @@ class ProxyProvider extends EventEmitter implements EthereumProvider {
       throw new Error("Killing deploy process");
     }
 
-    return this.#provider.request(requestArguments);
+    return await this.#provider.request(requestArguments);
   }
 
   public async close(): Promise<void> {
@@ -375,7 +375,7 @@ class ProxyProvider extends EventEmitter implements EthereumProvider {
       throw new Error("Killing deploy process");
     }
 
-    return this.#provider.close();
+    return await this.#provider.close();
   }
 
   public async send(method: string, params?: unknown[]): Promise<any> {
@@ -384,7 +384,7 @@ class ProxyProvider extends EventEmitter implements EthereumProvider {
       throw new Error("Killing deploy process");
     }
 
-    return this.#provider.send(method, params);
+    return await this.#provider.send(method, params);
   }
 
   public async sendAsync(jsonRpcRequest: any, callback: any): Promise<any> {

--- a/packages/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
+++ b/packages/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
@@ -29,7 +29,7 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
       // If we are in CI, the keystore should not be used
       // or even initialized
       if (isCi()) {
-        return next(context, variable);
+        return await next(context, variable);
       }
 
       // First try to get the value from the development keystore
@@ -58,7 +58,7 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
         return value;
       }
 
-      return next(context, variable);
+      return await next(context, variable);
     },
   };
 
@@ -112,7 +112,7 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
       return undefined;
     }
 
-    return keystore.readValue(variable.name, masterKey);
+    return await keystore.readValue(variable.name, masterKey);
   }
 
   return handlers;

--- a/packages/hardhat-keystore/src/internal/keystores/password.ts
+++ b/packages/hardhat-keystore/src/internal/keystores/password.ts
@@ -51,7 +51,7 @@ export async function setUpPassword(
   consoleLog(UserDisplayMessages.passwordRequirementsMessage());
   consoleLog("");
 
-  return createPassword(requestSecretInput, consoleLog);
+  return await createPassword(requestSecretInput, consoleLog);
 }
 
 export async function setUpPasswordForDevKeystore(
@@ -72,19 +72,22 @@ export async function setNewPassword(
   consoleLog(UserDisplayMessages.passwordRequirementsMessage());
   consoleLog("");
 
-  return createPassword(requestSecretInput, consoleLog);
+  return await createPassword(requestSecretInput, consoleLog);
 }
 
 export async function askPassword(
   requestSecretInput: KeystoreRequestSecretInput,
 ): Promise<string> {
-  return requestSecretInput(PLUGIN_ID, UserDisplayMessages.enterPasswordMsg());
+  return await requestSecretInput(
+    PLUGIN_ID,
+    UserDisplayMessages.enterPasswordMsg(),
+  );
 }
 
 export async function askPasswordForDevKeystore(
   devPasswordFilePath: string,
 ): Promise<string> {
-  return readUtf8File(devPasswordFilePath);
+  return await readUtf8File(devPasswordFilePath);
 }
 
 async function createPassword(

--- a/packages/hardhat-keystore/src/internal/loaders/file-manager.ts
+++ b/packages/hardhat-keystore/src/internal/loaders/file-manager.ts
@@ -20,7 +20,7 @@ export class FileManagerImpl implements FileManager {
     // First write to a temporary file, then move it to minimize the risk of file corruption
     const tmpPath = `${absolutePathToFile}.tmp`;
     await writeJsonFile(tmpPath, keystoreFile);
-    return move(tmpPath, absolutePathToFile);
+    return await move(tmpPath, absolutePathToFile);
   }
 
   public readJsonFile(absolutePathToFile: string): Promise<EncryptedKeystore> {

--- a/packages/hardhat-keystore/src/internal/loaders/keystore-file-loader.ts
+++ b/packages/hardhat-keystore/src/internal/loaders/keystore-file-loader.ts
@@ -36,7 +36,7 @@ export class KeystoreFileLoader implements KeystoreLoader {
       return true;
     }
 
-    return this.#fileManager.fileExists(this.#keystoreFilePath);
+    return await this.#fileManager.fileExists(this.#keystoreFilePath);
   }
 
   public async loadKeystore(): Promise<Keystore> {

--- a/packages/hardhat-ledger/src/internal/handler.ts
+++ b/packages/hardhat-ledger/src/internal/handler.ts
@@ -230,7 +230,7 @@ export class LedgerHandler {
           );
         });
 
-        return this.#toRpcSig(signature);
+        return await this.#toRpcSig(signature);
       }
     }
   }
@@ -292,7 +292,7 @@ export class LedgerHandler {
           );
           await this.#delayBeforeRetry(delay);
 
-          return this.init(retryAttempts + 1);
+          return await this.init(retryAttempts + 1);
         }
 
         // Give up - either not a retryable error or exhausted retries
@@ -375,7 +375,7 @@ export class LedgerHandler {
         await this.#resetConnection();
         await this.init();
 
-        return this.#derivePath(addressToFindAsBuffer, {
+        return await this.#derivePath(addressToFindAsBuffer, {
           ...retryState,
           reconnection: retryState.reconnection + 1,
         });
@@ -394,7 +394,7 @@ export class LedgerHandler {
           LedgerHandler.DEVICE_NOT_READY_RETRY_DELAY_SECONDS,
         );
 
-        return this.#derivePath(addressToFindAsBuffer, {
+        return await this.#derivePath(addressToFindAsBuffer, {
           ...retryState,
           deviceNotReady: retryState.deviceNotReady + 1,
         });
@@ -541,7 +541,7 @@ export class LedgerHandler {
         await this.#resetConnection();
         await this.init();
 
-        return this.#withConfirmation(func, {
+        return await this.#withConfirmation(func, {
           ...retryState,
           reconnection: retryState.reconnection + 1,
         });
@@ -560,7 +560,7 @@ export class LedgerHandler {
           LedgerHandler.DEVICE_NOT_READY_RETRY_DELAY_SECONDS,
         );
 
-        return this.#withConfirmation(func, {
+        return await this.#withConfirmation(func, {
           ...retryState,
           deviceNotReady: retryState.deviceNotReady + 1,
         });
@@ -638,7 +638,7 @@ export class LedgerHandler {
           );
         });
 
-        return this.#toRpcSig(signature);
+        return await this.#toRpcSig(signature);
       }
     }
   }
@@ -700,11 +700,15 @@ export class LedgerHandler {
       try {
         return await this.#eth.signEIP712Message(path, typedMessage);
       } catch (_error) {
-        return this.#eth.signEIP712HashedMessage(path, domainHash, structHash);
+        return await this.#eth.signEIP712HashedMessage(
+          path,
+          domainHash,
+          structHash,
+        );
       }
     });
 
-    return this.#toRpcSig(signature);
+    return await this.#toRpcSig(signature);
   }
 
   async #ethSendTransaction(params: any[]): Promise<{

--- a/packages/hardhat-ledger/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-ledger/src/internal/hook-handlers/config.ts
@@ -6,7 +6,7 @@ import { validateLedgerUserConfig } from "../config/validate-ledger-user-config.
 export default async (): Promise<Partial<ConfigHooks>> => {
   const handlers: Partial<ConfigHooks> = {
     validateUserConfig: async (userConfig) =>
-      validateLedgerUserConfig(userConfig),
+      await validateLedgerUserConfig(userConfig),
     resolveUserConfig: async (
       userConfig,
       resolveConfigurationVariable,

--- a/packages/hardhat-ledger/src/internal/hook-handlers/network.ts
+++ b/packages/hardhat-ledger/src/internal/hook-handlers/network.ts
@@ -43,7 +43,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
       ) {
         // Allow these methods to pass through untouched.
         // The ledger handler calls them directly, so intercepting them here would lead to infinite recursion.
-        return next(context, networkConnection, jsonRpcRequest);
+        return await next(context, networkConnection, jsonRpcRequest);
       }
 
       if (LedgerHandler === undefined) {
@@ -118,7 +118,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         return newRequestOrResponse;
       }
 
-      return next(context, networkConnection, newRequestOrResponse);
+      return await next(context, networkConnection, newRequestOrResponse);
     },
 
     async closeConnection<ChainTypeT extends ChainType | string>(
@@ -133,7 +133,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         ledgerHandlerPerConnection.delete(networkConnection);
       }
 
-      return next(context, networkConnection);
+      return await next(context, networkConnection);
     },
   };
 

--- a/packages/hardhat-ledger/test/internal/handler.ts
+++ b/packages/hardhat-ledger/test/internal/handler.ts
@@ -305,7 +305,7 @@ describe("LedgerHandler", () => {
           if (createCallCount <= 2) {
             throw new TransportError("No Ledger device found", "NoDeviceFound");
           }
-          return originalCreate(...args);
+          return await originalCreate(...args);
         };
 
         ledgerHandler = new LedgerHandler(

--- a/packages/hardhat-ledger/test/mocked-network-plugin.ts
+++ b/packages/hardhat-ledger/test/mocked-network-plugin.ts
@@ -32,7 +32,7 @@ const mockedNetworkPlugin: HardhatPlugin = {
             };
           }
 
-          return next(context, networkConnection, jsonRpcRequest);
+          return await next(context, networkConnection, jsonRpcRequest);
         },
       }),
     }),

--- a/packages/hardhat-mocha/src/hookHandlers/test.ts
+++ b/packages/hardhat-mocha/src/hookHandlers/test.ts
@@ -26,7 +26,7 @@ export default async (): Promise<Partial<TestHooks>> => {
         return "mocha";
       }
 
-      return next(context, filePath);
+      return await next(context, filePath);
     },
   };
 

--- a/packages/hardhat-mocha/src/task-action.ts
+++ b/packages/hardhat-mocha/src/task-action.ts
@@ -57,7 +57,7 @@ async function getTestFiles(
     return testFilesAbsolutePaths;
   }
 
-  return getAllFilesMatching(
+  return await getAllFilesMatching(
     config.paths.tests.mocha,
     (f) => isJavascriptFile(f) || isTypescriptFile(f),
   );

--- a/packages/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
+++ b/packages/hardhat-network-helpers/src/internal/network-helpers/network-helpers.ts
@@ -64,7 +64,7 @@ export class NetworkHelpers<ChainTypeT extends ChainType | string>
 
   public async dropTransaction(txHash: string): Promise<boolean> {
     await this.throwIfNotDevelopmentNetwork();
-    return dropTransaction(this.#provider, txHash);
+    return await dropTransaction(this.#provider, txHash);
   }
 
   public async getStorageAt(
@@ -73,12 +73,12 @@ export class NetworkHelpers<ChainTypeT extends ChainType | string>
     block: NumberLike | BlockTag = "latest",
   ): Promise<string> {
     await this.throwIfNotDevelopmentNetwork();
-    return getStorageAt(this.#provider, address, index, block);
+    return await getStorageAt(this.#provider, address, index, block);
   }
 
   public async impersonateAccount(address: string): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return impersonateAccount(this.#provider, address);
+    return await impersonateAccount(this.#provider, address);
   }
 
   public async loadFixture<T>(fixture: Fixture<T, ChainTypeT>): Promise<T> {
@@ -101,49 +101,49 @@ export class NetworkHelpers<ChainTypeT extends ChainType | string>
     options: { interval?: NumberLike } = { interval: 1 },
   ): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return mine(this.#provider, blocks, options);
+    return await mine(this.#provider, blocks, options);
   }
 
   public async mineUpTo(blockNumber: NumberLike): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return mineUpTo(this.#provider, blockNumber, this.time);
+    return await mineUpTo(this.#provider, blockNumber, this.time);
   }
 
   public async setBalance(address: string, balance: NumberLike): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setBalance(this.#provider, address, balance);
+    return await setBalance(this.#provider, address, balance);
   }
 
   public async setBlockGasLimit(blockGasLimit: NumberLike): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setBlockGasLimit(this.#provider, blockGasLimit);
+    return await setBlockGasLimit(this.#provider, blockGasLimit);
   }
 
   public async setCode(address: string, code: string): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setCode(this.#provider, address, code);
+    return await setCode(this.#provider, address, code);
   }
 
   public async setCoinbase(address: string): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setCoinbase(this.#provider, address);
+    return await setCoinbase(this.#provider, address);
   }
 
   public async setNextBlockBaseFeePerGas(
     baseFeePerGas: NumberLike,
   ): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setNextBlockBaseFeePerGas(this.#provider, baseFeePerGas);
+    return await setNextBlockBaseFeePerGas(this.#provider, baseFeePerGas);
   }
 
   public async setNonce(address: string, nonce: NumberLike): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setNonce(this.#provider, address, nonce);
+    return await setNonce(this.#provider, address, nonce);
   }
 
   public async setPrevRandao(prevRandao: NumberLike): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setPrevRandao(this.#provider, prevRandao);
+    return await setPrevRandao(this.#provider, prevRandao);
   }
 
   public async setStorageAt(
@@ -152,17 +152,17 @@ export class NetworkHelpers<ChainTypeT extends ChainType | string>
     value: NumberLike,
   ): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return setStorageAt(this.#provider, address, index, value);
+    return await setStorageAt(this.#provider, address, index, value);
   }
 
   public async stopImpersonatingAccount(address: string): Promise<void> {
     await this.throwIfNotDevelopmentNetwork();
-    return stopImpersonatingAccount(this.#provider, address);
+    return await stopImpersonatingAccount(this.#provider, address);
   }
 
   public async takeSnapshot(): Promise<SnapshotRestorer> {
     await this.throwIfNotDevelopmentNetwork();
-    return takeSnapshot(this.#provider);
+    return await takeSnapshot(this.#provider);
   }
 
   public async throwIfNotDevelopmentNetwork(): Promise<void> {

--- a/packages/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase.ts
+++ b/packages/hardhat-network-helpers/src/internal/network-helpers/time/helpers/increase.ts
@@ -20,5 +20,5 @@ export async function increase<ChainTypeT extends ChainType | string>(
 
   await networkHelpers.mine();
 
-  return networkHelpers.time.latest();
+  return await networkHelpers.time.latest();
 }

--- a/packages/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
+++ b/packages/hardhat-network-helpers/src/internal/network-helpers/time/time.ts
@@ -32,12 +32,16 @@ export class Time<ChainTypeT extends ChainType | string> implements TimeI {
 
   public async increase(amountInSeconds: NumberLike): Promise<number> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return increase(this.#provider, this.#networkHelpers, amountInSeconds);
+    return await increase(
+      this.#provider,
+      this.#networkHelpers,
+      amountInSeconds,
+    );
   }
 
   public async increaseTo(timestamp: NumberLike | Date): Promise<void> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return increaseTo(
+    return await increaseTo(
       this.#provider,
       this.#networkHelpers,
       timestamp,
@@ -47,18 +51,22 @@ export class Time<ChainTypeT extends ChainType | string> implements TimeI {
 
   public async latest(): Promise<number> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return latest(this.#provider);
+    return await latest(this.#provider);
   }
 
   public async latestBlock(): Promise<number> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return latestBlock(this.#provider);
+    return await latestBlock(this.#provider);
   }
 
   public async setNextBlockTimestamp(
     timestamp: NumberLike | Date,
   ): Promise<void> {
     await this.#networkHelpers.throwIfNotDevelopmentNetwork();
-    return setNextBlockTimestamp(this.#provider, timestamp, this.duration);
+    return await setNextBlockTimestamp(
+      this.#provider,
+      timestamp,
+      this.duration,
+    );
   }
 }

--- a/packages/hardhat-network-helpers/test/assertions.ts
+++ b/packages/hardhat-network-helpers/test/assertions.ts
@@ -61,7 +61,7 @@ describe("assertions", () => {
   describe("assertValidAddress", () => {
     it("should throw if the address is not a valid address", async () => {
       await assertRejectsWithHardhatError(
-        async () => assertValidAddress("0xZZZZ"),
+        async () => await assertValidAddress("0xZZZZ"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
         {
           value: "0xZZZZ",
@@ -72,7 +72,9 @@ describe("assertions", () => {
     it("should throw if the address is not a valid checksum address", async () => {
       await assertRejectsWithHardhatError(
         async () =>
-          assertValidAddress("0xCF5609B003B2776699EEA1233F7C82D5695CC9AA"),
+          await assertValidAddress(
+            "0xCF5609B003B2776699EEA1233F7C82D5695CC9AA",
+          ),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_CHECKSUM_ADDRESS,
         {
           value: "0xCF5609B003B2776699EEA1233F7C82D5695CC9AA",

--- a/packages/hardhat-network-helpers/test/helpers/mocked-web3-client-version.ts
+++ b/packages/hardhat-network-helpers/test/helpers/mocked-web3-client-version.ts
@@ -24,7 +24,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         };
       }
 
-      return next(context, networkConnection, jsonRpcRequest);
+      return await next(context, networkConnection, jsonRpcRequest);
     },
   };
 

--- a/packages/hardhat-network-helpers/test/network-helpers/drop-transaction.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/drop-transaction.ts
@@ -103,7 +103,7 @@ describe("network-helpers - dropTransaction", () => {
 
   it(`should throw because the transaction hash is invalid`, async function () {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.dropTransaction("0xaaa"),
+      async () => await networkHelpers.dropTransaction("0xaaa"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_TX_HASH,
       {
         value: "0xaaa",

--- a/packages/hardhat-network-helpers/test/network-helpers/get-storage-at.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/get-storage-at.ts
@@ -68,7 +68,7 @@ describe("network-helpers - getStorageAt", () => {
 
   it("should throw because the address is not valid", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.getStorageAt("0xaa", "0x1", "0xbeef"),
+      async () => await networkHelpers.getStorageAt("0xaa", "0x1", "0xbeef"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       {
         value: "0xaa",

--- a/packages/hardhat-network-helpers/test/network-helpers/impersonate-account.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/impersonate-account.ts
@@ -59,7 +59,7 @@ describe("network-helpers - impersonateAccount", () => {
 
   it("should throw because the address is not valid", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setBalance("0xaa", 1),
+      async () => await networkHelpers.setBalance("0xaa", 1),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       {
         value: "0xaa",

--- a/packages/hardhat-network-helpers/test/network-helpers/load-fixture.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/load-fixture.ts
@@ -162,7 +162,7 @@ describe("network-helpers - loadFixture", () => {
 
   it("should throw when an anonymous regular function is used", async function () {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.loadFixture(async function () {}),
+      async () => await networkHelpers.loadFixture(async function () {}),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .FIXTURE_ANONYMOUS_FUNCTION_ERROR,
       {},
@@ -171,7 +171,7 @@ describe("network-helpers - loadFixture", () => {
 
   it("should throw when an anonymous arrow function is used", async function () {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.loadFixture(async () => {}),
+      async () => await networkHelpers.loadFixture(async () => {}),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .FIXTURE_ANONYMOUS_FUNCTION_ERROR,
       {},

--- a/packages/hardhat-network-helpers/test/network-helpers/mine-up-to.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/mine-up-to.ts
@@ -31,7 +31,7 @@ describe("network-helpers - mineUpTo", () => {
     const initialHeight = await networkHelpers.time.latestBlock();
 
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.mineUpTo(initialHeight),
+      async () => await networkHelpers.mineUpTo(initialHeight),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .BLOCK_NUMBER_SMALLER_THAN_CURRENT,
       {

--- a/packages/hardhat-network-helpers/test/network-helpers/mine.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/mine.ts
@@ -104,7 +104,7 @@ describe("network-helpers - mine", () => {
 
   it("should throw because the string is not 0x-prefixed", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.mine("3"),
+      async () => await networkHelpers.mine("3"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .ONLY_ALLOW_0X_PREFIXED_STRINGS,
       {},
@@ -137,7 +137,7 @@ describe("network-helpers - mine", () => {
   it("should throw because the string is not 0x-prefixed", async () => {
     await assertRejectsWithHardhatError(
       async () =>
-        networkHelpers.mine(100, {
+        await networkHelpers.mine(100, {
           interval: "3",
         }),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL

--- a/packages/hardhat-network-helpers/test/network-helpers/set-balance.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-balance.ts
@@ -44,7 +44,7 @@ describe("network-helpers - setBalance", () => {
 
   it("should throw because the address is invalid", async function () {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setBalance("0xCF", 1),
+      async () => await networkHelpers.setBalance("0xCF", 1),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       {
         value: "0xCF",

--- a/packages/hardhat-network-helpers/test/network-helpers/set-block-gas-limit.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-block-gas-limit.ts
@@ -66,7 +66,7 @@ describe("network-helpers - setBlockGasLimit", () => {
 
     it("should not accept strings that are not 0x-prefixed", async () => {
       await assertRejectsWithHardhatError(
-        async () => networkHelpers.setBlockGasLimit("3"),
+        async () => await networkHelpers.setBlockGasLimit("3"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
           .ONLY_ALLOW_0X_PREFIXED_STRINGS,
         {},

--- a/packages/hardhat-network-helpers/test/network-helpers/set-code.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-code.ts
@@ -44,7 +44,7 @@ describe("network-helpers - setCode", () => {
   describe("accepted parameter types for code", () => {
     it("should not accept strings that are not 0x-prefixed", async () => {
       await assertRejectsWithHardhatError(
-        async () => networkHelpers.setCode(recipient, "a1a2a3"),
+        async () => await networkHelpers.setCode(recipient, "a1a2a3"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_HEX_STRING,
         { value: "a1a2a3" },
       );
@@ -52,7 +52,7 @@ describe("network-helpers - setCode", () => {
 
     it("should not accept invalid addresses", async () => {
       await assertRejectsWithHardhatError(
-        async () => networkHelpers.setCode("0x123", "0xaaa"),
+        async () => await networkHelpers.setCode("0x123", "0xaaa"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
         {
           value: "0x123",

--- a/packages/hardhat-network-helpers/test/network-helpers/set-coinbase.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-coinbase.ts
@@ -46,7 +46,7 @@ describe("network-helpers - setCoinbase", () => {
 
   it(`should throw because the address is invalid`, async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setCoinbase("0x123"),
+      async () => await networkHelpers.setCoinbase("0x123"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       { value: "0x123" },
     );

--- a/packages/hardhat-network-helpers/test/network-helpers/set-next-block-base-fee-per-gas.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-next-block-base-fee-per-gas.ts
@@ -66,7 +66,7 @@ describe("network-helpers - setNextBlockBaseFeePerGas", () => {
 
     it("should throw because the the string is not 0x-prefixed", async () => {
       await assertRejectsWithHardhatError(
-        async () => networkHelpers.setNextBlockBaseFeePerGas("3"),
+        async () => await networkHelpers.setNextBlockBaseFeePerGas("3"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
           .ONLY_ALLOW_0X_PREFIXED_STRINGS,
         {},

--- a/packages/hardhat-network-helpers/test/network-helpers/set-nonce.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-nonce.ts
@@ -91,7 +91,7 @@ describe("network-helpers - setNonce", () => {
 
   it("should throw because the address is invalid", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setNonce("0xCF", 1),
+      async () => await networkHelpers.setNonce("0xCF", 1),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       {
         value: "0xCF",
@@ -101,7 +101,7 @@ describe("network-helpers - setNonce", () => {
 
   it("should throw because the nonce is invalid", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setNonce(account, "CF"),
+      async () => await networkHelpers.setNonce(account, "CF"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .ONLY_ALLOW_0X_PREFIXED_STRINGS,
       {},

--- a/packages/hardhat-network-helpers/test/network-helpers/set-prevrandao.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-prevrandao.ts
@@ -63,7 +63,7 @@ describe("network-helpers - setPrevRandao", () => {
 
     it("should not accept strings that are not 0x-prefixed", async () => {
       await assertRejectsWithHardhatError(
-        async () => networkHelpers.setPrevRandao("3"),
+        async () => await networkHelpers.setPrevRandao("3"),
         HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
           .ONLY_ALLOW_0X_PREFIXED_STRINGS,
         {},

--- a/packages/hardhat-network-helpers/test/network-helpers/set-storage-at.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/set-storage-at.ts
@@ -51,7 +51,7 @@ describe("network-helpers - setStorageAt", () => {
 
   it("should throw because the address is not valid", async () => {
     await assertRejectsWithHardhatError(
-      async () => networkHelpers.setStorageAt("0xaa", "0x1", "0xbeef"),
+      async () => await networkHelpers.setStorageAt("0xaa", "0x1", "0xbeef"),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_ADDRESS,
       {
         value: "0xaa",

--- a/packages/hardhat-network-helpers/test/network-helpers/take-snapshot.ts
+++ b/packages/hardhat-network-helpers/test/network-helpers/take-snapshot.ts
@@ -55,7 +55,7 @@ describe("network-helpers - takeSnapshot", () => {
     await snapshot1.restore();
 
     await assertRejectsWithHardhatError(
-      async () => snapshot2.restore(),
+      async () => await snapshot2.restore(),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL.INVALID_SNAPSHOT,
       {},
     );

--- a/packages/hardhat-network-helpers/test/time/increase-to.ts
+++ b/packages/hardhat-network-helpers/test/time/increase-to.ts
@@ -36,14 +36,16 @@ describe("time - increaseTo", () => {
     const initialTimestamp = await time.latest();
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () => time.increaseTo(initialTimestamp));
+    await assert.rejects(async () => await time.increaseTo(initialTimestamp));
   });
 
   it("should throw if given a timestamp that is less than the current block timestamp", async () => {
     const initialTimestamp = await time.latest();
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () => time.increaseTo(initialTimestamp - 1));
+    await assert.rejects(
+      async () => await time.increaseTo(initialTimestamp - 1),
+    );
   });
 
   describe("accepted parameter types for timestamp", () => {

--- a/packages/hardhat-network-helpers/test/time/increase.ts
+++ b/packages/hardhat-network-helpers/test/time/increase.ts
@@ -34,12 +34,12 @@ describe("time - increase", () => {
 
   it("should throw if given zero number of seconds", async () => {
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () => time.increase(0));
+    await assert.rejects(async () => await time.increase(0));
   });
 
   it("should throw if given a negative number of seconds", async () => {
     await assertRejectsWithHardhatError(
-      async () => time.increase(-1),
+      async () => await time.increase(-1),
       HardhatError.ERRORS.NETWORK_HELPERS.GENERAL
         .CANNOT_CONVERT_NEGATIVE_NUMBER_TO_RPC_QUANTITY,
       {

--- a/packages/hardhat-network-helpers/test/time/set-next-block-timestamp.ts
+++ b/packages/hardhat-network-helpers/test/time/set-next-block-timestamp.ts
@@ -58,8 +58,8 @@ describe("time - setNextBlockTimestamp", () => {
     const initialTimestamp = await time.latest();
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () =>
-      time.setNextBlockTimestamp(initialTimestamp),
+    await assert.rejects(
+      async () => await time.setNextBlockTimestamp(initialTimestamp),
     );
   });
 
@@ -67,8 +67,8 @@ describe("time - setNextBlockTimestamp", () => {
     const initialTimestamp = await time.latest();
 
     // eslint-disable-next-line no-restricted-syntax -- only used in test to verify error not thrown by Hardhat
-    await assert.rejects(async () =>
-      time.setNextBlockTimestamp(initialTimestamp - 1),
+    await assert.rejects(
+      async () => await time.setNextBlockTimestamp(initialTimestamp - 1),
     );
   });
 

--- a/packages/hardhat-node-test-reporter/integration-tests/fixture-tests/errors-test/test.ts
+++ b/packages/hardhat-node-test-reporter/integration-tests/fixture-tests/errors-test/test.ts
@@ -10,7 +10,7 @@ test("aggregate error in top level test", async () => {
   );
   const promise2 = Promise.reject(new Error("Promise 2 failed"));
 
-  return Promise.any([promise1, promise2]);
+  return await Promise.any([promise1, promise2]);
 });
 
 // TODO: We're commenting out this test case because https://nodejs.org/en/blog/release/v22.16.0

--- a/packages/hardhat-node-test-runner/src/hookHandlers/test.ts
+++ b/packages/hardhat-node-test-runner/src/hookHandlers/test.ts
@@ -26,7 +26,7 @@ export default async (): Promise<Partial<TestHooks>> => {
         return "nodejs";
       }
 
-      return next(context, filePath);
+      return await next(context, filePath);
     },
   };
 

--- a/packages/hardhat-node-test-runner/src/task-action.ts
+++ b/packages/hardhat-node-test-runner/src/task-action.ts
@@ -45,7 +45,7 @@ async function getTestFiles(
     return testFiles;
   }
 
-  return getAllFilesMatching(
+  return await getAllFilesMatching(
     config.paths.tests.nodejs,
     (f) => isJavascriptFile(f) || isTypescriptFile(f),
   );

--- a/packages/hardhat-solx/src/internal/hook-handlers/solidity.ts
+++ b/packages/hardhat-solx/src/internal/hook-handlers/solidity.ts
@@ -85,7 +85,7 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
 
   getCompiler: async (context, compilerConfig, next) => {
     if (compilerConfig.type !== SOLX_COMPILER_TYPE) {
-      return next(context, compilerConfig);
+      return await next(context, compilerConfig);
     }
 
     // Honor custom path — skip version lookup and download

--- a/packages/hardhat-solx/src/internal/solx-compiler.ts
+++ b/packages/hardhat-solx/src/internal/solx-compiler.ts
@@ -41,6 +41,6 @@ export class SolxCompiler implements Compiler {
       },
     };
 
-    return this.#spawnCompile(this.compilerPath, args, modifiedInput);
+    return await this.#spawnCompile(this.compilerPath, args, modifiedInput);
   }
 }

--- a/packages/hardhat-solx/test/integration.ts
+++ b/packages/hardhat-solx/test/integration.ts
@@ -14,7 +14,7 @@ describe("hardhat-solx integration", () => {
   async function createHre() {
     const configPath = await resolveHardhatConfigPath();
     const userConfig = await importUserConfig(configPath);
-    return createHardhatRuntimeEnvironment(userConfig);
+    return await createHardhatRuntimeEnvironment(userConfig);
   }
 
   it("resolves plugin config through the HRE", async () => {

--- a/packages/hardhat-test-utils/src/fixture-projects.ts
+++ b/packages/hardhat-test-utils/src/fixture-projects.ts
@@ -82,5 +82,5 @@ async function getFixtureProjectPath(
     throw new Error(`Fixture project ${projectName} doesn't exist`);
   }
 
-  return getRealPath(projectPath);
+  return await getRealPath(projectPath);
 }

--- a/packages/hardhat-test-utils/test/hardhat-error.ts
+++ b/packages/hardhat-test-utils/test/hardhat-error.ts
@@ -160,22 +160,24 @@ describe("HardhatError helpers", () => {
 
   describe("assertRejectsWithHardhatError", () => {
     it("should throw if the function doesn't return a promise that rejects", async () => {
-      await assert.rejects(async () =>
-        assertRejectsWithHardhatError(
-          async () => {},
-          HardhatError.ERRORS.CORE.TASK_DEFINITIONS.INVALID_ACTION,
-          { task: "bar" },
-        ),
+      await assert.rejects(
+        async () =>
+          await assertRejectsWithHardhatError(
+            async () => {},
+            HardhatError.ERRORS.CORE.TASK_DEFINITIONS.INVALID_ACTION,
+            { task: "bar" },
+          ),
       );
     });
 
     it("should throw the promise that rejects", async () => {
-      await assert.rejects(async () =>
-        assertRejectsWithHardhatError(
-          Promise.resolve(1),
-          HardhatError.ERRORS.CORE.TASK_DEFINITIONS.INVALID_ACTION,
-          { task: "bar" },
-        ),
+      await assert.rejects(
+        async () =>
+          await assertRejectsWithHardhatError(
+            Promise.resolve(1),
+            HardhatError.ERRORS.CORE.TASK_DEFINITIONS.INVALID_ACTION,
+            { task: "bar" },
+          ),
       );
     });
 

--- a/packages/hardhat-typechain/src/internal/hook-handlers/solidity.ts
+++ b/packages/hardhat-typechain/src/internal/hook-handlers/solidity.ts
@@ -104,7 +104,7 @@ async function getContractArtifactPaths(
     }
   }
 
-  return Promise.all(
+  return await Promise.all(
     contractFqns.map((fqn) => context.artifacts.getArtifactPath(fqn)),
   );
 }

--- a/packages/hardhat-typechain/test/index.ts
+++ b/packages/hardhat-typechain/test/index.ts
@@ -336,8 +336,8 @@ describe("hardhat-typechain", () => {
       await hre.tasks.getTask("clean").run();
 
       // Build should throw due to compilation error
-      await assertRejects(async () =>
-        hre.tasks.getTask("build").run({ quiet: true }),
+      await assertRejects(
+        async () => await hre.tasks.getTask("build").run({ quiet: true }),
       );
 
       // Types should NOT be generated

--- a/packages/hardhat-utils/src/eth.ts
+++ b/packages/hardhat-utils/src/eth.ts
@@ -24,7 +24,7 @@ export function isAddress(value: unknown): value is PrefixedHexString {
  * @returns True if the value is an Ethereum address with a valid checksum, false otherwise.
  */
 export async function isValidChecksumAddress(value: unknown): Promise<boolean> {
-  return isAddress(value) && isValidChecksum(value);
+  return await (isAddress(value) && isValidChecksum(value));
 }
 
 /**
@@ -55,7 +55,7 @@ export function toEvmWord(value: bigint | number): PrefixedHexString {
  */
 export async function generateHashBytes(): Promise<Uint8Array> {
   const hashGenerator = await getHashGenerator();
-  return hashGenerator.next();
+  return await hashGenerator.next();
 }
 
 /**

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -69,7 +69,7 @@ export async function getAllFilesMatching(
           directoryFilter === undefined ||
           (await directoryFilter(absolutePathToFile))
         ) {
-          return getAllFilesMatching(
+          return await getAllFilesMatching(
             absolutePathToFile,
             matches,
             directoryFilter,
@@ -120,7 +120,7 @@ export async function getAllDirectoriesMatching(
         return absolutePathToFile;
       }
 
-      return getAllDirectoriesMatching(absolutePathToFile, matches);
+      return await getAllDirectoriesMatching(absolutePathToFile, matches);
     }),
   );
 

--- a/packages/hardhat-utils/src/package.ts
+++ b/packages/hardhat-utils/src/package.ts
@@ -158,7 +158,7 @@ export async function findDependencyPackageJson(
     const packageJsonPath = path.join(lookupPath, ...pathToTest);
 
     if (await exists(packageJsonPath)) {
-      return getRealPath(packageJsonPath);
+      return await getRealPath(packageJsonPath);
     }
   }
 }

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -615,7 +615,7 @@ export class AsyncMutex {
       };
     }
 
-    return new Promise<() => Promise<void>>((resolve) => {
+    return await new Promise<() => Promise<void>>((resolve) => {
       this.#queue.push(() => {
         resolve(this.#acquire());
       });

--- a/packages/hardhat-utils/test/subprocess.ts
+++ b/packages/hardhat-utils/test/subprocess.ts
@@ -27,7 +27,7 @@ async function checkIfSubprocessWasExecuted() {
   // within a specified number of attempts, an error is thrown, indicating a failure in subprocess execution.
   const MAX_COUNTER = 20;
 
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     let counter = 0;
 
     const intervalId = setInterval(async () => {
@@ -143,7 +143,9 @@ describe("subprocess", () => {
 
     await assert.rejects(
       async () =>
-        spawnDetachedSubProcess(pathToSubprocessFile, [], { env1: "env1" }),
+        await spawnDetachedSubProcess(pathToSubprocessFile, [], {
+          env1: "env1",
+        }),
       new SubprocessFileNotFoundError(pathToSubprocessFile),
     );
   });
@@ -153,7 +155,9 @@ describe("subprocess", () => {
 
     await assert.rejects(
       async () =>
-        spawnDetachedSubProcess(pathToSubprocessFile, [], { env1: "env1" }),
+        await spawnDetachedSubProcess(pathToSubprocessFile, [], {
+          env1: "env1",
+        }),
       new SubprocessPathIsDirectoryError(pathToSubprocessFile),
     );
   });

--- a/packages/hardhat-verify/src/internal/blockscout.ts
+++ b/packages/hardhat-verify/src/internal/blockscout.ts
@@ -415,7 +415,11 @@ export class Blockscout implements VerificationProvider {
     if (blockscoutResponse.isPending()) {
       await sleep(this.pollingIntervalMs);
 
-      return this.pollVerificationStatus(guid, contractAddress, contractName);
+      return await this.pollVerificationStatus(
+        guid,
+        contractAddress,
+        contractName,
+      );
     }
 
     if (blockscoutResponse.isAlreadyVerified()) {

--- a/packages/hardhat-verify/src/internal/bytecode.ts
+++ b/packages/hardhat-verify/src/internal/bytecode.ts
@@ -67,7 +67,7 @@ export class Bytecode {
       );
     }
 
-    return Bytecode.#parse(deployedBytecode);
+    return await Bytecode.#parse(deployedBytecode);
   }
 
   public hasVersionRange(): boolean {

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -58,9 +58,9 @@ export class ContractInformationResolver {
     deployedBytecode: Bytecode,
   ): Promise<ContractInformation> {
     if (contract !== undefined) {
-      return this.#resolveByFqn(contract, deployedBytecode);
+      return await this.#resolveByFqn(contract, deployedBytecode);
     } else {
-      return this.#resolveByBytecodeLookup(deployedBytecode);
+      return await this.#resolveByBytecodeLookup(deployedBytecode);
     }
   }
 

--- a/packages/hardhat-verify/src/internal/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/etherscan.ts
@@ -429,7 +429,11 @@ export class Etherscan implements VerificationProvider {
     if (etherscanResponse.isPending()) {
       await sleep(this.pollingIntervalMs);
 
-      return this.pollVerificationStatus(guid, contractAddress, contractName);
+      return await this.pollVerificationStatus(
+        guid,
+        contractAddress,
+        contractName,
+      );
     }
 
     if (etherscanResponse.isAlreadyVerified()) {
@@ -661,12 +665,12 @@ export class LazyEtherscanImpl implements LazyEtherscan {
 
   public async isVerified(address: string): Promise<boolean> {
     const etherscan = await this.#getEtherscan();
-    return etherscan.isVerified(address);
+    return await etherscan.isVerified(address);
   }
 
   public async verify(args: EtherscanVerifyArgs): Promise<string> {
     const etherscan = await this.#getEtherscan();
-    return etherscan.verify(args);
+    return await etherscan.verify(args);
   }
 
   public async pollVerificationStatus(
@@ -675,7 +679,7 @@ export class LazyEtherscanImpl implements LazyEtherscan {
     contractName: string,
   ): Promise<{ success: boolean; message: string }> {
     const etherscan = await this.#getEtherscan();
-    return etherscan.pollVerificationStatus(
+    return await etherscan.pollVerificationStatus(
       guid,
       contractAddress,
       contractName,
@@ -687,6 +691,6 @@ export class LazyEtherscanImpl implements LazyEtherscan {
     options?: EtherscanCustomApiCallOptions,
   ): Promise<EtherscanResponseBody> {
     const etherscan = await this.#getEtherscan();
-    return etherscan.customApiCall(params, options);
+    return await etherscan.customApiCall(params, options);
   }
 }

--- a/packages/hardhat-verify/src/internal/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/sourcify.ts
@@ -303,7 +303,11 @@ export class Sourcify implements VerificationProvider {
     if (verificationStatus.isPending()) {
       await sleep(this.pollingIntervalMs);
 
-      return this.pollVerificationStatus(guid, contractAddress, contractName);
+      return await this.pollVerificationStatus(
+        guid,
+        contractAddress,
+        contractName,
+      );
     }
 
     if (verificationStatus.isAlreadyVerified()) {

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -359,7 +359,7 @@ export async function createVerificationProviderInstance({
     dispatcher,
   });
 
-  return ProviderClass.create(createOptions);
+  return await ProviderClass.create(createOptions);
 }
 
 async function attemptVerification(

--- a/packages/hardhat-verify/src/verify.ts
+++ b/packages/hardhat-verify/src/verify.ts
@@ -9,5 +9,5 @@ export async function verifyContract(
   verifyContractArgs: VerifyContractArgs,
   hre: HardhatRuntimeEnvironment,
 ): Promise<boolean> {
-  return verify(verifyContractArgs, hre);
+  return await verify(verifyContractArgs, hre);
 }

--- a/packages/hardhat-verify/test/tasks/verify/task-action.ts
+++ b/packages/hardhat-verify/test/tasks/verify/task-action.ts
@@ -61,7 +61,7 @@ describe("verify/task-action", () => {
     });
 
     it("should set process.exitCode to 0 when verification is successful", async () => {
-      const verifyContract = async () => Promise.resolve(true);
+      const verifyContract = async () => await Promise.resolve(true);
 
       await internalVerifyAction(
         {
@@ -100,7 +100,7 @@ describe("verify/task-action", () => {
       }) => {
         if (provider === "etherscan") {
           console.log("Verification successful for Etherscan");
-          return Promise.resolve(true);
+          return await Promise.resolve(true);
         }
         throw new Error(`Verification failed for provider: ${provider}`);
       };
@@ -166,7 +166,7 @@ describe("verify/task-action", () => {
           constructorArgs: [],
         },
         localHre,
-        async () => Promise.resolve(true),
+        async () => await Promise.resolve(true),
       );
 
       assert.equal(process.exitCode, 0);

--- a/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
+++ b/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
@@ -38,7 +38,7 @@ export class HardhatViemAssertionsImpl<
       amount: bigint;
     }>,
   ): Promise<void> {
-    return balancesHaveChanged(this.#viem, resolvedTxHash, changes);
+    return await balancesHaveChanged(this.#viem, resolvedTxHash, changes);
   }
 
   public async emit<
@@ -49,7 +49,7 @@ export class HardhatViemAssertionsImpl<
     contract: ContractReturnType<ContractName>,
     eventName: EventName,
   ): Promise<void> {
-    return emit(this.#viem, contractFn, contract, eventName);
+    return await emit(this.#viem, contractFn, contract, eventName);
   }
 
   public async emitWithArgs<
@@ -61,20 +61,26 @@ export class HardhatViemAssertionsImpl<
     eventName: EventName,
     args: any[],
   ): Promise<void> {
-    return emitWithArgs(this.#viem, contractFn, contract, eventName, args);
+    return await emitWithArgs(
+      this.#viem,
+      contractFn,
+      contract,
+      eventName,
+      args,
+    );
   }
 
   public async revert(
     contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
   ): Promise<void> {
-    return revert(contractFn);
+    return await revert(contractFn);
   }
 
   public async revertWith(
     contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
     expectedRevertReason: string,
   ): Promise<void> {
-    return revertWith(contractFn, expectedRevertReason);
+    return await revertWith(contractFn, expectedRevertReason);
   }
 
   public async revertWithCustomError<ContractName extends keyof ContractAbis>(
@@ -82,7 +88,7 @@ export class HardhatViemAssertionsImpl<
     contract: ContractReturnType<ContractName>,
     customErrorName: string,
   ): Promise<void> {
-    return revertWithCustomError(contractFn, contract, customErrorName);
+    return await revertWithCustomError(contractFn, contract, customErrorName);
   }
 
   public async revertWithCustomErrorWithArgs<
@@ -93,7 +99,7 @@ export class HardhatViemAssertionsImpl<
     customErrorName: string,
     args: any[],
   ): Promise<void> {
-    return revertWithCustomErrorWithArgs(
+    return await revertWithCustomErrorWithArgs(
       contractFn,
       contract,
       customErrorName,

--- a/packages/hardhat-viem/src/internal/clients.ts
+++ b/packages/hardhat-viem/src/internal/clients.ts
@@ -143,7 +143,7 @@ export async function getDefaultWalletClient<
     );
   }
 
-  return getWalletClient(
+  return await getWalletClient(
     provider,
     chainType,
     chainDescriptors,

--- a/packages/hardhat-viem/test/contracts.ts
+++ b/packages/hardhat-viem/test/contracts.ts
@@ -267,7 +267,7 @@ describe("contracts", () => {
               result: [],
             };
           }
-          return next(context, netConn, jsonRpcRequest);
+          return await next(context, netConn, jsonRpcRequest);
         };
         const networkHooks: Partial<NetworkHooks> = {
           onRequest,

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -57,7 +57,7 @@ export class ArtifactManagerImplementation implements ArtifactManager {
       contractNameOrFullyQualifiedName,
     );
 
-    return readJsonFile(artifactPath);
+    return await readJsonFile(artifactPath);
   }
 
   public async getArtifactPath(

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/hook-handlers/hre.ts
@@ -20,62 +20,68 @@ class LazyArtifactManager implements ArtifactManager {
     contractNameOrFullyQualifiedName: ContractNameT,
   ): Promise<GetArtifactByName<ContractNameT>> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.readArtifact(contractNameOrFullyQualifiedName);
+    return await artifactManager.readArtifact(contractNameOrFullyQualifiedName);
   }
 
   public async getArtifactPath(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getArtifactPath(contractNameOrFullyQualifiedName);
+    return await artifactManager.getArtifactPath(
+      contractNameOrFullyQualifiedName,
+    );
   }
 
   public async artifactExists(
     contractNameOrFullyQualifiedName: string,
   ): Promise<boolean> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.artifactExists(contractNameOrFullyQualifiedName);
+    return await artifactManager.artifactExists(
+      contractNameOrFullyQualifiedName,
+    );
   }
 
   public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getAllFullyQualifiedNames();
+    return await artifactManager.getAllFullyQualifiedNames();
   }
 
   public async getAllArtifactPaths(): Promise<ReadonlySet<string>> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getAllArtifactPaths();
+    return await artifactManager.getAllArtifactPaths();
   }
 
   public async getBuildInfoId(
     contractNameOrFullyQualifiedName: string,
   ): Promise<string | undefined> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getBuildInfoId(contractNameOrFullyQualifiedName);
+    return await artifactManager.getBuildInfoId(
+      contractNameOrFullyQualifiedName,
+    );
   }
 
   public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getAllBuildInfoIds();
+    return await artifactManager.getAllBuildInfoIds();
   }
 
   public async getBuildInfoPath(
     buildInfoId: string,
   ): Promise<string | undefined> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getBuildInfoPath(buildInfoId);
+    return await artifactManager.getBuildInfoPath(buildInfoId);
   }
 
   public async getBuildInfoOutputPath(
     buildInfoId: string,
   ): Promise<string | undefined> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.getBuildInfoOutputPath(buildInfoId);
+    return await artifactManager.getBuildInfoOutputPath(buildInfoId);
   }
 
   public async clearCache(): Promise<void> {
     const artifactManager = await this.#getArtifactManager();
-    return artifactManager.clearCache();
+    return await artifactManager.clearCache();
   }
 
   async #getArtifactManager(): Promise<ArtifactManager> {

--- a/packages/hardhat/src/internal/builtin-plugins/clean/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/clean/index.ts
@@ -12,7 +12,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "global",
         description: "Clear the global cache",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   npmPackage: "hardhat",

--- a/packages/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -20,7 +20,7 @@ const hardhatPlugin: HardhatPlugin = {
         description: "Commands to run when the console starts",
         defaultValue: [],
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../solidity/index.js")],

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/solidity.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/solidity.ts
@@ -94,7 +94,7 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
         );
       }
     } else {
-      return next(context, sourceName, fsPath, fileContent, solcVersion);
+      return await next(context, sourceName, fsPath, fileContent, solcVersion);
     }
   },
   preprocessSolcInputBeforeBuilding: async (context, solcInput, next) => {
@@ -121,6 +121,6 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
       solcInput.sources[COVERAGE_LIBRARY_PATH] = { content };
     }
 
-    return next(context, solcInput);
+    return await next(context, solcInput);
   },
 });

--- a/packages/hardhat/src/internal/builtin-plugins/flatten/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/flatten/index.ts
@@ -14,7 +14,7 @@ const hardhatPlugin: HardhatPlugin = {
         description: "An optional list of files to flatten",
         type: ArgumentType.FILE,
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
 };

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
@@ -22,7 +22,7 @@ const hardhatPlugin: HardhatPlugin = {
         default: async (args, _hre, runSuper) => {
           // We don't need to do anything here, as the test task will forward
           // the arguments to its subtasks.
-          return runSuper(args);
+          return await runSuper(args);
         },
       }))
       .build(),
@@ -35,7 +35,9 @@ const hardhatPlugin: HardhatPlugin = {
         name: "snapshotCheck",
         description: "Check the snapshots match the stored values",
       })
-      .setAction(async () => import("./tasks/solidity-test/task-action.js"))
+      .setAction(
+        async () => await import("./tasks/solidity-test/task-action.js"),
+      )
       .build(),
   ],
   globalOptions: [

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -87,7 +87,7 @@ export const DEFAULT_EDR_NETWORK_HD_ACCOUNTS_CONFIG_PARAMS: EdrNetworkDefaultHDA
 export async function isDefaultEdrNetworkHDAccountsConfig(
   accounts: EdrNetworkHDAccountsConfig,
 ): Promise<boolean> {
-  return deepEqual(
+  return await deepEqual(
     {
       ...accounts,
       mnemonic: await accounts.mnemonic.get(),
@@ -325,7 +325,7 @@ export class EdrProvider extends BaseProvider {
         typeof jsonRpcResponse.result === "string",
         "Invalid client version response",
       );
-      return clientVersion(jsonRpcResponse.result);
+      return await clientVersion(jsonRpcResponse.result);
     } else {
       return jsonRpcResponse.result;
     }
@@ -496,7 +496,7 @@ export class EdrProvider extends BaseProvider {
       throw new UnknownError(error.message, error);
     }
 
-    return this.#handleEdrResponse(
+    return await this.#handleEdrResponse(
       edrResponse,
       request.method,
       Array.isArray(request.params) ? request.params : undefined,

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/genesis-state.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/genesis-state.ts
@@ -79,7 +79,7 @@ export async function getGenesisStateAndOwnedAccounts(
     return cached;
   }
 
-  return genesisStateAndAccountsCacheMutex.exclusiveRun(async () => {
+  return await genesisStateAndAccountsCacheMutex.exclusiveRun(async () => {
     // We need to check again inside the mutex callback in case another async
     // operation initialized it while we were waiting to acquire the mutex
     const cachedAfterWaiting = genesisStateAndAccountsCache

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -281,7 +281,7 @@ export async function hardhatAccountsToEdrOwnedAccounts(
     balance: account.balance,
   }));
 
-  return Promise.all(accountPromises);
+  return await Promise.all(accountPromises);
 }
 
 export async function normalizeEdrNetworkAccountsConfig(

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/hre.ts
@@ -17,7 +17,7 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
           networkManager = await createNetworkManager(hre, context);
         }
 
-        return networkManager.create(networkConnectionParams);
+        return await networkManager.create(networkConnectionParams);
       },
 
       async connect(networkConnectionParams) {
@@ -25,7 +25,7 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
           networkManager = await createNetworkManager(hre, context);
         }
 
-        return networkManager.connect(networkConnectionParams);
+        return await networkManager.connect(networkConnectionParams);
       },
 
       async getOrCreate(networkOrParams) {
@@ -33,7 +33,7 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
           networkManager = await createNetworkManager(hre, context);
         }
 
-        return networkManager.getOrCreate(networkOrParams);
+        return await networkManager.getOrCreate(networkOrParams);
       },
 
       async createServer(...params) {
@@ -41,7 +41,7 @@ export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
           networkManager = await createNetworkManager(hre, context);
         }
 
-        return networkManager.createServer(...params);
+        return await networkManager.createServer(...params);
       },
     };
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -78,7 +78,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         updatedRequest = newRequestOrResponse;
       }
 
-      return next(context, networkConnection, updatedRequest);
+      return await next(context, networkConnection, updatedRequest);
     },
 
     async closeConnection<ChainTypeT extends ChainType | string>(
@@ -93,7 +93,7 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         requestHandlersPerConnection.delete(networkConnection);
       }
 
-      return next(context, networkConnection);
+      return await next(context, networkConnection);
     },
   };
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/http-provider.ts
@@ -224,7 +224,11 @@ export class HttpProvider extends BaseProvider {
           retryCount,
         );
         if (this.#shouldRetryRequest(retryAfterSeconds, retryCount)) {
-          return this.#retry(jsonRpcRequest, retryAfterSeconds, retryCount);
+          return await this.#retry(
+            jsonRpcRequest,
+            retryAfterSeconds,
+            retryCount,
+          );
         }
 
         // eslint-disable-next-line no-restricted-syntax -- allow throwing ProviderError
@@ -269,7 +273,7 @@ export class HttpProvider extends BaseProvider {
     retryCount: number,
   ) {
     await sleep(retryAfterSeconds);
-    return this.#fetchJsonRpcResponse(request, retryCount + 1);
+    return await this.#fetchJsonRpcResponse(request, retryCount + 1);
   }
 }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -116,7 +116,11 @@ export class NetworkManagerImplementation implements NetworkManager {
       "newConnection",
       [],
       async (_context) =>
-        this.#initializeNetworkConnection(networkName, chainType, override),
+        await this.#initializeNetworkConnection(
+          networkName,
+          chainType,
+          override,
+        ),
     );
 
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -131,7 +135,7 @@ export class NetworkManagerImplementation implements NetworkManager {
   ): Promise<NetworkConnection<ChainTypeT>> {
     this.#connectCalled = true;
 
-    return this.create(networkOrParams);
+    return await this.create(networkOrParams);
   }
 
   public async getOrCreate<
@@ -170,7 +174,7 @@ export class NetworkManagerImplementation implements NetworkManager {
       return cached as NetworkConnection<ChainTypeT>;
     }
 
-    return this.#getOrCreateMutex.exclusiveRun(async () => {
+    return await this.#getOrCreateMutex.exclusiveRun(async () => {
       // Double-check after acquiring the mutex — another call may have
       // populated the cache while we were waiting.
       const cachedAfterWaiting = this.#getOrCreateCache
@@ -260,7 +264,7 @@ export class NetworkManagerImplementation implements NetworkManager {
           "network",
           "onRequest",
           [networkConnection, request],
-          async (_context, _connection, req) => defaultBehavior(req),
+          async (_context, _connection, req) => await defaultBehavior(req),
         );
 
       if (resolvedNetworkConfig.type === "edr-simulated") {
@@ -351,7 +355,7 @@ export class NetworkManagerImplementation implements NetworkManager {
 
         const includeCallTraces = verbosityToIncludeTraces(this.#verbosity);
 
-        return EdrProvider.create({
+        return await EdrProvider.create({
           chainDescriptors: this.#chainDescriptors,
           // The resolvedNetworkConfig can have its chainType set to `undefined`
           // so we default to the default chain type here.
@@ -375,7 +379,7 @@ export class NetworkManagerImplementation implements NetworkManager {
         });
       }
 
-      return HttpProvider.create({
+      return await HttpProvider.create({
         url: await resolvedNetworkConfig.url.getUrl(),
         networkName: resolvedNetworkName,
         extraHeaders: resolvedNetworkConfig.httpHeaders,
@@ -384,7 +388,7 @@ export class NetworkManagerImplementation implements NetworkManager {
       });
     };
 
-    return NetworkConnectionImplementation.create(
+    return await NetworkConnectionImplementation.create(
       this.#nextConnectionId++,
       resolvedNetworkName,
       resolvedChainType,

--- a/packages/hardhat/src/internal/builtin-plugins/node/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/index.ts
@@ -46,7 +46,7 @@ const hardhatPlugin: HardhatPlugin = {
         type: ArgumentType.INT,
         defaultValue: -1,
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../network-manager/index.js")],

--- a/packages/hardhat/src/internal/builtin-plugins/run/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/run/index.ts
@@ -14,7 +14,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "noCompile",
         description: "Do not compile the project before running the script",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../solidity/index.js")],

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts
@@ -31,7 +31,7 @@ export async function getBuildInfosAndOutputs(
 ): Promise<BuildInfoAndOutput[]> {
   const buildInfoIds = await artifactManager.getAllBuildInfoIds();
 
-  return Promise.all(
+  return await Promise.all(
     Array.from(buildInfoIds).map(async (buildInfoId) => {
       const buildInfoPath = await artifactManager.getBuildInfoPath(buildInfoId);
       const buildInfoOutputPath =
@@ -76,7 +76,7 @@ export async function buildEdrArtifactsWithMetadata(
 
   const artifacts = await Promise.all(
     Array.from(fullyQualifiedNames).map(async (fullyQualifiedName) => {
-      return artifactManager.readArtifact(fullyQualifiedName);
+      return await artifactManager.readArtifact(fullyQualifiedName);
     }),
   );
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/hook-handlers/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/hook-handlers/config.ts
@@ -19,7 +19,7 @@ export default async (): Promise<Partial<ConfigHooks>> => {
         resolveConfigurationVariable,
       );
 
-      return resolveSolidityTestUserConfig(
+      return await resolveSolidityTestUserConfig(
         userConfig,
         resolvedConfig,
         resolveConfigurationVariable,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/hook-handlers/test.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/hook-handlers/test.ts
@@ -15,7 +15,7 @@ export default async (): Promise<Partial<TestHooks>> => {
         return "solidity";
       }
 
-      return next(context, filePath);
+      return await next(context, filePath);
     },
   };
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -42,7 +42,7 @@ const hardhatPlugin: HardhatPlugin = {
         defaultValue: 0,
         hidden: true,
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -210,7 +210,9 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
               f.endsWith(".sol"),
             ),
             ...this.#options.soliditySourcesPaths.map(async (dir) => {
-              return getAllFilesMatching(dir, (f) => f.endsWith(".t.sol"));
+              return await getAllFilesMatching(dir, (f) =>
+                f.endsWith(".t.sol"),
+              );
             }),
           ])
         ).flat(1);
@@ -228,7 +230,9 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
               f.endsWith(".sol"),
             ),
             ...this.#options.soliditySourcesPaths.map(async (dir) => {
-              return getAllFilesMatching(dir, (f) => f.endsWith(".t.sol"));
+              return await getAllFilesMatching(dir, (f) =>
+                f.endsWith(".t.sol"),
+              );
             }),
           ])
         ).flat(1);
@@ -253,12 +257,12 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
   ): Promise<CompilationJobCreationError | Map<string, FileBuildResult>> {
     this.#ensureSplitCompilationModeIfTestsScope(options?.scope);
 
-    return this.#hooks.runHandlerChain(
+    return await this.#hooks.runHandlerChain(
       "solidity",
       "build",
       [rootFilePaths, options],
       async (_context, nextRootFilePaths, nextOptions) =>
-        this.#build(nextRootFilePaths, nextOptions),
+        await this.#build(nextRootFilePaths, nextOptions),
     );
   }
 
@@ -308,8 +312,9 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       // NOTE: We precompute the build ids in parallel here, which are cached
       // internally in each compilation job
       await Promise.all(
-        runnableCompilationJobs.map(async (runnableCompilationJob) =>
-          runnableCompilationJob.getBuildId(),
+        runnableCompilationJobs.map(
+          async (runnableCompilationJob) =>
+            await runnableCompilationJob.getBuildId(),
         ),
       );
 
@@ -539,7 +544,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
           "getCompiler",
           [compilerConfig],
           async (_context, cfg) =>
-            getSolcCompilerForConfig(cfg, buildProfile.preferWasm),
+            await getSolcCompilerForConfig(cfg, buildProfile.preferWasm),
         );
         longVersion = compiler.longVersion;
         longVersionMap.set(compilerConfig.version, longVersion);
@@ -805,7 +810,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       "getCompiler",
       [runnableCompilationJob.solcConfig],
       async (_context, cfg) =>
-        getSolcCompilerForConfig(cfg, buildProfile.preferWasm),
+        await getSolcCompilerForConfig(cfg, buildProfile.preferWasm),
     );
 
     log(
@@ -824,7 +829,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       "invokeSolc",
       [compiler, input, runnableCompilationJob.solcConfig],
       async (_context, nextCompiler, nextSolcInput) => {
-        return nextCompiler.compile(nextSolcInput);
+        return await nextCompiler.compile(nextSolcInput);
       },
     );
 
@@ -1165,7 +1170,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       preferWasm: false,
     });
 
-    return compiler.compile(buildInfo.input);
+    return await compiler.compile(buildInfo.input);
   }
 
   async #downloadConfiguredCompilers(quiet = false): Promise<void> {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job.ts
@@ -92,7 +92,7 @@ export class CompilationJobImplementation implements CompilationJob {
         // instrument the project file content when coverage feature is enabled.
         // We pass some additional data via the chain - i.e. the input source name and solc
         // version - but we expect any handlers to pass them on as-is without modification.
-        return this.#hooks.runHandlerChain(
+        return await this.#hooks.runHandlerChain(
           "solidity",
           "preprocessProjectFileBeforeBuilding",
           [file.inputSourceName, file.fsPath, file.content.text, solcVersion],

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -195,7 +195,7 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
 
     const downloadPath = this.#getCompilerBinaryPathFromBuild(build);
 
-    return exists(downloadPath);
+    return await exists(downloadPath);
   }
 
   public async downloadCompiler(version: string): Promise<boolean> {
@@ -208,7 +208,7 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
       path.join(this.#compilersDir, `compiler-download-${version}`),
     );
 
-    return mutex.use(async () => {
+    return await mutex.use(async () => {
       const isCompilerDownloaded = await this.isCompilerDownloaded(version);
 
       if (isCompilerDownloaded === true) {
@@ -240,7 +240,7 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
         }
       }
 
-      return this.#postProcessCompilerDownload(build, downloadPath);
+      return await this.#postProcessCompilerDownload(build, downloadPath);
     });
   }
 
@@ -295,7 +295,7 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
   }
 
   async #readCompilerList(listPath: string): Promise<CompilerList> {
-    return readJsonFile(listPath);
+    return await readJsonFile(listPath);
   }
 
   #getCompilerDownloadPathFromBuild(build: CompilerBuild): string {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/index.ts
@@ -124,10 +124,10 @@ export async function getCompiler(
 ): Promise<Compiler> {
   if (compilerPath !== undefined) {
     // If a compiler path is provided, it means the user is using a custom compiler
-    return getCompilerFromPath(version, compilerPath);
+    return await getCompilerFromPath(version, compilerPath);
   } else {
     // Otherwise we get or download the compiler for the specific version
-    return getCompilerFromVersion(version, { preferWasm });
+    return await getCompilerFromVersion(version, { preferWasm });
   }
 }
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/solcjs-runner.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/solcjs-runner.ts
@@ -6,7 +6,7 @@ async function readStream(
 ): Promise<string> {
   stream.setEncoding(encoding);
 
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     let data = "";
 
     stream.on("data", (chunk) => (data += chunk.toString(encoding)));

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph-building.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/dependency-graph-building.ts
@@ -33,7 +33,7 @@ export async function buildDependencyGraph(
       "readNpmPackageRemappings",
       [packageName, packageVersion, packagePath],
       async (_context, name, version, path) =>
-        defaultBehavior(name, version, path),
+        await defaultBehavior(name, version, path),
     );
 
   const resolver = await ResolverImplementation.create(

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/read-source-file.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/read-source-file.ts
@@ -6,11 +6,11 @@ export function readSourceFileFactory(
   hooks: HookManager,
 ): (absPath: string) => Promise<string> {
   return async (factoryAbsPath: string) => {
-    return hooks.runHandlerChain(
+    return await hooks.runHandlerChain(
       "solidity",
       "readSourceFile",
       [factoryAbsPath],
-      async (_context, absPath) => readUtf8File(absPath),
+      async (_context, absPath) => await readUtf8File(absPath),
     );
   };
 }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -133,8 +133,8 @@ export class ResolverImplementation implements Resolver {
   public async resolveProjectFile(
     absoluteFilePath: string,
   ): Promise<Result<ProjectResolvedFile, ProjectRootResolutionError>> {
-    return this.#mutex.exclusiveRun(async () => {
-      return this.#resolveProjectFile(absoluteFilePath);
+    return await this.#mutex.exclusiveRun(async () => {
+      return await this.#resolveProjectFile(absoluteFilePath);
     });
   }
 
@@ -146,8 +146,8 @@ export class ResolverImplementation implements Resolver {
       NpmRootResolutionError
     >
   > {
-    return this.#mutex.exclusiveRun(async () => {
-      return this.#resolveNpmDependencyFileAsRoot(npmModule);
+    return await this.#mutex.exclusiveRun(async () => {
+      return await this.#resolveNpmDependencyFileAsRoot(npmModule);
     });
   }
 
@@ -160,8 +160,8 @@ export class ResolverImplementation implements Resolver {
       ImportResolutionError
     >
   > {
-    return this.#mutex.exclusiveRun(async () =>
-      this.#resolveImport(from, importPath),
+    return await this.#mutex.exclusiveRun(
+      async () => await this.#resolveImport(from, importPath),
     );
   }
 
@@ -495,7 +495,7 @@ export class ResolverImplementation implements Resolver {
         };
       }
 
-      return this.#resolveRelativeImport({
+      return await this.#resolveRelativeImport({
         from,
         importPath,
         directImport,
@@ -504,7 +504,7 @@ export class ResolverImplementation implements Resolver {
       if (bestUserRemapping !== undefined) {
         // If the import isn't relative, and there's a user remapping, we
         // prioritize that.
-        return this.#resolveUserRemappedImport({
+        return await this.#resolveUserRemappedImport({
           from,
           importPath,
           directImport,
@@ -576,7 +576,7 @@ export class ResolverImplementation implements Resolver {
 
     const relativeFsPath = sourceNamePathToFsPath(relativeSourceNamePath);
 
-    return this.#commonImportResolution({
+    return await this.#commonImportResolution({
       from,
       importPath,
       npmPackage: from.package,
@@ -639,7 +639,7 @@ export class ResolverImplementation implements Resolver {
 
     const relativeFsPath = sourceNamePathToFsPath(relativeSourceNamePath);
 
-    return this.#commonImportResolution({
+    return await this.#commonImportResolution({
       from,
       importPath,
       npmPackage: targetNpmPackage,
@@ -796,7 +796,7 @@ export class ResolverImplementation implements Resolver {
     const relativePath = resolvedSubpath ?? subpath;
     const relativeFsPathWithinPackage = sourceNamePathToFsPath(relativePath);
 
-    return this.#commonImportResolution({
+    return await this.#commonImportResolution({
       from,
       importPath,
       npmPackage: dependency,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
@@ -457,7 +457,7 @@ export class RemappedNpmPackagesGraphImplementation
       npmPackage.version,
       npmPackage.rootFsPath,
       async (_packageName, _packageVersion, packagePath) =>
-        this.#defaultReadPackageRemappings(packagePath),
+        await this.#defaultReadPackageRemappings(packagePath),
     );
 
     return this.#parseAndDeduplicateRemappings(npmPackage, allRemappings);

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/config.ts
@@ -20,7 +20,7 @@ export default async (): Promise<Partial<ConfigHooks>> => {
         resolveConfigurationVariable,
       );
 
-      return resolveSolidityUserConfig(userConfig, resolvedConfig);
+      return await resolveSolidityUserConfig(userConfig, resolvedConfig);
     },
     validateResolvedConfig: async (resolvedConfig) =>
       validateSolidityConfig(resolvedConfig),

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/hook-handlers/hre.ts
@@ -38,12 +38,12 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options: { scope?: BuildScope } = {},
   ): Promise<string[]> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.getRootFilePaths(options);
+    return await buildSystem.getRootFilePaths(options);
   }
 
   public async getScope(fsPath: string): Promise<BuildScope> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.getScope(fsPath);
+    return await buildSystem.getScope(fsPath);
   }
 
   public isSuccessfulBuildResult(
@@ -59,7 +59,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options?: BuildOptions,
   ): Promise<CompilationJobCreationError | Map<string, FileBuildResult>> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.build(rootFiles, options);
+    return await buildSystem.build(rootFiles, options);
   }
 
   public async getCompilationJobs(
@@ -67,7 +67,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options?: GetCompilationJobsOptions,
   ): Promise<CompilationJobCreationError | GetCompilationJobsResult> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.getCompilationJobs(rootFiles, options);
+    return await buildSystem.getCompilationJobs(rootFiles, options);
   }
 
   public async runCompilationJob(
@@ -75,7 +75,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options?: RunCompilationJobOptions,
   ): Promise<RunCompilationJobResult> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.runCompilationJob(compilationJob, options);
+    return await buildSystem.runCompilationJob(compilationJob, options);
   }
 
   public async remapCompilerError(
@@ -84,7 +84,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     shouldShortenPaths?: boolean,
   ): Promise<CompilerOutputError> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.remapCompilerError(
+    return await buildSystem.remapCompilerError(
       compilationJob,
       error,
       shouldShortenPaths,
@@ -97,7 +97,11 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options: { scope?: BuildScope } = {},
   ): Promise<EmitArtifactsResult> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.emitArtifacts(compilationJob, compilerOutput, options);
+    return await buildSystem.emitArtifacts(
+      compilationJob,
+      compilerOutput,
+      options,
+    );
   }
 
   public async cleanupArtifacts(
@@ -105,7 +109,7 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options: { scope?: BuildScope } = {},
   ): Promise<void> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.cleanupArtifacts(rootFilePaths, options);
+    return await buildSystem.cleanupArtifacts(rootFilePaths, options);
   }
 
   public async compileBuildInfo(
@@ -113,12 +117,12 @@ class LazySolidityBuildSystem implements SolidityBuildSystem {
     options?: CompileBuildInfoOptions,
   ): Promise<CompilerOutput> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.compileBuildInfo(buildInfo, options);
+    return await buildSystem.compileBuildInfo(buildInfo, options);
   }
 
   public async getArtifactsDirectory(scope: BuildScope): Promise<string> {
     const buildSystem = await this.#getBuildSystem();
-    return buildSystem.getArtifactsDirectory(scope);
+    return await buildSystem.getArtifactsDirectory(scope);
   }
 
   async #getBuildSystem(): Promise<SolidityBuildSystem> {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/index.ts
@@ -32,7 +32,7 @@ const buildTask = task("build", "Build project")
     name: "noContracts",
     description: "Skip solidity contracts compilation",
   })
-  .setAction(async () => import("./tasks/build.js"))
+  .setAction(async () => await import("./tasks/build.js"))
   .build();
 
 const hardhatPlugin: HardhatPlugin = {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/solidity-hooks.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/solidity-hooks.ts
@@ -46,7 +46,7 @@ export async function getSolcCompilerForConfig(
   compilerConfig: SolidityCompilerConfig,
   buildProfilePreferWasm: boolean,
 ): Promise<Compiler> {
-  return getCompiler(compilerConfig.version, {
+  return await getCompiler(compilerConfig.version, {
     preferWasm: resolvePreferWasm(compilerConfig, buildProfilePreferWasm),
     compilerPath: compilerConfig.path,
   });

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/tasks/build.ts
@@ -119,7 +119,7 @@ const buildAction: NewTaskActionFunction<BuildActionArguments> = async (
     return { contractRootPaths, testRootPaths };
   }
 
-  return runSolidityBuild({
+  return await runSolidityBuild({
     buildProfile,
     files,
     force: args.force,
@@ -208,7 +208,7 @@ async function runSolidityBuild({
     return { contractRootPaths, testRootPaths };
   }
 
-  return partitionRootPathsByScope(solidity, builtRootPaths);
+  return await partitionRootPathsByScope(solidity, builtRootPaths);
 }
 
 /**
@@ -237,7 +237,7 @@ async function getRootsToBuild({
   isFullBuild: boolean;
 }> {
   if (isUnifiedModeOrScope === true) {
-    return getRootsToBuildInUnifiedMode({
+    return await getRootsToBuildInUnifiedMode({
       files,
       noContracts,
       noTests,
@@ -245,7 +245,7 @@ async function getRootsToBuild({
     });
   }
 
-  return getRootsToBuildForScope({
+  return await getRootsToBuildForScope({
     files,
     scope: isUnifiedModeOrScope,
     solidity,

--- a/packages/hardhat/src/internal/builtin-plugins/telemetry/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/telemetry/index.ts
@@ -14,7 +14,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "disable",
         description: "Disable telemetry",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   npmPackage: "hardhat",

--- a/packages/hardhat/src/internal/builtin-plugins/test/hook-handlers/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/hook-handlers/config.ts
@@ -14,7 +14,7 @@ export default async (): Promise<Partial<ConfigHooks>> => {
         resolveConfigurationVariable,
       );
 
-      return resolveTestUserConfig(userConfig, resolvedConfig);
+      return await resolveTestUserConfig(userConfig, resolvedConfig);
     },
   };
 

--- a/packages/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -32,7 +32,7 @@ const hardhatPlugin: HardhatPlugin = {
         name: "noCompile",
         description: "Do not compile the project before running the tests",
       })
-      .setAction(async () => import("./task-action.js"))
+      .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
   dependencies: () => [import("../solidity/index.js")],

--- a/packages/hardhat/src/internal/cli/telemetry/analytics/analytics.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/analytics/analytics.ts
@@ -60,7 +60,7 @@ export async function sendTaskAnalytics(taskId: string[]): Promise<boolean> {
     },
   };
 
-  return sendAnalytics(taskAnalyticsEvent);
+  return await sendAnalytics(taskAnalyticsEvent);
 }
 
 export async function sendProjectTypeAnalytics(
@@ -75,7 +75,7 @@ export async function sendProjectTypeAnalytics(
     },
   };
 
-  return sendAnalytics(initAnalyticsEvent);
+  return await sendAnalytics(initAnalyticsEvent);
 }
 
 // Return a boolean for testing purposes to confirm whether analytics were sent based on the consent value and not in CI environments

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/anonymizer.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/anonymizer.ts
@@ -359,7 +359,7 @@ export class Anonymizer {
   async #anonymizeFrames(frames: StackFrame[]): Promise<StackFrame[]> {
     const anonymizedFrames = await Promise.all(
       frames.map(async (frame) => {
-        return this.#anonymizeFrame(frame);
+        return await this.#anonymizeFrame(frame);
       }),
     );
     return anonymizedFrames;

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/reporter.ts
@@ -28,7 +28,7 @@ export async function sendErrorTelemetry(
   hint?: { unhandled?: boolean; mechanismType?: string },
 ): Promise<boolean> {
   const instance = await Reporter.getInstance();
-  return instance.reportErrorViaSubprocess(error, hint);
+  return await instance.reportErrorViaSubprocess(error, hint);
 }
 
 export function setCliHardhatConfigPath(configPath: string): void {

--- a/packages/hardhat/src/internal/cli/telemetry/sentry/transport.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/sentry/transport.ts
@@ -139,7 +139,7 @@ export async function sendEnvelopeToSentryBackend(
   dsn: string,
   envelope: Envelope,
 ): Promise<TransportMakeRequestResponse> {
-  return sendSerializedEnvelopeToSentryBackend(
+  return await sendSerializedEnvelopeToSentryBackend(
     dsn,
     serializeEnvelope(envelope),
   );

--- a/packages/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/telemetry-permissions.ts
@@ -35,7 +35,7 @@ export async function isTelemetryAllowed(
     return process.env.HARDHAT_TEST_TELEMETRY_ENABLED === "true" ? true : false;
   }
 
-  return isTelemetryEnabled(telemetryConfigFilePath);
+  return await isTelemetryEnabled(telemetryConfigFilePath);
 }
 
 /**

--- a/packages/hardhat/src/internal/config-loading.ts
+++ b/packages/hardhat/src/internal/config-loading.ts
@@ -34,15 +34,15 @@ export async function resolveHardhatConfigPath(
   userProvidedPath?: string,
 ): Promise<string> {
   if (userProvidedPath !== undefined) {
-    return normalizeConfigPath(userProvidedPath);
+    return await normalizeConfigPath(userProvidedPath);
   }
 
   if (process.env.HARDHAT_CONFIG !== undefined) {
     log("Using config file path from the HARDHAT_CONFIG env var");
-    return normalizeConfigPath(process.env.HARDHAT_CONFIG);
+    return await normalizeConfigPath(process.env.HARDHAT_CONFIG);
   }
 
-  return findClosestHardhatConfig();
+  return await findClosestHardhatConfig();
 }
 
 /**

--- a/packages/hardhat/src/internal/core/configuration-variables.ts
+++ b/packages/hardhat/src/internal/core/configuration-variables.ts
@@ -118,24 +118,25 @@ export class LazyResolvedConfigurationVariable extends BaseResolvedConfiguration
     const mutex = LazyResolvedConfigurationVariable.#mutexes.get(this.#hooks);
     assertHardhatInvariant(mutex !== undefined, "Mutex must be defined");
 
-    return mutex.exclusiveRun(async () =>
-      this.#hooks.runHandlerChain(
-        "configurationVariables",
-        "fetchValue",
-        [this.#variable],
-        async (_context, v) => {
-          const value = process.env[v.name];
+    return await mutex.exclusiveRun(
+      async () =>
+        await this.#hooks.runHandlerChain(
+          "configurationVariables",
+          "fetchValue",
+          [this.#variable],
+          async (_context, v) => {
+            const value = process.env[v.name];
 
-          if (typeof value !== "string") {
-            throw new HardhatError(
-              HardhatError.ERRORS.CORE.GENERAL.ENV_VAR_NOT_FOUND,
-              { name: v.name },
-            );
-          }
+            if (typeof value !== "string") {
+              throw new HardhatError(
+                HardhatError.ERRORS.CORE.GENERAL.ENV_VAR_NOT_FOUND,
+                { name: v.name },
+              );
+            }
 
-          return value;
-        },
-      ),
+            return value;
+          },
+        ),
     );
   }
 }

--- a/packages/hardhat/src/internal/core/hook-manager.ts
+++ b/packages/hardhat/src/internal/core/hook-manager.ts
@@ -124,7 +124,7 @@ export class HookManagerImplementation implements HookManager {
       return result;
     };
 
-    return next(...handlerParams);
+    return await next(...handlerParams);
   }
 
   public async runSequentialHandlers<
@@ -192,7 +192,7 @@ export class HookManagerImplementation implements HookManager {
       handlerParams = params;
     }
 
-    return Promise.all(
+    return await Promise.all(
       handlers.map((handler) => (handler as any)(...handlerParams)),
     );
   }
@@ -277,7 +277,7 @@ export class HookManagerImplementation implements HookManager {
     const categories: Array<
       Partial<HardhatHooks[HookCategoryNameT]> | undefined
     > = await this.#mutex.exclusiveRun(async () => {
-      return Promise.all(
+      return await Promise.all(
         this.#pluginsInReverseOrder.map(async (plugin) => {
           const existingCategory = this.#staticHookHandlerCategories
             .get(plugin.id)

--- a/packages/hardhat/src/internal/core/hre.ts
+++ b/packages/hardhat/src/internal/core/hre.ts
@@ -193,7 +193,9 @@ export class HardhatRuntimeEnvironmentImplementation
 export async function resolveProjectRoot(
   absolutePathWithinProject: string | undefined,
 ): Promise<string> {
-  return findClosestPackageRoot(absolutePathWithinProject ?? process.cwd());
+  return await findClosestPackageRoot(
+    absolutePathWithinProject ?? process.cwd(),
+  );
 }
 
 /**
@@ -292,7 +294,7 @@ async function runUserConfigExtensions(
   hooks: HookManager,
   config: HardhatUserConfig,
 ): Promise<HardhatUserConfig> {
-  return hooks.runHandlerChain(
+  return await hooks.runHandlerChain(
     "config",
     "extendUserConfig",
     [config],
@@ -320,7 +322,7 @@ async function resolveUserConfig(
     paths: resolvePaths(projectRoot, configPath, config.paths),
   } as HardhatConfig;
 
-  return hooks.runHandlerChain(
+  return await hooks.runHandlerChain(
     "config",
     "resolveUserConfig",
     [config, (variable) => resolveConfigurationVariable(hooks, variable)],

--- a/packages/hardhat/src/internal/core/plugins/resolve-plugin-list.ts
+++ b/packages/hardhat/src/internal/core/plugins/resolve-plugin-list.ts
@@ -12,7 +12,7 @@ export async function resolvePluginList(
   projectRoot: string,
   userConfigPluginList: HardhatPlugin[] = [],
 ): Promise<HardhatPlugin[]> {
-  return reverseTopologicalSort(projectRoot, userConfigPluginList);
+  return await reverseTopologicalSort(projectRoot, userConfigPluginList);
 }
 
 /**

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -175,13 +175,13 @@ export class ResolvedTask implements Task {
       if (currentIndex === 0) {
         /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
         We know that the first action in the array is a NewTaskActionFunction */
-        return (actionFn as NewTaskActionFunction)(
+        return await (actionFn as NewTaskActionFunction)(
           nextTaskArguments,
           this.#hre,
         );
       }
 
-      return actionFn(
+      return await actionFn(
         nextTaskArguments,
         this.#hre,
         async (newTaskArguments: TaskArguments) => {

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -185,12 +185,12 @@ export class ResolvedTask implements Task {
         nextTaskArguments,
         this.#hre,
         async (newTaskArguments: TaskArguments) => {
-          return next(newTaskArguments, currentIndex - 1);
+          return await next(newTaskArguments, currentIndex - 1);
         },
       );
     };
 
-    return next(validatedTaskArguments);
+    return await next(validatedTaskArguments);
   }
 
   /**

--- a/packages/hardhat/src/internal/core/user-interruptions.ts
+++ b/packages/hardhat/src/internal/core/user-interruptions.ts
@@ -21,8 +21,8 @@ export class UserInterruptionManagerImplementation
     interruptor: string,
     message: string,
   ): Promise<void> {
-    return this.#mutex.exclusiveRun(async () => {
-      return this.#hooks.runHandlerChain(
+    return await this.#mutex.exclusiveRun(async () => {
+      return await this.#hooks.runHandlerChain(
         "userInterruptions",
         "displayMessage",
         [interruptor, message],
@@ -35,8 +35,8 @@ export class UserInterruptionManagerImplementation
     interruptor: string,
     inputDescription: string,
   ): Promise<string> {
-    return this.#mutex.exclusiveRun(async () => {
-      return this.#hooks.runHandlerChain(
+    return await this.#mutex.exclusiveRun(async () => {
+      return await this.#hooks.runHandlerChain(
         "userInterruptions",
         "requestInput",
         [interruptor, inputDescription],
@@ -49,8 +49,8 @@ export class UserInterruptionManagerImplementation
     interruptor: string,
     inputDescription: string,
   ): Promise<string> {
-    return this.#mutex.exclusiveRun(async () => {
-      return this.#hooks.runHandlerChain(
+    return await this.#mutex.exclusiveRun(async () => {
+      return await this.#hooks.runHandlerChain(
         "userInterruptions",
         "requestSecretInput",
         [interruptor, inputDescription],
@@ -62,7 +62,7 @@ export class UserInterruptionManagerImplementation
   public async uninterrupted<ReturnT>(
     f: () => ReturnT,
   ): Promise<Awaited<ReturnT>> {
-    return this.#mutex.exclusiveRun(f);
+    return await this.#mutex.exclusiveRun(f);
   }
 }
 
@@ -84,7 +84,7 @@ async function defaultRequestInput(
     output: process.stdout,
   });
 
-  return new Promise<string>((resolve) => {
+  return await new Promise<string>((resolve) => {
     rl.question(
       chalk.blue(`[${interruptor}]`) + ` ${inputDescription}: `,
       (answer) => {
@@ -138,7 +138,7 @@ async function defaultRequestSecretInput(
     }
   };
 
-  return new Promise<string>((resolve) => {
+  return await new Promise<string>((resolve) => {
     rl.question(
       chalk.blue(`[${interruptor}]`) + ` ${inputDescription}: `,
       (answer) => {

--- a/packages/hardhat/src/internal/hre-initialization.ts
+++ b/packages/hardhat/src/internal/hre-initialization.ts
@@ -65,7 +65,7 @@ export async function createHardhatRuntimeEnvironment(
     unsafeOptions.globalOptionDefinitions = globalOptionDefinitions;
   }
 
-  return HardhatRuntimeEnvironmentImplementation.create(
+  return await HardhatRuntimeEnvironmentImplementation.create(
     config,
     userProvidedGlobalOptions,
     resolvedProjectRoot,

--- a/packages/hardhat/test/internal/builtin-plugins/flatten/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/flatten/task-action.ts
@@ -50,7 +50,7 @@ async function assertFlattenedFilesResult(flattened: string) {
 }
 
 async function createHRE() {
-  return createHardhatRuntimeEnvironment({}, {}, process.cwd());
+  return await createHardhatRuntimeEnvironment({}, {}, process.cwd());
 }
 
 describe("flatten/task-action", () => {

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/http-provider.ts
@@ -480,7 +480,7 @@ describe("http-provider", () => {
             result: expectedChainId,
           };
         } else {
-          return fetch(request);
+          return await fetch(request);
         }
       };
 

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -682,7 +682,7 @@ describe("NetworkManagerImplementation", () => {
         const networkHooks: Partial<NetworkHooks> = {
           newConnection: async (context, next) => {
             hookCalled = true;
-            return next(context);
+            return await next(context);
           },
         };
 
@@ -891,7 +891,7 @@ describe("NetworkManagerImplementation", () => {
             const handlers: Partial<ConfigHooks> = {
               resolveUserConfig: async (userConfig, rCV, next) => {
                 resolveUserConfigCallCount++;
-                return next(userConfig, rCV);
+                return await next(userConfig, rCV);
               },
             };
             return handlers;
@@ -1238,7 +1238,7 @@ describe("NetworkManagerImplementation", () => {
         next,
       ) => {
         hookCalled = true;
-        return next(context, networkConnection, jsonRpcRequest);
+        return await next(context, networkConnection, jsonRpcRequest);
       };
       const networkHooks: Partial<NetworkHooks> = {
         onRequest,

--- a/packages/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts
@@ -378,7 +378,7 @@ async function postRawJsonRpc(
   port: number,
   rawBody: string,
 ): Promise<unknown> {
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     const req = http.request(
       {
         hostname,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -75,7 +75,12 @@ async function _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
     builtinPlugin,
   ]);
 
-  return createHardhatRuntimeEnvironment(config, {}, resolvedProjectRoot, {
-    resolvedPlugins,
-  });
+  return await createHardhatRuntimeEnvironment(
+    config,
+    {},
+    resolvedProjectRoot,
+    {
+      resolvedPlugins,
+    },
+  );
 }

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job.ts
@@ -301,7 +301,7 @@ describe("CompilationJobImplementation", () => {
             next,
           ) => {
             solcInput.sources.test = { content: "test" };
-            return next(context, solcInput);
+            return await next(context, solcInput);
           },
         });
         assert.notEqual(
@@ -327,7 +327,13 @@ describe("CompilationJobImplementation", () => {
             solcVersion,
             next,
           ) => {
-            return next(context, inputSourceName, fsPath, "test", solcVersion);
+            return await next(
+              context,
+              inputSourceName,
+              fsPath,
+              "test",
+              solcVersion,
+            );
           },
         });
         assert.notEqual(
@@ -667,7 +673,7 @@ describe("CompilationJobImplementation", () => {
             next,
           ) => {
             solcInput.sources.test = { content };
-            return next(context, solcInput);
+            return await next(context, solcInput);
           },
         });
       });
@@ -707,7 +713,7 @@ describe("CompilationJobImplementation", () => {
             solcVersion,
             next,
           ) => {
-            return next(
+            return await next(
               context,
               name ?? inputSourceName,
               path ?? fsPath,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -230,7 +230,7 @@ describe(
           process.cwd(),
           async (url, destination, requestOptions, dispatcherOptions) => {
             if (stopMocking) {
-              return download(
+              return await download(
                 url,
                 destination,
                 requestOptions,
@@ -240,7 +240,7 @@ describe(
 
             if (!hasDownloadedOnce) {
               hasDownloadedOnce = true;
-              return download(
+              return await download(
                 url,
                 destination,
                 requestOptions,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/build-scopes.ts
@@ -56,7 +56,7 @@ function makeBuildHookAddingPlugin(
               const nextRoots = shouldAdd
                 ? [...rootFilePaths, extraFile]
                 : rootFilePaths;
-              return next(context, nextRoots, options);
+              return await next(context, nextRoots, options);
             },
           };
           return handlers;

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/tool-versions.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/tool-versions.ts
@@ -30,7 +30,7 @@ async function readBuildInfo(
   const buildInfoPath = await hre.artifacts.getBuildInfoPath(buildInfoId);
   assert.ok(buildInfoPath !== undefined, "Expected build info path to exist");
 
-  return readJsonFile<SolidityBuildInfo>(buildInfoPath);
+  return await readJsonFile<SolidityBuildInfo>(buildInfoPath);
 }
 
 describe(

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/helpers.ts
@@ -17,7 +17,7 @@ import { createHardhatRuntimeEnvironment } from "../../../../../../src/internal/
 export async function getHRE(
   project: TestProject,
 ): Promise<HardhatRuntimeEnvironment> {
-  return createHardhatRuntimeEnvironment(
+  return await createHardhatRuntimeEnvironment(
     {
       solidity: {
         profiles: {
@@ -103,7 +103,7 @@ export class TestProjectWrapper {
       .filter((filePath) => !filePath.endsWith(".output.json"))
       .map((basename) => path.join(this.buildInfosBasePath(), basename));
 
-    return Promise.all(
+    return await Promise.all(
       filePaths.map(async (filePath) => {
         const modificationTime = await this.getModificationTime(filePath);
         const buildId = path.basename(filePath).replace(".json", "");
@@ -132,7 +132,7 @@ export class TestProjectWrapper {
       .filter((filePath) => filePath.endsWith(".output.json"))
       .map((basename) => path.join(this.buildInfosBasePath(), basename));
 
-    return Promise.all(
+    return await Promise.all(
       filePaths.map(async (filePath) => ({
         path: filePath,
         modificationTime: await this.getModificationTime(filePath),
@@ -146,7 +146,7 @@ export class TestProjectWrapper {
   }
 
   public async getArtifactFolders(): Promise<string[]> {
-    return readdir(this.artifactsBasePath());
+    return await readdir(this.artifactsBasePath());
   }
 
   public async getArtifacts(): Promise<Record<string, FileDetail[]>> {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/output-layout-cache.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/output-layout-cache.ts
@@ -22,7 +22,7 @@ async function getHREWithSplitConfig(
   projectPath: string,
   splitTestsCompilation: boolean,
 ) {
-  return createHardhatRuntimeEnvironment(
+  return await createHardhatRuntimeEnvironment(
     {
       solidity: {
         profiles: {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/helpers.ts
@@ -122,7 +122,7 @@ export async function useTestProjectTemplate(
       return hre;
     },
     [Symbol.asyncDispose]: async () => {
-      return project.clean();
+      return await project.clean();
     },
   };
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
@@ -2051,7 +2051,7 @@ d/=../node_modules/d/`,
         defaultBehavior,
       ) => {
         hookCalls.push({ name, version, path: packagePath });
-        return defaultBehavior(name, version, packagePath);
+        return await defaultBehavior(name, version, packagePath);
       };
 
       const graph = await RemappedNpmPackagesGraphImplementation.create(
@@ -2121,7 +2121,7 @@ d/=../node_modules/d/`,
         defaultBehavior,
       ) => {
         hookCalls.push({ name, version, path: packagePath });
-        return defaultBehavior(name, version, packagePath);
+        return await defaultBehavior(name, version, packagePath);
       };
 
       const graph = await RemappedNpmPackagesGraphImplementation.create(

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
@@ -248,7 +248,7 @@ describe("solidity - hooks", () => {
                     // Filter to only first file
                     modifiedRootFilePaths = rootFilePaths.slice(0, 1);
 
-                    return next(context, modifiedRootFilePaths, {
+                    return await next(context, modifiedRootFilePaths, {
                       ...options,
                       force: true,
                     });
@@ -542,7 +542,7 @@ describe("solidity - hooks", () => {
                   capturedConfig = compilerConfig;
 
                   // Fall through to the default handler (solc)
-                  return next(context, compilerConfig);
+                  return await next(context, compilerConfig);
                 },
               };
 
@@ -608,7 +608,7 @@ describe("solidity - hooks", () => {
                   if ((compilerConfig.type as string) === "custom") {
                     return customCompiler;
                   }
-                  return next(_context, compilerConfig);
+                  return await next(_context, compilerConfig);
                 },
               };
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
@@ -67,7 +67,7 @@ contract AddedByHook {}`,
                     );
 
                     // Add extra file to the build
-                    return next(
+                    return await next(
                       context,
                       [...rootFilePaths, extraFile],
                       options,
@@ -194,7 +194,7 @@ contract Filter {}`,
                     const filteredPaths = rootFilePaths.filter(
                       (p) => !p.includes("Filter"),
                     );
-                    return next(context, filteredPaths, options);
+                    return await next(context, filteredPaths, options);
                   },
                 };
 
@@ -525,7 +525,7 @@ describe("build task - unified mode cleanup", () => {
                 ) => Promise<void>,
               ) => {
                 receivedArtifactPaths.push(...artifactPaths);
-                return next(_context, artifactPaths);
+                return await next(_context, artifactPaths);
               },
             };
 

--- a/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
@@ -314,7 +314,7 @@ describe("test/task-action", function () {
       buildOverride: ReturnType<typeof buildArgCaptor>["buildOverride"],
       splitTestsCompilation: boolean,
     ): Promise<HardhatRuntimeEnvironment> {
-      return createHardhatRuntimeEnvironment({
+      return await createHardhatRuntimeEnvironment({
         ...(splitTestsCompilation
           ? {
               solidity: {
@@ -368,7 +368,7 @@ describe("test/task-action", function () {
             default: async () => ({
               registerFileForTestRunner: async (context, filePath, next) => {
                 if (filePath === "runner-a-test.ts") return "runner-a";
-                return next(context, filePath);
+                return await next(context, filePath);
               },
             }),
           }),

--- a/packages/hardhat/test/internal/cli/init/init.ts
+++ b/packages/hardhat/test/internal/cli/init/init.ts
@@ -56,7 +56,7 @@ describe("getWorkspace", () => {
       await writeUtf8File(filePath, "some content");
 
       await assertRejectsWithHardhatError(
-        async () => getWorkspace(filePath),
+        async () => await getWorkspace(filePath),
         HardhatError.ERRORS.CORE.GENERAL.WORKSPACE_MUST_BE_A_DIRECTORY,
         {
           workspace: path.resolve(filePath),
@@ -69,7 +69,7 @@ describe("getWorkspace", () => {
     await ensureDir("hardhat-project");
     await writeUtf8File("hardhat.config.ts", "");
     await assertRejectsWithHardhatError(
-      async () => getWorkspace("hardhat-project"),
+      async () => await getWorkspace("hardhat-project"),
       HardhatError.ERRORS.CORE.GENERAL.HARDHAT_PROJECT_ALREADY_CREATED,
       {
         hardhatProjectRootPath: path.join(process.cwd(), "hardhat.config.ts"),
@@ -82,7 +82,7 @@ describe("getWorkspace", () => {
 describe("getTemplate", () => {
   it("should throw if the provided template does not exist", async () => {
     await assertRejectsWithHardhatError(
-      async () => getTemplate("hardhat-3", "non-existent-template"),
+      async () => await getTemplate("hardhat-3", "non-existent-template"),
       HardhatError.ERRORS.CORE.GENERAL.TEMPLATE_NOT_FOUND,
       {
         template: "non-existent-template",
@@ -145,7 +145,7 @@ describe("validatePackageJson", () => {
 
     await assertRejectsWithHardhatError(
       async () =>
-        validatePackageJson(
+        await validatePackageJson(
           process.cwd(),
           {
             name: "package-name",

--- a/packages/hardhat/test/internal/cli/init/prompt.ts
+++ b/packages/hardhat/test/internal/cli/init/prompt.ts
@@ -14,7 +14,7 @@ describe("promptForWorkspace", () => {
   it("should fail if the user is not in an interactive shell", async () => {
     if (!process.stdout.isTTY) {
       await assertRejectsWithHardhatError(
-        async () => promptForWorkspace(),
+        async () => await promptForWorkspace(),
         HardhatError.ERRORS.CORE.GENERAL.NOT_IN_INTERACTIVE_SHELL,
         {},
       );
@@ -26,7 +26,7 @@ describe("promptForTemplate", () => {
   it("should fail if the user is not in an interactive shell", async () => {
     if (!process.stdout.isTTY) {
       await assertRejectsWithHardhatError(
-        async () => promptForTemplate([]),
+        async () => await promptForTemplate([]),
         HardhatError.ERRORS.CORE.GENERAL.NOT_IN_INTERACTIVE_SHELL,
         {},
       );
@@ -38,7 +38,7 @@ describe("promptForForce", () => {
   it("should fail if the user is not in an interactive shell", async () => {
     if (!process.stdout.isTTY) {
       await assertRejectsWithHardhatError(
-        async () => promptForForce([]),
+        async () => await promptForForce([]),
         HardhatError.ERRORS.CORE.GENERAL.NOT_IN_INTERACTIVE_SHELL,
         {},
       );
@@ -50,7 +50,7 @@ describe("promptForInstall", () => {
   it("should fail if the user is not in an interactive shell", async () => {
     if (!process.stdout.isTTY) {
       await assertRejectsWithHardhatError(
-        async () => promptForInstall("foo"),
+        async () => await promptForInstall("foo"),
         HardhatError.ERRORS.CORE.GENERAL.NOT_IN_INTERACTIVE_SHELL,
         {},
       );

--- a/packages/hardhat/test/internal/cli/main.ts
+++ b/packages/hardhat/test/internal/cli/main.ts
@@ -533,7 +533,8 @@ GLOBAL OPTIONS:
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
       await assertRejectsWithHardhatError(
-        async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
+        async () =>
+          await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.CORE.ARGUMENTS.CANNOT_COMBINE_INIT_AND_CONFIG_PATH,
         {},
       );
@@ -546,7 +547,8 @@ GLOBAL OPTIONS:
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
       await assertRejectsWithHardhatError(
-        async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
+        async () =>
+          await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.CORE.ARGUMENTS.DUPLICATED_NAME,
         {
           name: "--config",
@@ -561,7 +563,8 @@ GLOBAL OPTIONS:
       const usedCliArguments = new Array(cliArguments.length).fill(false);
 
       await assertRejectsWithHardhatError(
-        async () => parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
+        async () =>
+          await parseBuiltinGlobalOptions(cliArguments, usedCliArguments),
         HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_CONFIG_FILE,
         {},
       );

--- a/packages/hardhat/test/internal/cli/telemetry/helpers.ts
+++ b/packages/hardhat/test/internal/cli/telemetry/helpers.ts
@@ -26,7 +26,7 @@ export async function checkIfSubprocessWasExecuted(
   // within a specified number of attempts, an error is thrown, indicating a failure in subprocess execution.
   const MAX_COUNTER = 100;
 
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     let counter = 0;
 
     const intervalId = setInterval(async () => {

--- a/packages/hardhat/test/internal/core/config-validation.ts
+++ b/packages/hardhat/test/internal/core/config-validation.ts
@@ -1943,9 +1943,14 @@ describe("resolved config validation", function () {
     const resolvedPlugins = await resolvePluginList(resolvedProjectRoot, [
       plugin,
     ]);
-    return createHardhatRuntimeEnvironment(config, {}, resolvedProjectRoot, {
-      resolvedPlugins,
-    });
+    return await createHardhatRuntimeEnvironment(
+      config,
+      {},
+      resolvedProjectRoot,
+      {
+        resolvedPlugins,
+      },
+    );
   }
 
   it("should throw INVALID_RESOLVED_CONFIG when validateResolvedConfig returns errors", async function () {

--- a/packages/hardhat/test/internal/core/plugins/detect-plugin-npm-dependency-problems.ts
+++ b/packages/hardhat/test/internal/core/plugins/detect-plugin-npm-dependency-problems.ts
@@ -67,7 +67,7 @@ describe("Plugins - detect npm dependency problems", () => {
 
       await assertRejectsWithHardhatError(
         async () =>
-          detectPluginNpmDependencyProblems(
+          await detectPluginNpmDependencyProblems(
             nonInstalledPackageProjectFixture,
             plugin,
             originalError,
@@ -87,7 +87,7 @@ describe("Plugins - detect npm dependency problems", () => {
 
       await assertRejectsWithHardhatError(
         async () =>
-          detectPluginNpmDependencyProblems(
+          await detectPluginNpmDependencyProblems(
             nonInstalledPackageProjectFixture,
             {
               ...pluginWithNpmPackageUndefined,
@@ -159,7 +159,7 @@ describe("Plugins - detect npm dependency problems", () => {
 
       await assertRejectsWithHardhatError(
         async () =>
-          detectPluginNpmDependencyProblems(
+          await detectPluginNpmDependencyProblems(
             peerDepWithWrongVersionFixture,
             plugin,
             originalError,

--- a/packages/hardhat/test/internal/core/plugins/resolve-plugin-list.ts
+++ b/packages/hardhat/test/internal/core/plugins/resolve-plugin-list.ts
@@ -201,7 +201,7 @@ describe("Plugins - resolve plugin list", () => {
     const copy = { id: "dup" };
 
     await assertRejectsWithHardhatError(
-      async () => resolvePluginList(installedPackageFixture, [a, copy]),
+      async () => await resolvePluginList(installedPackageFixture, [a, copy]),
       HardhatError.ERRORS.CORE.GENERAL.DUPLICATED_PLUGIN_ID,
       {
         id: "dup",
@@ -218,7 +218,7 @@ describe("Plugins - resolve plugin list", () => {
       };
 
       await assertRejectsWithHardhatError(
-        async () => resolvePluginList(installedPackageFixture, [plugin]),
+        async () => await resolvePluginList(installedPackageFixture, [plugin]),
         HardhatError.ERRORS.CORE.PLUGINS.PLUGIN_DEPENDENCY_FAILED_LOAD,
         { pluginId: plugin.id },
       );
@@ -236,7 +236,8 @@ describe("Plugins - resolve plugin list", () => {
       };
 
       await assertRejectsWithHardhatError(
-        async () => resolvePluginList(notInstalledPackageFixture, [plugin]),
+        async () =>
+          await resolvePluginList(notInstalledPackageFixture, [plugin]),
         HardhatError.ERRORS.CORE.PLUGINS.PLUGIN_NOT_INSTALLED,
         {
           pluginId: "example",

--- a/packages/hardhat/test/test-helpers/create-mock-hardhat-runtime-environment.ts
+++ b/packages/hardhat/test/test-helpers/create-mock-hardhat-runtime-environment.ts
@@ -19,12 +19,12 @@ export async function createMockHardhatRuntimeEnvironment(
 ): Promise<HardhatRuntimeEnvironment & { artifacts: MockArtifactManager }> {
   /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
   We know that the mockArtifactPlugin sets `hre.artifacts` to `MockArtifactManager */
-  return createHardhatRuntimeEnvironment(
+  return await (createHardhatRuntimeEnvironment(
     { ...config, plugins: [mockArtifactsPlugin, ...(config.plugins ?? [])] },
     userProvidedGlobalOptions,
     projectRoot,
     unsafeOptions,
-  ) as Promise<HardhatRuntimeEnvironment & { artifacts: MockArtifactManager }>;
+  ) as Promise<HardhatRuntimeEnvironment & { artifacts: MockArtifactManager }>);
 }
 
 const mockArtifactsPlugin: HardhatPlugin = {

--- a/packages/ignition-core/src/deploy.ts
+++ b/packages/ignition-core/src/deploy.ts
@@ -149,7 +149,7 @@ export async function deploy<
     executionEventListener,
   );
 
-  return deployer.deploy(
+  return await deployer.deploy(
     ignitionModule,
     deploymentParameters,
     accounts,

--- a/packages/ignition-core/src/internal/deployment-loader/ephemeral-deployment-loader.ts
+++ b/packages/ignition-core/src/internal/deployment-loader/ephemeral-deployment-loader.ts
@@ -99,7 +99,7 @@ export class EphemeralDeploymentLoader implements DeploymentLoader {
           `Unable to load artifact, underlying resolver returned undefined for ${saved.contractName}`,
         );
 
-        return fileArtifact;
+        return await fileArtifact;
       }
     }
   }

--- a/packages/ignition-core/src/internal/execution/future-processor/future-processor.ts
+++ b/packages/ignition-core/src/internal/execution/future-processor/future-processor.ts
@@ -183,7 +183,7 @@ export class FutureProcessor {
   ): Promise<JournalMessage | undefined> {
     switch (nextAction) {
       case NextAction.RUN_STRATEGY:
-        return runStrategy(exState, this._executionStrategy);
+        return await runStrategy(exState, this._executionStrategy);
 
       case NextAction.SEND_TRANSACTION:
         assertIgnitionInvariant(
@@ -191,7 +191,7 @@ export class FutureProcessor {
           `Unexpected transaction request in StaticCallExecutionState ${exState.id}`,
         );
 
-        return sendTransaction(
+        return await sendTransaction(
           exState,
           this._executionStrategy,
           this._jsonRpcClient,
@@ -201,7 +201,7 @@ export class FutureProcessor {
         );
 
       case NextAction.QUERY_STATIC_CALL:
-        return queryStaticCall(exState, this._jsonRpcClient);
+        return await queryStaticCall(exState, this._jsonRpcClient);
 
       case NextAction.MONITOR_ONCHAIN_INTERACTION:
         assertIgnitionInvariant(
@@ -209,7 +209,7 @@ export class FutureProcessor {
           `Unexpected transaction request in StaticCallExecutionState ${exState.id}`,
         );
 
-        return monitorOnchainInteraction({
+        return await monitorOnchainInteraction({
           exState,
           jsonRpcClient: this._jsonRpcClient,
           transactionTrackingTimer: this._transactionTrackingTimer,

--- a/packages/ignition-core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
+++ b/packages/ignition-core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
@@ -38,7 +38,7 @@ export async function runStaticCall(
   client: JsonRpcClient,
   staticCall: StaticCall,
 ): Promise<RawStaticCallResult> {
-  return client.call(
+  return await client.call(
     {
       from: staticCall.from,
       to: staticCall.to,

--- a/packages/ignition-core/src/internal/execution/future-processor/helpers/replay-strategy.ts
+++ b/packages/ignition-core/src/internal/execution/future-processor/helpers/replay-strategy.ts
@@ -184,22 +184,22 @@ export async function replayStrategy(
 > {
   switch (executionState.type) {
     case ExecutionSateType.DEPLOYMENT_EXECUTION_STATE:
-      return replayExecutionStrategyWithOnchainInteractions(
+      return await replayExecutionStrategyWithOnchainInteractions(
         executionState,
         strategy,
       );
     case ExecutionSateType.CALL_EXECUTION_STATE:
-      return replayExecutionStrategyWithOnchainInteractions(
+      return await replayExecutionStrategyWithOnchainInteractions(
         executionState,
         strategy,
       );
     case ExecutionSateType.SEND_DATA_EXECUTION_STATE:
-      return replayExecutionStrategyWithOnchainInteractions(
+      return await replayExecutionStrategyWithOnchainInteractions(
         executionState,
         strategy,
       );
     case ExecutionSateType.STATIC_CALL_EXECUTION_STATE:
-      return replayStaticCallExecutionStrategy(executionState, strategy);
+      return await replayStaticCallExecutionStrategy(executionState, strategy);
   }
 }
 

--- a/packages/ignition-core/src/internal/execution/future-processor/helpers/save-artifacts-for-future.ts
+++ b/packages/ignition-core/src/internal/execution/future-processor/helpers/save-artifacts-for-future.ts
@@ -18,14 +18,14 @@ export async function saveArtifactsForFuture(
     case FutureType.NAMED_ARTIFACT_CONTRACT_DEPLOYMENT:
     case FutureType.NAMED_ARTIFACT_LIBRARY_DEPLOYMENT:
     case FutureType.NAMED_ARTIFACT_CONTRACT_AT:
-      return _storeArtifactAndBuildInfoAgainstDeployment(future, {
+      return await _storeArtifactAndBuildInfoAgainstDeployment(future, {
         artifactResolver,
         deploymentLoader,
       });
     case FutureType.CONTRACT_DEPLOYMENT:
     case FutureType.LIBRARY_DEPLOYMENT:
     case FutureType.CONTRACT_AT:
-      return deploymentLoader.storeUserProvidedArtifact(
+      return await deploymentLoader.storeUserProvidedArtifact(
         future.id,
         future.artifact,
       );

--- a/packages/ignition-core/src/internal/reconciliation/reconcile-future-specific-reconciliations.ts
+++ b/packages/ignition-core/src/internal/reconciliation/reconcile-future-specific-reconciliations.ts
@@ -35,25 +35,25 @@ export async function reconcileFutureSpecificReconciliations(
 ): Promise<ReconciliationFutureResult> {
   switch (future.type) {
     case FutureType.NAMED_ARTIFACT_CONTRACT_DEPLOYMENT:
-      return reconcileNamedContractDeployment(
+      return await reconcileNamedContractDeployment(
         future,
         executionState as DeploymentExecutionState,
         context,
       );
     case FutureType.CONTRACT_DEPLOYMENT:
-      return reconcileArtifactContractDeployment(
+      return await reconcileArtifactContractDeployment(
         future,
         executionState as DeploymentExecutionState,
         context,
       );
     case FutureType.NAMED_ARTIFACT_LIBRARY_DEPLOYMENT:
-      return reconcileNamedLibraryDeployment(
+      return await reconcileNamedLibraryDeployment(
         future,
         executionState as DeploymentExecutionState,
         context,
       );
     case FutureType.LIBRARY_DEPLOYMENT:
-      return reconcileArtifactLibraryDeployment(
+      return await reconcileArtifactLibraryDeployment(
         future,
         executionState as DeploymentExecutionState,
         context,
@@ -77,13 +77,13 @@ export async function reconcileFutureSpecificReconciliations(
         context,
       );
     case FutureType.NAMED_ARTIFACT_CONTRACT_AT:
-      return reconcileNamedContractAt(
+      return await reconcileNamedContractAt(
         future,
         executionState as ContractAtExecutionState,
         context,
       );
     case FutureType.CONTRACT_AT: {
-      return reconcileArtifactContractAt(
+      return await reconcileArtifactContractAt(
         future,
         executionState as ContractAtExecutionState,
         context,

--- a/packages/ignition-core/src/internal/validation/validate.ts
+++ b/packages/ignition-core/src/internal/validation/validate.ts
@@ -63,77 +63,77 @@ async function _validateFuture(
 ): Promise<string[]> {
   switch (future.type) {
     case FutureType.CONTRACT_DEPLOYMENT:
-      return validateArtifactContractDeployment(
+      return await validateArtifactContractDeployment(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.LIBRARY_DEPLOYMENT:
-      return validateArtifactLibraryDeployment(
+      return await validateArtifactLibraryDeployment(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.CONTRACT_AT:
-      return validateArtifactContractAt(
+      return await validateArtifactContractAt(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.NAMED_ARTIFACT_CONTRACT_DEPLOYMENT:
-      return validateNamedContractDeployment(
+      return await validateNamedContractDeployment(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.NAMED_ARTIFACT_LIBRARY_DEPLOYMENT:
-      return validateNamedLibraryDeployment(
+      return await validateNamedLibraryDeployment(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.NAMED_ARTIFACT_CONTRACT_AT:
-      return validateNamedContractAt(
+      return await validateNamedContractAt(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.CONTRACT_CALL:
-      return validateNamedContractCall(
+      return await validateNamedContractCall(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.STATIC_CALL:
-      return validateNamedStaticCall(
+      return await validateNamedStaticCall(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.ENCODE_FUNCTION_CALL:
-      return validateNamedEncodeFunctionCall(
+      return await validateNamedEncodeFunctionCall(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.READ_EVENT_ARGUMENT:
-      return validateReadEventArgument(
+      return await validateReadEventArgument(
         future,
         artifactLoader,
         deploymentParameters,
         accounts,
       );
     case FutureType.SEND_DATA:
-      return validateSendData(
+      return await validateSendData(
         future,
         artifactLoader,
         deploymentParameters,

--- a/packages/ignition-core/src/internal/wiper.ts
+++ b/packages/ignition-core/src/internal/wiper.ts
@@ -53,7 +53,7 @@ export class Wiper {
       futureId,
     };
 
-    return applyNewMessage(
+    return await applyNewMessage(
       wipeMessage,
       deploymentState,
       this._deploymentLoader,

--- a/packages/ignition-core/src/list-deployments.ts
+++ b/packages/ignition-core/src/list-deployments.ts
@@ -14,5 +14,5 @@ export async function listDeployments(
     return [];
   }
 
-  return readdir(deploymentDir);
+  return await readdir(deploymentDir);
 }

--- a/packages/ignition-core/src/track-transaction.ts
+++ b/packages/ignition-core/src/track-transaction.ts
@@ -158,7 +158,7 @@ export async function trackTransaction(
           // case 2: the user sent a different transaction that replaced ours
           // so we check their transaction for the required number of confirmations
           else {
-            return checkConfirmations(
+            return await checkConfirmations(
               exState,
               networkInteraction,
               transaction,
@@ -181,7 +181,7 @@ export async function trackTransaction(
 
           // case 4: the user sent a different transaction that replaced ours
           // so we check their transaction for the required number of confirmations
-          return checkConfirmations(
+          return await checkConfirmations(
             exState,
             networkInteraction,
             transaction,


### PR DESCRIPTION
This PR changes an eslint rule to enforce that we always use `return await promise` instead of `return promise`. This pattern has been optimized, so its performance hit is minimal, and helps preserve the async context in stack traces and performance profiles.

This PR is huge, but it's an automatic fix by eslint and prettier.