### PR TITLE
Change type extensions handling

### DIFF
--- a/.changeset/hardhat-ethers-chai-matchers-update-type-extensions-handling.md
+++ b/.changeset/hardhat-ethers-chai-matchers-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-ethers-update-type-extensions-handling.md
+++ b/.changeset/hardhat-ethers-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-ignition-ethers-update-type-extensions-handling.md
+++ b/.changeset/hardhat-ignition-ethers-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition-ethers": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-ignition-update-type-extensions-handling.md
+++ b/.changeset/hardhat-ignition-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-ignition-viem-update-type-extensions-handling.md
+++ b/.changeset/hardhat-ignition-viem-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition-viem": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-keystore-update-type-extensions-handling.md
+++ b/.changeset/hardhat-keystore-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-keystore": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-ledger-update-type-extensions-handling.md
+++ b/.changeset/hardhat-ledger-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ledger": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-mocha-update-type-extensions-handling.md
+++ b/.changeset/hardhat-mocha-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-mocha": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-network-helpers-update-type-extensions-handling.md
+++ b/.changeset/hardhat-network-helpers-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-node-test-runner-update-type-extensions-handling.md
+++ b/.changeset/hardhat-node-test-runner-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-runner": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-toolbox-mocha-ethers-update-type-extensions-handling.md
+++ b/.changeset/hardhat-toolbox-mocha-ethers-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-toolbox-mocha-ethers": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-toolbox-viem-update-type-extensions-handling.md
+++ b/.changeset/hardhat-toolbox-viem-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-toolbox-viem": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-typechain-update-type-extensions-handling.md
+++ b/.changeset/hardhat-typechain-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-typechain": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-update-type-extensions-handling.md
+++ b/.changeset/hardhat-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-verify-update-type-extensions-handling.md
+++ b/.changeset/hardhat-verify-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-viem-assertions-update-type-extensions-handling.md
+++ b/.changeset/hardhat-viem-assertions-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/.changeset/hardhat-viem-update-type-extensions-handling.md
+++ b/.changeset/hardhat-viem-update-type-extensions-handling.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Update how type extensions are handled to optimize the bootstrap process of Hardhat.

--- a/packages/config/tsconfig.base.json
+++ b/packages/config/tsconfig.base.json
@@ -4,6 +4,7 @@
     "outDir": "${configDir}/dist",
     "declaration": true,
     "declarationMap": true,
+    "moduleDetection": "force",
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "isolatedDeclarations": true,

