### PR TITLE
Introduce profiles in solidity test config and types

### DIFF
--- a/.changeset/wise-birds-wait.md
+++ b/.changeset/wise-birds-wait.md
@@ -1,0 +1,7 @@
+---
+"hardhat": patch
+---
+
+Solidity test configuration now also accepts `{ profiles: { default: ... } }`. Only the `default` profile is currently supported, other profile names will be supported in a future release. The previous flat shape continues to work unchanged.
+
+The resolved `HardhatConfig.test.solidity` is now profile-keyed: read per-profile fields at `hre.config.test.solidity.profiles.default.*` instead of `hre.config.test.solidity.*`. Plugins that read the resolved Solidity test config need to be updated.

--- a/.changeset/wise-birds-wait.md
+++ b/.changeset/wise-birds-wait.md
@@ -1,5 +1,5 @@
 ---
-"hardhat": patch
+"hardhat": minor
 ---
 
 Solidity test configuration now also accepts `{ profiles: { default: ... } }`. Only the `default` profile is currently supported, other profile names will be supported in a future release. The previous flat shape continues to work unchanged.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -113,13 +113,13 @@ const solidityTestProfilesUserConfigType = z.object({
   profiles: z
     .record(z.string(), solidityTestProfileUserConfigType)
     .refine(
-      (profiles) => "default" in profiles,
+      (profiles) => DEFAULT_TEST_PROFILE in profiles,
       "A `default` profile is required when using `profiles`",
     )
     .refine(
       (profiles) =>
-        !("default" in profiles) ||
-        Object.keys(profiles).every((name) => name === "default"),
+        !(DEFAULT_TEST_PROFILE in profiles) ||
+        Object.keys(profiles).every((name) => name === DEFAULT_TEST_PROFILE),
       "Only the `default` profile is supported. Other profile names will be supported in a future release.",
     ),
 });

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -8,15 +8,17 @@ import type { HardhatUserConfigValidationError } from "../../../types/hooks.js";
 import type {
   SolidityTestForkingConfig,
   SolidityTestProfileConfig,
-  SolidityTestUserConfig,
+  SolidityTestProfileUserConfig,
 } from "../../../types/test.js";
 
 import path from "node:path";
 
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 import { resolveFromRoot } from "@nomicfoundation/hardhat-utils/path";
 import {
   conditionalUnionType,
+  incompatibleFieldType,
   sensitiveStringSchema,
   sensitiveUrlSchema,
   unionType,
@@ -30,7 +32,7 @@ import { DEFAULT_TEST_PROFILE } from "./test-profiles.js";
 export const DEFAULT_FUZZ_SEED =
   "0x7727ea51af0441c20da14dcd68a15dac8c9ebd589c5be8fa8c87c1d3720450bc";
 
-const solidityTestUserConfigType = z.object({
+const solidityTestProfileUserConfigType = z.object({
   fsPermissions: z
     .object({
       readWriteFile: z.array(z.string()).optional(),
@@ -99,6 +101,41 @@ const solidityTestUserConfigType = z.object({
     .optional(),
 });
 
+const solidityTestFlatUserConfigType = solidityTestProfileUserConfigType.extend(
+  {
+    profiles: incompatibleFieldType(
+      "This field is incompatible with the flat solidity test config",
+    ),
+  },
+);
+
+const solidityTestProfilesUserConfigType = z.object({
+  profiles: z
+    .record(z.string(), solidityTestProfileUserConfigType)
+    .refine(
+      (profiles) => "default" in profiles,
+      "A `default` profile is required when using `profiles`",
+    )
+    .refine(
+      (profiles) =>
+        !("default" in profiles) ||
+        Object.keys(profiles).every((name) => name === "default"),
+      "Only the `default` profile is supported. Other profile names will be supported in a future release.",
+    ),
+});
+
+const solidityTestUserConfigType = conditionalUnionType(
+  [
+    [
+      (data) =>
+        isObject(data) && "profiles" in data && Object.keys(data).length === 1,
+      solidityTestProfilesUserConfigType,
+    ],
+    [isObject, solidityTestFlatUserConfigType],
+  ],
+  "Expected a Solidity test config or a `{ profiles: { ... } }` wrapper",
+);
+
 const userConfigType = z.object({
   paths: z
     .object({
@@ -119,7 +156,7 @@ const userConfigType = z.object({
 });
 
 export function resolveSolidityTestForkingConfig(
-  forkingUserConfig: SolidityTestUserConfig["forking"],
+  forkingUserConfig: SolidityTestProfileUserConfig["forking"],
   resolveConfigurationVariable: ConfigurationVariableResolver,
 ): SolidityTestForkingConfig | undefined {
   if (forkingUserConfig === undefined) {
@@ -167,15 +204,27 @@ export async function resolveSolidityTestUserConfig(
 
   const defaultRpcCachePath = path.join(resolvedConfig.paths.cache, "edr");
 
+  const solidityUserConfig = userConfig.test?.solidity;
+  let profileUserConfig: SolidityTestProfileUserConfig | undefined;
+  if (solidityUserConfig !== undefined && "profiles" in solidityUserConfig) {
+    profileUserConfig = solidityUserConfig.profiles[DEFAULT_TEST_PROFILE];
+    assertHardhatInvariant(
+      profileUserConfig !== undefined,
+      "default profile must be present when the profiles wrapper user config is supplied",
+    );
+  } else {
+    profileUserConfig = solidityUserConfig;
+  }
+
   const resolvedForking = resolveSolidityTestForkingConfig(
-    userConfig.test?.solidity?.forking,
+    profileUserConfig?.forking,
     resolveConfigurationVariable,
   );
 
   const resolvedDefaultProfile = {
     rpcCachePath: defaultRpcCachePath,
-    ...userConfig.test?.solidity,
-    fuzz: resolveFuzzConfig(userConfig.test?.solidity?.fuzz),
+    ...profileUserConfig,
+    fuzz: resolveFuzzConfig(profileUserConfig?.fuzz),
     forking: resolvedForking,
     eip712Types: resolveEip712TypesConfig(
       userConfig.test?.solidity?.eip712Types,
@@ -201,7 +250,7 @@ export async function resolveSolidityTestUserConfig(
 }
 
 export function resolveFuzzConfig(
-  fuzzUserConfig: SolidityTestUserConfig["fuzz"] = {},
+  fuzzUserConfig: SolidityTestProfileUserConfig["fuzz"] = {},
 ): SolidityTestProfileConfig["fuzz"] {
   return {
     ...fuzzUserConfig,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -6,8 +6,8 @@ import type {
 } from "../../../types/config.js";
 import type { HardhatUserConfigValidationError } from "../../../types/hooks.js";
 import type {
-  SolidityTestConfig,
   SolidityTestForkingConfig,
+  SolidityTestProfileConfig,
   SolidityTestUserConfig,
 } from "../../../types/test.js";
 
@@ -23,6 +23,8 @@ import {
   validateUserConfigZodType,
 } from "@nomicfoundation/hardhat-zod-utils";
 import { z } from "zod";
+
+import { DEFAULT_TEST_PROFILE } from "./test-profiles.js";
 
 // the keccak256 of "built for ethereum"
 export const DEFAULT_FUZZ_SEED =
@@ -170,7 +172,7 @@ export async function resolveSolidityTestUserConfig(
     resolveConfigurationVariable,
   );
 
-  const solidityTest = {
+  const resolvedDefaultProfile = {
     rpcCachePath: defaultRpcCachePath,
     ...userConfig.test?.solidity,
     fuzz: resolveFuzzConfig(userConfig.test?.solidity?.fuzz),
@@ -191,14 +193,16 @@ export async function resolveSolidityTestUserConfig(
     },
     test: {
       ...resolvedConfig.test,
-      solidity: solidityTest,
+      solidity: {
+        profiles: { [DEFAULT_TEST_PROFILE]: resolvedDefaultProfile },
+      },
     },
   };
 }
 
 export function resolveFuzzConfig(
   fuzzUserConfig: SolidityTestUserConfig["fuzz"] = {},
-): SolidityTestConfig["fuzz"] {
+): SolidityTestProfileConfig["fuzz"] {
   return {
     ...fuzzUserConfig,
     seed: fuzzUserConfig.seed ?? DEFAULT_FUZZ_SEED,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -226,9 +226,7 @@ export async function resolveSolidityTestUserConfig(
     ...profileUserConfig,
     fuzz: resolveFuzzConfig(profileUserConfig?.fuzz),
     forking: resolvedForking,
-    eip712Types: resolveEip712TypesConfig(
-      userConfig.test?.solidity?.eip712Types,
-    ),
+    eip712Types: resolveEip712TypesConfig(profileUserConfig?.eip712Types),
   };
 
   return {
@@ -259,8 +257,8 @@ export function resolveFuzzConfig(
 }
 
 export function resolveEip712TypesConfig(
-  eip712TypesUserConfig: SolidityTestUserConfig["eip712Types"] = {},
-): SolidityTestConfig["eip712Types"] {
+  eip712TypesUserConfig: SolidityTestProfileUserConfig["eip712Types"] = {},
+): SolidityTestProfileConfig["eip712Types"] {
   return {
     include: eip712TypesUserConfig.include ?? [],
     exclude: eip712TypesUserConfig.exclude ?? [],

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -1,6 +1,6 @@
 import type { Abi } from "../../../types/artifacts.js";
 import type { ChainType } from "../../../types/network.js";
-import type { SolidityTestConfig } from "../../../types/test.js";
+import type { SolidityTestProfileConfig } from "../../../types/test.js";
 import type {
   SolidityTestRunnerConfigArgs,
   PathPermission,
@@ -32,7 +32,7 @@ interface SolidityTestConfigParams {
   chainType: ChainType;
   projectRoot: string;
   hardfork?: string;
-  config: Omit<SolidityTestConfig, "eip712Types">;
+  config: Omit<SolidityTestProfileConfig, "eip712Types">;
   verbosity: number;
   observability?: ObservabilityConfig;
   testPattern?: string;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -44,6 +44,7 @@ import {
 import { getTestFunctionOverrides } from "./inline-config/index.js";
 import { testReporter } from "./reporter.js";
 import { run } from "./runner.js";
+import { DEFAULT_TEST_PROFILE } from "./test-profiles.js";
 
 interface TestActionArguments {
   testFiles: string[];
@@ -201,7 +202,9 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   let includesFailures = false;
   let includesErrors = false;
 
-  const { eip712Types, ...solidityTestConfig } = hre.config.test.solidity;
+  const { eip712Types, ...solidityTestConfig } =
+    hre.config.test.solidity.profiles[DEFAULT_TEST_PROFILE];
+
   let observabilityConfig: ObservabilityConfig | undefined;
   if (hre.globalOptions.coverage) {
     const coverage = getCoverageManager(hre);

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/test-profiles.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/test-profiles.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TEST_PROFILE = "default";

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -128,6 +128,7 @@ declare module "../../../types/test.js" {
   }
 
   export interface SolidityTestProfileConfig {
+    rpcCachePath: string;
     fsPermissions?: SolidityTestFsPermissionsConfig;
     isolate?: boolean;
     ffi?: boolean;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -14,7 +14,28 @@ declare module "../../../types/config.js" {
 }
 
 declare module "../../../types/test.js" {
-  export interface SolidityTestFuzzConfigBase {
+  export interface SolidityTestFsPermissionsUserConfig {
+    readWriteFile?: string[];
+    readFile?: string[];
+    writeFile?: string[];
+    dangerouslyReadWriteDirectory?: string[];
+    readDirectory?: string[];
+    dangerouslyWriteDirectory?: string[];
+  }
+
+  export interface SolidityTestInvariantUserConfig {
+    failurePersistDir?: string;
+    runs?: number;
+    depth?: number;
+    failOnRevert?: boolean;
+    callOverride?: boolean;
+    dictionaryWeight?: number;
+    includeStorage?: boolean;
+    includePushBytes?: boolean;
+    shrinkRunLimit?: number;
+  }
+
+  export interface SolidityTestFuzzUserConfig {
     failurePersistDir?: string;
     failurePersistFile?: string;
     runs?: number;
@@ -26,19 +47,14 @@ declare module "../../../types/test.js" {
     showLogs?: boolean;
   }
 
-  export interface SolidityTestFuzzConfig extends SolidityTestFuzzConfigBase {
-    seed: string;
+  export interface SolidityTestForkingUserConfig {
+    url?: SensitiveString;
+    blockNumber?: number | bigint;
+    rpcEndpoints?: Record<string, SensitiveString>;
   }
 
-  export interface SolidityTestProfileConfigBase {
-    fsPermissions?: {
-      readWriteFile?: string[];
-      readFile?: string[];
-      writeFile?: string[];
-      dangerouslyReadWriteDirectory?: string[];
-      readDirectory?: string[];
-      dangerouslyWriteDirectory?: string[];
-    };
+  export interface SolidityTestProfileUserConfig {
+    fsPermissions?: SolidityTestFsPermissionsUserConfig;
     isolate?: boolean;
     ffi?: boolean;
     allowInternalExpectRevert?: boolean;
@@ -51,35 +67,13 @@ declare module "../../../types/test.js" {
     prevRandao?: bigint;
     gasLimit?: bigint;
     blockGasLimit?: bigint | false;
-
-    fuzz?: SolidityTestFuzzConfigBase;
-    invariant?: {
-      failurePersistDir?: string;
-      runs?: number;
-      depth?: number;
-      failOnRevert?: boolean;
-      callOverride?: boolean;
-      dictionaryWeight?: number;
-      includeStorage?: boolean;
-      includePushBytes?: boolean;
-      shrinkRunLimit?: number;
-    };
-
+    fuzz?: SolidityTestFuzzUserConfig;
+    invariant?: SolidityTestInvariantUserConfig;
+    forking?: SolidityTestForkingUserConfig;
     eip712Types?: {
       include?: string[];
       exclude?: string[];
     };
-  }
-
-  export interface SolidityTestForkingUserConfig {
-    url?: SensitiveString;
-    blockNumber?: number | bigint;
-    rpcEndpoints?: Record<string, SensitiveString>;
-  }
-
-  export interface SolidityTestProfileUserConfig
-    extends SolidityTestProfileConfigBase {
-    forking?: SolidityTestForkingUserConfig;
   }
 
   export interface SolidityTestProfilesUserConfig {
@@ -94,15 +88,61 @@ declare module "../../../types/test.js" {
     solidity?: SolidityTestUserConfig;
   }
 
+  export interface SolidityTestFsPermissionsConfig {
+    readWriteFile?: string[];
+    readFile?: string[];
+    writeFile?: string[];
+    dangerouslyReadWriteDirectory?: string[];
+    readDirectory?: string[];
+    dangerouslyWriteDirectory?: string[];
+  }
+
+  export interface SolidityTestInvariantConfig {
+    failurePersistDir?: string;
+    runs?: number;
+    depth?: number;
+    failOnRevert?: boolean;
+    callOverride?: boolean;
+    dictionaryWeight?: number;
+    includeStorage?: boolean;
+    includePushBytes?: boolean;
+    shrinkRunLimit?: number;
+  }
+
+  export interface SolidityTestFuzzConfig {
+    failurePersistDir?: string;
+    failurePersistFile?: string;
+    runs?: number;
+    maxTestRejects?: number;
+    seed: string;
+    dictionaryWeight?: number;
+    includeStorage?: boolean;
+    includePushBytes?: boolean;
+    showLogs?: boolean;
+  }
+
   export interface SolidityTestForkingConfig {
     url?: ResolvedConfigurationVariable;
     blockNumber?: bigint;
     rpcEndpoints?: Record<string, ResolvedConfigurationVariable>;
   }
 
-  export interface SolidityTestProfileConfig
-    extends SolidityTestProfileConfigBase {
+  export interface SolidityTestProfileConfig {
+    fsPermissions?: SolidityTestFsPermissionsConfig;
+    isolate?: boolean;
+    ffi?: boolean;
+    allowInternalExpectRevert?: boolean;
+    from?: string; // 0x-prefixed hex string
+    txOrigin?: string; // 0x-prefixed hex string
+    initialBalance?: bigint;
+    blockBaseFeePerGas?: bigint;
+    coinbase?: string; // 0x-prefixed hex string
+    blockTimestamp?: bigint;
+    prevRandao?: bigint;
+    gasLimit?: bigint;
+    blockGasLimit?: bigint | false;
     fuzz: SolidityTestFuzzConfig;
+    invariant?: SolidityTestInvariantConfig;
     forking?: SolidityTestForkingConfig;
     eip712Types: {
       include: string[];

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -91,7 +91,7 @@ declare module "../../../types/test.js" {
     rpcEndpoints?: Record<string, ResolvedConfigurationVariable>;
   }
 
-  export interface SolidityTestConfig extends SolidityTestConfigBase {
+  export interface SolidityTestProfileConfig extends SolidityTestConfigBase {
     fuzz: SolidityTestFuzzConfig;
     forking?: SolidityTestForkingConfig;
     eip712Types: {
@@ -99,6 +99,11 @@ declare module "../../../types/test.js" {
       exclude: string[];
     };
   }
+
+  export interface SolidityTestConfig {
+    profiles: Record<string, SolidityTestProfileConfig>;
+  }
+
   export interface HardhatTestConfig {
     solidity: SolidityTestConfig;
   }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -30,7 +30,7 @@ declare module "../../../types/test.js" {
     seed: string;
   }
 
-  export interface SolidityTestConfigBase {
+  export interface SolidityTestProfileConfigBase {
     fsPermissions?: {
       readWriteFile?: string[];
       readFile?: string[];
@@ -77,9 +77,18 @@ declare module "../../../types/test.js" {
     rpcEndpoints?: Record<string, SensitiveString>;
   }
 
-  export interface SolidityTestUserConfig extends SolidityTestConfigBase {
+  export interface SolidityTestProfileUserConfig
+    extends SolidityTestProfileConfigBase {
     forking?: SolidityTestForkingUserConfig;
   }
+
+  export interface SolidityTestProfilesUserConfig {
+    profiles: Record<string, SolidityTestProfileUserConfig>;
+  }
+
+  export type SolidityTestUserConfig =
+    | SolidityTestProfileUserConfig
+    | SolidityTestProfilesUserConfig;
 
   export interface HardhatTestUserConfig {
     solidity?: SolidityTestUserConfig;
@@ -91,7 +100,8 @@ declare module "../../../types/test.js" {
     rpcEndpoints?: Record<string, ResolvedConfigurationVariable>;
   }
 
-  export interface SolidityTestProfileConfig extends SolidityTestConfigBase {
+  export interface SolidityTestProfileConfig
+    extends SolidityTestProfileConfigBase {
     fuzz: SolidityTestFuzzConfig;
     forking?: SolidityTestForkingConfig;
     eip712Types: {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+
 import {
   DEFAULT_FUZZ_SEED,
   resolveFuzzConfig,
@@ -48,6 +50,54 @@ describe("config resolution", () => {
       assert.equal(result.dictionaryWeight, 50);
       assert.equal(result.showLogs, true);
       assert.equal(result.seed, DEFAULT_FUZZ_SEED);
+    });
+  });
+
+  describe("resolveSolidityTestUserConfig", () => {
+    it("should resolve a flat user config to the default profile", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        test: {
+          solidity: {
+            isolate: true,
+            fuzz: { runs: 50 },
+          },
+        },
+      });
+
+      const defaultProfile = hre.config.test.solidity.profiles.default;
+      assert.equal(defaultProfile.isolate, true);
+      assert.equal(defaultProfile.fuzz.runs, 50);
+      assert.equal(defaultProfile.fuzz.seed, DEFAULT_FUZZ_SEED);
+      assert.equal(defaultProfile.forking, undefined);
+    });
+
+    it("should resolve a `profiles` wrapper to the same shape as the equivalent flat config", async () => {
+      const flatHre = await createHardhatRuntimeEnvironment({
+        test: {
+          solidity: {
+            isolate: true,
+            fuzz: { runs: 50 },
+          },
+        },
+      });
+
+      const wrapperHre = await createHardhatRuntimeEnvironment({
+        test: {
+          solidity: {
+            profiles: {
+              default: {
+                isolate: true,
+                fuzz: { runs: 50 },
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(
+        wrapperHre.config.test.solidity,
+        flatHre.config.test.solidity,
+      );
     });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -27,7 +27,7 @@ describe("config validation", () => {
       solidityTestPlugin,
     );
 
-    assert.equal(hre.config.test.solidity.isolate, true);
+    assert.equal(hre.config.test.solidity.profiles.default.isolate, true);
   });
 
   it("should not throw when the `test.solidity` config is not set by the user", async () => {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -1,6 +1,4 @@
 import type { HardhatUserConfig } from "../../../../src/types/config.js";
-import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
-import type { HardhatPlugin } from "../../../../src/types/plugins.js";
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
@@ -10,33 +8,21 @@ import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-uti
 
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 
-import solidityTestPlugin from "../../../../src/internal/builtin-plugins/solidity-test/index.js";
-import { resolveProjectRoot } from "../../../../src/internal/core/hre.js";
-import { resolvePluginList } from "../../../../src/internal/core/plugins/resolve-plugin-list.js";
-
 describe("config validation", () => {
-  it("should validate an acceptable `test.solidity` config", async () => {
-    const hre = await _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
-      {
-        test: {
-          solidity: {
-            isolate: true,
-          },
+  it("should accept a flat `test.solidity` config", async () => {
+    const hre = await createHardhatRuntimeEnvironment({
+      test: {
+        solidity: {
+          isolate: true,
         },
       },
-      solidityTestPlugin,
-    );
+    });
 
     assert.equal(hre.config.test.solidity.profiles.default.isolate, true);
   });
 
   it("should not throw when the `test.solidity` config is not set by the user", async () => {
-    await _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
-      {
-        test: {},
-      },
-      solidityTestPlugin,
-    );
+    await createHardhatRuntimeEnvironment({ test: {} });
   });
 
   it("should throw when the `test.solidity` properties are invalid", async () => {
@@ -51,10 +37,7 @@ describe("config validation", () => {
     };
 
     await assertRejectsWithHardhatError(
-      _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
-        userConfig,
-        solidityTestPlugin,
-      ),
+      createHardhatRuntimeEnvironment(userConfig),
       HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
       {
         errors:
@@ -62,25 +45,85 @@ describe("config validation", () => {
       },
     );
   });
+
+  it("should accept a `profiles` wrapper with a `default` profile", async () => {
+    const hre = await createHardhatRuntimeEnvironment({
+      test: {
+        solidity: {
+          profiles: {
+            default: {
+              isolate: true,
+            },
+          },
+        },
+      },
+    });
+
+    assert.equal(hre.config.test.solidity.profiles.default.isolate, true);
+  });
+
+  it("should throw when the `profiles` wrapper is missing the `default` profile", async () => {
+    const userConfig: HardhatUserConfig = {
+      test: {
+        solidity: {
+          profiles: {
+            ci: { isolate: true },
+          },
+        },
+      },
+    };
+
+    await assertRejectsWithHardhatError(
+      createHardhatRuntimeEnvironment(userConfig),
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
+      {
+        errors:
+          "\t* Config error in config.test.solidity.profiles: A `default` profile is required when using `profiles`",
+      },
+    );
+  });
+
+  it("should throw when the `profiles` wrapper has a non-`default` profile", async () => {
+    const userConfig: HardhatUserConfig = {
+      test: {
+        solidity: {
+          profiles: {
+            default: { isolate: true },
+            ci: { isolate: false },
+          },
+        },
+      },
+    };
+
+    await assertRejectsWithHardhatError(
+      createHardhatRuntimeEnvironment(userConfig),
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
+      {
+        errors:
+          "\t* Config error in config.test.solidity.profiles: Only the `default` profile is supported. Other profile names will be supported in a future release.",
+      },
+    );
+  });
+
+  it("should throw when `profiles` is mixed with flat fields", async () => {
+    const userConfig: HardhatUserConfig = {
+      test: {
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          -- intentionally violating the types for the test */
+        solidity: {
+          profiles: { default: { isolate: true } },
+          fuzz: { runs: 50 },
+        } as any,
+      },
+    };
+
+    await assertRejectsWithHardhatError(
+      createHardhatRuntimeEnvironment(userConfig),
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
+      {
+        errors:
+          "\t* Config error in config.test.solidity.profiles: This field is incompatible with the flat solidity test config",
+      },
+    );
+  });
 });
-
-async function _createHardhatRuntimeEnvironmentWithOnlyBuiltinPlugin(
-  config: HardhatUserConfig,
-  builtinPlugin: HardhatPlugin,
-): Promise<HardhatRuntimeEnvironment> {
-  const projectRoot = undefined;
-  const resolvedProjectRoot = await resolveProjectRoot(projectRoot);
-
-  const resolvedPlugins = await resolvePluginList(resolvedProjectRoot, [
-    builtinPlugin,
-  ]);
-
-  return await createHardhatRuntimeEnvironment(
-    config,
-    {},
-    resolvedProjectRoot,
-    {
-      resolvedPlugins,
-    },
-  );
-}

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
@@ -41,7 +41,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
       const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
         chainType: GENERIC_CHAIN_TYPE,
         projectRoot: process.cwd(),
-        config: { fuzz: { seed: "0x1234" } },
+        config: { fuzz: { seed: "0x1234" }, rpcCachePath: "" },
         verbosity,
         generateGasReport: false,
       });
@@ -54,7 +54,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" } },
+      config: { fuzz: { seed: "0x1234" }, rpcCachePath: "" },
       verbosity: 3,
       generateGasReport: false,
     });
@@ -67,7 +67,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
       const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
         chainType: GENERIC_CHAIN_TYPE,
         projectRoot: process.cwd(),
-        config: { fuzz: { seed: "0x1234" } },
+        config: { fuzz: { seed: "0x1234" }, rpcCachePath: "" },
         verbosity,
         generateGasReport: false,
       });
@@ -81,7 +81,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
       const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
         chainType: GENERIC_CHAIN_TYPE,
         projectRoot: process.cwd(),
-        config: { fuzz: { seed: "0x1234" } },
+        config: { fuzz: { seed: "0x1234" }, rpcCachePath: "" },
         verbosity,
         generateGasReport: false,
       });
@@ -99,7 +99,11 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" }, blockGasLimit: undefined },
+      config: {
+        fuzz: { seed: "0x1234" },
+        rpcCachePath: "",
+        blockGasLimit: undefined,
+      },
       verbosity: 1,
       generateGasReport: false,
     });
@@ -112,7 +116,11 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" }, blockGasLimit: false },
+      config: {
+        fuzz: { seed: "0x1234" },
+        rpcCachePath: "",
+        blockGasLimit: false,
+      },
       verbosity: 1,
       generateGasReport: false,
     });
@@ -125,7 +133,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" }, blockGasLimit: 1n },
+      config: { fuzz: { seed: "0x1234" }, rpcCachePath: "", blockGasLimit: 1n },
       verbosity: 1,
       generateGasReport: false,
     });
@@ -138,7 +146,11 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" }, gasLimit: undefined },
+      config: {
+        fuzz: { seed: "0x1234" },
+        rpcCachePath: "",
+        gasLimit: undefined,
+      },
       verbosity: 1,
       generateGasReport: false,
     });
@@ -150,7 +162,11 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" }, gasLimit: 12_000_000n },
+      config: {
+        fuzz: { seed: "0x1234" },
+        rpcCachePath: "",
+        gasLimit: 12_000_000n,
+      },
       verbosity: 1,
       generateGasReport: false,
     });
@@ -162,7 +178,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" }, prevRandao: 123n },
+      config: { fuzz: { seed: "0x1234" }, rpcCachePath: "", prevRandao: 123n },
       verbosity: 1,
       generateGasReport: false,
     });
@@ -185,7 +201,11 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" }, forking: resolvedForkingConfig },
+      config: {
+        fuzz: { seed: "0x1234" },
+        rpcCachePath: "",
+        forking: resolvedForkingConfig,
+      },
       verbosity: 1,
       generateGasReport: false,
     });
@@ -210,7 +230,11 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" }, forking: resolvedForkingConfig },
+      config: {
+        fuzz: { seed: "0x1234" },
+        rpcCachePath: "",
+        forking: resolvedForkingConfig,
+      },
       verbosity: 1,
       generateGasReport: false,
     });
@@ -222,7 +246,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" } },
+      config: { fuzz: { seed: "0x1234" }, rpcCachePath: "" },
       verbosity: 0,
       generateGasReport: true,
     });
@@ -234,7 +258,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
     const args = await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType: GENERIC_CHAIN_TYPE,
       projectRoot: process.cwd(),
-      config: { fuzz: { seed: "0x1234" } },
+      config: { fuzz: { seed: "0x1234" }, rpcCachePath: "" },
       verbosity: 0,
       generateGasReport: false,
     });
@@ -248,7 +272,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
         chainType: L1_CHAIN_TYPE,
         projectRoot: process.cwd(),
         hardfork: "cancun",
-        config: { fuzz: { seed: "0x1234" } },
+        config: { fuzz: { seed: "0x1234" }, rpcCachePath: "" },
         verbosity: 2,
         generateGasReport: false,
       });
@@ -261,7 +285,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
         chainType: OPTIMISM_CHAIN_TYPE,
         projectRoot: process.cwd(),
         hardfork: "ecotone",
-        config: { fuzz: { seed: "0x1234" } },
+        config: { fuzz: { seed: "0x1234" }, rpcCachePath: "" },
         verbosity: 2,
         generateGasReport: false,
       });
@@ -274,7 +298,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
         chainType: L1_CHAIN_TYPE,
         projectRoot: process.cwd(),
         hardfork: undefined,
-        config: { fuzz: { seed: "0x1234" } },
+        config: { fuzz: { seed: "0x1234" }, rpcCachePath: "" },
         verbosity: 2,
         generateGasReport: false,
       });
@@ -288,7 +312,7 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
         chainType: OPTIMISM_CHAIN_TYPE,
         projectRoot: process.cwd(),
         hardfork: undefined,
-        config: { fuzz: { seed: "0x1234" } },
+        config: { fuzz: { seed: "0x1234" }, rpcCachePath: "" },
         verbosity: 2,
         generateGasReport: false,
       });

--- a/packages/hardhat/test/internal/builtin-plugins/test/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/test/config.ts
@@ -29,7 +29,7 @@ describe("test/config", function () {
     });
 
     assert.equal(
-      hre.config.test.solidity.isolate,
+      hre.config.test.solidity.profiles.default.isolate,
       existingTestConfig.solidity.isolate,
     );
   });


### PR DESCRIPTION
Introduce an alternative `{ profiles: { default: ... } }` wrapper for `test.solidity`, and moves the resolved `HardhatConfig.test.solidity` to a profile-keyed shape (`profiles.default.*`). Only default is accepted today, other profile names will be supported later.

Closes https://github.com/NomicFoundation/hardhat/issues/8172