### PR TITLE
feat(hardhat): support isolate and evmVersion in test inline config

### DIFF
--- a/.changeset/quiet-otters-vanish.md
+++ b/.changeset/quiet-otters-vanish.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add `isolate` and `evmVersion` to the Solidity test inline configuration.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/constants.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/constants.ts
@@ -1,8 +1,10 @@
 export const HARDHAT_CONFIG_PREFIX = "hardhat-config:";
 export const FORGE_CONFIG_PREFIX = "forge-config:";
 
-/** All supported inline config keys and their expected value types. */
-export const KEY_TYPES: Record<string, "number" | "boolean"> = {
+/**
+ * All supported inline config keys and their expected value types.
+ */
+export const KEY_TYPES: Record<string, "number" | "boolean" | "string"> = {
   "fuzz.runs": "number",
   "fuzz.maxTestRejects": "number",
   "fuzz.showLogs": "boolean",
@@ -13,6 +15,8 @@ export const KEY_TYPES: Record<string, "number" | "boolean"> = {
   "invariant.callOverride": "boolean",
   "invariant.timeout": "number",
   allowInternalExpectRevert: "boolean",
+  isolate: "boolean",
+  evmVersion: "string",
 };
 
 /** Top-level key categories (e.g. "fuzz", "invariant", "allowInternalExpectRevert"). */

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/helpers.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/helpers.ts
@@ -1,6 +1,7 @@
 import type { RawInlineOverride } from "./types.js";
 import type { TestFunctionConfigOverride } from "@nomicfoundation/edr";
 
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 import { bytesIncludesUtf8String } from "@nomicfoundation/hardhat-utils/bytes";
 
 import { getFullyQualifiedName } from "../../../../utils/contract-names.js";
@@ -57,10 +58,20 @@ export function buildConfigOverride(
 
   for (const override of overrides) {
     const expectedType = KEY_TYPES[override.key];
-    const parsed =
-      expectedType === "number"
-        ? Number(override.rawValue)
-        : override.rawValue.toLowerCase() === "true";
+    let parsed: number | boolean | string;
+    if (expectedType === "number") {
+      parsed = Number(override.rawValue);
+    } else if (expectedType === "boolean") {
+      parsed = override.rawValue.toLowerCase() === "true";
+    } else if (expectedType === "string") {
+      // Validation has already proven the surrounding double quotes.
+      parsed = override.rawValue.slice(1, -1);
+    } else {
+      assertHardhatInvariant(
+        false,
+        `Unhandled inline config value type for key ${override.key}`,
+      );
+    }
 
     const dotIndex = override.key.indexOf(".");
     if (dotIndex === -1) {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/validation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/validation.ts
@@ -1,6 +1,9 @@
 import type { RawInlineOverride } from "./types.js";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import {
+  HardhatError,
+  assertHardhatInvariant,
+} from "@nomicfoundation/hardhat-errors";
 
 import { KEY_TYPES } from "./constants.js";
 import { getFunctionFqn } from "./helpers.js";
@@ -9,8 +12,9 @@ import { getFunctionFqn } from "./helpers.js";
  * Validates a list of raw inline overrides, checking for:
  * - Valid keys
  * - No duplicate keys for the same function
- * - Values of the expected type (numbers must be non-negative integers, booleans
- *   must be "true" or "false")
+ * - Values of the expected type (numbers must be non-negative integers,
+ *   booleans must be "true" or "false", strings must be a non-empty
+ *   double-quoted literal)
  *
  * Throws a HardhatError if any validation fails.
  */
@@ -104,7 +108,7 @@ export function validateInlineOverrides(overrides: RawInlineOverride[]): void {
           },
         );
       }
-    } else {
+    } else if (expectedType === "boolean") {
       const lowerValue = rawValue.toLowerCase();
       if (lowerValue !== "true" && lowerValue !== "false") {
         throw new HardhatError(
@@ -117,6 +121,23 @@ export function validateInlineOverrides(overrides: RawInlineOverride[]): void {
           },
         );
       }
+    } else if (expectedType === "string") {
+      if (!/^"[^"\n]+"$/.test(rawValue)) {
+        throw new HardhatError(
+          HardhatError.ERRORS.CORE.SOLIDITY_TESTS.INLINE_CONFIG_INVALID_VALUE,
+          {
+            value: rawValue,
+            key: rawKey,
+            expectedType: "non-empty double-quoted string",
+            functionFqn,
+          },
+        );
+      }
+    } else {
+      assertHardhatInvariant(
+        false,
+        `Unhandled inline config value type for key ${key}`,
+      );
     }
   }
 }

