### PR TITLE
LPT scheduling in the build system

### DIFF
--- a/.changeset/quiet-clocks-reply.md
+++ b/.changeset/quiet-clocks-reply.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add LPT scheduling to the Solidity build system

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -340,7 +340,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
         ),
       );
 
-      // We sort the compilation jobs in decreased order of estimated
+      // We sort the compilation jobs in descending order of estimated
       // compilation cost. This way we can use this algorithm:
       // https://en.wikipedia.org/wiki/Longest-processing-time-first_scheduling
       //

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -71,6 +71,7 @@ import {
   getDuplicatedContractNamesDeclarationFile,
 } from "./artifacts.js";
 import { loadCache, saveCache } from "./cache.js";
+import { sortCompilationJobsByDescendingCost } from "./compilation-job-cost.js";
 import { CompilationJobImplementation } from "./compilation-job.js";
 import { downloadSolcCompilers, getCompiler } from "./compiler/index.js";
 import { buildDependencyGraph } from "./dependency-graph-building.js";
@@ -339,8 +340,18 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
         ),
       );
 
-      const results: CompilationResult[] = await pMap(
+      // We sort the compilation jobs in decreased order of estimated
+      // compilation cost. This way we can use this algorithm:
+      // https://en.wikipedia.org/wiki/Longest-processing-time-first_scheduling
+      //
+      // Note that it works because pMap schedules the jobs in the order they
+      // are in the array.
+      const sortedCompilationJobs = sortCompilationJobsByDescendingCost(
         runnableCompilationJobs,
+      );
+
+      const results: CompilationResult[] = await pMap(
+        sortedCompilationJobs,
         async (runnableCompilationJob) => {
           const { output, compiler } = await this.runCompilationJob(
             runnableCompilationJob,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
@@ -1,0 +1,45 @@
+import type { CompilationJob } from "../../../../types/solidity.js";
+
+// This doesn't need to be exact, it's used to account for the per-file
+// overhead, so that many small files don't look free
+const APPROXIMATE_AVARAGE_SIZE_OF_SOLIDITY_FILES = 10_000;
+
+export function estimateCompilationJobCost(job: CompilationJob): number {
+  let totalBytes = 0;
+  let fileCount = 0;
+
+  for (const file of job.dependencyGraph.getAllFiles()) {
+    totalBytes += file.content.text.length;
+    fileCount += 1;
+  }
+
+  const settings = job.solcConfig.settings ?? {};
+  const viaIR = settings.viaIR === true;
+  const optimizerEnabled = settings.optimizer?.enabled === true;
+  const optimizerRuns: number = settings.optimizer?.runs ?? 200; // default is 200
+
+  const viaIRMultiplier = viaIR === true ? 6.0 : 1.0;
+  const optimizerMultiplier = optimizerEnabled ? 1.4 : 1.0;
+
+  // The optimizer `runs` is not the number of times that the optimizer is run.
+  // It represents how many times the contract will be run.
+  // While it has an effect in the compilation time, it's not linear nor
+  // dominant.
+  //
+  // We use Math.log10 and Math.min to represent that:
+  //   - increasing runs probably has diminishing impact in cost
+  //   - going from 1 -> 200 matters more than 200 -> 20_000
+  //   - runs should contribute weakly compared with viaIR
+  const runsMultiplier = optimizerEnabled
+    ? 1 + Math.min(0.12, Math.log10(Math.max(1, optimizerRuns)) * 0.04)
+    : 1.0;
+
+  const fileOverhead = APPROXIMATE_AVARAGE_SIZE_OF_SOLIDITY_FILES * fileCount;
+
+  return (
+    (totalBytes + fileOverhead) *
+    viaIRMultiplier *
+    optimizerMultiplier *
+    runsMultiplier
+  );
+}

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
@@ -2,7 +2,7 @@ import type { CompilationJob } from "../../../../types/solidity.js";
 
 // This doesn't need to be exact, it's used to account for the per-file
 // overhead, so that many small files don't look free
-const APPROXIMATE_AVARAGE_SIZE_OF_SOLIDITY_FILES = 10_000;
+const APPROXIMATE_AVERAGE_SIZE_OF_SOLIDITY_FILES = 10_000;
 
 export function estimateCompilationJobCost(job: CompilationJob): number {
   let totalBytes = 0;
@@ -34,7 +34,7 @@ export function estimateCompilationJobCost(job: CompilationJob): number {
     ? 1 + Math.min(0.12, Math.log10(Math.max(1, optimizerRuns)) * 0.04)
     : 1.0;
 
-  const fileOverhead = APPROXIMATE_AVARAGE_SIZE_OF_SOLIDITY_FILES * fileCount;
+  const fileOverhead = APPROXIMATE_AVERAGE_SIZE_OF_SOLIDITY_FILES * fileCount;
 
   return (
     (totalBytes + fileOverhead) *

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
@@ -1,5 +1,7 @@
 import type { CompilationJob } from "../../../../types/solidity.js";
 
+import { SOLC_DEFAULT_OPTIMIZER_RUNS } from "../constants.js";
+
 // This doesn't need to be exact, it's used to account for the per-file
 // overhead, so that many small files don't look free
 const APPROXIMATE_AVERAGE_SIZE_OF_SOLIDITY_FILES = 10_000;
@@ -16,7 +18,8 @@ export function estimateCompilationJobCost(job: CompilationJob): number {
   const settings = job.solcConfig.settings ?? {};
   const viaIR = settings.viaIR === true;
   const optimizerEnabled = settings.optimizer?.enabled === true;
-  const optimizerRuns: number = settings.optimizer?.runs ?? 200; // default is 200
+  const optimizerRuns: number =
+    settings.optimizer?.runs ?? SOLC_DEFAULT_OPTIMIZER_RUNS;
 
   const viaIRMultiplier = viaIR === true ? 6.0 : 1.0;
   const optimizerMultiplier = optimizerEnabled ? 1.4 : 1.0;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
@@ -43,3 +43,16 @@ export function estimateCompilationJobCost(job: CompilationJob): number {
     runsMultiplier
   );
 }
+
+/**
+ * Returns a new array containing the given compilation jobs sorted by their
+ * estimated cost in descending order. The input array is not mutated.
+ */
+export function sortCompilationJobsByDescendingCost(
+  compilationJobs: CompilationJob[],
+): CompilationJob[] {
+  return compilationJobs
+    .map((job) => ({ job, cost: estimateCompilationJobCost(job) }))
+    .sort((a, b) => b.cost - a.cost)
+    .map(({ job }) => job);
+}

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
@@ -5,11 +5,11 @@ import type { CompilationJob } from "../../../../types/solidity.js";
 const APPROXIMATE_AVERAGE_SIZE_OF_SOLIDITY_FILES = 10_000;
 
 export function estimateCompilationJobCost(job: CompilationJob): number {
-  let totalBytes = 0;
+  let totalChars = 0;
   let fileCount = 0;
 
   for (const file of job.dependencyGraph.getAllFiles()) {
-    totalBytes += file.content.text.length;
+    totalChars += file.content.text.length;
     fileCount += 1;
   }
 
@@ -37,7 +37,7 @@ export function estimateCompilationJobCost(job: CompilationJob): number {
   const fileOverhead = APPROXIMATE_AVERAGE_SIZE_OF_SOLIDITY_FILES * fileCount;
 
   return (
-    (totalBytes + fileOverhead) *
+    (totalChars + fileOverhead) *
     viaIRMultiplier *
     optimizerMultiplier *
     runsMultiplier

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/config.ts
@@ -32,7 +32,10 @@ import {
   hasOfficialArm64Build,
   missesSomeOfficialNativeBuilds,
 } from "./build-system/solc-info.js";
-import { DEFAULT_OUTPUT_SELECTION } from "./constants.js";
+import {
+  DEFAULT_OUTPUT_SELECTION,
+  SOLC_DEFAULT_OPTIMIZER_RUNS,
+} from "./constants.js";
 
 /**
  * The top-level type SolidityUserConfig is a union type too complex for
@@ -542,7 +545,7 @@ function resolveSolidityCompilerConfig(
   if (production && isSolcSolidityCompilerUserConfig(compilerConfig)) {
     defaultSettings.optimizer = {
       enabled: true,
-      runs: 200,
+      runs: SOLC_DEFAULT_OPTIMIZER_RUNS,
     };
   }
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/constants.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/constants.ts
@@ -19,3 +19,6 @@ export const DEFAULT_OUTPUT_SELECTION: CompilerInput["settings"]["outputSelectio
       ],
     },
   };
+
+// This is the default that solc uses, which we also use during resolution
+export const SOLC_DEFAULT_OPTIMIZER_RUNS = 200;

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
@@ -1,0 +1,325 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions -- Mirrors
+   compilation-job.ts: the `HookContext` shape is intentionally cast in tests
+   that don't exercise hooks. */
+import type { SolidityCompilerConfig } from "../../../../../src/types/config.js";
+import type { HookContext } from "../../../../../src/types/hooks.js";
+import type { ResolvedNpmPackage } from "../../../../../src/types/solidity.js";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { estimateCompilationJobCost } from "../../../../../src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.js";
+import { CompilationJobImplementation } from "../../../../../src/internal/builtin-plugins/solidity/build-system/compilation-job.js";
+import { DependencyGraphImplementation } from "../../../../../src/internal/builtin-plugins/solidity/build-system/dependency-graph.js";
+import { HookManagerImplementation } from "../../../../../src/internal/core/hook-manager.js";
+import { ResolvedFileType } from "../../../../../src/types/solidity.js";
+
+// NOTE: These tests are a bit more white-box than ideal, and expectedCost
+// mostly duplicates the logic. However, this file also tests some properties
+// about the cost function, like the relative influence between the different
+// parameters/settings.
+
+const FILE_OVERHEAD = 10_000;
+
+function expectedCost(opts: {
+  totalBytes: number;
+  fileCount: number;
+  viaIR?: boolean;
+  optimizer?: boolean;
+  runs?: number;
+}): number {
+  const viaIR = opts.viaIR === true;
+  const optimizer = opts.optimizer === true;
+  const runs = opts.runs ?? 200;
+
+  const viaIRMul = viaIR ? 6.0 : 1.0;
+  const optMul = optimizer ? 1.4 : 1.0;
+  const runsMul = optimizer
+    ? 1 + Math.min(0.12, Math.log10(Math.max(1, runs)) * 0.04)
+    : 1.0;
+
+  return (
+    (opts.totalBytes + FILE_OVERHEAD * opts.fileCount) *
+    viaIRMul *
+    optMul *
+    runsMul
+  );
+}
+
+const testPackage: ResolvedNpmPackage = {
+  name: "hardhat-project",
+  version: "1.0.0",
+  rootFsPath: "/p",
+  inputSourceNameRoot: "project",
+};
+
+function makeJob(
+  fileTexts: string[],
+  settings?: SolidityCompilerConfig["settings"],
+): CompilationJobImplementation {
+  const graph = new DependencyGraphImplementation();
+  fileTexts.forEach((text, i) => {
+    const file = {
+      type: ResolvedFileType.PROJECT_FILE as const,
+      inputSourceName: `f${i}.sol`,
+      fsPath: `f${i}.sol`,
+      content: { text, importPaths: [], versionPragmas: [] },
+      package: testPackage,
+    };
+    graph.addRootFile(file.inputSourceName, file);
+  });
+
+  const hooks = new HookManagerImplementation(process.cwd(), []);
+  hooks.setContext({} as HookContext);
+
+  return new CompilationJobImplementation(
+    graph,
+    { version: "0.8.0", settings },
+    "0.8.0-c7dfd78",
+    hooks,
+  );
+}
+
+describe("estimateCompilationJobCost", () => {
+  describe("file aggregation", () => {
+    it("returns 0 for an empty graph", () => {
+      assert.equal(estimateCompilationJobCost(makeJob([])), 0);
+    });
+
+    it("computes (bytes + overhead) for a single file", () => {
+      const text = "a".repeat(500);
+      assert.equal(
+        estimateCompilationJobCost(makeJob([text])),
+        expectedCost({ totalBytes: 500, fileCount: 1 }),
+      );
+    });
+
+    it("sums file bytes and applies per-file overhead", () => {
+      const texts = ["a".repeat(300), "b".repeat(700), "c".repeat(1000)];
+      assert.equal(
+        estimateCompilationJobCost(makeJob(texts)),
+        expectedCost({ totalBytes: 2000, fileCount: 3 }),
+      );
+    });
+
+    it("charges per-file overhead even when files are empty", () => {
+      const cost = estimateCompilationJobCost(makeJob(["", "", ""]));
+      assert.equal(cost, FILE_OVERHEAD * 3);
+    });
+
+    it("makes many small files cost more than one large file with the same total bytes", () => {
+      const totalBytes = 1000;
+      const oneLarge = estimateCompilationJobCost(
+        makeJob(["x".repeat(totalBytes)]),
+      );
+      const manySmall = estimateCompilationJobCost(
+        makeJob(Array.from({ length: 10 }, () => "x".repeat(totalBytes / 10))),
+      );
+      assert.ok(
+        manySmall > oneLarge,
+        `expected many small (${manySmall}) > one large (${oneLarge})`,
+      );
+    });
+  });
+
+  describe("settings plumbing", () => {
+    it("treats absent settings as all defaults (no viaIR and no optimizer)", () => {
+      const text = "abc";
+      const absent = estimateCompilationJobCost(makeJob([text], undefined));
+      assert.equal(absent, expectedCost({ totalBytes: 3, fileCount: 1 }));
+    });
+
+    it("ignores `runs` when the optimizer is disabled", () => {
+      const text = "a".repeat(100);
+      const noOptimizer = estimateCompilationJobCost(makeJob([text], {}));
+      const optimizerOffWithRuns = estimateCompilationJobCost(
+        makeJob([text], { optimizer: { enabled: false, runs: 1_000_000 } }),
+      );
+
+      assert.equal(noOptimizer, optimizerOffWithRuns);
+    });
+
+    it("applies a 6x multiplier when viaIR === true", () => {
+      const text = "a".repeat(100);
+      const base = estimateCompilationJobCost(makeJob([text]));
+      const withViaIR = estimateCompilationJobCost(
+        makeJob([text], { viaIR: true }),
+      );
+
+      assert.equal(withViaIR, base * 6);
+    });
+
+    it("does not apply the viaIR multiplier when the field is omitted", () => {
+      const text = "a".repeat(100);
+      const base = estimateCompilationJobCost(makeJob([text]));
+      const omitted = estimateCompilationJobCost(makeJob([text], {}));
+
+      assert.equal(base, omitted);
+    });
+
+    it("defaults `runs` to 200 when the optimizer is enabled but `runs` is omitted", () => {
+      const text = "a".repeat(100);
+
+      const defaulted = estimateCompilationJobCost(
+        makeJob([text], { optimizer: { enabled: true } }),
+      );
+
+      const explicit = estimateCompilationJobCost(
+        makeJob([text], { optimizer: { enabled: true, runs: 200 } }),
+      );
+
+      assert.equal(defaulted, explicit);
+    });
+  });
+
+  describe("runs multiplier", () => {
+    const baseFiles = ["a".repeat(100)];
+
+    it("contributes nothing at runs=1", () => {
+      const cost = estimateCompilationJobCost(
+        makeJob(baseFiles, { optimizer: { enabled: true, runs: 1 } }),
+      );
+
+      assert.equal(
+        cost,
+        expectedCost({
+          totalBytes: 100,
+          fileCount: 1,
+          optimizer: true,
+          runs: 1,
+        }),
+      );
+    });
+
+    it("clamps runs < 1 to 1", () => {
+      const atZero = estimateCompilationJobCost(
+        makeJob(baseFiles, { optimizer: { enabled: true, runs: 0 } }),
+      );
+
+      const atOne = estimateCompilationJobCost(
+        makeJob(baseFiles, { optimizer: { enabled: true, runs: 1 } }),
+      );
+
+      assert.equal(atZero, atOne);
+    });
+
+    it("reaches the 0.12 cap exactly at runs=1000", () => {
+      const cost = estimateCompilationJobCost(
+        makeJob(baseFiles, { optimizer: { enabled: true, runs: 1000 } }),
+      );
+
+      // (100 + 10_000) * 1.4 * 1.12
+      const expected = (100 + FILE_OVERHEAD) * 1.4 * 1.12;
+      assert.equal(cost, expected);
+    });
+
+    it("saturates at the cap for very large runs values", () => {
+      const atCap = estimateCompilationJobCost(
+        makeJob(baseFiles, { optimizer: { enabled: true, runs: 1000 } }),
+      );
+
+      const wayAbove = estimateCompilationJobCost(
+        makeJob(baseFiles, { optimizer: { enabled: true, runs: 10_000_000 } }),
+      );
+
+      assert.equal(atCap, wayAbove);
+    });
+
+    it("is monotonically non-decreasing in runs", () => {
+      const costs = [1, 10, 100, 1000].map((runs) =>
+        estimateCompilationJobCost(
+          makeJob(baseFiles, { optimizer: { enabled: true, runs } }),
+        ),
+      );
+
+      for (let i = 1; i < costs.length; i++) {
+        assert.ok(
+          costs[i] >= costs[i - 1],
+          `cost should be non-decreasing in runs: ${costs.join(" -> ")}`,
+        );
+      }
+    });
+  });
+
+  describe("multiplier composition", () => {
+    it("multiplies viaIR, optimizer, and runs together", () => {
+      const text = "a".repeat(500);
+
+      const cost = estimateCompilationJobCost(
+        makeJob([text], {
+          viaIR: true,
+          optimizer: { enabled: true, runs: 1000 },
+        }),
+      );
+
+      const base = 500 + FILE_OVERHEAD;
+      assert.equal(cost, base * 6 * 1.4 * 1.12);
+    });
+  });
+
+  describe("relative weight of the multipliers", () => {
+    // The intended hierarchy is: viaIR (6x) >> optimizer toggle (1.4x) > runs sweep (<= 1.12x).
+    // These tests pin that ordering so the constants can't be re-tuned in a way
+    // that silently re-orders the cost knobs.
+
+    const smallGraph = ["a".repeat(100)];
+    const largeGraph = Array.from({ length: 10 }, () => "a".repeat(50_000));
+
+    function relativeWeightAssertions(files: string[], label: string): void {
+      it(`viaIR alone outweighs optimizer alone with maxed runs (${label})`, () => {
+        const viaIROnly = estimateCompilationJobCost(
+          makeJob(files, { viaIR: true }),
+        );
+
+        const optimizerMaxed = estimateCompilationJobCost(
+          makeJob(files, {
+            optimizer: { enabled: true, runs: 10_000_000 },
+          }),
+        );
+
+        assert.ok(
+          viaIROnly > optimizerMaxed,
+          `viaIR alone (${viaIROnly}) should outweigh optimizer + max runs (${optimizerMaxed})`,
+        );
+      });
+
+      it(`the optimizer toggle moves cost more than the runs sweep (${label})`, () => {
+        const optimizerOff = estimateCompilationJobCost(makeJob(files, {}));
+
+        const optimizerOnLowRuns = estimateCompilationJobCost(
+          makeJob(files, { optimizer: { enabled: true, runs: 1 } }),
+        );
+
+        const optimizerOnHighRuns = estimateCompilationJobCost(
+          makeJob(files, {
+            optimizer: { enabled: true, runs: 10_000_000 },
+          }),
+        );
+
+        const toggleJump = optimizerOnLowRuns - optimizerOff;
+        const runsJump = optimizerOnHighRuns - optimizerOnLowRuns;
+
+        assert.ok(
+          toggleJump > runsJump,
+          `optimizer on/off jump (${toggleJump}) should exceed full runs sweep (${runsJump})`,
+        );
+      });
+    }
+
+    relativeWeightAssertions(smallGraph, "small graph");
+    relativeWeightAssertions(largeGraph, "large graph");
+  });
+
+  describe("sanity checks", () => {
+    it("is deterministic", () => {
+      const job = makeJob(["a".repeat(123)], {
+        viaIR: true,
+        optimizer: { enabled: true, runs: 500 },
+      });
+      assert.equal(
+        estimateCompilationJobCost(job),
+        estimateCompilationJobCost(job),
+      );
+    });
+  });
+});

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
@@ -8,7 +8,10 @@ import type { ResolvedNpmPackage } from "../../../../../src/types/solidity.js";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { estimateCompilationJobCost } from "../../../../../src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.js";
+import {
+  estimateCompilationJobCost,
+  sortCompilationJobsByDescendingCost,
+} from "../../../../../src/internal/builtin-plugins/solidity/build-system/compilation-job-cost.js";
 import { CompilationJobImplementation } from "../../../../../src/internal/builtin-plugins/solidity/build-system/compilation-job.js";
 import { DependencyGraphImplementation } from "../../../../../src/internal/builtin-plugins/solidity/build-system/dependency-graph.js";
 import { HookManagerImplementation } from "../../../../../src/internal/core/hook-manager.js";
@@ -321,5 +324,32 @@ describe("estimateCompilationJobCost", () => {
         estimateCompilationJobCost(job),
       );
     });
+  });
+});
+
+describe("sortCompilationJobsByDescendingCost", () => {
+  // Three jobs with clearly-separated costs, one per multiplier "tier":
+  //   cheap    ≈ 10_000  (no settings)
+  //   medium   ≈ 14_000  (optimizer on, default runs)
+  //   expensive ≈ 60_000 (viaIR on)
+  // The gaps are wide enough to survive constants tuning.
+  const cheap = makeJob(["a"]);
+  const medium = makeJob(["a"], { optimizer: { enabled: true } });
+  const expensive = makeJob(["a"], { viaIR: true });
+
+  it("returns jobs in descending cost order", () => {
+    const sorted = sortCompilationJobsByDescendingCost([
+      cheap,
+      expensive,
+      medium,
+    ]);
+    assert.deepEqual(sorted, [expensive, medium, cheap]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [cheap, expensive, medium];
+    const before = [...input];
+    sortCompilationJobsByDescendingCost(input);
+    assert.deepEqual(input, before);
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compilation-job-cost.ts
@@ -25,7 +25,7 @@ import { ResolvedFileType } from "../../../../../src/types/solidity.js";
 const FILE_OVERHEAD = 10_000;
 
 function expectedCost(opts: {
-  totalBytes: number;
+  totalChars: number;
   fileCount: number;
   viaIR?: boolean;
   optimizer?: boolean;
@@ -42,7 +42,7 @@ function expectedCost(opts: {
     : 1.0;
 
   return (
-    (opts.totalBytes + FILE_OVERHEAD * opts.fileCount) *
+    (opts.totalChars + FILE_OVERHEAD * opts.fileCount) *
     viaIRMul *
     optMul *
     runsMul
@@ -89,19 +89,19 @@ describe("estimateCompilationJobCost", () => {
       assert.equal(estimateCompilationJobCost(makeJob([])), 0);
     });
 
-    it("computes (bytes + overhead) for a single file", () => {
+    it("computes (chars + overhead) for a single file", () => {
       const text = "a".repeat(500);
       assert.equal(
         estimateCompilationJobCost(makeJob([text])),
-        expectedCost({ totalBytes: 500, fileCount: 1 }),
+        expectedCost({ totalChars: 500, fileCount: 1 }),
       );
     });
 
-    it("sums file bytes and applies per-file overhead", () => {
+    it("sums file chars and applies per-file overhead", () => {
       const texts = ["a".repeat(300), "b".repeat(700), "c".repeat(1000)];
       assert.equal(
         estimateCompilationJobCost(makeJob(texts)),
-        expectedCost({ totalBytes: 2000, fileCount: 3 }),
+        expectedCost({ totalChars: 2000, fileCount: 3 }),
       );
     });
 
@@ -110,13 +110,13 @@ describe("estimateCompilationJobCost", () => {
       assert.equal(cost, FILE_OVERHEAD * 3);
     });
 
-    it("makes many small files cost more than one large file with the same total bytes", () => {
-      const totalBytes = 1000;
+    it("makes many small files cost more than one large file with the same total chars", () => {
+      const totalChars = 1000;
       const oneLarge = estimateCompilationJobCost(
-        makeJob(["x".repeat(totalBytes)]),
+        makeJob(["x".repeat(totalChars)]),
       );
       const manySmall = estimateCompilationJobCost(
-        makeJob(Array.from({ length: 10 }, () => "x".repeat(totalBytes / 10))),
+        makeJob(Array.from({ length: 10 }, () => "x".repeat(totalChars / 10))),
       );
       assert.ok(
         manySmall > oneLarge,
@@ -129,7 +129,7 @@ describe("estimateCompilationJobCost", () => {
     it("treats absent settings as all defaults (no viaIR and no optimizer)", () => {
       const text = "abc";
       const absent = estimateCompilationJobCost(makeJob([text], undefined));
-      assert.equal(absent, expectedCost({ totalBytes: 3, fileCount: 1 }));
+      assert.equal(absent, expectedCost({ totalChars: 3, fileCount: 1 }));
     });
 
     it("ignores `runs` when the optimizer is disabled", () => {
@@ -186,7 +186,7 @@ describe("estimateCompilationJobCost", () => {
       assert.equal(
         cost,
         expectedCost({
-          totalBytes: 100,
+          totalChars: 100,
           fileCount: 1,
           optimizer: true,
           runs: 1,


### PR DESCRIPTION
This PR introduces [Longest processing time (LPT) scheduling](https://en.wikipedia.org/wiki/Longest-processing-time-first_scheduling) into the build system.

It introduces a function that approximates the cost of compilation job (i.e. time it takes to compile), and then sorts the queue of compilation jobs to run in descending cost, so that the most expensive ones get allocated first. 

LPT works because long jobs are the ones most likely to create a slow tail at the end.

If you do short jobs first, you can finish lots of work quickly, but then still be stuck waiting for one expensive job to finish. By starting with the expensive jobs, you get the slowest work going early, and the smaller jobs can fit around it later.

The basic idea is: Start the work that can delay everything the most as early as possible.