### PR TITLE
Optimize true case path

### DIFF
--- a/.changeset/wise-women-prove.md
+++ b/.changeset/wise-women-prove.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+"hardhat": patch
+---
+
+Introduce a TrueCasePathResolver class to optimize repeated filesystem casing resolution

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -388,10 +388,7 @@ export async function getAllDirectoriesMatching(
  * @throws FileNotFoundError if the starting directory or the relative path doesn't exist.
  * @throws NotADirectoryError if the starting directory is not a directory.
  * @throws FileSystemAccessError for any other error.
- * @deprecated Creates a fresh {@link TrueCasePathResolver} per call, so it
- *  provides no caching across invocations. For hot paths that resolve many
- *  paths against the same directories, instantiate a `TrueCasePathResolver`
- *  once and reuse it.
+ * @deprecated Use {@link TrueCasePathResolver} instead.
  */
 export async function getFileTrueCase(
   from: string,

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -94,7 +94,8 @@ export class TrueCasePathResolver {
    *
    * @param from The absolute path of the directory to start the search from.
    * @param relativePath The relative path to get the true case of.
-   * @returns The true case of the relative path.
+   * @returns The true case of the relative path. Returns an empty string if
+   * relativePath points to from.
    * @throws FileNotFoundError if the starting directory or the relative path
    *  doesn't exist or is ambiguous.
    * @throws NotADirectoryError if the starting directory, or an intermediate
@@ -105,9 +106,23 @@ export class TrueCasePathResolver {
     from: string,
     relativePath: string,
   ): Promise<string> {
+    if (path.normalize(relativePath) === ".") {
+      return "";
+    }
+
     const absoluteFrom = path.resolve(from);
     const resolved = await this.#resolveFrom(absoluteFrom, relativePath);
-    return path.relative(absoluteFrom, resolved);
+    const resolvedRelativePath = path.relative(absoluteFrom, resolved);
+
+    if (
+      resolvedRelativePath === ".." ||
+      resolvedRelativePath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(resolvedRelativePath)
+    ) {
+      throw new FileNotFoundError(path.resolve(absoluteFrom, relativePath));
+    }
+
+    return resolvedRelativePath;
   }
 
   /**

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -59,9 +59,12 @@ interface DirEntries {
  *
  * This class caches successful resolutions internally, and may do some
  * duplicate work when multiple concurrent lookups for the same path are made
- * before the first one finishes, but it avoids caching failed lookups and stale
- * results after `clear()`. If profiling shows that this work duplication is a
- * problem, we can either cache in-flight operations, or add a mutex.
+ * before the first one finishes. It does not cache failed resolutions as
+ * negative result entries, but it does cache directory listings, so filesystem
+ * changes may not be observed until `clear()` is called. After `clear()`,
+ * previously cached directory and resolution data is discarded. If profiling
+ * shows that this work duplication is a problem, we can either cache in-flight
+ * operations, or add a mutex.
  */
 export class TrueCasePathResolver {
   /**

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -106,11 +106,16 @@ export class TrueCasePathResolver {
     from: string,
     relativePath: string,
   ): Promise<string> {
+    const absoluteFrom = path.resolve(from);
+
     if (path.normalize(relativePath) === ".") {
+      // There's no casing to resolve, but we still read `from` so that callers
+      // get the documented FileNotFoundError / NotADirectoryError if it
+      // doesn't exist or isn't a directory.
+      await this.#getDirEntries(absoluteFrom);
       return "";
     }
 
-    const absoluteFrom = path.resolve(from);
     const resolved = await this.#resolveFrom(absoluteFrom, relativePath);
     const resolvedRelativePath = path.relative(absoluteFrom, resolved);
 

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -25,6 +25,234 @@ import {
   readdirWithFileTypesOrEmpty,
 } from "./internal/fs.js";
 
+const AMBIGUOUS_CASING_DIR_ENTRY = Symbol("ambiguous");
+
+type CaseFoldedEntry = string | typeof AMBIGUOUS_CASING_DIR_ENTRY;
+
+/**
+ * The entries in a directory, which stores their exact name, and also a
+ * case-folded mapping to support case-insensitive lookups.
+ */
+interface DirEntries {
+  /**
+   * The exact names present in the directory, as returned by `readdir`.
+   */
+  readonly exactNames: Set<string>;
+
+  /**
+   * Case-folded key -> the actual on-disk spelling, or
+   * AMBIGUOUS_CASING_DIR_ENTRY when multiple entries in the directory fold to
+   * the same key.
+   */
+  readonly caseFoldedNames: Map<string, CaseFoldedEntry>;
+}
+
+/**
+ * Resolves paths to their true (on-disk) casing, caching directory listings
+ * and resolutions so repeated lookups against the same directories don't re-hit
+ * the filesystem.
+ *
+ * Intended to be used in hot paths where the same `from` directories are seen
+ * over and over.
+ *
+ * Does not resolve symbolic links.
+ *
+ * This class caches successful resolutions internally, and may do some
+ * duplicate work when multiple concurrent lookups for the same path are made
+ * before the first one finishes, but it avoids caching failed lookups and stale
+ * results after `clear()`. If profiling shows that this work duplication is a
+ * problem, we can either cache in-flight operations, or add a mutex.
+ */
+export class TrueCasePathResolver {
+  /**
+   * A cache of DirEntries for the directories we've seen, keyed by their
+   * normalized absolute path as read. For example, if the same physical
+   * directory is read as `/a/foo` and `/a/Foo`, each path gets its own entry.
+   */
+  readonly #dirCache = new Map<string, DirEntries>();
+
+  /**
+   * A cache of successful resolutions, grouped by their `from` trusted starting
+   * directory.
+   *
+   * The outer key is the normalized absolute `from` path, and the inner key is
+   * the normalized `relativePath`.
+   *
+   * This keeps paths like `/a/B` + `foo.ts` distinct from `/a` + `B/foo.ts`,
+   * even if they point to the same location.
+   */
+  readonly #resultCache = new Map<string, Map<string, string>>();
+
+  /**
+   * Determines the true-case path of a given relative path from a specified
+   * directory, without resolving symbolic links.
+   *
+   * Note that the casing of the `from` path is not checked against the
+   * filesystem, and is trusted as-is. This avoids unnecessary directory
+   * listings for every ancestor of `from`, which can result in permission
+   * errors for directories that are otherwise accessible.
+   *
+   * @param from The absolute path of the directory to start the search from.
+   * @param relativePath The relative path to get the true case of.
+   * @returns The true case of the relative path.
+   * @throws FileNotFoundError if the starting directory or the relative path
+   *  doesn't exist or is ambiguous.
+   * @throws NotADirectoryError if the starting directory, or an intermediate
+   *  segment, is not a directory.
+   * @throws FileSystemAccessError for any other error.
+   */
+  public async getFileTrueCase(
+    from: string,
+    relativePath: string,
+  ): Promise<string> {
+    const absoluteFrom = path.resolve(from);
+    const resolved = await this.#resolveFrom(absoluteFrom, relativePath);
+    return path.relative(absoluteFrom, resolved);
+  }
+
+  /**
+   * Clears all cached directory listings and resolutions.
+   */
+  public clear(): void {
+    this.#dirCache.clear();
+    this.#resultCache.clear();
+  }
+
+  async #resolveFrom(from: string, relativePath: string): Promise<string> {
+    const fromCacheKey = this.#getResultFromCacheKey(from);
+    const relativePathCacheKey =
+      this.#getResultRelativePathCacheKey(relativePath);
+
+    const cached = this.#resultCache
+      .get(fromCacheKey)
+      ?.get(relativePathCacheKey);
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const resolved = await this.#doResolveFrom(from, relativePath);
+
+    let resultsFromCache = this.#resultCache.get(fromCacheKey);
+    if (resultsFromCache === undefined) {
+      resultsFromCache = new Map<string, string>();
+      this.#resultCache.set(fromCacheKey, resultsFromCache);
+    }
+
+    resultsFromCache.set(relativePathCacheKey, resolved);
+
+    return resolved;
+  }
+
+  async #doResolveFrom(from: string, relativePath: string): Promise<string> {
+    let currentPath = from;
+
+    const segments = path
+      .normalize(relativePath)
+      .split(path.sep)
+      .filter((s) => s.length > 0);
+
+    for (const requestedName of segments) {
+      if (requestedName === ".") {
+        continue;
+      }
+
+      if (requestedName === "..") {
+        currentPath = path.join(currentPath, requestedName);
+        continue;
+      }
+
+      const entries = await this.#getDirEntries(currentPath);
+      const actualName = this.#lookupChild(entries, requestedName);
+
+      if (actualName === undefined) {
+        throw new FileNotFoundError(path.resolve(from, relativePath));
+      }
+
+      currentPath = path.join(currentPath, actualName);
+    }
+
+    return currentPath;
+  }
+
+  async #getDirEntries(dirPath: string): Promise<DirEntries> {
+    const cacheKey = this.#getDirCacheKey(dirPath);
+    const cached = this.#dirCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const entries = await this.#readDirEntries(dirPath);
+    this.#dirCache.set(cacheKey, entries);
+
+    return entries;
+  }
+
+  async #readDirEntries(dirPath: string): Promise<DirEntries> {
+    const names = await readdir(dirPath);
+
+    const exactNames = new Set<string>();
+    const caseFoldedNames = new Map<string, CaseFoldedEntry>();
+
+    for (const name of names) {
+      exactNames.add(name);
+
+      const folded = this.#caseFold(name);
+      const previous = caseFoldedNames.get(folded);
+      if (previous === undefined) {
+        caseFoldedNames.set(folded, name);
+      } else if (previous !== name) {
+        caseFoldedNames.set(folded, AMBIGUOUS_CASING_DIR_ENTRY);
+      }
+    }
+
+    return { exactNames, caseFoldedNames };
+  }
+
+  #lookupChild(entries: DirEntries, requestedName: string): string | undefined {
+    if (entries.exactNames.has(requestedName)) {
+      return requestedName;
+    }
+
+    const candidate = entries.caseFoldedNames.get(
+      this.#caseFold(requestedName),
+    );
+
+    if (candidate === undefined || candidate === AMBIGUOUS_CASING_DIR_ENTRY) {
+      return undefined;
+    }
+
+    return candidate;
+  }
+
+  #getResultFromCacheKey(from: string): string {
+    return path.normalize(from);
+  }
+
+  #getResultRelativePathCacheKey(relativePath: string): string {
+    return path.normalize(relativePath);
+  }
+
+  #getDirCacheKey(dirPath: string): string {
+    return path.normalize(dirPath);
+  }
+
+  /**
+   * Returns a case-folded version of the given name, which can be thought of as
+   * a "normalized uppercase" form. This is used to implement case-insensitive
+   * comparisons.
+   *
+   * This is not an exact match with what every filesystem would do, but a good
+   * enough approximation for our purposes.
+   *
+   * @param name The name to fold.
+   * @returns The case-folded version of the name.
+   */
+  #caseFold(name: string): string {
+    return name.normalize("NFC").toUpperCase();
+  }
+}
+
 /**
  * Determines the canonical pathname for a given path, resolving any symbolic
  * links, and returns it.
@@ -141,34 +369,16 @@ export async function getAllDirectoriesMatching(
  * @throws FileNotFoundError if the starting directory or the relative path doesn't exist.
  * @throws NotADirectoryError if the starting directory is not a directory.
  * @throws FileSystemAccessError for any other error.
+ * @deprecated Creates a fresh {@link TrueCasePathResolver} per call, so it
+ *  provides no caching across invocations. For hot paths that resolve many
+ *  paths against the same directories, instantiate a `TrueCasePathResolver`
+ *  once and reuse it.
  */
 export async function getFileTrueCase(
   from: string,
   relativePath: string,
 ): Promise<string> {
-  const dirEntries = await readdirOrEmpty(from);
-
-  const segments = relativePath.split(path.sep);
-  const nextDir = segments[0];
-  const nextDirLowerCase = nextDir.toLowerCase();
-
-  for (const dirEntry of dirEntries) {
-    if (dirEntry.toLowerCase() === nextDirLowerCase) {
-      if (segments.length === 1) {
-        return dirEntry;
-      }
-
-      return path.join(
-        dirEntry,
-        await getFileTrueCase(
-          path.join(from, dirEntry),
-          path.relative(nextDir, relativePath),
-        ),
-      );
-    }
-  }
-
-  throw new FileNotFoundError(path.join(from, relativePath));
+  return await new TrueCasePathResolver().getFileTrueCase(from, relativePath);
 }
 
 /**

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -173,13 +173,9 @@ export class TrueCasePathResolver {
     const segments = path
       .normalize(relativePath)
       .split(path.sep)
-      .filter((s) => s.length > 0);
+      .filter((s) => s.length > 0 || s === ".");
 
     for (const requestedName of segments) {
-      if (requestedName === ".") {
-        continue;
-      }
-
       if (requestedName === "..") {
         currentPath = path.join(currentPath, requestedName);
         continue;

--- a/packages/hardhat-utils/test/fs.ts
+++ b/packages/hardhat-utils/test/fs.ts
@@ -900,6 +900,30 @@ describe("File system utils", () => {
       });
     });
 
+    it("Should throw FileNotFoundError when relativePath is '.' and the starting directory doesn't exist", async () => {
+      const missingDir = path.join(getTmpDir(), "missing");
+
+      const resolver = new TrueCasePathResolver();
+
+      await assert.rejects(resolver.getFileTrueCase(missingDir, "."), {
+        name: "FileNotFoundError",
+      });
+      await assert.rejects(resolver.getFileTrueCase(missingDir, ""), {
+        name: "FileNotFoundError",
+      });
+    });
+
+    it("Should throw NotADirectoryError when relativePath is '.' and the starting directory is a file", async () => {
+      const filePath = path.join(getTmpDir(), "fileAsFrom");
+      await createFile(filePath);
+
+      const resolver = new TrueCasePathResolver();
+
+      await assert.rejects(resolver.getFileTrueCase(filePath, "."), {
+        name: "NotADirectoryError",
+      });
+    });
+
     it("Should throw FileSystemAccessError if a different error is thrown", async () => {
       const linkPath = path.join(getTmpDir(), "link");
       await fsPromises.symlink(linkPath, linkPath);

--- a/packages/hardhat-utils/test/fs.ts
+++ b/packages/hardhat-utils/test/fs.ts
@@ -660,6 +660,57 @@ describe("File system utils", () => {
       );
     });
 
+    it("Should return an empty path when resolving the starting directory itself", async () => {
+      const resolver = new TrueCasePathResolver();
+
+      assert.equal(await resolver.getFileTrueCase(getTmpDir(), ""), "");
+      assert.equal(await resolver.getFileTrueCase(getTmpDir(), "."), "");
+      assert.equal(
+        await resolver.getFileTrueCase(getTmpDir(), path.join("dir", "..")),
+        "",
+      );
+    });
+
+    it("Should resolve relative paths with parent segments that stay within the starting directory", async () => {
+      const mixedCaseFilePath = path.join(getTmpDir(), "mixedCaseFile");
+      const mixedCaseDirPath = path.join(getTmpDir(), "mixedCaseDir");
+
+      await createFile(mixedCaseFilePath);
+      await mkdir(mixedCaseDirPath);
+
+      const resolver = new TrueCasePathResolver();
+
+      assert.equal(
+        await resolver.getFileTrueCase(
+          getTmpDir(),
+          path.join("mixedCaseDir", "..", "mixedcasefile"),
+        ),
+        "mixedCaseFile",
+      );
+    });
+
+    it("Should throw FileNotFoundError if the resolved path escapes the starting directory", async () => {
+      const rootPath = path.join(getTmpDir(), "root");
+      const nestedPath = path.join(rootPath, "nested");
+      const secretPath = path.join(getTmpDir(), "secret");
+
+      await mkdir(nestedPath);
+      await createFile(secretPath);
+
+      const resolver = new TrueCasePathResolver();
+
+      await assert.rejects(
+        resolver.getFileTrueCase(
+          rootPath,
+          path.join("nested", "..", "..", "secret"),
+        ),
+        {
+          name: "FileNotFoundError",
+          message: `File ${secretPath} not found`,
+        },
+      );
+    });
+
     it("Should cache directory listings across calls to the same resolver", async () => {
       const filePath = path.join(getTmpDir(), "cachedFile");
       await createFile(filePath);

--- a/packages/hardhat-utils/test/fs.ts
+++ b/packages/hardhat-utils/test/fs.ts
@@ -1,3 +1,4 @@
+// cSpell:ignore APFS ambig AMBIG Ambig
 import type { Dirent } from "node:fs";
 
 import assert from "node:assert/strict";

--- a/packages/hardhat-utils/test/fs.ts
+++ b/packages/hardhat-utils/test/fs.ts
@@ -19,6 +19,7 @@ import {
   getChangeTime,
   getFileTrueCase,
   getRealPath,
+  TrueCasePathResolver,
   isDirectory,
   mkdir,
   move,
@@ -624,6 +625,236 @@ describe("File system utils", () => {
       await fsPromises.symlink(linkPath, linkPath);
 
       await assert.rejects(getFileTrueCase(linkPath, "file"), {
+        name: "FileSystemAccessError",
+      });
+    });
+  });
+
+  describe("TrueCasePathResolver", () => {
+    it("Should return the true case of files and directories", async () => {
+      const mixedCaseFilePath = path.join(getTmpDir(), "mixedCaseFile");
+      const mixedCaseDirPath = path.join(getTmpDir(), "mixedCaseDir");
+      const mixedCaseFile2Path = path.join(mixedCaseDirPath, "mixedCaseFile2");
+
+      await createFile(mixedCaseFilePath);
+      await mkdir(mixedCaseDirPath);
+      await createFile(mixedCaseFile2Path);
+
+      const resolver = new TrueCasePathResolver();
+
+      assert.equal(
+        await resolver.getFileTrueCase(getTmpDir(), "mixedcasefile"),
+        "mixedCaseFile",
+      );
+      assert.equal(
+        await resolver.getFileTrueCase(getTmpDir(), "MIXEDCASEDIR"),
+        "mixedCaseDir",
+      );
+      assert.equal(
+        await resolver.getFileTrueCase(
+          getTmpDir(),
+          path.join("mixedcasedir", "MIXEDCASEFILE2"),
+        ),
+        path.join("mixedCaseDir", "mixedCaseFile2"),
+      );
+    });
+
+    it("Should cache directory listings across calls to the same resolver", async () => {
+      const filePath = path.join(getTmpDir(), "cachedFile");
+      await createFile(filePath);
+
+      const resolver = new TrueCasePathResolver();
+
+      assert.equal(
+        await resolver.getFileTrueCase(getTmpDir(), "cachedFile"),
+        "cachedFile",
+      );
+
+      // Remove the file behind the resolver's back; because both the
+      // directory listing and the result are cached, subsequent lookups
+      // should still succeed.
+      await remove(filePath);
+
+      assert.equal(
+        await resolver.getFileTrueCase(getTmpDir(), "cachedFile"),
+        "cachedFile",
+      );
+      assert.equal(
+        await resolver.getFileTrueCase(getTmpDir(), "CACHEDFILE"),
+        "cachedFile",
+      );
+
+      resolver.clear();
+
+      await assert.rejects(
+        resolver.getFileTrueCase(getTmpDir(), "cachedFile"),
+        { name: "FileNotFoundError" },
+      );
+    });
+
+    it("Should cache resolutions separately for different trusted starting directories", async (t) => {
+      const root = path.join(getTmpDir(), "root");
+      const trustedFrom = path.join(root, "B"); // Note that it's uppercase
+
+      // We mock `readdir` so that it mimics a case-insensitive filesystem where
+      // root/b/foo.ts exists - Note the lowercase b.
+      let numberOfCallsToReaddir = 0;
+      t.mock.method(fsPromises, "readdir", async (...args: any[]) => {
+        numberOfCallsToReaddir++;
+        const dirPath = path.normalize(String(args[0]));
+
+        if (dirPath === path.normalize(trustedFrom)) {
+          return ["foo.ts"];
+        }
+
+        if (dirPath === path.normalize(root)) {
+          return ["b"];
+        }
+
+        if (dirPath === path.normalize(path.join(root, "b"))) {
+          return ["foo.ts"];
+        }
+
+        throw Object.assign(new Error(`Unexpected readdir: ${dirPath}`), {
+          code: "ENOENT",
+        });
+      });
+
+      const resolver = new TrueCasePathResolver();
+
+      // Resolving from root/B, it readdirs root/B.
+      assert.equal(
+        await resolver.getFileTrueCase(trustedFrom, "foo.ts"),
+        "foo.ts",
+      );
+      assert.equal(numberOfCallsToReaddir, 1);
+
+      // Resolving from root, it readdirs root and root/b, not using the cache,
+      // because the trusted starting directory is different.
+      assert.equal(
+        await resolver.getFileTrueCase(root, path.join("B", "foo.ts")),
+        path.join("b", "foo.ts"),
+      );
+      assert.equal(numberOfCallsToReaddir, 3);
+    });
+
+    it("Should not resolve the true casing of the trusted starting directory", async (t) => {
+      const trustedFrom = path.join(getTmpDir(), "a", "B");
+
+      // We mock `readdir` so that only the trusted starting directory can be
+      // read. If the resolver tries to read any ancestor of `from`, this test
+      // fails.
+      let numberOfCallsToReaddir = 0;
+      t.mock.method(fsPromises, "readdir", async (...args: any[]) => {
+        numberOfCallsToReaddir++;
+        const dirPath = path.normalize(String(args[0]));
+
+        if (dirPath === path.normalize(trustedFrom)) {
+          return ["foo.ts"];
+        }
+
+        throw Object.assign(new Error(`Unexpected readdir: ${dirPath}`), {
+          code: "EACCES",
+        });
+      });
+
+      const resolver = new TrueCasePathResolver();
+
+      // Resolving from a/B only readdirs a/B, trusting the casing of `from`.
+      assert.equal(
+        await resolver.getFileTrueCase(trustedFrom, "foo.ts"),
+        "foo.ts",
+      );
+      assert.equal(numberOfCallsToReaddir, 1);
+    });
+
+    it("Should not throw when a previous call threw and the path now exists", async () => {
+      const resolver = new TrueCasePathResolver();
+
+      await assert.rejects(
+        resolver.getFileTrueCase(getTmpDir(), "laterCreated"),
+        { name: "FileNotFoundError" },
+      );
+
+      await createFile(path.join(getTmpDir(), "laterCreated"));
+
+      // The directory listing from the first call is cached, so without
+      // `clear()` the new file is invisible.
+      await assert.rejects(
+        resolver.getFileTrueCase(getTmpDir(), "laterCreated"),
+        { name: "FileNotFoundError" },
+      );
+
+      resolver.clear();
+
+      assert.equal(
+        await resolver.getFileTrueCase(getTmpDir(), "laterCreated"),
+        "laterCreated",
+      );
+    });
+
+    it("Should throw FileNotFoundError when the case-folded name is ambiguous", async function () {
+      // This test requires a case-sensitive filesystem in the tmp dir.
+      // macOS APFS and Windows NTFS default to case-insensitive, so two
+      // entries differing only in case can't coexist there.
+      if (process.platform !== "linux") {
+        return;
+      }
+
+      await createFile(path.join(getTmpDir(), "ambig"));
+      await createFile(path.join(getTmpDir(), "AMBIG"));
+
+      const resolver = new TrueCasePathResolver();
+
+      // Exact matches still work.
+      assert.equal(
+        await resolver.getFileTrueCase(getTmpDir(), "ambig"),
+        "ambig",
+      );
+      assert.equal(
+        await resolver.getFileTrueCase(getTmpDir(), "AMBIG"),
+        "AMBIG",
+      );
+
+      // A spelling that folds to the ambiguous key is rejected.
+      await assert.rejects(resolver.getFileTrueCase(getTmpDir(), "Ambig"), {
+        name: "FileNotFoundError",
+      });
+    });
+
+    it("Should throw NotADirectoryError if an intermediate segment is not a directory", async () => {
+      const filePath = path.join(getTmpDir(), "file");
+      await createFile(filePath);
+
+      const resolver = new TrueCasePathResolver();
+
+      await assert.rejects(
+        resolver.getFileTrueCase(getTmpDir(), path.join("file", "child.ts")),
+        {
+          name: "NotADirectoryError",
+          message: `Path ${filePath} is not a directory`,
+        },
+      );
+    });
+
+    it("Should throw NotADirectoryError if the starting directory is not a directory", async () => {
+      const filePath = path.join(getTmpDir(), "file");
+      await createFile(filePath);
+
+      const resolver = new TrueCasePathResolver();
+
+      await assert.rejects(resolver.getFileTrueCase(filePath, "asd"), {
+        name: "NotADirectoryError",
+      });
+    });
+
+    it("Should throw FileSystemAccessError if a different error is thrown", async () => {
+      const linkPath = path.join(getTmpDir(), "link");
+      await fsPromises.symlink(linkPath, linkPath);
+
+      const resolver = new TrueCasePathResolver();
+
+      await assert.rejects(resolver.getFileTrueCase(linkPath, "file"), {
         name: "FileSystemAccessError",
       });
     });

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -24,7 +24,10 @@ import type { Result } from "../../../../../types/utils.js";
 import path from "node:path";
 
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
-import { exists } from "@nomicfoundation/hardhat-utils/fs";
+import {
+  exists,
+  TrueCasePathResolver,
+} from "@nomicfoundation/hardhat-utils/fs";
 import { AsyncMutex } from "@nomicfoundation/hardhat-utils/synchronization";
 import { analyze } from "@nomicfoundation/solidity-analyzer";
 
@@ -81,6 +84,9 @@ export class ResolverImplementation implements Resolver {
    * the same logic we use for imports.
    */
   readonly #fakeRootFile: ProjectResolvedFile;
