### PR TITLE
feat(e2e): substitute `${localEnv:NAME}` tokens in scenario env

### DIFF
--- a/scripts/end-to-end/helpers/directory.ts
+++ b/scripts/end-to-end/helpers/directory.ts
@@ -2,6 +2,7 @@ import path, { basename, dirname, resolve } from "node:path";
 import type { Scenario, ScenarioDefinition } from "../types.ts";
 import { isScenarioDefinition } from "../schema/scenario-schema.ts";
 import { readFileSync } from "node:fs";
+import { resolveEnv } from "./env.ts";
 
 export function loadScenario(
   e2eCloneDirectory: string,
@@ -14,6 +15,10 @@ export function loadScenario(
     scenarioFilePath,
   );
   const definition = _readScenarioJson(scenarioFilePath);
+
+  if (definition.env !== undefined) {
+    definition.env = resolveEnv(definition.env, scenarioFilePath);
+  }
 
   return {
     id,

--- a/scripts/end-to-end/helpers/env.test.ts
+++ b/scripts/end-to-end/helpers/env.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveEnv } from "./env.ts";
+
+describe("resolveEnv", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = process.env;
+    process.env = {};
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("passes through values with no tokens", () => {
+    const resolved = resolveEnv(
+      { FOO: "bar", BAZ: "qux" },
+      "scenarios/test.json",
+    );
+
+    assert.deepEqual(resolved, { FOO: "bar", BAZ: "qux" });
+  });
+
+  it("substitutes a single ${localEnv:NAME} token", () => {
+    process.env.ALCHEMY_URL = "https://example.com/key";
+
+    const resolved = resolveEnv(
+      { FOUNDRY_RPC_URL: "${localEnv:ALCHEMY_URL}" },
+      "scenarios/test.json",
+    );
+
+    assert.deepEqual(resolved, { FOUNDRY_RPC_URL: "https://example.com/key" });
+  });
+
+  it("substitutes multiple tokens within a single value", () => {
+    process.env.SCHEME = "https";
+    process.env.HOST = "example.com";
+
+    const resolved = resolveEnv(
+      { URL: "${localEnv:SCHEME}://${localEnv:HOST}/path" },
+      "scenarios/test.json",
+    );
+
+    assert.deepEqual(resolved, { URL: "https://example.com/path" });
+  });
+
+  it("substitutes tokens across multiple keys", () => {
+    process.env.ALCHEMY_URL = "https://alchemy.example/key";
+    process.env.INFURA_URL = "https://infura.example/key";
+
+    const resolved = resolveEnv(
+      {
+        FOUNDRY_RPC_URL: "${localEnv:ALCHEMY_URL}",
+        BACKUP_RPC_URL: "${localEnv:INFURA_URL}",
+      },
+      "scenarios/test.json",
+    );
+
+    assert.deepEqual(resolved, {
+      FOUNDRY_RPC_URL: "https://alchemy.example/key",
+      BACKUP_RPC_URL: "https://infura.example/key",
+    });
+  });
+
+  it("substitutes an explicitly empty string", () => {
+    process.env.MAYBE_EMPTY = "";
+
+    const resolved = resolveEnv(
+      { VALUE: "prefix-${localEnv:MAYBE_EMPTY}-suffix" },
+      "scenarios/test.json",
+    );
+
+    assert.deepEqual(resolved, { VALUE: "prefix--suffix" });
+  });
+
+  it("throws when a referenced host variable is unset", () => {
+    assert.throws(
+      () =>
+        resolveEnv(
+          { FOUNDRY_RPC_URL: "${localEnv:MISSING_VAR}" },
+          "scenarios/test.json",
+        ),
+      (err: Error) =>
+        err.message.includes("scenarios/test.json") &&
+        err.message.includes("MISSING_VAR"),
+    );
+  });
+
+  it("leaves unrecognized ${...} tokens untouched", () => {
+    const resolved = resolveEnv(
+      {
+        A: "${containerEnv:FOO}",
+        B: "${something}",
+      },
+      "scenarios/test.json",
+    );
+
+    assert.deepEqual(resolved, {
+      A: "${containerEnv:FOO}",
+      B: "${something}",
+    });
+  });
+
+  it("does not substitute keys", () => {
+    process.env.FOO = "value";
+
+    const resolved = resolveEnv(
+      { "${localEnv:FOO}": "literal" },
+      "scenarios/test.json",
+    );
+
+    assert.deepEqual(resolved, { "${localEnv:FOO}": "literal" });
+  });
+});

