### PR TITLE
docs: mark Ignition APIs as public

### DIFF
--- a/.changeset/honest-laws-applaud.md
+++ b/.changeset/honest-laws-applaud.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/ignition-core": patch
+---
+
+Mark Ignition core APIs as public in the generated API documentation.

--- a/packages/ignition-core/src/batches.ts
+++ b/packages/ignition-core/src/batches.ts
@@ -11,7 +11,7 @@ import { deploymentStateReducer } from "./internal/execution/reducers/deployment
  * @param ignitionModule - the Ignition module to be get batch information for
  * @returns the batches Ignition will use for the module
  *
- * @beta
+ * @public
  */
 export function batches(
   ignitionModule: IgnitionModule<string, string, IgnitionModuleResult<string>>,

--- a/packages/ignition-core/src/build-module.ts
+++ b/packages/ignition-core/src/build-module.ts
@@ -14,7 +14,7 @@ import { isValidIgnitionIdentifier } from "./internal/utils/identifier-validator
  * IgnitionModuleBuilder to configure the deployment
  * @returns a module definition
  *
- * @beta
+ * @public
  */
 export function buildModule<
   ModuleIdT extends string,

--- a/packages/ignition-core/src/deploy.ts
+++ b/packages/ignition-core/src/deploy.ts
@@ -31,7 +31,7 @@ import { ExecutionEventType } from "./types/execution-events.js";
 /**
  * Deploy an IgnitionModule to the chain
  *
- * @beta
+ * @public
  */
 export async function deploy<
   ModuleIdT extends string,

--- a/packages/ignition-core/src/ignition-module-serializer.ts
+++ b/packages/ignition-core/src/ignition-module-serializer.ts
@@ -78,7 +78,7 @@ interface SerializeContext {
 /**
  * Serialize an Ignition module.
  *
- * @beta
+ * @public
  */
 export class IgnitionModuleSerializer {
   public static serialize(
@@ -459,7 +459,7 @@ export class IgnitionModuleSerializer {
  * Deserialize an `IgnitionModule` that was previously serialized using
  * IgnitionModuleSerializer.
  *
- * @beta
+ * @public
  */
 export class IgnitionModuleDeserializer {
   public static deserialize(

--- a/packages/ignition-core/src/internal/deployment-loader/types.ts
+++ b/packages/ignition-core/src/internal/deployment-loader/types.ts
@@ -4,7 +4,7 @@ import type { JournalMessage } from "../execution/types/messages.js";
 /**
  * Read and write to the deployment storage.
  *
- * @beta
+ * @public
  */
 export interface DeploymentLoader {
   recordToJournal(message: JournalMessage): Promise<void>;

--- a/packages/ignition-core/src/internal/formatters.ts
+++ b/packages/ignition-core/src/internal/formatters.ts
@@ -93,7 +93,7 @@ export function formatCustomError(errorName: string, args: EvmTuple): string {
 /**
  * Formats a Solidity parameter into a human-readable string.
  *
- * @beta
+ * @public
  */
 export function formatSolidityParameter(param: SolidityParameterType): string {
   if (Array.isArray(param)) {

--- a/packages/ignition-core/src/internal/journal/file-journal.ts
+++ b/packages/ignition-core/src/internal/journal/file-journal.ts
@@ -14,7 +14,7 @@ import { serializeReplacer } from "./utils/serialize-replacer.js";
 /**
  * A file-based journal.
  *
- * @beta
+ * @public
  */
 export class FileJournal implements Journal {
   constructor(

--- a/packages/ignition-core/src/internal/journal/memory-journal.ts
+++ b/packages/ignition-core/src/internal/journal/memory-journal.ts
@@ -7,7 +7,7 @@ import { emitExecutionEvent } from "./utils/emitExecutionEvent.js";
 /**
  * An in-memory journal.
  *
- * @beta
+ * @public
  */
 export class MemoryJournal implements Journal {
   private readonly _messages: JournalMessage[] = [];

--- a/packages/ignition-core/src/internal/journal/types/index.ts
+++ b/packages/ignition-core/src/internal/journal/types/index.ts
@@ -3,7 +3,7 @@ import type { JournalMessage } from "../../execution/types/messages.js";
 /**
  * Store a deployments execution state as a transaction log.
  *
- * @beta
+ * @public
  */
 export interface Journal {
   /**

--- a/packages/ignition-core/src/list-deployments.ts
+++ b/packages/ignition-core/src/list-deployments.ts
@@ -5,7 +5,7 @@ import { exists, readdir } from "@nomicfoundation/hardhat-utils/fs";
  *
  * @param deploymentDir - the directory of the deployments
  *
- * @beta
+ * @public
  */
 export async function listDeployments(
   deploymentDir: string,

--- a/packages/ignition-core/src/list-transactions.ts
+++ b/packages/ignition-core/src/list-transactions.ts
@@ -32,7 +32,7 @@ import {
  * @param artifactResolver - the artifact resolver to use when loading artifacts
  * for a future
  *
- * @beta
+ * @public
  */
 export async function listTransactions(
   deploymentDir: string,

--- a/packages/ignition-core/src/status.ts
+++ b/packages/ignition-core/src/status.ts
@@ -14,7 +14,7 @@ import { findStatus } from "./internal/views/find-status.js";
  * @param deploymentDir - the directory of the deployment to get the status of
  * @param _artifactResolver - DEPRECATED: this parameter is not used and will be removed in the future
  *
- * @beta
+ * @public
  */
 export async function status(
   deploymentDir: string,

--- a/packages/ignition-core/src/strategies/create2-strategy.ts
+++ b/packages/ignition-core/src/strategies/create2-strategy.ts
@@ -72,7 +72,7 @@ const CREATE_X_PRESIGNED_DEPLOYER_ADDRESS =
  *   ...
  * }
  *
- * @beta
+ * @public
  */
 export class Create2Strategy implements ExecutionStrategy {
   public readonly name: string = "create2";

--- a/packages/ignition-core/src/track-transaction.ts
+++ b/packages/ignition-core/src/track-transaction.ts
@@ -40,7 +40,7 @@ import { getNetworkExecutionStates } from "./internal/views/execution-state/get-
  * @param requiredConfirmations - the number of confirmations required for the transaction to be considered confirmed
  * @param applyNewMessageFn - only used for ease of testing this function and should not be used otherwise
  *
- * @beta
+ * @public
  */
 export async function trackTransaction(
   deploymentDir: string,

--- a/packages/ignition-core/src/type-guards.ts
+++ b/packages/ignition-core/src/type-guards.ts
@@ -40,7 +40,7 @@ function isValidEnumValue(
 /**
  * Returns true if potential is of type Artifact.
  *
- * @beta
+ * @public
  */
 export function isArtifactType(potential: unknown): potential is Artifact {
   return (
@@ -60,7 +60,7 @@ export function isArtifactType(potential: unknown): potential is Artifact {
 /**
  * Returns true if potential is of type FutureType.
  *
- * @beta
+ * @public
  */
 export function isFutureType(potential: unknown): potential is FutureType {
   return (
@@ -71,7 +71,7 @@ export function isFutureType(potential: unknown): potential is FutureType {
 /**
  * Returns true if potential is of type Future.
  *
- * @beta
+ * @public
  */
 export function isFuture(potential: unknown): potential is Future {
   return (
@@ -85,7 +85,7 @@ export function isFuture(potential: unknown): potential is Future {
 /**
  * Returns true if future is of type ContractFuture<string>.
  *
- * @beta
+ * @public
  */
 export function isContractFuture(
   future: Future,
@@ -108,7 +108,7 @@ export function isContractFuture(
 /**
  * Returns true if future is of type CallableContractFuture<string>.
  *
- * @beta
+ * @public
  */
 export function isCallableContractFuture(
   future: Future,
@@ -129,7 +129,7 @@ export function isCallableContractFuture(
 /**
  * Returns true if future is of type AddressResolvable.
  *
- * @beta
+ * @public
  */
 export function isAddressResolvableFuture(
   future: Future,
@@ -144,7 +144,7 @@ export function isAddressResolvableFuture(
 /**
  * Returns true if future is of type FunctionCallFuture\<string, string\>.
  *
- * @beta
+ * @public
  */
 export function isFunctionCallFuture(
   future: Future,
@@ -158,7 +158,7 @@ export function isFunctionCallFuture(
 /**
  * Returns true if future is of type NamedStaticCallFuture.
  *
- * @beta
+ * @public
  */
 export function isNamedStaticCallFuture(
   future: Future,
@@ -169,7 +169,7 @@ export function isNamedStaticCallFuture(
 /**
  * Returns true if future is of type EncodeFunctionCallFuture\<string, string\>.
  *
- * @beta
+ * @public
  */
 export function isEncodeFunctionCallFuture(
   potential: unknown,
@@ -182,7 +182,7 @@ export function isEncodeFunctionCallFuture(
 /**
  * Returns true if future is of type ReadEventArgumentFuture.
  *
- * @beta
+ * @public
  */
 export function isReadEventArgumentFuture(
   future: Future,
@@ -193,7 +193,7 @@ export function isReadEventArgumentFuture(
 /**
  * Returns true if future is of type NamedContractDeploymentFuture.
  *
- * @beta
+ * @public
  */
 export function isNamedContractDeploymentFuture(
   future: Future,
@@ -204,7 +204,7 @@ export function isNamedContractDeploymentFuture(
 /**
  * Returns true if future is of type ArtifactContractDeploymentFuture.
  *
- * @beta
+ * @public
  */
 export function isArtifactContractDeploymentFuture(
   future: Future,
@@ -215,7 +215,7 @@ export function isArtifactContractDeploymentFuture(
 /**
  * Returns true if future is of type NamedLibraryDeploymentFuture.
  *
- * @beta
+ * @public
  */
 export function isNamedLibraryDeploymentFuture(
   future: Future,
@@ -226,7 +226,7 @@ export function isNamedLibraryDeploymentFuture(
 /**
  * Returns true if future is of type ArtifactLibraryDeploymentFuture.
  *
- * @beta
+ * @public
  */
 export function isArtifactLibraryDeploymentFuture(
   future: Future,
@@ -237,7 +237,7 @@ export function isArtifactLibraryDeploymentFuture(
 /**
  * Returns true if future is of type NamedContractAtFuture.
  *
- * @beta
+ * @public
  */
 export function isNamedContractAtFuture(
   future: Future,
@@ -248,7 +248,7 @@ export function isNamedContractAtFuture(
 /**
  * Returns true if future is of type ArtifactContractAtFuture.
  *
- * @beta
+ * @public
  */
 export function isArtifactContractAtFuture(
   future: Future,
@@ -259,7 +259,7 @@ export function isArtifactContractAtFuture(
 /**
  * Returns true if the type is of type DeploymentFuture<string>.
  *
- * @beta
+ * @public
  */
 export function isDeploymentType(
   potential: unknown,
@@ -280,7 +280,7 @@ export function isDeploymentType(
 /**
  * Returns true if future is of type DeploymentFuture<string>.
  *
- * @beta
+ * @public
  */
 export function isDeploymentFuture(
   future: Future,
@@ -291,7 +291,7 @@ export function isDeploymentFuture(
 /**
  * Returns true if the future requires submitting a transaction on-chain
  *
- * @beta
+ * @public
  */
 export function isFutureThatSubmitsOnchainTransaction(
   f: Future,
@@ -320,7 +320,7 @@ export function isFutureThatSubmitsOnchainTransaction(
 /**
  * Returns true if potential is of type RuntimeValueType.
  *
- * @beta
+ * @public
  */
 export function isRuntimeValueType(
   potential: unknown,
@@ -334,7 +334,7 @@ export function isRuntimeValueType(
 /**
  * Returns true if potential is of type RuntimeValue.
  *
- * @beta
+ * @public
  */
 export function isRuntimeValue(potential: unknown): potential is RuntimeValue {
   return (
@@ -348,7 +348,7 @@ export function isRuntimeValue(potential: unknown): potential is RuntimeValue {
 /**
  * Return true if potential is an account runtime value.
  *
- * @beta
+ * @public
  */
 export function isAccountRuntimeValue(
   potential: unknown,
@@ -361,7 +361,7 @@ export function isAccountRuntimeValue(
 /**
  * Returns true if potential is of type ModuleParameterRuntimeValue<any>.
  *
- * @beta
+ * @public
  */
 export function isModuleParameterRuntimeValue(
   potential: unknown,

--- a/packages/ignition-core/src/types/artifact.ts
+++ b/packages/ignition-core/src/types/artifact.ts
@@ -1,14 +1,14 @@
 /**
  * The type of the contract artifact's ABI.
  *
- * @beta
+ * @public
  */
 export type Abi = readonly any[] | any[];
 
 /**
  * The links between libraries and their references in the bytecode.
  *
- * @beta
+ * @public
  */
 export type LinkReferences = Record<
   string,
@@ -22,7 +22,7 @@ export type LinkReferences = Record<
  * Each immutable variable is represented by an id, which in the case of solc
  * is the id of the AST node that represents the variable.
  *
- * @beta
+ * @public
  */
 export interface ImmutableReferences {
   [immutableId: string]: Array<{ start: number; length: number }>;
@@ -31,7 +31,7 @@ export interface ImmutableReferences {
 /**
  * An compilation artifact representing a smart contract.
  *
- * @beta
+ * @public
  */
 export interface Artifact<AbiT extends Abi = Abi> {
   _format: string;
@@ -50,7 +50,7 @@ export interface Artifact<AbiT extends Abi = Abi> {
 /**
  * Retrieve artifacts based on contract name.
  *
- * @beta
+ * @public
  */
 export interface ArtifactResolver {
   loadArtifact(contractName: string): Promise<Artifact>;
@@ -62,7 +62,7 @@ export interface ArtifactResolver {
  * includes all the necessary information to recreate that exact same run, and
  * all of its output.
  *
- * @beta
+ * @public
  */
 export interface BuildInfo {
   _format: string;
@@ -76,7 +76,7 @@ export interface BuildInfo {
 /**
  * The solc input for running the compilation.
  *
- * @beta
+ * @public
  */
 export interface CompilerInput {
   language: string;
@@ -111,7 +111,7 @@ export interface CompilerInput {
 /**
  * The output of a compiled contract from solc.
  *
- * @beta
+ * @public
  */
 export interface CompilerOutputContract {
   abi: any;
@@ -127,7 +127,7 @@ export interface CompilerOutputContract {
 /**
  * The compilation output from solc.
  *
- * @beta
+ * @public
  */
 export interface CompilerOutput {
   sources: CompilerOutputSources;
@@ -141,7 +141,7 @@ export interface CompilerOutput {
 /**
  * The ast for a compiled contract.
  *
- * @beta
+ * @public
  */
 export interface CompilerOutputSource {
   id: number;
@@ -151,7 +151,7 @@ export interface CompilerOutputSource {
 /**
  * The asts for the compiled contracts.
  *
- * @beta
+ * @public
  */
 export interface CompilerOutputSources {
   [sourceName: string]: CompilerOutputSource;
@@ -160,7 +160,7 @@ export interface CompilerOutputSources {
 /**
  * The solc bytecode output.
  *
- * @beta
+ * @public
  */
 export interface CompilerOutputBytecode {
   object: string;

--- a/packages/ignition-core/src/types/deploy.ts
+++ b/packages/ignition-core/src/types/deploy.ts
@@ -3,7 +3,7 @@ import type { ModuleParameters } from "./module.js";
 /**
  * Configuration options for the deployment.
  *
- * @beta
+ * @public
  */
 export interface DeployConfig {
   /**
@@ -50,7 +50,7 @@ export interface DeployConfig {
 /**
  * The result of running a deployment.
  *
- * @beta
+ * @public
  */
 export type DeploymentResult =
   | ValidationErrorDeploymentResult
@@ -62,7 +62,7 @@ export type DeploymentResult =
 /**
  * The different kinds of results that a deployment can produce.
  *
- * @beta
+ * @public
  */
 export enum DeploymentResultType {
   /**
@@ -95,7 +95,7 @@ export enum DeploymentResultType {
 /**
  * A deployment result where one or more futures failed validation.
  *
- * @beta
+ * @public
  */
 export interface ValidationErrorDeploymentResult {
   type: DeploymentResultType.VALIDATION_ERROR;
@@ -111,7 +111,7 @@ export interface ValidationErrorDeploymentResult {
 /**
  * A deployment result where one or more futures failed reconciliation.
  *
- * @beta
+ * @public
  */
 export interface ReconciliationErrorDeploymentResult {
   type: DeploymentResultType.RECONCILIATION_ERROR;
@@ -128,7 +128,7 @@ export interface ReconciliationErrorDeploymentResult {
  * A deployment result where one or more futures errored during execution or
  * timed out.
  *
- * @beta
+ * @public
  */
 export interface ExecutionErrorDeploymentResult {
   type: DeploymentResultType.EXECUTION_ERROR;
@@ -171,7 +171,7 @@ export interface ExecutionErrorDeploymentResult {
  * A deployment result where one or more futures from a previous run failed or timed out
  * and need their state wiped.
  *
- * @beta
+ * @public
  */
 export interface PreviousRunErrorDeploymentResult {
   type: DeploymentResultType.PREVIOUS_RUN_ERROR;
@@ -187,7 +187,7 @@ export interface PreviousRunErrorDeploymentResult {
 /**
  * The details of a deployed contract.
  *
- * @beta
+ * @public
  */
 export interface DeployedContract {
   id: string;
@@ -202,7 +202,7 @@ export interface DeployedContract {
  * The deployed contracts returned include the deployed contracts from previous
  * runs.
  *
- * @beta
+ * @public
  */
 export interface SuccessfulDeploymentResult {
   type: DeploymentResultType.SUCCESSFUL_DEPLOYMENT;
@@ -220,7 +220,7 @@ export interface SuccessfulDeploymentResult {
 /**
  * An object containing a map of module ID's to their respective ModuleParameters.
  *
- * @beta
+ * @public
  */
 export interface DeploymentParameters {
   [moduleId: string]: ModuleParameters;
@@ -229,7 +229,7 @@ export interface DeploymentParameters {
 /**
  * The config options for the deployment strategies.
  *
- * @beta
+ * @public
  */
 export interface StrategyConfig {
   basic: Record<PropertyKey, never>;

--- a/packages/ignition-core/src/types/execution-events.ts
+++ b/packages/ignition-core/src/types/execution-events.ts
@@ -4,7 +4,7 @@ import type { DeploymentResult } from "./deploy.js";
  * Events emitted by the execution engine to allow tracking
  * progress of a deploy.
  *
- * @beta
+ * @public
  */
 export type ExecutionEvent =
   | DeploymentInitializeEvent
@@ -39,7 +39,7 @@ export type ExecutionEvent =
 /**
  * The types of diagnostic events emitted during a deploy.
  *
- * @beta
+ * @public
  */
 export enum ExecutionEventType {
   WIPE_APPLY = "WIPE_APPLY",
@@ -77,7 +77,7 @@ export enum ExecutionEventType {
 /**
  * An event indicating that a deployment has started.
  *
- * @beta
+ * @public
  */
 export interface DeploymentStartEvent {
   type: ExecutionEventType.DEPLOYMENT_START;
@@ -91,7 +91,7 @@ export interface DeploymentStartEvent {
 /**
  * An event indicating a new deployment has been initialized.
  *
- * @beta
+ * @public
  */
 export interface DeploymentInitializeEvent {
   type: ExecutionEventType.DEPLOYMENT_INITIALIZE;
@@ -101,7 +101,7 @@ export interface DeploymentInitializeEvent {
 /**
  * An event indicating that batches have been generated for a deployment run.
  *
- * @beta
+ * @public
  */
 export interface BatchInitializeEvent {
   type: ExecutionEventType.BATCH_INITIALIZE;
@@ -111,7 +111,7 @@ export interface BatchInitializeEvent {
 /**
  * An event indicating that the deployment is commenencing an execution run.
  *
- * @beta
+ * @public
  */
 export interface RunStartEvent {
   type: ExecutionEventType.RUN_START;
@@ -121,7 +121,7 @@ export interface RunStartEvent {
  * An event indicating that the execution engine has moved onto
  * the next batch.
  *
- * @beta
+ * @public
  */
 export interface BeginNextBatchEvent {
   type: ExecutionEventType.BEGIN_NEXT_BATCH;
@@ -130,7 +130,7 @@ export interface BeginNextBatchEvent {
 /**
  * An event indicating that a deployment has started.
  *
- * @beta
+ * @public
  */
 export interface DeploymentCompleteEvent {
   type: ExecutionEventType.DEPLOYMENT_COMPLETE;
@@ -140,7 +140,7 @@ export interface DeploymentCompleteEvent {
 /**
  * An event indicating that a deployment has reconciliation warnings.
  *
- * @beta
+ * @public
  */
 export interface ReconciliationWarningsEvent {
   type: ExecutionEventType.RECONCILIATION_WARNINGS;
@@ -151,7 +151,7 @@ export interface ReconciliationWarningsEvent {
  * An event indicating a future that deploys a contract
  * or library has started execution.
  *
- * @beta
+ * @public
  */
 export interface DeploymentExecutionStateInitializeEvent {
   type: ExecutionEventType.DEPLOYMENT_EXECUTION_STATE_INITIALIZE;
@@ -162,7 +162,7 @@ export interface DeploymentExecutionStateInitializeEvent {
  * An event indicating that a future that deploys a contract
  * or library has completed execution.
  *
- * @beta
+ * @public
  */
 export interface DeploymentExecutionStateCompleteEvent {
   type: ExecutionEventType.DEPLOYMENT_EXECUTION_STATE_COMPLETE;
@@ -174,7 +174,7 @@ export interface DeploymentExecutionStateCompleteEvent {
  * An event indicating a future that calls a function onchain
  * via transactions has started execution.
  *
- * @beta
+ * @public
  */
 export interface CallExecutionStateInitializeEvent {
   type: ExecutionEventType.CALL_EXECUTION_STATE_INITIALIZE;
@@ -185,7 +185,7 @@ export interface CallExecutionStateInitializeEvent {
  * An event indicating a future that calls a function onchain
  * via transactions has completed execution.
  *
- * @beta
+ * @public
  */
 export interface CallExecutionStateCompleteEvent {
   type: ExecutionEventType.CALL_EXECUTION_STATE_COMPLETE;
@@ -197,7 +197,7 @@ export interface CallExecutionStateCompleteEvent {
  * An event indicating that a future that makes a static call
  * has started execution.
  *
- * @beta
+ * @public
  */
 export interface StaticCallExecutionStateInitializeEvent {
   type: ExecutionEventType.STATIC_CALL_EXECUTION_STATE_INITIALIZE;
@@ -208,7 +208,7 @@ export interface StaticCallExecutionStateInitializeEvent {
  * An event indicating that a future that makes a static call
  * has completed execution.
  *
- * @beta
+ * @public
  */
 export interface StaticCallExecutionStateCompleteEvent {
   type: ExecutionEventType.STATIC_CALL_EXECUTION_STATE_COMPLETE;
@@ -220,7 +220,7 @@ export interface StaticCallExecutionStateCompleteEvent {
  * An event indicationing that a future that sends data or eth to a contract
  * has started execution.
  *
- * @beta
+ * @public
  */
 export interface SendDataExecutionStateInitializeEvent {
   type: ExecutionEventType.SEND_DATA_EXECUTION_STATE_INITIALIZE;
@@ -231,7 +231,7 @@ export interface SendDataExecutionStateInitializeEvent {
  * An event indicationing that a future that sends data or eth to a contract
  * has completed execution.
  *
- * @beta
+ * @public
  */
 export interface SendDataExecutionStateCompleteEvent {
   type: ExecutionEventType.SEND_DATA_EXECUTION_STATE_COMPLETE;
@@ -244,7 +244,7 @@ export interface SendDataExecutionStateCompleteEvent {
  * has been initialized, there is no complete event as it initializes
  * as complete.
  *
- * @beta
+ * @public
  */
 export interface ContractAtExecutionStateInitializeEvent {
   type: ExecutionEventType.CONTRACT_AT_EXECUTION_STATE_INITIALIZE;
@@ -256,7 +256,7 @@ export interface ContractAtExecutionStateInitializeEvent {
  * from a previous futures onchain interaction, there is no complete event
  * as it initializes as complete.
  *
- * @beta
+ * @public
  */
 export interface ReadEventArgExecutionStateInitializeEvent {
   type: ExecutionEventType.READ_EVENT_ARGUMENT_EXECUTION_STATE_INITIALIZE;
@@ -269,7 +269,7 @@ export interface ReadEventArgExecutionStateInitializeEvent {
  * call has been initialized, there is no complete event as it initializes
  * as complete.
  *
- * @beta
+ * @public
  */
 export interface EncodeFunctionCallExecutionStateInitializeEvent {
   type: ExecutionEventType.ENCODE_FUNCTION_CALL_EXECUTION_STATE_INITIALIZE;
@@ -280,7 +280,7 @@ export interface EncodeFunctionCallExecutionStateInitializeEvent {
 /**
  * An event indicating the user has clear the previous execution of a future.
  *
- * @beta
+ * @public
  */
 export interface WipeApplyEvent {
   type: ExecutionEventType.WIPE_APPLY;
@@ -291,7 +291,7 @@ export interface WipeApplyEvent {
  * An event indicating that a future has requested a network interaction,
  * either a transaction or a static call query.
  *
- * @beta
+ * @public
  */
 export interface NetworkInteractionRequestEvent {
   type: ExecutionEventType.NETWORK_INTERACTION_REQUEST;
@@ -302,7 +302,7 @@ export interface NetworkInteractionRequestEvent {
 /**
  * An event indicating that a transaction is about to be sent to the network.
  *
- * @beta
+ * @public
  */
 export interface TransactionPrepareSendEvent {
   type: ExecutionEventType.TRANSACTION_PREPARE_SEND;
@@ -312,7 +312,7 @@ export interface TransactionPrepareSendEvent {
 /**
  * An event indicating that a transaction has been sent to the network.
  *
- * @beta
+ * @public
  */
 export interface TransactionSendEvent {
   type: ExecutionEventType.TRANSACTION_SEND;
@@ -323,7 +323,7 @@ export interface TransactionSendEvent {
 /**
  * An event indicating has been detected as confirmed on-chain.
  *
- * @beta
+ * @public
  */
 export interface TransactionConfirmEvent {
   type: ExecutionEventType.TRANSACTION_CONFIRM;
@@ -335,7 +335,7 @@ export interface TransactionConfirmEvent {
  * An event indicating that a static call has been successfully run
  * against the chain.
  *
- * @beta
+ * @public
  */
 export interface StaticCallCompleteEvent {
   type: ExecutionEventType.STATIC_CALL_COMPLETE;
@@ -346,7 +346,7 @@ export interface StaticCallCompleteEvent {
  * An event indicating that a future's onchain interaction has had
  * its its latest transaction fee bumped.
  *
- * @beta
+ * @public
  */
 export interface OnchainInteractionBumpFeesEvent {
   type: ExecutionEventType.ONCHAIN_INTERACTION_BUMP_FEES;
@@ -357,7 +357,7 @@ export interface OnchainInteractionBumpFeesEvent {
  * An event indicating that a future's onchain interaction has
  * had its transaction dropped and will be resent.
  *
- * @beta
+ * @public
  */
 export interface OnchainInteractionDroppedEvent {
   type: ExecutionEventType.ONCHAIN_INTERACTION_DROPPED;
@@ -368,7 +368,7 @@ export interface OnchainInteractionDroppedEvent {
  * An event indicating that a future's onchain interaction has
  * been replaced by a transaction from the user.
  *
- * @beta
+ * @public
  */
 export interface OnchainInteractionReplacedByUserEvent {
   type: ExecutionEventType.ONCHAIN_INTERACTION_REPLACED_BY_USER;
@@ -379,7 +379,7 @@ export interface OnchainInteractionReplacedByUserEvent {
  * An event indicating that a future's onchain interaction has
  * timed out.
  *
- * @beta
+ * @public
  */
 export interface OnchainInteractionTimeoutEvent {
   type: ExecutionEventType.ONCHAIN_INTERACTION_TIMEOUT;
@@ -389,7 +389,7 @@ export interface OnchainInteractionTimeoutEvent {
 /**
  * An event indicating the current moduleId being validated.
  *
- * @beta
+ * @public
  */
 export interface SetModuleIdEvent {
   type: ExecutionEventType.SET_MODULE_ID;
@@ -399,7 +399,7 @@ export interface SetModuleIdEvent {
 /**
  * An event indicating the type of strategy being used.
  *
- * @beta
+ * @public
  */
 export interface SetStrategyEvent {
   type: ExecutionEventType.SET_STRATEGY;
@@ -409,7 +409,7 @@ export interface SetStrategyEvent {
 /**
  * The types of network interactions that can be requested by a future.
  *
- * @beta
+ * @public
  */
 export enum ExecutionEventNetworkInteractionType {
   ONCHAIN_INTERACTION = "ONCHAIN_INTERACTION",
@@ -419,7 +419,7 @@ export enum ExecutionEventNetworkInteractionType {
 /**
  * The status of a future's completed execution.
  *
- * @beta
+ * @public
  */
 export enum ExecutionEventResultType {
   SUCCESS = "SUCCESS",
@@ -430,7 +430,7 @@ export enum ExecutionEventResultType {
 /**
  * The result of a future's completed execution.
  *
- * @beta
+ * @public
  */
 export type ExecutionEventResult =
   | ExecutionEventSuccess
@@ -440,7 +440,7 @@ export type ExecutionEventResult =
 /**
  * A successful result of a future's execution.
  *
- * @beta
+ * @public
  */
 export interface ExecutionEventSuccess {
   type: ExecutionEventResultType.SUCCESS;
@@ -450,7 +450,7 @@ export interface ExecutionEventSuccess {
 /**
  * An errored result of a future's execution.
  *
- * @beta
+ * @public
  */
 export interface ExecutionEventError {
   type: ExecutionEventResultType.ERROR;
@@ -460,7 +460,7 @@ export interface ExecutionEventError {
 /**
  * A hold result of a future's execution.
  *
- * @beta
+ * @public
  */
 export interface ExecutionEventHeld {
   type: ExecutionEventResultType.HELD;
@@ -471,7 +471,7 @@ export interface ExecutionEventHeld {
 /**
  * A mapping of execution event types to their corresponding event.
  *
- * @beta
+ * @public
  */
 export interface ExecutionEventTypeMap {
   [ExecutionEventType.WIPE_APPLY]: WipeApplyEvent;
@@ -509,7 +509,7 @@ export interface ExecutionEventTypeMap {
 /**
  * A utility type for mapping enum values to function names
  *
- * @beta
+ * @public
  */
 export type SnakeToCamelCase<S extends string> =
   S extends `${infer T}_${infer U}`
@@ -519,7 +519,7 @@ export type SnakeToCamelCase<S extends string> =
 /**
  * A listener for execution events.
  *
- * @beta
+ * @public
  */
 export type ExecutionEventListener = {
   [eventType in ExecutionEventType as SnakeToCamelCase<eventType>]: (

--- a/packages/ignition-core/src/types/list-transactions.ts
+++ b/packages/ignition-core/src/types/list-transactions.ts
@@ -3,7 +3,7 @@ import type { SolidityParameterType } from "./module.js";
 /**
  * The status of a transaction.
  *
- * @beta
+ * @public
  */
 export enum TransactionStatus {
   SUCCESS = "SUCCESS",
@@ -15,7 +15,7 @@ export enum TransactionStatus {
 /**
  * The information of a transaction.
  *
- * @beta
+ * @public
  */
 export interface TransactionInfo {
   type: string;
@@ -33,6 +33,6 @@ export interface TransactionInfo {
 /**
  * An array of transaction information.
  *
- * @beta
+ * @public
  */
 export type ListTransactionsResult = TransactionInfo[];

--- a/packages/ignition-core/src/types/module-builder.ts
+++ b/packages/ignition-core/src/types/module-builder.ts
@@ -26,7 +26,7 @@ import type {
 /**
  * The options for a `contract` deployment.
  *
- * @beta
+ * @public
  */
 export interface ContractOptions {
   /**
@@ -62,7 +62,7 @@ export interface ContractOptions {
 /**
  * The options for a `library` call.
  *
- * @beta
+ * @public
  */
 export interface LibraryOptions {
   /**
@@ -89,7 +89,7 @@ export interface LibraryOptions {
 /**
  * The options for a `call` call.
  *
- * @beta
+ * @public
  */
 export interface CallOptions {
   /**
@@ -120,7 +120,7 @@ export interface CallOptions {
 /**
  * The options for a `staticCall` call.
  *
- * @beta
+ * @public
  */
 export interface StaticCallOptions {
   /**
@@ -142,7 +142,7 @@ export interface StaticCallOptions {
 /**
  * The options for an `encodeFunctionCall` call.
  *
- * @beta
+ * @public
  */
 export interface EncodeFunctionCallOptions {
   /**
@@ -159,7 +159,7 @@ export interface EncodeFunctionCallOptions {
 /**
  * The options for a `contractAt` call.
  *
- * @beta
+ * @public
  */
 export interface ContractAtOptions {
   /**
@@ -176,7 +176,7 @@ export interface ContractAtOptions {
 /**
  * The options for a `readEventArgument` call.
  *
- * @beta
+ * @public
  */
 export interface ReadEventArgumentOptions {
   /**
@@ -200,7 +200,7 @@ export interface ReadEventArgumentOptions {
 /**
  * The options for a `send` call.
  *
- * @beta
+ * @public
  */
 export interface SendDataOptions {
   /**
@@ -217,7 +217,7 @@ export interface SendDataOptions {
 /**
  * The build api for configuring a deployment within a module.
  *
- * @beta
+ * @public
  */
 export interface IgnitionModuleBuilder {
   /**

--- a/packages/ignition-core/src/types/module.ts
+++ b/packages/ignition-core/src/types/module.ts
@@ -4,7 +4,7 @@ import type { Abi, Artifact } from "./artifact.js";
  * Base argument type that smart contracts can receive in their constructors
  * and functions.
  *
- * @beta
+ * @public
  */
 export type BaseArgumentType =
   | number
@@ -20,7 +20,7 @@ export type BaseArgumentType =
 /**
  * Argument type that smart contracts can receive in their constructors and functions.
  *
- * @beta
+ * @public
  */
 export type ArgumentType =
   | BaseArgumentType
@@ -30,7 +30,7 @@ export type ArgumentType =
 /**
  * The different future types supported by Ignition.
  *
- * @beta
+ * @public
  */
 export enum FutureType {
   NAMED_ARTIFACT_CONTRACT_DEPLOYMENT = "NAMED_ARTIFACT_CONTRACT_DEPLOYMENT",
@@ -49,7 +49,7 @@ export enum FutureType {
 /**
  * The unit of execution in an Ignition deploy.
  *
- * @beta
+ * @public
  */
 export type Future =
   | NamedArtifactContractDeploymentFuture<string>
@@ -68,7 +68,7 @@ export type Future =
  * A future representing a contract. Either an existing one or one
  * that will be deployed.
  *
- * @beta
+ * @public
  */
 export type ContractFuture<ContractNameT extends string> =
   | NamedArtifactContractDeploymentFuture<ContractNameT>
@@ -82,7 +82,7 @@ export type ContractFuture<ContractNameT extends string> =
  * A future representing only contracts that can be called off-chain (i.e. not libraries).
  * Either an existing one or one that will be deployed.
  *
- * @beta
+ * @public
  */
 export type CallableContractFuture<ContractNameT extends string> =
   | NamedArtifactContractDeploymentFuture<ContractNameT>
@@ -93,7 +93,7 @@ export type CallableContractFuture<ContractNameT extends string> =
 /**
  * A future representing a deployment.
  *
- * @beta
+ * @public
  */
 export type DeploymentFuture<ContractNameT extends string> =
   | NamedArtifactContractDeploymentFuture<ContractNameT>
@@ -104,7 +104,7 @@ export type DeploymentFuture<ContractNameT extends string> =
 /**
  * A future representing a call. Either a static one or one that modifies contract state
  *
- * @beta
+ * @public
  */
 export type FunctionCallFuture<
   ContractNameT extends string,
@@ -116,7 +116,7 @@ export type FunctionCallFuture<
 /**
  * A future that can be resolved to a standard Ethereum address.
  *
- * @beta
+ * @public
  */
 export type AddressResolvableFuture =
   | ContractFuture<string>
@@ -126,7 +126,7 @@ export type AddressResolvableFuture =
 /**
  * A future representing the deployment of a contract that belongs to this project.
  *
- * @beta
+ * @public
  */
 export interface NamedArtifactContractDeploymentFuture<
   ContractNameT extends string,
@@ -150,7 +150,7 @@ export interface NamedArtifactContractDeploymentFuture<
  * A future representing the deployment of a contract that we only know its artifact.
  * It may not belong to this project, and we may struggle to type.
  *
- * @beta
+ * @public
  */
 export interface ContractDeploymentFuture<AbiT extends Abi = Abi> {
   type: FutureType.CONTRACT_DEPLOYMENT;
@@ -172,7 +172,7 @@ export interface ContractDeploymentFuture<AbiT extends Abi = Abi> {
 /**
  * A future representing the deployment of a library that belongs to this project
  *
- * @beta
+ * @public
  */
 export interface NamedArtifactLibraryDeploymentFuture<
   LibraryNameT extends string,
@@ -190,7 +190,7 @@ export interface NamedArtifactLibraryDeploymentFuture<
  * A future representing the deployment of a library that we only know its artifact.
  * It may not belong to this project, and we may struggle to type.
  *
- * @beta
+ * @public
  */
 export interface LibraryDeploymentFuture<AbiT extends Abi = Abi> {
   type: FutureType.LIBRARY_DEPLOYMENT;
@@ -206,7 +206,7 @@ export interface LibraryDeploymentFuture<AbiT extends Abi = Abi> {
 /**
  * A future representing the calling of a contract function that modifies on-chain state
  *
- * @beta
+ * @public
  */
 export interface ContractCallFuture<
   ContractNameT extends string,
@@ -230,7 +230,7 @@ export interface ContractCallFuture<
 /**
  * A future representing the static calling of a contract function that does not modify state
  *
- * @beta
+ * @public
  */
 export interface StaticCallFuture<
   ContractNameT extends string,
@@ -250,7 +250,7 @@ export interface StaticCallFuture<
 /**
  * A future representing the encoding of a contract function call
  *
- * @beta
+ * @public
  */
 export interface EncodeFunctionCallFuture<
   ContractNameT extends string,
@@ -268,7 +268,7 @@ export interface EncodeFunctionCallFuture<
 /**
  * A future representing a previously deployed contract at a known address that belongs to this project.
  *
- * @beta
+ * @public
  */
 export interface NamedArtifactContractAtFuture<ContractNameT extends string> {
   type: FutureType.NAMED_ARTIFACT_CONTRACT_AT;
@@ -286,7 +286,7 @@ export interface NamedArtifactContractAtFuture<ContractNameT extends string> {
  * A future representing a previously deployed contract at a known address with a given artifact.
  * It may not belong to this project, and we may struggle to type.
  *
- * @beta
+ * @public
  */
 export interface ContractAtFuture<AbiT extends Abi = Abi> {
   type: FutureType.CONTRACT_AT;
@@ -305,7 +305,7 @@ export interface ContractAtFuture<AbiT extends Abi = Abi> {
  * A future that represents reading an argument of an event emitted by the
  * transaction that executed another future.
  *
- * @beta
+ * @public
  */
 export interface ReadEventArgumentFuture {
   type: FutureType.READ_EVENT_ARGUMENT;
@@ -326,7 +326,7 @@ export interface ReadEventArgumentFuture {
 /**
  * A future that represents sending arbitrary data to the EVM.
  *
- * @beta
+ * @public
  */
 export interface SendDataFuture {
   type: FutureType.SEND_DATA;
@@ -346,14 +346,14 @@ export interface SendDataFuture {
 /**
  * Base type of module parameters's values.
  *
- * @beta
+ * @public
  */
 export type BaseSolidityParameterType = number | bigint | string | boolean;
 
 /**
  * Types that can be passed across the Solidity ABI boundary.
  *
- * @beta
+ * @public
  */
 export type SolidityParameterType =
   | BaseSolidityParameterType
@@ -363,14 +363,14 @@ export type SolidityParameterType =
 /**
  * Type of module parameters's values.
  *
- * @beta
+ * @public
  */
 export type ModuleParameterType = SolidityParameterType | AccountRuntimeValue;
 
 /**
  * The different runtime values supported by Ignition.
  *
- * @beta
+ * @public
  */
 export enum RuntimeValueType {
   ACCOUNT = "ACCOUNT",
@@ -380,7 +380,7 @@ export enum RuntimeValueType {
 /**
  * A value that's only available during deployment.
  *
- * @beta
+ * @public
  */
 export type RuntimeValue =
   | AccountRuntimeValue
@@ -389,7 +389,7 @@ export type RuntimeValue =
 /**
  * A local account.
  *
- * @beta
+ * @public
  */
 export interface AccountRuntimeValue {
   type: RuntimeValueType.ACCOUNT;
@@ -399,7 +399,7 @@ export interface AccountRuntimeValue {
 /**
  * A module parameter.
  *
- * @beta
+ * @public
  */
 export interface ModuleParameterRuntimeValue<
   ParamTypeT extends ModuleParameterType,
@@ -413,7 +413,7 @@ export interface ModuleParameterRuntimeValue<
 /**
  * An object containing the parameters passed into the module.
  *
- * @beta
+ * @public
  */
 export interface ModuleParameters {
   [parameterName: string]: SolidityParameterType;
@@ -422,7 +422,7 @@ export interface ModuleParameters {
 /**
  * The results of deploying a module must be a dictionary of contract futures
  *
- * @beta
+ * @public
  */
 export interface IgnitionModuleResult<ContractNameT extends string> {
   [name: string]: ContractFuture<ContractNameT>;
@@ -431,7 +431,7 @@ export interface IgnitionModuleResult<ContractNameT extends string> {
 /**
  * A recipe for deploying and configuring contracts.
  *
- * @beta
+ * @public
  */
 export interface IgnitionModule<
   ModuleIdT extends string = string,

--- a/packages/ignition-core/src/types/provider.ts
+++ b/packages/ignition-core/src/types/provider.ts
@@ -1,7 +1,7 @@
 /**
  * Arguments for a request to an EIP-1193 Provider.
  *
- * @beta
+ * @public
  */
 export interface RequestArguments {
   readonly method: string;
@@ -11,7 +11,7 @@ export interface RequestArguments {
 /**
  * A provider for on-chain interactions.
  *
- * @beta
+ * @public
  */
 export interface EIP1193Provider {
   request(args: RequestArguments): Promise<any>;

--- a/packages/ignition-core/src/types/serialization.ts
+++ b/packages/ignition-core/src/types/serialization.ts
@@ -4,7 +4,7 @@ import type { FutureType } from "./module.js";
 /**
  * A serialized bigint.
  *
- * @beta
+ * @public
  */
 export interface SerializedBigInt {
   _kind: "bigint";
@@ -14,7 +14,7 @@ export interface SerializedBigInt {
 /**
  * The serialized version of BaseArgumentType
  *
- * @beta
+ * @public
  */
 export type SerializedBaseArgumentType =
   | number
@@ -27,7 +27,7 @@ export type SerializedBaseArgumentType =
 /**
  * The serialized version of ArgumentType
  *
- * @beta
+ * @public
  */
 export type SerializedArgumentType =
   | SerializedBaseArgumentType
@@ -38,7 +38,7 @@ export type SerializedArgumentType =
  * In serialized form a pointer to a future stored at the top level
  * within the module.
  *
- * @beta
+ * @public
  */
 export interface FutureToken {
   futureId: string;
@@ -49,7 +49,7 @@ export interface FutureToken {
  * In serialized form a pointer to a module stored at the top level
  * within the deployment.
  *
- * @beta
+ * @public
  */
 export interface ModuleToken {
   moduleId: string;
@@ -59,7 +59,7 @@ export interface ModuleToken {
 /**
  * The base of the different serialized futures.
  *
- * @beta
+ * @public
  */
 export interface BaseSerializedFuture {
   id: string;
@@ -71,7 +71,7 @@ export interface BaseSerializedFuture {
 /**
  * The serialized version of the NamedContractDeploymentFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedNamedContractDeploymentFuture
   extends BaseSerializedFuture {
@@ -86,7 +86,7 @@ export interface SerializedNamedContractDeploymentFuture
 /**
  * The serialized version of the ArtifactContractDeploymentFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedArtifactContractDeploymentFuture
   extends BaseSerializedFuture {
@@ -102,7 +102,7 @@ export interface SerializedArtifactContractDeploymentFuture
 /**
  * The serialized version of the NamedLibraryDeploymentFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedNamedLibraryDeploymentFuture
   extends BaseSerializedFuture {
@@ -115,7 +115,7 @@ export interface SerializedNamedLibraryDeploymentFuture
 /**
  * The serialized version of the ArtifactLibraryDeploymentFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedArtifactLibraryDeploymentFuture
   extends BaseSerializedFuture {
@@ -129,7 +129,7 @@ export interface SerializedArtifactLibraryDeploymentFuture
 /**
  * The serialized version of NamedContractCallFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedNamedContractCallFuture
   extends BaseSerializedFuture {
@@ -144,7 +144,7 @@ export interface SerializedNamedContractCallFuture
 /**
  * The serialized version of NamedStaticCallFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedNamedStaticCallFuture extends BaseSerializedFuture {
   type: FutureType.STATIC_CALL;
@@ -158,7 +158,7 @@ export interface SerializedNamedStaticCallFuture extends BaseSerializedFuture {
 /**
  * The serialized version of NamedEncodeFunctionCallFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedNamedEncodeFunctionCallFuture
   extends BaseSerializedFuture {
@@ -171,7 +171,7 @@ export interface SerializedNamedEncodeFunctionCallFuture
 /**
  * The serialized version of NamedContractAtFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedNamedContractAtFuture extends BaseSerializedFuture {
   type: FutureType.NAMED_ARTIFACT_CONTRACT_AT;
@@ -182,7 +182,7 @@ export interface SerializedNamedContractAtFuture extends BaseSerializedFuture {
 /**
  * The serialized version of ArtifactContractAtFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedArtifactContractAtFuture
   extends BaseSerializedFuture {
@@ -195,7 +195,7 @@ export interface SerializedArtifactContractAtFuture
 /**
  * The serialized version of ReadEventArgumentFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedReadEventArgumentFuture
   extends BaseSerializedFuture {
@@ -210,7 +210,7 @@ export interface SerializedReadEventArgumentFuture
 /**
  * The serialized version of ReadEventArgumentFuture.
  *
- * @beta
+ * @public
  */
 export interface SerializedSendDataFuture extends BaseSerializedFuture {
   type: FutureType.SEND_DATA;
@@ -227,7 +227,7 @@ export interface SerializedSendDataFuture extends BaseSerializedFuture {
 /**
  * The srialized version of RuntimeValue.
  *
- * @beta
+ * @public
  */
 export type SerializedRuntimeValue =
   | SerializedAccountRuntimeValue
@@ -236,7 +236,7 @@ export type SerializedRuntimeValue =
 /**
  * The serialized version of AccountRuntimeValue.
  *
- * @beta
+ * @public
  */
 export interface SerializedAccountRuntimeValue {
   _kind: "AccountRuntimeValue";
@@ -246,7 +246,7 @@ export interface SerializedAccountRuntimeValue {
 /**
  * The serialized version of ModuleParameterRuntimeValue.
  *
- * @beta
+ * @public
  */
 export interface SerializedModuleParameterRuntimeValue {
   _kind: "ModuleParameterRuntimeValue";
@@ -260,7 +260,7 @@ export interface SerializedModuleParameterRuntimeValue {
 /**
  * The serialized version of an Ignition module and its submodules.
  *
- * @beta
+ * @public
  */
 export interface SerializedIgnitionModule {
   startModule: string;
@@ -273,7 +273,7 @@ export interface SerializedIgnitionModule {
  * A subpart of the `SerializedIgnitionModule` that describes one
  * module/submodule and its relations to futures and other submodule.
  *
- * @beta
+ * @public
  */
 export interface SerializedModuleDescription {
   id: string;
@@ -286,14 +286,14 @@ export interface SerializedModuleDescription {
  * The serialized libraries, where each library
  * has been replaced by a token.
  *
- * @beta
+ * @public
  */
 export type SerializedLibraries = Array<[name: string, token: FutureToken]>;
 
 /**
  * The set of serialized future types
  *
- * @beta
+ * @public
  */
 export type SerializedFuture =
   | SerializedNamedContractDeploymentFuture

--- a/packages/ignition-core/src/types/status.ts
+++ b/packages/ignition-core/src/types/status.ts
@@ -7,7 +7,7 @@ import type {
 /**
  * The information of a deployed contract.
  *
- * @beta
+ * @public
  */
 export interface GenericContractInfo extends DeployedContract {
   sourceName: string;
@@ -18,7 +18,7 @@ export interface GenericContractInfo extends DeployedContract {
  * The result of requesting the status of a deployment. It lists the futures
  * broken down by their status, and includes the deployed contracts.
  *
- * @beta
+ * @public
  */
 export interface StatusResult
   extends Omit<ExecutionErrorDeploymentResult, "type"> {

--- a/packages/ignition-core/src/types/verify.ts
+++ b/packages/ignition-core/src/types/verify.ts
@@ -3,7 +3,7 @@ import type { SolidityParameterType } from "./module.js";
 /**
  * The configuration info needed to verify a contract on Etherscan on a given chain.
  *
- * @beta
+ * @public
  */
 export interface ChainConfig {
   network: string;
@@ -19,7 +19,7 @@ export interface ChainConfig {
  * Used to verify contracts with libraries that cannot be derived from the bytecode.
  * i.e. contracts that use libraries in their constructor
  *
- * @beta
+ * @public
  */
 export interface SourceToLibraryToAddress {
   [sourceName: string]: {
@@ -30,7 +30,7 @@ export interface SourceToLibraryToAddress {
 /**
  * The information required to verify a contract.
  *
- * @beta
+ * @public
  */
 export interface VerifyInfo {
   address: string;
@@ -46,6 +46,6 @@ export interface VerifyInfo {
  * Alternatively, it returns the contract name if the contract used
  * external artifacts that could not be resolved for verification.
  *
- * @beta
+ * @public
  */
 export type VerifyResult = VerifyInfo | string;

--- a/packages/ignition-core/src/verify.ts
+++ b/packages/ignition-core/src/verify.ts
@@ -21,7 +21,7 @@ import { findExecutionStatesByType } from "./internal/views/find-execution-state
  *
  * @param deploymentDir - the file directory of the deployment
  *
- * @beta
+ * @public
  */
 export async function* getVerificationInformation(
   deploymentDir: string,

--- a/packages/ignition-core/src/wipe.ts
+++ b/packages/ignition-core/src/wipe.ts
@@ -10,7 +10,7 @@ import { Wiper } from "./internal/wiper.js";
  * @param deploymentDir - the file directory of the deployment
  * @param futureId - the future to be cleared
  *
- * @beta
+ * @public
  */
 export async function wipe(
   deploymentDir: string,


### PR DESCRIPTION
Fixes #8202

## Summary
- update Ignition core TSDoc release tags from `@beta` to API Extractor stable `@public` tags
- keep the change mechanical and scoped to `packages/ignition-core/src`

## Tests
- `pnpm --filter @nomicfoundation/ignition-core build`
- `pnpm --dir packages/ignition-core prettier --check "src/**/*.ts"`
- `pnpm --filter @nomicfoundation/ignition-core api-extractor`
- `git diff --check`
