### PR TITLE
fix: update memory usage when passing coverage

### DIFF
--- a/.changeset/mean-dingos-chew.md
+++ b/.changeset/mean-dingos-chew.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Reduced internal memory usage during coverage test runs ([#8213](https://github.com/NomicFoundation/hardhat/pull/8213))

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -74,7 +74,7 @@ export class CoverageManagerImplementation implements CoverageManager {
   /**
    * @private exposed for testing purposes only
    */
-  public data: CoverageData = [];
+  public data: Map<string, number> = new Map();
 
   readonly #coveragePath: string;
 
@@ -91,8 +91,8 @@ export class CoverageManagerImplementation implements CoverageManager {
   }
 
   public async addData(data: CoverageData): Promise<void> {
-    for (const entry of data) {
-      this.data.push(entry);
+    for (const tag of data) {
+      this.data.set(tag, (this.data.get(tag) ?? 0) + 1);
     }
 
     log("Added data", JSON.stringify(data, null, 2));
@@ -122,14 +122,14 @@ export class CoverageManagerImplementation implements CoverageManager {
   public async clearData(id: string): Promise<void> {
     const dataPath = await this.#getDataPath(id);
     await remove(dataPath);
-    this.data = [];
+    this.data = new Map();
     log("Cleared data from disk and memory");
   }
 
   public async saveData(id: string): Promise<void> {
     const dataPath = await this.#getDataPath(id);
     const filePath = path.join(dataPath, `${crypto.randomUUID()}.json`);
-    const data = this.data;
+    const data = Object.fromEntries(this.data);
     await writeJsonFile(filePath, data);
     log("Saved data", id, filePath);
   }
@@ -170,15 +170,19 @@ export class CoverageManagerImplementation implements CoverageManager {
    * @private exposed for testing purposes only
    */
   public async loadData(...ids: string[]): Promise<void> {
-    this.data = [];
+    this.data = new Map();
+
     for (const id of ids) {
       const dataPath = await this.#getDataPath(id);
       const filePaths = await getAllFilesMatching(dataPath);
+
       for (const filePath of filePaths) {
-        const entries = await readJsonFile<CoverageData>(filePath);
-        for (const entry of entries) {
-          this.data.push(entry);
+        const entries = await readJsonFile<Record<string, number>>(filePath);
+
+        for (const [tag, count] of Object.entries(entries)) {
+          this.data.set(tag, (this.data.get(tag) ?? 0) + count);
         }
+
         log("Loaded data", id, filePath);
       }
     }
@@ -188,7 +192,7 @@ export class CoverageManagerImplementation implements CoverageManager {
    * @private exposed for testing purposes only
    */
   public async getReport(): Promise<Report> {
-    const allExecutedTags = new Set(this.data);
+    const allExecutedTags = this.data;
 
     const reportPromises = Array.from(this.filesMetadata.entries()).map(
       async ([fileRelativePath, fileStatements]) => {

--- a/packages/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -140,10 +140,7 @@ describe("CoverageManagerImplementation", () => {
     const allData = coverageManager.data;
 
     for (const item of [...data1, ...data2]) {
-      assert.ok(
-        allData.includes(item),
-        `The loaded data should include ${item}`,
-      );
+      assert.ok(allData.has(item), `The loaded data should include ${item}`);
     }
   });
 
@@ -181,11 +178,33 @@ describe("CoverageManagerImplementation", () => {
     const allData = coverageManager.data;
 
     for (const item of [...data1]) {
-      assert.ok(
-        allData.includes(item),
-        `The loaded data should include ${item}`,
-      );
+      assert.ok(allData.has(item), `The loaded data should include ${item}`);
     }
+  });
+
+  it("should aggregate repeated tags as counts", async () => {
+    await coverageManager.addData(["a", "b", "a", "a", "b"]);
+
+    assert.equal(coverageManager.data.get("a"), 3);
+    assert.equal(coverageManager.data.get("b"), 2);
+    assert.equal(coverageManager.data.size, 2);
+  });
+
+  it("should sum counts across saved shards on load", async () => {
+    const cm1 = new CoverageManagerImplementation(process.cwd());
+    const cm2 = new CoverageManagerImplementation(process.cwd());
+
+    await cm1.addData(["a", "a", "b"]);
+    await cm1.saveData(id);
+
+    await cm2.addData(["a", "c"]);
+    await cm2.saveData(id);
+
+    await coverageManager.loadData(id);
+
+    assert.equal(coverageManager.data.get("a"), 3);
+    assert.equal(coverageManager.data.get("b"), 1);
+    assert.equal(coverageManager.data.get("c"), 1);
   });
 
   it("should store all the metadata", async () => {
@@ -235,13 +254,13 @@ describe("CoverageManagerImplementation", () => {
 
     let allData = coverageManager.data;
 
-    assert.ok(allData.length !== 0, "The data should be saved to memory");
+    assert.ok(allData.size !== 0, "The data should be saved to memory");
 
     await coverageManager.clearData(id);
 
     allData = coverageManager.data;
 
-    assert.ok(allData.length === 0, "The data should be cleared from memory");
+    assert.ok(allData.size === 0, "The data should be cleared from memory");
   });
 
   it("should clear the data from disk", async () => {


### PR DESCRIPTION
Improve memory usage during `--coverage` runs of both Solidity test and JS/TS tests.

We do this by holding less hit count data - swapping an array that is appended to and eventually processed with a map structure where processing happens immediately on count data coming across the EDR NAPI boundary.

Fixes #8212
