### PR TITLE
Fix tx leak in viem.assertions.emit / emitWithArgs when ABI shape check fails

### DIFF
--- a/.changeset/fix-viem-assertions-leak-tx.md
+++ b/.changeset/fix-viem-assertions-leak-tx.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+Fix `emit` and `emitWithArgs` leaking the underlying transaction into the next test when the synchronous ABI shape check failed. These helpers now always settle `contractFn` before any assertion can throw.

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
@@ -15,6 +15,8 @@ import assert from "node:assert/strict";
 
 import { parseEventLogs } from "viem";
 
+import { settle } from "../../helpers.js";
+
 export async function handleEmit<
   ContractName extends keyof ContractAbis,
   EventName extends ContractEventName<ContractAbis[ContractName]>,
@@ -25,6 +27,10 @@ export async function handleEmit<
   contract: ContractReturnType<ContractName>,
   eventName: EventName,
 ): Promise<Array<{ args?: Record<string, any> }>> {
+  // Settle `contractFn` first so the tx doesn't leak into the next test, but
+  // defer rethrowing so ABI errors still take precedence over tx reverts.
+  const contractFnResult = await settle(contractFn);
+
   const abiEvents: AbiEvent[] = contract.abi.filter(
     (item): item is AbiEvent =>
       item.type === "event" && item.name === eventName,
@@ -35,7 +41,10 @@ export async function handleEmit<
     `Event "${eventName}" not found in the contract ABI`,
   );
 
-  await contractFn;
+  if (contractFnResult.ok === false) {
+    // eslint-disable-next-line no-restricted-syntax -- propagate the original tx-revert error
+    throw contractFnResult.error;
+  }
 
   const publicClient = await viem.getPublicClient();
 

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
@@ -15,7 +15,7 @@ import assert from "node:assert/strict";
 
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 
-import { stringifyArgs } from "../../helpers.js";
+import { settle, stringifyArgs } from "../../helpers.js";
 import { isArgumentMatch } from "../../predicates.js";
 
 import { handleEmit } from "./core.js";
@@ -31,6 +31,10 @@ export async function emitWithArgs<
   eventName: EventName,
   expectedArgs: any[],
 ): Promise<void> {
+  // Settle `contractFn` first so the tx doesn't leak into the next test, but
+  // defer rethrowing so ABI errors still take precedence over tx reverts.
+  const contractFnResult = await settle(contractFn);
+
   const abiEvents: AbiEvent[] = contract.abi.filter(
     (item): item is AbiEvent =>
       item.type === "event" &&
@@ -48,9 +52,21 @@ export async function emitWithArgs<
     `There are multiple events named "${eventName}" that accepts ${expectedArgs.length} input arguments. This scenario is currently not supported.`,
   );
 
+  if (contractFnResult.ok === false) {
+    // eslint-disable-next-line no-restricted-syntax -- propagate the original tx-revert error
+    throw contractFnResult.error;
+  }
+
   const expectedAbiEvent = abiEvents[0];
 
-  const parsedLogs = await handleEmit(viem, contractFn, contract, eventName);
+  // contractFn has already been awaited above; pass an already-resolved promise
+  // so handleEmit's internal await is a no-op and we don't double-submit.
+  const parsedLogs = await handleEmit(
+    viem,
+    Promise.resolve(contractFnResult.value),
+    contract,
+    eventName,
+  );
 
   for (const { args: logArgs } of parsedLogs) {
     let emittedArgs: any[] = [];

--- a/packages/hardhat-viem-assertions/src/internal/helpers.ts
+++ b/packages/hardhat-viem-assertions/src/internal/helpers.ts
@@ -14,7 +14,7 @@ export function stringifyArgs(obj: any): string {
 export async function settle<T>(
   promise: Promise<T>,
 ): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> {
-  return promise.then(
+  return await promise.then(
     (value) => ({ ok: true, value }) as const,
     (error: unknown) => ({ ok: false, error }) as const,
   );

--- a/packages/hardhat-viem-assertions/src/internal/helpers.ts
+++ b/packages/hardhat-viem-assertions/src/internal/helpers.ts
@@ -6,3 +6,16 @@ export function stringifyArgs(obj: any): string {
     typeof value === "bigint" ? value.toString() : value,
   );
 }
+
+/**
+ * Awaits `promise` and returns a tagged result so callers can decide when to
+ * surface a rejection.
+ */
+export async function settle<T>(
+  promise: Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> {
+  return promise.then(
+    (value) => ({ ok: true, value }) as const,
+    (error: unknown) => ({ ok: false, error }) as const,
+  );
+}

--- a/packages/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Events.sol
+++ b/packages/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Events.sol
@@ -24,6 +24,10 @@ contract Events {
 
   function doNotEmit() public {}
 
+  function reverts() public {
+    revert("Intentional revert for testing purposes");
+  }
+
   function emitWithoutArgs() public {
     emit WithoutArgs();
   }

--- a/packages/hardhat-viem-assertions/test/helpers/error-includes-test-file.ts
+++ b/packages/hardhat-viem-assertions/test/helpers/error-includes-test-file.ts
@@ -1,0 +1,27 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
+
+const projectRootPath = path.normalize(
+  path.join(fileURLToPath(import.meta.url), "../../../"),
+);
+
+export function errorIncludesTestFile(
+  error: unknown,
+  testAbsolutePath: string,
+): boolean {
+  ensureError(error);
+  const relativeTestPath = path.relative(projectRootPath, testAbsolutePath);
+
+  let cause: any = error;
+  while (cause !== undefined) {
+    if (cause.stack.includes(relativeTestPath) === true) {
+      return true;
+    }
+
+    cause = cause.cause;
+  }
+
+  return false;
+}

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
@@ -2,6 +2,7 @@ import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
 import type { EthereumProvider } from "hardhat/types/providers";
 
+import assert from "node:assert/strict";
 import { before, beforeEach, describe, it } from "node:test";
 
 import {
@@ -377,6 +378,89 @@ describe("emitWithArgs", () => {
             'Expected: ["1","<predicate>"]',
             'Emitted: ["1","2"]',
           ].every((msg) => error.message.includes(msg)),
+      );
+    });
+  });
+
+  describe("contractFn promise lifecycle", () => {
+    it("awaits contractFn before throwing on argument count mismatch", async () => {
+      const contract = await viem.deployContract("Events");
+
+      const writePromise = contract.write.emitInt([1n]);
+      let writeSettled = false;
+      writePromise.then(
+        () => {
+          writeSettled = true;
+        },
+        () => {
+          writeSettled = true;
+        },
+      );
+
+      await assertRejects(
+        viem.assertions.emitWithArgs(
+          writePromise,
+          contract,
+          "WithIntArg",
+          // WithIntArg has 1 input, intentionally pass 2 to trigger the
+          // synchronous ABI shape check.
+          [1n, 2n],
+        ),
+        (error) =>
+          isExpectedError(
+            error,
+            `Event "WithIntArg" with argument count 2 not found in the contract ABI`,
+            false,
+            true,
+          ),
+      );
+
+      assert.equal(
+        writeSettled,
+        true,
+        "emitWithArgs must await contractFn before throwing on argument count mismatch, otherwise the tx leaks into the next test",
+      );
+    });
+
+    it("awaits contractFn before throwing on ambiguous overloaded event", async () => {
+      const contract = await viem.deployContract("Events");
+
+      const writePromise = contract.write.emitSameEventDifferentArgs2([
+        1n,
+        "x",
+      ]);
+      let writeSettled = false;
+      writePromise.then(
+        () => {
+          writeSettled = true;
+        },
+        () => {
+          writeSettled = true;
+        },
+      );
+
+      await assertRejects(
+        viem.assertions.emitWithArgs(
+          writePromise,
+          contract,
+          "SameEventDifferentArgs",
+          // Two overloads of SameEventDifferentArgs accept 2 inputs, so this
+          // hits the "multiple events ... not supported" synchronous check.
+          [1n, 2n],
+        ),
+        (error) =>
+          isExpectedError(
+            error,
+            `There are multiple events named "SameEventDifferentArgs" that accepts 2 input arguments. This scenario is currently not supported.`,
+            false,
+            true,
+          ),
+      );
+
+      assert.equal(
+        writeSettled,
+        true,
+        "emitWithArgs must await contractFn before throwing on ambiguous overloaded events",
       );
     });
   });

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
@@ -14,6 +14,7 @@ import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 
 import hardhatViemAssertions from "../../../../src/index.js";
 import { anyValue } from "../../../../src/internal/predicates.js";
+import { errorIncludesTestFile } from "../../../helpers/error-includes-test-file.js";
 import { isExpectedError } from "../../../helpers/is-expected-error.js";
 
 describe("emitWithArgs", () => {
@@ -461,6 +462,55 @@ describe("emitWithArgs", () => {
         writeSettled,
         true,
         "emitWithArgs must await contractFn before throwing on ambiguous overloaded events",
+      );
+    });
+
+    it("should keep the stack frame of the test when throwing due to a reversion", async () => {
+      const contract = await viem.deployContract("Events");
+
+      const writePromise = contract.write.reverts();
+
+      try {
+        await viem.assertions.emitWithArgs(
+          writePromise,
+          contract,
+          "CustomErrorWithInt",
+          [1n],
+        );
+      } catch (error) {
+        assert.equal(
+          errorIncludesTestFile(error, import.meta.filename),
+          true,
+          "emitWithArgs must keep the stack frame of the test",
+        );
+
+        return;
+      }
+    });
+
+    it("should keep the stack frame of the test when throwing due to an ABI mismatch", async () => {
+      const contract = await viem.deployContract("Events");
+
+      const writePromise = contract.write.reverts();
+
+      try {
+        await viem.assertions.emitWithArgs(
+          writePromise,
+          contract,
+          "NonExistingEvent",
+          [1n],
+        );
+      } catch (error) {
+        assert.equal(
+          errorIncludesTestFile(error, import.meta.filename),
+          true,
+          "emitWithArgs must keep the stack frame of the test",
+        );
+        return;
+      }
+
+      assert.fail(
+        "emitWithArgs should have thrown due to the event not existing in the ABI",
       );
     });
   });

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
@@ -12,6 +12,7 @@ import hardhatViem from "@nomicfoundation/hardhat-viem";
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 
 import hardhatViemAssertions from "../../../../src/index.js";
+import { errorIncludesTestFile } from "../../../helpers/error-includes-test-file.js";
 import { isExpectedError } from "../../../helpers/is-expected-error.js";
 
 describe("emit", () => {
@@ -125,6 +126,48 @@ describe("emit", () => {
       writeSettled,
       true,
       "emit must await contractFn before throwing when the event is not in the ABI, otherwise the tx leaks into the next test",
+    );
+  });
+
+  it("should keep the stack frame of the test when throwing due to a reversion", async () => {
+    const contract = await viem.deployContract("Events");
+
+    const writePromise = contract.write.reverts();
+
+    try {
+      await viem.assertions.emit(writePromise, contract, "WithoutArgs");
+    } catch (error) {
+      assert.equal(
+        errorIncludesTestFile(error, import.meta.filename),
+        true,
+        "emit must keep the stack frame of the test",
+      );
+      return;
+    }
+
+    assert.fail(
+      "emit should have thrown due to the transaction reverting, but it did not",
+    );
+  });
+
+  it("should keep the stack frame of the test when throwing due to an ABI mismatch", async () => {
+    const contract = await viem.deployContract("Events");
+
+    const writePromise = contract.write.reverts();
+
+    try {
+      await viem.assertions.emit(writePromise, contract, "NonExistingEvent");
+    } catch (error) {
+      assert.equal(
+        errorIncludesTestFile(error, import.meta.filename),
+        true,
+        "emit must keep the stack frame of the test",
+      );
+      return;
+    }
+
+    assert.fail(
+      "emit should have thrown due to the event not existing in the ABI",
     );
   });
 });

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
@@ -1,6 +1,7 @@
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
 
+import assert from "node:assert/strict";
 import { before, beforeEach, describe, it } from "node:test";
 
 import {
@@ -92,6 +93,38 @@ describe("emit", () => {
           false,
           true,
         ),
+    );
+  });
+
+  it("awaits contractFn before throwing on missing event name", async () => {
+    const contract = await viem.deployContract("Events");
+
+    const writePromise = contract.write.doNotEmit();
+    let writeSettled = false;
+    writePromise.then(
+      () => {
+        writeSettled = true;
+      },
+      () => {
+        writeSettled = true;
+      },
+    );
+
+    await assertRejects(
+      viem.assertions.emit(writePromise, contract, "NotExists"),
+      (error) =>
+        isExpectedError(
+          error,
+          `Event "NotExists" not found in the contract ABI`,
+          false,
+          true,
+        ),
+    );
+
+    assert.equal(
+      writeSettled,
+      true,
+      "emit must await contractFn before throwing when the event is not in the ABI, otherwise the tx leaks into the next test",
     );
   });
 });


### PR DESCRIPTION
Both helpers run synchronous `assert.ok` checks against the contract ABI before awaiting `contractFn`. Since viem submits the write as soon as the promise is created, when one of these checks fails (wrong arg count, missing event, ambiguous overload) the in-flight tx is left dangling and ends up mining inside the next test, which has been a fairly nasty source of cross-test state bleed.

This settles `contractFn` first via a small `settle()` helper and only rethrows its rejection after the ABI checks pass, so the existing precedence (ABI errors over tx reverts) stays the same.

The other assertion helpers all await their promise as the first thing inside a `try`, so they aren't affected.

Adds three regression tests that pin the contract promise lifetime down by attaching a settlement flag and asserting it's true after the assertion error escapes — they fail on `v-next` without the source change and pass with it.