### PR TITLE
Add `peek` and `resolvedEntries` sync methods to `SharedPromiseCache`

### DIFF
--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -748,6 +748,41 @@ export class SharedPromiseCache<ValueT> {
   }
 
   /**
+   * Returns the cached value associated to the key without invoking any
+   * producer. If the entry is in-flight, the value is not yet available and
+   * this method returns `undefined` exactly as it would for a missing key.
+   *
+   * Use this for synchronous fast-path lookups; if the result is `undefined`
+   * and you still want to compute the value, fall through to `getOrCompute`.
+   *
+   * @param key The cache key.
+   * @returns The cached value, or `undefined` if the key is missing or
+   * in-flight.
+   */
+  public peek(key: string): ValueT | undefined {
+    const cached = this.#cache.get(key);
+    if (cached === undefined || cached instanceof Promise) {
+      return undefined;
+    }
+    return cached.value;
+  }
+
+  /**
+   * Iterates over the entries that are already resolved, yielding
+   * `[key, value]` pairs. In-flight entries are skipped because their value
+   * is not yet known.
+   *
+   * Producers are never invoked.
+   */
+  public *resolvedEntries(): IterableIterator<[string, ValueT]> {
+    for (const [key, cached] of this.#cache) {
+      if (!(cached instanceof Promise)) {
+        yield [key, cached.value];
+      }
+    }
+  }
+
+  /**
    * Deletes the cached value associated to the key, if any. Note that this does
    * not cancel any ongoing operation. Callers that already observed the
    * in-flight promise will still wait for the original operation to complete,

--- a/packages/hardhat-utils/src/synchronization.ts
+++ b/packages/hardhat-utils/src/synchronization.ts
@@ -755,6 +755,10 @@ export class SharedPromiseCache<ValueT> {
    * Use this for synchronous fast-path lookups; if the result is `undefined`
    * and you still want to compute the value, fall through to `getOrCompute`.
    *
+   * Note that if `ValueT` includes `undefined` as a valid value, you won't be
+   * able to distinguish between a cached `undefined` and a missing/in-flight
+   * entry, but that's an intentional tradeoff to keep this method simple.
+   *
    * @param key The cache key.
    * @returns The cached value, or `undefined` if the key is missing or
    * in-flight.
@@ -768,9 +772,9 @@ export class SharedPromiseCache<ValueT> {
   }
 
   /**
-   * Iterates over the entries that are already resolved, yielding
+   * Iterates over the entries that are successfully resolved, yielding
    * `[key, value]` pairs. In-flight entries are skipped because their value
-   * is not yet known.
+   * is not yet known, and failed ones are removed from the cache.
    *
    * Producers are never invoked.
    */

--- a/packages/hardhat-utils/test/synchronization.ts
+++ b/packages/hardhat-utils/test/synchronization.ts
@@ -1802,4 +1802,151 @@ describe("SharedPromiseCache", () => {
     assert.equal(secondErrorValue, originalError);
     assert.equal(firstErrorValue, secondErrorValue);
   });