--- a/scripts/end-to-end/helpers/env.ts
+++ b/scripts/end-to-end/helpers/env.ts
@@ -1,0 +1,29 @@
+const LOCAL_ENV_TOKEN = /\$\{localEnv:([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+/**
+ * Substitute `${localEnv:NAME}` tokens in scenario `env` values with the
+ * corresponding host environment variable. Throws if a referenced variable
+ * is unset; an explicitly empty string is substituted as-is.
+ */
+export function resolveEnv(
+  env: Record<string, string>,
+  scenarioPath: string,
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(env)) {
+    resolved[key] = value.replace(LOCAL_ENV_TOKEN, (_, name: string) => {
+      const hostValue = process.env[name];
+
+      if (hostValue === undefined) {
+        throw new Error(
+          `Scenario ${scenarioPath} references host environment variable "${name}" via \${localEnv:${name}}, but it is not set`,
+        );
+      }
+
+      return hostValue;
+    });
+  }
+
+  return resolved;
+}

--- a/scripts/end-to-end/schema/scenario.schema.json
+++ b/scripts/end-to-end/schema/scenario.schema.json
@@ -52,7 +52,7 @@
     "env": {
       "type": "object",
       "additionalProperties": { "type": "string" },
-      "description": "Environment variables to set during install/exec"
+      "description": "Environment variables to set during install/exec. Values may reference host variables with the devcontainer-style token ${localEnv:NAME} (e.g. \"FOUNDRY_RPC_URL\": \"${localEnv:ALCHEMY_URL}\"); the referenced host variable must be set or the run will fail."
     },
     "submodules": {
       "type": "boolean",


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8274

## Summary

Lets `scenario.json` `env` values reference host environment variables using the devcontainer-style `${localEnv:NAME}` token. CI can then route an existing secret (e.g. `ALCHEMY_URL`) into whatever variable name a scenario expects (e.g. `FOUNDRY_RPC_URL`) without inventing per-scenario secret names.

## Motivation

CI exposes a small set of shared secrets, but external scenarios expect their _own_ variable names — `FOUNDRY_RPC_URL`, `MAINNET_RPC_URL`, etc. Without substitution, each new scenario forces either a new CI secret or a runner-side rename. Now the scenario declares the mapping itself:

```json
"env": {
  "FOUNDRY_RPC_URL": "${localEnv:ALCHEMY_URL}",
  "MAINNET_RPC_URL": "${localEnv:ALCHEMY_URL}"
}
```

## Syntax

Mirrors the [devcontainer.json variable spec](https://containers.dev/implementors/json_reference/#variables-in-devcontainer-json):

- Token: `${localEnv:NAME}`, where `NAME` matches `[A-Za-z_][A-Za-z0-9_]*`.
- Only `env` _values_ are substituted; keys are never touched.
- Multiple tokens per value are supported; surrounding text is preserved (`"prefix-${localEnv:FOO}-suffix"` works).
- A `${...}` token that isn't `localEnv:` is left literal (no error), matching devcontainer's lenient behavior.

## Unset vs. empty

| State of `process.env.NAME` | Behavior |
|---|---|
| **unset** (`undefined`) | Throw, naming both the scenario file and the missing variable |
| **empty string** (`""`) | Substitute `""` |

Rationale: in CI an unset variable almost always means a misconfigured workflow — failing loudly catches that. Empty is rare but legitimate (e.g. opt-out flags) and gets through.

## Implementation

- New `resolveEnv(env, scenarioPath)` in [scripts/end-to-end/helpers/env.ts](scripts/end-to-end/helpers/env.ts).
- Called once inside `loadScenario` ([scripts/end-to-end/helpers/directory.ts](scripts/end-to-end/helpers/directory.ts)), right after `_readScenarioJson`. Every downstream consumer reads the resolved `scenario.definition.env` — single source of truth, no parallel raw-vs-resolved variants.
- Schema's `env.description` updated to document the syntax; type stays `string` (substitution runs after validation, so `isScenarioDefinition` is unchanged).

## Out of scope

- `${containerEnv:...}`, `${localWorkspaceFolder}`, and the default-value form `${localEnv:NAME:default}`.
- Substitution in non-`env` fields (`defaultCommand`, `repo`, etc.).

## Test plan

`pnpm test:scripts` covers, in [scripts/end-to-end/helpers/env.test.ts](scripts/end-to-end/helpers/env.test.ts):

- [x] Passes through values with no tokens.
- [x] Substitutes a single `${localEnv:NAME}`.
- [x] Multiple tokens in one value.
- [x] Tokens across multiple keys.
- [x] Empty-string host value substitutes as `""`.
- [x] Unset host value throws, with scenario path + variable name in the message.
- [x] Unrecognized `${...}` tokens left literal.
- [x] Keys are not substituted.

Tests stub `process.env` and restore in `afterEach`.