### PR TITLE
Optimize `getAllFilesMatching` and `getAllDirectoriesMatching`

### DIFF
--- a/.changeset/tough-lines-begin.md
+++ b/.changeset/tough-lines-begin.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+"hardhat": patch
+---
+
+Optimize file system traversal helpers

--- a/cspell.dictionary.txt
+++ b/cspell.dictionary.txt
@@ -29,6 +29,7 @@ dedup
 defi
 Defi
 dessant
+dirents
 distros
 DISTROS
 dorny

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -495,17 +495,24 @@ export async function readdir(absolutePathToDir: string): Promise<string[]> {
 }
 
 /**
- * Wrapper around `readdir` that returns an empty array if the directory doesn't exist.
+ * Reads a directory and returns its content as an array of strings, returning
+ * an empty array if the directory doesn't exist.
  *
- * @see readdir
+ * @param absolutePathToDir The path to the directory.
+ * @returns An array of strings with the names of the files and directories in the directory, and an empty array if the directory doesn't exist.
+ * @throws NotADirectoryError if the path is not a directory.
+ * @throws FileSystemAccessError for any other error.
  */
-async function readdirOrEmpty(dirFrom: string): Promise<string[]> {
+export async function readdirOrEmpty(
+  absolutePathToDir: string,
+): Promise<string[]> {
   try {
-    return await readdir(dirFrom);
+    return await readdir(absolutePathToDir);
   } catch (error) {
     if (error instanceof FileNotFoundError) {
       return [];
     }
+
     throw error;
   }
 }

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -1,5 +1,4 @@
 import type { JsonTypes, ParsedElementInfo } from "@streamparser/json-node";
-import type { Dirent } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 
 import fsPromises from "node:fs/promises";
@@ -21,6 +20,10 @@ import {
   IsDirectoryError,
   DirectoryNotEmptyError,
 } from "./errors/fs.js";
+import {
+  isDirectoryDirentAware,
+  readdirWithFileTypesOrEmpty,
+} from "./internal/fs.js";
 
 /**
  * Determines the canonical pathname for a given path, resolving any symbolic
@@ -882,54 +885,6 @@ export async function isBinaryFile(
 
   // Heuristic: if more than ~30% of bytes are non-printable, assume binary
   return nonPrintable / bytesRead > 0.3;
-}
-
-/**
- * Like `readdirOrEmpty`, but returns `Dirent` entries to know if an entry is a
- * directory or not without an extra `lstat` syscall.
- */
-async function readdirWithFileTypesOrEmpty(dirFrom: string): Promise<Dirent[]> {
-  try {
-    return await fsPromises.readdir(dirFrom, { withFileTypes: true });
-  } catch (e) {
-    ensureNodeErrnoExceptionError(e);
-
-    if (e.code === "ENOENT") {
-      return [];
-    }
-
-    if (e.code === "ENOTDIR") {
-      throw new NotADirectoryError(dirFrom, e);
-    }
-
-    throw new FileSystemAccessError(e.message, e);
-  }
-}
-
-/**
- * Determines if a dirent refers to a directory, falling back to `lstat` only
- * when the dirent type is unknown.
- */
-async function isDirectoryDirentAware(
-  absolutePath: string,
-  dirent: Dirent,
-): Promise<boolean> {
-  if (dirent.isDirectory()) {
-    return true;
-  }
-
-  if (
-    dirent.isFile() ||
-    dirent.isSymbolicLink() ||
-    dirent.isBlockDevice() ||
-    dirent.isCharacterDevice() ||
-    dirent.isFIFO() ||
-    dirent.isSocket()
-  ) {
-    return false;
-  }
-
-  return await isDirectory(absolutePath);
 }
 
 export {

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -1,4 +1,5 @@
 import type { JsonTypes, ParsedElementInfo } from "@streamparser/json-node";
+import type { Dirent } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 
 import fsPromises from "node:fs/promises";
@@ -59,12 +60,12 @@ export async function getAllFilesMatching(
   matches?: (absolutePathToFile: string) => Promise<boolean> | boolean,
   directoryFilter?: (absolutePathToDir: string) => Promise<boolean> | boolean,
 ): Promise<string[]> {
-  const dirContent = await readdirOrEmpty(dirFrom);
+  const dirContent = await readdirWithFileTypesOrEmpty(dirFrom);
 
   const results = await Promise.all(
-    dirContent.map(async (file) => {
-      const absolutePathToFile = path.join(dirFrom, file);
-      if (await isDirectory(absolutePathToFile)) {
+    dirContent.map(async (dirent) => {
+      const absolutePathToFile = path.join(dirFrom, dirent.name);
+      if (await isDirectoryDirentAware(absolutePathToFile, dirent)) {
         if (
           directoryFilter === undefined ||
           (await directoryFilter(absolutePathToFile))
@@ -107,12 +108,12 @@ export async function getAllDirectoriesMatching(
   dirFrom: string,
   matches?: (absolutePathToDir: string) => Promise<boolean> | boolean,
 ): Promise<string[]> {
-  const dirContent = await readdirOrEmpty(dirFrom);
+  const dirContent = await readdirWithFileTypesOrEmpty(dirFrom);
 
   const results = await Promise.all(
-    dirContent.map(async (file) => {
-      const absolutePathToFile = path.join(dirFrom, file);
-      if (!(await isDirectory(absolutePathToFile))) {
+    dirContent.map(async (dirent) => {
+      const absolutePathToFile = path.join(dirFrom, dirent.name);
+      if (!(await isDirectoryDirentAware(absolutePathToFile, dirent))) {
         return [];
       }
 
@@ -874,6 +875,54 @@ export async function isBinaryFile(
 
   // Heuristic: if more than ~30% of bytes are non-printable, assume binary
   return nonPrintable / bytesRead > 0.3;
+}
+
+/**
+ * Like `readdirOrEmpty`, but returns `Dirent` entries to know if an entry is a
+ * directory or not without an extra `lstat` syscall.
+ */
+async function readdirWithFileTypesOrEmpty(dirFrom: string): Promise<Dirent[]> {
+  try {
+    return await fsPromises.readdir(dirFrom, { withFileTypes: true });
+  } catch (e) {
+    ensureNodeErrnoExceptionError(e);
+
+    if (e.code === "ENOENT") {
+      return [];
+    }
+
+    if (e.code === "ENOTDIR") {
+      throw new NotADirectoryError(dirFrom, e);
+    }
+
+    throw new FileSystemAccessError(e.message, e);
+  }
+}
+
+/**
+ * Determines if a dirent refers to a directory, falling back to `lstat` only
+ * when the dirent type is unknown.
+ */
+async function isDirectoryDirentAware(
+  absolutePath: string,
+  dirent: Dirent,
+): Promise<boolean> {
+  if (dirent.isDirectory()) {
+    return true;
+  }
+
+  if (
+    dirent.isFile() ||
+    dirent.isSymbolicLink() ||
+    dirent.isBlockDevice() ||
+    dirent.isCharacterDevice() ||
+    dirent.isFIFO() ||
+    dirent.isSocket()
+  ) {
+    return false;
+  }
+
+  return await isDirectory(absolutePath);
 }
 
 export {

--- a/packages/hardhat-utils/src/internal/fs.ts
+++ b/packages/hardhat-utils/src/internal/fs.ts
@@ -1,0 +1,57 @@
+import type { Dirent } from "node:fs";
+
+import fsPromises from "node:fs/promises";
+
+import { ensureNodeErrnoExceptionError } from "../error.js";
+import { FileSystemAccessError, NotADirectoryError } from "../errors/fs.js";
+import { isDirectory } from "../fs.js";
+
+/**
+ * Like `readdirOrEmpty`, but returns `Dirent` entries to know if an entry is a
+ * directory or not without an extra `lstat` syscall.
+ */
+export async function readdirWithFileTypesOrEmpty(
+  dirFrom: string,
+): Promise<Dirent[]> {
+  try {
+    return await fsPromises.readdir(dirFrom, { withFileTypes: true });
+  } catch (e) {
+    ensureNodeErrnoExceptionError(e);
+
+    if (e.code === "ENOENT") {
+      return [];
+    }
+
+    if (e.code === "ENOTDIR") {
+      throw new NotADirectoryError(dirFrom, e);
+    }
+
+    throw new FileSystemAccessError(e.message, e);
+  }
+}
+
+/**
+ * Determines if a dirent refers to a directory, falling back to `lstat` only
+ * when the dirent type is unknown.
+ */
+export async function isDirectoryDirentAware(
+  absolutePath: string,
+  dirent: Dirent,
+): Promise<boolean> {
+  if (dirent.isDirectory()) {
+    return true;
+  }
+
+  if (
+    dirent.isFile() ||
+    dirent.isSymbolicLink() ||
+    dirent.isBlockDevice() ||
+    dirent.isCharacterDevice() ||
+    dirent.isFIFO() ||
+    dirent.isSocket()
+  ) {
+    return false;
+  }
+
+  return await isDirectory(absolutePath);
+}

--- a/packages/hardhat-utils/test/fs.ts
+++ b/packages/hardhat-utils/test/fs.ts
@@ -1,3 +1,5 @@
+import type { Dirent } from "node:fs";
+
 import assert from "node:assert/strict";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
@@ -35,6 +37,30 @@ import {
 } from "../src/fs.js";
 
 import { useTmpDir } from "./helpers/fs.js";
+
+function withUnknownDirentType(dirent: Dirent): Dirent {
+  const cloned: Dirent = Object.create(dirent);
+  cloned.isDirectory = () => false;
+  cloned.isFile = () => false;
+  cloned.isSymbolicLink = () => false;
+  cloned.isBlockDevice = () => false;
+  cloned.isCharacterDevice = () => false;
+  cloned.isFIFO = () => false;
+  cloned.isSocket = () => false;
+  return cloned;
+}
+
+function withKnownFileDirentType(dirent: Dirent): Dirent {
+  const cloned: Dirent = Object.create(dirent);
+  cloned.isDirectory = () => false;
+  cloned.isFile = () => true;
+  cloned.isSymbolicLink = () => false;
+  cloned.isBlockDevice = () => false;
+  cloned.isCharacterDevice = () => false;
+  cloned.isFIFO = () => false;
+  cloned.isSocket = () => false;
+  return cloned;
+}
 
 describe("File system utils", () => {
   const getTmpDir = useTmpDir("fs");
@@ -209,6 +235,78 @@ describe("File system utils", () => {
       );
     });
 
+    it("Should recurse into directories when the dirent type is unknown", async (t) => {
+      const originalReaddir = fsPromises.readdir;
+      const originalLstat = fsPromises.lstat;
+
+      const unknownDirPath = path.join(getTmpDir(), "dir-with-files");
+      const knownFilePath = path.join(getTmpDir(), "file-1.txt");
+      const lstatPaths: string[] = [];
+
+      t.mock.method(fsPromises, "readdir", async (...args: any[]) => {
+        const [absolutePathToDir, options] = args;
+        const dirents: Dirent[] = await Reflect.apply(
+          originalReaddir,
+          fsPromises,
+          args,
+        );
+
+        if (
+          absolutePathToDir !== getTmpDir() ||
+          options?.withFileTypes !== true
+        ) {
+          return dirents;
+        }
+
+        return dirents.map((dirent) => {
+          if (dirent.name === path.basename(unknownDirPath)) {
+            return withUnknownDirentType(dirent);
+          }
+
+          if (dirent.name === path.basename(knownFilePath)) {
+            return withKnownFileDirentType(dirent);
+          }
+
+          return dirent;
+        });
+      });
+
+      t.mock.method(fsPromises, "lstat", async (...args: any[]) => {
+        lstatPaths.push(String(args[0]));
+        return await Reflect.apply(originalLstat, fsPromises, args);
+      });
+
+      const files = await getAllFilesMatching(getTmpDir());
+
+      assert.deepEqual(
+        new Set(files),
+        new Set([
+          path.join(getTmpDir(), "file-1.txt"),
+          path.join(getTmpDir(), "file-2.txt"),
+          path.join(getTmpDir(), "file-3.json"),
+          path.join(getTmpDir(), "dir-with-files", "inner-file-1.json"),
+          path.join(getTmpDir(), "dir-with-files", "inner-file-2.txt"),
+          path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-3.txt"),
+          path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-4.json"),
+          path.join(getTmpDir(), "dir-WithCasing", "file-WithCASING"),
+          path.join(
+            getTmpDir(),
+            "dir-with-files",
+            "dir-within-dir",
+            "file-deep",
+          ),
+        ]),
+      );
+      assert.ok(
+        lstatPaths.includes(unknownDirPath),
+        `expected lstat to be used for unknown dirent path ${unknownDirPath}`,
+      );
+      assert.ok(
+        !lstatPaths.includes(knownFilePath),
+        `expected lstat to not be used for known file path ${knownFilePath}`,
+      );
+    });
+
     it("Should throw NotADirectoryError if the path is not a directory", async () => {
       const dirPath = path.join(getTmpDir(), "file-1.txt");
 
@@ -359,6 +457,58 @@ describe("File system utils", () => {
         getTmpDir(),
         async (d) => (await getAllFilesMatching(d)).length !== 0,
         [path.join(getTmpDir(), "dir-with-files")],
+      );
+    });
+
+    it("Should match directories when the dirent type is unknown", async (t) => {
+      const originalReaddir = fsPromises.readdir;
+      const originalLstat = fsPromises.lstat;
+
+      const unknownDirPath = path.join(getTmpDir(), "dir-with-files");
+      const lstatPaths: string[] = [];
+
+      t.mock.method(fsPromises, "readdir", async (...args: any[]) => {
+        const [absolutePathToDir, options] = args;
+        const dirents: Dirent[] = await Reflect.apply(
+          originalReaddir,
+          fsPromises,
+          args,
+        );
+
+        if (
+          absolutePathToDir !== getTmpDir() ||
+          options?.withFileTypes !== true
+        ) {
+          return dirents;
+        }
+
+        return dirents.map((dirent) =>
+          dirent.name === path.basename(unknownDirPath)
+            ? withUnknownDirentType(dirent)
+            : dirent,
+        );
+      });
+
+      t.mock.method(fsPromises, "lstat", async (...args: any[]) => {
+        lstatPaths.push(String(args[0]));
+        return await Reflect.apply(originalLstat, fsPromises, args);
+      });
+
+      const dirs = await getAllDirectoriesMatching(getTmpDir());
+
+      assert.deepEqual(
+        new Set(dirs),
+        new Set([
+          path.join(getTmpDir(), "dir-empty"),
+          path.join(getTmpDir(), "dir-with-files"),
+          path.join(getTmpDir(), "dir-with-subdir"),
+          path.join(getTmpDir(), "dir-with-extension.txt"),
+          path.join(getTmpDir(), "dir-WithCasing"),
+        ]),
+      );
+      assert.ok(
+        lstatPaths.includes(unknownDirPath),
+        `expected lstat to be used for unknown dirent path ${unknownDirPath}`,
       );
     });
   });

--- a/packages/hardhat-utils/test/fs.ts
+++ b/packages/hardhat-utils/test/fs.ts
@@ -34,6 +34,7 @@ import {
   readJsonFileAsStream,
   writeJsonFileAsStream,
   mkdtemp,
+  readdirOrEmpty,
 } from "../src/fs.js";
 
 import { useTmpDir } from "./helpers/fs.js";
@@ -1080,6 +1081,52 @@ describe("File system utils", () => {
       const invalidPath = "\0";
 
       await assert.rejects(readdir(invalidPath), {
+        name: "FileSystemAccessError",
+      });
+    });
+  });
+
+  describe("readdirOrEmpty", () => {
+    it("Should return the files in a directory", async () => {
+      const dirPath = path.join(getTmpDir(), "dir");
+      await mkdir(dirPath);
+
+      const files = ["file1.txt", "file2.txt", "file3.json"];
+      for (const file of files) {
+        await createFile(path.join(dirPath, file));
+      }
+
+      const subDirPath = path.join(dirPath, "subdir");
+      await mkdir(subDirPath);
+      await createFile(path.join(subDirPath, "file4.txt"));
+
+      // should include the subdir but not its content as it's not recursive
+      assert.deepEqual(
+        new Set(await readdirOrEmpty(dirPath)),
+        new Set(["file1.txt", "file2.txt", "file3.json", "subdir"]),
+      );
+    });
+
+    it("Should return an empty array if the directory doesn't exist", async () => {
+      const dirPath = path.join(getTmpDir(), "not-exists");
+
+      assert.deepEqual(await readdirOrEmpty(dirPath), []);
+    });
+
+    it("Should throw NotADirectoryError if the path is not a directory", async () => {
+      const filePath = path.join(getTmpDir(), "file");
+      await createFile(filePath);
+
+      await assert.rejects(readdirOrEmpty(filePath), {
+        name: "NotADirectoryError",
+        message: `Path ${filePath} is not a directory`,
+      });
+    });
+
+    it("Should throw FileSystemAccessError if a different error is thrown", async () => {
+      const invalidPath = "\0";
+
+      await assert.rejects(readdirOrEmpty(invalidPath), {
         name: "FileSystemAccessError",
       });
     });

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -119,6 +119,8 @@ export class ArtifactManagerImplementation implements ArtifactManager {
       return new Set();
     }
 
+    // The build-info directory is expected to be flat: every build-info file
+    // lives directly under it, so a non-recursive `readdir` is enough.
     const buildInfoIds = (await readdir(buildInfosDir))
       .filter(
         (entry) => entry.endsWith(".json") && !entry.endsWith(".output.json"),

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -14,7 +14,7 @@ import {
 import {
   exists,
   getAllFilesMatching,
-  readdir,
+  readdirOrEmpty,
   readJsonFile,
 } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -115,17 +115,14 @@ export class ArtifactManagerImplementation implements ArtifactManager {
   public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
     const buildInfosDir = path.join(this.#artifactsPath, BUILD_INFO_DIR_NAME);
 
-    if (!(await exists(buildInfosDir))) {
-      return new Set();
-    }
-
     // The build-info directory is expected to be flat: every build-info file
     // lives directly under it, so a non-recursive `readdir` is enough.
-    const buildInfoIds = (await readdir(buildInfosDir))
-      .filter(
-        (entry) => entry.endsWith(".json") && !entry.endsWith(".output.json"),
-      )
-      .map((entry) => path.basename(entry, ".json"));
+    const buildInfoFiles = await readdirOrEmpty(buildInfosDir);
+
+    const jsonExtensionLength = ".json".length;
+    const buildInfoIds = buildInfoFiles
+      .filter((f) => f.endsWith(".json") && !f.endsWith(".output.json"))
+      .map((entry) => entry.slice(0, entry.length - jsonExtensionLength));
 
     return new Set(buildInfoIds);
   }

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -14,6 +14,7 @@ import {
 import {
   exists,
   getAllFilesMatching,
+  readdir,
   readJsonFile,
 } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -112,12 +113,19 @@ export class ArtifactManagerImplementation implements ArtifactManager {
   }
 
   public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
-    const paths = await getAllFilesMatching(
-      path.join(this.#artifactsPath, BUILD_INFO_DIR_NAME),
-      (p) => p.endsWith(".json") && !p.endsWith(".output.json"),
-    );
+    const buildInfosDir = path.join(this.#artifactsPath, BUILD_INFO_DIR_NAME);
 
-    return new Set(paths.map((p) => path.basename(p, ".json")));
+    if (!(await exists(buildInfosDir))) {
+      return new Set();
+    }
+
+    const buildInfoIds = (await readdir(buildInfosDir))
+      .filter(
+        (entry) => entry.endsWith(".json") && !entry.endsWith(".output.json"),
+      )
+      .map((entry) => path.basename(entry, ".json"));
+
+    return new Set(buildInfoIds);
   }
 
   public async getBuildInfoPath(

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
@@ -7,6 +7,7 @@ import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import {
   FileNotFoundError,
   readdir,
+  readdirOrEmpty,
   readJsonFile,
   remove,
   writeJsonFile,
@@ -116,9 +117,8 @@ async function deleteOrphanedSnapshotFiles(
   snapshotsDir: string,
   currentGroups: Set<string>,
 ): Promise<void> {
-  let dirEntries: string[];
   try {
-    dirEntries = await readdir(snapshotsDir);
+    const dirEntries = await readdirOrEmpty(snapshotsDir);
 
     for (const entry of dirEntries) {
       if (entry.endsWith(".json")) {
@@ -131,10 +131,6 @@ async function deleteOrphanedSnapshotFiles(
     }
   } catch (error) {
     ensureError(error);
-    // Directory doesn't exist yet, nothing to clean up
-    if (error instanceof FileNotFoundError) {
-      return;
-    }
     throw new HardhatError(
       HardhatError.ERRORS.CORE.SOLIDITY_TESTS.SNAPSHOT_WRITE_ERROR,
       { snapshotsPath: snapshotsDir, error: error.message },

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -177,22 +177,13 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
   ): Promise<string[]> {
     const scope = options.scope ?? "contracts";
     const unified = !this.#options.solidityConfig.splitTestsCompilation;
+    const { localContractFiles, sourceTestFiles } =
+      await this.#getSoliditySourcesRootFilePaths();
 
     this.#ensureSplitCompilationModeIfTestsScope(scope);
 
     switch (scope) {
       case "contracts": {
-        const localContractFiles = (
-          await Promise.all(
-            this.#options.soliditySourcesPaths.map((dir) =>
-              getAllFilesMatching(
-                dir,
-                (f) => f.endsWith(".sol") && !f.endsWith(".t.sol"),
-              ),
-            ),
-          )
-        ).flat(1);
-
         const npmFilesToBuild =
           this.#options.solidityConfig.npmFilesToBuild.map(
             npmModuleToNpmRootPath,
@@ -204,18 +195,12 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
 
         // In unified mode, contracts scope returns all roots: contracts,
         // tests, and npm files.
-        const testFiles = (
-          await Promise.all([
-            getAllFilesMatching(this.#options.solidityTestsPath, (f) =>
-              f.endsWith(".sol"),
-            ),
-            ...this.#options.soliditySourcesPaths.map(async (dir) => {
-              return await getAllFilesMatching(dir, (f) =>
-                f.endsWith(".t.sol"),
-              );
-            }),
-          ])
-        ).flat(1);
+        const testFiles = [
+          ...(await getAllFilesMatching(this.#options.solidityTestsPath, (f) =>
+            f.endsWith(".sol"),
+          )),
+          ...sourceTestFiles,
+        ];
 
         // Remove duplicates in case there is an intersection between
         // the tests.solidity paths and the sources paths
@@ -224,18 +209,12 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
         );
       }
       case "tests": {
-        let rootFilePaths = (
-          await Promise.all([
-            getAllFilesMatching(this.#options.solidityTestsPath, (f) =>
-              f.endsWith(".sol"),
-            ),
-            ...this.#options.soliditySourcesPaths.map(async (dir) => {
-              return await getAllFilesMatching(dir, (f) =>
-                f.endsWith(".t.sol"),
-              );
-            }),
-          ])
-        ).flat(1);
+        let rootFilePaths = [
+          ...(await getAllFilesMatching(this.#options.solidityTestsPath, (f) =>
+            f.endsWith(".sol"),
+          )),
+          ...sourceTestFiles,
+        ];
 
         // NOTE: We remove duplicates in case there is an intersection between
         // the tests.solidity paths and the sources paths
@@ -243,6 +222,45 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
         return rootFilePaths;
       }
     }
+  }
+
+  /**
+   * Returns all the root files from the different solidity sources dirs in the
+   * config, partitioned in test and files, according to their extensions.
+   */
+  async #getSoliditySourcesRootFilePaths(): Promise<{
+    localContractFiles: string[];
+    sourceTestFiles: string[];
+  }> {
+    const sourceFileGroups = await Promise.all(
+      this.#options.soliditySourcesPaths.map(async (dir) => {
+        const localSolidityFiles = await getAllFilesMatching(dir, (f) =>
+          f.endsWith(".sol"),
+        );
+
+        const localContractFiles: string[] = [];
+        const sourceTestFiles: string[] = [];
+
+        for (const file of localSolidityFiles) {
+          if (file.endsWith(".t.sol")) {
+            sourceTestFiles.push(file);
+          } else {
+            localContractFiles.push(file);
+          }
+        }
+
+        return { localContractFiles, sourceTestFiles };
+      }),
+    );
+
+    return {
+      localContractFiles: sourceFileGroups.flatMap(
+        ({ localContractFiles }) => localContractFiles,
+      ),
+      sourceTestFiles: sourceFileGroups.flatMap(
+        ({ sourceTestFiles }) => sourceTestFiles,
+      ),
+    };
   }
 
   public isSuccessfulBuildResult(

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1128,7 +1128,13 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     const buildInfoFiles = await readdirOrEmpty(buildInfosDir);
 
     for (const buildInfoFile of buildInfoFiles) {
-      const id = buildInfoFile.substring(0, buildInfoFile.indexOf("."));
+      // We ignore files that don't have .json extension
+      const jsonIndex = buildInfoFile.indexOf(".json");
+      if (jsonIndex === -1) {
+        continue;
+      }
+
+      const id = buildInfoFile.substring(0, jsonIndex);
 
       if (!reachableBuildInfoIdsSet.has(id)) {
         await remove(path.join(buildInfosDir, buildInfoFile));

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -177,11 +177,12 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     options: { scope?: BuildScope } = {},
   ): Promise<string[]> {
     const scope = options.scope ?? "contracts";
+
+    this.#ensureSplitCompilationModeIfTestsScope(scope);
+
     const unified = !this.#options.solidityConfig.splitTestsCompilation;
     const { localContractFiles, sourceTestFiles } =
       await this.#getSoliditySourcesRootFilePaths();
-
-    this.#ensureSplitCompilationModeIfTestsScope(scope);
 
     switch (scope) {
       case "contracts": {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -226,8 +226,9 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
   }
 
   /**
-   * Returns all the root files from the different solidity sources dirs in the
-   * config, partitioned in test and files, according to their extensions.
+   * Returns all the root files from the different solidity source dirs in the
+   * config, partitioned into contract files and test files according to their
+   * extensions.
    */
   async #getSoliditySourcesRootFilePaths(): Promise<{
     localContractFiles: string[];

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -44,6 +44,7 @@ import {
   getAllDirectoriesMatching,
   getAllFilesMatching,
   move,
+  readdir,
   readJsonFile,
   remove,
   writeJsonFile,
@@ -1120,10 +1121,11 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       reachableBuildInfoIds.filter((id) => id !== undefined),
     );
 
-    // Get all the reachable build info files
-    const buildInfoFiles = await getAllFilesMatching(buildInfosDir, (f) =>
-      f.startsWith(buildInfosDir + path.sep),
-    );
+    const buildInfoFiles = !(await exists(buildInfosDir))
+      ? []
+      : (await readdir(buildInfosDir)).map((entry) =>
+          path.join(buildInfosDir, entry),
+        );
 
     for (const buildInfoFile of buildInfoFiles) {
       const basename = path.basename(buildInfoFile);

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1128,13 +1128,15 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     const buildInfoFiles = await readdirOrEmpty(buildInfosDir);
 
     for (const buildInfoFile of buildInfoFiles) {
-      // We ignore files that don't have .json extension
-      const jsonIndex = buildInfoFile.indexOf(".json");
-      if (jsonIndex === -1) {
+      let id: string | undefined;
+
+      if (buildInfoFile.endsWith(".output.json")) {
+        id = buildInfoFile.slice(0, -".output.json".length);
+      } else if (buildInfoFile.endsWith(".json")) {
+        id = buildInfoFile.slice(0, -".json".length);
+      } else {
         continue;
       }
-
-      const id = buildInfoFile.substring(0, jsonIndex);
 
       if (!reachableBuildInfoIdsSet.has(id)) {
         await remove(path.join(buildInfosDir, buildInfoFile));

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -44,12 +44,12 @@ import {
   getAllDirectoriesMatching,
   getAllFilesMatching,
   move,
-  readdir,
   readJsonFile,
   remove,
   writeJsonFile,
   writeJsonFileAsStream,
   writeUtf8File,
+  readdirOrEmpty,
 } from "@nomicfoundation/hardhat-utils/fs";
 import { shortenPath } from "@nomicfoundation/hardhat-utils/path";
 import { createSpinner } from "@nomicfoundation/hardhat-utils/spinner";
@@ -1124,19 +1124,13 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
 
     // The build-info directory is expected to be flat: every build-info file
     // lives directly under it, so a non-recursive `readdir` is enough.
-    const buildInfoFiles = !(await exists(buildInfosDir))
-      ? []
-      : (await readdir(buildInfosDir)).map((entry) =>
-          path.join(buildInfosDir, entry),
-        );
+    const buildInfoFiles = await readdirOrEmpty(buildInfosDir);
 
     for (const buildInfoFile of buildInfoFiles) {
-      const basename = path.basename(buildInfoFile);
-
-      const id = basename.substring(0, basename.indexOf("."));
+      const id = buildInfoFile.substring(0, buildInfoFile.indexOf("."));
 
       if (!reachableBuildInfoIdsSet.has(id)) {
-        await remove(buildInfoFile);
+        await remove(path.join(buildInfosDir, buildInfoFile));
       }
     }
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1121,6 +1121,8 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       reachableBuildInfoIds.filter((id) => id !== undefined),
     );
 
+    // The build-info directory is expected to be flat: every build-info file
+    // lives directly under it, so a non-recursive `readdir` is enough.
     const buildInfoFiles = !(await exists(buildInfosDir))
       ? []
       : (await readdir(buildInfosDir)).map((entry) =>

--- a/packages/hardhat/src/internal/cli/init/init.ts
+++ b/packages/hardhat/src/internal/cli/init/init.ts
@@ -12,7 +12,6 @@ import {
   copy,
   ensureDir,
   exists,
-  getAllFilesMatching,
   isDirectory,
   mkdir,
   readJsonFile,
@@ -435,17 +434,36 @@ export async function copyProjectFiles(
   template: Template,
   force?: boolean,
 ): Promise<void> {
-  // Find all the files in the workspace that would have been overwritten by the template files
-  const matchingRelativeWorkspacePaths = await getAllFilesMatching(
-    workspace,
-    (file) => {
-      const relativeWorkspacePath = path.relative(workspace, file);
-      const relativeTemplatePath = relativeWorkspaceToTemplatePath(
-        relativeWorkspacePath,
-      );
-      return template.files.includes(relativeTemplatePath);
-    },
-  ).then((files) => files.map((f) => path.relative(workspace, f)));
+  // Find all the paths in the template that clash with an existing one in the
+  // workspace
+  const matchingRelativeWorkspacePaths = (
+    await Promise.all(
+      template.files.map(async (relativeTemplatePath) => {
+        const relativeWorkspacePath =
+          relativeTemplateToWorkspacePath(relativeTemplatePath);
+
+        const absoluteWorkspacePath = path.join(
+          workspace,
+          relativeWorkspacePath,
+        );
+
+        if (!(await exists(absoluteWorkspacePath))) {
+          return undefined;
+        }
+
+        // We ignore directories in this clash detection
+        if (await isDirectory(absoluteWorkspacePath)) {
+          return undefined;
+        }
+
+        return relativeWorkspacePath;
+      }),
+    )
+  ).filter((relativeWorkspacePath) => relativeWorkspacePath !== undefined);
+
+  const matchingRelativeWorkspacePathsSet = new Set(
+    matchingRelativeWorkspacePaths,
+  );
 
   // Ask the user for permission to overwrite existing files if needed
   if (matchingRelativeWorkspacePaths.length !== 0) {
@@ -461,7 +479,7 @@ export async function copyProjectFiles(
 
     if (
       force === false &&
-      matchingRelativeWorkspacePaths.includes(relativeWorkspacePath)
+      matchingRelativeWorkspacePathsSet.has(relativeWorkspacePath)
     ) {
       continue;
     }

--- a/packages/hardhat/src/internal/cli/init/template.ts
+++ b/packages/hardhat/src/internal/cli/init/template.ts
@@ -5,7 +5,7 @@ import {
   exists,
   getAllFilesMatching,
   isDirectory,
-  readdir,
+  readdirOrEmpty,
   readJsonFile,
 } from "@nomicfoundation/hardhat-utils/fs";
 import {
@@ -40,11 +40,7 @@ export async function getTemplates(
   const packageRoot = await findClosestPackageRoot(import.meta.url);
   const pathToTemplates = path.join(packageRoot, "templates", templatesDir);
 
-  if (!(await exists(pathToTemplates))) {
-    return [];
-  }
-
-  const pathsToTemplates = await readdir(pathToTemplates);
+  const pathsToTemplates = await readdirOrEmpty(pathToTemplates);
   pathsToTemplates.sort();
 
   const templates = await Promise.all(

--- a/packages/hardhat/src/internal/cli/init/template.ts
+++ b/packages/hardhat/src/internal/cli/init/template.ts
@@ -65,27 +65,26 @@ export async function getTemplates(
 
       const packageJson: PackageJson =
         await readJsonFile<PackageJson>(pathToPackageJson);
-      const files = await getAllFilesMatching(pathToTemplate, (f) => {
-        // Ignore the package.json file because it is handled separately
-        if (f === pathToPackageJson) {
-          return false;
-        }
-        // .gitignore files are expected to be called gitignore in the templates
-        // because npm ignores .gitignore files during npm pack (see https://github.com/npm/npm/issues/3763)
-        if (path.basename(f) === ".gitignore") {
-          return false;
-        }
-        // We should ignore all the files according to the .gitignore rules
-        // However, for simplicity, we just ignore the node_modules folder
-        // If we needed to implement a more complex ignore logic, we could
-        // use recently introduced glob from node:fs/promises
-        if (
-          path.relative(pathToTemplate, f).split(path.sep)[0] === "node_modules"
-        ) {
-          return false;
-        }
-        return true;
-      }).then((fs) => fs.map((f) => path.relative(pathToTemplate, f)));
+
+      const matchingFiles = await getAllFilesMatching(
+        pathToTemplate,
+        (f) => {
+          // Ignore the package.json file because it is handled separately
+          if (f === pathToPackageJson) {
+            return false;
+          }
+
+          // .gitignore files are expected to be called gitignore in the templates
+          // because npm ignores .gitignore files during npm pack (see https://github.com/npm/npm/issues/3763)
+          if (path.basename(f) === ".gitignore") {
+            return false;
+          }
+          return true;
+        },
+        (dir) => path.basename(dir) !== "node_modules",
+      );
+
+      const files = matchingFiles.map((f) => path.relative(pathToTemplate, f));
 
       return {
         name,

--- a/packages/hardhat/test/internal/builtin-plugins/artifacts/artifact-manager.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/artifacts/artifact-manager.ts
@@ -106,6 +106,24 @@ describe("ArtifactManagerImplementation", () => {
     });
   });
 
+  describe("getAllBuildInfoIds", () => {
+    it("should return all build info ids", async () => {
+      const buildInfoId = await artifactManager.getBuildInfoId("Counter");
+
+      assert.ok(
+        buildInfoId !== undefined,
+        "Expected build info id to be defined",
+      );
+
+      const buildInfoIds = await artifactManager.getAllBuildInfoIds();
+
+      assert.ok(
+        buildInfoIds.has(buildInfoId),
+        `Expected build info ids to include ${buildInfoId}`,
+      );
+    });
+  });
+
   describe("artifactExists", () => {
     it("should return true for an existing bare name", async () => {
       const result = await artifactManager.artifactExists("Counter");

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../../../../src/types/solidity.js";
 
 import assert from "node:assert/strict";
+import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { before, beforeEach, describe, it, mock } from "node:test";
 
@@ -17,6 +18,8 @@ import {
   useFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import {
+  createFile,
+  ensureDir,
   exists,
   getAllFilesMatching,
   readJsonFile,
@@ -510,5 +513,83 @@ describe("SolidityBuildSystemImplementation.getScope", () => {
       await solidity.getScope(path.join(projectRoot, "elsewhere", "Foo.sol")),
       "contracts",
     );
+  });
+});
+
+describe("SolidityBuildSystemImplementation.getRootFilePaths", () => {
+  it("Regression test: walks each sources path only once in unified mode", async () => {
+    const projectRoot = await getTmpDir("solidity-build-system-root-files");
+    const contractsPath = path.join(projectRoot, "contracts");
+    const testsPath = path.join(projectRoot, "tests");
+
+    await ensureDir(contractsPath);
+    await ensureDir(testsPath);
+    await createFile(path.join(contractsPath, "Foo.sol"));
+    await createFile(path.join(contractsPath, "Foo.t.sol"));
+    await createFile(path.join(testsPath, "Bar.sol"));
+
+    const hooks = new HookManagerImplementation(projectRoot, []);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- hooks context is irrelevant for getRootFilePaths
+    hooks.setContext({} as HookContext);
+
+    const solidity = new SolidityBuildSystemImplementation(hooks, {
+      solidityConfig: {
+        profiles: {
+          default: {
+            compilers: [],
+            overrides: {},
+            isolated: false,
+            preferWasm: false,
+          },
+        },
+        npmFilesToBuild: [],
+        registeredCompilerTypes: ["solc"],
+        splitTestsCompilation: false,
+      },
+      projectRoot,
+      soliditySourcesPaths: [contractsPath],
+      artifactsPath: path.join(projectRoot, "artifacts"),
+      cachePath: path.join(projectRoot, "cache"),
+      solidityTestsPath: testsPath,
+    });
+
+    const originalReaddir = fsPromises.readdir;
+    let contractsPathReads = 0;
+
+    const readdirMock = mock.method(
+      fsPromises,
+      "readdir",
+      async (...args: Parameters<typeof originalReaddir>) => {
+        if (args[0] === contractsPath && args[1]?.withFileTypes === true) {
+          contractsPathReads += 1;
+        }
+
+        return await Reflect.apply(originalReaddir, fsPromises, args);
+      },
+    );
+
+    try {
+      const rootFilePaths = await solidity.getRootFilePaths();
+
+      assert.equal(
+        contractsPathReads,
+        1,
+        "expected unified root discovery to walk each sources path only once",
+      );
+      assert.ok(
+        rootFilePaths.some((file) => file.endsWith("Foo.sol")),
+        "expected roots to include Foo.sol",
+      );
+      assert.ok(
+        rootFilePaths.some((file) => file.endsWith("Foo.t.sol")),
+        "expected unified roots to include Foo.t.sol",
+      );
+      assert.ok(
+        rootFilePaths.some((file) => file.endsWith("Bar.sol")),
+        "expected unified roots to include tests/Bar.sol",
+      );
+    } finally {
+      readdirMock.mock.restore();
+    }
   });
 });

--- a/packages/hardhat/test/internal/cli/init/init.ts
+++ b/packages/hardhat/test/internal/cli/init/init.ts
@@ -2,11 +2,13 @@ import type { Template } from "../../../../src/internal/cli/init/template.js";
 import type { PackageJson } from "@nomicfoundation/hardhat-utils/package";
 
 import assert from "node:assert/strict";
+import fsPromises from "node:fs/promises";
 import path from "node:path";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
+  assertRejects,
   assertRejectsWithHardhatError,
   disableConsole,
   useTmpDir,
@@ -14,6 +16,7 @@ import {
 import {
   ensureDir,
   exists,
+  createFile,
   readJsonFile,
   readUtf8File,
   remove,
@@ -349,6 +352,60 @@ describe("copyProjectFiles", () => {
       assert.ok(
         !(await exists(path.join(process.cwd(), "gitignore"))),
         "gitignore should NOT exist",
+      );
+    });
+
+    it("Regression test: should not scan unrelated workspace files to detect overwrites", async () => {
+      const [template] = await getTemplate("hardhat-3", "mocha-ethers");
+      const unrelatedDirPath = path.join(process.cwd(), "unrelated");
+      const unrelatedFilePath = path.join(unrelatedDirPath, "ignored.txt");
+      await ensureDir(unrelatedDirPath);
+      await createFile(unrelatedFilePath);
+
+      const originalReaddir = fsPromises.readdir;
+      const readdirMock = mock.method(
+        fsPromises,
+        "readdir",
+        async (...args: Parameters<typeof originalReaddir>) => {
+          if (args[0] === process.cwd() && args[1]?.withFileTypes === true) {
+            throw new Error(
+              "copyProjectFiles should not scan the workspace recursively",
+            );
+          }
+
+          return await Reflect.apply(originalReaddir, fsPromises, args);
+        },
+      );
+
+      try {
+        await copyProjectFiles(process.cwd(), template, false);
+
+        const oneCopiedTemplateFile = path.join(
+          process.cwd(),
+          relativeTemplateToWorkspacePath(template.files[0]),
+        );
+        assert.ok(
+          await exists(oneCopiedTemplateFile),
+          `expected template file ${oneCopiedTemplateFile} to be copied without walking the workspace`,
+        );
+      } finally {
+        readdirMock.mock.restore();
+      }
+    });
+
+    it("Regression test: should still throw if a directory clashes with a destination file", async () => {
+      const [template] = await getTemplate("hardhat-3", "mocha-ethers");
+      const pathWithDirectoryClash = path.join(
+        process.cwd(),
+        "hardhat.config.ts",
+      );
+
+      await ensureDir(pathWithDirectoryClash);
+
+      await assertRejects(
+        copyProjectFiles(process.cwd(), template, false),
+        (error) => error.name === "IsDirectoryError",
+        "expected copyProjectFiles to reject with IsDirectoryError",
       );
     });
   });

--- a/packages/hardhat/test/internal/cli/init/template.ts
+++ b/packages/hardhat/test/internal/cli/init/template.ts
@@ -1,9 +1,11 @@
 import type { Template } from "../../../../src/internal/cli/init/template.js";
+import type { Dirent } from "node:fs";
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import fsPromises from "node:fs/promises";
 import path from "node:path";
-import { after, before, describe, it } from "node:test";
+import { after, before, describe, it, mock } from "node:test";
 
 import { exists, remove } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -32,6 +34,55 @@ describe("getTemplates", () => {
           `Template file ${file} does not exist`,
         );
       }
+    }
+  });
+
+  it("Regression test: should not descend into node_modules when reading template files", async () => {
+    const originalReaddir = fsPromises.readdir;
+    const readdirMock = mock.method(
+      fsPromises,
+      "readdir",
+      async (...args: Parameters<typeof originalReaddir>) => {
+        const [pathToRead, options] = args;
+
+        if (
+          typeof pathToRead === "string" &&
+          pathToRead.endsWith(`${path.sep}node_modules`) &&
+          options?.withFileTypes === true
+        ) {
+          throw new Error("getTemplates should not recurse into node_modules");
+        }
+
+        const dirents = await Reflect.apply(originalReaddir, fsPromises, args);
+
+        if (
+          typeof pathToRead !== "string" ||
+          options?.withFileTypes !== true ||
+          !pathToRead.includes(
+            `${path.sep}templates${path.sep}hardhat-3${path.sep}`,
+          )
+        ) {
+          return dirents;
+        }
+
+        const nodeModulesDirent: Dirent = Object.create(dirents[0] ?? {});
+        nodeModulesDirent.name = "node_modules";
+        nodeModulesDirent.isDirectory = () => true;
+        nodeModulesDirent.isFile = () => false;
+        nodeModulesDirent.isSymbolicLink = () => false;
+        nodeModulesDirent.isBlockDevice = () => false;
+        nodeModulesDirent.isCharacterDevice = () => false;
+        nodeModulesDirent.isFIFO = () => false;
+        nodeModulesDirent.isSocket = () => false;
+
+        return [...dirents, nodeModulesDirent];
+      },
+    );
+
+    try {
+      await getTemplates("hardhat-3");
+    } finally {
+      readdirMock.mock.restore();
     }
   });
 });


### PR DESCRIPTION
This PR optimizes the `hardhat-utils` functions `getAllFilesMatching` and `getAllDirectoriesMatching`, by decreasing the number of `syscall`s they have to do. This is done by using `fsPromises.readdir(dirFrom, { withFileTypes: true });`, which returns the the file type of each entry.

For filesystems where this isn't supported, the new implementations fallback to an added `lstat` per entry, which is the previous behavior.

On top of that, this PR optimizes the usage of these functions, by:
- Remove it's usage from `init.ts`
- Improve how `getAllFilesMatching` is used in `template.ts`
- Avoid a duplicated `getAllFilesMatching` when getting the root files in the build system.
- Stop using `getAllFilesMatching` to fetch the `build-info` files, as it's a flat directory.

This PR is based on #8177, but it's independent from it