### PR TITLE
Sanitize snapshot cheatcode group names

### DIFF
--- a/.changeset/tame-snakes-write.md
+++ b/.changeset/tame-snakes-write.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Sanitized snapshot cheatcode group names to avoid issues when persisting them to disk. A warning is shown when a group is renamed suggesting the user to update their snapshot group names to match the on-disk names.

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -1243,6 +1243,13 @@ Double-check the paths you are providing to the \`test solidity\` task.`,
         websiteTitle: "Selected Solidity test files do not exist",
         websiteDescription: `You ran the \`test solidity\` task with files that do not exist on disk.`,
       },
+      SNAPSHOT_GROUP_NAME_COLLISION: {
+        number: 817,
+        messageTemplate: `Snapshot group names "{nameA}" and "{nameB}" both produce the on-disk filename "{sanitized}.json" after sanitization. Rename one of them in your Solidity tests so they produce different filenames.`,
+        websiteTitle: "Snapshot group name collision after sanitization",
+        websiteDescription:
+          "Two distinct snapshot group names sanitize to the same on-disk filename. Rename one of the groups in your Solidity tests so they produce different filenames.",
+      },
     },
     SOLIDITY: {
       PROJECT_ROOT_RESOLUTION_ERROR: {

--- a/packages/hardhat-utils/src/path.ts
+++ b/packages/hardhat-utils/src/path.ts
@@ -67,7 +67,7 @@ export function shortenPath(absolutePath: string): string {
  * @returns A non-empty filename-safe string.
  */
 export function sanitizeFilename(name: string): string {
-  let result = name.replace(/[<>:"/\\|?*\x00-\x1F]/g, "");
+  let result = name.replace(/[<>:"/\\|?*\x00-\x1F\x7F]/g, "");
   result = result.replace(/[\s.]+$/, "");
 
   if (result === "" || result === "." || result === "..") {

--- a/packages/hardhat-utils/src/path.ts
+++ b/packages/hardhat-utils/src/path.ts
@@ -53,3 +53,26 @@ export function shortenPath(absolutePath: string): string {
 
   return absolutePath;
 }
+
+/**
+ * Returns a version of {@link name} that is safe to use as a single filename
+ * component on POSIX, macOS, and Windows.
+ *
+ * Strips characters that are reserved on at least one of those platforms
+ * (`<>:"/\|?*` and ASCII control chars), trims trailing dots and whitespace
+ * (Windows silently strips them on write), and falls back to `_` if the
+ * result is empty or one of the path-traversal literals `.` / `..`.
+ *
+ * @param name The string to sanitize.
+ * @returns A non-empty filename-safe string.
+ */
+export function sanitizeFilename(name: string): string {
+  let result = name.replace(/[<>:"/\\|?*\x00-\x1F]/g, "");
+  result = result.replace(/[\s.]+$/, "");
+
+  if (result === "" || result === "." || result === "..") {
+    result = "_";
+  }
+
+  return result;
+}

--- a/packages/hardhat-utils/test/path.ts
+++ b/packages/hardhat-utils/test/path.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { after, before, describe, it } from "node:test";
 
 import { ensureDir } from "../src/fs.js";
-import { resolveFromRoot, shortenPath } from "../src/path.js";
+import { resolveFromRoot, sanitizeFilename, shortenPath } from "../src/path.js";
 
 describe("path", () => {
   describe("resolveFromRoot", () => {
@@ -95,6 +95,70 @@ describe("path", () => {
       process.chdir(cwd);
 
       assert.equal(shortenPath(import.meta.dirname), import.meta.dirname);
+    });
+  });
+
+  describe("sanitizeFilename", () => {
+    it("Should pass through names that are already filesystem-safe", () => {
+      assert.equal(sanitizeFilename("foo"), "foo");
+      assert.equal(sanitizeFilename("foo bar 123"), "foo bar 123");
+      assert.equal(sanitizeFilename(".foo"), ".foo");
+      assert.equal(sanitizeFilename("a.b.c"), "a.b.c");
+      assert.equal(sanitizeFilename("hello-world_42"), "hello-world_42");
+    });
+
+    it('Should strip the reserved characters <>:"/\\|?*', () => {
+      assert.equal(sanitizeFilename("a<b>c"), "abc");
+      assert.equal(sanitizeFilename('a"b'), "ab");
+      assert.equal(sanitizeFilename("a:b"), "ab");
+      assert.equal(sanitizeFilename("a/b"), "ab");
+      assert.equal(sanitizeFilename("a\\b"), "ab");
+      assert.equal(sanitizeFilename("a|b"), "ab");
+      assert.equal(sanitizeFilename("a?b"), "ab");
+      assert.equal(sanitizeFilename("a*b"), "ab");
+      assert.equal(sanitizeFilename('<>:"/\\|?*'), "_");
+    });
+
+    it("Should strip ASCII control characters", () => {
+      assert.equal(sanitizeFilename("a\x00b"), "ab");
+      assert.equal(sanitizeFilename("a\x1fb"), "ab");
+      assert.equal(sanitizeFilename("a\tb\nc\rd"), "abcd");
+    });
+
+    it("Should strip trailing dots and trailing whitespace", () => {
+      assert.equal(sanitizeFilename("foo."), "foo");
+      assert.equal(sanitizeFilename("foo..."), "foo");
+      assert.equal(sanitizeFilename("foo "), "foo");
+      assert.equal(sanitizeFilename("foo   "), "foo");
+      assert.equal(sanitizeFilename("foo. . ."), "foo");
+    });
+
+    it("Should preserve leading whitespace and inner dots", () => {
+      assert.equal(sanitizeFilename(" foo"), " foo");
+      assert.equal(sanitizeFilename("a.b.c"), "a.b.c");
+      assert.equal(sanitizeFilename("..foo"), "..foo");
+    });
+
+    it('Should map literal "." and ".." to the placeholder', () => {
+      assert.equal(sanitizeFilename("."), "_");
+      assert.equal(sanitizeFilename(".."), "_");
+    });
+
+    it("Should fall back to the placeholder for empty input or input that strips to empty", () => {
+      assert.equal(sanitizeFilename(""), "_");
+      assert.equal(sanitizeFilename("   "), "_");
+      assert.equal(sanitizeFilename("..."), "_");
+      assert.equal(sanitizeFilename("///"), "_");
+    });
+
+    it("Should flatten path-traversal attempts into a single component", () => {
+      assert.equal(sanitizeFilename("../etc/passwd"), "..etcpasswd");
+      assert.equal(sanitizeFilename("/abs/path"), "abspath");
+      assert.equal(sanitizeFilename("a/b/c"), "abc");
+      assert.equal(
+        sanitizeFilename("..\\windows\\system32"),
+        "..windowssystem32",
+      );
     });
   });
 });

--- a/packages/hardhat-utils/test/path.ts
+++ b/packages/hardhat-utils/test/path.ts
@@ -122,6 +122,7 @@ describe("path", () => {
     it("Should strip ASCII control characters", () => {
       assert.equal(sanitizeFilename("a\x00b"), "ab");
       assert.equal(sanitizeFilename("a\x1fb"), "ab");
+      assert.equal(sanitizeFilename("a\x7fb"), "ab");
       assert.equal(sanitizeFilename("a\tb\nc\rd"), "abcd");
     });
 

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
@@ -90,9 +90,9 @@ export function getSnapshotCheatcodesPath(
 }
 
 /**
- * Rekeys {@link snapshots} so each group name is safe to use as a filename
- * component, returning the rekeyed map alongside the list of names that
- * were actually changed by sanitization.
+ * Rekeys {@link snapshotCheatcodes} so each group name is safe to use as a
+ * filename component, returning the rekeyed map alongside the list of names
+ * that were actually changed by sanitization.
  *
  * @throws `SOLIDITY_TESTS.SNAPSHOT_GROUP_NAME_COLLISION` if two distinct
  * original names sanitize to the same on-disk filename. Originals are

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
@@ -13,6 +13,7 @@ import {
   remove,
   writeJsonFile,
 } from "@nomicfoundation/hardhat-utils/fs";
+import { sanitizeFilename } from "@nomicfoundation/hardhat-utils/path";
 
 import {
   getFullyQualifiedName,
@@ -22,6 +23,16 @@ import {
 import { formatSectionHeader, getUserFqn } from "./helpers/utils.js";
 
 export const SNAPSHOT_CHEATCODES_DIR = "snapshots";
+
+export interface RenamedSnapshotGroup {
+  original: string;
+  sanitized: string;
+}
+
+export interface SanitizedSnapshotCheatcodes {
+  snapshotCheatcodes: SnapshotCheatcodesWithMetadataMap;
+  renamedGroups: RenamedSnapshotGroup[];
+}
 
 export type SnapshotCheatcodesMap = Map<
   string, // group
@@ -68,6 +79,7 @@ export interface SnapshotCheatcodesCheckResult {
   passed: boolean;
   comparison: SnapshotCheatcodesComparison;
   written: boolean;
+  renamedGroups: RenamedSnapshotGroup[];
 }
 
 export function getSnapshotCheatcodesPath(
@@ -75,6 +87,53 @@ export function getSnapshotCheatcodesPath(
   filename: string,
 ): string {
   return path.join(basePath, SNAPSHOT_CHEATCODES_DIR, filename);
+}
+
+/**
+ * Rekeys {@link snapshots} so each group name is safe to use as a filename
+ * component, returning the rekeyed map alongside the list of names that
+ * were actually changed by sanitization.
+ *
+ * @throws `SOLIDITY_TESTS.SNAPSHOT_GROUP_NAME_COLLISION` if two distinct
+ * original names sanitize to the same on-disk filename. Originals are
+ * sorted by codepoint in the error message so the same input always
+ * produces the same error text.
+ */
+export function sanitizeSnapshotCheatcodes(
+  snapshotCheatcodes: SnapshotCheatcodesWithMetadataMap,
+): SanitizedSnapshotCheatcodes {
+  const sanitizedSnapshotCheatcodes: SnapshotCheatcodesWithMetadataMap =
+    new Map();
+  const originalBySanitized = new Map<string, string>();
+  const renamedGroups: RenamedSnapshotGroup[] = [];
+
+  for (const [original, entries] of snapshotCheatcodes) {
+    const sanitizedName = sanitizeFilename(original);
+
+    const previousOriginal = originalBySanitized.get(sanitizedName);
+    if (previousOriginal !== undefined) {
+      const [nameA, nameB] =
+        previousOriginal < original
+          ? [previousOriginal, original]
+          : [original, previousOriginal];
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.SOLIDITY_TESTS.SNAPSHOT_GROUP_NAME_COLLISION,
+        { nameA, nameB, sanitized: sanitizedName },
+      );
+    }
+
+    originalBySanitized.set(sanitizedName, original);
+    sanitizedSnapshotCheatcodes.set(sanitizedName, entries);
+
+    if (sanitizedName !== original) {
+      renamedGroups.push({ original, sanitized: sanitizedName });
+    }
+  }
+
+  return {
+    snapshotCheatcodes: sanitizedSnapshotCheatcodes,
+    renamedGroups,
+  };
 }
 
 export function extractSnapshotCheatcodes(
@@ -295,7 +354,9 @@ export async function checkSnapshotCheatcodes(
   basePath: string,
   suiteResults: SuiteResult[],
 ): Promise<SnapshotCheatcodesCheckResult> {
-  const snapshotCheatcodes = extractSnapshotCheatcodes(suiteResults);
+  const { snapshotCheatcodes, renamedGroups } = sanitizeSnapshotCheatcodes(
+    extractSnapshotCheatcodes(suiteResults),
+  );
 
   let previousSnapshotCheatcodes;
   try {
@@ -316,6 +377,7 @@ export async function checkSnapshotCheatcodes(
           changed: [],
         },
         written,
+        renamedGroups,
       };
     }
 
@@ -338,6 +400,7 @@ export async function checkSnapshotCheatcodes(
     passed: comparison.changed.length === 0,
     comparison,
     written: hasAddedOrRemoved,
+    renamedGroups,
   };
 }
 
@@ -447,4 +510,30 @@ export function printSnapshotCheatcodeChanges(
       logger();
     }
   }
+}
+
+export function logSnapshotRenameWarnings(
+  renamedGroups: RenamedSnapshotGroup[],
+  logger: typeof console.log = console.log,
+): void {
+  if (renamedGroups.length === 0) {
+    return;
+  }
+
+  logger(
+    styleText(
+      "yellow",
+      `Renamed ${renamedGroups.length} snapshot group name(s) for safe filesystem use:`,
+    ),
+  );
+  for (const { original, sanitized } of renamedGroups) {
+    logger(styleText("yellow", `  "${original}" → "${sanitized}"`));
+  }
+  logger(
+    styleText(
+      "yellow",
+      "If you'd like the on-disk filename(s) to match exactly, consider renaming the group(s) in Solidity.",
+    ),
+  );
+  logger();
 }

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/tasks/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/tasks/solidity-test/task-action.ts
@@ -174,6 +174,16 @@ export function logSnapshotCheckResult(
 
   logSnapshotCheatcodesSection(snapshotCheatcodesCheck, logger);
 
+  // Add an extra newline if only the rename warnings have output
+  // (logSnapshotCheatcodesSection adds one if it has output)
+  if (
+    !functionGasHasOutput &&
+    !snapshotCheatcodesHasOutput &&
+    snapshotCheatcodesCheck.renamedGroups.length > 0
+  ) {
+    logger();
+  }
+
   logSnapshotRenameWarnings(snapshotCheatcodesCheck.renamedGroups, logger);
 
   if (!functionGasSnapshotsCheck.passed || !snapshotCheatcodesCheck.passed) {

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/tasks/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/tasks/solidity-test/task-action.ts
@@ -2,7 +2,10 @@ import type { TaskOverrideActionFunction } from "../../../../../types/tasks.js";
 import type { Result } from "../../../../../types/utils.js";
 import type { SolidityTestRunResult } from "../../../solidity-test/task-action.js";
 import type { FunctionGasSnapshotCheckResult } from "../../function-gas-snapshots.js";
-import type { SnapshotCheatcodesCheckResult } from "../../snapshot-cheatcodes.js";
+import type {
+  SnapshotCheatcodesCheckResult,
+  RenamedSnapshotGroup,
+} from "../../snapshot-cheatcodes.js";
 import type { SuiteResult } from "@nomicfoundation/edr";
 
 import { styleText } from "node:util";
@@ -20,6 +23,8 @@ import {
   checkSnapshotCheatcodes,
   extractSnapshotCheatcodes,
   logSnapshotCheatcodesSection,
+  logSnapshotRenameWarnings,
+  sanitizeSnapshotCheatcodes,
   writeSnapshotCheatcodes,
 } from "../../snapshot-cheatcodes.js";
 
@@ -30,6 +35,7 @@ interface GasAnalyticsTestActionArguments {
 
 export interface SnapshotResult {
   functionGasSnapshotsWritten: boolean;
+  renamedGroups: RenamedSnapshotGroup[];
 }
 
 export interface SnapshotCheckResult {
@@ -91,11 +97,14 @@ export async function handleSnapshot(
     await writeFunctionGasSnapshots(basePath, functionGasSnapshots);
   }
 
-  const snapshotCheatcodes = extractSnapshotCheatcodes(suiteResults);
+  const { snapshotCheatcodes, renamedGroups } = sanitizeSnapshotCheatcodes(
+    extractSnapshotCheatcodes(suiteResults),
+  );
   await writeSnapshotCheatcodes(basePath, snapshotCheatcodes);
 
   return {
     functionGasSnapshotsWritten: testsPassed,
+    renamedGroups,
   };
 }
 
@@ -107,6 +116,7 @@ export function logSnapshotResult(
     logger(styleText("green", "Function gas snapshots written successfully"));
     logger();
   }
+  logSnapshotRenameWarnings(result.renamedGroups, logger);
 }
 
 export async function handleSnapshotCheck(
@@ -163,6 +173,8 @@ export function logSnapshotCheckResult(
   }
 
   logSnapshotCheatcodesSection(snapshotCheatcodesCheck, logger);
+
+  logSnapshotRenameWarnings(snapshotCheatcodesCheck.renamedGroups, logger);
 
   if (!functionGasSnapshotsCheck.passed || !snapshotCheatcodesCheck.passed) {
     logger(

--- a/packages/hardhat/test/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
@@ -1003,7 +1003,7 @@ ZGroup#entry-z: 300`;
       await emptyDir(tmpDir);
     });
 
-    it("Should rekey groups whose names need sanitization and report renames", () => {
+    it("should rekey groups whose names need sanitization and report renames", () => {
       const input: SnapshotCheatcodesWithMetadataMap = new Map([
         [
           "liquidationCall (reportDeficit): full",
@@ -1028,7 +1028,7 @@ ZGroup#entry-z: 300`;
       ]);
     });
 
-    it("Should flatten path-traversal attempts into a single component", () => {
+    it("should flatten path-traversal attempts into a single component", () => {
       const input: SnapshotCheatcodesWithMetadataMap = new Map([
         [
           "../../etc/passwd",
@@ -1048,7 +1048,7 @@ ZGroup#entry-z: 300`;
       ]);
     });
 
-    it("Should pass already-safe names through and report no renames", () => {
+    it("should pass already-safe names through and report no renames", () => {
       const input: SnapshotCheatcodesWithMetadataMap = new Map<
         string,
         Record<string, { value: string; metadata: { source: string } }>
@@ -1078,7 +1078,7 @@ ZGroup#entry-z: 300`;
       assert.deepEqual(renamedGroups, []);
     });
 
-    it("Should throw SNAPSHOT_GROUP_NAME_COLLISION when distinct originals collide", () => {
+    it("should throw SNAPSHOT_GROUP_NAME_COLLISION when distinct originals collide", () => {
       const input: SnapshotCheatcodesWithMetadataMap = new Map<
         string,
         Record<string, { value: string; metadata: { source: string } }>
@@ -1100,7 +1100,7 @@ ZGroup#entry-z: 300`;
       );
     });
 
-    it("Should produce a deterministic collision message regardless of input order", () => {
+    it("should produce a deterministic collision message regardless of input order", () => {
       const a: SnapshotCheatcodesWithMetadataMap = new Map<
         string,
         Record<string, { value: string; metadata: { source: string } }>
@@ -1140,7 +1140,7 @@ ZGroup#entry-z: 300`;
       );
     });
 
-    it("Should round-trip through write/read/compare without spurious diffs when a group is renamed", async () => {
+    it("should round-trip through write/read/compare without spurious diffs when a group is renamed", async () => {
       const input: SnapshotCheatcodesWithMetadataMap = new Map([
         [
           "foo:bar",
@@ -1172,12 +1172,12 @@ ZGroup#entry-z: 300`;
       output = [];
     });
 
-    it("Should not write anything when there are no renames", () => {
+    it("should not write anything when there are no renames", () => {
       logSnapshotRenameWarnings([], logger);
       assert.equal(output.length, 0);
     });
 
-    it("Should emit the rename warning for a single rename", () => {
+    it("should emit the rename warning for a single rename", () => {
       const renames: RenamedSnapshotGroup[] = [
         { original: "foo:bar", sanitized: "foobar" },
       ];
@@ -1190,7 +1190,7 @@ ZGroup#entry-z: 300`;
       assert.match(text, /consider renaming the group\(s\) in Solidity/);
     });
 
-    it("Should emit the rename warning for multiple renames", () => {
+    it("should emit the rename warning for multiple renames", () => {
       const renames: RenamedSnapshotGroup[] = [
         { original: "foo:bar", sanitized: "foobar" },
         { original: "../traversal", sanitized: "..traversal" },

--- a/packages/hardhat/test/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
@@ -3,12 +3,15 @@ import type {
   SnapshotCheatcodeChange,
   SnapshotCheatcodesMap,
   SnapshotCheatcodesWithMetadataMap,
+  RenamedSnapshotGroup,
 } from "../../../../src/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.js";
 
 import assert from "node:assert/strict";
 import path from "node:path";
 import { afterEach, before, describe, it } from "node:test";
 
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
 import {
   emptyDir,
   exists,
@@ -21,8 +24,10 @@ import {
   compareSnapshotCheatcodes,
   extractSnapshotCheatcodes,
   getSnapshotCheatcodesPath,
+  logSnapshotRenameWarnings,
   printSnapshotCheatcodeChanges,
   readSnapshotCheatcodes,
+  sanitizeSnapshotCheatcodes,
   SNAPSHOT_CHEATCODES_DIR,
   stringifySnapshotCheatcodes,
   writeSnapshotCheatcodes,
@@ -984,6 +989,220 @@ ZGroup#entry-z: 300`;
 
       const text = getLoggerOutput();
       assert.equal(text, "");
+    });
+  });
+
+  describe("sanitizeSnapshotCheatcodes", () => {
+    let tmpDir: string;
+
+    before(async () => {
+      tmpDir = await mkdtemp("snapshot-cheatcodes-sanitize-test-");
+    });
+
+    afterEach(async () => {
+      await emptyDir(tmpDir);
+    });
+
+    it("Should rekey groups whose names need sanitization and report renames", () => {
+      const input: SnapshotCheatcodesWithMetadataMap = new Map([
+        [
+          "liquidationCall (reportDeficit): full",
+          { x: { value: "1", metadata: { source: "tests/Test.sol" } } },
+        ],
+      ]);
+
+      const { snapshotCheatcodes, renamedGroups } =
+        sanitizeSnapshotCheatcodes(input);
+
+      assert.equal(snapshotCheatcodes.size, 1);
+      assert.ok(
+        snapshotCheatcodes.get("liquidationCall (reportDeficit) full") !==
+          undefined,
+        "Map should be rekeyed by the sanitized name",
+      );
+      assert.deepEqual(renamedGroups, [
+        {
+          original: "liquidationCall (reportDeficit): full",
+          sanitized: "liquidationCall (reportDeficit) full",
+        },
+      ]);
+    });
+
+    it("Should flatten path-traversal attempts into a single component", () => {
+      const input: SnapshotCheatcodesWithMetadataMap = new Map([
+        [
+          "../../etc/passwd",
+          { x: { value: "1", metadata: { source: "tests/Test.sol" } } },
+        ],
+      ]);
+
+      const { snapshotCheatcodes, renamedGroups } =
+        sanitizeSnapshotCheatcodes(input);
+
+      assert.ok(
+        snapshotCheatcodes.get("....etcpasswd") !== undefined,
+        "Map should be rekeyed by the flattened name",
+      );
+      assert.deepEqual(renamedGroups, [
+        { original: "../../etc/passwd", sanitized: "....etcpasswd" },
+      ]);
+    });
+
+    it("Should pass already-safe names through and report no renames", () => {
+      const input: SnapshotCheatcodesWithMetadataMap = new Map<
+        string,
+        Record<string, { value: string; metadata: { source: string } }>
+      >([
+        [
+          "GroupA",
+          { x: { value: "1", metadata: { source: "tests/Test.sol" } } },
+        ],
+        [
+          "GroupB",
+          { y: { value: "2", metadata: { source: "tests/Test.sol" } } },
+        ],
+      ]);
+
+      const { snapshotCheatcodes, renamedGroups } =
+        sanitizeSnapshotCheatcodes(input);
+
+      assert.equal(snapshotCheatcodes.size, 2);
+      assert.ok(
+        snapshotCheatcodes.get("GroupA") !== undefined,
+        "GroupA preserved",
+      );
+      assert.ok(
+        snapshotCheatcodes.get("GroupB") !== undefined,
+        "GroupB preserved",
+      );
+      assert.deepEqual(renamedGroups, []);
+    });
+
+    it("Should throw SNAPSHOT_GROUP_NAME_COLLISION when distinct originals collide", () => {
+      const input: SnapshotCheatcodesWithMetadataMap = new Map<
+        string,
+        Record<string, { value: string; metadata: { source: string } }>
+      >([
+        [
+          "foo:bar",
+          { x: { value: "1", metadata: { source: "tests/Test.sol" } } },
+        ],
+        [
+          "foo*bar",
+          { y: { value: "2", metadata: { source: "tests/Test.sol" } } },
+        ],
+      ]);
+
+      assertThrowsHardhatError(
+        () => sanitizeSnapshotCheatcodes(input),
+        HardhatError.ERRORS.CORE.SOLIDITY_TESTS.SNAPSHOT_GROUP_NAME_COLLISION,
+        { nameA: "foo*bar", nameB: "foo:bar", sanitized: "foobar" },
+      );
+    });
+
+    it("Should produce a deterministic collision message regardless of input order", () => {
+      const a: SnapshotCheatcodesWithMetadataMap = new Map<
+        string,
+        Record<string, { value: string; metadata: { source: string } }>
+      >([
+        [
+          "foo*bar",
+          { y: { value: "2", metadata: { source: "tests/Test.sol" } } },
+        ],
+        [
+          "foo:bar",
+          { x: { value: "1", metadata: { source: "tests/Test.sol" } } },
+        ],
+      ]);
+      const b: SnapshotCheatcodesWithMetadataMap = new Map<
+        string,
+        Record<string, { value: string; metadata: { source: string } }>
+      >([
+        [
+          "foo:bar",
+          { x: { value: "1", metadata: { source: "tests/Test.sol" } } },
+        ],
+        [
+          "foo*bar",
+          { y: { value: "2", metadata: { source: "tests/Test.sol" } } },
+        ],
+      ]);
+
+      assertThrowsHardhatError(
+        () => sanitizeSnapshotCheatcodes(a),
+        HardhatError.ERRORS.CORE.SOLIDITY_TESTS.SNAPSHOT_GROUP_NAME_COLLISION,
+        { nameA: "foo*bar", nameB: "foo:bar", sanitized: "foobar" },
+      );
+      assertThrowsHardhatError(
+        () => sanitizeSnapshotCheatcodes(b),
+        HardhatError.ERRORS.CORE.SOLIDITY_TESTS.SNAPSHOT_GROUP_NAME_COLLISION,
+        { nameA: "foo*bar", nameB: "foo:bar", sanitized: "foobar" },
+      );
+    });
+
+    it("Should round-trip through write/read/compare without spurious diffs when a group is renamed", async () => {
+      const input: SnapshotCheatcodesWithMetadataMap = new Map([
+        [
+          "foo:bar",
+          { x: { value: "100", metadata: { source: "tests/Test.sol" } } },
+        ],
+      ]);
+
+      const { snapshotCheatcodes } = sanitizeSnapshotCheatcodes(input);
+      await writeSnapshotCheatcodes(tmpDir, snapshotCheatcodes);
+
+      const previous = await readSnapshotCheatcodes(tmpDir);
+      const comparison = compareSnapshotCheatcodes(
+        previous,
+        snapshotCheatcodes,
+      );
+
+      assert.deepEqual(comparison, { added: [], removed: [], changed: [] });
+    });
+  });
+
+  describe("logSnapshotRenameWarnings", () => {
+    let output: string[] = [];
+    const logger: typeof console.log = (...args: unknown[]) => {
+      output.push(args.join(" "));
+    };
+    const getLoggerOutput = (): string => output.join("\n");
+
+    afterEach(() => {
+      output = [];
+    });
+
+    it("Should not write anything when there are no renames", () => {
+      logSnapshotRenameWarnings([], logger);
+      assert.equal(output.length, 0);
+    });
+
+    it("Should emit the rename warning for a single rename", () => {
+      const renames: RenamedSnapshotGroup[] = [
+        { original: "foo:bar", sanitized: "foobar" },
+      ];
+
+      logSnapshotRenameWarnings(renames, logger);
+
+      const text = getLoggerOutput();
+      assert.match(text, /Renamed 1 snapshot group name\(s\)/);
+      assert.match(text, /"foo:bar" → "foobar"/);
+      assert.match(text, /consider renaming the group\(s\) in Solidity/);
+    });
+
+    it("Should emit the rename warning for multiple renames", () => {
+      const renames: RenamedSnapshotGroup[] = [
+        { original: "foo:bar", sanitized: "foobar" },
+        { original: "../traversal", sanitized: "..traversal" },
+      ];
+
+      logSnapshotRenameWarnings(renames, logger);
+
+      const text = getLoggerOutput();
+      assert.match(text, /Renamed 2 snapshot group name\(s\)/);
+      assert.match(text, /"foo:bar" → "foobar"/);
+      assert.match(text, /"\.\.\/traversal" → "\.\.traversal"/);
+      assert.match(text, /consider renaming the group\(s\) in Solidity/);
     });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/gas-analytics/tasks/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/gas-analytics/tasks/solidity-test/task-action.ts
@@ -142,7 +142,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
     });
 
     it("should log success message when function gas snapshots were written", () => {
-      const result = { functionGasSnapshotsWritten: true };
+      const result = { functionGasSnapshotsWritten: true, renamedGroups: [] };
 
       logSnapshotResult(result, logger);
 
@@ -151,7 +151,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
     });
 
     it("should not log anything when function gas snapshots were not written", () => {
-      const result = { functionGasSnapshotsWritten: false };
+      const result = { functionGasSnapshotsWritten: false, renamedGroups: [] };
 
       logSnapshotResult(result, logger);
 
@@ -548,6 +548,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           passed: true,
           comparison: { added: [], removed: [], changed: [] },
           written: false,
+          renamedGroups: [],
         },
       };
 
@@ -582,6 +583,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
             ],
           },
           written: false,
+          renamedGroups: [],
         },
       };
 
@@ -608,6 +610,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           passed: true,
           comparison: { added: [], removed: [], changed: [] },
           written: false,
+          renamedGroups: [],
         },
       };
 
@@ -637,6 +640,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
             changed: [],
           },
           written: true,
+          renamedGroups: [],
         },
       };
 
@@ -666,6 +670,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           passed: true,
           comparison: { added: [], removed: [], changed: [] },
           written: false,
+          renamedGroups: [],
         },
       };
 
@@ -699,6 +704,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           passed: true,
           comparison: { added: [], removed: [], changed: [] },
           written: false,
+          renamedGroups: [],
         },
       };
 
@@ -732,6 +738,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
             changed: [],
           },
           written: true,
+          renamedGroups: [],
         },
       };
 
@@ -768,6 +775,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           passed: true,
           comparison: { added: [], removed: [], changed: [] },
           written: false,
+          renamedGroups: [],
         },
       };
 
@@ -801,6 +809,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
             changed: [],
           },
           written: true,
+          renamedGroups: [],
         },
       };
 
@@ -826,6 +835,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
               passed: true,
               comparison: { added: [], removed: [], changed: [] },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -858,6 +868,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
               passed: true,
               comparison: { added: [], removed: [], changed: [] },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -896,6 +907,7 @@ Function gas snapshots: 1 added
               passed: true,
               comparison: { added: [], removed: [], changed: [] },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -950,6 +962,7 @@ Function gas snapshots: 1 removed
               passed: true,
               comparison: { added: [], removed: [], changed: [] },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -982,6 +995,7 @@ Function gas snapshots: 2 added, 1 removed
               passed: true,
               comparison: { added: [], removed: [], changed: [] },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -1024,6 +1038,7 @@ Function gas snapshots:
                 changed: [],
               },
               written: true,
+              renamedGroups: [],
             },
           };
 
@@ -1066,6 +1081,7 @@ Snapshot cheatcodes: 1 added
                 changed: [],
               },
               written: true,
+              renamedGroups: [],
             },
           };
 
@@ -1119,6 +1135,7 @@ Snapshot cheatcodes: 1 removed
                 changed: [],
               },
               written: true,
+              renamedGroups: [],
             },
           };
 
@@ -1151,6 +1168,7 @@ Snapshot cheatcodes: 1 added, 2 removed
               passed: true,
               comparison: { added: [], removed: [], changed: [] },
               written: true,
+              renamedGroups: [],
             },
           };
 
@@ -1179,6 +1197,7 @@ Snapshot cheatcodes:
               passed: true,
               comparison: { added: [], removed: [], changed: [] },
               written: true,
+              renamedGroups: [],
             },
           };
 
@@ -1226,6 +1245,7 @@ Snapshot cheatcodes:
               passed: true,
               comparison: { added: [], removed: [], changed: [] },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -1270,6 +1290,7 @@ To update snapshots, run your tests with --snapshot
                 ],
               },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -1327,6 +1348,7 @@ To update snapshots, run your tests with --snapshot
                 ],
               },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -1400,6 +1422,7 @@ To update snapshots, run your tests with --snapshot
               passed: true,
               comparison: { added: [], removed: [], changed: [] },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -1472,6 +1495,7 @@ To update snapshots, run your tests with --snapshot
                 ],
               },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -1559,6 +1583,7 @@ To update snapshots, run your tests with --snapshot
                 ],
               },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -1638,6 +1663,7 @@ To update snapshots, run your tests with --snapshot
                 ],
               },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -1707,6 +1733,7 @@ To update snapshots, run your tests with --snapshot
                 changed: [],
               },
               written: true,
+              renamedGroups: [],
             },
           };
 
@@ -1763,6 +1790,7 @@ To update snapshots, run your tests with --snapshot
                 ],
               },
               written: false,
+              renamedGroups: [],
             },
           };
 
@@ -1816,6 +1844,7 @@ To update snapshots, run your tests with --snapshot
                 changed: [],
               },
               written: true,
+              renamedGroups: [],
             },
           };
 


### PR DESCRIPTION
## Summary

* Sanitize Solidity test snapshot group names before writing them to disk.
* Show a warning when names are renamed during sanitization.
* Throw an error if two group names sanitize to the same value.

This unblocks the EDR team from reverting https://github.com/NomicFoundation/edr/issues/1326.

Closes https://github.com/NomicFoundation/hardhat/issues/8252.

## Screenshots

--snapshot
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/5971da26-0e2c-45a6-b448-13968b36bf05" />

--snapshot-check
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/93e4184d-de3a-43c1-a58c-a93dfe01567d" />
