### PR TITLE
Always load the builtin plugins type extensions

### DIFF
--- a/.changeset/fruity-cities-drive.md
+++ b/.changeset/fruity-cities-drive.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Always load the builtin plugins' type extensions

--- a/packages/hardhat/src/config.ts
+++ b/packages/hardhat/src/config.ts
@@ -3,8 +3,6 @@ export * from "./internal/core/config.js";
 
 export type { HardhatUserConfig } from "./types/config.js";
 
-// NOTE: We export the built-in plugin types to load their type extensions
-export type * from "./internal/builtin-plugins/index.js";
 import type { HardhatUserConfig } from "./types/config.js";
 
 import { throwUsingHardhat2PluginError } from "./internal/using-hardhat2-plugin-errors.js";

--- a/packages/hardhat/src/hre.ts
+++ b/packages/hardhat/src/hre.ts
@@ -1,6 +1,3 @@
-// NOTE: We export the built-in plugin types to load their type extensions
-export type * from "./internal/builtin-plugins/index.js";
-
 export { importUserConfig } from "./internal/config-loading.js";
 export { resolveHardhatConfigPath } from "./internal/config-loading.js";
 export { createHardhatRuntimeEnvironment } from "./internal/hre-initialization.js";

--- a/packages/hardhat/src/index.ts
+++ b/packages/hardhat/src/index.ts
@@ -10,9 +10,6 @@ import type { UserInterruptionManager } from "./types/user-interruptions.js";
 
 import { getOrCreateGlobalHardhatRuntimeEnvironment } from "./internal/hre-initialization.js";
 
-// NOTE: We export the built-in plugin types to load their type extensions
-export type * from "./internal/builtin-plugins/index.js";
-
 const hre: HardhatRuntimeEnvironment =
   // eslint-disable-next-line no-restricted-syntax -- Allow top-level await here
   await getOrCreateGlobalHardhatRuntimeEnvironment();

--- a/packages/hardhat/src/types/arguments.ts
+++ b/packages/hardhat/src/types/arguments.ts
@@ -1,3 +1,5 @@
+import "./builtin-plugin-type-extensions.js";
+
 /**
  * The possible types of a global or task option.
  */

--- a/packages/hardhat/src/types/artifacts.ts
+++ b/packages/hardhat/src/types/artifacts.ts
@@ -1,6 +1,8 @@
 import type { SolidityBuildInfo } from "./solidity/solidity-artifacts.js";
 import type { NonNeverKeys } from "./utils.js";
 
