### PR TITLE
Introduce `SharedPromiseCache`

### DIFF
--- a/.changeset/famous-loops-stop.md
+++ b/.changeset/famous-loops-stop.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-utils": minor
+---
+
+Introduce the SharedPromiseCache synchronization primitive

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -667,17 +667,16 @@ type SharedPromiseCachedResult<ValueT> =
  * original thrown value, so their own `getOrCompute` call site won't
  * necessarily be present in the error stack.
  *
- * Notes on concurrency: For non-reentrant calls, `getOrCompute` stores the
- * in-flight promise in the cache before returning control to the event loop.
- * Subsequent calls with the same key observe that promise and await the same
- * computation instead of invoking their own function.
+ * Notes on concurrency: `getOrCompute` stores the in-flight promise in the
+ * cache before invoking the producer function. Subsequent calls with the same
+ * key, including synchronous same-key reentrant calls from the producer,
+ * observe that promise and await the same computation instead of invoking their
+ * own function. A producer must still not await a same-key reentrant call
+ * before completing, because it would wait on its own in-flight result.
  *
  * This guarantee only applies while the cache entry remains installed. Calling
  * `delete` or `clear` during an in-flight computation lets later callers start
  * a new computation, and the older in-flight result won't repopulate the cache.
- *
- * The producer function is invoked before the in-flight promise is stored, so it
- * should not synchronously call `getOrCompute` with the same key.
  */
 export class SharedPromiseCache<ValueT> {
   readonly #cache = new Map<string, SharedPromiseCachedResult<ValueT>>();
@@ -716,23 +715,28 @@ export class SharedPromiseCache<ValueT> {
       throw cachedResult.error;
     }
 
-    // Don't update `this.#cache` from inside this IIFE — doing so would let a
-    // resolution overwrite a concurrent `delete()`/`clear()`. The cache write
-    // is deferred to `#updateResolvedPromiseCache`, which gates on reference
-    // equality.
-    const promise: Promise<SharedPromiseExecutionResult<ValueT>> =
-      (async () => {
-        try {
-          const value = await fn();
-          return { success: true, value };
-        } catch (error) {
-          return { success: false, error };
-        }
-      })();
+    // Create and cache the in-flight promise before invoking `fn`, because
+    // `fn` can synchronously re-enter `getOrCompute` with the same key. The
+    // reentrant call must observe this promise instead of a cache miss, or it
+    // could start a second computation for the same key.
+    //
+    // `Promise.withResolvers` lets the first caller still await `fn` directly,
+    // preserving the producer async stack.
+    const { promise, resolve } =
+      Promise.withResolvers<SharedPromiseExecutionResult<ValueT>>();
 
     this.#cache.set(key, promise);
 
-    const result = await promise;
+    let result: SharedPromiseExecutionResult<ValueT>;
+
+    try {
+      const value = await fn();
+      result = { success: true, value };
+    } catch (error) {
+      result = { success: false, error };
+    }
+
+    resolve(result);
 
     this.#updateResolvedPromiseCache(key, promise, result);
 

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -632,7 +632,7 @@ type SharedPromiseExecutionResult<ValueT> =
   | { success: false; error: Error | unknown };
 
 type SharedPromiseCachedResult<ValueT> =
-  // We wrapped the resolved value so that we can distingush not-cached from
+  // We wrapped the resolved value so that we can distinguish not-cached from
   // `undefined` cached values, and between Promise and value.
   | SharedPromiseSuccessfulExecutionResult<ValueT>
   | Promise<SharedPromiseExecutionResult<ValueT>>;

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -621,3 +621,152 @@ export class AsyncMutex {
     });
   }
 }
