### PR TITLE
edr: make TestResult fixtures forward-compatible with napi-rs v3

### DIFF
--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/solidity-stack-trace.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/solidity-stack-trace.ts
@@ -42,7 +42,6 @@ import {
 } from "@nomicfoundation/edr";
 
 export {
-  SourceReference,
   StackTraceEntryType,
   CheatcodeErrorCode,
   stackTraceEntryTypeToString,
@@ -56,6 +55,7 @@ export {
 };
 
 export type {
+  SourceReference,
   CallstackEntryStackTraceEntry,
   UnrecognizedCreateCallstackEntryStackTraceEntry,
   UnrecognizedContractCallstackEntryStackTraceEntry,

--- a/packages/hardhat/test/internal/builtin-plugins/gas-analytics/suite-result-helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/gas-analytics/suite-result-helpers.ts
@@ -22,6 +22,9 @@ export function createStandardTestResult(
     },
     stackTrace: () => null,
     callTraces: () => [],
+    reason: undefined,
+    counterexample: undefined,
+    valueSnapshotGroups: undefined,
   };
 }
 
@@ -43,6 +46,9 @@ export function createFuzzTestResult(
     },
     stackTrace: () => null,
     callTraces: () => [],
+    reason: undefined,
+    counterexample: undefined,
+    valueSnapshotGroups: undefined,
   };
 }
 
@@ -65,6 +71,9 @@ export function createInvariantTestResult(
     },
     stackTrace: () => null,
     callTraces: () => [],
+    reason: undefined,
+    counterexample: undefined,
+    valueSnapshotGroups: undefined,
   };
 }
 
@@ -87,6 +96,8 @@ export function createTestResultWithSnapshots(
     },
     stackTrace: () => null,
     callTraces: () => [],
+    reason: undefined,
+    counterexample: undefined,
     valueSnapshotGroups,
   };
 }

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
@@ -90,6 +90,9 @@ const mocker = {
                         mocker.trace(trace),
                       );
                     },
+                    reason: undefined,
+                    counterexample: undefined,
+                    valueSnapshotGroups: undefined,
                   }) satisfies TestResult,
               )
               .reverse(),


### PR DESCRIPTION
## Summary

Adds explicit `undefined` for the three optional `TestResult` members — `reason`, `counterexample`, and `valueSnapshotGroups` — to the five `TestResult`-shaped fixture builders in `gas-analytics/suite-result-helpers.ts` and `solidity-test/reporter.ts`.

Also moves the `SourceReference` re-export in `solidity-stack-trace.ts` to the `export type {}` clause: it's an interface imported with `import type`, so re-exporting it as a value relies on elision that loaders like `tsx/esm` don't perform.

## Why

The upcoming EDR napi-rs v3 release ([NomicFoundation/edr#1385](https://github.com/NomicFoundation/edr/pull/1385)) emits these members as class getters (`get reason(): string | undefined`) instead of optional class fields (`readonly reason?: string`). TypeScript treats class getters as structurally required members, so object literals assigned to `TestResult` must include the keys explicitly.

Explicit `undefined` is also assignable to the current optional fields, so this compiles against both the published EDR (`0.12.0`) and the v3 release. Merging it now means the future EDR bump won't need any test changes.

## Verification

- **Against `@nomicfoundation/edr@0.12.0`** (what `main` depends on): `pnpm build` and lint clean, 216 tests passing across the gas-analytics and solidity-test suites.
- **Against a locally-built EDR from the napi-rs v3 branch** (installed via Verdaccio): `pnpm build` clean with zero TS errors, 272 tests passing across `network-manager/edr` (incl. JSON-RPC provider e2e), `gas-analytics`, and `solidity-test` (incl. real EVM execution through the v3 binary).
