### PR TITLE
ci(release): add Slack notifications for npm-publish env gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,7 +327,8 @@ jobs:
               echo "::warning::Approvals API returned no approver; falling back to github.actor=${GITHUB_ACTOR}"
             fi
           else
-            echo "::warning::Approvals API call failed: $(<"$err"); falling back to github.actor=${GITHUB_ACTOR}"
+            echo "::warning::Approvals API call failed (see step log); falling back to github.actor=${GITHUB_ACTOR}"
+            cat "$err" >&2
             approver=
           fi
           echo "login=${approver:-$GITHUB_ACTOR}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,17 +254,118 @@ jobs:
             git diff --color=always --no-index tarballs/$NORMALIZED_NAME/latest/package/package.json tarballs/$NORMALIZED_NAME/proposed/package/package.json || true
           done
 
+  notify-deploy:
+    name: Notify pre-deploy to Slack
+    needs: [pack, review]
+    if: needs.pack.outputs.hasPackages == 'true'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify pre-deploy
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Deployment review requested by ${{ github.actor }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Deployment review requested by ${{ github.actor }}*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}> / Publish packages"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "`npm-publish` waiting for review"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ github.repository }}"
+                    }
+                  ]
+                }
+              ]
+            }
+
   publish:
     name: Publish packages
-    needs: review
+    needs: [review, notify-deploy]
     if: needs.pack.outputs.hasPackages == 'true'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
-      actions: read # To download the tarball to publish
+      actions: read # To download the tarball to publish, and to read approvals for the deployment-approved notification
       id-token: write # Needed for npm Trusted Publishing (OIDC)
     steps:
+      - name: Get approver
+        id: approver
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          approver=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/approvals" --jq '.[0].user.login // empty' 2>/dev/null || true)
+          echo "login=${approver:-${{ github.actor }}}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify deployment approved
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "Deployment review approved by ${{ steps.approver.outputs.login }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Deployment review approved by ${{ steps.approver.outputs.login }}*\n:rocket: Publishing packages now"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Publish packages • `npm-publish`"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ github.repository }}"
+                    }
+                  ]
+                }
+              ]
+            }
+
       - name: Download pnpm list json
         uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,8 +320,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          approver=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/approvals" --jq '.[0].user.login // empty' 2>/dev/null || true)
-          echo "login=${approver:-${{ github.actor }}}" >> "$GITHUB_OUTPUT"
+          approver=$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" --jq '.[0].user.login // empty' 2>/dev/null || true)
+          echo "login=${approver:-$GITHUB_ACTOR}" >> "$GITHUB_OUTPUT"
 
       - name: Notify deployment approved
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  pull_request: # TEMP: for testing the Slack notification job below; revert before merge
 
 defaults:
   run:
@@ -13,6 +14,7 @@ defaults:
 jobs:
   pr:
     name: Conditionally create a release PR
+    if: github.event_name != 'pull_request' # TEMP: prevent release pipeline from firing on PR test trigger
     timeout-minutes: 60
     runs-on: ubuntu-latest
     outputs:
@@ -446,3 +448,106 @@ jobs:
           # by the `gh` command line tool internally
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/github-release/create-releases.ts
+
+  # TEMP: fires both Slack notifications on PR push so we can verify the webhook end-to-end. Revert before merge.
+  test-slack-notifications:
+    name: TEST Slack notifications
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # for the approvals API call (will return empty on PR; tests fallback to github.actor)
+    steps:
+      - name: Notify pre-deploy
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "TESTTESTTEST Deployment review requested by ${{ github.actor }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*TESTTESTTEST Deployment review requested by ${{ github.actor }}*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}> / Publish packages"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "`npm-publish` waiting for review"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ github.repository }}"
+                    }
+                  ]
+                }
+              ]
+            }
+
+      - name: Get approver
+        id: approver
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          approver=$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" --jq '.[0].user.login // empty' 2>/dev/null || true)
+          echo "login=${approver:-$GITHUB_ACTOR}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify deployment approved
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "TESTTESTTEST Deployment review approved by ${{ steps.approver.outputs.login }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*TESTTESTTEST Deployment review approved by ${{ steps.approver.outputs.login }}*\n:rocket: Publishing packages now"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Publish packages • `npm-publish`"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ github.repository }}"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,7 @@ jobs:
     steps:
       - name: Notify pre-deploy
         continue-on-error: true
+        timeout-minutes: 1
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
@@ -335,6 +336,7 @@ jobs:
 
       - name: Notify deployment approved
         continue-on-error: true
