### PR TITLE
Add receipt-wait option for hardhat-ethers signer

### DIFF
--- a/.changeset/hardhat-ethers-wait-for-receipt.md
+++ b/.changeset/hardhat-ethers-wait-for-receipt.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Add a per-network `ethers.waitForTransactionReceipt` option that makes `HardhatEthersSigner.sendTransaction` wait until the transaction receipt is available before resolving.

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -23,6 +23,26 @@ export default defineConfig({
 });
 ```
 
+## Configuration
+
+By default, `HardhatEthersSigner.sendTransaction` follows ethers.js and resolves as soon as the submitted transaction is available from the network. If you want a network connection to wait until each submitted transaction has a receipt before resolving, enable `waitForTransactionReceipt` in that network's `ethers` config:
+
+```ts
+export default defineConfig({
+  networks: {
+    anvil: {
+      type: "http",
+      url: "http://127.0.0.1:8545",
+      ethers: {
+        waitForTransactionReceipt: true,
+      },
+    },
+  },
+});
+```
+
+This is useful when running tests written against Hardhat's in-process network on external nodes whose `eth_sendTransaction` method returns before mining. Reverted transactions still resolve to a transaction response, so callers and matchers can inspect the receipt.
+
 ## Usage
 
 This plugin adds an `ethers` property to each network connection:

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -30,7 +30,7 @@ By default, `HardhatEthersSigner.sendTransaction` follows ethers.js and resolves
 ```ts
 export default defineConfig({
   networks: {
-    anvil: {
+    externalNode: {
       type: "http",
       url: "http://127.0.0.1:8545",
       ethers: {

--- a/packages/hardhat-ethers/package.json
+++ b/packages/hardhat-ethers/package.json
@@ -59,8 +59,10 @@
   "dependencies": {
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.15",
     "@nomicfoundation/hardhat-utils": "workspace:^4.1.2",
+    "@nomicfoundation/hardhat-zod-utils": "workspace:^3.0.5",
     "ethereum-cryptography": "^2.2.1",
-    "ethers": "^6.14.0"
+    "ethers": "^6.14.0",
+    "zod": "^3.23.8"
   },
   "peerDependencies": {
     "hardhat": "workspace:^3.8.0"

--- a/packages/hardhat-ethers/src/index.ts
+++ b/packages/hardhat-ethers/src/index.ts
@@ -7,6 +7,7 @@ export type * from "./type-extensions.js";
 const hardhatEthersPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-ethers",
   hookHandlers: {
+    config: () => import("./internal/hook-handlers/config.js"),
     network: () => import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ethers",

--- a/packages/hardhat-ethers/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-ethers/src/internal/hook-handlers/config.ts
@@ -1,0 +1,94 @@
+import type {
+  ConfigurationVariableResolver,
+  HardhatConfig,
+  HardhatEthersNetworkConfig,
+  HardhatEthersNetworkUserConfig,
+  HardhatUserConfig,
+  NetworkConfig,
+} from "hardhat/types/config";
+import type {
+  ConfigHooks,
+  HardhatUserConfigValidationError,
+} from "hardhat/types/hooks";
+
+import { isObject } from "@nomicfoundation/hardhat-utils/lang";
+import { validateUserConfigZodType } from "@nomicfoundation/hardhat-zod-utils";
+import { z } from "zod";
+
+const ethersUserConfigSchema = z.object({
+  ethers: z
+    .object({
+      waitForTransactionReceipt: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+export default async (): Promise<Partial<ConfigHooks>> => ({
+  validateUserConfig,
+  resolveUserConfig,
+});
+
+export async function validateUserConfig(
+  userConfig: HardhatUserConfig,
+): Promise<HardhatUserConfigValidationError[]> {
+  if (userConfig.networks === undefined) {
+    return [];
+  }
+
+  const networksErrors: HardhatUserConfigValidationError[] = [];
+
+  for (const [networkName, network] of Object.entries(userConfig.networks)) {
+    if (!isObject(network)) {
+      continue;
+    }
+
+    const errors = validateUserConfigZodType(
+      { ethers: network.ethers },
+      ethersUserConfigSchema,
+    ).map((err) => {
+      err.message = `network "${networkName}" - ${err.message}`;
+      return err;
+    });
+
+    networksErrors.push(...errors);
+  }
+
+  return networksErrors;
+}
+
+export async function resolveUserConfig(
+  userConfig: HardhatUserConfig,
+  resolveConfigurationVariable: ConfigurationVariableResolver,
+  next: (
+    nextUserConfig: HardhatUserConfig,
+    nextResolveConfigurationVariable: ConfigurationVariableResolver,
+  ) => Promise<HardhatConfig>,
+): Promise<HardhatConfig> {
+  const resolvedConfig = await next(userConfig, resolveConfigurationVariable);
+
+  const networks: Record<string, NetworkConfig> = {};
+
+  for (const [networkName, networkConfig] of Object.entries(
+    resolvedConfig.networks,
+  )) {
+    networks[networkName] = {
+      ...networkConfig,
+      ethers: resolveHardhatEthersNetworkConfig(
+        userConfig.networks?.[networkName]?.ethers,
+      ),
+    };
+  }
+
+  return {
+    ...resolvedConfig,
+    networks,
+  };
+}
+
+function resolveHardhatEthersNetworkConfig(
+  userConfig: HardhatEthersNetworkUserConfig = {},
+): HardhatEthersNetworkConfig {
+  return {
+    waitForTransactionReceipt: userConfig.waitForTransactionReceipt ?? false,
+  };
+}

--- a/packages/hardhat-ethers/src/internal/signers/signers.ts
+++ b/packages/hardhat-ethers/src/internal/signers/signers.ts
@@ -43,6 +43,7 @@ type SignerAccounts =
 
 export class HardhatEthersSigner implements HardhatEthersSignerI {
   readonly #signerAccounts: SignerAccounts;
+  readonly #waitForTransactionReceipt: boolean;
   #cachedPrivateKey: string | undefined;
 
   public readonly address: string;
@@ -64,18 +65,25 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
         ? { type: "http", accounts: networkConfig.accounts }
         : { type: "edr-simulated", accounts: networkConfig.accounts };
 
-    return new HardhatEthersSigner(address, provider, signerAccounts);
+    return new HardhatEthersSigner(
+      address,
+      provider,
+      signerAccounts,
+      networkConfig.ethers.waitForTransactionReceipt,
+    );
   }
 
   private constructor(
     address: string,
     provider: ethers.JsonRpcProvider | HardhatEthersProvider,
     signerAccounts: SignerAccounts,
+    waitForTransactionReceipt: boolean,
   ) {
     this.address = getAddress(address);
     this.provider = provider;
 
     this.#signerAccounts = signerAccounts;
+    this.#waitForTransactionReceipt = waitForTransactionReceipt;
   }
 
   public connect(
@@ -85,6 +93,7 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
       this.address,
       provider,
       this.#signerAccounts,
+      this.#waitForTransactionReceipt,
     );
   }
 
@@ -176,26 +185,36 @@ export class HardhatEthersSigner implements HardhatEthersSignerI {
     // for a response, and we need the actual transaction, so we poll
     // for it; it should show up very quickly
 
-    return await new Promise((resolve) => {
-      const timeouts = [1000, 100];
-      const checkTx = async () => {
-        // Try getting the transaction
-        const txPolled = await this.provider.getTransaction(hash);
-        if (txPolled !== null) {
-          resolve(txPolled.replaceableTransaction(blockNumber));
-          return;
-        }
+    const transactionResponse = await new Promise<ethers.TransactionResponse>(
+      (resolve) => {
+        const timeouts = [1000, 100];
+        const checkTx = async () => {
+          // Try getting the transaction
+          const txPolled = await this.provider.getTransaction(hash);
+          if (txPolled !== null) {
+            resolve(txPolled.replaceableTransaction(blockNumber));
+            return;
+          }
 
-        // Wait another 4 seconds
-        setTimeout(() => {
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises -- this check must be done in an async way
-          checkTx();
-        }, timeouts.pop() ?? 4000);
-      };
+          // Wait another 4 seconds
+          setTimeout(() => {
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises -- this check must be done in an async way
+            checkTx();
+          }, timeouts.pop() ?? 4000);
+        };
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- this check must be done in an async way
-      checkTx();
-    });
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises -- this check must be done in an async way
+        checkTx();
+      },
+    );
+
+    if (this.#waitForTransactionReceipt) {
+      // Don't use transactionResponse.wait(): it throws on status=0 receipts,
+      // but callers and matchers still need the response for reverted txs.
+      await this.provider.waitForTransaction(transactionResponse.hash);
+    }
+
+    return transactionResponse;
   }
 
   public signMessage(message: string | Uint8Array): Promise<string> {

--- a/packages/hardhat-ethers/src/type-extensions.ts
+++ b/packages/hardhat-ethers/src/type-extensions.ts
@@ -8,3 +8,45 @@ declare module "hardhat/types/network" {
     ethers: HardhatEthers;
   }
 }
+
+declare module "hardhat/types/config" {
+  export interface HardhatEthersNetworkUserConfig {
+    /**
+     * When enabled, HardhatEthersSigner.sendTransaction resolves only after the
+     * transaction has been mined and its receipt is available (one
+     * confirmation), instead of as soon as the transaction is visible to the
+     * node.
+     *
+     * Reverted transactions still resolve to a TransactionResponse (the signer
+     * does not throw), so callers and chai matchers can inspect the receipt.
+     *
+     * The default is false, matching ethers' JsonRpcSigner behavior.
+     *
+     * Enable this only for compatibility runs against external nodes (anvil,
+     * geth, reth) whose eth_sendTransaction returns before mining. Leave it
+     * off otherwise, since it changes pending-transaction timing and waits for
+     * mining on every send.
+     */
+    waitForTransactionReceipt?: boolean;
+  }
+
+  export interface HardhatEthersNetworkConfig {
+    waitForTransactionReceipt: boolean;
+  }
+
+  export interface HttpNetworkUserConfig {
+    ethers?: HardhatEthersNetworkUserConfig;
+  }
+
+  export interface EdrNetworkUserConfig {
+    ethers?: HardhatEthersNetworkUserConfig;
+  }
+
+  export interface HttpNetworkConfig {
+    ethers: HardhatEthersNetworkConfig;
+  }
+
+  export interface EdrNetworkConfig {
+    ethers: HardhatEthersNetworkConfig;
+  }
+}

--- a/packages/hardhat-ethers/src/type-extensions.ts
+++ b/packages/hardhat-ethers/src/type-extensions.ts
@@ -22,10 +22,10 @@ declare module "hardhat/types/config" {
      *
      * The default is false, matching ethers' JsonRpcSigner behavior.
      *
-     * Enable this only for compatibility runs against external nodes (anvil,
-     * geth, reth) whose eth_sendTransaction returns before mining. Leave it
-     * off otherwise, since it changes pending-transaction timing and waits for
-     * mining on every send.
+     * Enable this only for compatibility runs against external nodes whose
+     * eth_sendTransaction returns before mining. Leave it off otherwise, since
+     * it changes pending-transaction timing and waits for mining on every
+     * send.
      */
     waitForTransactionReceipt?: boolean;
   }

--- a/packages/hardhat-ethers/test/helpers/helpers.ts
+++ b/packages/hardhat-ethers/test/helpers/helpers.ts
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 
+import hardhatEthersPlugin from "../../src/index.js";
 import { initializeEthers } from "../../src/internal/initialization.js";
 
 import { MockArtifactManager } from "./artifact-manager-mock.js";
@@ -25,7 +26,10 @@ export async function initializeTestEthers(
   artifactManager: ArtifactManager;
   hre: HardhatRuntimeEnvironment;
 }> {
-  const hre = await createHardhatRuntimeEnvironment(config);
+  const hre = await createHardhatRuntimeEnvironment({
+    ...config,
+    plugins: [hardhatEthersPlugin, ...(config.plugins ?? [])],
+  });
 
   const network =
     config.networks?.localhost !== undefined ? "localhost" : "default";

--- a/packages/hardhat-ethers/test/network-config.ts
+++ b/packages/hardhat-ethers/test/network-config.ts
@@ -6,6 +6,8 @@ import type { EthereumProvider } from "hardhat/types/providers";
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 
+import { validateUserConfig } from "../src/internal/hook-handlers/config.js";
+
 import { initializeTestEthers, spawnTestRpcServer } from "./helpers/helpers.js";
 
 const ARTIFACTS = [{ artifactName: "Example", fileName: "gas-config" }];
@@ -17,6 +19,19 @@ interface InitResult {
 }
 
 describe("network config behavior", () => {
+  describe("validation", () => {
+    it("doesn't throw when a network entry isn't an object", async () => {
+      const errors = await validateUserConfig({
+        networks: {
+          // @ts-expect-error -- force invalid user config to test validation behavior
+          invalid: null,
+        },
+      });
+
+      assert.deepEqual(errors, []);
+    });
+  });
+
   describe("in-process hardhat network", () => {
     defineNetworkConfigTests(() => initializeTestEthers(ARTIFACTS));
   });

--- a/packages/hardhat-ethers/test/transactions.ts
+++ b/packages/hardhat-ethers/test/transactions.ts
@@ -91,4 +91,94 @@ describe("transactions", () => {
       params: [true],
     });
   });
+
+  it("should not wait for a transaction receipt by default", async () => {
+    const [signer] = await ethers.getSigners();
+
+    await ethereumProvider.request({
+      method: "evm_setAutomine",
+      params: [false],
+    });
+
+    try {
+      const tx = await signer.sendTransaction({ to: signer });
+
+      assert.equal(await ethers.provider.getTransactionReceipt(tx.hash), null);
+    } finally {
+      await ethereumProvider.request({ method: "hardhat_mine" });
+      await ethereumProvider.request({
+        method: "evm_setAutomine",
+        params: [true],
+      });
+    }
+  });
+
+  it("should wait for a transaction receipt when configured", async () => {
+    ({ ethers, provider: ethereumProvider } = await initializeTestEthers([], {
+      networks: {
+        default: {
+          type: "edr-simulated",
+          ethers: {
+            waitForTransactionReceipt: true,
+          },
+        },
+      },
+    }));
+
+    const [signer] = await ethers.getSigners();
+    const initialPendingNonce = await ethers.provider.getTransactionCount(
+      signer.address,
+      "pending",
+    );
+
+    await ethereumProvider.request({
+      method: "evm_setAutomine",
+      params: [false],
+    });
+
+    try {
+      let transactionWasSent = false;
+      let sendTransactionResolved = false;
+
+      const sendTransactionPromise = signer
+        .sendTransaction({ to: signer })
+        .then((transactionResponse) => {
+          sendTransactionResolved = true;
+          return transactionResponse;
+        });
+
+      for (let i = 0; i < 20; i++) {
+        const pendingNonce = await ethers.provider.getTransactionCount(
+          signer.address,
+          "pending",
+        );
+
+        if (pendingNonce === initialPendingNonce + 1) {
+          transactionWasSent = true;
+          break;
+        }
+
+        await sleep(50);
+      }
+
+      await Promise.race([sendTransactionPromise, sleep(250)]);
+      assert.equal(transactionWasSent, true);
+      assert.equal(sendTransactionResolved, false);
+
+      await ethereumProvider.request({ method: "hardhat_mine" });
+
+      const tx = await sendTransactionPromise;
+
+      assert.notEqual(
+        await ethers.provider.getTransactionReceipt(tx.hash),
+        null,
+      );
+    } finally {
+      await ethereumProvider.request({ method: "hardhat_mine" });
+      await ethereumProvider.request({
+        method: "evm_setAutomine",
+        params: [true],
+      });
+    }
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,12 +298,18 @@ importers:
       '@nomicfoundation/hardhat-utils':
         specifier: workspace:^4.1.2
         version: link:../hardhat-utils
+      '@nomicfoundation/hardhat-zod-utils':
+        specifier: workspace:^3.0.5
+        version: link:../hardhat-zod-utils
       ethereum-cryptography:
         specifier: ^2.2.1
         version: 2.2.1
       ethers:
         specifier: ^6.14.0
         version: 6.15.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@nomicfoundation/hardhat-node-test-reporter':
         specifier: workspace:^3.1.0


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.

---

## Motivation

`HardhatEthersSigner.sendTransaction` currently mirrors ethers' `JsonRpcSigner`: after `eth_sendTransaction`, it polls `eth_getTransactionByHash` and resolves once the transaction is visible to the node. It does not wait for a receipt.

That behavior is correct as the default because it preserves ethers-compatible pending-transaction semantics. Some Hardhat tests and user code intentionally rely on receiving a `TransactionResponse` before the transaction is mined, especially when automining is disabled.

At the same time, many existing Hardhat test suites were authored against Hardhat's in-process network, where `eth_sendTransaction` effectively behaves synchronously because the transaction is mined before the call returns. When those suites are pointed at external nodes such as anvil, geth, or reth, a common pattern becomes racy:

```ts
await contract.stateChangingMethod();
const value = await contract.read();
```

On external RPC nodes, `eth_sendTransaction` can return after mempool insertion but before mining, so the read may observe pre-transaction state. This makes otherwise useful cross-client or fork-based test runs fail for reasons unrelated to contract behavior.

## What Changed

This PR adds an opt-in, per-network `hardhat-ethers` configuration option:

```ts
networks: {
  anvil: {
    type: "http",
    url: "http://127.0.0.1:8545",
    ethers: {
      waitForTransactionReceipt: true,
    },
  },
}
```

When enabled for a network, `HardhatEthersSigner.sendTransaction` still returns the same `TransactionResponse`, but only after `provider.waitForTransaction(hash)` has observed a receipt.

## Why This Is Safe

- The default remains `false`, so existing ethers-compatible behavior is unchanged.
- The option is scoped per network, so users can enable it only for external-node compatibility runs.
- The implementation is contained within `@nomicfoundation/hardhat-ethers`; it does not change Hardhat core or the network manager.
- The signer waits through `provider.waitForTransaction(hash)` instead of `transactionResponse.wait()`. This is intentional: `TransactionResponse.wait()` throws for `status === 0` receipts, but callers and chai matchers still need the response so they can inspect reverted transactions themselves.
- Existing pending-transaction workflows remain covered by tests that assert the default behavior does not wait for a receipt.

## Testing

From `packages/hardhat-ethers`:

```bash
pnpm lint
pnpm build
node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter "test/contracts.ts" "test/error-messages.ts" "test/gas-price.ts" "test/hardhat-ethers-provider.ts" "test/hardhat-ethers-signer.ts" "test/index.ts" "test/network-config.ts" "test/no-accounts.ts" "test/plugin-functionalities.ts" "test/provider-events.ts" "test/revert-error-cause.ts" "test/transactions.ts"
```

Result: `266 passing`, `2 skipped`.