+import "./builtin-plugin-type-extensions.js";
+
 /**
  * A map of bare contract names and fully qualified contract names to their
  * artifacts that will be completed by Hardhat's build system using module

--- a/packages/hardhat/src/types/builtin-plugin-type-extensions.ts
+++ b/packages/hardhat/src/types/builtin-plugin-type-extensions.ts
@@ -1,0 +1,15 @@
+// This is an internal file that needs to be imported by every top-level type
+// file, so that they load the builtin plugin type extensions.
+//
+// The trade-off here is that we end up with one unnecessary runtime import of
+// an empty file (this one) if a `src/types/*` file is imported without the
+// `type` annotation (e.g. the CLI's indirectly importing task-related enums),
+// in exchange for better DX.
+//
+// The reason we can't just use the `export type *` from the other files instead
+// is that in some cases that leads to a circular export of types that TS can't
+// handle.
+//
+// The reason we can't use `import type` is that those get erased during
+// compilation.
+export type * from "../internal/builtin-plugins/index.js";

--- a/packages/hardhat/src/types/config.ts
+++ b/packages/hardhat/src/types/config.ts
@@ -1,3 +1,5 @@
+import "./builtin-plugin-type-extensions.js";
+
 /**
  * A configuration variable to be fetched at runtime from
  * different sources, depending on the user's setup.

--- a/packages/hardhat/src/types/global-options.ts
+++ b/packages/hardhat/src/types/global-options.ts
@@ -1,5 +1,7 @@
 import type { GlobalOptionDefinition } from "./arguments.js";
 
+import "./builtin-plugin-type-extensions.js";
+
 /**
  * The values of each global option for a certain instance of the Hardhat
  * Runtime Environment are defined here. This interface can be extended through

--- a/packages/hardhat/src/types/hooks.ts
+++ b/packages/hardhat/src/types/hooks.ts
@@ -14,6 +14,8 @@ import type {
   Return,
 } from "./utils.js";
 
+import "./builtin-plugin-type-extensions.js";
+
 // We add the HookManager to the HRE with a module augmentation to avoid
 // introducing a circular dependency that would look like this:
 // hre.ts -> hooks.ts -> hre.ts

--- a/packages/hardhat/src/types/hre.ts
+++ b/packages/hardhat/src/types/hre.ts
@@ -2,6 +2,8 @@ import type { GlobalOptions } from "./global-options.js";
 import type { UserInterruptionManager } from "./user-interruptions.js";
 import type { HardhatConfig, HardhatUserConfig } from "../types/config.js";
 
+import "./builtin-plugin-type-extensions.js";
+
 /**
  * The Hardhat Runtime Environment (HRE) is an object that exposes
  * all the functionality available through Hardhat.

--- a/packages/hardhat/src/types/index.ts
+++ b/packages/hardhat/src/types/index.ts
@@ -1,3 +1,5 @@
+import "./builtin-plugin-type-extensions.js";
+
 export * from "./arguments.js";
 export * from "./artifacts.js";
 export * from "./config.js";

--- a/packages/hardhat/src/types/network.ts
+++ b/packages/hardhat/src/types/network.ts
@@ -1,6 +1,8 @@
 import type { NetworkConfig, NetworkConfigOverride } from "./config.js";
 import type { EthereumProvider } from "./providers.js";
 
+import "./builtin-plugin-type-extensions.js";
+
 /**
  * Represents the possible chain types for the network. The options are:
  * - `GenericNetworkType`: Represents the most generic type of network.

--- a/packages/hardhat/src/types/plugins.ts
+++ b/packages/hardhat/src/types/plugins.ts
@@ -2,8 +2,7 @@ import type { GlobalOptionDefinition } from "./arguments.js";
 import type { HardhatHooks } from "./hooks.js";
 import type { TaskDefinition } from "./tasks.js";
 
-// NOTE: We export the built-in plugin types to load their type extensions
-export type * from "../internal/builtin-plugins/index.js";
+import "./builtin-plugin-type-extensions.js";
 
 // We add the plugins to the config types with a module augmentation to avoid
 // introducing a circular dependency that would look like this:

--- a/packages/hardhat/src/types/providers.ts
+++ b/packages/hardhat/src/types/providers.ts
@@ -1,5 +1,7 @@
 import type EventEmitter from "node:events";
 
+import "./builtin-plugin-type-extensions.js";
+
 export interface RequestArguments {
   readonly method: string;
   readonly params?: readonly unknown[] | object;

--- a/packages/hardhat/src/types/solidity.ts
+++ b/packages/hardhat/src/types/solidity.ts
@@ -1,3 +1,5 @@
+import "./builtin-plugin-type-extensions.js";
+
 export * from "./solidity/build-system.js";
 export * from "./solidity/compilation-job.js";
 export * from "./solidity/compiler.js";

--- a/packages/hardhat/src/types/tasks.ts
+++ b/packages/hardhat/src/types/tasks.ts
@@ -8,6 +8,8 @@ import type { HardhatRuntimeEnvironment } from "./hre.js";
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- used in JSDoc {@link} */
 import type { Result } from "./utils.js";
 
+import "./builtin-plugin-type-extensions.js";
+
 // We add the TaskManager to the HRE with a module augmentation to avoid
 // introducing a circular dependency that would look like this:
 // hre.ts -> tasks.ts -> hre.ts

--- a/packages/hardhat/src/types/test.ts
+++ b/packages/hardhat/src/types/test.ts
@@ -1,3 +1,5 @@
+import "./builtin-plugin-type-extensions.js";
+
 /* eslint-disable-next-line @typescript-eslint/no-empty-interface -- Empty
 interface allow plugins to extend the Test user configuration for Hardhat. */
 export interface HardhatTestUserConfig {}

--- a/packages/hardhat/src/types/user-interruptions.ts
+++ b/packages/hardhat/src/types/user-interruptions.ts
@@ -1,3 +1,5 @@
+import "./builtin-plugin-type-extensions.js";
+
 /**
  * This interface is used to interact with the user in the middle of the
  * execution of an unrelated piece of functionality.


### PR DESCRIPTION
Another take on how we load the builtin plugin type extension. This time making sure that we always load them, so we don't have edge cases of incomplete type, at the cost of a runtime import of an empty js file.

There's an explanation this in `packages/hardhat/src/types/builtin-plugin-type-extensions.ts`.

What motivated this change is that @Wodann was hitting the edge cases of the previous approach in one of his tests.