### PR TITLE
Export `package.json` files

### DIFF
--- a/.changeset/export-package-json-hardhat-errors.md
+++ b/.changeset/export-package-json-hardhat-errors.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-errors": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-ethers-chai-matchers.md
+++ b/.changeset/export-package-json-hardhat-ethers-chai-matchers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-ethers.md
+++ b/.changeset/export-package-json-hardhat-ethers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-foundry.md
+++ b/.changeset/export-package-json-hardhat-foundry.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-foundry": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-ignition.md
+++ b/.changeset/export-package-json-hardhat-ignition.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-keystore.md
+++ b/.changeset/export-package-json-hardhat-keystore.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-keystore": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-ledger.md
+++ b/.changeset/export-package-json-hardhat-ledger.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ledger": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-mocha.md
+++ b/.changeset/export-package-json-hardhat-mocha.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-mocha": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-network-helpers.md
+++ b/.changeset/export-package-json-hardhat-network-helpers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-node-test-reporter.md
+++ b/.changeset/export-package-json-hardhat-node-test-reporter.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-reporter": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-node-test-runner.md
+++ b/.changeset/export-package-json-hardhat-node-test-runner.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-runner": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-toolbox-mocha-ethers.md
+++ b/.changeset/export-package-json-hardhat-toolbox-mocha-ethers.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-toolbox-mocha-ethers": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-toolbox-viem.md
+++ b/.changeset/export-package-json-hardhat-toolbox-viem.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-toolbox-viem": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-utils.md
+++ b/.changeset/export-package-json-hardhat-utils.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-vendored.md
+++ b/.changeset/export-package-json-hardhat-vendored.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-vendored": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-verify.md
+++ b/.changeset/export-package-json-hardhat-verify.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-viem-assertions.md
+++ b/.changeset/export-package-json-hardhat-viem-assertions.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-viem.md
+++ b/.changeset/export-package-json-hardhat-viem.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat-zod-utils.md
+++ b/.changeset/export-package-json-hardhat-zod-utils.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-zod-utils": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-hardhat.md
+++ b/.changeset/export-package-json-hardhat.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/.changeset/export-package-json-ignition-core.md
+++ b/.changeset/export-package-json-ignition-core.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/ignition-core": patch
+---
+
+Export `./package.json` so consumers can import the package's manifest.

