### PR TITLE
Replace `semver` with in-tree `fast-semver` helper

### DIFF
--- a/.changeset/brave-otters-sing.md
+++ b/.changeset/brave-otters-sing.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Improved performance by replacing the semver dependency with a lightweight in-tree implementation.

--- a/.changeset/swift-tigers-leap.md
+++ b/.changeset/swift-tigers-leap.md
@@ -1,0 +1,6 @@
+---
+"hardhat": patch
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Improved performance by replacing the semver dependency with a lightweight in-tree implementation.

--- a/packages/hardhat-utils/package.json
+++ b/packages/hardhat-utils/package.json
@@ -23,6 +23,7 @@
     "./env": "./dist/src/env.js",
     "./error": "./dist/src/error.js",
     "./eth": "./dist/src/eth.js",
+    "./fast-semver": "./dist/src/fast-semver.js",
     "./format": "./dist/src/format.js",
     "./fs": "./dist/src/fs.js",
     "./global-dir": "./dist/src/global-dir.js",

--- a/packages/hardhat-utils/src/fast-semver.ts
+++ b/packages/hardhat-utils/src/fast-semver.ts
@@ -1,0 +1,95 @@
+/**
+ * A small, fast subset of semver: strict `MAJOR.MINOR.PATCH` parsing and
+ * triple-wise comparison helpers.
+ *
+ * This module exists because the full `semver` package is slow to load and is
+ * overkill for the many call sites in Hardhat that compare against hard-coded
+ * `x.y.z` literals. For range grammar (caret/tilde, disjunctions, prerelease
+ * subset, etc.) keep using `semver`.
+ */
+
+export type SemverVersion = [major: number, minor: number, patch: number];
+
+const VERSION_REGEX = /^(\d+)\.(\d+)\.(\d+)(?:\+[0-9A-Za-z.-]+)?$/;
+
+/**
+ * Parses a strict `MAJOR.MINOR.PATCH` version string into a `SemverVersion`
+ * tuple.
+ *
+ * An optional `+build` suffix is accepted and stripped silently. A
+ * `-prerelease` suffix is rejected.
+ *
+ * @param version The version string to parse.
+ * @returns The parsed `SemverVersion`, or `undefined` if the input does not
+ * match the strict `\d+\.\d+\.\d+` shape.
+ */
+export function parseVersion(version: string): SemverVersion | undefined {
+  const match = VERSION_REGEX.exec(version);
+  if (match === null) {
+    return undefined;
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/**
+ * `Array#sort`-style comparator for `SemverVersion` tuples: returns a negative
+ * number, zero, or a positive number depending on whether `a` is lower than,
+ * equal to, or greater than `b`.
+ */
+export function compare(a: SemverVersion, b: SemverVersion): number {
+  if (a[0] !== b[0]) {
+    return a[0] - b[0];
+  }
+  if (a[1] !== b[1]) {
+    return a[1] - b[1];
+  }
+  return a[2] - b[2];
+}
+
+/**
+ * Returns `true` if `a` and `b` represent the same `MAJOR.MINOR.PATCH`.
+ */
+export function equals(a: SemverVersion, b: SemverVersion): boolean {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+}
+
+/**
+ * Returns `true` if `compared` is strictly lower than `comparator`.
+ */
+export function lowerThan(
+  compared: SemverVersion,
+  comparator: SemverVersion,
+): boolean {
+  return compare(compared, comparator) < 0;
+}
+
+/**
+ * Returns `true` if `compared` is lower than or equal to `comparator`.
+ */
+export function lowerThanOrEqual(
+  compared: SemverVersion,
+  comparator: SemverVersion,
+): boolean {
+  return compare(compared, comparator) <= 0;
+}
+
+/**
+ * Returns `true` if `compared` is strictly greater than `comparator`.
+ */
+export function greaterThan(
+  compared: SemverVersion,
+  comparator: SemverVersion,
+): boolean {
+  return compare(compared, comparator) > 0;
+}
+
+/**
+ * Returns `true` if `compared` is greater than or equal to `comparator`.
+ */
+export function greaterThanOrEqual(
+  compared: SemverVersion,
+  comparator: SemverVersion,
+): boolean {
+  return compare(compared, comparator) >= 0;
+}

--- a/packages/hardhat-utils/test/fast-semver.ts
+++ b/packages/hardhat-utils/test/fast-semver.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  compare,
+  equals,
+  greaterThan,
+  greaterThanOrEqual,
+  lowerThan,
+  lowerThanOrEqual,
+  parseVersion,
+  type SemverVersion,
+} from "../src/fast-semver.js";
+
+describe("fast-semver", () => {
+  describe("parseVersion", () => {
+    it("Should parse a strict x.y.z version", () => {
+      assert.deepEqual(parseVersion("0.0.0"), [0, 0, 0]);
+      assert.deepEqual(parseVersion("1.2.3"), [1, 2, 3]);
+      assert.deepEqual(parseVersion("10.20.30"), [10, 20, 30]);
+    });
+
+    it("Should strip a +build suffix", () => {
+      assert.deepEqual(parseVersion("0.8.31+commit.7eddb6a8"), [0, 8, 31]);
+      assert.deepEqual(parseVersion("1.2.3+build.1"), [1, 2, 3]);
+    });
+
+    it("Should reject prerelease versions", () => {
+      assert.equal(parseVersion("1.2.3-rc.1"), undefined);
+      assert.equal(parseVersion("1.2.3-alpha"), undefined);
+      assert.equal(parseVersion("1.2.3-0"), undefined);
+    });
+
+    it("Should reject invalid inputs", () => {
+      assert.equal(parseVersion("v1.2.3"), undefined);
+      assert.equal(parseVersion("1.2"), undefined);
+      assert.equal(parseVersion(""), undefined);
+      assert.equal(parseVersion("1.2.3.4"), undefined);
+      assert.equal(parseVersion("1.2.x"), undefined);
+      assert.equal(parseVersion("a.b.c"), undefined);
+      assert.equal(parseVersion(" 1.2.3"), undefined);
+      assert.equal(parseVersion("1.2.3 "), undefined);
+    });
+  });
+
+  describe("compare", () => {
+    it("Should produce a total order over a fixture array", () => {
+      const versions: SemverVersion[] = [
+        [0, 8, 31],
+        [0, 4, 7],
+        [1, 0, 0],
+        [0, 8, 22],
+        [0, 5, 0],
+        [0, 8, 22],
+        [10, 0, 0],
+        [2, 1, 1],
+      ];
+
+      const sorted = [...versions].sort(compare);
+
+      assert.deepEqual(sorted, [
+        [0, 4, 7],
+        [0, 5, 0],
+        [0, 8, 22],
+        [0, 8, 22],
+        [0, 8, 31],
+        [1, 0, 0],
+        [2, 1, 1],
+        [10, 0, 0],
+      ]);
+    });
+
+    it("Should return zero for equal versions", () => {
+      assert.equal(compare([1, 2, 3], [1, 2, 3]), 0);
+    });
+
+    it("Should compare major before minor before patch", () => {
+      assert.ok(
+        compare([2, 0, 0], [1, 99, 99]) > 0,
+        "major should dominate minor and patch",
+      );
+      assert.ok(
+        compare([1, 2, 0], [1, 1, 99]) > 0,
+        "minor should dominate patch",
+      );
+      assert.ok(compare([1, 1, 2], [1, 1, 1]) > 0, "patch should be compared");
+    });
+  });
+
+  describe("equals", () => {
+    it("Should return true for identical versions", () => {
+      assert.equal(equals([1, 2, 3], [1, 2, 3]), true);
+      assert.equal(equals([0, 0, 0], [0, 0, 0]), true);
+    });
+
+    it("Should return false when any component differs", () => {
+      assert.equal(equals([1, 2, 3], [2, 2, 3]), false);
+      assert.equal(equals([1, 2, 3], [1, 3, 3]), false);
+      assert.equal(equals([1, 2, 3], [1, 2, 4]), false);
+    });
+  });
+
+  describe("lowerThan", () => {
+    it("Should return true only when strictly lower", () => {
+      assert.equal(lowerThan([1, 2, 3], [1, 2, 4]), true);
+      assert.equal(lowerThan([1, 2, 3], [1, 2, 3]), false);
+      assert.equal(lowerThan([1, 2, 4], [1, 2, 3]), false);
+    });
+  });
+
+  describe("lowerThanOrEqual", () => {
+    it("Should return true when lower or equal", () => {
+      assert.equal(lowerThanOrEqual([1, 2, 3], [1, 2, 4]), true);
+      assert.equal(lowerThanOrEqual([1, 2, 3], [1, 2, 3]), true);
+      assert.equal(lowerThanOrEqual([1, 2, 4], [1, 2, 3]), false);
+    });
+  });
+
+  describe("greaterThan", () => {
+    it("Should return true only when strictly greater", () => {
+      assert.equal(greaterThan([1, 2, 4], [1, 2, 3]), true);
+      assert.equal(greaterThan([1, 2, 3], [1, 2, 3]), false);
+      assert.equal(greaterThan([1, 2, 3], [1, 2, 4]), false);
+    });
+  });
+
+  describe("greaterThanOrEqual", () => {
+    it("Should return true when greater or equal", () => {
+      assert.equal(greaterThanOrEqual([1, 2, 4], [1, 2, 3]), true);
+      assert.equal(greaterThanOrEqual([1, 2, 3], [1, 2, 3]), true);
+      assert.equal(greaterThanOrEqual([1, 2, 3], [1, 2, 4]), false);
+    });
+  });
+});

--- a/packages/hardhat-verify/package.json
+++ b/packages/hardhat-verify/package.json
@@ -51,7 +51,6 @@
     "@nomicfoundation/hardhat-node-test-reporter": "workspace:^3.0.5",
     "@nomicfoundation/hardhat-test-utils": "workspace:^",
     "@types/node": "^22.0.0",
-    "@types/semver": "^7.5.8",
     "c8": "^9.1.0",
     "eslint": "9.25.1",
     "expect-type": "^1.2.1",
@@ -67,7 +66,6 @@
     "@nomicfoundation/hardhat-utils": "workspace:^4.0.4",
     "@nomicfoundation/hardhat-zod-utils": "workspace:^3.0.4",
     "cbor2": "^1.9.0",
-    "semver": "^7.6.3",
     "zod": "^3.23.8"
   },
   "peerDependencies": {

--- a/packages/hardhat-verify/src/internal/bytecode.ts
+++ b/packages/hardhat-verify/src/internal/bytecode.ts
@@ -1,3 +1,4 @@
+import type { InferredSolcVersion } from "./metadata.js";
 import type { EthereumProvider } from "hardhat/types/providers";
 import type { CompilerOutputBytecode } from "hardhat/types/solidity";
 
@@ -14,8 +15,6 @@ import {
   getMetadataSectionBytesLength,
   inferSolcVersion,
   METADATA_LENGTH_FIELD_SIZE,
-  MISSING_METADATA_VERSION_RANGE,
-  SOLC_NOT_FOUND_IN_METADATA_VERSION_RANGE,
 } from "./metadata.js";
 
 interface ByteOffset {
@@ -26,7 +25,7 @@ interface ByteOffset {
 export class Bytecode {
   private constructor(
     public readonly bytecode: string,
-    public readonly solcVersion: string,
+    public readonly solcVersion: InferredSolcVersion,
     public readonly executableSection: string,
   ) {}
 
@@ -71,10 +70,7 @@ export class Bytecode {
   }
 
   public hasVersionRange(): boolean {
-    return (
-      this.solcVersion === MISSING_METADATA_VERSION_RANGE ||
-      this.solcVersion === SOLC_NOT_FOUND_IN_METADATA_VERSION_RANGE
-    );
+    return this.solcVersion.type !== "exact";
   }
 
   /**

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -16,6 +16,7 @@ import {
 } from "hardhat/utils/contract-names";
 
 import { getBuildInfoAndOutput } from "./artifacts.js";
+import { formatInferredSolcVersion } from "./metadata.js";
 
 export interface ContractInformation {
   compilerInput: CompilerInput;
@@ -113,9 +114,12 @@ export class ContractInformationResolver {
       buildInfoAndOutput.buildInfo.solcVersion,
     );
     if (!isSolcVersionCompatible) {
+      const formattedSolcVersion = formatInferredSolcVersion(
+        deployedBytecode.solcVersion,
+      );
       const versionDetails = deployedBytecode.hasVersionRange()
-        ? `a Solidity version in the range ${deployedBytecode.solcVersion}`
-        : `the Solidity version ${deployedBytecode.solcVersion}`;
+        ? `a Solidity version in the range ${formattedSolcVersion}`
+        : `the Solidity version ${formattedSolcVersion}`;
 
       throw new HardhatError(
         HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.BUILD_INFO_SOLC_VERSION_MISMATCH,

--- a/packages/hardhat-verify/src/internal/metadata.ts
+++ b/packages/hardhat-verify/src/internal/metadata.ts
@@ -1,3 +1,5 @@
+import type { SemverVersion } from "@nomicfoundation/hardhat-utils/fast-semver";
+
 import util from "node:util";
 
 import { bytesToHexString } from "@nomicfoundation/hardhat-utils/bytes";
@@ -8,9 +10,28 @@ const log = createDebug("hardhat:verify:metadata");
 
 export const METADATA_LENGTH_FIELD_SIZE = 2;
 
-export const SOLC_NOT_FOUND_IN_METADATA_VERSION_RANGE = "0.4.7 - 0.5.8";
+/**
+ * The Solidity compiler version inferred from a contract's deployed bytecode.
+ *
+ * Bytecode metadata was introduced in Solidity v0.4.7, and the explicit
+ * version field was added in v0.5.9. Below those thresholds we can only
+ * narrow the version down to a range.
+ */
+export type InferredSolcVersion =
+  | { type: "exact"; version: SemverVersion }
+  | { type: "lessThan"; bound: SemverVersion }
+  | { type: "between"; min: SemverVersion; max: SemverVersion };
 
-export const MISSING_METADATA_VERSION_RANGE = "<0.4.7";
+const MISSING_METADATA: InferredSolcVersion = {
+  type: "lessThan",
+  bound: [0, 4, 7],
+};
+
+const SOLC_NOT_FOUND_IN_METADATA: InferredSolcVersion = {
+  type: "between",
+  min: [0, 4, 7],
+  max: [0, 5, 8],
+};
 
 /**
  * Attempts to infer the Solidity compiler version from the bytecode metadata.
@@ -21,25 +42,28 @@ export const MISSING_METADATA_VERSION_RANGE = "<0.4.7";
  * See https://docs.soliditylang.org/en/v0.5.9/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode
  *
  * @param bytecode The deployed bytecode as a Uint8Array.
- * @returns The inferred solc version (e.g., "0.8.17"), or a fallback
- * version range constant if the version cannot be inferred.
+ * @returns The inferred solc version, either as an exact `x.y.z` or, when
+ * the metadata is missing or incomplete, as a fallback range.
  */
-export async function inferSolcVersion(bytecode: Uint8Array): Promise<string> {
+export async function inferSolcVersion(
+  bytecode: Uint8Array,
+): Promise<InferredSolcVersion> {
   let solcMetadata: unknown;
   try {
     solcMetadata = await decodeSolcMetadata(bytecode);
   } catch {
     // Decoding failed, likely an older compiler or non-Solidity bytecode
     log("Failed to decode metadata.");
-    return MISSING_METADATA_VERSION_RANGE;
+    return MISSING_METADATA;
   }
 
   if (solcMetadata instanceof Uint8Array) {
     if (solcMetadata.length === 3) {
       const [major, minor, patch] = solcMetadata;
-      const solcVersion = `${major}.${minor}.${patch}`;
-      log(`Detected Solidity version from metadata: ${solcVersion}`);
-      return solcVersion;
+      log(
+        `Detected Solidity version from metadata: ${major}.${minor}.${patch}`,
+      );
+      return { type: "exact", version: [major, minor, patch] };
     }
     // Unexpected length. Log raw metadata for inspection
     log(
@@ -49,7 +73,27 @@ export async function inferSolcVersion(bytecode: Uint8Array): Promise<string> {
 
   // Metadata was decoded but contained no version field
   log("Metadata decoded but Solidity version not found.");
-  return SOLC_NOT_FOUND_IN_METADATA_VERSION_RANGE;
+  return SOLC_NOT_FOUND_IN_METADATA;
+}
+
+/**
+ * Formats an `InferredSolcVersion` as a human-readable string suitable for
+ * inclusion in error messages: an exact `x.y.z`, a `<x.y.z` upper bound, or
+ * an `x.y.z - x.y.z` closed range.
+ */
+export function formatInferredSolcVersion(v: InferredSolcVersion): string {
+  switch (v.type) {
+    case "exact":
+      return formatTuple(v.version);
+    case "lessThan":
+      return `<${formatTuple(v.bound)}`;
+    case "between":
+      return `${formatTuple(v.min)} - ${formatTuple(v.max)}`;
+  }
+}
+
+function formatTuple(v: SemverVersion): string {
+  return `${v[0]}.${v[1]}.${v[2]}`;
 }
 
 /**

--- a/packages/hardhat-verify/src/internal/solc-versions.ts
+++ b/packages/hardhat-verify/src/internal/solc-versions.ts
@@ -2,10 +2,7 @@ import type { InferredSolcVersion } from "./metadata.js";
 import type { SemverVersion } from "@nomicfoundation/hardhat-utils/fast-semver";
 import type { SolidityBuildProfileConfig } from "hardhat/types/config";
 
-import {
-  HardhatError,
-  assertHardhatInvariant,
-} from "@nomicfoundation/hardhat-errors";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
   equals,
   greaterThanOrEqual,
@@ -48,11 +45,7 @@ export function resolveSupportedSolcVersions({
 
   const unsupportedSolcVersions = solcVersions.filter((version) => {
     const parsed = parseVersion(version);
-    assertHardhatInvariant(
-      parsed !== undefined,
-      `Invalid solc version: ${version}`,
-    );
-    return lowerThan(parsed, MIN_SUPPORTED_SOLC_VERSION);
+    return parsed === undefined || lowerThan(parsed, MIN_SUPPORTED_SOLC_VERSION);
   });
   if (unsupportedSolcVersions.length > 0) {
     throw new HardhatError(
@@ -80,10 +73,9 @@ export function filterVersionsByInferred(
 ): string[] {
   return versions.filter((version) => {
     const parsed = parseVersion(version);
-    assertHardhatInvariant(
-      parsed !== undefined,
-      `Invalid solc version: ${version}`,
-    );
+    if (parsed === undefined) {
+      return false;
+    }
     switch (inferred.type) {
       case "exact":
         return equals(parsed, inferred.version);

--- a/packages/hardhat-verify/src/internal/solc-versions.ts
+++ b/packages/hardhat-verify/src/internal/solc-versions.ts
@@ -45,7 +45,9 @@ export function resolveSupportedSolcVersions({
 
   const unsupportedSolcVersions = solcVersions.filter((version) => {
     const parsed = parseVersion(version);
-    return parsed === undefined || lowerThan(parsed, MIN_SUPPORTED_SOLC_VERSION);
+    return (
+      parsed === undefined || lowerThan(parsed, MIN_SUPPORTED_SOLC_VERSION)
+    );
   });
   if (unsupportedSolcVersions.length > 0) {
     throw new HardhatError(

--- a/packages/hardhat-verify/src/internal/solc-versions.ts
+++ b/packages/hardhat-verify/src/internal/solc-versions.ts
@@ -1,7 +1,22 @@
+import type { InferredSolcVersion } from "./metadata.js";
+import type { SemverVersion } from "@nomicfoundation/hardhat-utils/fast-semver";
 import type { SolidityBuildProfileConfig } from "hardhat/types/config";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import semver from "semver";
+import {
+  HardhatError,
+  assertHardhatInvariant,
+} from "@nomicfoundation/hardhat-errors";
+import {
+  equals,
+  greaterThanOrEqual,
+  lowerThan,
+  lowerThanOrEqual,
+  parseVersion,
+} from "@nomicfoundation/hardhat-utils/fast-semver";
+
+// Etherscan only supports solidity versions higher than or equal to v0.4.11.
+// See https://etherscan.io/solcversions
+const MIN_SUPPORTED_SOLC_VERSION: SemverVersion = [0, 4, 11];
 
 // TODO: Consider splitting this into two steps: collecting compiler versions
 // and validating them. Version collection could be delegated to a helper
@@ -31,12 +46,14 @@ export function resolveSupportedSolcVersions({
     }
   }
 
-  // Etherscan only supports solidity versions higher than or equal to v0.4.11.
-  // See https://etherscan.io/solcversions
-  const SUPPORTED_SOLC_VERSION_RANGE = ">=0.4.11";
-  const unsupportedSolcVersions = solcVersions.filter(
-    (version) => !semver.satisfies(version, SUPPORTED_SOLC_VERSION_RANGE),
-  );
+  const unsupportedSolcVersions = solcVersions.filter((version) => {
+    const parsed = parseVersion(version);
+    assertHardhatInvariant(
+      parsed !== undefined,
+      `Invalid solc version: ${version}`,
+    );
+    return lowerThan(parsed, MIN_SUPPORTED_SOLC_VERSION);
+  });
   if (unsupportedSolcVersions.length > 0) {
     throw new HardhatError(
       HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.SOLC_VERSION_NOT_SUPPORTED,
@@ -50,16 +67,33 @@ export function resolveSupportedSolcVersions({
 }
 
 /**
- * Filters the given versions, returning only those that satisfy the provided
- * semver range.
+ * Filters the given versions, returning only those compatible with the
+ * `InferredSolcVersion` extracted from the deployed bytecode.
  *
- * @param versions An array of version strings (e.g. ["0.8.17", "0.4.25"])
- * @param range A semver range string (e.g. ">=0.4.11")
- * @returns An array of versions that satisfy the range.
+ * @param versions An array of version strings (e.g. `["0.8.17", "0.4.25"]`).
+ * @param inferred The version inferred from the deployed bytecode metadata.
+ * @returns The subset of `versions` that fall within the inferred constraint.
  */
-export function filterVersionsByRange(
+export function filterVersionsByInferred(
   versions: string[],
-  range: string,
+  inferred: InferredSolcVersion,
 ): string[] {
-  return versions.filter((version) => semver.satisfies(version, range));
+  return versions.filter((version) => {
+    const parsed = parseVersion(version);
+    assertHardhatInvariant(
+      parsed !== undefined,
+      `Invalid solc version: ${version}`,
+    );
+    switch (inferred.type) {
+      case "exact":
+        return equals(parsed, inferred.version);
+      case "lessThan":
+        return lowerThan(parsed, inferred.bound);
+      case "between":
+        return (
+          greaterThanOrEqual(parsed, inferred.min) &&
+          lowerThanOrEqual(parsed, inferred.max)
+        );
+    }
+  });
 }

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -21,8 +21,9 @@ import { encodeConstructorArgs } from "./constructor-args.js";
 import { ContractInformationResolver } from "./contract.js";
 import { ETHERSCAN_PROVIDER_NAME } from "./etherscan.js";
 import { resolveLibraryInformation } from "./libraries.js";
+import { formatInferredSolcVersion } from "./metadata.js";
 import {
-  filterVersionsByRange,
+  filterVersionsByInferred,
   resolveSupportedSolcVersions,
 } from "./solc-versions.js";
 import { VERIFICATION_PROVIDERS } from "./verification-providers.js";
@@ -154,7 +155,7 @@ Explorer: ${instance.getContractUrl(address)}`);
     networkName,
   );
 
-  const compatibleSolcVersions = filterVersionsByRange(
+  const compatibleSolcVersions = filterVersionsByInferred(
     supportedSolcVersions,
     deployedBytecode.solcVersion,
   );
@@ -168,7 +169,9 @@ Explorer: ${instance.getContractUrl(address)}`);
       HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.SOLC_VERSION_MISMATCH,
       {
         configuredSolcVersionSummary,
-        deployedSolcVersion: deployedBytecode.solcVersion,
+        deployedSolcVersion: formatInferredSolcVersion(
+          deployedBytecode.solcVersion,
+        ),
         networkName,
       },
     );

--- a/packages/hardhat-verify/test/bytecode.ts
+++ b/packages/hardhat-verify/test/bytecode.ts
@@ -25,11 +25,7 @@ import {
   getImmutableOffsets,
   getCallProtectionOffsets,
 } from "../src/internal/bytecode.js";
-import {
-  METADATA_LENGTH_FIELD_SIZE,
-  MISSING_METADATA_VERSION_RANGE,
-  SOLC_NOT_FOUND_IN_METADATA_VERSION_RANGE,
-} from "../src/internal/metadata.js";
+import { METADATA_LENGTH_FIELD_SIZE } from "../src/internal/metadata.js";
 
 import { MockEthereumProvider } from "./utils.js";
 
@@ -59,7 +55,10 @@ describe("bytecode", () => {
           networkName,
         );
 
-        assert.equal(deployedBytecode.solcVersion, "0.8.30");
+        assert.deepEqual(deployedBytecode.solcVersion, {
+          type: "exact",
+          version: [0, 8, 30],
+        });
         assert.equal(deployedBytecode.bytecode, bytecode);
         assert.equal(deployedBytecode.executableSection, executableSection);
       });
@@ -82,7 +81,7 @@ describe("bytecode", () => {
     });
 
     describe("hasVersionRange", () => {
-      it("should return true if the solc version is a range - MISSING_METADATA_VERSION_RANGE", async () => {
+      it("should return true when no metadata can be decoded (lessThan fallback)", async () => {
         const executableSection = "deadbeefcafebabe"; // dummy bytecode
 
         const bytecode = buildBytecode(executableSection, "");
@@ -97,14 +96,14 @@ describe("bytecode", () => {
           networkName,
         );
 
-        assert.equal(
-          deployedBytecode.solcVersion,
-          MISSING_METADATA_VERSION_RANGE,
-        );
+        assert.deepEqual(deployedBytecode.solcVersion, {
+          type: "lessThan",
+          bound: [0, 4, 7],
+        });
         assert.equal(deployedBytecode.hasVersionRange(), true);
       });
 
-      it("should return true if the solc version is a range - SOLC_NOT_FOUND_IN_METADATA_VERSION_RANGE", async () => {
+      it("should return true when metadata lacks a version field (between fallback)", async () => {
         const metadata = {};
         const encodedMetadata = encode(metadata);
         const metadataSection = getUnprefixedHexString(
@@ -124,14 +123,15 @@ describe("bytecode", () => {
           networkName,
         );
 
-        assert.equal(
-          deployedBytecode.solcVersion,
-          SOLC_NOT_FOUND_IN_METADATA_VERSION_RANGE,
-        );
+        assert.deepEqual(deployedBytecode.solcVersion, {
+          type: "between",
+          min: [0, 4, 7],
+          max: [0, 5, 8],
+        });
         assert.equal(deployedBytecode.hasVersionRange(), true);
       });
 
-      it("should return false if the solc version is not a range", async () => {
+      it("should return false when the solc version is exact", async () => {
         const metadata = { solc: new Uint8Array([0, 6, 0]) }; // [major, minor, patch]
         const encodedMetadata = encode(metadata);
         const metadataSection = getUnprefixedHexString(
@@ -151,7 +151,10 @@ describe("bytecode", () => {
           networkName,
         );
 
-        assert.equal(deployedBytecode.solcVersion, "0.6.0");
+        assert.deepEqual(deployedBytecode.solcVersion, {
+          type: "exact",
+          version: [0, 6, 0],
+        });
         assert.equal(deployedBytecode.hasVersionRange(), false);
       });
     });

--- a/packages/hardhat-verify/test/metadata.ts
+++ b/packages/hardhat-verify/test/metadata.ts
@@ -7,15 +7,14 @@ import {
 } from "@nomicfoundation/hardhat-utils/bytes";
 
 import {
+  formatInferredSolcVersion,
   getMetadataSectionBytesLength,
   inferSolcVersion,
-  MISSING_METADATA_VERSION_RANGE,
-  SOLC_NOT_FOUND_IN_METADATA_VERSION_RANGE,
 } from "../src/internal/metadata.js";
 
 describe("metadata", () => {
   describe("inferSolcVersion", () => {
-    it("should return the exact compiler version", async () => {
+    it("should return an exact compiler version", async () => {
       // Bytecode generated with Solidity 0.5.9
       const solc059Bytecode = hexStringToBytes(
         "0x6080604052348015600f57600080fd5b50603e80601d6000396000f3fe6080604052600080fdfea265627a7a723058201d7a6a3b37a66e79d9dd0abb90d493ba6ba82af0d76bf7bcbd53aa63fad4316664736f6c63430005090032",
@@ -25,11 +24,17 @@ describe("metadata", () => {
         "0x6080604052348015600f57600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea26469706673582212205a428cebe312fc68fec73aec069d4922dd88c8404183b33f93424ee0ee18423b64736f6c63430008130033",
       );
 
-      assert.equal(await inferSolcVersion(solc059Bytecode), "0.5.9");
-      assert.equal(await inferSolcVersion(solc0819Bytecode), "0.8.19");
+      assert.deepEqual(await inferSolcVersion(solc059Bytecode), {
+        type: "exact",
+        version: [0, 5, 9],
+      });
+      assert.deepEqual(await inferSolcVersion(solc0819Bytecode), {
+        type: "exact",
+        version: [0, 8, 19],
+      });
     });
 
-    it("should return '<0.4.7' if it throws when decoding the metadata", async () => {
+    it("should return the lessThan-0.4.7 fallback when metadata can't be decoded", async () => {
       const emptyBytecode = new Uint8Array([0, 0]);
       const noBytecode = utf8StringToBytes("This is no contract bytecode.");
       // Bytecode generated with Solidity 0.4.6
@@ -37,21 +42,13 @@ describe("metadata", () => {
         "0x6060604052346000575b60098060156000396000f360606040525b600056",
       );
 
-      assert.equal(
-        await inferSolcVersion(emptyBytecode),
-        MISSING_METADATA_VERSION_RANGE,
-      );
-      assert.equal(
-        await inferSolcVersion(noBytecode),
-        MISSING_METADATA_VERSION_RANGE,
-      );
-      assert.equal(
-        await inferSolcVersion(noMetadataBytecode),
-        MISSING_METADATA_VERSION_RANGE,
-      );
+      const expected = { type: "lessThan", bound: [0, 4, 7] };
+      assert.deepEqual(await inferSolcVersion(emptyBytecode), expected);
+      assert.deepEqual(await inferSolcVersion(noBytecode), expected);
+      assert.deepEqual(await inferSolcVersion(noMetadataBytecode), expected);
     });
 
-    it("should return '0.4.7 - 0.5.8' if it can't find a solc version in the metadata", async () => {
+    it("should return the 0.4.7-to-0.5.8 fallback when metadata has no version field", async () => {
       // Bytecode generated with Solidity 0.4.7
       const solc047Bytecode = hexStringToBytes(
         "0x6060604052346000575b60358060166000396000f30060606040525b60005600a165627a7a7230582074ab9e158d4cb2b2c83bd9efe2ee6bd219f3e2cda7d80ddfe56a1e844f81a2950029",
@@ -61,13 +58,39 @@ describe("metadata", () => {
         "0x6080604052348015600f57600080fd5b50603580601d6000396000f3fe6080604052600080fdfea165627a7a723058209251767f58375bfe02f871bf86ffdae7ab9f6503c50146effb0e7bf96e5a0db90029",
       );
 
+      const expected = {
+        type: "between",
+        min: [0, 4, 7],
+        max: [0, 5, 8],
+      };
+      assert.deepEqual(await inferSolcVersion(solc047Bytecode), expected);
+      assert.deepEqual(await inferSolcVersion(solc058Bytecode), expected);
+    });
+  });
+
+  describe("formatInferredSolcVersion", () => {
+    it("should format an exact version as x.y.z", () => {
       assert.equal(
-        await inferSolcVersion(solc047Bytecode),
-        SOLC_NOT_FOUND_IN_METADATA_VERSION_RANGE,
+        formatInferredSolcVersion({ type: "exact", version: [0, 8, 19] }),
+        "0.8.19",
       );
+    });
+
+    it("should format a lessThan bound as <x.y.z", () => {
       assert.equal(
-        await inferSolcVersion(solc058Bytecode),
-        SOLC_NOT_FOUND_IN_METADATA_VERSION_RANGE,
+        formatInferredSolcVersion({ type: "lessThan", bound: [0, 4, 7] }),
+        "<0.4.7",
+      );
+    });
+
+    it("should format a between range as 'x.y.z - x.y.z'", () => {
+      assert.equal(
+        formatInferredSolcVersion({
+          type: "between",
+          min: [0, 4, 7],
+          max: [0, 5, 8],
+        }),
+        "0.4.7 - 0.5.8",
       );
     });
   });

--- a/packages/hardhat-verify/test/solc-versions.ts
+++ b/packages/hardhat-verify/test/solc-versions.ts
@@ -5,8 +5,8 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import {
+  filterVersionsByInferred,
   resolveSupportedSolcVersions,
-  filterVersionsByRange,
 } from "../src/internal/solc-versions.js";
 
 describe("solc-versions", () => {
@@ -184,23 +184,86 @@ describe("solc-versions", () => {
     });
   });
 
-  describe("filterVersionsByRange", () => {
-    it("should return the versions that satisfy the given range", async () => {
-      const versions = ["0.8.18", "0.7.2", "0.4.11", "0.3.5"];
-      const range = ">=0.4.11";
+  describe("filterVersionsByInferred", () => {
+    const versions = ["0.4.10", "0.4.11", "0.5.0", "0.5.8", "0.5.9", "0.8.18"];
 
-      const filteredVersions = filterVersionsByRange(versions, range);
+    describe("exact", () => {
+      it("should keep only the matching version", () => {
+        assert.deepEqual(
+          filterVersionsByInferred(versions, {
+            type: "exact",
+            version: [0, 5, 9],
+          }),
+          ["0.5.9"],
+        );
+      });
 
-      assert.deepEqual(filteredVersions, ["0.8.18", "0.7.2", "0.4.11"]);
+      it("should return an empty array when no version matches", () => {
+        assert.deepEqual(
+          filterVersionsByInferred(versions, {
+            type: "exact",
+            version: [0, 7, 0],
+          }),
+          [],
+        );
+      });
     });
 
-    it("should return an empty array if no versions satisfy the given range", async () => {
-      const versions = ["0.3.5", "0.2.1"];
-      const range = ">=0.4.11";
+    describe("lessThan", () => {
+      it("should keep versions strictly below the bound", () => {
+        assert.deepEqual(
+          filterVersionsByInferred(versions, {
+            type: "lessThan",
+            bound: [0, 4, 11],
+          }),
+          ["0.4.10"],
+        );
+      });
 
-      const filteredVersions = filterVersionsByRange(versions, range);
+      it("should exclude the bound itself", () => {
+        assert.deepEqual(
+          filterVersionsByInferred(["0.4.7", "0.4.6"], {
+            type: "lessThan",
+            bound: [0, 4, 7],
+          }),
+          ["0.4.6"],
+        );
+      });
+    });
 
-      assert.deepEqual(filteredVersions, []);
+    describe("between", () => {
+      it("should keep versions in the closed range", () => {
+        assert.deepEqual(
+          filterVersionsByInferred(versions, {
+            type: "between",
+            min: [0, 4, 7],
+            max: [0, 5, 8],
+          }),
+          ["0.4.10", "0.4.11", "0.5.0", "0.5.8"],
+        );
+      });
+
+      it("should include both endpoints", () => {
+        assert.deepEqual(
+          filterVersionsByInferred(["0.4.7", "0.5.8"], {
+            type: "between",
+            min: [0, 4, 7],
+            max: [0, 5, 8],
+          }),
+          ["0.4.7", "0.5.8"],
+        );
+      });
+
+      it("should return an empty array when no version is in range", () => {
+        assert.deepEqual(
+          filterVersionsByInferred(["0.3.5", "0.6.0"], {
+            type: "between",
+            min: [0, 4, 7],
+            max: [0, 5, 8],
+          }),
+          [],
+        );
+      });
     });
   });
 });

--- a/packages/hardhat-verify/test/solc-versions.ts
+++ b/packages/hardhat-verify/test/solc-versions.ts
@@ -182,6 +182,32 @@ describe("solc-versions", () => {
         },
       );
     });
+
+    it("should treat malformed versions as unsupported", async () => {
+      const solidityConfig = {
+        compilers: [
+          {
+            version: "0.8.18",
+            settings: {},
+          },
+          {
+            version: "not-a-version",
+            settings: {},
+          },
+        ],
+        overrides: {},
+        isolated: false,
+        preferWasm: false,
+      };
+
+      assertThrowsHardhatError(
+        () => resolveSupportedSolcVersions(solidityConfig),
+        HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.SOLC_VERSION_NOT_SUPPORTED,
+        {
+          unsupportedSolcVersions: ["not-a-version"],
+        },
+      );
+    });
   });
 
   describe("filterVersionsByInferred", () => {
@@ -262,6 +288,34 @@ describe("solc-versions", () => {
             max: [0, 5, 8],
           }),
           [],
+        );
+      });
+    });
+
+    describe("malformed versions", () => {
+      it("should silently filter out malformed versions for any inferred type", () => {
+        const mixed = ["0.5.9", "not-a-version", "0.8", "0.4.11"];
+        assert.deepEqual(
+          filterVersionsByInferred(mixed, {
+            type: "exact",
+            version: [0, 5, 9],
+          }),
+          ["0.5.9"],
+        );
+        assert.deepEqual(
+          filterVersionsByInferred(mixed, {
+            type: "lessThan",
+            bound: [0, 5, 0],
+          }),
+          ["0.4.11"],
+        );
+        assert.deepEqual(
+          filterVersionsByInferred(mixed, {
+            type: "between",
+            min: [0, 4, 0],
+            max: [0, 6, 0],
+          }),
+          ["0.5.9", "0.4.11"],
         );
       });
     });

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/instrumentation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/instrumentation.ts
@@ -4,7 +4,11 @@ import {
   addStatementCoverageInstrumentation,
   latestSupportedSolidityVersion,
 } from "@nomicfoundation/edr";
-import { satisfies } from "semver";
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import {
+  lowerThanOrEqual,
+  parseVersion,
+} from "@nomicfoundation/hardhat-utils/fast-semver";
 
 /**
  * Instruments a solidity source file as part of a compilation job. i.e. the
@@ -37,8 +41,23 @@ export function instrumentSolidityFileForCompilationJob({
   instrumentationVersion: string;
 } {
   const latestSupportedVersion = latestSupportedSolidityVersion();
+  const parsedLatestSupportedVersion = parseVersion(latestSupportedVersion);
+  assertHardhatInvariant(
+    parsedLatestSupportedVersion !== undefined,
+    `Invalid latest supported solidity version: ${latestSupportedVersion}`,
+  );
   let instrumentationVersion = compilationJobSolcVersion;
-  if (!satisfies(instrumentationVersion, `<=${latestSupportedVersion}`)) {
+  const parsedInstrumentationVersion = parseVersion(instrumentationVersion);
+  assertHardhatInvariant(
+    parsedInstrumentationVersion !== undefined,
+    `Invalid solc version: ${instrumentationVersion}`,
+  );
+  if (
+    !lowerThanOrEqual(
+      parsedInstrumentationVersion,
+      parsedLatestSupportedVersion,
+    )
+  ) {
     instrumentationVersion = latestSupportedVersion;
   }
   const { source, metadata } = addStatementCoverageInstrumentation(

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/compiler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/compiler.ts
@@ -171,10 +171,12 @@ export class NativeCompiler implements Compiler {
     // If solcVersion is not defined or <= 0.6.8, do not add extra args.
     if (this.version !== undefined) {
       const parsed = parseVersion(this.version);
-      assertHardhatInvariant(
-        parsed !== undefined,
-        `Invalid solc version: ${this.version}`,
-      );
+      if (parsed === undefined) {
+        throw new HardhatError(
+          HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
+          { version: this.version },
+        );
+      }
       if (greaterThanOrEqual(parsed, NO_IMPORT_CALLBACK_MIN_VERSION)) {
         // version >= 0.8.22
         args.push("--no-import-callback");

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/compiler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/compiler.ts
@@ -3,6 +3,7 @@ import type {
   CompilerOutput,
 } from "../../../../../types/solidity/compiler-io.js";
 import type { Compiler } from "../../../../../types/solidity/compiler.js";
+import type { SemverVersion } from "@nomicfoundation/hardhat-utils/fast-semver";
 
 import { spawn } from "node:child_process";
 import fsPromises from "node:fs/promises";
@@ -17,12 +18,18 @@ import {
 } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import {
+  greaterThanOrEqual,
+  parseVersion,
+} from "@nomicfoundation/hardhat-utils/fast-semver";
+import {
   mkdtemp,
   readJsonFileAsStream,
   remove,
 } from "@nomicfoundation/hardhat-utils/fs";
 import { createNonClosingWriter } from "@nomicfoundation/hardhat-utils/stream";
-import * as semver from "semver";
+
+const NO_IMPORT_CALLBACK_MIN_VERSION: SemverVersion = [0, 8, 22];
+const BASE_PATH_MIN_VERSION: SemverVersion = [0, 6, 9];
 
 /**
  * Spawns a compilation process and returns its output.
@@ -163,10 +170,15 @@ export class NativeCompiler implements Compiler {
     // Logic to make sure that solc default import callback is not being used.
     // If solcVersion is not defined or <= 0.6.8, do not add extra args.
     if (this.version !== undefined) {
-      if (semver.gte(this.version, "0.8.22")) {
+      const parsed = parseVersion(this.version);
+      assertHardhatInvariant(
+        parsed !== undefined,
+        `Invalid solc version: ${this.version}`,
+      );
+      if (greaterThanOrEqual(parsed, NO_IMPORT_CALLBACK_MIN_VERSION)) {
         // version >= 0.8.22
         args.push("--no-import-callback");
-      } else if (semver.gte(this.version, "0.6.9")) {
+      } else if (greaterThanOrEqual(parsed, BASE_PATH_MIN_VERSION)) {
         // version >= 0.6.9
         const tmpFolder = await mkdtemp("hardhat-solc-");
         args.push(`--base-path`);

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/solcjs-wrapper.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/solcjs-wrapper.ts
@@ -1,8 +1,18 @@
 // This wrapper was created by extracting the parts of the solc-js package
 // (https://github.com/ethereum/solc-js) that we need to perform compilation.
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import * as semver from "semver";
+import type { SemverVersion } from "@nomicfoundation/hardhat-utils/fast-semver";
+
+import {
+  HardhatError,
+  assertHardhatInvariant,
+} from "@nomicfoundation/hardhat-errors";
+import {
+  greaterThanOrEqual,
+  parseVersion,
+} from "@nomicfoundation/hardhat-utils/fast-semver";
+
+const VERSION_6: SemverVersion = [0, 6, 0];
 
 interface Solc {
   cwrap<T>(ident: string, returnType: string | null, argTypes: string[]): T;
@@ -36,8 +46,15 @@ export type CompileWrapper = (input: string) => string;
 
 export default function wrapper(solc: Solc): SolcWrapper {
   const version = bindVersion(solc);
-  const semverVersion = versionToSemver(version());
-  const isVersion6OrNewer = semver.gte(semverVersion, "0.6.0");
+  const rawVersion = version();
+  const match = rawVersion.match(/^(\d+\.\d+\.\d+)/);
+  assertHardhatInvariant(match !== null, `Invalid solc version: ${rawVersion}`);
+  const parsedVersion = parseVersion(match[1]);
+  assertHardhatInvariant(
+    parsedVersion !== undefined,
+    `Invalid solc version: ${rawVersion}`,
+  );
+  const isVersion6OrNewer = greaterThanOrEqual(parsedVersion, VERSION_6);
   const reset = bindReset(solc);
   const compile = bindCompile(solc, isVersion6OrNewer);
 
@@ -123,22 +140,4 @@ function bindCompile(
   }
 
   return undefined;
-}
-
-function versionToSemver(version: string): string {
-  // FIXME: parse more detail, but this is a good start
-  const parsed = version.match(
-    /^([0-9]+\.[0-9]+\.[0-9]+)-([0-9a-f]{8})[/*].*$/,
-  );
-  if (parsed !== null) {
-    return parsed[1] + "+commit." + parsed[2];
-  }
-  if (version.indexOf("0.1.3-0") !== -1) {
-    return "0.1.3";
-  }
-  if (version.indexOf("0.3.5-0") !== -1) {
-    return "0.3.5";
-  }
-  // assume it is already semver compatible
-  return version;
 }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/solcjs-wrapper.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/solcjs-wrapper.ts
@@ -47,9 +47,7 @@ export type CompileWrapper = (input: string) => string;
 export default function wrapper(solc: Solc): SolcWrapper {
   const version = bindVersion(solc);
   const rawVersion = version();
-  const match = rawVersion.match(/^(\d+\.\d+\.\d+)/);
-  assertHardhatInvariant(match !== null, `Invalid solc version: ${rawVersion}`);
-  const parsedVersion = parseVersion(match[1]);
+  const parsedVersion = parseVersion(rawVersion);
   assertHardhatInvariant(
     parsedVersion !== undefined,
     `Invalid solc version: ${rawVersion}`,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-info.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-info.ts
@@ -2,7 +2,7 @@ import type { SemverVersion } from "@nomicfoundation/hardhat-utils/fast-semver";
 
 import os from "node:os";
 
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
   greaterThanOrEqual,
   lowerThan,
@@ -21,10 +21,12 @@ export const FIRST_ARM64_MIRROR_SOLC_VERSION: SemverVersion = [0, 5, 0];
  */
 export function hasOfficialArm64Build(version: string): boolean {
   const parsed = parseVersion(version);
-  assertHardhatInvariant(
-    parsed !== undefined,
-    `Invalid solc version: ${version}`,
-  );
+  if (parsed === undefined) {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
+      { version },
+    );
+  }
   return greaterThanOrEqual(parsed, FIRST_OFFICIAL_ARM64_SOLC_VERSION);
 }
 
@@ -34,10 +36,12 @@ export function hasOfficialArm64Build(version: string): boolean {
  */
 export function hasArm64MirrorBuild(version: string): boolean {
   const parsed = parseVersion(version);
-  assertHardhatInvariant(
-    parsed !== undefined,
-    `Invalid solc version: ${version}`,
-  );
+  if (parsed === undefined) {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
+      { version },
+    );
+  }
   return (
     greaterThanOrEqual(parsed, FIRST_ARM64_MIRROR_SOLC_VERSION) &&
     lowerThan(parsed, FIRST_OFFICIAL_ARM64_SOLC_VERSION)

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-info.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-info.ts
@@ -1,19 +1,31 @@
+import type { SemverVersion } from "@nomicfoundation/hardhat-utils/fast-semver";
+
 import os from "node:os";
 
-import semver from "semver";
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import {
+  greaterThanOrEqual,
+  lowerThan,
+  parseVersion,
+} from "@nomicfoundation/hardhat-utils/fast-semver";
 
 // The first solc version with official ARM64 Linux builds
-export const FIRST_OFFICIAL_ARM64_SOLC_VERSION = "0.8.31";
+export const FIRST_OFFICIAL_ARM64_SOLC_VERSION: SemverVersion = [0, 8, 31];
 
 // The lowest solc version available in the frozen ARM64 mirror repo
 // (https://github.com/NomicFoundation/solc-linux-arm64-mirror/tree/main/public/linux/aarch64)
-export const FIRST_ARM64_MIRROR_SOLC_VERSION = "0.5.0";
+export const FIRST_ARM64_MIRROR_SOLC_VERSION: SemverVersion = [0, 5, 0];
 
 /**
  * Determines if a solc version has an official ARM64 Linux build.
  */
 export function hasOfficialArm64Build(version: string): boolean {
-  return semver.gte(version, FIRST_OFFICIAL_ARM64_SOLC_VERSION);
+  const parsed = parseVersion(version);
+  assertHardhatInvariant(
+    parsed !== undefined,
+    `Invalid solc version: ${version}`,
+  );
+  return greaterThanOrEqual(parsed, FIRST_OFFICIAL_ARM64_SOLC_VERSION);
 }
 
 /**
@@ -21,9 +33,14 @@ export function hasOfficialArm64Build(version: string): boolean {
  * in the community mirror (versions 0.5.0–0.8.30).
  */
 export function hasArm64MirrorBuild(version: string): boolean {
+  const parsed = parseVersion(version);
+  assertHardhatInvariant(
+    parsed !== undefined,
+    `Invalid solc version: ${version}`,
+  );
   return (
-    semver.gte(version, FIRST_ARM64_MIRROR_SOLC_VERSION) === true &&
-    semver.lt(version, FIRST_OFFICIAL_ARM64_SOLC_VERSION) === true
+    greaterThanOrEqual(parsed, FIRST_ARM64_MIRROR_SOLC_VERSION) &&
+    lowerThan(parsed, FIRST_OFFICIAL_ARM64_SOLC_VERSION)
   );
 }
 

--- a/packages/hardhat/src/internal/cli/init/package-manager.ts
+++ b/packages/hardhat/src/internal/cli/init/package-manager.ts
@@ -1,6 +1,8 @@
+import type { SemverVersion } from "@nomicfoundation/hardhat-utils/fast-semver";
+
 import { execSync } from "node:child_process";
 
-import semver from "semver";
+import { parseVersion } from "@nomicfoundation/hardhat-utils/fast-semver";
 
 type PackageManager = "npm" | "yarn" | "pnpm" | "bun" | "deno";
 
@@ -156,7 +158,7 @@ export async function installsPeerDependenciesByDefault(
         config,
       );
       // If we couldn't retrieve the npm version, we assume it is higher than 7
-      if (npmVersion === undefined || npmVersion.major >= 7) {
+      if (npmVersion === undefined || npmVersion[0] >= 7) {
         // If legacy-peer-deps hasn't been explicitly set to true,
         // peer dependencies are installed by default
         if (legacyPeerDeps !== "true") {
@@ -177,7 +179,7 @@ export async function installsPeerDependenciesByDefault(
         config,
       );
       // If we couldn't retrieve the pnpm version, we assume it is higher than 8
-      if (pnpmVersion === undefined || pnpmVersion.major >= 8) {
+      if (pnpmVersion === undefined || pnpmVersion[0] >= 8) {
         // If auto-install-peers hasn't been explicitly set to false,
         // peer dependencies are installed by default
         if (autoInstallPeers !== "false") {
@@ -207,16 +209,16 @@ async function getVersion(
   workspace: string,
   packageManager: PackageManager,
   version?: string,
-): Promise<semver.SemVer | undefined> {
+): Promise<SemverVersion | undefined> {
   if (version !== undefined) {
-    return semver.parse(version) ?? undefined;
+    return parseVersion(version.trim());
   }
   try {
     const versionString = execSync(`${packageManager} --version`, {
       cwd: workspace,
       encoding: "utf8",
     });
-    return semver.parse(versionString) ?? undefined;
+    return parseVersion(versionString.trim());
   } catch (_error) {
     return undefined;
   }

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/output-selection.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/output-selection.ts
@@ -1,16 +1,21 @@
 import type { CompilerOutput } from "../../../../../src/types/solidity.js";
+import type { SemverVersion } from "@nomicfoundation/hardhat-utils/fast-semver";
 
 import assert from "node:assert/strict";
 import path from "node:path";
 import { describe, it } from "node:test";
 
-import { gte } from "semver";
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import {
+  greaterThanOrEqual,
+  parseVersion,
+} from "@nomicfoundation/hardhat-utils/fast-semver";
 
 import { createHardhatRuntimeEnvironment } from "../../../../../src/internal/hre-initialization.js";
 
 import { useTestProjectTemplate } from "./resolver/helpers.js";
 
-const FIRST_VERSION_WITH_IMMUTABLE_REFERENCES = "0.6.5";
+const FIRST_VERSION_WITH_IMMUTABLE_REFERENCES: SemverVersion = [0, 6, 5];
 
 const CONTRACTS: Record<string, string> = {
   // Oldest version supported by hardhat
@@ -155,8 +160,13 @@ describe(
           "Expected evm.methodIdentifiers in output",
         );
 
-        const supportsImmutables = gte(
-          version,
+        const parsedVersion = parseVersion(version);
+        assertHardhatInvariant(
+          parsedVersion !== undefined,
+          `Invalid solc version: ${version}`,
+        );
+        const supportsImmutables = greaterThanOrEqual(
+          parsedVersion,
           FIRST_VERSION_WITH_IMMUTABLE_REFERENCES,
         );
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/solc-info.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/solc-info.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import { describe, it } from "node:test";
 
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
+
 import {
   hasArm64MirrorBuild,
   hasOfficialArm64Build,
@@ -23,6 +26,19 @@ describe("solc-info", () => {
       assert.equal(hasOfficialArm64Build("0.9.0"), true);
       assert.equal(hasOfficialArm64Build("1.0.0"), true);
     });
+
+    it("throws INVALID_SOLC_VERSION for malformed input", () => {
+      assertThrowsHardhatError(
+        () => hasOfficialArm64Build("not-a-version"),
+        HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
+        { version: "not-a-version" },
+      );
+      assertThrowsHardhatError(
+        () => hasOfficialArm64Build("0.8"),
+        HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
+        { version: "0.8" },
+      );
+    });
   });
 
   describe("hasArm64MirrorBuild", () => {
@@ -42,6 +58,19 @@ describe("solc-info", () => {
       assert.equal(hasArm64MirrorBuild("0.8.31"), false);
       assert.equal(hasArm64MirrorBuild("0.9.0"), false);
       assert.equal(hasArm64MirrorBuild("1.0.0"), false);
+    });
+
+    it("throws INVALID_SOLC_VERSION for malformed input", () => {
+      assertThrowsHardhatError(
+        () => hasArm64MirrorBuild("not-a-version"),
+        HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
+        { version: "not-a-version" },
+      );
+      assertThrowsHardhatError(
+        () => hasArm64MirrorBuild("0.8"),
+        HardhatError.ERRORS.CORE.SOLIDITY.INVALID_SOLC_VERSION,
+        { version: "0.8" },
+      );
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1376,9 +1376,6 @@ importers:
       cbor2:
         specifier: ^1.9.0
         version: 1.12.0
-      semver:
-        specifier: ^7.6.3
-        version: 7.7.4
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -1392,9 +1389,6 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.18.7
-      '@types/semver':
-        specifier: ^7.5.8
-        version: 7.7.1
       c8:
         specifier: ^9.1.0
         version: 9.1.0


### PR DESCRIPTION
## Overview

Adds `fast-semver`, a small zero-dependency module in `@nomicfoundation/hardhat-utils` for parsing and comparing `x.y.z` versions using tuples, and migrates all call sites in the monorepo that don't require full npm range support.

The `semver` dependency is kept in three places in `packages/hardhat` that still rely on full range semantics (caret, tilde, disjunctions, prerelease-aware `subset`, `maxSatisfying` over user pragmas).

Closes https://github.com/NomicFoundation/hardhat/issues/8159.

**Review note:** the PR is split into three commits that can be reviewed independently.

## API

`fast-semver` is intentionally minimal and tuple-based. It does not support prereleases or ranges:

```ts
export type SemverVersion = [major: number, minor: number, patch: number];

export function parseVersion(version: string): SemverVersion | undefined;
export function compare(a: SemverVersion, b: SemverVersion): number;
export function equals(a: SemverVersion, b: SemverVersion): boolean;
export function lowerThan(compared, comparator): boolean;
export function lowerThanOrEqual(compared, comparator): boolean;
export function greaterThan(compared, comparator): boolean;
export function greaterThanOrEqual(compared, comparator): boolean;
```

`parseVersion` returns `undefined` for inputs that don't strictly match `\d+\.\d+\.\d+`. A `+build` suffix is stripped; a `-prerelease` suffix is rejected. Comparison helpers never throw. Call sites use `assertHardhatInvariant` when validity is guaranteed.

## Tests

 - `pnpm hardhat compile` tested with `0.8.22`, `0.7.6`, and `0.5.17`
 - `pnpm hardhat verify` tested with a contract compiled using `0.8.22`
 - Unit tests added in `packages/hardhat-utils/test/fast-semver.ts`, covering valid parsing, invalid input, build metadata stripping, prerelease rejection, ordering, and all comparison helpers
 - Existing test suites in `packages/hardhat` and `packages/hardhat-verify` updated for the migrated modules and pass.

## Benchmark

Compared against `semver@7` on the relevant paths in the Hardhat monorepo:

| Path                       | `semver`         | `fast-semver`    | Δ          |
| -------------------------- | ---------------- | ---------------- | ---------- |
| Cold load (mean)           | 8.70 ms          | 1.28 ms          | −85%       |
| `parse`                    | 5.65M ops/s      | 17.8M ops/s      | +3.2×      |
| `gte` vs literal           | 3.34M ops/s      | 16.1M ops/s      | +4.8×      |
| `lt` vs literal            | 3.38M ops/s      | 16.5M ops/s      | +4.9×      |
| `satisfies('<=X')`         | 1.90M ops/s      | 17.6M ops/s      | +9.3×      |
| `satisfies('>=X')`         | 2.01M ops/s      | 17.4M ops/s      | +8.7×      |