### PR TITLE
Fix bug in solidity test artifact valdation

### DIFF
--- a/.changeset/fix-solidity-tests-selection-error.md
+++ b/.changeset/fix-solidity-tests-selection-error.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix `hardhat test solidity --no-compile` failing with `SELECTED_TEST_FILES_NOT_COMPILED` when no test files are specified.

--- a/cspell.dictionary.txt
+++ b/cspell.dictionary.txt
@@ -123,6 +123,7 @@ txts
 ufixed
 Uints
 Uncontended
+uncompiled
 unidici
 unmined
 unpad

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -141,9 +141,10 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     ({ edrArtifactsWithMetadata, allBuildInfosAndOutputs } =
       await loadArtifacts(hre.solidity, ["contracts"]));
 
-    // When noCompile, validate selected test roots have compiled artifacts when
-    // they are provided by the user, otherwise we know we have all the compiled
-    // artifacts already so we can skip this validation
+    // When noCompile is enabled, only validate compiled artifacts for test roots
+    // explicitly selected by the user. If no files were specified, skip
+    // validating every discovered test root and run whatever compiled test
+    // suites are available.
     if (noCompile === true && testFiles.length > 0) {
       const compiledSources = new Set(
         edrArtifactsWithMetadata.map(({ userSourceName }) =>

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -141,8 +141,10 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     ({ edrArtifactsWithMetadata, allBuildInfosAndOutputs } =
       await loadArtifacts(hre.solidity, ["contracts"]));
 
-    // When noCompile, validate selected test roots have compiled artifacts
-    if (noCompile === true) {
+    // When noCompile, validate selected test roots have compiled artifacts when
+    // they are provided by the user, otherwise we know we have all the compiled
+    // artifacts already so we can skip this validation
+    if (noCompile === true && testFiles.length > 0) {
       const compiledSources = new Set(
         edrArtifactsWithMetadata.map(({ userSourceName }) =>
           resolveFromRoot(hre.config.paths.root, userSourceName),

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -484,6 +484,24 @@ describe("solidity-test/task-action", function () {
       }
     });
 
+    it("should not throw when noCompile is true and no testFiles are provided, even if the tests path covers uncompiled files", async () => {
+      // tests path "test" includes `not-in-test-path.t.sol`, which the
+      // before-hook build (scoped to `test/contracts`) never compiled. Without
+      // user-provided testFiles, the task must skip the "compiled artifacts"
+      // validation and just run whichever compiled tests it finds.
+      const notBuildConfig = {
+        ...hardhatConfig,
+        paths: { tests: { solidity: "test" } },
+      };
+      const notBuiltHre = await createHardhatRuntimeEnvironment(notBuildConfig);
+
+      const result = await notBuiltHre.tasks
+        .getTask(["test", "solidity"])
+        .run({ noCompile: true });
+
+      assert.equal(result.success, true);
+    });
+
     it("should throw when a selected test file does not exist on disk", async () => {
       hre = await createHardhatRuntimeEnvironment(hardhatConfigPartialTests);
       await assertRejectsWithHardhatError(


### PR DESCRIPTION
When running `test solidity --no-compile` without providing explicit test file we were running the validation of artifacts anyway.

This was unnecessary, and lead to some edge cases that we don't even need to handle. For example, test files that don't have any contract are roots, but don't have artifacts.