--- a/packages/hardhat-errors/package.json
+++ b/packages/hardhat-errors/package.json
@@ -14,7 +14,8 @@
   "types": "dist/src/index.d.ts",
   "exports": {
     ".": "./dist/src/index.js",
-    "./descriptors": "./dist/src/descriptors.js"
+    "./descriptors": "./dist/src/descriptors.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-ethers-chai-matchers/package.json
+++ b/packages/hardhat-ethers-chai-matchers/package.json
@@ -15,7 +15,8 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./panic": "./dist/src/panic.js",
-    "./withArgs": "./dist/src/withArgs.js"
+    "./withArgs": "./dist/src/withArgs.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-ethers/package.json
+++ b/packages/hardhat-ethers/package.json
@@ -13,7 +13,8 @@
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js",
-    "./types": "./dist/src/types.js"
+    "./types": "./dist/src/types.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-foundry/package.json
+++ b/packages/hardhat-foundry/package.json
@@ -13,7 +13,8 @@
   "type": "module",
   "types": "dist/src/index.d.ts",
   "exports": {
-    ".": "./dist/src/index.js"
+    ".": "./dist/src/index.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-ignition/package.json
+++ b/packages/hardhat-ignition/package.json
@@ -16,7 +16,8 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./modules": "./dist/src/modules.js",
-    "./helpers": "./dist/src/helpers.js"
+    "./helpers": "./dist/src/helpers.js",
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {

--- a/packages/hardhat-keystore/package.json
+++ b/packages/hardhat-keystore/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./dist/src/index.js"
+    ".": "./dist/src/index.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "keystore",

--- a/packages/hardhat-ledger/package.json
+++ b/packages/hardhat-ledger/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./dist/src/index.js"
+    ".": "./dist/src/index.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-mocha/package.json
+++ b/packages/hardhat-mocha/package.json
@@ -13,7 +13,8 @@
   "type": "module",
   "exports": {
     ".": "./dist/src/index.js",
-    "./test-worker-done": "./dist/src/test-worker-done.js"
+    "./test-worker-done": "./dist/src/test-worker-done.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-network-helpers/package.json
+++ b/packages/hardhat-network-helpers/package.json
@@ -14,7 +14,8 @@
   "types": "dist/src/index.d.ts",
   "exports": {
     ".": "./dist/src/index.js",
-    "./types": "./dist/src/types.js"
+    "./types": "./dist/src/types.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-node-test-reporter/package.json
+++ b/packages/hardhat-node-test-reporter/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./dist/src/reporter.js"
+    ".": "./dist/src/reporter.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-node-test-runner/package.json
+++ b/packages/hardhat-node-test-runner/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./dist/src/index.js"
+    ".": "./dist/src/index.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-solx/package.json
+++ b/packages/hardhat-solx/package.json
@@ -14,7 +14,8 @@
   "type": "module",
   "types": "dist/src/index.d.ts",
   "exports": {
-    ".": "./dist/src/index.js"
+    ".": "./dist/src/index.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-test-utils/package.json
+++ b/packages/hardhat-test-utils/package.json
@@ -13,7 +13,8 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./dist/src/index.js"
+    ".": "./dist/src/index.js",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "lint": "pnpm prettier --check && pnpm eslint",

--- a/packages/hardhat-toolbox-mocha-ethers/package.json
+++ b/packages/hardhat-toolbox-mocha-ethers/package.json
@@ -13,7 +13,8 @@
   "type": "module",
   "types": "",
   "exports": {
-    ".": "./dist/src/index.js"
+    ".": "./dist/src/index.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-toolbox-viem/package.json
+++ b/packages/hardhat-toolbox-viem/package.json
@@ -13,7 +13,8 @@
   "type": "module",
   "types": "",
   "exports": {
-    ".": "./dist/src/index.js"
+    ".": "./dist/src/index.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-utils/package.json
+++ b/packages/hardhat-utils/package.json
@@ -39,7 +39,8 @@
     "./stream": "./dist/src/stream.js",
     "./subprocess": "./dist/src/subprocess.js",
     "./synchronization": "./dist/src/synchronization.js",
-    "./spinner": "./dist/src/spinner.js"
+    "./spinner": "./dist/src/spinner.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-vendored/package.json
+++ b/packages/hardhat-vendored/package.json
@@ -13,7 +13,8 @@
   "type": "module",
   "exports": {
     "./coverage": "./dist/src/coverage-module/index.js",
-    "./coverage/types": "./dist/src/coverage-module/types.js"
+    "./coverage/types": "./dist/src/coverage-module/types.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "hardhat"

--- a/packages/hardhat-verify/package.json
+++ b/packages/hardhat-verify/package.json
@@ -15,7 +15,8 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./verify": "./dist/src/verify.js",
-    "./types": "./dist/src/types.js"
+    "./types": "./dist/src/types.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-viem-assertions/package.json
+++ b/packages/hardhat-viem-assertions/package.json
@@ -15,7 +15,8 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./types": "./dist/src/types.js",
-    "./predicates": "./dist/src/predicates.js"
+    "./predicates": "./dist/src/predicates.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-viem/package.json
+++ b/packages/hardhat-viem/package.json
@@ -14,7 +14,8 @@
   "types": "dist/src/index.d.ts",
   "exports": {
     ".": "./dist/src/index.js",
-    "./types": "./dist/src/types.js"
+    "./types": "./dist/src/types.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat-zod-utils/package.json
+++ b/packages/hardhat-zod-utils/package.json
@@ -14,7 +14,8 @@
   "types": "dist/src/index.d.ts",
   "exports": {
     ".": "./dist/src/index.js",
-    "./rpc": "./dist/src/rpc/index.js"
+    "./rpc": "./dist/src/rpc/index.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -44,7 +44,8 @@
     "./utils/result": "./dist/src/utils/result.js",
     "./types/runtime": "./dist/src/internal/deprecated-module-imported-from-hardhat2-plugin.js",
     "./builtin-tasks/task-names": "./dist/src/internal/deprecated-module-imported-from-hardhat2-plugin.js",
-    "./internal/artifacts": "./dist/src/internal/deprecated-module-imported-from-hardhat2-plugin.js"
+    "./internal/artifacts": "./dist/src/internal/deprecated-module-imported-from-hardhat2-plugin.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",

--- a/packages/ignition-core/package.json
+++ b/packages/ignition-core/package.json
@@ -15,7 +15,8 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": "./dist/src/index.js",
-    "./ui-helpers": "./dist/src/ui-helpers.js"
+    "./ui-helpers": "./dist/src/ui-helpers.js",
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {

--- a/packages/template-package/package.json
+++ b/packages/template-package/package.json
@@ -15,7 +15,8 @@
   "types": "dist/src/index.d.ts",
   "exports": {
     ".": "./dist/src/index.js",
-    "./other": "./dist/src/other-entry-point.js"
+    "./other": "./dist/src/other-entry-point.js",
+    "./package.json": "./package.json"
   },
   "keywords": [
     "ethereum",


### PR DESCRIPTION
This PR adds `"./package.json": "./package.json"` to all the existing `package.json`s that use `exports`, and adds the appropriate changesets.

The reason for this is that agents do `require("package/package.json").version` to check the versions of dependencies.

Here's some help to review the change:

## Which packages need to be modified

This will print the list of packages that use `package.json#exports`:

```sh
rg '"exports"' packages/*/package.json -l
```

```
packages/hardhat-viem-assertions/package.json
packages/hardhat-solx/package.json
packages/hardhat-keystore/package.json
packages/hardhat-test-utils/package.json
packages/hardhat-ledger/package.json
packages/hardhat-viem/package.json
packages/hardhat-toolbox-mocha-ethers/package.json
packages/hardhat-mocha/package.json
packages/hardhat-zod-utils/package.json
packages/hardhat-ethers-chai-matchers/package.json
packages/hardhat-errors/package.json
packages/hardhat-toolbox-viem/package.json
packages/ignition-core/package.json
packages/hardhat-typechain/package.json
packages/hardhat-ethers/package.json
packages/hardhat-foundry/package.json
packages/hardhat-network-helpers/package.json
packages/hardhat-node-test-runner/package.json
packages/hardhat-vendored/package.json
packages/hardhat-utils/package.json
packages/hardhat/package.json
packages/hardhat-verify/package.json
packages/hardhat-ignition/package.json
packages/hardhat-node-test-reporter/package.json
packages/template-package/package.json
```

## How to verify they have been modified correctly:

This should print `"./package.json"` for every package that from the lis above:

```sh
rg '"exports"' packages/*/package.json -l | xargs jq '.exports["./package.json"]'
```

```
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
"./package.json"
```

## Changesets validation

There are 25 packages with `package.json#exports`, but the typechain plugin already had the `package.json` exported, so 24 were modified.

At the same time, `packages/hardhat-test-utils`, `packages/hardhat-solx`, and `packages/template-package` are private, so they don't need a changeset, making them 21.

This validation checks that there are 21 changesets created for the modified packages:

```sh
ls .changeset/export-package-json-* | wc -l
```

```
21
```