+
+type SharedPromiseExecutionResult<ValueT> =
+  | { success: true; value: ValueT }
+  | { success: false; error: Error | unknown };
+
+type SharedPromiseCachedResult<ValueT> =
+  | ValueT
+  | Promise<SharedPromiseExecutionResult<ValueT>>;
+
+/**
+ * A class that deduplicates the concurrent computations of an asynchronous
+ * operation based on a string key, by sharing the same Promise for all
+ * concurrent calls.
+ *
+ * This class is useful when the operation is expensive, or you need to
+ * guarantee that it's only executed once per key.
+ *
+ * For this cache to work correctly, the operation has to be either idempotent,
+ * or virtually idempotent (e.g. reading the same file multiple times in a very
+ * short time, in a context where it shouldn't be changed).
+ *
+ * The results of the first operation run per key are cached during the lifetime
+ * of the class, or until the `delete` or `clear` methods are called.
+ *
+ * Note that you should always use the same function/operation per cache key. If
+ * you call `getOrCompute` with the same key but different functions, the
+ * first function will be used for all the calls.
+ *
+ * Notes on async stack traces: This class is designed to preserve as much as
+ * possible of the producer async stack trace, including the place where the
+ * first `getOrCompute` computation is started and where the producer throws. To
+ * achieve this, you should provide an async lambda of the shape
+ * `async () => await myFunction()`, instead of directly passing `myFunction`.
+ * You should also try to immediately await the calls to `getOrCompute`.
+ *
+ * Concurrent callers for the same in-flight computation receive the same
+ * original thrown value, so their own `getOrCompute` call site won't
+ * necessarily be present in the error stack.
+ *
+ * Notes on concurrency: For non-reentrant calls, `getOrCompute` stores the
+ * in-flight promise in the cache before returning control to the event loop.
+ * Subsequent calls with the same key observe that promise and await the same
+ * computation instead of invoking their own function.
+ *
+ * This guarantee only applies while the cache entry remains installed. Calling
+ * `delete` or `clear` during an in-flight computation lets later callers start
+ * a new computation, and the older in-flight result won't repopulate the cache.
+ *
+ * The producer function is invoked before the in-flight promise is stored, so it
+ * should not synchronously call `getOrCompute` with the same key.
+ */
+export class SharedPromiseCache<ValueT> {
+  readonly #cache = new Map<string, SharedPromiseCachedResult<ValueT>>();
+
+  /**
+   * Returns the cached value associated to the key, or computes it if needed,
+   * guaranteeing that it's only computed once per key.
+   *
+   * @param key The cache key associated to the value.
+   * @param fn The function that computes the value when it's not cached. Please
+   * read the class docs to understand the requirements it should meet.
+   * @returns The value.
+   * @throws The original value thrown or rejected by the function. Concurrent
+   * callers for the same in-flight computation observe the same thrown value, so
+   * their stack reflects the original computation, not necessarily each
+   * awaiting call site.
+   */
+  public async getOrCompute(
+    key: string,
+    fn: () => Promise<ValueT>,
+  ): Promise<ValueT> {
+    if (this.#cache.has(key)) {
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions 
+      -- As we may need to cache `undefined` values, we can't just `get` and
+      check for not `undefined`, so we need to assert here. */
+      const cached = this.#cache.get(key) as SharedPromiseCachedResult<ValueT>;
+
+      if (!(cached instanceof Promise)) {
+        return cached;
+      }
+
+      const cachedResult = await cached;
+
+      if (this.#cache.get(key) === cached) {
+        if (cachedResult.success) {
+          this.#cache.set(key, cachedResult.value);
+        } else {
+          this.#cache.delete(key);
+        }
+      }
+
+      if (cachedResult.success) {
+        return cachedResult.value;
+      }
+
+      throw cachedResult.error;
+    }
+
+    const promise: Promise<SharedPromiseExecutionResult<ValueT>> =
+      (async () => {
+        try {
+          const value = await fn();
+          return { success: true, value };
+        } catch (error) {
+          return { success: false, error };
+        }
+      })();
+
+    this.#cache.set(key, promise);
+
+    const result = await promise;
+
+    // If the promise that we just awaited is the one that's cached, we replace
+    // it with the actual value if it succeeded, or remove it if it failed.
+    if (this.#cache.get(key) === promise) {
+      if (result.success) {
+        this.#cache.set(key, result.value);
+      } else {
+        this.#cache.delete(key);
+      }
+    }
+
+    if (result.success) {
+      return result.value;
+    }
+
+    throw result.error;
+  }
+
+  /**
+   * Deletes the cached value associated to the key, if any. Note that this does
+   * not cancel any ongoing operation, so if there's a concurrent call to
+   * `getOrCompute` with the same key, it will still wait for the original
+   * operation to complete.
+   *
+   * @param key The cache key to delete.
+   */
+  public delete(key: string): void {
+    this.#cache.delete(key);
+  }
+
+  /**
+   * Clears the cache, removing all the stored values, but without cancelling
+   * any ongoing operation.
+   */
+  public clear(): void {
+    this.#cache.clear();
+  }
+}

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -632,8 +632,8 @@ type SharedPromiseExecutionResult<ValueT> =
   | { success: false; error: Error | unknown };
 
 type SharedPromiseCachedResult<ValueT> =
