### PR TITLE
Better handle node versions lower than minimum

### DIFF
--- a/.changeset/dry-icons-end.md
+++ b/.changeset/dry-icons-end.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+"hardhat": patch
+---
+
+Improved the logic for handling `Node.js` versions that fall below the minimum requirement.

--- a/packages/hardhat-utils/package.json
+++ b/packages/hardhat-utils/package.json
@@ -33,6 +33,7 @@
     "./panic-errors": "./dist/src/panic-errors.js",
     "./path": "./dist/src/path.js",
     "./request": "./dist/src/request.js",
+    "./runtime": "./dist/src/runtime.js",
     "./string": "./dist/src/string.js",
     "./stream": "./dist/src/stream.js",
     "./subprocess": "./dist/src/subprocess.js",

--- a/packages/hardhat-utils/src/runtime.ts
+++ b/packages/hardhat-utils/src/runtime.ts
@@ -1,0 +1,45 @@
+interface RuntimeInfo {
+  runtime: "bun" | "deno" | "node";
+  version: string;
+}
+
+declare const globalThis: {
+  Deno?: { version?: { deno?: string } };
+};
+
+/**
+ * Detects the JavaScript runtime environment (Node.js, Deno, Bun, or unknown)
+ * and its version.
+ *
+ * @returns An object containing the runtime type and version, or `undefined`
+ * if the runtime cannot be detected.
+ */
+export function getRuntimeInfo(): RuntimeInfo | undefined {
+  // Deno
+  const deno = globalThis.Deno;
+  if (typeof deno === "object" && deno?.version?.deno !== undefined) {
+    return {
+      runtime: "deno",
+      version: deno.version.deno,
+    };
+  }
+
+  // Bun: this should be checked before Node.js since Bun also defines
+  // `process.versions.node`
+  if (typeof process !== "undefined" && process.versions?.bun !== undefined) {
+    return {
+      runtime: "bun",
+      version: process.versions.bun,
+    };
+  }
+
+  // Node
+  if (typeof process !== "undefined" && process.versions?.node !== undefined) {
+    return {
+      runtime: "node",
+      version: process.versions.node,
+    };
+  }
+
+  return undefined;
+}

--- a/packages/hardhat-utils/src/runtime.ts
+++ b/packages/hardhat-utils/src/runtime.ts
@@ -1,4 +1,4 @@
-interface RuntimeInfo {
+export interface RuntimeInfo {
   runtime: "bun" | "deno" | "node";
   version: string;
 }

--- a/packages/hardhat-utils/test/runtime.ts
+++ b/packages/hardhat-utils/test/runtime.ts
@@ -7,7 +7,17 @@ declare const globalThis: {
   Deno?: unknown;
 };
 
-const ORIGINAL_VERSIONS = process.versions;
+function getOriginalVersionsDescriptor(): PropertyDescriptor {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "versions");
+
+  if (descriptor === undefined) {
+    throw new Error("process.versions descriptor not found");
+  }
+
+  return descriptor;
+}
+
+const ORIGINAL_VERSIONS_DESCRIPTOR = getOriginalVersionsDescriptor();
 const HAS_ORIGINAL_DENO = "Deno" in globalThis;
 const ORIGINAL_DENO = globalThis.Deno;
 
