### PR TITLE
Fix artifacts being deleted when their path has a .sol-suffixed segment

### DIFF
--- a/.changeset/grumpy-bottles-dream.md
+++ b/.changeset/grumpy-bottles-dream.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix compilation artifacts accidentally being deleted when their path contains an intermediate directory whose name ends in `.sol`.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1103,7 +1103,7 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     // source files that compile but produce no contracts emit only the
     // declaration file, but their parent dir still belongs in the cleanup
     // candidate set.
-    // TODO: This logic is duplicated with respect to the artifacts manager
+    // TODO: This logic is originated with the artifacts manager, but now uses both json files and `artifacts.d.ts` as the test
     const allArtifactFiles = await getAllFilesMatching(
       artifactsDirectory,
       (p) => {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -43,7 +43,6 @@ import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
 import {
   exists,
   ensureDir,
-  getAllDirectoriesMatching,
   getAllFilesMatching,
   move,
   readJsonFile,
@@ -1098,29 +1097,46 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
 
     const userSourceNamesSet = new Set(userSourceNames);
 
-    for (const file of await getAllDirectoriesMatching(
+    const buildInfosDir = path.join(artifactsDirectory, `build-info`);
+
+    // We accept both `.json` files and per-file `artifacts.d.ts` files:
+    // source files that compile but produce no contracts emit only the
+    // declaration file, but their parent dir still belongs in the cleanup
+    // candidate set.
+    // TODO: This logic is duplicated with respect to the artifacts manager
+    const allArtifactFiles = await getAllFilesMatching(
       artifactsDirectory,
-      (d) => d.endsWith(".sol"),
-    )) {
+      (p) => {
+        // Ignore top level files (e.g. the project-wide artifacts.d.ts)
+        if (
+          p.indexOf(path.sep, artifactsDirectory.length + path.sep.length) ===
+          -1
+        ) {
+          return false;
+        }
+        return p.endsWith(".json") || path.basename(p) === "artifacts.d.ts";
+      },
+      (dir) => dir !== buildInfosDir,
+    );
+
+    const artifactDirs = new Set(
+      allArtifactFiles.map((file) => path.dirname(file)),
+    );
+    const removedDirs = new Set<string>();
+
+    for (const dir of artifactDirs) {
       const relativePath = toForwardSlash(
-        path.relative(artifactsDirectory, file),
+        path.relative(artifactsDirectory, dir),
       );
 
       if (!userSourceNamesSet.has(relativePath)) {
-        await remove(file);
+        await remove(dir);
+        removedDirs.add(dir);
       }
     }
 
-    const buildInfosDir = path.join(artifactsDirectory, `build-info`);
-
-    // TODO: This logic is duplicated with respect to the artifacts manager
-    const artifactPaths = await getAllFilesMatching(
-      artifactsDirectory,
-      (p) =>
-        p.endsWith(".json") && // Only consider json files
-        // Ignore top level json files
-        p.indexOf(path.sep, artifactsDirectory.length + path.sep.length) !== -1,
-      (dir) => dir !== buildInfosDir,
+    const artifactPaths = allArtifactFiles.filter(
+      (p) => p.endsWith(".json") && !removedDirs.has(path.dirname(p)),
     );
 
     const reachableBuildInfoIds = await Promise.all(

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
@@ -419,6 +419,288 @@ contract ToDelete {}`,
           "ToDelete.sol artifact should be removed after source file deleted",
         );
       });
+
+      it("should remove the directory of a deleted source file that produced only artifacts.d.ts", async () => {
+        // A source file with no contracts (e.g. only file-level constants or
+        // free functions) emits artifacts.d.ts but no .json. Cleanup must
+        // still pick its parent dir up as a candidate when the source is
+        // removed.
+        await using project = await useTestProjectTemplate({
+          name: "test-cleanup-stale-no-json",
+          version: "1.0.0",
+          files: {
+            "contracts/Permanent.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Permanent {}`,
+            "contracts/Constants.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+uint256 constant FOO = 1;`,
+          },
+        });
+
+        const hre = await createHardhatRuntimeEnvironment(
+          {
+            solidity: "0.8.28",
+          },
+          {},
+          project.path,
+        );
+
+        await hre.tasks.getTask("build").run({
+          force: true,
+          quiet: true,
+        });
+
+        const constantsDir = path.join(
+          project.path,
+          "artifacts",
+          "contracts",
+          "Constants.sol",
+        );
+        const constantsDts = path.join(constantsDir, "artifacts.d.ts");
+
+        assert.ok(
+          await exists(constantsDts),
+          "Constants.sol should have an artifacts.d.ts after first build",
+        );
+
+        await remove(path.join(project.path, "contracts/Constants.sol"));
+
+        await hre.tasks.getTask("build").run({
+          force: true,
+          quiet: true,
+        });
+
+        assert.ok(
+          !(await exists(constantsDir)),
+          "Constants.sol directory should be removed after source file deleted",
+        );
+      });
+    });
+
+    describe("when a path segment above the artifact ends in .sol", () => {
+      it("keeps the npm artifact across cleanup when the package directory ends in .sol", async () => {
+        await using project = await useTestProjectTemplate({
+          name: "test-cleanup-npm-sol-suffix-keep",
+          version: "1.0.0",
+          files: {},
+          dependencies: {
+            "@example/fake-pkg.sol": {
+              name: "@example/fake-pkg.sol",
+              version: "1.0.0",
+              files: {
+                "Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+              },
+              exports: {
+                "./*": "./*",
+              },
+            },
+          },
+        });
+
+        const hre = await createHardhatRuntimeEnvironment(
+          {
+            solidity: {
+              version: "0.8.28",
+              npmFilesToBuild: ["@example/fake-pkg.sol/Foo.sol"],
+            },
+          },
+          {},
+          project.path,
+        );
+
+        await hre.tasks.getTask("build").run({
+          force: true,
+          quiet: true,
+        });
+
+        const fooArtifact = path.join(
+          project.path,
+          "artifacts",
+          "@example",
+          "fake-pkg.sol",
+          "Foo.sol",
+          "Foo.json",
+        );
+
+        assert.ok(
+          await exists(fooArtifact),
+          "Foo.json under @example/fake-pkg.sol/Foo.sol should survive cleanup",
+        );
+      });
+
+      it("keeps the project artifact across cleanup when a project subfolder ends in .sol", async () => {
+        await using project = await useTestProjectTemplate({
+          name: "test-cleanup-project-sol-suffix-keep",
+          version: "1.0.0",
+          files: {
+            "contracts/foo.sol/Helper.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Helper {}`,
+          },
+        });
+
+        const hre = await createHardhatRuntimeEnvironment(
+          {
+            solidity: "0.8.28",
+          },
+          {},
+          project.path,
+        );
+
+        await hre.tasks.getTask("build").run({
+          force: true,
+          quiet: true,
+        });
+
+        const helperArtifact = path.join(
+          project.path,
+          "artifacts",
+          "contracts",
+          "foo.sol",
+          "Helper.sol",
+          "Helper.json",
+        );
+
+        assert.ok(
+          await exists(helperArtifact),
+          "Helper.json under contracts/foo.sol/Helper.sol should survive cleanup",
+        );
+      });
+
+      it("removes the npm artifact when the source is no longer in npmFilesToBuild", async () => {
+        await using project = await useTestProjectTemplate({
+          name: "test-cleanup-npm-sol-suffix-delete",
+          version: "1.0.0",
+          files: {
+            "contracts/Stable.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Stable {}`,
+          },
+          dependencies: {
+            "@example/fake-pkg.sol": {
+              name: "@example/fake-pkg.sol",
+              version: "1.0.0",
+              files: {
+                "Foo.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Foo {}`,
+              },
+              exports: {
+                "./*": "./*",
+              },
+            },
+          },
+        });
+
+        const hreWithNpm = await createHardhatRuntimeEnvironment(
+          {
+            solidity: {
+              version: "0.8.28",
+              npmFilesToBuild: ["@example/fake-pkg.sol/Foo.sol"],
+            },
+          },
+          {},
+          project.path,
+        );
+
+        await hreWithNpm.tasks.getTask("build").run({
+          force: true,
+          quiet: true,
+        });
+
+        const fooArtifact = path.join(
+          project.path,
+          "artifacts",
+          "@example",
+          "fake-pkg.sol",
+          "Foo.sol",
+          "Foo.json",
+        );
+
+        assert.ok(
+          await exists(fooArtifact),
+          "Foo.json should exist after the first build",
+        );
+
+        // Drop the npm file and rebuild: the artifact must be cleaned up.
+        const hreWithoutNpm = await createHardhatRuntimeEnvironment(
+          {
+            solidity: {
+              version: "0.8.28",
+              npmFilesToBuild: [],
+            },
+          },
+          {},
+          project.path,
+        );
+
+        await hreWithoutNpm.tasks.getTask("build").run({
+          force: true,
+          quiet: true,
+        });
+
+        assert.ok(
+          !(await exists(fooArtifact)),
+          "Foo.json should be removed after dropping it from npmFilesToBuild",
+        );
+      });
+
+      it("removes the project artifact when a source under a .sol-suffixed subfolder is deleted", async () => {
+        await using project = await useTestProjectTemplate({
+          name: "test-cleanup-project-sol-suffix-delete",
+          version: "1.0.0",
+          files: {
+            "contracts/Stable.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Stable {}`,
+            "contracts/foo.sol/Helper.sol": `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+contract Helper {}`,
+          },
+        });
+
+        const hre = await createHardhatRuntimeEnvironment(
+          {
+            solidity: "0.8.28",
+          },
+          {},
+          project.path,
+        );
+
+        await hre.tasks.getTask("build").run({
+          force: true,
+          quiet: true,
+        });
+
+        const helperArtifact = path.join(
+          project.path,
+          "artifacts",
+          "contracts",
+          "foo.sol",
+          "Helper.sol",
+          "Helper.json",
+        );
+
+        assert.ok(
+          await exists(helperArtifact),
+          "Helper.json should exist after the first build",
+        );
+
+        await remove(path.join(project.path, "contracts/foo.sol/Helper.sol"));
+
+        await hre.tasks.getTask("build").run({
+          force: true,
+          quiet: true,
+        });
+
+        assert.ok(
+          !(await exists(helperArtifact)),
+          "Helper.json should be removed after deleting its source file",
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Fix compilation artifacts accidentally being deleted when their path contains an intermediate directory whose name ends in `.sol`.

Fixes #8230.