### PR TITLE
feat(test): support excluding tests with --invert flag

### DIFF
--- a/packages/hardhat-mocha/src/index.ts
+++ b/packages/hardhat-mocha/src/index.ts
@@ -25,6 +25,10 @@ const hardhatPlugin: HardhatPlugin = {
         defaultValue: undefined,
       })
       .addFlag({
+        name: "invert",
+        description: "Run tests that do NOT match the grep pattern",
+      })
+      .addFlag({
         name: "noCompile",
         description: "Don't compile the project before running the tests",
       })

--- a/packages/hardhat-mocha/src/task-action.ts
+++ b/packages/hardhat-mocha/src/task-action.ts
@@ -6,7 +6,7 @@ import type { MochaOptions } from "mocha";
 
 import { resolve as pathResolve } from "node:path";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { HardhatError, HardhatPluginError } from "@nomicfoundation/hardhat-errors";
 import { setGlobalOptionsAsEnvVariables } from "@nomicfoundation/hardhat-utils/env";
 import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
 import debug from "debug";
@@ -20,6 +20,7 @@ interface TestActionArguments {
   bail: boolean;
   grep?: string;
   noCompile: boolean;
+  invert: boolean;
 }
 
 type PerformancePhase =
@@ -65,7 +66,7 @@ async function getTestFiles(
 
 let testsAlreadyRun = false;
 const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
-  { testFiles, bail, grep, noCompile },
+  { testFiles, bail, grep, noCompile, invert },
   hre,
 ): Promise<Result<TestRunResult, TestRunResult>> => {
   // Set an environment variable that plugins can use to detect when a process is running tests
@@ -145,8 +146,19 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
 
   const mochaConfig: MochaOptions = { ...hre.config.test.mocha };
 
+  if (invert && (grep === undefined || grep === "")) {
+    throw new HardhatPluginError(
+      "@nomicfoundation/hardhat-mocha",
+      "--invert requires --grep to be specified",
+    );
+  }
+
   if (grep !== undefined && grep !== "") {
     mochaConfig.grep = grep;
+  }
+
+  if (invert) {
+    mochaConfig.invert = true;
   }
 
   if (bail) {

--- a/packages/hardhat-mocha/src/task-action.ts
+++ b/packages/hardhat-mocha/src/task-action.ts
@@ -6,7 +6,7 @@ import type { MochaOptions } from "mocha";
 
 import { resolve as pathResolve } from "node:path";
 
-import { HardhatError, HardhatPluginError } from "@nomicfoundation/hardhat-errors";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { setGlobalOptionsAsEnvVariables } from "@nomicfoundation/hardhat-utils/env";
 import { getAllFilesMatching } from "@nomicfoundation/hardhat-utils/fs";
 import debug from "debug";
@@ -145,13 +145,6 @@ const testWithHardhat: NewTaskActionFunction<TestActionArguments> = async (
   }
 
   const mochaConfig: MochaOptions = { ...hre.config.test.mocha };
-
-  if (invert && (grep === undefined || grep === "")) {
-    throw new HardhatPluginError(
-      "@nomicfoundation/hardhat-mocha",
-      "--invert requires --grep to be specified",
-    );
-  }
 
   if (grep !== undefined && grep !== "") {
     mochaConfig.grep = grep;

--- a/packages/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -29,6 +29,10 @@ const hardhatPlugin: HardhatPlugin = {
         defaultValue: undefined,
       })
       .addFlag({
+        name: "invert",
+        description: "Run tests that do NOT match the grep pattern",
+      })
+      .addFlag({
         name: "noCompile",
         description: "Do not compile the project before running the tests",
       })

--- a/packages/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -24,6 +24,7 @@ interface TestActionArguments {
   chainType: string;
   grep: string | undefined;
   noCompile: boolean;
+  invert: boolean;
 }
 
 // Old plugins may only return { failed, passed } without skipped/todo,
@@ -50,7 +51,7 @@ function isTestRunResult(
 }
 
 const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
-  { testFiles, chainType, grep, noCompile, ...otherArgs },
+  { testFiles, chainType, grep, noCompile, invert, ...otherArgs },
   hre,
 ): Promise<Result<void, void>> => {
   // If this code is executed, it means the user has not specified a test runner.
@@ -100,6 +101,10 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
       grep,
       noCompile: subtask.options.has("noCompile"),
     };
+
+    if (subtask.options.has("invert")) {
+      args.invert = invert;
+    }
 
     if (subtask.options.has("chainType")) {
       args.chainType = chainType;


### PR DESCRIPTION


- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.


---

Closes #8184

### Problem

Hardhat supports `--grep` to run specific tests, but there is no way to exclude tests from execution.

### Solution

Add a new `--invert` flag that inverts the `--grep` match, allowing users to run all tests except those matching a pattern.

### Implementation

- Added `--invert` flag to the `test` task
- Passed the flag through task layers to the Mocha runner
- Used Mocha’s built-in `invert` option

### Example

npx hardhat test --grep "TestFork" --invert

Runs all tests except those matching "TestFork".

### Notes

- Tests were run locally but encountered Windows-specific issues related to symlink permissions and mutex locks.
- This appears to be environment-specific and unrelated to the implementation.