@@ -20,11 +30,7 @@ function setProcessVersions(versions: Record<string, string>): void {
 }
 
 function restoreProcessVersions(): void {
-  Object.defineProperty(process, "versions", {
-    value: ORIGINAL_VERSIONS,
-    configurable: true,
-    writable: true,
-  });
+  Object.defineProperty(process, "versions", ORIGINAL_VERSIONS_DESCRIPTOR);
 }
 
 function setDeno(deno: unknown): void {

--- a/packages/hardhat-utils/test/runtime.ts
+++ b/packages/hardhat-utils/test/runtime.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { getRuntimeInfo } from "../src/runtime.js";
+
+declare const globalThis: {
+  Deno?: unknown;
+};
+
+const ORIGINAL_VERSIONS = process.versions;
+const HAS_ORIGINAL_DENO = "Deno" in globalThis;
+const ORIGINAL_DENO = globalThis.Deno;
+
+function setProcessVersions(versions: Record<string, string>): void {
+  Object.defineProperty(process, "versions", {
+    value: versions,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function restoreProcessVersions(): void {
+  Object.defineProperty(process, "versions", {
+    value: ORIGINAL_VERSIONS,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function setDeno(deno: unknown): void {
+  globalThis.Deno = deno;
+}
+
+function restoreDeno(): void {
+  if (HAS_ORIGINAL_DENO) {
+    globalThis.Deno = ORIGINAL_DENO;
+  } else {
+    delete globalThis.Deno;
+  }
+}
+
+describe("runtime", () => {
+  describe("getRuntimeInfo", () => {
+    afterEach(() => {
+      restoreProcessVersions();
+      restoreDeno();
+    });
+
+    it("detects Node.js", () => {
+      setProcessVersions({ node: "22.10.0" });
+      assert.deepEqual(getRuntimeInfo(), {
+        runtime: "node",
+        version: "22.10.0",
+      });
+    });
+
+    it("detects Bun even when process.versions.node is also defined", () => {
+      setProcessVersions({ node: "22.10.0", bun: "1.1.0" });
+      assert.deepEqual(getRuntimeInfo(), {
+        runtime: "bun",
+        version: "1.1.0",
+      });
+    });
+
+    it("detects Deno", () => {
+      setDeno({ version: { deno: "2.1.0" } });
+      // Deno also emulates process.versions.node
+      setProcessVersions({ node: "22.10.0" });
+      assert.deepEqual(getRuntimeInfo(), {
+        runtime: "deno",
+        version: "2.1.0",
+      });
+    });
+
+    it("returns undefined when no known runtime is detected", () => {
+      setProcessVersions({});
+      assert.equal(getRuntimeInfo(), undefined);
+    });
+  });
+});

--- a/packages/hardhat/src/cli.ts
+++ b/packages/hardhat/src/cli.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
-import { exitIfNodeVersionNotSupported } from "./internal/cli/node-version.js";
+import {
+  exitIfNodeVersionNotSupported,
+  warnIfUnofficialRuntime,
+} from "./internal/cli/node-version.js";
 
 // We enable the sourcemaps before loading main, so that everything except this
 // small file is loaded with sourcemaps enabled.
@@ -10,6 +13,10 @@ process.setSourceMapsEnabled(true);
 // unsupported js syntax or Node API elsewhere, we get to exit with a clear
 // error before crashing.
 exitIfNodeVersionNotSupported();
+
+// Bun and Deno are not officially supported yet. We warn the user so they
+// know some functionality may not work as expected.
+warnIfUnofficialRuntime();
 
 // eslint-disable-next-line no-restricted-syntax -- Allow top-level await here
 const { main } = await import("./internal/cli/main.js");

--- a/packages/hardhat/src/cli.ts
+++ b/packages/hardhat/src/cli.ts
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 
-import {
-  exitIfNodeVersionNotSupported,
-  warnIfUnofficialRuntime,
-} from "./internal/cli/node-version.js";
+import { exitIfNodeVersionNotSupported } from "./internal/cli/node-version.js";
 
 // We enable the sourcemaps before loading main, so that everything except this
 // small file is loaded with sourcemaps enabled.
@@ -13,10 +10,6 @@ process.setSourceMapsEnabled(true);
 // unsupported js syntax or Node API elsewhere, we get to exit with a clear
 // error before crashing.
 exitIfNodeVersionNotSupported();
-
-// Bun and Deno are not officially supported yet. We warn the user so they
-// know some functionality may not work as expected.
-warnIfUnofficialRuntime();
 
 // eslint-disable-next-line no-restricted-syntax -- Allow top-level await here
 const { main } = await import("./internal/cli/main.js");

--- a/packages/hardhat/src/cli.ts
+++ b/packages/hardhat/src/cli.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 
-import { printNodeJsVersionWarningIfNecessary } from "./internal/cli/node-version.js";
+import { exitIfNodeVersionNotSupported } from "./internal/cli/node-version.js";
 
 // We enable the sourcemaps before loading main, so that everything except this
 // small file is loaded with sourcemaps enabled.
 process.setSourceMapsEnabled(true);
 
-// We also print this warning before loading main, so that if there is some
-// unsupported js syntax or Node API elsewhere, we get to print it before
-// crashing.
-printNodeJsVersionWarningIfNecessary();
+// We check the Node.js version before loading main, so that if there is some
+// unsupported js syntax or Node API elsewhere, we get to exit with a clear
+// error before crashing.
+exitIfNodeVersionNotSupported();
 
 // eslint-disable-next-line no-restricted-syntax -- Allow top-level await here
 const { main } = await import("./internal/cli/main.js");

--- a/packages/hardhat/src/internal/cli/node-version.ts
+++ b/packages/hardhat/src/internal/cli/node-version.ts
@@ -3,6 +3,12 @@
 //
 // NOTE: This file shouldn't import any non-builtin dependency, as it's imported
 // before enabling source maps support.
+//
+// EXCEPTION: we share `getRuntimeInfo` with the rest of the codebase instead
+// of duplicating it. The helper has no transitive dependencies, so the risk of
+// an unreadable stack trace from its import graph is negligible.
+
+import { getRuntimeInfo } from "@nomicfoundation/hardhat-utils/runtime";
 
 export const MIN_SUPPORTED_NODE_VERSION: number[] = [22, 10, 0];
 
@@ -37,6 +43,13 @@ export function isNodeVersionSupported(): boolean {
 }
 
 export function exitIfNodeVersionNotSupported(): void {
+  // Only enforce the Node.js version when we're actually running on Node.js.
+  // Bun and Deno emulate `process.versions.node`, so checking it there would
+  // incorrectly reject users on those runtimes.
+  if (getRuntimeInfo()?.runtime !== "node") {
+    return;
+  }
+
   if (!isNodeVersionSupported()) {
     process.stderr.write(
       `\nERROR: You are using Node.js ${process.versions.node} which is not supported by Hardhat.\n` +
@@ -45,4 +58,18 @@ export function exitIfNodeVersionNotSupported(): void {
 
     process.exit(1);
   }
+}
+
+export function warnIfUnofficialRuntime(): void {
+  const info = getRuntimeInfo();
+
+  if (info === undefined || info.runtime === "node") {
+    return;
+  }
+
+  const runtimeName = info.runtime === "bun" ? "Bun" : "Deno";
+
+  process.stderr.write(
+    `\nWARNING: You are running Hardhat on ${runtimeName} ${info.version}. ${runtimeName} is not officially supported yet, so some functionality may not work as expected.\n\n`,
+  );
 }

--- a/packages/hardhat/src/internal/cli/node-version.ts
+++ b/packages/hardhat/src/internal/cli/node-version.ts
@@ -59,17 +59,3 @@ export function exitIfNodeVersionNotSupported(): void {
     process.exit(1);
   }
 }
-
-export function warnIfUnofficialRuntime(): void {
-  const info = getRuntimeInfo();
-
-  if (info === undefined || info.runtime === "node") {
-    return;
-  }
-
-  const runtimeName = info.runtime === "bun" ? "Bun" : "Deno";
-
-  process.stderr.write(
-    `\nWARNING: You are running Hardhat on ${runtimeName} ${info.version}. ${runtimeName} is not officially supported yet, so some functionality may not work as expected.\n\n`,
-  );
-}

--- a/packages/hardhat/src/internal/cli/node-version.ts
+++ b/packages/hardhat/src/internal/cli/node-version.ts
@@ -2,9 +2,7 @@
 // is always run during the initialization of the CLI.
 //
 // NOTE: This file shouldn't import any non-builtin dependency, as it's imported
-// before enabling source maps support. TODO: Change chalk to util.styleText
-
-import chalk from "chalk";
+// before enabling source maps support.
 
 export const MIN_SUPPORTED_NODE_VERSION: number[] = [22, 10, 0];
 
@@ -14,10 +12,6 @@ export function isNodeVersionSupported(): boolean {
     const major = parseInt(majorStr, 10);
     const minor = parseInt(minorStr, 10);
     const patch = parseInt(patchStr, 10);
-
-    if (major % 2 === 1) {
-      return false;
-    }
 
     if (major < MIN_SUPPORTED_NODE_VERSION[0]) {
       return false;
@@ -42,12 +36,13 @@ export function isNodeVersionSupported(): boolean {
   return true;
 }
 
-export function printNodeJsVersionWarningIfNecessary(): void {
+export function exitIfNodeVersionNotSupported(): void {
   if (!isNodeVersionSupported()) {
-    console.log(
-      chalk.bold(`\n${chalk.yellow("WARNING:")} You are using Node.js ${process.versions.node} which is not supported by Hardhat.
-Please upgrade to ${MIN_SUPPORTED_NODE_VERSION.join(".")} or a later LTS version (even major version number)\n`),
+    process.stderr.write(
+      `\nERROR: You are using Node.js ${process.versions.node} which is not supported by Hardhat.\n` +
+        `Please upgrade to Node.js ${MIN_SUPPORTED_NODE_VERSION.join(".")} or later.\n\n`,
     );
-    return;
+
+    process.exit(1);
   }
 }

--- a/packages/hardhat/src/internal/cli/node-version.ts
+++ b/packages/hardhat/src/internal/cli/node-version.ts
@@ -51,9 +51,9 @@ export function exitIfNodeVersionNotSupported(): void {
   }
 
   if (!isNodeVersionSupported()) {
-    process.stderr.write(
+    console.error(
       `\nERROR: You are using Node.js ${process.versions.node} which is not supported by Hardhat.\n` +
-        `Please upgrade to Node.js ${MIN_SUPPORTED_NODE_VERSION.join(".")} or later.\n\n`,
+        `Please upgrade to Node.js ${MIN_SUPPORTED_NODE_VERSION.join(".")} or later.\n`,
     );
 
     process.exit(1);

--- a/packages/hardhat/test/internal/cli/node-version.ts
+++ b/packages/hardhat/test/internal/cli/node-version.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it, afterEach, beforeEach } from "node:test";
 
 import {
+  exitIfNodeVersionNotSupported,
   isNodeVersionSupported,
   MIN_SUPPORTED_NODE_VERSION,
 } from "../../../src/internal/cli/node-version.js";
@@ -88,13 +89,75 @@ describe("Node version", () => {
       );
     });
 
-    it("is false when the major version is above the minimum but non LTS (odd)", async () => {
+    it("is true when the major version is above the minimum and odd (non-LTS)", () => {
       const [major, minor, patch] = MIN_SUPPORTED_NODE_VERSION;
 
       setNodeVersion(`${major + 1}.${minor}.${patch}`);
       assert(
-        !isNodeVersionSupported(),
-        `${process.versions.node} should not be supported`,
+        isNodeVersionSupported(),
+        `${process.versions.node} should be supported`,
+      );
+    });
+  });
+
+  describe("exitIfNodeVersionNotSupported", () => {
+    it("writes an error to stderr and calls process.exit(1) when the version is unsupported", (t) => {
+      const [major, minor, patch] = MIN_SUPPORTED_NODE_VERSION;
+      const unsupported = `${major}.${minor}.${patch - 1}`;
+
+      setNodeVersion(unsupported);
+
+      const writeMock = t.mock.method(process.stderr, "write", () => true);
+      const exitMock = t.mock.method(process, "exit", () => undefined);
+
+      exitIfNodeVersionNotSupported();
+
+      assert.equal(
+        exitMock.mock.callCount(),
+        1,
+        "process.exit should be called exactly once",
+      );
+      assert.deepEqual(
+        exitMock.mock.calls[0].arguments,
+        [1],
+        "process.exit should be called with code 1",
+      );
+      assert.equal(
+        writeMock.mock.callCount(),
+        1,
+        "process.stderr.write should be called exactly once",
+      );
+
+      const writtenMessage = String(writeMock.mock.calls[0].arguments[0]);
+      assert.ok(
+        writtenMessage.includes(unsupported),
+        `stderr message should include the current version (${unsupported}): ${writtenMessage}`,
+      );
+      assert.ok(
+        writtenMessage.includes(MIN_SUPPORTED_NODE_VERSION.join(".")),
+        `stderr message should include the minimum version (${MIN_SUPPORTED_NODE_VERSION.join(".")}): ${writtenMessage}`,
+      );
+    });
+
+    it("does nothing when the version is supported", (t) => {
+      const [major, minor, patch] = MIN_SUPPORTED_NODE_VERSION;
+
+      setNodeVersion(`${major}.${minor}.${patch}`);
+
+      const writeMock = t.mock.method(process.stderr, "write", () => true);
+      const exitMock = t.mock.method(process, "exit", () => undefined);
+
+      exitIfNodeVersionNotSupported();
+
+      assert.equal(
+        exitMock.mock.callCount(),
+        0,
+        "process.exit should not be called",
+      );
+      assert.equal(
+        writeMock.mock.callCount(),
+        0,
+        "process.stderr.write should not be called",
       );
     });
   });

--- a/packages/hardhat/test/internal/cli/node-version.ts
+++ b/packages/hardhat/test/internal/cli/node-version.ts
@@ -5,7 +5,6 @@ import {
   exitIfNodeVersionNotSupported,
   isNodeVersionSupported,
   MIN_SUPPORTED_NODE_VERSION,
-  warnIfUnofficialRuntime,
 } from "../../../src/internal/cli/node-version.js";
 
 let originalNodeVersion: string;
@@ -193,54 +192,6 @@ describe("Node version", () => {
         writeMock.mock.callCount(),
         0,
         "process.stderr.write should not be called on Bun",
-      );
-    });
-  });
-
-  describe("warnIfUnofficialRuntime", () => {
-    it("does nothing on Node.js", (t) => {
-      const writeMock = t.mock.method(process.stderr, "write", () => true);
-
-      warnIfUnofficialRuntime();
-
-      assert.equal(
-        writeMock.mock.callCount(),
-        0,
-        "process.stderr.write should not be called on Node.js",
-      );
-    });
-
-    it("writes a warning mentioning Bun when running on Bun", (t) => {
-      t.after(() => {
-        Object.defineProperty(process.versions, "bun", {
-          value: undefined,
-          configurable: true,
-        });
-      });
-
-      Object.defineProperty(process.versions, "bun", {
-        value: "1.1.0",
-        writable: false,
-        configurable: true,
-      });
-      const writeMock = t.mock.method(process.stderr, "write", () => true);
-
-      warnIfUnofficialRuntime();
-
-      assert.equal(
-        writeMock.mock.callCount(),
-        1,
-        "process.stderr.write should be called exactly once",
-      );
-
-      const message = String(writeMock.mock.calls[0].arguments[0]);
-      assert.ok(
-        message.includes("Bun"),
-        `warning should mention Bun: ${message}`,
-      );
-      assert.ok(
-        message.includes("1.1.0"),
-        `warning should include the Bun version: ${message}`,
       );
     });
   });

--- a/packages/hardhat/test/internal/cli/node-version.ts
+++ b/packages/hardhat/test/internal/cli/node-version.ts
@@ -5,6 +5,7 @@ import {
   exitIfNodeVersionNotSupported,
   isNodeVersionSupported,
   MIN_SUPPORTED_NODE_VERSION,
+  warnIfUnofficialRuntime,
 } from "../../../src/internal/cli/node-version.js";
 
 let originalNodeVersion: string;
@@ -158,6 +159,88 @@ describe("Node version", () => {
         writeMock.mock.callCount(),
         0,
         "process.stderr.write should not be called",
+      );
+    });
+
+    it("does nothing on Bun even when the emulated node version would be unsupported", (t) => {
+      t.after(() => {
+        Object.defineProperty(process.versions, "bun", {
+          value: undefined,
+          configurable: true,
+        });
+      });
+
+      const [major, minor, patch] = MIN_SUPPORTED_NODE_VERSION;
+
+      setNodeVersion(`${major}.${minor}.${patch - 1}`);
+      Object.defineProperty(process.versions, "bun", {
+        value: "1.1.0",
+        writable: false,
+        configurable: true,
+      });
+
+      const writeMock = t.mock.method(process.stderr, "write", () => true);
+      const exitMock = t.mock.method(process, "exit", () => undefined);
+
+      exitIfNodeVersionNotSupported();
+
+      assert.equal(
+        exitMock.mock.callCount(),
+        0,
+        "process.exit should not be called on Bun",
+      );
+      assert.equal(
+        writeMock.mock.callCount(),
+        0,
+        "process.stderr.write should not be called on Bun",
+      );
+    });
+  });
+
+  describe("warnIfUnofficialRuntime", () => {
+    it("does nothing on Node.js", (t) => {
+      const writeMock = t.mock.method(process.stderr, "write", () => true);
+
+      warnIfUnofficialRuntime();
+
+      assert.equal(
+        writeMock.mock.callCount(),
+        0,
+        "process.stderr.write should not be called on Node.js",
+      );
+    });
+
+    it("writes a warning mentioning Bun when running on Bun", (t) => {
+      t.after(() => {
+        Object.defineProperty(process.versions, "bun", {
+          value: undefined,
+          configurable: true,
+        });
+      });
+
+      Object.defineProperty(process.versions, "bun", {
+        value: "1.1.0",
+        writable: false,
+        configurable: true,
+      });
+      const writeMock = t.mock.method(process.stderr, "write", () => true);
+
+      warnIfUnofficialRuntime();
+
+      assert.equal(
+        writeMock.mock.callCount(),
+        1,
+        "process.stderr.write should be called exactly once",
+      );
+
+      const message = String(writeMock.mock.calls[0].arguments[0]);
+      assert.ok(
+        message.includes("Bun"),
+        `warning should mention Bun: ${message}`,
+      );
+      assert.ok(
+        message.includes("1.1.0"),
+        `warning should include the Bun version: ${message}`,
       );
     });
   });


### PR DESCRIPTION
### What is done:
- Suppressed warnings for non-LTS Node.js versions
- Added a fallback warning for versions below the minimum requirement (rendered without colors for compatibility when node style is unavailable)
- Enforced a process exit if the Node.js version is lower than the minimum supported version