### PR TITLE
chore: drop beta references from init process and templates

### DIFF
--- a/.changeset/slow-mayflies-sit.md
+++ b/.changeset/slow-mayflies-sit.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Drop "Beta" wording from the `hardhat --init` version selector and the Hardhat 3 project templates ahead of the stable release.

--- a/.changeset/slow-mayflies-sit.md
+++ b/.changeset/slow-mayflies-sit.md
@@ -1,5 +1,6 @@
 ---
 "hardhat": patch
+# docs: https://github.com/NomicFoundation/hardhat-website/pull/266
 ---
 
 Drop "Beta" wording from the `hardhat --init` version selector and the Hardhat 3 project templates ahead of the stable release.

--- a/.changeset/slow-mayflies-sit.md
+++ b/.changeset/slow-mayflies-sit.md
@@ -1,5 +1,5 @@
 ---
-"hardhat": patch
+"hardhat": minor
 # docs: https://github.com/NomicFoundation/hardhat-website/pull/266
 ---
 

--- a/.changeset/slow-mayflies-sit.md
+++ b/.changeset/slow-mayflies-sit.md
@@ -3,4 +3,4 @@
 # docs: https://github.com/NomicFoundation/hardhat-website/pull/266
 ---
 
-Drop "Beta" wording from the `hardhat --init` version selector and the Hardhat 3 project templates ahead of the stable release.
+Hardhat 3 is now stable, the "Beta" wording is being dropped from the `hardhat --init` process and project templates.

