### PR TITLE
chore: update node test sequential testing changeset

### DIFF
--- a/.changeset/strange-books-explode.md
+++ b/.changeset/strange-books-explode.md
@@ -1,5 +1,6 @@
 ---
 "@nomicfoundation/hardhat-node-test-runner": patch
+"hardhat": patch
 ---
 
 Make `node:test` sequential by default and run test files in the same process (`isolation: "none"`).


### PR DESCRIPTION
Add `hardhat` to the `node:test` sequential changeset to ensure Hardhat user's are notified in the changelog.