--- a/packages/hardhat-ethers-chai-matchers/src/index.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatChaiMatchersPlugin: HardhatPlugin = {
   id: "hardhat-ethers-chai-matchers",

--- a/packages/hardhat-ethers-chai-matchers/src/type-extensions.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/type-extensions.ts
@@ -1,5 +1,7 @@
 import type { HardhatEthers } from "@nomicfoundation/hardhat-ethers/types";
 
+export type * from "@nomicfoundation/hardhat-ethers";
+
 // We use declare global instead of declare module "chai", because that's what
 // @types/chai does.
 declare global {

--- a/packages/hardhat-ethers/src/index.ts
+++ b/packages/hardhat-ethers/src/index.ts
@@ -1,6 +1,6 @@
-import "./type-extensions.js";
-
 import type { HardhatPlugin } from "hardhat/types/plugins";
+
+export type * from "./type-extensions.js";
 
 const hardhatEthersPlugin: HardhatPlugin = {
   id: "hardhat-ethers",

--- a/packages/hardhat-ethers/src/type-extensions.ts
+++ b/packages/hardhat-ethers/src/type-extensions.ts
@@ -1,4 +1,3 @@
-import "hardhat/types/network";
 import type { HardhatEthers } from "./types.js";
 
 declare module "hardhat/types/network" {

--- a/packages/hardhat-ignition-ethers/src/index.ts
+++ b/packages/hardhat-ignition-ethers/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatIgnitionEthersPlugin: HardhatPlugin = {
   id: "hardhat-ignition-ethers",

--- a/packages/hardhat-ignition-ethers/src/internal/ethers-ignition-helper.ts
+++ b/packages/hardhat-ignition-ethers/src/internal/ethers-ignition-helper.ts
@@ -1,4 +1,3 @@
-import "@nomicfoundation/hardhat-ethers";
 import type {
   EthersIgnitionHelper,
   IgnitionModuleResultsTToEthersContracts,
@@ -19,7 +18,6 @@ import type { HardhatConfig } from "hardhat/types/config";
 import type { HookManager, UserInterruptionHooks } from "hardhat/types/hooks";
 import type { ChainType, NetworkConnection } from "hardhat/types/network";
 import type { UserInterruptionManager } from "hardhat/types/user-interruptions";
-import "@nomicfoundation/hardhat-ignition";
 
 import path from "node:path";
 

--- a/packages/hardhat-ignition-viem/src/index.ts
+++ b/packages/hardhat-ignition-viem/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatIgnitionViemPlugin: HardhatPlugin = {
   id: "hardhat-ignition-viem",

--- a/packages/hardhat-ignition/src/index.ts
+++ b/packages/hardhat-ignition/src/index.ts
@@ -5,7 +5,7 @@ import { ArgumentType } from "hardhat/types/arguments";
 
 import { PLUGIN_ID } from "./internal/constants.js";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatIgnitionPlugin: HardhatPlugin = {
   id: PLUGIN_ID,

--- a/packages/hardhat-ignition/src/type-extensions.ts
+++ b/packages/hardhat-ignition/src/type-extensions.ts
@@ -2,7 +2,6 @@ import type {
   DeployConfig,
   StrategyConfig,
 } from "@nomicfoundation/ignition-core";
-import "hardhat/types/config";
 
 export type * from "@nomicfoundation/hardhat-verify";
 

--- a/packages/hardhat-ignition/src/type-extensions.ts
+++ b/packages/hardhat-ignition/src/type-extensions.ts
@@ -1,9 +1,10 @@
-import "hardhat/types/config";
-
 import type {
   DeployConfig,
   StrategyConfig,
 } from "@nomicfoundation/ignition-core";
+import "hardhat/types/config";
+
+export type * from "@nomicfoundation/hardhat-verify";
 
 declare module "hardhat/types/config" {
   export interface ProjectPathsUserConfig {

--- a/packages/hardhat-keystore/src/index.ts
+++ b/packages/hardhat-keystore/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./internal/type-extensions.js";
+export type * from "./internal/type-extensions.js";
 
 import { emptyTask, task } from "hardhat/config";
 import { ArgumentType } from "hardhat/types/arguments";

--- a/packages/hardhat-keystore/src/internal/type-extensions.ts
+++ b/packages/hardhat-keystore/src/internal/type-extensions.ts
@@ -1,5 +1,3 @@
-import "hardhat/types/config";
-
 declare module "hardhat/types/config" {
   export interface HardhatConfig {
     keystore: {

--- a/packages/hardhat-ledger/src/index.ts
+++ b/packages/hardhat-ledger/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 import { PLUGIN_NAME } from "./internal/plugin-name.js";
 

--- a/packages/hardhat-ledger/src/type-extensions.ts
+++ b/packages/hardhat-ledger/src/type-extensions.ts
@@ -1,4 +1,3 @@
-import "hardhat/types/config";
 import type { DerivationFunction } from "./internal/types.js";
 
 declare module "hardhat/types/config" {

--- a/packages/hardhat-mocha/src/index.ts
+++ b/packages/hardhat-mocha/src/index.ts
@@ -3,7 +3,7 @@ import type { HardhatPlugin } from "hardhat/types/plugins";
 import { task } from "hardhat/config";
 import { ArgumentType } from "hardhat/types/arguments";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-mocha",

--- a/packages/hardhat-mocha/src/type-extensions.ts
+++ b/packages/hardhat-mocha/src/type-extensions.ts
@@ -1,5 +1,3 @@
-import "hardhat/types/config";
-
 import type { MochaOptions } from "mocha";
 
 declare module "hardhat/types/config" {
@@ -12,7 +10,6 @@ declare module "hardhat/types/config" {
   }
 }
 
-import "hardhat/types/test";
 declare module "hardhat/types/test" {
   export interface HardhatTestUserConfig {
     mocha?: MochaOptions;

--- a/packages/hardhat-network-helpers/src/index.ts
+++ b/packages/hardhat-network-helpers/src/index.ts
@@ -1,6 +1,6 @@
-import "./type-extensions.js";
-
 import type { HardhatPlugin } from "hardhat/types/plugins";
+
+export type * from "./type-extensions.js";
 
 const hardhatNetworkHelpersPlugin: HardhatPlugin = {
   id: "hardhat-network-helpers",

--- a/packages/hardhat-network-helpers/src/type-extensions.ts
+++ b/packages/hardhat-network-helpers/src/type-extensions.ts
@@ -1,4 +1,3 @@
-import "hardhat/types/network";
 import type { NetworkHelpers } from "./types.js";
 
 declare module "hardhat/types/network" {

--- a/packages/hardhat-node-test-runner/src/index.ts
+++ b/packages/hardhat-node-test-runner/src/index.ts
@@ -3,7 +3,7 @@ import type { HardhatPlugin } from "hardhat/types/plugins";
 import { task } from "hardhat/config";
 import { ArgumentType } from "hardhat/types/arguments";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-node-test-runner",

--- a/packages/hardhat-node-test-runner/src/type-extensions.ts
+++ b/packages/hardhat-node-test-runner/src/type-extensions.ts
@@ -1,5 +1,3 @@
-import "hardhat/types/config";
-
 declare module "hardhat/types/config" {
   export interface TestPathsUserConfig {
     nodejs?: string;

--- a/packages/hardhat-solx/src/index.ts
+++ b/packages/hardhat-solx/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatSolxPlugin: HardhatPlugin = {
   id: "hardhat-solx",

--- a/packages/hardhat-solx/src/type-extensions.ts
+++ b/packages/hardhat-solx/src/type-extensions.ts
@@ -1,5 +1,3 @@
-import "hardhat/types/config";
-
 declare module "hardhat/types/config" {
   export interface SolidityCompilerTypeDefinitions {
     solx: true;

--- a/packages/hardhat-toolbox-mocha-ethers/src/index.ts
+++ b/packages/hardhat-toolbox-mocha-ethers/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatToolboxMochaEthersPlugin: HardhatPlugin = {
   id: "hardhat-toolbox-mocha-ethers",

--- a/packages/hardhat-toolbox-viem/src/index.ts
+++ b/packages/hardhat-toolbox-viem/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatToolboxViemPlugin: HardhatPlugin = {
   id: "hardhat-toolbox-viem",

--- a/packages/hardhat-typechain/src/index.ts
+++ b/packages/hardhat-typechain/src/index.ts
@@ -1,7 +1,8 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
 import { globalFlag } from "hardhat/config";
+
+export type * from "./type-extensions.js";
 
 const hardhatTypechain: HardhatPlugin = {
   id: "hardhat-typechain",

--- a/packages/hardhat-typechain/src/type-extensions.ts
+++ b/packages/hardhat-typechain/src/type-extensions.ts
@@ -1,4 +1,3 @@
-import "hardhat/types/config";
 import type { TypechainConfig, TypechainUserConfig } from "./types.js";
 
 export type * from "@nomicfoundation/hardhat-ethers";
@@ -13,7 +12,6 @@ declare module "hardhat/types/config" {
   }
 }
 
-import "hardhat/types/global-options";
 declare module "hardhat/types/global-options" {
   interface GlobalOptions {
     noTypechain: boolean;

--- a/packages/hardhat-typechain/src/type-extensions.ts
+++ b/packages/hardhat-typechain/src/type-extensions.ts
@@ -1,6 +1,8 @@
 import "hardhat/types/config";
 import type { TypechainConfig, TypechainUserConfig } from "./types.js";
 
+export type * from "@nomicfoundation/hardhat-ethers";
+
 declare module "hardhat/types/config" {
   export interface HardhatUserConfig {
     typechain?: TypechainUserConfig;

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -1,10 +1,11 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
 import verifyBlockscoutTask from "./internal/tasks/verify/blockscout/index.js";
 import verifyEtherscanTask from "./internal/tasks/verify/etherscan/index.js";
 import verifyTask from "./internal/tasks/verify/index.js";
 import verifySourcifyTask from "./internal/tasks/verify/sourcify/index.js";
+
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-verify",

--- a/packages/hardhat-verify/src/type-extensions.ts
+++ b/packages/hardhat-verify/src/type-extensions.ts
@@ -1,6 +1,5 @@
 import type { VerificationHelpers } from "./types.js";
 
-import "hardhat/types/config";
 declare module "hardhat/types/config" {
   export interface HardhatUserConfig {
     verify?: VerificationProvidersUserConfig;
@@ -56,7 +55,6 @@ declare module "hardhat/types/config" {
   }
 }
 
-import "hardhat/types/network";
 declare module "hardhat/types/network" {
   interface NetworkConnection<
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- the ChainTypeT must be declared in the interface but in this scenario it's not used

--- a/packages/hardhat-viem-assertions/src/index.ts
+++ b/packages/hardhat-viem-assertions/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-viem-assertions",

--- a/packages/hardhat-viem-assertions/src/type-extensions.ts
+++ b/packages/hardhat-viem-assertions/src/type-extensions.ts
@@ -1,5 +1,6 @@
-import "@nomicfoundation/hardhat-viem";
 import type { HardhatViemAssertions } from "./types.js";
+
+export type * from "@nomicfoundation/hardhat-viem";
 
 declare module "@nomicfoundation/hardhat-viem/types" {
   interface HardhatViemHelpers {

--- a/packages/hardhat-viem/src/index.ts
+++ b/packages/hardhat-viem/src/index.ts
@@ -1,6 +1,6 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "hardhat-viem",

--- a/packages/hardhat-viem/src/type-extensions.ts
+++ b/packages/hardhat-viem/src/type-extensions.ts
@@ -1,6 +1,5 @@
 import type { HardhatViemHelpers } from "./types.js";
 
-import "hardhat/types/network";
 declare module "hardhat/types/network" {
   interface NetworkConnection<
     ChainTypeT extends ChainType | string = DefaultChainType,

--- a/packages/hardhat/src/config.ts
+++ b/packages/hardhat/src/config.ts
@@ -3,9 +3,8 @@ export * from "./internal/core/config.js";
 
 export type { HardhatUserConfig } from "./types/config.js";
 
-// NOTE: We import the builtin plugins in this module, so that their
-// type-extensions are loaded when the user imports `hardhat/config`.
-import "./internal/builtin-plugins/index.js";
+// NOTE: We export the built-in plugin types to load their type extensions
+export type * from "./internal/builtin-plugins/index.js";
 import type { HardhatUserConfig } from "./types/config.js";
 
 import { throwUsingHardhat2PluginError } from "./internal/using-hardhat2-plugin-errors.js";

--- a/packages/hardhat/src/hre.ts
+++ b/packages/hardhat/src/hre.ts
@@ -1,6 +1,5 @@
-// NOTE: We import the builtin plugins in this module, so that their
-// type-extensions are loaded when the user imports `hardhat/hre`.
-import "./internal/builtin-plugins/index.js";
+// NOTE: We export the built-in plugin types to load their type extensions
+export type * from "./internal/builtin-plugins/index.js";
 
 export { importUserConfig } from "./internal/config-loading.js";
 export { resolveHardhatConfigPath } from "./internal/config-loading.js";

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -10,9 +10,8 @@ import type { UserInterruptionManager } from "./types/user-interruptions.js";
 
 import { getOrCreateGlobalHardhatRuntimeEnvironment } from "./internal/hre-initialization.js";
 
-// NOTE: We import the builtin plugins in this module, so that their
-// type-extensions are loaded when the user imports `hardhat`.
-import "./internal/builtin-plugins/index.js";
+// NOTE: We export the built-in plugin types to load their type extensions
+export type * from "./internal/builtin-plugins/index.js";
 
 const hre: HardhatRuntimeEnvironment =
   // eslint-disable-next-line no-restricted-syntax -- Allow top-level await here

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/index.ts
@@ -1,5 +1,5 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:artifacts",

--- a/packages/hardhat/src/internal/builtin-plugins/clean/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/clean/index.ts
@@ -2,7 +2,7 @@ import type { HardhatPlugin } from "../../../types/plugins.js";
 
 import { task } from "../../core/config.js";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:clean",

--- a/packages/hardhat/src/internal/builtin-plugins/clean/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/clean/type-extensions.ts
@@ -1,4 +1,3 @@
-import "../../../types/hooks.js";
 declare module "../../../types/hooks.js" {
   export interface HardhatHooks {
     clean: CleanHooks;

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/index.ts
@@ -2,7 +2,7 @@ import type { HardhatPlugin } from "../../../types/plugins.js";
 
 import { globalFlag } from "../../core/config.js";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:coverage",

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/type-extensions.ts
@@ -1,4 +1,3 @@
-import "../../../types/global-options.js";
 declare module "../../../types/global-options.js" {
   export interface GlobalOptions {
     coverage: boolean;

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
@@ -3,7 +3,7 @@ import type { HardhatPlugin } from "../../../types/plugins.js";
 import { ArgumentType } from "../../../types/arguments.js";
 import { globalFlag, globalOption, overrideTask } from "../../core/config.js";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:gas-analytics",

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/type-extensions.ts
@@ -1,4 +1,3 @@
-import "../../../types/global-options.js";
 declare module "../../../types/global-options.js" {
   export interface GlobalOptions {
     gasStats: boolean;

--- a/packages/hardhat/src/internal/builtin-plugins/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/index.ts
@@ -14,21 +14,21 @@ import solidityTest from "./solidity-test/index.js";
 import telemetry from "./telemetry/index.js";
 import test from "./test/index.js";
 
-// Note: When importing a plugin, you have to export its types, so that its
-// type extensions, if any, also get loaded.
+// NOTE: We export the built-in plugin types to have a centralized way to
+// re-export them and force their type extensions to be loaded.
 export type * from "./artifacts/index.js";
-export type * from "./solidity/index.js";
-export type * from "./test/index.js";
-export type * from "./solidity-test/index.js";
-export type * from "./gas-analytics/index.js";
-export type * from "./network-manager/index.js";
 export type * from "./clean/index.js";
 export type * from "./console/index.js";
-export type * from "./run/index.js";
-export type * from "./node/index.js";
-export type * from "./flatten/index.js";
 export type * from "./coverage/index.js";
+export type * from "./flatten/index.js";
+export type * from "./gas-analytics/index.js";
+export type * from "./network-manager/index.js";
+export type * from "./node/index.js";
+export type * from "./run/index.js";
+export type * from "./solidity/index.js";
+export type * from "./solidity-test/index.js";
 export type * from "./telemetry/index.js";
+export type * from "./test/index.js";
 
 // This array should be kept in order, respecting the dependencies between the
 // plugins.

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/index.ts
@@ -3,10 +3,10 @@ import type { HardhatPlugin } from "../../../types/plugins.js";
 import { ArgumentType } from "../../../types/arguments.js";
 import { globalOption } from "../../core/config.js";
 
-import "./type-extensions/config.js";
-import "./type-extensions/global-options.js";
-import "./type-extensions/hooks.js";
-import "./type-extensions/hre.js";
+export type * from "./type-extensions/config.js";
+export type * from "./type-extensions/global-options.js";
+export type * from "./type-extensions/hooks.js";
+export type * from "./type-extensions/hre.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:network-manager",

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/config.ts
@@ -1,6 +1,5 @@
 import type { ChainType, DefaultChainType } from "../../../../types/network.js";
 
-import "../../../../types/config.js";
 declare module "../../../../types/config.js" {
   export interface HardhatUserConfig {
     chainDescriptors?: ChainDescriptorsUserConfig;

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/global-options.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/global-options.ts
@@ -1,4 +1,3 @@
-import "../../../../types/global-options.js";
 declare module "../../../../types/global-options.js" {
   export interface GlobalOptions {
     network: string;

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/hooks.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/hooks.ts
@@ -9,7 +9,6 @@ import type {
 import type { CoverageData } from "../../coverage/types.js";
 import type { GasMeasurement } from "../../gas-analytics/types.js";
 
-import "../../../../types/hooks.js";
 declare module "../../../../types/hooks.js" {
   export interface HardhatHooks {
     network: NetworkHooks;

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/hre.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-extensions/hre.ts
@@ -1,6 +1,5 @@
 import type { NetworkManager } from "../../../../types/network.js";
 
-import "../../../../types/hre.js";
 declare module "../../../../types/hre.js" {
   export interface HardhatRuntimeEnvironment {
     network: NetworkManager;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -4,7 +4,7 @@ import { ArgumentType } from "hardhat/types/arguments";
 
 import { task } from "../../core/config.js";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:solidity-tests",

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -1,4 +1,3 @@
-import "../../../types/config.js";
 import type {
   SensitiveString,
   ResolvedConfigurationVariable,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/index.ts
@@ -3,7 +3,7 @@ import type { HardhatPlugin } from "../../../types/plugins.js";
 import { ArgumentType } from "../../../types/arguments.js";
 import { globalOption, task } from "../../core/config.js";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const buildTask = task("build", "Build project")
   .addFlag({

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
@@ -11,7 +11,6 @@ import type {
   CompilerOutput,
 } from "../../../types/solidity.js";
 
-import "../../../types/config.js";
 declare module "../../../types/config.js" {
   /**
    * An interface with a key per compiler type.
@@ -318,21 +317,18 @@ declare module "../../../types/config.js" {
   }
 }
 
-import "../../../types/hre.js";
 declare module "../../../types/hre.js" {
   export interface HardhatRuntimeEnvironment {
     solidity: SolidityBuildSystem;
   }
 }
 
-import "../../../types/global-options.js";
 declare module "../../../types/global-options.js" {
   export interface GlobalOptions {
     buildProfile: string;
   }
 }
 
-import "../../../types/hooks.js";
 declare module "../../../types/hooks.js" {
   export interface HardhatHooks {
     solidity: SolidityHooks;

--- a/packages/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -3,7 +3,7 @@ import type { HardhatPlugin } from "../../../types/plugins.js";
 import { ArgumentType } from "../../../types/arguments.js";
 import { task } from "../../core/config.js";
 
-import "./type-extensions.js";
+export type * from "./type-extensions.js";
 
 const hardhatPlugin: HardhatPlugin = {
   id: "builtin:test",

--- a/packages/hardhat/src/internal/builtin-plugins/test/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/type-extensions.ts
@@ -1,4 +1,3 @@
-import "../../../types/hooks.js";
 import type {
   HardhatTestConfig,
   HardhatTestUserConfig,

--- a/packages/hardhat/src/types/config.ts
+++ b/packages/hardhat/src/types/config.ts
@@ -1,6 +1,3 @@
-// NOTE: We export the built-in plugin types to load their type extensions
-export type * from "../internal/builtin-plugins/index.js";
-
 /**
  * A configuration variable to be fetched at runtime from
  * different sources, depending on the user's setup.

--- a/packages/hardhat/src/types/config.ts
+++ b/packages/hardhat/src/types/config.ts
@@ -1,6 +1,5 @@
-// NOTE: We import the builtin plugins in this module, so that their
-// type-extensions are loaded when the user imports `hardhat/types/config`.
-import "../internal/builtin-plugins/index.js";
+// NOTE: We export the built-in plugin types to load their type extensions
+export type * from "../internal/builtin-plugins/index.js";
 
 /**
  * A configuration variable to be fetched at runtime from

--- a/packages/hardhat/src/types/plugins.ts
+++ b/packages/hardhat/src/types/plugins.ts
@@ -2,9 +2,8 @@ import type { GlobalOptionDefinition } from "./arguments.js";
 import type { HardhatHooks } from "./hooks.js";
 import type { TaskDefinition } from "./tasks.js";
 
-// NOTE: We import the builtin plugins in this module, so that their
-// type-extensions are loaded when the user imports `hardhat/types/plugins`.
-import "../internal/builtin-plugins/index.js";
+// NOTE: We export the built-in plugin types to load their type extensions
+export type * from "../internal/builtin-plugins/index.js";
 
 // We add the plugins to the config types with a module augmentation to avoid
 // introducing a circular dependency that would look like this:


### PR DESCRIPTION
This is the first change to complete this: 

- https://github.com/NomicFoundation/hardhat/issues/8164

It reworked how we handle type-extensions preventing Hardhat from importing every single type files. It currently only imports the ones with `enum`s.