--- a/packages/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -9,6 +9,7 @@ import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { after, before, beforeEach, describe, it } from "node:test";
+import { stripVTControlCharacters } from "node:util";
 
 import {
   disableConsole,
@@ -301,37 +302,28 @@ describe("CoverageManagerImplementation", () => {
   });
 
   it("should format the markdown report", async () => {
-    const originalNoColor = process.env.NO_COLOR;
-    process.env.NO_COLOR = "1";
+    const actual = stripVTControlCharacters(
+      coverageManager.formatMarkdownReport(report),
+    );
 
-    try {
-      const actual = coverageManager.formatMarkdownReport(report);
-
-      assert.equal(
-        actual,
-        [
-          "╔══════════════════════════════════════════════════════════════╗",
-          "║                       Coverage Report                        ║",
-          "╚══════════════════════════════════════════════════════════════╝",
-          "╔══════════════════════════════════════════════════════════════╗",
-          "║ File Coverage                                                ║",
-          "╟─────────────────────┬────────┬─────────────┬─────────────────╢",
-          "║ File Path           │ Line % │ Statement % │ Uncovered Lines ║",
-          "╟─────────────────────┼────────┼─────────────┼─────────────────╢",
-          "║ contracts/test.sol  │ 80.00  │ 75.00       │ 6               ║",
-          "║ contracts/other.sol │ 0.00   │ 0.00        │ 1-2             ║",
-          "╟─────────────────────┼────────┼─────────────┼─────────────────╢",
-          "║ Total               │ 57.14  │ 50.00       │                 ║",
-          "╚═════════════════════╧════════╧═════════════╧═════════════════╝",
-        ].join("\n"),
-      );
-    } finally {
-      if (originalNoColor === undefined) {
-        delete process.env.NO_COLOR;
-      } else {
-        process.env.NO_COLOR = originalNoColor;
-      }
-    }
+    assert.equal(
+      actual,
+      [
+        "╔══════════════════════════════════════════════════════════════╗",
+        "║                       Coverage Report                        ║",
+        "╚══════════════════════════════════════════════════════════════╝",
+        "╔══════════════════════════════════════════════════════════════╗",
+        "║ File Coverage                                                ║",
+        "╟─────────────────────┬────────┬─────────────┬─────────────────╢",
+        "║ File Path           │ Line % │ Statement % │ Uncovered Lines ║",
+        "╟─────────────────────┼────────┼─────────────┼─────────────────╢",
+        "║ contracts/test.sol  │ 80.00  │ 75.00       │ 6               ║",
+        "║ contracts/other.sol │ 0.00   │ 0.00        │ 1-2             ║",
+        "╟─────────────────────┼────────┼─────────────┼─────────────────╢",
+        "║ Total               │ 57.14  │ 50.00       │                 ║",
+        "╚═════════════════════╧════════╧═════════════╧═════════════════╝",
+      ].join("\n"),
+    );
   });
 
   const expectedRelativePath: Array<[string, string]> = [

--- a/packages/hardhat/test/internal/builtin-plugins/node/json-rpc/server.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/node/json-rpc/server.ts
@@ -18,17 +18,16 @@ describe("JSON-RPC server", function () {
 
   it("should respond to a request over the network the same as in memory", async function () {
     const hostname = (await exists("/.dockerenv")) ? "0.0.0.0" : "127.0.0.1";
-    const port = 8545;
 
     const connection = await hre.network.create();
     const server = new JsonRpcServerImplementation({
       hostname,
-      port,
+      port: 0,
       provider: connection.provider,
     });
 
     try {
-      await server.listen();
+      const { port } = await server.listen();
 
       const edrProvider = connection.provider;
       const httpProvider = await HttpProvider.create({

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/helpers.ts
@@ -115,5 +115,14 @@ describe("inline-config - helpers", () => {
         { fuzz: { showLogs: false } },
       );
     });
+
+    it("should strip surrounding double quotes from string values", () => {
+      assert.deepEqual(
+        buildConfigOverride([
+          makeRawOverride({ key: "evmVersion", rawValue: '"cancun"' }),
+        ]),
+        { evmVersion: "cancun" },
+      );
+    });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/validation.ts
@@ -56,7 +56,7 @@ describe("inline-config - validation", () => {
           key: "fuzz.nonexistent",
           functionFqn: getFunctionFqn("test/MyTest.sol", "MyTest", "testFoo"),
           validKeys:
-            "fuzz.runs, fuzz.maxTestRejects, fuzz.showLogs, fuzz.timeout, invariant.runs, invariant.depth, invariant.failOnRevert, invariant.callOverride, invariant.timeout, allowInternalExpectRevert",
+            "fuzz.runs, fuzz.maxTestRejects, fuzz.showLogs, fuzz.timeout, invariant.runs, invariant.depth, invariant.failOnRevert, invariant.callOverride, invariant.timeout, allowInternalExpectRevert, isolate, evmVersion",
         },
       );
     });
@@ -236,7 +236,7 @@ describe("inline-config - validation", () => {
           key: "invariant.runs",
           testType: "fuzz",
           validKeys:
-            "fuzz.runs, fuzz.maxTestRejects, fuzz.showLogs, fuzz.timeout, allowInternalExpectRevert",
+            "fuzz.runs, fuzz.maxTestRejects, fuzz.showLogs, fuzz.timeout, allowInternalExpectRevert, isolate, evmVersion",
           functionFqn: getFunctionFqn("test/MyTest.sol", "MyTest", "testFoo"),
         },
       );
@@ -258,7 +258,7 @@ describe("inline-config - validation", () => {
           key: "fuzz.runs",
           testType: "invariant",
           validKeys:
-            "invariant.runs, invariant.depth, invariant.failOnRevert, invariant.callOverride, invariant.timeout, allowInternalExpectRevert",
+            "invariant.runs, invariant.depth, invariant.failOnRevert, invariant.callOverride, invariant.timeout, allowInternalExpectRevert, isolate, evmVersion",
           functionFqn: getFunctionFqn(
             "test/MyTest.sol",
             "MyTest",
@@ -295,6 +295,60 @@ describe("inline-config - validation", () => {
           rawValue: "10",
         }),
       ]);
+    });
+
+    it("should accept double-quoted string values", () => {
+      validateInlineOverrides([
+        makeRawOverride({ key: "evmVersion", rawValue: '"cancun"' }),
+      ]);
+    });
+
+    it("should throw INVALID_VALUE for unquoted string", () => {
+      assertThrowsHardhatError(
+        () =>
+          validateInlineOverrides([
+            makeRawOverride({ key: "evmVersion", rawValue: "cancun" }),
+          ]),
+        HardhatError.ERRORS.CORE.SOLIDITY_TESTS.INLINE_CONFIG_INVALID_VALUE,
+        {
+          value: "cancun",
+          key: "evmVersion",
+          expectedType: "non-empty double-quoted string",
+          functionFqn: getFunctionFqn("test/MyTest.sol", "MyTest", "testFoo"),
+        },
+      );
+    });
+
+    it("should throw INVALID_VALUE for single-quoted string", () => {
+      assertThrowsHardhatError(
+        () =>
+          validateInlineOverrides([
+            makeRawOverride({ key: "evmVersion", rawValue: "'cancun'" }),
+          ]),
+        HardhatError.ERRORS.CORE.SOLIDITY_TESTS.INLINE_CONFIG_INVALID_VALUE,
+        {
+          value: "'cancun'",
+          key: "evmVersion",
+          expectedType: "non-empty double-quoted string",
+          functionFqn: getFunctionFqn("test/MyTest.sol", "MyTest", "testFoo"),
+        },
+      );
+    });
+
+    it("should throw INVALID_VALUE for empty quoted string", () => {
+      assertThrowsHardhatError(
+        () =>
+          validateInlineOverrides([
+            makeRawOverride({ key: "evmVersion", rawValue: '""' }),
+          ]),
+        HardhatError.ERRORS.CORE.SOLIDITY_TESTS.INLINE_CONFIG_INVALID_VALUE,
+        {
+          value: '""',
+          key: "evmVersion",
+          expectedType: "non-empty double-quoted string",
+          functionFqn: getFunctionFqn("test/MyTest.sol", "MyTest", "testFoo"),
+        },
+      );
     });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
@@ -4,6 +4,9 @@ import type { HardhatPlugin } from "../../../../src/types/plugins.js";
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 
+import { getTmpDir } from "@nomicfoundation/hardhat-test-utils";
+import { remove } from "@nomicfoundation/hardhat-utils/fs";
+
 import { overrideTask, task } from "../../../../src/config.js";
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
 import { getGasAnalyticsManager } from "../../../../src/internal/builtin-plugins/gas-analytics/helpers/accessors.js";
@@ -360,6 +363,11 @@ describe("test/task-action", function () {
     it("should not include stale data from a skipped runner in the gas stats report", async (t) => {
       const consoleMock = t.mock.method(console, "log", () => {});
 
+      const cacheDir = await getTmpDir("gas-stats");
+      t.after(async () => {
+        await remove(cacheDir);
+      });
+
       // Plugin that maps "runner-a-test.ts" → "runner-a", leaving "runner-b" unregistered
       const fileMapperPlugin: HardhatPlugin = {
         id: "test-file-mapper",
@@ -383,6 +391,7 @@ describe("test/task-action", function () {
             mockRunner("runner-a", () => undefined),
             mockRunner("runner-b", () => undefined),
           ],
+          paths: { cache: cacheDir },
         },
         { gasStats: true },
       );


### PR DESCRIPTION
Add `isolate` and `evmVersion` as top-level keys in the Solidity test inline configuration. String values must be double-quoted to match Foundry's `forge-config:` syntax.
Also fixes three flaky tests that were causing issues in local environments.

Docs: https://github.com/NomicFoundation/hardhat-website/pull/258