### PR TITLE
Handle no-data execution errors in revert matcher

### DIFF
--- a/.changeset/hardhat-ethers-chai-matchers-no-data-execution-errors.md
+++ b/.changeset/hardhat-ethers-chai-matchers-no-data-execution-errors.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+---
+
+The broad `.revert(ethers)` matcher now recognizes EVM execution failures that some providers report without revert data, such as invalid opcode, out-of-gas, and other exceptional halts. Reason-specific matchers like `.revertedWith` are unchanged and still require revert data.

--- a/.changeset/hardhat-ethers-chai-matchers-no-data-execution-errors.md
+++ b/.changeset/hardhat-ethers-chai-matchers-no-data-execution-errors.md
@@ -2,4 +2,6 @@
 "@nomicfoundation/hardhat-ethers-chai-matchers": patch
 ---
 
-The broad `.revert(ethers)` matcher now recognizes EVM execution failures that some providers report without revert data, such as invalid opcode, out-of-gas, and other exceptional halts. Reason-specific matchers like `.revertedWith` are unchanged and still require revert data.
+The broad `.revert(ethers)` matcher now recognizes EVM execution failures that some providers report without revert data, such as invalid opcode and out-of-gas errors. This makes `.revert(ethers)` behave consistently across providers that omit revert data on these failures. Reason-specific matchers like `.revertedWith` are unchanged and still require revert data.
+
+As a consequence, `.not.to.be.revert(ethers)` now fails for these no-data execution failures, since they are treated as reverts.

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/revert.ts
@@ -13,6 +13,7 @@ import {
   decodeReturnData,
   getReturnDataFromError,
   hasTransactionHash,
+  isNoDataExecutionError,
   parseBytes32String,
 } from "./utils.js";
 
@@ -103,8 +104,14 @@ export function supportRevert(
         }
       };
 
