### PR TITLE
gitignore .codex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,7 @@ pnpm-publish-summary.json
 
 # Personal Claude files
 .claude/local/
+
+# Ignored for now, should be reconsidered if we want codex-specific settings.
+# The reason to ignore it is that codex creates a .codex file if the folder doesn't exist.
+/.codex


### PR DESCRIPTION
If we don't have a need for codex specific config now, we should `.gitignore` `/.codex`.

The reason for this is that if you launch `codex` it creates an empty `.codex` file, which is annoying.