-  // We wrapped the resolved Promise to distinguish the case where ValueT is
-  // itself a Promise.
+  // We wrapped the resolved value so that we can distingush not-cached from
+  // `undefined` cached values, and between Promise and value.
   | SharedPromiseSuccessfulExecutionResult<ValueT>
   | Promise<SharedPromiseExecutionResult<ValueT>>;
 

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -707,13 +707,7 @@ export class SharedPromiseCache<ValueT> {
 
       const cachedResult = await cached;
 
-      if (this.#cache.get(key) === cached) {
-        if (cachedResult.success) {
-          this.#cache.set(key, { success: true, value: cachedResult.value });
-        } else {
-          this.#cache.delete(key);
-        }
-      }
+      this.#updateResolvedPromiseCache(key, cached, cachedResult);
 
       if (cachedResult.success) {
         return cachedResult.value;
@@ -722,6 +716,10 @@ export class SharedPromiseCache<ValueT> {
       throw cachedResult.error;
     }
 
+    // Don't update `this.#cache` from inside this IIFE — doing so would let a
+    // resolution overwrite a concurrent `delete()`/`clear()`. The cache write
+    // is deferred to `#updateResolvedPromiseCache`, which gates on reference
+    // equality.
     const promise: Promise<SharedPromiseExecutionResult<ValueT>> =
       (async () => {
         try {
@@ -736,15 +734,7 @@ export class SharedPromiseCache<ValueT> {
 
     const result = await promise;
 
-    // If the promise that we just awaited is the one that's cached, we replace
-    // it with the actual value if it succeeded, or remove it if it failed.
-    if (this.#cache.get(key) === promise) {
-      if (result.success) {
-        this.#cache.set(key, { success: true, value: result.value });
-      } else {
-        this.#cache.delete(key);
-      }
-    }
+    this.#updateResolvedPromiseCache(key, promise, result);
 
     if (result.success) {
       return result.value;
@@ -771,5 +761,29 @@ export class SharedPromiseCache<ValueT> {
    */
   public clear(): void {
     this.#cache.clear();
+  }
+
+  /**
+   * Updates the cache if needed once a promise got resolved.
+   *
+   * @param key The cache key.
+   * @param promise The promise that got resolved.
+   * @param result The result of the resolved promise.
+   */
+  #updateResolvedPromiseCache(
+    key: string,
+    promise: Promise<SharedPromiseExecutionResult<ValueT>>,
+    result: SharedPromiseExecutionResult<ValueT>,
+  ): void {
+    // We only update the cache if the cached promise is still the one that got
+    // resolved, which may not always be the case. The reason is that the
+    // resolved promise may have been deleted and/or replaced in the cache.
+    if (this.#cache.get(key) === promise) {
+      if (result.success) {
+        this.#cache.set(key, { success: true, value: result.value });
+      } else {
+        this.#cache.delete(key);
+      }
+    }
   }
 }

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -699,12 +699,8 @@ export class SharedPromiseCache<ValueT> {
     key: string,
     fn: () => Promise<ValueT>,
   ): Promise<ValueT> {
-    if (this.#cache.has(key)) {
-      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions 
-      -- As we may need to cache `undefined` values, we can't just `get` and
-      check for not `undefined`, so we need to assert here. */
-      const cached = this.#cache.get(key) as SharedPromiseCachedResult<ValueT>;
-
+    const cached = this.#cache.get(key);
+    if (cached !== undefined) {
       if (!(cached instanceof Promise)) {
         return cached.value;
       }

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -749,9 +749,9 @@ export class SharedPromiseCache<ValueT> {
 
   /**
    * Deletes the cached value associated to the key, if any. Note that this does
-   * not cancel any ongoing operation, so if there's a concurrent call to
-   * `getOrCompute` with the same key, it will still wait for the original
-   * operation to complete.
+   * not cancel any ongoing operation. Callers that already observed the
+   * in-flight promise will still wait for the original operation to complete,
+   * but callers that start after the deletion may start a new computation.
    *
    * @param key The cache key to delete.
    */

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -622,12 +622,19 @@ export class AsyncMutex {
   }
 }
 
+interface SharedPromiseSuccessfulExecutionResult<ValueT> {
+  success: true;
+  value: ValueT;
+}
+
 type SharedPromiseExecutionResult<ValueT> =
-  | { success: true; value: ValueT }
+  | SharedPromiseSuccessfulExecutionResult<ValueT>
   | { success: false; error: Error | unknown };
 
 type SharedPromiseCachedResult<ValueT> =
-  | ValueT
+  // We wrapped the resolved Promise to distinguish the case where ValueT is
+  // itself a Promise.
+  | SharedPromiseSuccessfulExecutionResult<ValueT>
   | Promise<SharedPromiseExecutionResult<ValueT>>;
 
 /**
@@ -699,14 +706,14 @@ export class SharedPromiseCache<ValueT> {
       const cached = this.#cache.get(key) as SharedPromiseCachedResult<ValueT>;
 
       if (!(cached instanceof Promise)) {
-        return cached;
+        return cached.value;
       }
 
       const cachedResult = await cached;
 
       if (this.#cache.get(key) === cached) {
         if (cachedResult.success) {
-          this.#cache.set(key, cachedResult.value);
+          this.#cache.set(key, { success: true, value: cachedResult.value });
         } else {
           this.#cache.delete(key);
         }
@@ -737,7 +744,7 @@ export class SharedPromiseCache<ValueT> {
     // it with the actual value if it succeeded, or remove it if it failed.
     if (this.#cache.get(key) === promise) {
       if (result.success) {
-        this.#cache.set(key, result.value);
+        this.#cache.set(key, { success: true, value: result.value });
       } else {
         this.#cache.delete(key);
       }

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -629,7 +629,7 @@ interface SharedPromiseSuccessfulExecutionResult<ValueT> {
 
 type SharedPromiseExecutionResult<ValueT> =
   | SharedPromiseSuccessfulExecutionResult<ValueT>
-  | { success: false; error: Error | unknown };
+  | { success: false; error: unknown };
 
 type SharedPromiseCachedResult<ValueT> =
   // We wrapped the resolved value so that we can distinguish not-cached from

--- a/packages/hardhat-utils/test/synchronization.ts
+++ b/packages/hardhat-utils/test/synchronization.ts
@@ -1358,6 +1358,40 @@ describe("SharedPromiseCache", () => {
     assert.equal(reentrantCalls, 0);
   });
 
+  it("should share producer failures with same-key reentrant calls", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const cause = new Error("failure");
+    let outerCalls = 0;
+    let reentrantCalls = 0;
+    let reentrantResult: Promise<string> | undefined;
+
+    const result = assert.rejects(
+      cache.getOrCompute("key", async () => {
+        outerCalls++;
+        reentrantResult = cache.getOrCompute("key", async () => {
+          reentrantCalls++;
+          return "reentrant";
+        });
+
+        throw cause;
+      }),
+      (error) => {
+        assert.equal(error, cause);
+        return true;
+      },
+    );
+
+    await result;
+
+    assert.ok(reentrantResult !== undefined, "Expected a reentrant result");
+    await assert.rejects(reentrantResult, (error) => {
+      assert.equal(error, cause);
+      return true;
+    });
+    assert.equal(outerCalls, 1);
+    assert.equal(reentrantCalls, 0);
+  });
+
   it("should ignore later functions for concurrent calls with the same key, only using the first one", async () => {
     const cache = new SharedPromiseCache<string>();
     const deferred = Promise.withResolvers<string>();

--- a/packages/hardhat-utils/test/synchronization.ts
+++ b/packages/hardhat-utils/test/synchronization.ts
@@ -1365,29 +1365,28 @@ describe("SharedPromiseCache", () => {
     let reentrantCalls = 0;
     let reentrantResult: Promise<string> | undefined;
 
-    const result = assert.rejects(
-      cache.getOrCompute("key", async () => {
-        outerCalls++;
-        reentrantResult = cache.getOrCompute("key", async () => {
-          reentrantCalls++;
-          return "reentrant";
-        });
+    const result = cache.getOrCompute("key", async () => {
+      outerCalls++;
+      reentrantResult = cache.getOrCompute("key", async () => {
+        reentrantCalls++;
+        return "reentrant";
+      });
 
-        throw cause;
-      }),
-      (error) => {
+      throw cause;
+    });
+    assert.ok(reentrantResult !== undefined, "Expected a reentrant result");
+
+    await Promise.all([
+      assert.rejects(result, (error) => {
         assert.equal(error, cause);
         return true;
-      },
-    );
+      }),
+      assert.rejects(reentrantResult, (error) => {
+        assert.equal(error, cause);
+        return true;
+      }),
+    ]);
 
-    await result;
-
-    assert.ok(reentrantResult !== undefined, "Expected a reentrant result");
-    await assert.rejects(reentrantResult, (error) => {
-      assert.equal(error, cause);
-      return true;
-    });
     assert.equal(outerCalls, 1);
     assert.equal(reentrantCalls, 0);
   });
@@ -1694,11 +1693,12 @@ describe("SharedPromiseCache", () => {
     newDeferred.resolve("new");
     assert.equal(await newResult, "new");
 
-    oldDeferred.reject(cause);
-    await assert.rejects(oldResult, (error) => {
+    const oldFailure = assert.rejects(oldResult, (error) => {
       assert.equal(error, cause);
       return true;
     });
+    oldDeferred.reject(cause);
+    await oldFailure;
 
     const finalResult = await cache.getOrCompute("key", async () => {
       finalCalls++;

--- a/packages/hardhat-utils/test/synchronization.ts
+++ b/packages/hardhat-utils/test/synchronization.ts
@@ -1670,6 +1670,47 @@ describe("SharedPromiseCache", () => {
     assert.equal(calls, 2);
   });
 
+  it("should not delete a newer cache entry when an old in-flight computation fails after delete", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const oldDeferred = Promise.withResolvers<string>();
+    const newDeferred = Promise.withResolvers<string>();
+    const cause = new Error("old failure");
+    let oldCalls = 0;
+    let newCalls = 0;
+    let finalCalls = 0;
+
+    const oldResult = cache.getOrCompute("key", async () => {
+      oldCalls++;
+      return await oldDeferred.promise;
+    });
+
+    cache.delete("key");
+
+    const newResult = cache.getOrCompute("key", async () => {
+      newCalls++;
+      return await newDeferred.promise;
+    });
+
+    newDeferred.resolve("new");
+    assert.equal(await newResult, "new");
+
+    oldDeferred.reject(cause);
+    await assert.rejects(oldResult, (error) => {
+      assert.equal(error, cause);
+      return true;
+    });
+
+    const finalResult = await cache.getOrCompute("key", async () => {
+      finalCalls++;
+      return "final";
+    });
+
+    assert.equal(finalResult, "new");
+    assert.equal(oldCalls, 1);
+    assert.equal(newCalls, 1);
+    assert.equal(finalCalls, 0);
+  });
+
   it("should preserve the producer async stack when awaited directly", async () => {
     const cache = new SharedPromiseCache<string>();
 

--- a/packages/hardhat-utils/test/synchronization.ts
+++ b/packages/hardhat-utils/test/synchronization.ts
@@ -1335,6 +1335,29 @@ describe("SharedPromiseCache", () => {
     assert.equal(calls, 1);
   });
 
+  it("should store the in-flight promise before invoking the producer", async () => {
+    const cache = new SharedPromiseCache<string>();
+    let outerCalls = 0;
+    let reentrantCalls = 0;
+    let reentrantResult: Promise<string> | undefined;
+
+    const result = await cache.getOrCompute("key", async () => {
+      outerCalls++;
+      reentrantResult = cache.getOrCompute("key", async () => {
+        reentrantCalls++;
+        return "reentrant";
+      });
+
+      return "outer";
+    });
+
+    assert.equal(result, "outer");
+    assert.ok(reentrantResult !== undefined, "Expected a reentrant result");
+    assert.equal(await reentrantResult, "outer");
+    assert.equal(outerCalls, 1);
+    assert.equal(reentrantCalls, 0);
+  });
+
   it("should ignore later functions for concurrent calls with the same key, only using the first one", async () => {
     const cache = new SharedPromiseCache<string>();
     const deferred = Promise.withResolvers<string>();

--- a/packages/hardhat-utils/test/synchronization.ts
+++ b/packages/hardhat-utils/test/synchronization.ts
@@ -17,6 +17,7 @@ import {
   MultiProcessMutex,
   MultiProcessMutexError,
   MultiProcessMutexTimeoutError,
+  SharedPromiseCache,
   StaleMultiProcessMutexError,
 } from "../src/synchronization.js";
 
@@ -1209,5 +1210,498 @@ describe("AsyncMutex", () => {
 
     assert.equal(maxRunning, 1);
     assert.equal(running, 0);
+  });
+});
+
+function assertAsyncStackHasThrowAndGetOrComputeFrames(
+  error: unknown,
+): asserts error is Error {
+  assert.ok(error instanceof Error, "Expected an Error object");
+
+  const stack = error.stack ?? "";
+  assert.ok(
+    stack.includes(import.meta.filename),
+    "Should include the stack entry for the test file",
+  );
+  assert.match(stack, /at failAfterAsyncBoundary/);
+  assert.match(stack, /at async SharedPromiseCache\.getOrCompute/);
+}
+
+async function getRejectedValue(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn();
+  } catch (error) {
+    return error;
+  }
+
+  assert.fail("Expected promise to reject");
+}
+
+describe("SharedPromiseCache", () => {
+  it("should compute on first miss", async () => {
+    const cache = new SharedPromiseCache<string>();
+    let calls = 0;
+
+    const result = await cache.getOrCompute("key", async () => {
+      calls++;
+      return "value";
+    });
+
+    assert.equal(result, "value");
+    assert.equal(calls, 1);
+  });
+
+  it("should cache a successful result", async () => {
+    const cache = new SharedPromiseCache<string>();
+    let firstCalls = 0;
+    let secondCalls = 0;
+
+    const firstResult = await cache.getOrCompute("key", async () => {
+      firstCalls++;
+      return "first";
+    });
+    const secondResult = await cache.getOrCompute("key", async () => {
+      secondCalls++;
+      return "second";
+    });
+
+    assert.equal(firstResult, "first");
+    assert.equal(secondResult, "first");
+    assert.equal(firstCalls, 1);
+    assert.equal(secondCalls, 0);
+  });
+
+  it("should cache a successful undefined result", async () => {
+    const cache = new SharedPromiseCache<string | undefined>();
+    let calls = 0;
+
+    const firstResult = await cache.getOrCompute("key", async () => {
+      calls++;
+      return undefined;
+    });
+
+    const secondResult = await cache.getOrCompute("key", async () => {
+      calls++;
+      return "second";
+    });
+
+    assert.equal(firstResult, undefined);
+    assert.equal(secondResult, undefined);
+    assert.equal(calls, 1);
+  });
+
+  it("should use independent cache entries per key", async () => {
+    const cache = new SharedPromiseCache<string>();
+    let firstCalls = 0;
+    let secondCalls = 0;
+
+    const firstResult = await cache.getOrCompute("first", async () => {
+      firstCalls++;
+      return "first-value";
+    });
+
+    const secondResult = await cache.getOrCompute("second", async () => {
+      secondCalls++;
+      return "second-value";
+    });
+
+    assert.equal(firstResult, "first-value");
+    assert.equal(secondResult, "second-value");
+    assert.equal(firstCalls, 1);
+    assert.equal(secondCalls, 1);
+  });
+
+  it("should deduplicate concurrent calls", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const deferred = Promise.withResolvers<string>();
+    let calls = 0;
+
+    const fn = async () => {
+      calls++;
+      return await deferred.promise;
+    };
+
+    const first = cache.getOrCompute("key", fn);
+    const second = cache.getOrCompute("key", fn);
+    const third = cache.getOrCompute("key", fn);
+
+    deferred.resolve("first");
+
+    assert.deepEqual(await Promise.all([first, second, third]), [
+      "first",
+      "first",
+      "first",
+    ]);
+    assert.equal(calls, 1);
+  });
+
+  it("should ignore later functions for concurrent calls with the same key, only using the first one", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const deferred = Promise.withResolvers<string>();
+    let firstCalls = 0;
+    let secondCalls = 0;
+    let thirdCalls = 0;
+
+    const first = cache.getOrCompute("key", async () => {
+      firstCalls++;
+      return await deferred.promise;
+    });
+
+    const second = cache.getOrCompute("key", async () => {
+      secondCalls++;
+      return "second";
+    });
+
+    const third = cache.getOrCompute("key", async () => {
+      thirdCalls++;
+      return "third";
+    });
+
+    deferred.resolve("first");
+
+    assert.deepEqual(await Promise.all([first, second, third]), [
+      "first",
+      "first",
+      "first",
+    ]);
+    assert.equal(firstCalls, 1);
+    assert.equal(secondCalls, 0);
+    assert.equal(thirdCalls, 0);
+  });
+
+  it("should not deduplicate different keys, even if they use the same function", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const deferred = Promise.withResolvers<string>();
+    let calls = 0;
+
+    const fn = async () => {
+      calls++;
+      return await deferred.promise;
+    };
+
+    const first = cache.getOrCompute("first", fn);
+
+    const second = cache.getOrCompute("second", fn);
+
+    deferred.resolve("value");
+
+    assert.deepEqual(await Promise.all([first, second]), ["value", "value"]);
+    assert.equal(calls, 2);
+  });
+
+  it("should rethrow computation failures without wrapping them", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const cause = new Error("failure");
+
+    await assert.rejects(
+      cache.getOrCompute("key", async () => {
+        throw cause;
+      }),
+      (error) => {
+        assert.equal(error, cause);
+        return true;
+      },
+    );
+  });
+
+  it("should share concurrent failures without wrapping them", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const deferred = Promise.withResolvers<string>();
+    const cause = new Error("failure");
+    let calls = 0;
+
+    const first = assert.rejects(
+      cache.getOrCompute("key", async () => {
+        calls++;
+        return await deferred.promise;
+      }),
+      (error) => {
+        assert.equal(error, cause);
+        return true;
+      },
+    );
+
+    const second = assert.rejects(
+      cache.getOrCompute("key", async () => "second"),
+      (error) => {
+        assert.equal(error, cause);
+        return true;
+      },
+    );
+
+    deferred.reject(cause);
+
+    await Promise.all([first, second]);
+    assert.equal(calls, 1);
+  });
+
+  it("should not cache failures", async () => {
+    const cache = new SharedPromiseCache<string>();
+    let calls = 0;
+
+    await assert.rejects(
+      cache.getOrCompute("key", async () => {
+        calls++;
+        throw new Error("failure");
+      }),
+    );
+
+    const result = await cache.getOrCompute("key", async () => {
+      calls++;
+      return "value";
+    });
+
+    assert.equal(result, "value");
+    assert.equal(calls, 2);
+  });
+
+  it("should rethrow non-Error thrown values without wrapping them", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const thrown = "failure";
+
+    await assert.rejects(
+      cache.getOrCompute("key", async () => {
+        throw thrown;
+      }),
+      (error) => {
+        assert.equal(error, thrown);
+        return true;
+      },
+    );
+  });
+
+  it("should clear cached successful results", async () => {
+    const cache = new SharedPromiseCache<string>();
+    let calls = 0;
+
+    const firstResult = await cache.getOrCompute("key", async () => {
+      calls++;
+      return "first";
+    });
+
+    cache.clear();
+
+    const secondResult = await cache.getOrCompute("key", async () => {
+      calls++;
+      return "second";
+    });
+
+    assert.equal(firstResult, "first");
+    assert.equal(secondResult, "second");
+    assert.equal(calls, 2);
+  });
+
+  it("should not cancel in-flight work when cleared", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const deferred = Promise.withResolvers<string>();
+
+    const resultPromise = cache.getOrCompute(
+      "key",
+      async () => await deferred.promise,
+    );
+
+    cache.clear();
+    deferred.resolve("value");
+
+    assert.equal(await resultPromise, "value");
+  });
+
+  it("should not repopulate the cache with an in-flight result after clear", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const deferred = Promise.withResolvers<string>();
+    let calls = 0;
+
+    const oldResult = cache.getOrCompute("key", async () => {
+      calls++;
+      return await deferred.promise;
+    });
+
+    cache.clear();
+    deferred.resolve("old");
+
+    assert.equal(await oldResult, "old");
+
+    const newResult = await cache.getOrCompute("key", async () => {
+      calls++;
+      return "new";
+    });
+
+    assert.equal(newResult, "new");
+    assert.equal(calls, 2);
+  });
+
+  it("should keep a new in-flight computation after clearing an old one", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const oldDeferred = Promise.withResolvers<string>();
+    const newDeferred = Promise.withResolvers<string>();
+    let oldCalls = 0;
+    let newCalls = 0;
+    let finalCalls = 0;
+
+    const oldResult = cache.getOrCompute("key", async () => {
+      oldCalls++;
+      return await oldDeferred.promise;
+    });
+
+    cache.clear();
+
+    const newResult = cache.getOrCompute("key", async () => {
+      newCalls++;
+      return await newDeferred.promise;
+    });
+
+    oldDeferred.resolve("old");
+    newDeferred.resolve("new");
+
+    assert.equal(await oldResult, "old");
+    assert.equal(await newResult, "new");
+
+    const finalResult = await cache.getOrCompute("key", async () => {
+      finalCalls++;
+      return "final";
+    });
+
+    assert.equal(finalResult, "new");
+
+    assert.equal(oldCalls, 1);
+    assert.equal(newCalls, 1);
+    assert.equal(finalCalls, 0);
+  });
+
+  it("should delete cached successful results", async () => {
+    const cache = new SharedPromiseCache<string>();
+    let calls = 0;
+
+    const firstResult = await cache.getOrCompute("key", async () => {
+      calls++;
+      return "first";
+    });
+
+    cache.delete("key");
+
+    const secondResult = await cache.getOrCompute("key", async () => {
+      calls++;
+      return "second";
+    });
+
+    assert.equal(firstResult, "first");
+    assert.equal(secondResult, "second");
+    assert.equal(calls, 2);
+  });
+
+  it("should not repopulate the cache with an in-flight result after delete", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const deferred = Promise.withResolvers<string>();
+    let calls = 0;
+
+    const oldResult = cache.getOrCompute("key", async () => {
+      calls++;
+      return await deferred.promise;
+    });
+
+    cache.delete("key");
+    deferred.resolve("old");
+
+    assert.equal(await oldResult, "old");
+
+    const newResult = await cache.getOrCompute("key", async () => {
+      calls++;
+      return "new";
+    });
+
+    assert.equal(newResult, "new");
+    assert.equal(calls, 2);
+  });
+
+  it("should preserve the producer async stack when awaited directly", async () => {
+    const cache = new SharedPromiseCache<string>();
+
+    async function failAfterAsyncBoundary(): Promise<string> {
+      await sleep(0.001);
+      throw new Error("fail");
+    }
+
+    await assert.rejects(
+      cache.getOrCompute("key", async () => await failAfterAsyncBoundary()),
+      (error) => {
+        assertAsyncStackHasThrowAndGetOrComputeFrames(error);
+        return true;
+      },
+    );
+  });
+
+  it("should preserve the producer async stack when awaited after other async work", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const deferred = Promise.withResolvers<void>();
+
+    async function failAfterAsyncBoundary(): Promise<string> {
+      await deferred.promise;
+      throw new Error("fail");
+    }
+
+    const result = cache.getOrCompute(
+      "key",
+      async () => await failAfterAsyncBoundary(),
+    );
+
+    await sleep(0.001);
+
+    const rejection = assert.rejects(result, (error) => {
+      assertAsyncStackHasThrowAndGetOrComputeFrames(error);
+      return true;
+    });
+
+    deferred.resolve();
+
+    await rejection;
+  });
+
+  it("should share the original producer error with coalesced callers", async () => {
+    const cache = new SharedPromiseCache<string>();
+    const deferred = Promise.withResolvers<void>();
+    let calls = 0;
+    let originalError: Error | undefined;
+
+    async function failAfterAsyncBoundary(): Promise<string> {
+      await deferred.promise;
+      originalError = new Error("fail");
+      throw originalError;
+    }
+
+    const firstError = getRejectedValue(
+      async () =>
+        await cache.getOrCompute("key", async () => {
+          calls++;
+          return await failAfterAsyncBoundary();
+        }),
+    );
+
+    await sleep(0.001);
+
+    const secondError = getRejectedValue(
+      async () =>
+        await cache.getOrCompute("key", async () => {
+          calls++;
+          return "second";
+        }),
+    );
+
+    deferred.resolve();
+
+    const [firstErrorValue, secondErrorValue] = await Promise.all([
+      firstError,
+      secondError,
+    ]);
+
+    // Note: In this test we intentionally observe the errors through
+    // getRejectedValue so that both coalesced callers can be asserted together.
+    // That breaks the async chain whose stack shape is checked in the previous
+    // tests. This test only verifies that coalesced callers receive the exact
+    // same original error object.
+
+    assert.equal(calls, 1);
+    assert.equal(firstErrorValue, originalError);
+    assert.equal(secondErrorValue, originalError);
+    assert.equal(firstErrorValue, secondErrorValue);
   });
 });


### PR DESCRIPTION
Introduce the `SharedPromiseCache` synchronization primitive. This allows you to have a cache of `async`-produced values, where the value associated to a key is only computed once, without using a mutex, but instead sharing the first `Promise` that produces it.