### PR TITLE
claude: pre-approve agent-only pnpm scripts and ignore local settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm build)",
+      "Bash(pnpm test)",
+      "Bash(pnpm test:file *)",
+      "Bash(pnpm lint)",
+      "Bash(pnpm lint:fix)",
+      "Bash(pnpm lint:file *)",
+      "Bash(pnpm spellcheck)",
+      "Bash(pnpm spellcheck:file *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ pnpm-publish-summary.json
 
 # Personal Claude files
 .claude/local/
+.claude/settings.local.json
 
 # Ignored for now, should be reconsidered if we want codex-specific settings.
 # The reason to ignore it is that codex creates a .codex file if the folder doesn't exist.


### PR DESCRIPTION
Added a `.claude/settings.json` which allows `build`, `lint`, `lint:fix`, `test` and `spellcheck`, as well as their file specific versions. Gitignore the `.claude/settings.local.json`.