+        timeout-minutes: 1
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request: # TEMP: for testing the Slack notification job below; revert before merge
 
 defaults:
   run:
@@ -14,7 +13,6 @@ defaults:
 jobs:
   pr:
     name: Conditionally create a release PR
-    if: github.event_name != 'pull_request' # TEMP: prevent release pipeline from firing on PR test trigger
     timeout-minutes: 60
     runs-on: ubuntu-latest
     outputs:
@@ -448,106 +446,3 @@ jobs:
           # by the `gh` command line tool internally
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/github-release/create-releases.ts
-
-  # TEMP: fires both Slack notifications on PR push so we can verify the webhook end-to-end. Revert before merge.
-  test-slack-notifications:
-    name: TEST Slack notifications
-    if: github.event_name == 'pull_request'
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read # for the approvals API call (will return empty on PR; tests fallback to github.actor)
-    steps:
-      - name: Notify pre-deploy
-        continue-on-error: true
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        with:
-          webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "TESTTESTTEST Deployment review requested by ${{ github.actor }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*TESTTESTTEST Deployment review requested by ${{ github.actor }}*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}> / Publish packages"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "`npm-publish` waiting for review"
-                  }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "${{ github.repository }}"
-                    }
-                  ]
-                }
-              ]
-            }
-
-      - name: Get approver
-        id: approver
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          approver=$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" --jq '.[0].user.login // empty' 2>/dev/null || true)
-          echo "login=${approver:-$GITHUB_ACTOR}" >> "$GITHUB_OUTPUT"
-
-      - name: Notify deployment approved
-        continue-on-error: true
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        with:
-          webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "TESTTESTTEST Deployment review approved by ${{ steps.approver.outputs.login }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*TESTTESTTEST Deployment review approved by ${{ steps.approver.outputs.login }}*\n:rocket: Publishing packages now"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}>"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Publish packages • `npm-publish`"
-                  }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "${{ github.repository }}"
-                    }
-                  ]
-                }
-              ]
-            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,7 @@ jobs:
     if: needs.pack.outputs.hasPackages == 'true'
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    permissions: {} # Slack webhook only, no GitHub API calls
     steps:
       - name: Notify pre-deploy
         continue-on-error: true
@@ -306,7 +307,7 @@ jobs:
 
   publish:
     name: Publish packages
-    needs: [review, notify-deploy]
+    needs: [pack, review, notify-deploy]
     if: needs.pack.outputs.hasPackages == 'true'
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,7 +321,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          approver=$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" --jq '.[0].user.login // empty' 2>/dev/null || true)
+          err=$(mktemp)
+          if approver=$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" --jq '.[0].user.login // empty' 2>"$err"); then
+            if [[ -z "$approver" ]]; then
+              echo "::warning::Approvals API returned no approver; falling back to github.actor=${GITHUB_ACTOR}"
+            fi
+          else
+            echo "::warning::Approvals API call failed: $(<"$err"); falling back to github.actor=${GITHUB_ACTOR}"
+            approver=
+          fi
           echo "login=${approver:-$GITHUB_ACTOR}" >> "$GITHUB_OUTPUT"
 
       - name: Notify deployment approved


### PR DESCRIPTION
Replaces the GitHub-Slack integration's deployment notifications with custom workflow messages so that, when adding new deployment environments alongside `npm-publish`, we can pick which ones notify Slack rather than getting all-or-nothing from the GitHub integration.

- New `notify-deploy` job runs after `review`, gated on `pack.outputs.hasPackages == 'true'` (same condition as `publish`), so the message only fires when a release is actually about to happen.
- `publish.needs` now includes `notify-deploy` so the message lands before the env-approval gate is evaluated.
- First steps of `publish` fetch the approver via `gh api .../approvals` (with `github.actor` fallback) and post a "review approved / publishing now" message.
- Both Slack steps are `continue-on-error: true` so a Slack outage cannot block a release.
- Uses the same action pin and `PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL` secret as edr / solx for consistency.

## Testing

End-to-end validated by [c5879ce](https://github.com/NomicFoundation/hardhat/commit/c5879ce4d) using a temporary commit that fired both Slack notifications via a `pull_request` trigger so the webhook could be exercised without running the real release pipeline. Verified both messages landed in #publishing-notifications (with `TESTTESTTEST` markers); reverted in [e7d8638](https://github.com/NomicFoundation/hardhat/commit/e7d863831).