### PR TITLE
feat: add per-cheatcode suggestions for unsupported cheatcodes

### DIFF
--- a/.changeset/cheatcode-suggestions.md
+++ b/.changeset/cheatcode-suggestions.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Explain the unsupported cheatcode `eip712HashType(string,string)` and point to the documentation for the alternative instead.

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -28,19 +28,8 @@ const CHEATCODE_SUGGESTIONS: Record<string, string> = {
 
 export function getCheatcodeSuggestion(cheatcode: string): string {
   const suggestion = CHEATCODE_SUGGESTIONS[cheatcode];
-  if (suggestion !== undefined) {
-    return suggestion;
-  }
 
-  // Match by function name prefix for overloaded variants
-  const name = cheatcode.split("(")[0];
-  for (const [key, value] of Object.entries(CHEATCODE_SUGGESTIONS)) {
-    if (key.startsWith(name + "(")) {
-      return value;
-    }
-  }
-
-  return "";
+  return suggestion ?? "";
 }
 
 export function createSolidityErrorWithStackTrace(

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -29,7 +29,7 @@ interface CheatcodeSuggestion {
 const CHEATCODE_SUGGESTIONS: Record<string, CheatcodeSuggestion> = {
   "eip712HashType(string,string)": {
     message:
-      "Please use the 'eip712HashType(string)' cheatcode instead, which accepts a type definition directly.",
+      "Providing a path to a bindings file is not supported, please use the eip712HashType(string calldata typeNameOrDefinition) cheatcode instead.",
     docsUrl:
       "https://hardhat.org/docs/reference/cheatcodes/utilities/eip712-hash-type",
   },

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -21,15 +21,30 @@ import {
   UNRECOGNIZED_FUNCTION_NAME,
 } from "./solidity-stack-trace.js";
 
-const CHEATCODE_SUGGESTIONS: Record<string, string> = {
-  "eip712HashType(string,string)":
-    "Please use the 'eip712HashType(string)' cheatcode instead, which accepts a type definition directly.",
+interface CheatcodeSuggestion {
+  message: string;
+  docsUrl?: string;
+}
+
+const CHEATCODE_SUGGESTIONS: Record<string, CheatcodeSuggestion> = {
+  "eip712HashType(string,string)": {
+    message:
+      "Please use the 'eip712HashType(string)' cheatcode instead, which accepts a type definition directly.",
+    docsUrl:
+      "https://hardhat.org/docs/reference/cheatcodes/utilities/eip712-hash-type",
+  },
 };
 
 export function getCheatcodeSuggestion(cheatcode: string): string {
   const suggestion = CHEATCODE_SUGGESTIONS[cheatcode];
 
-  return suggestion ?? "";
+  if (suggestion === undefined) {
+    return "";
+  }
+
+  return suggestion.docsUrl !== undefined
+    ? `${suggestion.message} See ${suggestion.docsUrl} for more information.`
+    : suggestion.message;
 }
 
 export function createSolidityErrorWithStackTrace(

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -23,7 +23,7 @@ import {
 
 const CHEATCODE_SUGGESTIONS: Record<string, string> = {
   "eip712HashType(string,string)":
-    " Please use the 'eip712HashType(string)' cheatcode instead, which accepts a type definition directly.",
+    "Please use the 'eip712HashType(string)' cheatcode instead, which accepts a type definition directly.",
 };
 
 export function getCheatcodeSuggestion(cheatcode: string): string {
@@ -288,9 +288,13 @@ function getMessageFromLastStackTraceEntry(
         switch (stackTraceEntry.details.code) {
           case CheatcodeErrorCode.UnsupportedCheatcode:
             message = `Cheatcode '${stackTraceEntry.details.cheatcode}' is not supported by Hardhat.`;
-            message += getCheatcodeSuggestion(
+
+            const suggestion = getCheatcodeSuggestion(
               stackTraceEntry.details.cheatcode,
             );
+
+            message += suggestion.length > 0 ? " " + suggestion : "";
+
             break;
           case CheatcodeErrorCode.MissingCheatcode:
             message = `Cheatcode '${stackTraceEntry.details.cheatcode}' is not yet available in this version of Hardhat.`;

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -21,6 +21,28 @@ import {
   UNRECOGNIZED_FUNCTION_NAME,
 } from "./solidity-stack-trace.js";
 
+const CHEATCODE_SUGGESTIONS: Record<string, string> = {
+  "eip712HashType(string,string)":
+    " Please use the 'eip712HashType(string)' cheatcode instead, which accepts a type definition directly.",
+};
+
+export function getCheatcodeSuggestion(cheatcode: string): string {
+  const suggestion = CHEATCODE_SUGGESTIONS[cheatcode];
+  if (suggestion !== undefined) {
+    return suggestion;
+  }
+
+  // Match by function name prefix for overloaded variants
+  const name = cheatcode.split("(")[0];
+  for (const [key, value] of Object.entries(CHEATCODE_SUGGESTIONS)) {
+    if (key.startsWith(name + "(")) {
+      return value;
+    }
+  }
+
+  return "";
+}
+
 export function createSolidityErrorWithStackTrace(
   fallbackMessage: string,
   stackTrace: SolidityStackTrace,
@@ -277,6 +299,9 @@ function getMessageFromLastStackTraceEntry(
         switch (stackTraceEntry.details.code) {
           case CheatcodeErrorCode.UnsupportedCheatcode:
             message = `Cheatcode '${stackTraceEntry.details.cheatcode}' is not supported by Hardhat.`;
+            message += getCheatcodeSuggestion(
+              stackTraceEntry.details.cheatcode,
+            );
             break;
           case CheatcodeErrorCode.MissingCheatcode:
             message = `Cheatcode '${stackTraceEntry.details.cheatcode}' is not yet available in this version of Hardhat.`;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
@@ -6,7 +6,6 @@ import {
   StackTraceEntryType,
   CheatcodeErrorCode,
 } from "../network-manager/edr/stack-traces/solidity-stack-trace.js";
-
 import { getCheatcodeSuggestion } from "../network-manager/edr/stack-traces/stack-trace-solidity-errors.js";
 
 export function getMessageFromLastStackTraceEntry(
@@ -73,7 +72,11 @@ export function getMessageFromLastStackTraceEntry(
       if (stackTraceEntry.details !== undefined) {
         switch (stackTraceEntry.details.code) {
           case CheatcodeErrorCode.UnsupportedCheatcode:
-            return `Cheatcode '${stackTraceEntry.details.cheatcode}' is not supported by Hardhat.${getCheatcodeSuggestion(stackTraceEntry.details.cheatcode)}`;
+            const suggestion = getCheatcodeSuggestion(
+              stackTraceEntry.details.cheatcode,
+            );
+
+            return `Cheatcode '${stackTraceEntry.details.cheatcode}' is not supported by Hardhat.${suggestion.length > 0 ? " " + suggestion : ""}`;
           case CheatcodeErrorCode.MissingCheatcode:
             return `Cheatcode '${stackTraceEntry.details.cheatcode}' is not yet available in this version of Hardhat.`;
         }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
@@ -7,6 +7,8 @@ import {
   CheatcodeErrorCode,
 } from "../network-manager/edr/stack-traces/solidity-stack-trace.js";
 
+import { getCheatcodeSuggestion } from "../network-manager/edr/stack-traces/stack-trace-solidity-errors.js";
+
 export function getMessageFromLastStackTraceEntry(
   stackTraceEntry: SolidityStackTraceEntry,
 ): string | undefined {
@@ -71,7 +73,7 @@ export function getMessageFromLastStackTraceEntry(
       if (stackTraceEntry.details !== undefined) {
         switch (stackTraceEntry.details.code) {
           case CheatcodeErrorCode.UnsupportedCheatcode:
-            return `Cheatcode '${stackTraceEntry.details.cheatcode}' is not supported by Hardhat.`;
+            return `Cheatcode '${stackTraceEntry.details.cheatcode}' is not supported by Hardhat.${getCheatcodeSuggestion(stackTraceEntry.details.cheatcode)}`;
           case CheatcodeErrorCode.MissingCheatcode:
             return `Cheatcode '${stackTraceEntry.details.cheatcode}' is not yet available in this version of Hardhat.`;
         }

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -173,6 +173,10 @@ describe("getCheatcodeSuggestion", () => {
 
     assert.ok(suggestion.length > 0, "a suggestion should be returned");
     assert.match(suggestion, /eip712HashType\(string\)/);
+    assert.match(
+      suggestion,
+      /https:\/\/hardhat\.org\/docs\/reference\/cheatcodes\/utilities\/eip712-hash-type/,
+    );
   });
 
   it("returns an empty string for an unknown cheatcode", () => {

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -171,7 +171,7 @@ describe("getCheatcodeSuggestion", () => {
   it("returns a suggestion for a known cheatcode", () => {
     const suggestion = getCheatcodeSuggestion("eip712HashType(string,string)");
 
-    assert.ok(suggestion.length > 0);
+    assert.ok(suggestion.length > 0, "a suggestion should be returned");
     assert.match(suggestion, /eip712HashType\(string\)/);
   });
 

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -12,6 +12,7 @@ import {
 import {
   createSolidityErrorWithStackTrace,
   encodeStackTraceEntry,
+  getCheatcodeSuggestion,
   SolidityCallSite,
   SolidityError,
 } from "../../../../../../src/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.js";
@@ -137,6 +138,42 @@ describe("createSolidityErrorWithStackTrace", () => {
         "VM Exception while processing transaction: Cheatcode 'someNewCheatcode(uint256)' is not yet available in this version of Hardhat.",
       );
     });
+
+    it("appends a suggestion for unsupported cheatcodes with known alternatives", () => {
+      const entry: SolidityStackTraceEntry = {
+        type: StackTraceEntryType.CHEATCODE_ERROR,
+        message:
+          "cheatcode 'eip712HashType(string,string)' is not supported",
+        sourceReference: dummySourceReference,
+        details: {
+          code: CheatcodeErrorCode.UnsupportedCheatcode,
+          cheatcode: "eip712HashType(string,string)",
+        },
+      };
+
+      const error = createSolidityErrorWithStackTrace(
+        "fallback",
+        [entry],
+        "0x",
+      );
+      assert.match(
+        error.message,
+        /Please use the 'eip712HashType\(string\)' cheatcode instead/,
+      );
+    });
+  });
+});
+
+describe("getCheatcodeSuggestion", () => {
+  it("returns a suggestion for a known cheatcode", () => {
+    const suggestion = getCheatcodeSuggestion("eip712HashType(string,string)");
+    assert.ok(suggestion.length > 0);
+    assert.match(suggestion, /eip712HashType\(string\)/);
+  });
+
+  it("returns an empty string for an unknown cheatcode", () => {
+    const suggestion = getCheatcodeSuggestion("unknownCheatcode(uint256)");
+    assert.equal(suggestion, "");
   });
 
   describe("solidityStack", () => {

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -89,6 +89,7 @@ describe("createSolidityErrorWithStackTrace", () => {
         [entry],
         "0x",
       );
+
       assert.equal(
         error.message,
         "VM Exception while processing transaction: cheatcode 'broadcast(address)' is not supported",
@@ -111,6 +112,7 @@ describe("createSolidityErrorWithStackTrace", () => {
         [entry],
         "0x",
       );
+
       assert.equal(
         error.message,
         "VM Exception while processing transaction: Cheatcode 'broadcast(address)' is not supported by Hardhat.",
@@ -133,6 +135,7 @@ describe("createSolidityErrorWithStackTrace", () => {
         [entry],
         "0x",
       );
+
       assert.equal(
         error.message,
         "VM Exception while processing transaction: Cheatcode 'someNewCheatcode(uint256)' is not yet available in this version of Hardhat.",
@@ -142,8 +145,7 @@ describe("createSolidityErrorWithStackTrace", () => {
     it("appends a suggestion for unsupported cheatcodes with known alternatives", () => {
       const entry: SolidityStackTraceEntry = {
         type: StackTraceEntryType.CHEATCODE_ERROR,
-        message:
-          "cheatcode 'eip712HashType(string,string)' is not supported",
+        message: "cheatcode 'eip712HashType(string,string)' is not supported",
         sourceReference: dummySourceReference,
         details: {
           code: CheatcodeErrorCode.UnsupportedCheatcode,
@@ -156,6 +158,7 @@ describe("createSolidityErrorWithStackTrace", () => {
         [entry],
         "0x",
       );
+
       assert.match(
         error.message,
         /Please use the 'eip712HashType\(string\)' cheatcode instead/,
@@ -167,12 +170,14 @@ describe("createSolidityErrorWithStackTrace", () => {
 describe("getCheatcodeSuggestion", () => {
   it("returns a suggestion for a known cheatcode", () => {
     const suggestion = getCheatcodeSuggestion("eip712HashType(string,string)");
+
     assert.ok(suggestion.length > 0);
     assert.match(suggestion, /eip712HashType\(string\)/);
   });
 
   it("returns an empty string for an unknown cheatcode", () => {
     const suggestion = getCheatcodeSuggestion("unknownCheatcode(uint256)");
+
     assert.equal(suggestion, "");
   });
 

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/stack-traces/stack-trace-solidity-errors.ts
@@ -161,28 +161,9 @@ describe("createSolidityErrorWithStackTrace", () => {
 
       assert.match(
         error.message,
-        /Please use the 'eip712HashType\(string\)' cheatcode instead/,
+        /please use the eip712HashType\(string calldata typeNameOrDefinition\) cheatcode instead/,
       );
     });
-  });
-});
-
-describe("getCheatcodeSuggestion", () => {
-  it("returns a suggestion for a known cheatcode", () => {
-    const suggestion = getCheatcodeSuggestion("eip712HashType(string,string)");
-
-    assert.ok(suggestion.length > 0, "a suggestion should be returned");
-    assert.match(suggestion, /eip712HashType\(string\)/);
-    assert.match(
-      suggestion,
-      /https:\/\/hardhat\.org\/docs\/reference\/cheatcodes\/utilities\/eip712-hash-type/,
-    );
-  });
-
-  it("returns an empty string for an unknown cheatcode", () => {
-    const suggestion = getCheatcodeSuggestion("unknownCheatcode(uint256)");
-
-    assert.equal(suggestion, "");
   });
 
   describe("solidityStack", () => {
@@ -272,5 +253,27 @@ describe("getCheatcodeSuggestion", () => {
       );
       assert.equal(typeof error.solidityStack, "string");
     });
+  });
+});
+
+describe("getCheatcodeSuggestion", () => {
+  it("returns a suggestion for a known cheatcode", () => {
+    const suggestion = getCheatcodeSuggestion("eip712HashType(string,string)");
+
+    assert.ok(suggestion.length > 0, "a suggestion should be returned");
+    assert.match(
+      suggestion,
+      /eip712HashType\(string calldata typeNameOrDefinition\)/,
+    );
+    assert.match(
+      suggestion,
+      /https:\/\/hardhat\.org\/docs\/reference\/cheatcodes\/utilities\/eip712-hash-type/,
+    );
+  });
+
+  it("returns an empty string for an unknown cheatcode", () => {
+    const suggestion = getCheatcodeSuggestion("unknownCheatcode(uint256)");
+
+    assert.equal(suggestion, "");
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
@@ -76,7 +76,7 @@ describe("getMessageFromLastStackTraceEntry", () => {
 
       assert.equal(
         getMessageFromLastStackTraceEntry(entry),
-        "Cheatcode 'eip712HashType(string,string)' is not supported by Hardhat. Please use the 'eip712HashType(string)' cheatcode instead, which accepts a type definition directly.",
+        "Cheatcode 'eip712HashType(string,string)' is not supported by Hardhat. Please use the 'eip712HashType(string)' cheatcode instead, which accepts a type definition directly. See https://hardhat.org/docs/reference/cheatcodes/utilities/eip712-hash-type for more information.",
       );
     });
   });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
@@ -62,5 +62,22 @@ describe("getMessageFromLastStackTraceEntry", () => {
         "Cheatcode 'someNewCheatcode(uint256)' is not yet available in this version of Hardhat.",
       );
     });
+
+    it("appends a suggestion for unsupported cheatcodes with known alternatives", () => {
+      const entry: SolidityStackTraceEntry = {
+        type: StackTraceEntryType.CHEATCODE_ERROR,
+        message: "cheatcode 'eip712HashType(string,string)' is not supported",
+        sourceReference: dummySourceReference,
+        details: {
+          code: CheatcodeErrorCode.UnsupportedCheatcode,
+          cheatcode: "eip712HashType(string,string)",
+        },
+      };
+
+      assert.equal(
+        getMessageFromLastStackTraceEntry(entry),
+        "Cheatcode 'eip712HashType(string,string)' is not supported by Hardhat. Please use the 'eip712HashType(string)' cheatcode instead, which accepts a type definition directly.",
+      );
+    });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/stack-trace-solidity-errors.ts
@@ -76,7 +76,7 @@ describe("getMessageFromLastStackTraceEntry", () => {
 
       assert.equal(
         getMessageFromLastStackTraceEntry(entry),
-        "Cheatcode 'eip712HashType(string,string)' is not supported by Hardhat. Please use the 'eip712HashType(string)' cheatcode instead, which accepts a type definition directly. See https://hardhat.org/docs/reference/cheatcodes/utilities/eip712-hash-type for more information.",
+        "Cheatcode 'eip712HashType(string,string)' is not supported by Hardhat. Providing a path to a bindings file is not supported, please use the eip712HashType(string calldata typeNameOrDefinition) cheatcode instead. See https://hardhat.org/docs/reference/cheatcodes/utilities/eip712-hash-type for more information.",
       );
     });
   });


### PR DESCRIPTION
When an unsupported cheatcode error is reported, this appends a context-specific suggestion if a known alternative exists. For example, using `eip712HashType(string,string)` now suggests `eip712HashType(string)` instead.

The suggestion map lives in a simple Record and can be extended as more cheatcode alternatives are identified.

Fixes #8209

Tested with the existing CHEATCODE_ERROR test suite plus new cases for suggestion lookup.