### PR TITLE
feat(hardhat): expose fuzz.showLogs in the Solidity test user config

### DIFF
--- a/.changeset/clever-foxes-whisper.md
+++ b/.changeset/clever-foxes-whisper.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add a `fuzz.showLogs` option to the Solidity test config to display `console.log` output from fuzz tests.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -61,6 +61,7 @@ const solidityTestUserConfigType = z.object({
       dictionaryWeight: z.number().optional(),
       includeStorage: z.boolean().optional(),
       includePushBytes: z.boolean().optional(),
+      showLogs: z.boolean().optional(),
     })
     .optional(),
   forking: z

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -24,6 +24,7 @@ declare module "../../../types/test.js" {
     dictionaryWeight?: number;
     includeStorage?: boolean;
     includePushBytes?: boolean;
+    showLogs?: boolean;
   }
 
   export interface SolidityTestFuzzConfig extends SolidityTestFuzzConfigBase {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
@@ -39,12 +39,14 @@ describe("config resolution", () => {
         runs: 500,
         maxTestRejects: 100,
         dictionaryWeight: 50,
+        showLogs: true,
       });
 
       assert.ok(result !== undefined, "result is undefined");
       assert.equal(result.runs, 500);
       assert.equal(result.maxTestRejects, 100);
       assert.equal(result.dictionaryWeight, 50);
+      assert.equal(result.showLogs, true);
       assert.equal(result.seed, DEFAULT_FUZZ_SEED);
     });
   });


### PR DESCRIPTION
EDR 0.12.0-next.30 added `showLogs` to the global fuzz config but Hardhat didn't expose it at the user-config level. This adds `showLogs?: boolean` to the `SolidityTestUserConfig`.