-      const onError = (error: any) => {
+      const onError = (error: unknown) => {
         const assert = buildAssert(negated, onError);
+
+        if (isNoDataExecutionError(error)) {
+          assert(true, undefined, `Expected transaction NOT to be reverted`);
+          return;
+        }
+
         const returnData = getReturnDataFromError(error);
         const decodedReturnData = decodeReturnData(returnData);
 

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
@@ -37,15 +37,13 @@ export function getReturnDataFromError(error: unknown): string {
   }
 
   const errorData = getErrorData(error);
-
   if (errorData === undefined) {
     // eslint-disable-next-line no-restricted-syntax -- re-throw because the error is not related to a reverted transaction
     throw error;
   }
 
   const returnData = getReturnData(errorData);
-
-  if (returnData === undefined || typeof returnData !== "string") {
+  if (returnData === undefined) {
     // eslint-disable-next-line no-restricted-syntax -- re-throw because the error is not related to a reverted transaction
     throw error;
   }
@@ -69,6 +67,16 @@ export function isNoDataExecutionError(error: unknown): boolean {
   );
 }
 
+/**
+ * Returns true when the error is the one ethers throws after a failed
+ * `eth_call` or `eth_estimateGas` that came back without any revert data.
+ *
+ * In that case ethers wraps the failure in a `CALL_EXCEPTION` with no data or
+ * reason and the short message "missing revert data", while keeping the
+ * original provider error under `error.info.error`. We only treat it as a
+ * no-data revert when that original error also looks like a known EVM
+ * execution failure (matching by message, and by code when it has one).
+ */
 function isEthersCallExceptionWithoutData(error: Error): boolean {
   if (!isObject(error)) {
     return false;
@@ -98,24 +106,36 @@ function isEthersCallExceptionWithoutData(error: Error): boolean {
     typeof rpcError.message === "string" &&
     isKnownEvmExecutionErrorMessage(rpcError.message) &&
     getReturnData(rpcError.data) === undefined &&
+    // The ethers CALL_EXCEPTION wrapper already tells us this was a no-data
+    // execution failure, so we don't insist on a code here and accept errors
+    // that don't carry one (like Geth's plain errors). The provider branch has
+    // no such wrapper to rely on, so there we do require a known code.
     (rpcError.code === undefined || isJsonRpcExecutionErrorCode(rpcError.code))
   );
 }
 
+/**
+ * Returns true for an execution failure that a JSON-RPC provider reports
+ * directly, instead of through ethers' call handling.
+ *
+ * Here the failure shows up as a plain provider error (sometimes nested one
+ * level under `error.error`) that carries a known JSON-RPC execution code and a
+ * known EVM execution message, but again has no revert data to work with.
+ */
 function isProviderExecutionErrorWithoutData(error: Error): boolean {
   if (!isObject(error)) {
     return false;
   }
 
-  const nestedError = isObject(error.error) ? error.error : undefined;
-  const code = nestedError?.code ?? error.code;
-  const message = nestedError?.message ?? error.message;
+  // Read code and message from the same source (the nested provider error if
+  // present, otherwise the top-level error)
+  const source = isObject(error.error) ? error.error : error;
 
   return (
     getReturnData(getErrorData(error)) === undefined &&
-    isJsonRpcExecutionErrorCode(code) &&
-    typeof message === "string" &&
-    isKnownEvmExecutionErrorMessage(message)
+    isJsonRpcExecutionErrorCode(source.code) &&
+    typeof source.message === "string" &&
+    isKnownEvmExecutionErrorMessage(source.message)
   );
 }
 
@@ -158,7 +178,7 @@ export function isKnownEvmExecutionErrorMessage(message: string): boolean {
     /^Transaction reverted: contract call run out of gas and made the transaction revert$/i.test(
       message,
     ) ||
-    /^VM Exception while processing transaction: (?:invalid opcode|out of gas|reverted\b|Transaction reverted\b)/i.test(
+    /^VM Exception while processing transaction: (?:invalid opcode|out of gas|reverted\b)/i.test(
       message,
     ) ||
     /(?:^|:\s*)invalid opcode\b/i.test(message) ||

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
@@ -2,6 +2,7 @@ import type { Result } from "ethers/abi";
 import type { TransactionRequest, TransactionResponse } from "ethers/providers";
 
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
+import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 import { assert as chaiAssert, AssertionError } from "chai";
 import { AbiCoder, decodeBytes32String } from "ethers/abi";
 
@@ -29,23 +30,20 @@ const PANIC_CODE_PREFIX = "0x4e487b71";
  * If the value is an error but it doesn't have data, we assume it's not related
  * to a reverted transaction and we re-throw it.
  */
-export function getReturnDataFromError(error: any): string {
+export function getReturnDataFromError(error: unknown): string {
   if (!(error instanceof Error)) {
     // eslint-disable-next-line no-restricted-syntax -- keep the original chai error structure
     throw new AssertionError("Expected an Error object");
   }
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- some properties do not exist in the default Error instance
-  const typedError = error as any;
-
-  const errorData = typedError.data ?? typedError.error?.data;
+  const errorData = getErrorData(error);
 
   if (errorData === undefined) {
     // eslint-disable-next-line no-restricted-syntax -- re-throw because the error is not related to a reverted transaction
     throw error;
   }
 
-  const returnData = typeof errorData === "string" ? errorData : errorData.data;
+  const returnData = getReturnData(errorData);
 
   if (returnData === undefined || typeof returnData !== "string") {
     // eslint-disable-next-line no-restricted-syntax -- re-throw because the error is not related to a reverted transaction
@@ -53,6 +51,149 @@ export function getReturnDataFromError(error: any): string {
   }
 
   return returnData;
+}
+
+/**
+ * Some JSON-RPC clients report EVM execution failures from eth_call or
+ * eth_estimateGas without return data. These can satisfy the broad revert
+ * matcher, but reason-specific matchers still need actual return data.
+ */
+export function isNoDataExecutionError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    isEthersCallExceptionWithoutData(error) ||
+    isProviderExecutionErrorWithoutData(error)
+  );
+}
+
+function isEthersCallExceptionWithoutData(error: Error): boolean {
+  if (!isObject(error)) {
+    return false;
+  }
+
+  if (
+    error.code !== "CALL_EXCEPTION" ||
+    (error.action !== "call" && error.action !== "estimateGas") ||
+    error.data !== null ||
+    error.reason !== null ||
+    error.shortMessage !== "missing revert data"
+  ) {
+    return false;
+  }
+
+  if (!isObject(error.info)) {
+    return false;
+  }
+
+  const rpcError = error.info.error;
+
+  if (!isObject(rpcError)) {
+    return false;
+  }
+
+  return (
+    typeof rpcError.message === "string" &&
+    isKnownEvmExecutionErrorMessage(rpcError.message) &&
+    getReturnData(rpcError.data) === undefined &&
+    (rpcError.code === undefined || isJsonRpcExecutionErrorCode(rpcError.code))
+  );
+}
+
+function isProviderExecutionErrorWithoutData(error: Error): boolean {
+  if (!isObject(error)) {
+    return false;
+  }
+
+  const nestedError = isObject(error.error) ? error.error : undefined;
+  const code = nestedError?.code ?? error.code;
+  const message = nestedError?.message ?? error.message;
+
+  return (
+    getReturnData(getErrorData(error)) === undefined &&
+    isJsonRpcExecutionErrorCode(code) &&
+    typeof message === "string" &&
+    isKnownEvmExecutionErrorMessage(message)
+  );
+}
+
+function getErrorData(error: Error): unknown {
+  if (!isObject(error)) {
+    return undefined;
+  }
+
+  const nestedError = isObject(error.error) ? error.error : undefined;
+
+  return error.data ?? nestedError?.data;
+}
+
+function getReturnData(errorData: unknown): string | undefined {
+  if (typeof errorData === "string") {
+    return errorData;
+  }
+
+  if (isObject(errorData) && typeof errorData.data === "string") {
+    return errorData.data;
+  }
+
+  return undefined;
+}
+
+function isJsonRpcExecutionErrorCode(code: unknown): boolean {
+  return code === 3 || code === -32000 || code === -32003;
+}
+
+/**
+ * Checks if an error message is a known JSON-RPC provider message for an EVM
+ * execution failure when no return data is available.
+ */
+export function isKnownEvmExecutionErrorMessage(message: string): boolean {
+  return (
+    /^execution reverted\b/i.test(message) ||
+    /^Transaction reverted (?:without a reason(?: string)?|and Hardhat couldn't infer the reason\.)/i.test(
+      message,
+    ) ||
+    /^Transaction reverted: contract call run out of gas and made the transaction revert$/i.test(
+      message,
+    ) ||
+    /^VM Exception while processing transaction: (?:invalid opcode|out of gas|reverted\b|Transaction reverted\b)/i.test(
+      message,
+    ) ||
+    /(?:^|:\s*)invalid opcode\b/i.test(message) ||
+    isEvmExceptionalHaltMessage(message)
+  );
+}
+
+// This list is a verbatim copy of the `ExceptionalHalt` enum in
+// `@nomicfoundation/edr`'s `index.d.ts`, which is the source of truth.
+// It can silently drift on EDR bumps, so keep it in sync.
+const EVM_EXCEPTIONAL_HALT_MESSAGES = new Set([
+  "OutOfGas",
+  "OpcodeNotFound",
+  "InvalidFEOpcode",
+  "InvalidJump",
+  "NotActivated",
+  "StackUnderflow",
+  "StackOverflow",
+  "OutOfOffset",
+  "CreateCollision",
+  "PrecompileError",
+  "NonceOverflow",
+  "CreateContractSizeLimit",
+  "CreateContractStartingWithEF",
+  "CreateInitCodeSizeLimit",
+]);
+
+function isEvmExceptionalHaltMessage(message: string): boolean {
+  const match = /^EVM error:?\s+([A-Z][A-Za-z0-9_]*)\b/.exec(message);
+
+  return (
+    match !== null &&
+    match[1] !== undefined &&
+    EVM_EXCEPTIONAL_HALT_MESSAGES.has(match[1])
+  );
 }
 
 export async function getTransactionRevertData(

--- a/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/internal/matchers/reverted/utils.ts
@@ -165,31 +165,32 @@ function isJsonRpcExecutionErrorCode(code: unknown): boolean {
   return code === 3 || code === -32000 || code === -32003;
 }
 
+// Provider and Hardhat message formats that signal an EVM execution failure
+// with no return data.
+const EVM_EXECUTION_ERROR_MESSAGE_PATTERNS = [
+  /^execution reverted\b/i,
+  /^Transaction reverted (?:without a reason(?: string)?|and Hardhat couldn't infer the reason\.)/i,
+  /^Transaction reverted: contract call run out of gas and made the transaction revert$/i,
+  /^VM Exception while processing transaction: (?:invalid opcode|out of gas|reverted\b)/i,
+  /(?:^|:\s*)invalid opcode\b/i,
+];
+
 /**
  * Checks if an error message is a known JSON-RPC provider message for an EVM
  * execution failure when no return data is available.
  */
 export function isKnownEvmExecutionErrorMessage(message: string): boolean {
   return (
-    /^execution reverted\b/i.test(message) ||
-    /^Transaction reverted (?:without a reason(?: string)?|and Hardhat couldn't infer the reason\.)/i.test(
-      message,
-    ) ||
-    /^Transaction reverted: contract call run out of gas and made the transaction revert$/i.test(
-      message,
-    ) ||
-    /^VM Exception while processing transaction: (?:invalid opcode|out of gas|reverted\b)/i.test(
-      message,
-    ) ||
-    /(?:^|:\s*)invalid opcode\b/i.test(message) ||
-    isEvmExceptionalHaltMessage(message)
+    EVM_EXECUTION_ERROR_MESSAGE_PATTERNS.some((pattern) =>
+      pattern.test(message),
+    ) || isEvmExceptionalHaltMessage(message)
   );
 }
 
 // This list is a verbatim copy of the `ExceptionalHalt` enum in
 // `@nomicfoundation/edr`'s `index.d.ts`, which is the source of truth.
 // It can silently drift on EDR bumps, so keep it in sync.
-const EVM_EXCEPTIONAL_HALT_MESSAGES = new Set([
+const EVM_EXCEPTIONAL_HALT_NAMES = new Set([
   "OutOfGas",
   "OpcodeNotFound",
   "InvalidFEOpcode",
@@ -207,13 +208,9 @@ const EVM_EXCEPTIONAL_HALT_MESSAGES = new Set([
 ]);
 
 function isEvmExceptionalHaltMessage(message: string): boolean {
-  const match = /^EVM error:?\s+([A-Z][A-Za-z0-9_]*)\b/.exec(message);
+  const [, haltName] = /^EVM error:?\s+([A-Z]\w*)/.exec(message) ?? [];
 
-  return (
-    match !== null &&
-    match[1] !== undefined &&
-    EVM_EXCEPTIONAL_HALT_MESSAGES.has(match[1])
-  );
+  return haltName !== undefined && EVM_EXCEPTIONAL_HALT_NAMES.has(haltName);
 }
 
 export async function getTransactionRevertData(

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/no-data-error-fixtures.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/no-data-error-fixtures.ts
@@ -1,0 +1,71 @@
+// Shared error fixtures that mimic the no-data EVM execution failures providers
+// report through eth_call / eth_estimateGas. Used by both the unit tests for the
+// classification helpers and the integration tests for the `.revert` matcher.
+
+/**
+ * The error ethers throws for a failed call/estimateGas with no return data: a
+ * `CALL_EXCEPTION` wrapper that keeps the original provider error under
+ * `info.error`.
+ */
+export function createNoDataCallException(
+  action: "call" | "estimateGas",
+  rpcError: Error | { code?: number; data?: unknown; message: string } = {
+    code: -32003,
+    message: "EVM error InvalidFEOpcode",
+  },
+): Error {
+  return Object.assign(new Error("missing revert data"), {
+    code: "CALL_EXCEPTION",
+    action,
+    data: null,
+    reason: null,
+    shortMessage: "missing revert data",
+    info: {
+      error: rpcError,
+    },
+  });
+}
+
+/**
+ * A plain provider error reported directly (no ethers wrapper), carrying a
+ * JSON-RPC execution code and message but no return data.
+ */
+export function createNoDataProviderExecutionError(
+  code: number,
+  message = "EVM error InvalidFEOpcode",
+): Error {
+  return Object.assign(new Error(message), {
+    code,
+    data: undefined,
+  });
+}
+
+/**
+ * A provider error whose `data` holds the JSON-RPC error envelope (with no
+ * nested return-data field), as some HTTP/EDR providers populate it.
+ */
+export function createNoDataProviderExecutionErrorWithEnvelopeData(
+  code: number,
+): Error {
+  return Object.assign(new Error("EVM error InvalidFEOpcode"), {
+    code,
+    data: {
+      code,
+      message: "EVM error InvalidFEOpcode",
+    },
+  });
+}
+
+/**
+ * A provider error wrapped one level down, where the meaningful code and message
+ * live under `error.error`.
+ */
+export function createNestedNoDataProviderExecutionError(code: number): Error {
+  return Object.assign(new Error("missing revert data"), {
+    code: -1,
+    error: {
+      code,
+      message: "EVM error InvalidFEOpcode",
+    },
+  });
+}

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
@@ -22,6 +22,13 @@ import {
   initEnvironment,
 } from "../../helpers/helpers.js";
 
+import {
+  createNoDataCallException,
+  createNoDataProviderExecutionError,
+  createNoDataProviderExecutionErrorWithEnvelopeData,
+  createNestedNoDataProviderExecutionError,
+} from "./no-data-error-fixtures.js";
+
 addChaiMatchers();
 
 describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
@@ -593,54 +600,3 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
     });
   }
 });
-
-function createNoDataCallException(
-  action: "call" | "estimateGas",
-  rpcError: Error | { code?: number; data?: unknown; message: string } = {
-    code: -32003,
-    message: "EVM error InvalidFEOpcode",
-  },
-): Error {
-  return Object.assign(new Error("missing revert data"), {
-    code: "CALL_EXCEPTION",
-    action,
-    data: null,
-    reason: null,
-    shortMessage: "missing revert data",
-    info: {
-      error: rpcError,
-    },
-  });
-}
-
-function createNoDataProviderExecutionError(
-  code: number,
-  message = "EVM error InvalidFEOpcode",
-): Error {
-  return Object.assign(new Error(message), {
-    code,
-    data: undefined,
-  });
-}
-
-function createNoDataProviderExecutionErrorWithEnvelopeData(
-  code: number,
-): Error {
-  return Object.assign(new Error("EVM error InvalidFEOpcode"), {
-    code,
-    data: {
-      name: "ProviderError",
-      stack: "ProviderError: EVM error InvalidFEOpcode",
-    },
-  });
-}
-
-function createNestedNoDataProviderExecutionError(code: number): Error {
-  return Object.assign(new Error("missing revert data"), {
-    code: -1,
-    error: {
-      code,
-      message: "EVM error InvalidFEOpcode",
-    },
-  });
-}

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/revert.ts
@@ -425,11 +425,103 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
     });
 
     describe("invalid rejection values", () => {
+      const expectNoDataExecutionError = async (error: Error) => {
+        await expect(Promise.reject(error)).to.be.revert(ethers);
+      };
+
+      const expectNonRevertError = async (error: Error, message: string) => {
+        await expect(
+          expect(Promise.reject(error)).to.be.revert(ethers),
+        ).to.be.rejectedWith(message);
+      };
+
       it("non-errors", async () => {
         await expectAssertionError(
           expect(Promise.reject({})).to.be.revert(ethers),
           "Expected an Error object",
         );
+      });
+
+      it("no-data call exceptions", async () => {
+        for (const action of ["call", "estimateGas"] as const) {
+          await expectNoDataExecutionError(createNoDataCallException(action));
+        }
+
+        await expectNoDataExecutionError(
+          createNoDataCallException("call", new Error("execution reverted")),
+        );
+
+        await expectAssertionError(
+          expect(
+            Promise.reject(createNoDataCallException("call")),
+          ).not.to.be.revert(ethers),
+          "Expected transaction NOT to be reverted",
+        );
+      });
+
+      it("no-data provider execution errors", async () => {
+        for (const code of [-32003, -32000, 3]) {
+          await expectNoDataExecutionError(
+            createNoDataProviderExecutionError(code),
+          );
+        }
+
+        await expectNoDataExecutionError(
+          createNoDataProviderExecutionError(-32003, "EVM error OutOfGas"),
+        );
+        await expectNoDataExecutionError(
+          createNoDataProviderExecutionErrorWithEnvelopeData(-32003),
+        );
+        await expectNoDataExecutionError(
+          createNestedNoDataProviderExecutionError(-32003),
+        );
+
+        await expectNonRevertError(
+          new Error("execution reverted"),
+          "execution reverted",
+        );
+        await expectNonRevertError(
+          new Error("invalid opcode: INVALID"),
+          "invalid opcode: INVALID",
+        );
+        await expectNonRevertError(
+          createNoDataProviderExecutionError(
+            -32003,
+            "EVM error; database error: failed to get account",
+          ),
+          "EVM error; database error: failed to get account",
+        );
+        await expectNonRevertError(
+          createNoDataProviderExecutionError(-32003, "EVM error DatabaseError"),
+          "EVM error DatabaseError",
+        );
+      });
+
+      it("no-data execution errors still require return data for reason-specific matchers", async () => {
+        const reasonSpecificAssertions = [
+          () =>
+            expect(
+              Promise.reject(createNoDataProviderExecutionError(-32003)),
+            ).to.be.revertedWith("some reason"),
+          () =>
+            expect(
+              Promise.reject(createNoDataProviderExecutionError(-32003)),
+            ).to.be.revertedWithPanic(),
+          () =>
+            expect(
+              Promise.reject(createNoDataProviderExecutionError(-32003)),
+            ).to.be.revertedWithCustomError(matchers, "SomeCustomError"),
+          () =>
+            expect(
+              Promise.reject(createNoDataProviderExecutionError(-32003)),
+            ).to.be.revertedWithoutReason(ethers),
+        ];
+
+        for (const assertion of reasonSpecificAssertions) {
+          await expect(assertion()).to.be.rejectedWith(
+            "EVM error InvalidFEOpcode",
+          );
+        }
       });
 
       it("errors that are not related to a reverted transaction", async () => {
@@ -501,3 +593,54 @@ describe("INTEGRATION: Revert", { timeout: 60000 }, () => {
     });
   }
 });
+
+function createNoDataCallException(
+  action: "call" | "estimateGas",
+  rpcError: Error | { code?: number; data?: unknown; message: string } = {
+    code: -32003,
+    message: "EVM error InvalidFEOpcode",
+  },
+): Error {
+  return Object.assign(new Error("missing revert data"), {
+    code: "CALL_EXCEPTION",
+    action,
+    data: null,
+    reason: null,
+    shortMessage: "missing revert data",
+    info: {
+      error: rpcError,
+    },
+  });
+}
+
+function createNoDataProviderExecutionError(
+  code: number,
+  message = "EVM error InvalidFEOpcode",
+): Error {
+  return Object.assign(new Error(message), {
+    code,
+    data: undefined,
+  });
+}
+
+function createNoDataProviderExecutionErrorWithEnvelopeData(
+  code: number,
+): Error {
+  return Object.assign(new Error("EVM error InvalidFEOpcode"), {
+    code,
+    data: {
+      name: "ProviderError",
+      stack: "ProviderError: EVM error InvalidFEOpcode",
+    },
+  });
+}
+
+function createNestedNoDataProviderExecutionError(code: number): Error {
+  return Object.assign(new Error("missing revert data"), {
+    code: -1,
+    error: {
+      code,
+      message: "EVM error InvalidFEOpcode",
+    },
+  });
+}

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/utils.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/utils.ts
@@ -59,6 +59,17 @@ describe("isNoDataExecutionError", () => {
       ),
       false,
     );
+
+    // ethers call exception whose nested rpc error has a non-execution code
+    assert.equal(
+      isNoDataExecutionError(
+        createNoDataCallException("call", {
+          code: -1,
+          message: "EVM error InvalidFEOpcode",
+        }),
+      ),
+      false,
+    );
   });
 
   it("Should return false when revert data is present", () => {
@@ -82,6 +93,16 @@ describe("isNoDataExecutionError", () => {
       ),
       false,
     );
+
+    // ethers call exception that itself carries data is not a no-data error
+    assert.equal(
+      isNoDataExecutionError(
+        Object.assign(createNoDataCallException("call"), {
+          data: "0x08c379a0",
+        }),
+      ),
+      false,
+    );
   });
 });
 
@@ -94,6 +115,7 @@ describe("isKnownEvmExecutionErrorMessage", () => {
       "Transaction reverted and Hardhat couldn't infer the reason.",
       "VM Exception while processing transaction: invalid opcode",
       "VM Exception while processing transaction: out of gas",
+      "VM Exception while processing transaction: reverted with reason string 'x'",
       "Transaction reverted: contract call run out of gas and made the transaction revert",
       "invalid opcode: INVALID",
       "Provider error: invalid opcode",

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/utils.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/utils.ts
@@ -6,34 +6,11 @@ import {
   isNoDataExecutionError,
 } from "../../../src/internal/matchers/reverted/utils.js";
 
-function createNoDataCallException(
-  action: "call" | "estimateGas",
-  rpcError: Error | { code?: number; data?: unknown; message: string } = {
-    code: -32003,
-    message: "EVM error InvalidFEOpcode",
-  },
-): Error {
-  return Object.assign(new Error("missing revert data"), {
-    code: "CALL_EXCEPTION",
-    action,
-    data: null,
-    reason: null,
-    shortMessage: "missing revert data",
-    info: {
-      error: rpcError,
-    },
-  });
-}
-
-function createNoDataProviderExecutionError(
-  code: number,
-  message = "EVM error InvalidFEOpcode",
-): Error {
-  return Object.assign(new Error(message), {
-    code,
-    data: undefined,
-  });
-}
+import {
+  createNoDataCallException,
+  createNoDataProviderExecutionError,
+  createNestedNoDataProviderExecutionError,
+} from "./no-data-error-fixtures.js";
 
 describe("isNoDataExecutionError", () => {
   it("Should return true for no-data ethers call exceptions", () => {
@@ -62,15 +39,10 @@ describe("isNoDataExecutionError", () => {
       );
     }
 
-    const nestedError = Object.assign(new Error("missing revert data"), {
-      code: -1,
-      error: {
-        code: -32003,
-        message: "EVM error InvalidFEOpcode",
-      },
-    });
-
-    assert.equal(isNoDataExecutionError(nestedError), true);
+    assert.equal(
+      isNoDataExecutionError(createNestedNoDataProviderExecutionError(-32003)),
+      true,
+    );
   });
 
   it("Should return false for values that are not no-data execution errors", () => {

--- a/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/utils.ts
+++ b/packages/hardhat-ethers-chai-matchers/test/matchers/reverted/utils.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  isKnownEvmExecutionErrorMessage,
+  isNoDataExecutionError,
+} from "../../../src/internal/matchers/reverted/utils.js";
+
+function createNoDataCallException(
+  action: "call" | "estimateGas",
+  rpcError: Error | { code?: number; data?: unknown; message: string } = {
+    code: -32003,
+    message: "EVM error InvalidFEOpcode",
+  },
+): Error {
+  return Object.assign(new Error("missing revert data"), {
+    code: "CALL_EXCEPTION",
+    action,
+    data: null,
+    reason: null,
+    shortMessage: "missing revert data",
+    info: {
+      error: rpcError,
+    },
+  });
+}
+
+function createNoDataProviderExecutionError(
+  code: number,
+  message = "EVM error InvalidFEOpcode",
+): Error {
+  return Object.assign(new Error(message), {
+    code,
+    data: undefined,
+  });
+}
+
+describe("isNoDataExecutionError", () => {
+  it("Should return true for no-data ethers call exceptions", () => {
+    for (const action of ["call", "estimateGas"] as const) {
+      assert.equal(
+        isNoDataExecutionError(createNoDataCallException(action)),
+        true,
+        action,
+      );
+    }
+
+    assert.equal(
+      isNoDataExecutionError(
+        createNoDataCallException("call", new Error("execution reverted")),
+      ),
+      true,
+    );
+  });
+
+  it("Should return true for no-data provider execution errors", () => {
+    for (const code of [3, -32000, -32003]) {
+      assert.equal(
+        isNoDataExecutionError(createNoDataProviderExecutionError(code)),
+        true,
+        `code ${code}`,
+      );
+    }
+
+    const nestedError = Object.assign(new Error("missing revert data"), {
+      code: -1,
+      error: {
+        code: -32003,
+        message: "EVM error InvalidFEOpcode",
+      },
+    });
+
+    assert.equal(isNoDataExecutionError(nestedError), true);
+  });
+
+  it("Should return false for values that are not no-data execution errors", () => {
+    assert.equal(isNoDataExecutionError({}), false);
+
+    assert.equal(
+      isNoDataExecutionError(new Error("execution reverted")),
+      false,
+    );
+
+    assert.equal(
+      isNoDataExecutionError(
+        createNoDataProviderExecutionError(-32003, "EVM error DatabaseError"),
+      ),
+      false,
+    );
+  });
+
+  it("Should return false when revert data is present", () => {
+    assert.equal(
+      isNoDataExecutionError(
+        Object.assign(new Error("execution reverted"), {
+          code: -32000,
+          data: "0x08c379a0",
+        }),
+      ),
+      false,
+    );
+
+    assert.equal(
+      isNoDataExecutionError(
+        createNoDataCallException("call", {
+          code: -32003,
+          data: "0x08c379a0",
+          message: "execution reverted",
+        }),
+      ),
+      false,
+    );
+  });
+});
+
+describe("isKnownEvmExecutionErrorMessage", () => {
+  it("Should return true for known EVM execution error messages", () => {
+    const messages = [
+      "execution reverted",
+      "execution reverted: reason",
+      "Transaction reverted without a reason string",
+      "Transaction reverted and Hardhat couldn't infer the reason.",
+      "VM Exception while processing transaction: invalid opcode",
+      "VM Exception while processing transaction: out of gas",
+      "Transaction reverted: contract call run out of gas and made the transaction revert",
+      "invalid opcode: INVALID",
+      "Provider error: invalid opcode",
+      "EVM error InvalidFEOpcode",
+      "EVM error OutOfGas",
+    ];
+
+    for (const message of messages) {
+      assert.equal(isKnownEvmExecutionErrorMessage(message), true, message);
+    }
+  });
+
+  it("Should return false for non-execution provider errors", () => {
+    const messages = [
+      "execution failed",
+      "EVM error; database error: failed to get account",
+      "EVM error: database error",
+      "EVM error DatabaseError",
+      "insufficient funds for gas * price",
+      "Transaction reverted: trying to deploy a contract whose code is too large",
+      "some upstream service mentioned invalid opcode",
+    ];
+
+    for (const message of messages) {
+      assert.equal(isKnownEvmExecutionErrorMessage(message), false, message);
+    }
+  });
+});


### PR DESCRIPTION
## Why

The broad `.revert(ethers)` matcher is used to assert that contract execution failed. Some clients and provider stacks report EVM execution failures from `eth_call` and `eth_estimateGas` without revert return data, especially for invalid opcode and out-of-gas style failures. Those failures should satisfy the broad matcher, while reason-specific matchers should continue to require actual revert data.

This follows the existing Ignition behavior of normalizing recognized no-data execution failures.

## What changed

- The broad `.revert(ethers)` matcher now accepts recognized no-data EVM execution failures from call and gas-estimation paths.
- `.revertedWith`, `.revertedWithPanic`, `.revertedWithCustomError`, and `.revertedWithoutReason` remain data-driven and still require actual revert return data.
- The `isKnownEvmExecutionErrorMessage` message classifier is an internal helper of `hardhat-ethers-chai-matchers`. No other packages are changed.
- The message classifier matches existing Hardhat/provider execution-failure formats, including no-reason reverts, invalid opcode, out-of-gas, and explicit EVM exceptional halt names such as `InvalidFEOpcode` and `OutOfGas` (a verbatim copy of EDR's `ExceptionalHalt` enum).
- The classifier avoids treating arbitrary capitalized `EVM error ...` messages as execution failures.
- Matcher utility error handling now uses `unknown` inputs and explicit narrowing instead of `any`-based property access.

## Tests

- Added matcher coverage for no-data call exceptions, provider execution errors, nested provider errors, out-of-gas exceptional halts, unrelated provider errors, and the reason-specific matcher invariant.
- Added unit coverage for `isNoDataExecutionError` and for accepted/rejected provider messages in `isKnownEvmExecutionErrorMessage`.

Verification run from `packages/hardhat-ethers-chai-matchers`:

- `pnpm build`
- `pnpm lint`
- `node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter test/matchers/reverted/*.ts`
