### PR TITLE
feat(verdaccio): add `--since-release` publish mode

### DIFF
--- a/scripts/verdaccio/main.ts
+++ b/scripts/verdaccio/main.ts
@@ -1,5 +1,5 @@
 import { start } from "./start.ts";
-import { publish } from "./publish.ts";
+import { publish, sinceReleasePublish } from "./publish.ts";
 import { stop } from "./stop.ts";
 import { logError } from "./helpers/logging.ts";
 
@@ -39,6 +39,8 @@ OPTIONS
   --no-git-checks      Skip the clean working tree check (use with publish)
   --changes            Re-publish only packages with uncommitted changes (use with publish)
                        Implies --no-git-checks
+  --since-release      Detect packages changed since their release tag, bump their
+                       patch version, and publish (use with publish)
 
 EXAMPLES
   pnpm verdaccio start
@@ -69,12 +71,17 @@ async function main(): Promise<void> {
   const noGitChecks = args.includes("--no-git-checks");
   const background = args.includes("--background");
   const changes = args.includes("--changes");
+  const sinceRelease = args.includes("--since-release");
 
   try {
     if (command === "start") {
       await start(background);
     } else if (command === "publish") {
-      publish(changes, noGitChecks);
+      if (sinceRelease) {
+        sinceReleasePublish();
+      } else {
+        publish(changes, noGitChecks);
+      }
     } else if (command === "stop") {
       stop();
     } else {

--- a/scripts/verdaccio/publish.test.ts
+++ b/scripts/verdaccio/publish.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { decidePublishAction } from "./publish.ts";
+
+describe("decidePublishAction", () => {
+  it("bumps when there is no release tag (new package)", () => {
+    assert.equal(decidePublishAction(undefined, "0.1.0", false), "bump");
+  });
+
+  it("bumps when version matches tag and code changed since release", () => {
+    assert.equal(decidePublishAction("3.3.0", "3.3.0", true), "bump");
+  });
+
+  it("skips when version matches tag and no code changes since release", () => {
+    assert.equal(decidePublishAction("3.3.0", "3.3.0", false), "skip");
+  });
+
+  it("publishes without bumping when already bumped (no further changes)", () => {
+    assert.equal(decidePublishAction("3.3.0", "3.3.1", false), "publish");
+  });
+
+  it("publishes without bumping when already bumped (with further changes)", () => {
+    assert.equal(decidePublishAction("3.3.0", "3.3.1", true), "publish");
+  });
+});

--- a/scripts/verdaccio/publish.ts
+++ b/scripts/verdaccio/publish.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fmt, log, logStep } from "./helpers/logging.ts";
 import {
@@ -205,4 +205,187 @@ function reportPublished(): void {
       `\n  ${summary.publishedPackages.length} package(s) published to ${VERDACCIO_URL}`,
     ),
   );
+}
+
+const EXCLUDED_PACKAGES = [
+  "config",
+  "example-project",
+  "template-package",
+  "hardhat-test-utils",
+  "hardhat-solx",
+];
+
+/**
+ * Detect packages that changed since their last release tag, bump their
+ * patch version, and publish them to Verdaccio. This avoids the npm proxy
+ * problem where pnpm publish skips versions that already exist on npm.
+ */
+export function sinceReleasePublish(): void {
+  ensureVerdaccioRunning();
+
+  const { toBump, toPublishOnly } = detectChangedSinceRelease();
+
+  if (toBump.length === 0 && toPublishOnly.length === 0) {
+    log("No packages changed since their last release.");
+    return;
+  }
+
+  bumpPatchVersions(toBump);
+  publishPackages([...toBump, ...toPublishOnly]);
+  reportPublished();
+}
+
+function detectChangedSinceRelease(): {
+  toBump: string[];
+  toPublishOnly: string[];
+} {
+  logStep("Detecting packages changed since release");
+
+  const packagesDir = resolve(ROOT_DIR, "packages");
+  const toBump: string[] = [];
+  const toPublishOnly: string[] = [];
+
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || EXCLUDED_PACKAGES.includes(entry.name)) {
+      continue;
+    }
+
+    const packageDir = `packages/${entry.name}`;
+    const pkgJsonPath = resolve(ROOT_DIR, packageDir, "package.json");
+
+    if (!existsSync(pkgJsonPath)) {
+      continue;
+    }
+
+    const { name, version } = readPackageInfo(packageDir);
+
+    // Find the latest existing release tag for this package
+    const releaseTag = findLatestReleaseTag(name);
+
+    const tagVersion =
+      releaseTag !== undefined
+        ? releaseTag.slice(name.length + 1) // "hardhat@3.3.0" → "3.3.0"
+        : undefined;
+
+    const excludePatterns = [
+      `:!${packageDir}/package.json`,
+      `:!${packageDir}/CHANGELOG.md`,
+    ];
+
+    const hasCodeChangesSinceRelease =
+      releaseTag !== undefined &&
+      git([
+        "diff",
+        "--name-only",
+        releaseTag,
+        "--",
+        packageDir,
+        ...excludePatterns,
+      ]) !== "";
+
+    const action = decidePublishAction(
+      tagVersion,
+      version,
+      hasCodeChangesSinceRelease,
+    );
+
+    if (action === "skip") {
+      continue;
+    }
+
+    if (action === "bump") {
+      const reason =
+        tagVersion === undefined
+          ? "(no release tag)"
+          : `(changed since ${releaseTag})`;
+      log(`  ${fmt.pkg(name)} ${fmt.deemphasize(reason)}`);
+      toBump.push(packageDir);
+    } else {
+      log(
+        `  ${fmt.pkg(name)} ${fmt.deemphasize(`(already bumped to ${version})`)}`,
+      );
+      toPublishOnly.push(packageDir);
+    }
+  }
+
+  const total = toBump.length + toPublishOnly.length;
+
+  if (total > 0) {
+    log(fmt.success(`\n  ${total} package(s) changed since release`));
+  }
+
+  return { toBump, toPublishOnly };
+}
+
+/**
+ * Find the latest release tag for a package by listing all tags matching
+ * `<name>@*` and picking the most recent by version sort.
+ */
+function findLatestReleaseTag(packageName: string): string | undefined {
+  try {
+    const tags = git([
+      "tag",
+      "--list",
+      `${packageName}@*`,
+      "--sort=-v:refname",
+    ]);
+
+    if (tags === "") {
+      return undefined;
+    }
+
+    // First line is the latest tag
+    return tags.split("\n")[0];
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Pure decision function for --use-local / --since-release: what action
+ * should be taken for a given package?
+ *
+ * - No release tag → bump (new package)
+ * - Already bumped (version differs from tag) → publish current version
+ *   without bumping (Verdaccio storage is wiped per run, so we always
+ *   need to (re)publish, but the on-disk version was already bumped on a
+ *   prior run and shouldn't compound)
+ * - Not bumped + code changed since release → bump
+ * - Not bumped + no code changes → skip
+ */
+export function decidePublishAction(
+  releaseTagVersion: string | undefined,
+  currentVersion: string,
+  hasCodeChangesSinceRelease: boolean,
+): "bump" | "publish" | "skip" {
+  if (releaseTagVersion === undefined) {
+    return "bump";
+  }
+
+  if (currentVersion !== releaseTagVersion) {
+    return "publish";
+  }
+
+  return hasCodeChangesSinceRelease ? "bump" : "skip";
+}
+
+function bumpPatchVersions(packageDirs: string[]): void {
+  logStep("Bumping patch versions");
+
+  for (const dir of packageDirs) {
+    const pkgJsonPath = resolve(ROOT_DIR, dir, "package.json");
+    const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+    const oldVersion: string = pkgJson.version;
+
+    const parts = oldVersion.split(".");
+    parts[parts.length - 1] = String(Number(parts[parts.length - 1]) + 1);
+    const newVersion = parts.join(".");
+
+    pkgJson.version = newVersion;
+    writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + "\n");
+
+    log(
+      `  ${fmt.pkg(pkgJson.name)} ${fmt.deemphasize(oldVersion)} → ${fmt.version(newVersion)}`,
+    );
+  }
 }


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8272 

## Summary

Adds `pnpm verdaccio publish --since-release`: detects every workspace package that has changed since its last release git tag, bumps the patch version, and publishes the bumped versions to the local Verdaccio. Lets downstream tooling (next PRs in this stack: `--use-local` for `pnpm e2e`/`pnpm bench`) pin scenarios to local builds without needing changesets first.

## The problem this solves

Verdaccio proxies to npm. When `pnpm publish -r --registry $VERDACCIO_URL` runs, pnpm asks the registry whether each version already exists — and Verdaccio answers "yes" for anything that's on npm. So packages whose `package.json` version matches the latest npm release are silently **skipped**, even on a fresh Verdaccio.

| # | State of working tree | Has changeset? | What `versionForRelease` does | What `verdaccioPublish` does | Published? |
|---|---|---|---|---|---|
| 1 | clean since last release | — | no-op | versions match npm → skip | no ✓ |
| 2 | changes committed | yes | bumps versions | new versions → publish | yes |
| 3 | changes committed | **no** | **no-op** | versions match npm → **skip** | **no** ✗ |
| 4 | changes uncommitted | yes | bumps versions | new versions → publish | yes |
| 5 | changes uncommitted | **no** | **no-op** | versions match npm → **skip** | **no** ✗ |

Cases 3 and 5 are the gap — never reaching the Verdaccio registry. `--use-local` (next PR) needs those cases to work.

## What `--since-release` does

For each workspace package (excluding `config`, `example-project`, `template-package`, `hardhat-test-utils`, `hardhat-solx`), the new `decidePublishAction(releaseTagVersion, currentVersion, hasChangesSinceRelease)` chooses:

| Release tag | Current version | Code changed since release? | Action |
|---|---|---|---|
| missing (new pkg) | any | — | **bump** patch, then publish |
| `3.3.0` | `3.3.0` | yes | **bump** patch, then publish |
| `3.3.0` | `3.3.0` | no | **skip** |
| `3.3.0` | `3.3.1` (already bumped) | no | **publish** (don't double-bump) |
| `3.3.0` | `3.3.1` (already bumped) | yes | **publish** (don't double-bump) |

"Changed" is determined by `git diff <tag> -- packages/<dir>/` excluding `package.json` and `CHANGELOG.md`. Patch bumps are written directly to `package.json` — no changesets required. Bumped versions don't exist on npm or Verdaccio, so pnpm accepts them.

Re-running is idempotent: if the version is already bumped and there's nothing new since release, the package is skipped — no double-bumps across repeated `--use-local` invocations.

## Usage

```
pnpm verdaccio start --background
pnpm verdaccio publish --since-release
pnpm verdaccio stop
```

## Test plan

- [x] `pnpm test:scripts` — five `decidePublishAction` cases (one per row of the table above) covered in [scripts/verdaccio/publish.test.ts](scripts/verdaccio/publish.test.ts) without touching git.
- [x] manual testing using `pnpm bench` (see later PRs in stack)