--- a/packages/hardhat/src/internal/cli/init/prompt.ts
+++ b/packages/hardhat/src/internal/cli/init/prompt.ts
@@ -22,7 +22,7 @@ export async function promptForHardhatVersion(): Promise<
       choices: [
         {
           name: "hardhat-3",
-          message: "Hardhat 3 Beta (recommended for new projects)",
+          message: "Hardhat 3 (recommended for new projects)",
           value: "hardhat-3",
         },
         {

--- a/packages/hardhat/templates/hardhat-3/01-node-test-runner-viem/README.md
+++ b/packages/hardhat/templates/hardhat-3/01-node-test-runner-viem/README.md
@@ -1,8 +1,8 @@
-# Sample Hardhat 3 Beta Project (`node:test` and `viem`)
+# Sample Hardhat 3 Project (`node:test` and `viem`)
 
-This project showcases a Hardhat 3 Beta project using the native Node.js test runner (`node:test`) and the `viem` library for Ethereum interactions.
+This project showcases a Hardhat 3 project using the native Node.js test runner (`node:test`) and the `viem` library for Ethereum interactions.
 
-To learn more about the Hardhat 3 Beta, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, join our [Hardhat 3 Beta](https://hardhat.org/hardhat3-beta-telegram-group) Telegram group or [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
+To learn more about Hardhat 3, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
 
 ## Project Overview
 

--- a/packages/hardhat/templates/hardhat-3/01-node-test-runner-viem/README.md
+++ b/packages/hardhat/templates/hardhat-3/01-node-test-runner-viem/README.md
@@ -2,7 +2,7 @@
 
 This project showcases a Hardhat 3 project using the native Node.js test runner (`node:test`) and the `viem` library for Ethereum interactions.
 
-To learn more about Hardhat 3, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, join our [Hardhat 3](https://hardhat.org/hardhat3-beta-telegram-group) Telegram group or [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
+To learn more about Hardhat 3, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, join our [Hardhat 3](https://hardhat.org/hardhat3-telegram-group) Telegram group or [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
 
 ## Project Overview
 

--- a/packages/hardhat/templates/hardhat-3/01-node-test-runner-viem/README.md
+++ b/packages/hardhat/templates/hardhat-3/01-node-test-runner-viem/README.md
@@ -2,7 +2,7 @@
 
 This project showcases a Hardhat 3 project using the native Node.js test runner (`node:test`) and the `viem` library for Ethereum interactions.
 
-To learn more about Hardhat 3, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
+To learn more about Hardhat 3, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, join our [Hardhat 3](https://hardhat.org/hardhat3-beta-telegram-group) Telegram group or [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
 
 ## Project Overview
 

--- a/packages/hardhat/templates/hardhat-3/02-mocha-ethers/README.md
+++ b/packages/hardhat/templates/hardhat-3/02-mocha-ethers/README.md
@@ -1,8 +1,8 @@
-# Sample Hardhat 3 Beta Project (`mocha` and `ethers`)
+# Sample Hardhat 3 Project (`mocha` and `ethers`)
 
-This project showcases a Hardhat 3 Beta project using `mocha` for tests and the `ethers` library for Ethereum interactions.
+This project showcases a Hardhat 3 project using `mocha` for tests and the `ethers` library for Ethereum interactions.
 
-To learn more about the Hardhat 3 Beta, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, join our [Hardhat 3 Beta](https://hardhat.org/hardhat3-beta-telegram-group) Telegram group or [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
+To learn more about Hardhat 3, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
 
 ## Project Overview
 

--- a/packages/hardhat/templates/hardhat-3/02-mocha-ethers/README.md
+++ b/packages/hardhat/templates/hardhat-3/02-mocha-ethers/README.md
@@ -2,7 +2,7 @@
 
 This project showcases a Hardhat 3 project using `mocha` for tests and the `ethers` library for Ethereum interactions.
 
-To learn more about Hardhat 3, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
+To learn more about Hardhat 3, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, join our [Hardhat 3](https://hardhat.org/hardhat3-beta-telegram-group) Telegram group or [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
 
 ## Project Overview
 

--- a/packages/hardhat/templates/hardhat-3/02-mocha-ethers/README.md
+++ b/packages/hardhat/templates/hardhat-3/02-mocha-ethers/README.md
@@ -2,7 +2,7 @@
 
 This project showcases a Hardhat 3 project using `mocha` for tests and the `ethers` library for Ethereum interactions.
 
-To learn more about Hardhat 3, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, join our [Hardhat 3](https://hardhat.org/hardhat3-beta-telegram-group) Telegram group or [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
+To learn more about Hardhat 3, please visit the [Getting Started guide](https://hardhat.org/docs/getting-started#getting-started-with-hardhat-3). To share your feedback, join our [Hardhat 3](https://hardhat.org/hardhat3-telegram-group) Telegram group or [open an issue](https://github.com/NomicFoundation/hardhat/issues/new) in our GitHub issue tracker.
 
 ## Project Overview
 

--- a/packages/hardhat/templates/hardhat-3/03-minimal/README.md
+++ b/packages/hardhat/templates/hardhat-3/03-minimal/README.md
@@ -1,6 +1,6 @@
-# Sample Hardhat 3 Beta Project (minimal)
+# Sample Hardhat 3 Project (minimal)
 
-This project has a minimal setup of Hardhat 3 Beta, without any plugins.
+This project has a minimal setup of Hardhat 3, without any plugins.
 
 ## What's included?
 


### PR DESCRIPTION
⚠️ This PR should *NOT* be merged yet. It must be merged when all the beta tasks are done.

## Summary
- Remove "Beta" from the Hardhat 3 version selection prompt in `--init`
- Update all three starter template README files to remove beta branding
- Remove the beta-specific Telegram group link from templates

**Files changed:**
- `packages/hardhat/src/internal/cli/init/prompt.ts` — prompt text
- `templates/hardhat-3/01-node-test-runner-viem/README.md`
- `templates/hardhat-3/02-mocha-ethers/README.md`
- `templates/hardhat-3/03-minimal/README.md`

**Intentionally untouched:**
- `@beta` JSDoc annotations (TSDoc API visibility markers, not user-facing)
- Historical version strings in tests

Fixes #8170

## Test plan
- [ ] Run `npx hardhat --init` and verify the prompt no longer says "Beta"
- [ ] Verify generated project README files have correct non-beta text