### PR TITLE
feat(e2e): accept pnpm as a scenario `packageManager`

### DIFF
--- a/scripts/end-to-end/schema/scenario-schema.test.ts
+++ b/scripts/end-to-end/schema/scenario-schema.test.ts
@@ -60,6 +60,19 @@ describe("isScenarioDefinition", () => {
     assert.equal(isScenarioDefinition(value), true);
   });
 
+  it("accepts pnpm as a package manager", () => {
+    const value = {
+      description: "Uniswap V4 core with pnpm",
+      repo: "ChristopherDedominici/core",
+      commit: "abc123",
+      packageManager: "pnpm",
+      defaultCommand: "pnpm run test",
+      tags: ["external-repo"],
+    };
+
+    assert.equal(isScenarioDefinition(value), true);
+  });
+
   it("accepts a scenario with disabled: true", () => {
     const value = {
       description: "A disabled scenario",
@@ -131,7 +144,7 @@ describe("isScenarioDefinition", () => {
       isScenarioDefinition({
         repo: "org/repo",
         commit: "abc",
-        packageManager: "pnpm",
+        packageManager: "volt",
         tags: [],
         description: "a scenario",
         defaultCommand: "npx hardhat test",

--- a/scripts/end-to-end/schema/scenario-schema.ts
+++ b/scripts/end-to-end/schema/scenario-schema.ts
@@ -15,7 +15,8 @@ export function isScenarioDefinition(
     typeof obj.commit === "string" &&
     (obj.packageManager === "npm" ||
       obj.packageManager === "bun" ||
-      obj.packageManager === "yarn") &&
+      obj.packageManager === "yarn" ||
+      obj.packageManager === "pnpm") &&
     typeof obj.defaultCommand === "string" &&
     Array.isArray(obj.tags) &&
     obj.tags.every((t: unknown) => typeof t === "string") &&

--- a/scripts/end-to-end/schema/scenario.schema.json
+++ b/scripts/end-to-end/schema/scenario.schema.json
@@ -28,7 +28,7 @@
     },
     "packageManager": {
       "type": "string",
-      "enum": ["npm", "bun", "yarn"],
+      "enum": ["npm", "bun", "yarn", "pnpm"],
       "description": "Package manager used by the repo"
     },
     "defaultCommand": {

--- a/scripts/end-to-end/types.ts
+++ b/scripts/end-to-end/types.ts
@@ -9,7 +9,7 @@ export interface ScenarioDefinition {
   description: string;
   repo: string;
   commit: string;
-  packageManager: "npm" | "bun" | "yarn";
+  packageManager: "npm" | "bun" | "yarn" | "pnpm";
   defaultCommand: string;
   preinstall?: string;
   install?: string;


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8273 

Adds support for `pnpm` to E2E scenarios. This is required for adding some of our new scenarios.