+
+  describe("peek", () => {
+    it("should return undefined for a missing key", () => {
+      const cache = new SharedPromiseCache<string>();
+      assert.equal(cache.peek("missing"), undefined);
+    });
+
+    it("should return the value for a resolved entry", async () => {
+      const cache = new SharedPromiseCache<string>();
+      await cache.getOrCompute("key", async () => "value");
+
+      assert.equal(cache.peek("key"), "value");
+    });
+
+    it("should return undefined for an in-flight entry", async () => {
+      const cache = new SharedPromiseCache<string>();
+      const deferred = Promise.withResolvers<string>();
+
+      // Kick off the computation but don't await it; the entry is in-flight.
+      const inFlight = cache.getOrCompute(
+        "key",
+        async () => await deferred.promise,
+      );
+
+      assert.equal(cache.peek("key"), undefined);
+
+      deferred.resolve("value");
+      await inFlight;
+
+      // Once resolved, peek now sees the value.
+      assert.equal(cache.peek("key"), "value");
+    });
+
+    it("should not invoke the producer", async () => {
+      const cache = new SharedPromiseCache<string>();
+      let calls = 0;
+
+      // Seed the cache with a resolved entry first so peek has something
+      // to return; verify the producer count never increases.
+      await cache.getOrCompute("key", async () => {
+        calls++;
+        return "value";
+      });
+
+      cache.peek("key");
+      cache.peek("missing");
+
+      assert.equal(calls, 1);
+    });
+
+    it("should return undefined after a failed computation", async () => {
+      const cache = new SharedPromiseCache<string>();
+
+      await assert.rejects(
+        cache.getOrCompute("key", async () => {
+          throw new Error("fail");
+        }),
+      );
+
+      assert.equal(cache.peek("key"), undefined);
+    });
+
+    it("should reflect cached undefined values", async () => {
+      const cache = new SharedPromiseCache<string | undefined>();
+      await cache.getOrCompute("key", async () => undefined);
+
+      // The entry is resolved with `undefined` as the value. `peek` cannot
+      // distinguish that from a missing key, but documenting this here makes
+      // the behavior explicit.
+      assert.equal(cache.peek("key"), undefined);
+    });
+  });
+
+  describe("resolvedEntries", () => {
+    it("should yield nothing for an empty cache", () => {
+      const cache = new SharedPromiseCache<string>();
+      assert.deepEqual([...cache.resolvedEntries()], []);
+    });
+
+    it("should yield resolved entries", async () => {
+      const cache = new SharedPromiseCache<string>();
+      await cache.getOrCompute("a", async () => "1");
+      await cache.getOrCompute("b", async () => "2");
+
+      assert.deepEqual([...cache.resolvedEntries()].sort(), [
+        ["a", "1"],
+        ["b", "2"],
+      ]);
+    });
+
+    it("should skip in-flight entries", async () => {
+      const cache = new SharedPromiseCache<string>();
+      await cache.getOrCompute("resolved", async () => "value");
+
+      const deferred = Promise.withResolvers<string>();
+      const inFlight = cache.getOrCompute(
+        "in-flight",
+        async () => await deferred.promise,
+      );
+
+      assert.deepEqual(
+        [...cache.resolvedEntries()],
+        [["resolved", "value"]],
+      );
+
+      deferred.resolve("late");
+      await inFlight;
+
+      // Once the in-flight entry resolves, it shows up.
+      assert.deepEqual([...cache.resolvedEntries()].sort(), [
+        ["in-flight", "late"],
+        ["resolved", "value"],
+      ]);
+    });
+
+    it("should not include entries whose computation failed", async () => {
+      const cache = new SharedPromiseCache<string>();
+      await cache.getOrCompute("good", async () => "ok");
+      await assert.rejects(
+        cache.getOrCompute("bad", async () => {
+          throw new Error("fail");
+        }),
+      );
+
+      assert.deepEqual(
+        [...cache.resolvedEntries()],
+        [["good", "ok"]],
+      );
+    });
+
+    it("should not invoke any producer", async () => {
+      const cache = new SharedPromiseCache<string>();
+      let calls = 0;
+      await cache.getOrCompute("key", async () => {
+        calls++;
+        return "value";
+      });
+
+      // Iterate twice; producer count must stay at 1.
+      const first = [...cache.resolvedEntries()];
+      const second = [...cache.resolvedEntries()];
+
+      assert.deepEqual(first, [["key", "value"]]);
+      assert.deepEqual(second, [["key", "value"]]);
+      assert.equal(calls, 1);
+    });
+  });
 });

--- a/packages/hardhat-utils/test/synchronization.ts
+++ b/packages/hardhat-utils/test/synchronization.ts
@@ -1902,10 +1902,7 @@ describe("SharedPromiseCache", () => {
         async () => await deferred.promise,
       );
 
-      assert.deepEqual(
-        [...cache.resolvedEntries()],
-        [["resolved", "value"]],
-      );
+      assert.deepEqual([...cache.resolvedEntries()], [["resolved", "value"]]);
 
       deferred.resolve("late");
       await inFlight;
@@ -1926,10 +1923,7 @@ describe("SharedPromiseCache", () => {
         }),
       );
 
-      assert.deepEqual(
-        [...cache.resolvedEntries()],
-        [["good", "ok"]],
-      );
+      assert.deepEqual([...cache.resolvedEntries()], [["good", "ok"]]);
     });
 
     it("should not invoke any producer", async () => {


### PR DESCRIPTION
These methods are added for two reasons:

- `peek` to be able to implement synchronous fast-paths, and without the need to pass the producer.
- `resolvedEntries` to have a way to inspect the cache.