### PR TITLE
misc: ignore .cpuprofile files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ pnpm-publish-summary.json
 # Ignored for now, should be reconsidered if we want codex-specific settings.
 # The reason to ignore it is that codex creates a .codex file if the folder doesn't exist.
 /.codex
+
+# CPU Profiler output
+*.cpuprofile


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---
Ignores `.cpuprofile` files, which are generated when using a sampling profiler for the CPU.

> ℹ️ **NOTE**
> This is the first in a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier
