### PR TITLE
Wait for receipts in revertedWith* matchers

### DIFF
--- a/.changeset/slow-walls-remember.md
+++ b/.changeset/slow-walls-remember.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+---
+
+Make `revertedWith`, `revertedWithoutReason`, `revertedWithPanic`, and `revertedWithCustomError` wait for transaction receipts before asserting on resolved transaction responses.

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
@@ -12,6 +12,7 @@ import { preventAsyncMatcherChaining } from "../../utils/prevent-chaining.js";
 import {
   decodeReturnData,
   getReturnDataFromError,
+  hasTransactionHash,
   parseBytes32String,
 } from "./utils.js";
 
@@ -37,12 +38,12 @@ export function supportRevert(
       const onSuccess = async (value: unknown) => {
         const assert = buildAssert(negated, onSuccess);
 
-        if (isTransactionResponse(value) || typeof value === "string") {
+        if (hasTransactionHash(value) || typeof value === "string") {
           const hash = typeof value === "string" ? value : value.hash;
 
           if (!isHash(hash)) {
             chaiAssert.fail(
-              `Expected a valid transaction hash, but got "${hash}"`,
+              `Expected a valid transaction hash, but got "${String(hash)}"`,
             );
           }
 
@@ -147,14 +148,6 @@ export function supportRevert(
 
 async function waitForTransactionReceipt(ethers: HardhatEthers, hash: string) {
   return await ethers.provider.waitForTransaction(hash);
-}
-
-function isTransactionResponse(x: unknown): x is { hash: string } {
-  if (typeof x === "object" && x !== null) {
-    return "hash" in x;
-  }
-
-  return false;
 }
 
 function isTransactionReceipt(x: unknown): x is { status: number } {

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWith.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWith.ts
@@ -5,7 +5,13 @@ import { REVERTED_WITH_MATCHER } from "../../constants.js";
 import { buildAssert } from "../../utils/build-assert.js";
 import { preventAsyncMatcherChaining } from "../../utils/prevent-chaining.js";
 
-import { decodeReturnData, getReturnDataFromError } from "./utils.js";
+import {
+  decodeReturnData,
+  ErrorWithData,
+  getReturnDataFromError,
+  getTransactionRevertData,
+  throwRevertDataNotRetrievedError,
+} from "./utils.js";
 
 export function supportRevertedWith(
   Assertion: Chai.AssertionStatic,
@@ -38,8 +44,28 @@ export function supportRevertedWith(
 
       preventAsyncMatcherChaining(this, REVERTED_WITH_MATCHER, chaiUtils);
 
-      const onSuccess = () => {
+      const onSuccess = async (value: unknown) => {
         const assert = buildAssert(negated, onSuccess);
+        const revertData = await getTransactionRevertData(value);
+
+        if (revertData.kind === "Revert") {
+          if (revertData.returnData !== undefined) {
+            onError(new ErrorWithData(revertData.returnData));
+            return;
+          }
+
+          throwRevertDataNotRetrievedError(
+            `Expected transaction to be reverted with reason '${expectedReasonString}', but the revert data couldn't be retrieved`,
+            revertData.retrievalError,
+          );
+        } else if (revertData.kind === "Success") {
+          assert(
+            false,
+            `Expected transaction to be reverted with reason '${expectedReasonString}', but it didn't revert`,
+          );
+
+          return;
+        }
 
         assert(
           false,

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithCustomError.ts
@@ -15,8 +15,11 @@ import { preventAsyncMatcherChaining } from "../../utils/prevent-chaining.js";
 
 import {
   decodeReturnData,
+  ErrorWithData,
   getReturnDataFromError,
+  getTransactionRevertData,
   resultToArray,
+  throwRevertDataNotRetrievedError,
 } from "./utils.js";
 
 export const REVERTED_WITH_CUSTOM_ERROR_CALLED = "customErrorAssertionCalled";
@@ -55,12 +58,32 @@ export function supportRevertedWithCustomError(
         chaiUtils,
       );
 
-      const onSuccess = () => {
+      const onSuccess = async (value: unknown) => {
         if (chaiUtils.flag(this, ASSERTION_ABORTED) === true) {
           return;
         }
 
         const assert = buildAssert(negated, onSuccess);
+        const revertData = await getTransactionRevertData(value);
+
+        if (revertData.kind === "Revert") {
+          if (revertData.returnData !== undefined) {
+            onError(new ErrorWithData(revertData.returnData));
+            return;
+          }
+
+          throwRevertDataNotRetrievedError(
+            `Expected transaction to be reverted with custom error '${expectedCustomErrorName}', but the revert data couldn't be retrieved`,
+            revertData.retrievalError,
+          );
+        } else if (revertData.kind === "Success") {
+          assert(
+            false,
+            `Expected transaction to be reverted with custom error '${expectedCustomErrorName}', but it didn't revert`,
+          );
+
+          return;
+        }
 
         assert(
           false,

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithPanic.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithPanic.ts
@@ -8,7 +8,13 @@ import { buildAssert } from "../../utils/build-assert.js";
 import { preventAsyncMatcherChaining } from "../../utils/prevent-chaining.js";
 
 import { panicErrorCodeToReason } from "./panic.js";
-import { decodeReturnData, getReturnDataFromError } from "./utils.js";
+import {
+  decodeReturnData,
+  ErrorWithData,
+  getReturnDataFromError,
+  getTransactionRevertData,
+  throwRevertDataNotRetrievedError,
+} from "./utils.js";
 
 export function supportRevertedWithPanic(
   Assertion: Chai.AssertionStatic,
@@ -57,8 +63,28 @@ export function supportRevertedWithPanic(
 
       preventAsyncMatcherChaining(this, REVERTED_WITH_PANIC_MATCHER, chaiUtils);
 
-      const onSuccess = () => {
+      const onSuccess = async (value: unknown) => {
         const assert = buildAssert(negated, onSuccess);
+        const revertData = await getTransactionRevertData(value);
+
+        if (revertData.kind === "Revert") {
+          if (revertData.returnData !== undefined) {
+            onError(new ErrorWithData(revertData.returnData));
+            return;
+          }
+
+          throwRevertDataNotRetrievedError(
+            `Expected transaction to be reverted with ${formattedPanicCode}, but the revert data couldn't be retrieved`,
+            revertData.retrievalError,
+          );
+        } else if (revertData.kind === "Success") {
+          assert(
+            false,
+            `Expected transaction to be reverted with ${formattedPanicCode}, but it didn't revert`,
+          );
+
+          return;
+        }
 
         assert(
           false,

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithoutReason.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revertedWithoutReason.ts
@@ -4,7 +4,13 @@ import { REVERTED_WITHOUT_REASON_MATCHER } from "../../constants.js";
 import { buildAssert } from "../../utils/build-assert.js";
 import { preventAsyncMatcherChaining } from "../../utils/prevent-chaining.js";
 
-import { decodeReturnData, getReturnDataFromError } from "./utils.js";
+import {
+  decodeReturnData,
+  ErrorWithData,
+  getReturnDataFromError,
+  getTransactionRevertData,
+  throwRevertDataNotRetrievedError,
+} from "./utils.js";
 
 export function supportRevertedWithoutReason(
   Assertion: Chai.AssertionStatic,
@@ -20,8 +26,28 @@ export function supportRevertedWithoutReason(
       chaiUtils,
     );
 
-    const onSuccess = () => {
+    const onSuccess = async (value: unknown) => {
       const assert = buildAssert(negated, onSuccess);
+      const revertData = await getTransactionRevertData(value);
+
+      if (revertData.kind === "Revert") {
+        if (revertData.returnData !== undefined) {
+          onError(new ErrorWithData(revertData.returnData));
+          return;
+        }
+
+        throwRevertDataNotRetrievedError(
+          "Expected transaction to be reverted without a reason, but the revert data couldn't be retrieved",
+          revertData.retrievalError,
+        );
+      } else if (revertData.kind === "Success") {
+        assert(
+          false,
+          `Expected transaction to be reverted without a reason, but it didn't revert`,
+        );
+
+        return;
+      }
 
       assert(
         false,

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
@@ -1,10 +1,21 @@
 import type { Result } from "ethers/abi";
+import type { TransactionRequest, TransactionResponse } from "ethers/providers";
 
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { assert as chaiAssert, AssertionError } from "chai";
 import { AbiCoder, decodeBytes32String } from "ethers/abi";
 
 import { panicErrorCodeToReason } from "./panic.js";
+
+type TransactionRevertData =
+  | { kind: "NotTransaction" }
+  | { kind: "Success" }
+  | { kind: "Revert"; returnData?: string; retrievalError?: unknown };
+
+interface TransactionRevertDataRecovery {
+  returnData?: string;
+  retrievalError?: unknown;
+}
 
 // method id of 'Error(string)'
 const ERROR_STRING_PREFIX = "0x08c379a0";
@@ -42,6 +53,54 @@ export function getReturnDataFromError(error: any): string {
   }
 
   return returnData;
+}
+
+export async function getTransactionRevertData(
+  value: unknown,
+): Promise<TransactionRevertData> {
+  if (!isProviderBackedTransactionResponse(value)) {
+    return { kind: "NotTransaction" };
+  }
+
+  const receipt = await value.provider.waitForTransaction(value.hash);
+  if (receipt === null) {
+    return { kind: "NotTransaction" };
+  }
+
+  if (receipt.status !== 0) {
+    return { kind: "Success" };
+  }
+
+  return {
+    kind: "Revert",
+    ...(await getReturnDataFromTransaction(value, receipt.blockNumber)),
+  };
+}
+
+export function throwRevertDataNotRetrievedError(
+  message: string,
+  cause?: unknown,
+): never {
+  try {
+    chaiAssert.fail(message);
+  } catch (error) {
+    ensureError(error);
+
+    if (cause !== undefined) {
+      error.cause = cause;
+    }
+
+    throw error;
+  }
+}
+
+export class ErrorWithData extends Error {
+  public readonly data: string;
+
+  constructor(data: string) {
+    super();
+    this.data = data;
+  }
 }
 
 type DecodedReturnData =
@@ -151,4 +210,87 @@ export function resultToArray(result: Result): any[] {
 
 export function parseBytes32String(v: string): string {
   return decodeBytes32String(v);
+}
+
+export function hasTransactionHash(x: unknown): x is { hash: unknown } {
+  return typeof x === "object" && x !== null && "hash" in x;
+}
+
+function isProviderBackedTransactionResponse(
+  x: unknown,
+): x is TransactionResponse {
+  return (
+    hasTransactionHash(x) &&
+    typeof x.hash === "string" &&
+    "provider" in x &&
+    typeof x.provider === "object" &&
+    x.provider !== null &&
+    "waitForTransaction" in x.provider &&
+    typeof x.provider.waitForTransaction === "function" &&
+    "call" in x.provider &&
+    typeof x.provider.call === "function"
+  );
+}
+
+async function getReturnDataFromTransaction(
+  tx: TransactionResponse,
+  blockNumber: number,
+): Promise<TransactionRevertDataRecovery> {
+  try {
+    await tx.provider.call(buildReplayTransactionRequest(tx, blockNumber));
+  } catch (error) {
+    try {
+      return { returnData: getReturnDataFromError(error) };
+    } catch {
+      return { retrievalError: error };
+    }
+  }
+
+  return {};
+}
+
+function buildReplayTransactionRequest(
+  tx: TransactionResponse,
+  blockNumber: number,
+): TransactionRequest {
+  const request: TransactionRequest = {
+    blockTag: blockNumber,
+    chainId: tx.chainId,
+    data: tx.data,
+    from: tx.from,
+    gasLimit: tx.gasLimit,
+    nonce: tx.nonce,
+    to: tx.to ?? undefined,
+    type: tx.type,
+    value: tx.value,
+  };
+
+  if (isDefined(tx.maxFeePerGas) || isDefined(tx.maxPriorityFeePerGas)) {
+    request.maxFeePerGas = tx.maxFeePerGas ?? undefined;
+    request.maxPriorityFeePerGas = tx.maxPriorityFeePerGas ?? undefined;
+  } else if (isDefined(tx.gasPrice)) {
+    request.gasPrice = tx.gasPrice;
+  }
+
+  if (isDefined(tx.accessList)) {
+    request.accessList = tx.accessList;
+  }
+
+  if (isDefined(tx.maxFeePerBlobGas)) {
+    request.maxFeePerBlobGas = tx.maxFeePerBlobGas;
+  }
+
+  if (isDefined(tx.blobVersionedHashes)) {
+    request.blobVersionedHashes = tx.blobVersionedHashes;
+  }
+
+  if (isDefined(tx.authorizationList)) {
+    request.authorizationList = tx.authorizationList;
+  }
+
+  return request;
+}
+
+function isDefined<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
 }

--- a/packages/hardhat-ethers-chai-matchers/test/helpers/helpers.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/helpers/helpers.ts
@@ -119,6 +119,19 @@ export async function mineRevertedTransaction(
   return tx;
 }
 
+export async function withAutomineOff(
+  provider: EthereumProvider,
+  body: () => Promise<void>,
+): Promise<void> {
+  await provider.request({ method: "evm_setAutomine", params: [false] });
+
+  try {
+    await body();
+  } finally {
+    await provider.request({ method: "evm_setAutomine", params: [true] });
+  }
+}
+
 async function mineBlocksUntilTxIsIncluded(
   provider: EthereumProvider,
   ethers: HardhatEthers,

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWith.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWith.ts
@@ -18,6 +18,7 @@ import {
   runFailedAsserts,
   mineSuccessfulTransaction,
   initEnvironment,
+  withAutomineOff,
 } from "../../helpers/helpers.js";
 
 addChaiMatchers();
@@ -265,6 +266,23 @@ describe("INTEGRATION: Reverted with", { timeout: 60000 }, () => {
           return;
         }
         expect.fail("Expected an exception but none was thrown");
+      });
+    });
+
+    describe("When automining is disabled", () => {
+      it("should wait for the tx to be mined and detect the revert reason", async () => {
+        await withAutomineOff(provider, async () => {
+          const tx = await matchers.revertsWith("some reason", {
+            gasLimit: 1_000_000,
+          });
+
+          const revertedWithPromise =
+            expect(tx).to.be.revertedWith("some reason");
+
+          await provider.request({ method: "hardhat_mine", params: [] });
+
+          await revertedWithPromise;
+        });
       });
     });
   }

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithCustomError.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithCustomError.ts
@@ -19,6 +19,7 @@ import {
   runFailedAsserts,
   mineSuccessfulTransaction,
   initEnvironment,
+  withAutomineOff,
 } from "../../helpers/helpers.js";
 
 addChaiMatchers();
@@ -565,6 +566,24 @@ describe("INTEGRATION: Reverted with custom error", { timeout: 60000 }, () => {
           return;
         }
         expect.fail("Expected an exception but none was thrown");
+      });
+    });
+
+    describe("When automining is disabled", () => {
+      it("should wait for the tx to be mined and detect the custom error", async () => {
+        await withAutomineOff(provider, async () => {
+          const tx = await matchers.revertWithSomeCustomError({
+            gasLimit: 1_000_000,
+          });
+
+          const revertedWithCustomErrorPromise = expect(
+            tx,
+          ).to.be.revertedWithCustomError(matchers, "SomeCustomError");
+
+          await provider.request({ method: "hardhat_mine", params: [] });
+
+          await revertedWithCustomErrorPromise;
+        });
       });
     });
   }

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithPanic.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithPanic.ts
@@ -19,6 +19,7 @@ import {
   runFailedAsserts,
   mineSuccessfulTransaction,
   initEnvironment,
+  withAutomineOff,
 } from "../../helpers/helpers.js";
 
 addChaiMatchers();
@@ -335,6 +336,20 @@ describe("INTEGRATION: Reverted with panic", { timeout: 60000 }, () => {
           return;
         }
         expect.fail("Expected an exception but none was thrown");
+      });
+    });
+
+    describe("When automining is disabled", () => {
+      it("should wait for the tx to be mined and detect the panic", async () => {
+        await withAutomineOff(provider, async () => {
+          const tx = await matchers.panicAssert({ gasLimit: 1_000_000 });
+
+          const revertedWithPanicPromise = expect(tx).to.be.revertedWithPanic();
+
+          await provider.request({ method: "hardhat_mine", params: [] });
+
+          await revertedWithPanicPromise;
+        });
       });
     });
   }

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithoutReason.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revertedWithoutReason.ts
@@ -1,5 +1,6 @@
 import type { MatchersContract } from "../../helpers/contracts.js";
 import type { HardhatEthers } from "@nomicfoundation/hardhat-ethers/types";
+import type { EthereumProvider } from "hardhat/types/providers";
 
 import path from "node:path";
 import { before, beforeEach, describe, it } from "node:test";
@@ -13,6 +14,7 @@ import {
   runSuccessfulAsserts,
   runFailedAsserts,
   initEnvironment,
+  withAutomineOff,
 } from "../../helpers/helpers.js";
 
 addChaiMatchers();
@@ -28,9 +30,10 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
     let matchers: MatchersContract;
 
     let ethers: HardhatEthers;
+    let provider: EthereumProvider;
 
     before(async () => {
-      ({ ethers } = await initEnvironment("reverted-without-reason"));
+      ({ ethers, provider } = await initEnvironment("reverted-without-reason"));
     });
 
     beforeEach(async () => {
@@ -207,6 +210,23 @@ describe("INTEGRATION: Reverted without reason", { timeout: 60000 }, () => {
           return;
         }
         expect.fail("Expected an exception but none was thrown");
+      });
+    });
+
+    describe("When automining is disabled", () => {
+      it("should wait for the tx to be mined and detect the empty revert", async () => {
+        await withAutomineOff(provider, async () => {
+          const tx = await matchers.revertsWithoutReason({
+            gasLimit: 1_000_000,
+          });
+
+          const revertedWithoutReasonPromise =
+            expect(tx).to.be.revertedWithoutReason(ethers);
+
+          await provider.request({ method: "hardhat_mine", params: [] });
+
+          await revertedWithoutReasonPromise;
+        });
       });
     });
   }

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/transactionResponses.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/transactionResponses.ts
@@ -70,6 +70,9 @@ describe("Reverted transaction responses", () => {
         (error) =>
           error instanceof AssertionError &&
           error.message.includes(message) &&
+          // `in` narrowing exposes `cause` regardless of how chai's
+          // `AssertionError` type is declared (chai v5's typings omit it).
+          "cause" in error &&
           error.cause === callError,
         `Expected ${name} to fail and preserve the replay call error`,
       );

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/transactionResponses.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/transactionResponses.ts
@@ -1,0 +1,185 @@
+import { describe, it } from "node:test";
+
+import { assertRejects } from "@nomicfoundation/hardhat-test-utils";
+import { AssertionError, expect } from "chai";
+import { AbiCoder, Interface } from "ethers/abi";
+
+import { addChaiMatchers } from "../../../src/internal/add-chai-matchers.js";
+
+addChaiMatchers();
+
+const BLOCK_NUMBER = 123;
+const FROM = "0x0000000000000000000000000000000000000001";
+const TO = "0x0000000000000000000000000000000000000002";
+const HASH = `0x${"1".repeat(64)}`;
+
+describe("Reverted transaction responses", () => {
+  const noDataAssertions = [
+    {
+      name: "revertedWith",
+      assertion: async (tx: unknown) => {
+        await expect(tx).not.to.be.revertedWith("some reason");
+      },
+      message:
+        "Expected transaction to be reverted with reason 'some reason', but the revert data couldn't be retrieved",
+    },
+    {
+      name: "revertedWithCustomError",
+      assertion: async (tx: unknown) => {
+        const contract = {
+          interface: new Interface(["error SomeCustomError()"]),
+        };
+
+        await expect(tx).not.to.be.revertedWithCustomError(
+          contract,
+          "SomeCustomError",
+        );
+      },
+      message:
+        "Expected transaction to be reverted with custom error 'SomeCustomError', but the revert data couldn't be retrieved",
+    },
+    {
+      name: "revertedWithPanic",
+      assertion: async (tx: unknown) => {
+        await expect(tx).not.to.be.revertedWithPanic();
+      },
+      message:
+        "Expected transaction to be reverted with some panic code, but the revert data couldn't be retrieved",
+    },
+    {
+      name: "revertedWithoutReason",
+      assertion: async (tx: unknown) => {
+        await expect(tx).not.to.be.revertedWithoutReason(Object.create(null));
+      },
+      message:
+        "Expected transaction to be reverted without a reason, but the revert data couldn't be retrieved",
+    },
+  ];
+
+  it("fails negated assertions when revert data can't be recovered", async () => {
+    for (const { name, assertion, message } of noDataAssertions) {
+      const callError = new Error("replay call failed");
+      const tx = createRevertedTransactionResponse({
+        call: async () => {
+          throw callError;
+        },
+      });
+
+      await assertRejects(
+        assertion(tx),
+        (error) =>
+          error instanceof AssertionError &&
+          error.message.includes(message) &&
+          error.cause === callError,
+        `Expected ${name} to fail and preserve the replay call error`,
+      );
+    }
+  });
+
+  it("preserves EIP-1559 envelope fields when replaying", async () => {
+    let replayRequest: unknown;
+    const accessList = [
+      {
+        address: TO,
+        storageKeys: [`0x${"0".repeat(64)}`],
+      },
+    ];
+
+    const tx = createRevertedTransactionResponse({
+      accessList,
+      call: async (request) => {
+        replayRequest = request;
+        throwErrorWithReason("some reason");
+      },
+    });
+
+    await expect(tx).to.be.revertedWith("some reason");
+
+    expect(replayRequest).to.deep.include({
+      chainId: 31_337n,
+      maxFeePerGas: 10n,
+      maxPriorityFeePerGas: 2n,
+      nonce: 7,
+      type: 2,
+      accessList,
+    });
+    expect(replayRequest).not.to.have.property("gasPrice");
+  });
+
+  it("preserves legacy gasPrice without adding EIP-1559 fees", async () => {
+    let replayRequest: unknown;
+    const tx = createRevertedTransactionResponse({
+      maxFeePerGas: null,
+      maxPriorityFeePerGas: null,
+      type: 0,
+      call: async (request) => {
+        replayRequest = request;
+        throwErrorWithReason("some reason");
+      },
+    });
+
+    await expect(tx).to.be.revertedWith("some reason");
+
+    expect(replayRequest).to.include({
+      gasPrice: 8n,
+      type: 0,
+    });
+    expect(replayRequest).not.to.have.property("maxFeePerGas");
+    expect(replayRequest).not.to.have.property("maxPriorityFeePerGas");
+  });
+});
+
+function createRevertedTransactionResponse({
+  accessList = null,
+  call,
+  gasPrice = 8n,
+  maxFeePerGas = 10n,
+  maxPriorityFeePerGas = 2n,
+  type = 2,
+}: {
+  accessList?: unknown;
+  call: (request: unknown) => Promise<unknown>;
+  gasPrice?: bigint;
+  maxFeePerGas?: bigint | null;
+  maxPriorityFeePerGas?: bigint | null;
+  type?: number;
+}) {
+  return {
+    accessList,
+    authorizationList: null,
+    blobVersionedHashes: null,
+    chainId: 31_337n,
+    data: "0x1234",
+    from: FROM,
+    gasLimit: 50_000n,
+    gasPrice,
+    hash: HASH,
+    maxFeePerBlobGas: null,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    nonce: 7,
+    provider: {
+      call,
+      waitForTransaction: async () => ({
+        blockNumber: BLOCK_NUMBER,
+        status: 0,
+      }),
+    },
+    to: TO,
+    type,
+    value: 3n,
+    wait: async () => ({
+      blockNumber: BLOCK_NUMBER,
+      status: 0,
+    }),
+  };
+}
+
+function throwErrorWithReason(reason: string): never {
+  const abi = new AbiCoder();
+  const data = `0x08c379a0${abi.encode(["string"], [reason]).slice(2)}`;
+  const error = new Error("execution reverted");
+
+  Object.assign(error, { data });
+  throw error;
+}


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Why

The `revertedWith*` matchers should handle transactions that resolve to a `TransactionResponse` the same way they handle calls that reject with revert data. This matters when a transaction is accepted by the node, mined later, and then ends up with a reverted receipt, which is common with async mining and external JSON-RPC nodes.

## What changed

- `revertedWith`, `revertedWithoutReason`, `revertedWithPanic`, and `revertedWithCustomError` now wait for the receipt when their subject resolves to a `TransactionResponse`.
- Reverted receipts are replayed with `eth_call` at the receipt block so the matchers can decode reason strings, panic codes, custom errors, and empty revert data.
- The receipt-waiting behavior is aligned with the existing `.revert(ethers)` matcher pattern.
- Replay requests preserve transaction envelope fields that can affect execution, including nonce, type, chain id, access list, and legacy vs EIP-1559 fee fields.
- Reverted receipts whose data cannot be recovered now fail with a clear "revert data couldn't be retrieved" assertion and preserve the replay error as the assertion cause.
- The broad `.revert(ethers)` matcher shares the transaction-hash structural helper while keeping its existing hash-only behavior.

## Tests

- Added automine-disabled regression coverage for the affected receipt-waiting matchers.
- Added focused `TransactionResponse` coverage for unrecoverable revert data and replay envelope preservation.

Verification run for `@nomicfoundation/hardhat-ethers-chai-matchers`:

- `pnpm --filter @nomicfoundation/hardhat-ethers-chai-matchers build`
- `node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter test/matchers/reverted/transactionResponses.ts`
- `pnpm --filter @nomicfoundation/hardhat-ethers-chai-matchers lint`
