### PR TITLE
Test/implement solidity config resolution todos

### DIFF
--- a/packages/hardhat/test/internal/builtin-plugins/solidity/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/config.ts
@@ -1122,8 +1122,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   describe("splitTestsCompilation resolution", () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
-
     it("should default splitTestsCompilation to false for a string config", async () => {
       const resolvedConfig = await resolveSolidityUserConfig(
         { solidity: "0.8.28" },
@@ -1194,8 +1192,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   describe("profile-level preferWasm setting resolution", function () {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
-
     it("resolves to false when build profile is production and preferWasm is not specified", async () => {
       const resolvedConfig = await resolveSolidityUserConfig(
         {
@@ -1277,8 +1273,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   describe("per-compiler preferWasm resolution", () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
-
     it("should preserve per-compiler preferWasm when explicitly set", async () => {
       const resolvedConfig = await resolveSolidityUserConfig(
         {
@@ -1321,8 +1315,6 @@ describe("solidity plugin config resolution", () => {
       skip: !missesSomeOfficialNativeBuilds(),
     },
     () => {
-      const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
-
       it("should default preferWasm to true for versions below the ARM64 mirror threshold in all profiles", async () => {
         const resolvedConfig = await resolveSolidityUserConfig(
           {
@@ -1431,8 +1423,6 @@ describe("solidity plugin config resolution", () => {
       skip: missesSomeOfficialNativeBuilds(),
     },
     () => {
-      const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
-
       it("should leave preferWasm undefined when not on ARM64 Linux", async () => {
         const resolvedConfig = await resolveSolidityUserConfig(
           {
@@ -1451,8 +1441,6 @@ describe("solidity plugin config resolution", () => {
   );
 
   describe("config resolution with type discriminator", () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
-
     it("should resolve compiler entry without type with type undefined (backward compat)", async () => {
       const resolvedConfig = await resolveSolidityUserConfig(
         {
@@ -1510,8 +1498,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   describe("shouldn't enable the optimizer in non-solc production compilers", () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
-
     it("should not add optimizer defaults for non-solc compilers in production", async () => {
       const resolvedConfig = await resolveSolidityUserConfig(
         {
@@ -1540,8 +1526,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   describe("copyFromDefault preserves type field", () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
-
     it("should preserve type on auto-generated production profile", async () => {
       const resolvedConfig = await resolveSolidityUserConfig(
         {
@@ -1583,8 +1567,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   describe("backward compatibility", () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
-
     it("should resolve an existing multi-version config identically (no type field)", async () => {
       const resolvedConfig = await resolveSolidityUserConfig(
         {
@@ -1678,8 +1660,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   describe("toolVersionsInBuildInfo resolution", function () {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
-
     it("defaults to true for the production profile when using a string config", async () => {
       const resolvedConfig = await resolveSolidityUserConfig(
         { solidity: "0.8.28" },

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/config.ts
@@ -14,6 +14,10 @@ import {
   validateSolidityConfig,
   validateSolidityUserConfig,
 } from "../../../../src/internal/builtin-plugins/solidity/config.js";
+import {
+  DEFAULT_OUTPUT_SELECTION,
+  SOLC_DEFAULT_OPTIMIZER_RUNS,
+} from "../../../../src/internal/builtin-plugins/solidity/constants.js";
 
 describe("solidity plugin config validation", () => {
   describe("sources paths", () => {
@@ -941,15 +945,184 @@ describe("solidity plugin config validation", () => {
 });
 
 describe("solidity plugin config resolution", () => {
-  it.todo("should resolve a config with a single version string", () => {});
+  it("should resolve a config with a single version string", async () => {
+    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
+    const resolvedConfig = await resolveSolidityUserConfig(
+      { solidity: "0.8.28" },
+      otherResolvedConfig,
+    );
 
-  it.todo("should resolve a config with multiple version strings", () => {});
+    const { solidity } = resolvedConfig;
+    assert.deepEqual(solidity.npmFilesToBuild, []);
+    assert.deepEqual(solidity.registeredCompilerTypes, ["solc"]);
+    assert.equal(solidity.splitTestsCompilation, false);
 
-  it.todo("should resolve a SingleVersionSolidityUserConfig value", () => {});
+    const defaultProfile = solidity.profiles.default;
+    assert.equal(defaultProfile.compilers.length, 1);
+    assert.equal(defaultProfile.compilers[0].version, "0.8.28");
+    assert.equal(defaultProfile.isolated, false);
+    assert.deepEqual(defaultProfile.compilers[0].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+    });
 
-  it.todo("should resolve a MultiVersionSolidityUserConfig value", () => {});
+    const productionProfile = solidity.profiles.production;
+    assert.equal(productionProfile.compilers.length, 1);
+    assert.equal(productionProfile.compilers[0].version, "0.8.28");
+    assert.equal(productionProfile.isolated, true);
+    assert.deepEqual(productionProfile.compilers[0].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+      optimizer: { enabled: true, runs: SOLC_DEFAULT_OPTIMIZER_RUNS },
+    });
+  });
 
-  it.todo("should resolve a BuildProfilesSolidityUserConfig value", () => {});
+  it("should resolve a config with multiple version strings", async () => {
+    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
+    const resolvedConfig = await resolveSolidityUserConfig(
+      { solidity: ["0.8.28", "0.7.0"] },
+      otherResolvedConfig,
+    );
+
+    const { solidity } = resolvedConfig;
+    assert.deepEqual(solidity.npmFilesToBuild, []);
+    assert.deepEqual(solidity.registeredCompilerTypes, ["solc"]);
+    assert.equal(solidity.splitTestsCompilation, false);
+
+    const defaultProfile = solidity.profiles.default;
+    assert.equal(defaultProfile.compilers.length, 2);
+    assert.equal(defaultProfile.compilers[0].version, "0.8.28");
+    assert.equal(defaultProfile.compilers[1].version, "0.7.0");
+    assert.equal(defaultProfile.isolated, false);
+    assert.deepEqual(defaultProfile.compilers[0].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+    });
+
+    const productionProfile = solidity.profiles.production;
+    assert.equal(productionProfile.compilers.length, 2);
+    assert.equal(productionProfile.compilers[0].version, "0.8.28");
+    assert.equal(productionProfile.compilers[1].version, "0.7.0");
+    assert.equal(productionProfile.isolated, true);
+    assert.deepEqual(productionProfile.compilers[0].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+      optimizer: { enabled: true, runs: SOLC_DEFAULT_OPTIMIZER_RUNS },
+    });
+    assert.deepEqual(productionProfile.compilers[1].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+      optimizer: { enabled: true, runs: SOLC_DEFAULT_OPTIMIZER_RUNS },
+    });
+  });
+
+  it("should resolve a SingleVersionSolidityUserConfig value", async () => {
+    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
+    const resolvedConfig = await resolveSolidityUserConfig(
+      { solidity: { version: "0.8.28" } },
+      otherResolvedConfig,
+    );
+
+    const { solidity } = resolvedConfig;
+    assert.deepEqual(solidity.npmFilesToBuild, []);
+    assert.deepEqual(solidity.registeredCompilerTypes, ["solc"]);
+    assert.equal(solidity.splitTestsCompilation, false);
+
+    const defaultProfile = solidity.profiles.default;
+    assert.equal(defaultProfile.compilers.length, 1);
+    assert.equal(defaultProfile.compilers[0].version, "0.8.28");
+    assert.equal(defaultProfile.isolated, false);
+    assert.deepEqual(defaultProfile.compilers[0].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+    });
+
+    const productionProfile = solidity.profiles.production;
+    assert.equal(productionProfile.compilers.length, 1);
+    assert.equal(productionProfile.compilers[0].version, "0.8.28");
+    assert.equal(productionProfile.isolated, true);
+    assert.deepEqual(productionProfile.compilers[0].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+      optimizer: { enabled: true, runs: SOLC_DEFAULT_OPTIMIZER_RUNS },
+    });
+  });
+
+  it("should resolve a MultiVersionSolidityUserConfig value", async () => {
+    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
+    const resolvedConfig = await resolveSolidityUserConfig(
+      {
+        solidity: {
+          compilers: [{ version: "0.8.28" }, { version: "0.7.0" }],
+        },
+      },
+      otherResolvedConfig,
+    );
+
+    const { solidity } = resolvedConfig;
+    assert.deepEqual(solidity.npmFilesToBuild, []);
+    assert.deepEqual(solidity.registeredCompilerTypes, ["solc"]);
+    assert.equal(solidity.splitTestsCompilation, false);
+
+    const defaultProfile = solidity.profiles.default;
+    assert.equal(defaultProfile.compilers.length, 2);
+    assert.equal(defaultProfile.compilers[0].version, "0.8.28");
+    assert.equal(defaultProfile.compilers[1].version, "0.7.0");
+    assert.equal(defaultProfile.isolated, false);
+    assert.deepEqual(defaultProfile.compilers[0].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+    });
+
+    const productionProfile = solidity.profiles.production;
+    assert.equal(productionProfile.compilers.length, 2);
+    assert.equal(productionProfile.compilers[0].version, "0.8.28");
+    assert.equal(productionProfile.compilers[1].version, "0.7.0");
+    assert.equal(productionProfile.isolated, true);
+    assert.deepEqual(productionProfile.compilers[0].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+      optimizer: { enabled: true, runs: SOLC_DEFAULT_OPTIMIZER_RUNS },
+    });
+    assert.deepEqual(productionProfile.compilers[1].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+      optimizer: { enabled: true, runs: SOLC_DEFAULT_OPTIMIZER_RUNS },
+    });
+  });
+
+  it("should resolve a BuildProfilesSolidityUserConfig value", async () => {
+    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
+    const resolvedConfig = await resolveSolidityUserConfig(
+      {
+        solidity: {
+          profiles: {
+            default: { version: "0.8.28" },
+            staging: { compilers: [{ version: "0.7.0" }] },
+          },
+        },
+      },
+      otherResolvedConfig,
+    );
+
+    const { solidity } = resolvedConfig;
+    assert.deepEqual(solidity.npmFilesToBuild, []);
+    assert.deepEqual(solidity.registeredCompilerTypes, ["solc"]);
+    assert.equal(solidity.splitTestsCompilation, false);
+
+    const defaultProfile = solidity.profiles.default;
+    assert.equal(defaultProfile.compilers.length, 1);
+    assert.equal(defaultProfile.compilers[0].version, "0.8.28");
+    assert.equal(defaultProfile.isolated, false);
+    assert.deepEqual(defaultProfile.compilers[0].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+    });
+
+    const stagingProfile = solidity.profiles.staging;
+    assert.equal(stagingProfile.compilers.length, 1);
+    assert.equal(stagingProfile.compilers[0].version, "0.7.0");
+    assert.equal(stagingProfile.isolated, false);
+
+    // production is auto-generated from default
+    const productionProfile = solidity.profiles.production;
+    assert.equal(productionProfile.compilers.length, 1);
+    assert.equal(productionProfile.compilers[0].version, "0.8.28");
+    assert.equal(productionProfile.isolated, true);
+    assert.deepEqual(productionProfile.compilers[0].settings, {
+      outputSelection: DEFAULT_OUTPUT_SELECTION,
+      optimizer: { enabled: true, runs: SOLC_DEFAULT_OPTIMIZER_RUNS },
+    });
+  });
 
   describe("splitTestsCompilation resolution", () => {
     const otherResolvedConfig = { paths: { root: process.cwd() } } as any;

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/config.ts
@@ -945,8 +945,9 @@ describe("solidity plugin config validation", () => {
 });
 
 describe("solidity plugin config resolution", () => {
+  const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
+
   it("should resolve a config with a single version string", async () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
     const resolvedConfig = await resolveSolidityUserConfig(
       { solidity: "0.8.28" },
       otherResolvedConfig,
@@ -976,7 +977,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   it("should resolve a config with multiple version strings", async () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
     const resolvedConfig = await resolveSolidityUserConfig(
       { solidity: ["0.8.28", "0.7.0"] },
       otherResolvedConfig,
@@ -1012,7 +1012,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   it("should resolve a SingleVersionSolidityUserConfig value", async () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
     const resolvedConfig = await resolveSolidityUserConfig(
       { solidity: { version: "0.8.28" } },
       otherResolvedConfig,
@@ -1042,7 +1041,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   it("should resolve a MultiVersionSolidityUserConfig value", async () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
     const resolvedConfig = await resolveSolidityUserConfig(
       {
         solidity: {
@@ -1082,7 +1080,6 @@ describe("solidity plugin config resolution", () => {
   });
 
   it("should resolve a BuildProfilesSolidityUserConfig value", async () => {
-    const otherResolvedConfig = { paths: { root: process.cwd() } } as any;
     const resolvedConfig = await resolveSolidityUserConfig(
       {
         solidity: {


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

I've been using Hardhat for a while now and genuinely love the developer experience — the tooling feels thoughtful and the v3 direction is exciting. Thanks for building something the community actually enjoys using. Happy to contribute back in whatever small way I can!


Implements five `it.todo` stubs in the `"solidity plugin config resolution"` describe block in `packages/hardhat/test/internal/builtin-plugins/solidity/config.ts` that were previously left unimplemented.

The five tests cover the core `resolveSolidityUserConfig` resolution paths:
- single version string
- array of version strings
- `SingleVersionSolidityUserConfig`
- `MultiVersionSolidityUserConfig`
- `BuildProfilesSolidityUserConfig`

Each test asserts compiler versions, `default`/`production` profile isolation, optimizer settings (`enabled: true, runs: 200`) on the production profile, and top-level resolved fields (`npmFilesToBuild`, `registeredCompilerTypes`, `splitTestsCompilation`).

The shared `otherResolvedConfig` fixture is hoisted to the `describe` scope to match the style of the surrounding test suite.