+
+  readonly #trueCasePathResolver: TrueCasePathResolver =
+    new TrueCasePathResolver();
 
   /**
    * Creates a new resolver.
@@ -221,6 +227,7 @@ export class ResolverImplementation implements Resolver {
     }
 
     const pathValidation = await validateFsPath(
+      this.#trueCasePathResolver,
       this.#projectRoot,
       relativeFilePath,
     );
@@ -839,6 +846,7 @@ export class ResolverImplementation implements Resolver {
     >
   > {
     const pathValidation = await validateFsPath(
+      this.#trueCasePathResolver,
       npmPackage.rootFsPath,
       relativeFsPathWithinPackage,
     );

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
@@ -4,7 +4,10 @@ import type { TrueCasePathResolver } from "@nomicfoundation/hardhat-utils/fs";
 
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
-import { FileNotFoundError } from "@nomicfoundation/hardhat-utils/fs";
+import {
+  FileNotFoundError,
+  NotADirectoryError,
+} from "@nomicfoundation/hardhat-utils/fs";
 import { exports } from "resolve.exports";
 
 export enum PathValidationErrorType {
@@ -27,12 +30,19 @@ export async function validateFsPath(
   try {
     trueCaseFsPath = await resolver.getFileTrueCase(from, relative);
   } catch (error) {
-    ensureError(error, FileNotFoundError);
+    ensureError(error);
 
-    return {
-      success: false,
-      error: { type: PathValidationErrorType.DOES_NOT_EXIST },
-    };
+    if (
+      error instanceof FileNotFoundError ||
+      error instanceof NotADirectoryError
+    ) {
+      return {
+        success: false,
+        error: { type: PathValidationErrorType.DOES_NOT_EXIST },
+      };
+    }
+
+    throw error;
   }
 
   if (relative !== trueCaseFsPath) {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
@@ -1,12 +1,10 @@
 import type { ResolvedNpmPackage } from "../../../../../types/solidity.js";
 import type { Result } from "../../../../../types/utils.js";
+import type { TrueCasePathResolver } from "@nomicfoundation/hardhat-utils/fs";
 
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
-import {
-  FileNotFoundError,
-  getFileTrueCase,
-} from "@nomicfoundation/hardhat-utils/fs";
+import { FileNotFoundError } from "@nomicfoundation/hardhat-utils/fs";
 import { exports } from "resolve.exports";
 
 export enum PathValidationErrorType {
@@ -15,6 +13,7 @@ export enum PathValidationErrorType {
 }
 
 export async function validateFsPath(
+  resolver: TrueCasePathResolver,
   from: string,
   relative: string,
 ): Promise<
@@ -26,7 +25,7 @@ export async function validateFsPath(
 > {
   let trueCaseFsPath: string;
   try {
-    trueCaseFsPath = await getFileTrueCase(from, relative);
+    trueCaseFsPath = await resolver.getFileTrueCase(from, relative);
   } catch (error) {
     ensureError(error, FileNotFoundError);
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
@@ -7,6 +7,7 @@ import { after, before, describe, it } from "node:test";
 import {
   mkdtemp,
   remove,
+  TrueCasePathResolver,
   writeUtf8File,
 } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -30,12 +31,15 @@ describe("Resolver utils", () => {
     it("Should return an error if the path doesn't exist", async () => {
       const relativePath = "nope";
 
-      assert.deepEqual(await validateFsPath(dir, relativePath), {
-        success: false,
-        error: {
-          type: PathValidationErrorType.DOES_NOT_EXIST,
+      assert.deepEqual(
+        await validateFsPath(new TrueCasePathResolver(), dir, relativePath),
+        {
+          success: false,
+          error: {
+            type: PathValidationErrorType.DOES_NOT_EXIST,
+          },
         },
-      });
+      );
     });
 
     it("Should return an error if the path exists with a different casing", async () => {
@@ -44,13 +48,20 @@ describe("Resolver utils", () => {
       const absolutePath = path.join(dir, relativePathCorrect);
       await writeUtf8File(absolutePath, "txt");
 
-      assert.deepEqual(await validateFsPath(dir, relativePathIncorrect), {
-        success: false,
-        error: {
-          type: PathValidationErrorType.CASING_ERROR,
-          correctCasing: relativePathCorrect,
+      assert.deepEqual(
+        await validateFsPath(
+          new TrueCasePathResolver(),
+          dir,
+          relativePathIncorrect,
+        ),
+        {
+          success: false,
+          error: {
+            type: PathValidationErrorType.CASING_ERROR,
+            correctCasing: relativePathCorrect,
+          },
         },
-      });
+      );
     });
 
     it("Should return success if the path exists with the correct casing", async () => {
@@ -58,10 +69,13 @@ describe("Resolver utils", () => {
       const absolutePath = path.join(dir, relativePath);
       await writeUtf8File(absolutePath, "txt");
 
-      assert.deepEqual(await validateFsPath(dir, relativePath), {
-        success: true,
-        value: undefined,
-      });
+      assert.deepEqual(
+        await validateFsPath(new TrueCasePathResolver(), dir, relativePath),
+        {
+          success: true,
+          value: undefined,
+        },
+      );
     });
   });
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
@@ -42,6 +42,26 @@ describe("Resolver utils", () => {
       );
     });
 
+    it("Should return an error if the path traverses through a file", async () => {
+      const fileName = "not-a-dir.txt";
+      const absolutePath = path.join(dir, fileName);
+      await writeUtf8File(absolutePath, "txt");
+
+      assert.deepEqual(
+        await validateFsPath(
+          new TrueCasePathResolver(),
+          dir,
+          path.join(fileName, "child.sol"),
+        ),
+        {
+          success: false,
+          error: {
+            type: PathValidationErrorType.DOES_NOT_EXIST,
+          },
+        },
+      );
+    });
+
     it("Should return an error if the path exists with a different casing", async () => {
       const relativePathIncorrect = "FILE.txt";
       const relativePathCorrect = "file.txt";


### PR DESCRIPTION
This PR introduces a new class to the `fs` module of `hardhat-utils`, which caches the intermediate lookups used to get files' true case path. The reason this is an optimization is that we get the true case path for multiple files per npm package in the build system.