### PR TITLE
feat(e2e): add --use-local, --force-checkout, --force-publish

### DIFF
--- a/scripts/end-to-end/helpers/args.ts
+++ b/scripts/end-to-end/helpers/args.ts
@@ -1,11 +1,13 @@
 import { log } from "node:console";
 import { normalizeScenarioPath } from "./directory.ts";
+import { ForceCheckout, ForcePublish, UseLocal } from "../subcommands/init.ts";
 
-const DEFAULT_CLONE_DIR = "/tmp/end-to-end";
+export const DEFAULT_CLONE_DIR = "/tmp/end-to-end";
 
 export function resolveAndValidateArgs(args: string[]) {
   const scenarioPathRaw =
     getArgValue(args, "--scenario") ?? process.env.E2E_SCENARIO;
+
   const scenarioPath =
     scenarioPathRaw !== undefined
       ? normalizeScenarioPath(scenarioPathRaw)
@@ -16,6 +18,16 @@ export function resolveAndValidateArgs(args: string[]) {
   const cleanFlag = args.includes("clean");
 
   const command = getArgValue(args, "--command");
+
+  const useLocal = args.includes("--use-local") ? UseLocal.Yes : UseLocal.No;
+
+  const forceCheckout = args.includes("--force-checkout")
+    ? ForceCheckout.Yes
+    : ForceCheckout.No;
+
+  const forcePublish = args.includes("--force-publish")
+    ? ForcePublish.Yes
+    : ForcePublish.No;
 
   let e2eCloneDirectory =
     getArgValue(args, "--e2e-clone-dir") ?? process.env.E2E_CLONE_DIR;
@@ -50,6 +62,9 @@ export function resolveAndValidateArgs(args: string[]) {
     e2eCloneDirectory,
     scenarioPath,
     command,
+    useLocal,
+    forceCheckout,
+    forcePublish,
   };
 }
 

--- a/scripts/end-to-end/helpers/install.test.ts
+++ b/scripts/end-to-end/helpers/install.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getInstallArgs } from "./install.ts";
+
+const REGISTRY = "http://127.0.0.1:4873";
+
+describe("getInstallArgs", () => {
+  describe("yarn", () => {
+    it("omits --registry (env var carries it) when lockfile updates are not allowed", () => {
+      assert.deepEqual(getInstallArgs("yarn", false, REGISTRY), ["install"]);
+    });
+
+    it("appends --no-immutable when lockfile updates are allowed", () => {
+      assert.deepEqual(getInstallArgs("yarn", true, REGISTRY), [
+        "install",
+        "--no-immutable",
+      ]);
+    });
+  });
+
+  describe("npm", () => {
+    it("passes --registry when lockfile updates are not allowed", () => {
+      assert.deepEqual(getInstallArgs("npm", false, REGISTRY), [
+        "install",
+        `--registry=${REGISTRY}`,
+      ]);
+    });
+
+    it("does not append a lockfile flag (npm install never freezes)", () => {
+      assert.deepEqual(getInstallArgs("npm", true, REGISTRY), [
+        "install",
+        `--registry=${REGISTRY}`,
+      ]);
+    });
+  });
+
+  describe("pnpm", () => {
+    it("passes --registry when lockfile updates are not allowed", () => {
+      assert.deepEqual(getInstallArgs("pnpm", false, REGISTRY), [
+        "install",
+        `--registry=${REGISTRY}`,
+      ]);
+    });
+
+    it("appends --no-frozen-lockfile when lockfile updates are allowed", () => {
+      assert.deepEqual(getInstallArgs("pnpm", true, REGISTRY), [
+        "install",
+        `--registry=${REGISTRY}`,
+        "--no-frozen-lockfile",
+      ]);
+    });
+  });
+
+  describe("bun", () => {
+    it("passes --registry when lockfile updates are not allowed", () => {
+      assert.deepEqual(getInstallArgs("bun", false, REGISTRY), [
+        "install",
+        `--registry=${REGISTRY}`,
+      ]);
+    });
+
+    it("appends --no-frozen-lockfile when lockfile updates are allowed", () => {
+      assert.deepEqual(getInstallArgs("bun", true, REGISTRY), [
+        "install",
+        `--registry=${REGISTRY}`,
+        "--no-frozen-lockfile",
+      ]);
+    });
+  });
+});

--- a/scripts/end-to-end/helpers/install.ts
+++ b/scripts/end-to-end/helpers/install.ts
@@ -15,6 +15,7 @@ import type { ScenarioDefinition } from "../types.ts";
 export function installDependencies(
   workDir: string,
   packageManager: ScenarioDefinition["packageManager"],
+  allowLockfileUpdates: boolean,
   env?: Record<string, string>,
 ): void {
   writeRegistryConfig(workDir, packageManager);
@@ -30,17 +31,60 @@ export function installDependencies(
 
   logStep("Installing dependencies");
 
-  const installArgs =
-    packageManager === "yarn"
-      ? ["install"]
-      : // Required by bun as it may not pickup the cwd bunfig.toml
-        ["install", `--registry=${VERDACCIO_URL}`];
+  const installArgs = getInstallArgs(
+    packageManager,
+    allowLockfileUpdates,
+    VERDACCIO_URL,
+  );
 
   execFileSync(which(packageManager), installArgs, {
     cwd: workDir,
     stdio: "inherit",
-    env: { ...process.env, ...env, COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+    env: {
+      ...process.env,
+      ...env,
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+      npm_config_minimum_release_age: "0",
+      // Yarn Classic doesn't honor project .yarnrc for `registry` on the
+      // GitHub Actions runner, so force the registry via env var. This is
+      // the highest-priority npm config source, so it overrides any
+      // user/global .npmrc that might be present.
+      npm_config_registry: VERDACCIO_URL,
+    },
   });
+}
+
+/**
+ * Build the package-manager-specific `install` args for a Verdaccio-backed
+ * install.
+ *
+ * `--use-local` patches the scenario's package.json, drifting the lockfile.
+ * Since CI defaults to frozen-lockfile mode for pnpm and Yarn Berry, we allow
+ * lockfile updates.
+ */
+export function getInstallArgs(
+  packageManager: ScenarioDefinition["packageManager"],
+  allowLockfileUpdates: boolean,
+  registryUrl: string,
+): string[] {
+  // bun doesn't reliably read cwd `bunfig.toml`, so it needs the `--registry` CLI flag.
+  // npm & pnpm don't strictly need `--registry` but we pass it for redundancy.
+  // yarn is excluded because it rejects `--registry` as a CLI flag.
+  const args =
+    packageManager === "yarn"
+      ? ["install"]
+      : ["install", `--registry=${registryUrl}`];
+
+  if (allowLockfileUpdates) {
+    // npm install never freezes (only `npm ci` does), so it doesn't need any flag.
+    if (packageManager === "pnpm" || packageManager === "bun") {
+      args.push("--no-frozen-lockfile");
+    } else if (packageManager === "yarn") {
+      args.push("--no-immutable");
+    }
+  }
+
+  return args;
 }
 
 function writeRegistryConfig(
@@ -52,6 +96,8 @@ function writeRegistryConfig(
     writeFileSync(bunfigPath, `[install]\nregistry = "${VERDACCIO_URL}"\n`);
     log(`Wrote bunfig.toml → ${VERDACCIO_URL}`);
   } else if (packageManager === "yarn") {
+    // Yarn Berry reads `.yarnrc.yml`. Yarn Classic doesn't read it, but the
+    // `npm_config_registry` env var passed at install time covers Classic.
     const yarnrcPath = resolve(dir, ".yarnrc.yml");
 
     let existing = "";

--- a/scripts/end-to-end/main.ts
+++ b/scripts/end-to-end/main.ts
@@ -21,6 +21,13 @@ OPTIONS
   --e2e-clone-dir <path>   Override clone directory (default: $E2E_CLONE_DIR or "/tmp/end-to-end")
   --scenario <path>        The scenario folder or file to work on (default: $E2E_SCENARIO)
   --command <cmd>          Command to run (optional with \`exec\`, falls back to scenario defaultCommand)
+  --use-local              Detect packages changed since their release tag, bump versions,
+                           publish to Verdaccio, and pin scenario deps to the published versions.
+                           If Verdaccio is already running, publish is skipped (the existing
+                           registry contents are reused) unless --force-publish is also passed.
+  --force-checkout         Force git checkouts even if there are uncommitted changes in the scenario working directory
+  --force-publish          Allow publishing to an already-running Verdaccio instance, potentially
+                           overwriting its current contents
 
 VERDACCIO
   If Verdaccio is already running it will be used as-is.
@@ -42,13 +49,29 @@ async function main(): Promise<void> {
     e2eCloneDirectory,
     scenarioPath,
     command,
+    useLocal,
+    forceCheckout,
+    forcePublish,
   } = resolveAndValidateArgs(process.argv.slice(2));
 
   try {
     if (initFlag) {
-      await init(e2eCloneDirectory, scenarioPath);
+      await init(
+        e2eCloneDirectory,
+        scenarioPath,
+        useLocal,
+        forceCheckout,
+        forcePublish,
+      );
     } else if (execFlag) {
-      await exec(e2eCloneDirectory, scenarioPath, command);
+      await exec(
+        e2eCloneDirectory,
+        scenarioPath,
+        command,
+        useLocal,
+        forceCheckout,
+        forcePublish,
+      );
     } else if (cleanFlag) {
       clean(e2eCloneDirectory, scenarioPath);
     } else {

--- a/scripts/end-to-end/subcommands/exec.ts
+++ b/scripts/end-to-end/subcommands/exec.ts
@@ -1,18 +1,27 @@
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { loadScenario } from "../helpers/directory.ts";
-import { init } from "./init.ts";
+import { init, ForceCheckout, ForcePublish, UseLocal } from "./init.ts";
 import { logStep } from "../helpers/log.ts";
 
 export async function exec(
   e2eCloneDirectory: string,
   scenarioPath: string,
   command: string | undefined,
+  useLocal: UseLocal,
+  forceCheckout: ForceCheckout,
+  forcePublish: ForcePublish,
 ): Promise<void> {
   const scenario = loadScenario(e2eCloneDirectory, scenarioPath);
 
   if (!existsSync(scenario.workingDir)) {
-    await init(e2eCloneDirectory, scenarioPath);
+    await init(
+      e2eCloneDirectory,
+      scenarioPath,
+      useLocal,
+      forceCheckout,
+      forcePublish,
+    );
   }
 
   const resolvedCommand = command ?? scenario.definition.defaultCommand;

--- a/scripts/end-to-end/subcommands/init.ts
+++ b/scripts/end-to-end/subcommands/init.ts
@@ -1,19 +1,69 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { installDependencies } from "../helpers/install.ts";
 import { git, which, ROOT_DIR } from "../helpers/shell.ts";
-import { log, logStep, logWarning } from "../helpers/log.ts";
-import { isVerdaccioRunning } from "../../verdaccio/helpers/shell.ts";
+import { fmt, log, logStep, logWarning } from "../helpers/log.ts";
+import {
+  isVerdaccioRunning,
+  VERDACCIO_URL,
+} from "../../verdaccio/helpers/shell.ts";
 import { loadScenario } from "../helpers/directory.ts";
 import { start as verdaccioStart } from "../../verdaccio/start.ts";
-import { publish as verdaccioPublish } from "../../verdaccio/publish.ts";
+import {
+  publish as verdaccioPublish,
+  sinceReleasePublish,
+} from "../../verdaccio/publish.ts";
 import { stop as verdaccioStop } from "../../verdaccio/stop.ts";
 import type { Scenario } from "../types.ts";
+
+export const ForceCheckout = {
+  Yes: "Yes",
+  No: "No",
+} as const;
+
+/**
+ * Enum for whether to force checkout in git operations.
+ *
+ * Used to avoid mixing boolean flags with different semantics
+ * (e.g. --force-publish).
+ */
+export type ForceCheckout = (typeof ForceCheckout)[keyof typeof ForceCheckout];
+
+export const ForcePublish = {
+  Yes: "Yes",
+  No: "No",
+} as const;
+
+/**
+ * Enum for whether to force publish packages to an already-running
+ * Verdaccio instance.
+ *
+ * Used to avoid mixing boolean flags with different semantics
+ * (e.g. --force-checkout).
+ */
+export type ForcePublish = (typeof ForcePublish)[keyof typeof ForcePublish];
+
+export const UseLocal = {
+  Yes: "Yes",
+  No: "No",
+} as const;
+
+/**
+ * Enum for whether to detect local package changes, publish to Verdaccio, and
+ * pin scenario dependencies to the published versions. Only applies when init runs.
+ *
+ * Used to avoid mixing boolean flags with different semantics
+ * (e.g. --force-checkout).
+ */
+export type UseLocal = (typeof UseLocal)[keyof typeof UseLocal];
 
 export async function init(
   e2eCloneDirectory: string,
   scenarioPath: string,
+  useLocal: UseLocal,
+  forceCheckout: ForceCheckout,
+  forcePublish: ForcePublish,
 ): Promise<void> {
   const scenario = loadScenario(e2eCloneDirectory, scenarioPath);
 
@@ -23,18 +73,46 @@ export async function init(
     return;
   }
 
-  const runTemporaryVerdaccioInstance = !isVerdaccioRunning();
+  const verdaccioAlreadyRunning = isVerdaccioRunning();
 
-  if (runTemporaryVerdaccioInstance) {
+  if (
+    useLocal === UseLocal.Yes &&
+    verdaccioAlreadyRunning &&
+    forcePublish === ForcePublish.No
+  ) {
+    log(
+      "A Verdaccio instance is already running. Skipping --use-local's\n" +
+        "  bump-and-publish step — the scenario will use whatever the running\n" +
+        "  registry already contains.\n\n" +
+        "  To force a fresh bump-and-publish to the running instance, pass\n" +
+        "  --force-publish. Or stop the running instance first:\n" +
+        "    pnpm verdaccio stop",
+    );
+  }
+
+  if (!verdaccioAlreadyRunning) {
     await verdaccioStart(true);
+  }
 
-    verdaccioPublish(false, true);
+  const startedVerdaccio = !verdaccioAlreadyRunning;
+  if (startedVerdaccio || forcePublish === ForcePublish.Yes) {
+    if (useLocal === UseLocal.Yes) {
+      sinceReleasePublish();
+    } else {
+      verdaccioPublish(false, true);
+    }
   }
 
   try {
-    initializeScenario(scenario);
+    setupScenario(scenario, forceCheckout);
+
+    if (useLocal === UseLocal.Yes) {
+      await upgradeLocalDependencies(scenario);
+    }
+
+    installScenarioDeps(scenario, useLocal === UseLocal.Yes);
   } finally {
-    if (runTemporaryVerdaccioInstance) {
+    if (startedVerdaccio) {
       verdaccioStop();
     }
   }
@@ -44,25 +122,25 @@ export async function init(
 }
 
 /**
- * Clone/setup a scenario repo and install hardhat from Verdaccio.
+ * Clone/setup a scenario repo and run preinstall scripts.
  * Idempotent: reuses existing checkouts (fetch + checkout + clean).
  */
-function initializeScenario(scenario: Scenario): void {
+function setupScenario(scenario: Scenario, forceCheckout: ForceCheckout): void {
   const { scenarioDir, workingDir, definition } = scenario;
   const submodules = definition.submodules ?? false;
 
   if (!existsSync(workingDir)) {
     // Fresh clone flow
     clone(workingDir, definition.repo);
-    checkout(workingDir, definition.commit);
+    checkout(workingDir, definition.commit, forceCheckout);
 
     if (submodules) {
       updateSubmodules(workingDir);
     }
   } else {
     // Re-init flow
-    fetch(workingDir, definition.repo);
-    checkout(workingDir, definition.commit);
+    fetch(workingDir, definition.repo, definition.commit);
+    checkout(workingDir, definition.commit, forceCheckout);
     clean(workingDir);
 
     if (submodules) {
@@ -78,8 +156,19 @@ function initializeScenario(scenario: Scenario): void {
       definition.env,
     );
   }
+}
 
-  if (scenario.definition.install !== undefined) {
+/**
+ * Install dependencies using the scenario's package manager or custom
+ * install script.
+ */
+function installScenarioDeps(
+  scenario: Scenario,
+  allowLockfileUpdates: boolean,
+): void {
+  const { scenarioDir, workingDir, definition } = scenario;
+
+  if (definition.install !== undefined) {
     runCustomInstallScript(
       resolve(scenarioDir, definition.install),
       scenarioDir,
@@ -87,7 +176,75 @@ function initializeScenario(scenario: Scenario): void {
       definition.env,
     );
   } else {
-    installDependencies(workingDir, definition.packageManager, definition.env);
+    installDependencies(
+      workingDir,
+      definition.packageManager,
+      allowLockfileUpdates,
+      definition.env,
+    );
+  }
+}
+
+/**
+ * Patch the scenario's package.json to pin hardhat / @nomicfoundation/*
+ * dependencies to the latest versions available in Verdaccio. Verdaccio
+ * merges locally published packages with npm (via proxy), so this returns
+ * bumped local versions where available and npm versions for everything else.
+ */
+async function upgradeLocalDependencies(scenario: Scenario): Promise<void> {
+  logStep("Upgrading dependencies to latest Verdaccio versions");
+
+  const pkgJsonPath = resolve(scenario.workingDir, "package.json");
+  const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+
+  let updated = false;
+
+  for (const depField of ["dependencies", "devDependencies"] as const) {
+    const deps = pkgJson[depField] as Record<string, string> | undefined;
+
+    if (deps === undefined) {
+      continue;
+    }
+
+    for (const name of Object.keys(deps)) {
+      if (name !== "hardhat" && !name.startsWith("@nomicfoundation/")) {
+        continue;
+      }
+
+      const version = await getLatestFromVerdaccio(name);
+
+      if (version !== undefined) {
+        deps[name] = version;
+        updated = true;
+        log(`  ${fmt.pkg(name)} → ${fmt.version(version)}`);
+      }
+    }
+  }
+
+  if (updated) {
+    writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + "\n");
+  } else {
+    log("No matching dependencies to update");
+  }
+}
+
+async function getLatestFromVerdaccio(
+  packageName: string,
+): Promise<string | undefined> {
+  try {
+    const response = await globalThis.fetch(`${VERDACCIO_URL}/${packageName}`);
+
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const metadata = (await response.json()) as {
+      "dist-tags"?: { latest?: string };
+    };
+
+    return metadata["dist-tags"]?.latest;
+  } catch {
+    return undefined;
   }
 }
 
@@ -100,10 +257,14 @@ function clone(scenarioWorkingDir: string, repo: string): void {
   );
 }
 
-function fetch(scenarioWorkingDir: string, repo: string): void {
+function fetch(scenarioWorkingDir: string, repo: string, commit: string): void {
   logStep(`Fetching ${repo}`);
 
-  git(["fetch", "origin"], scenarioWorkingDir);
+  // Fetch the specific commit by SHA so that the checkout below succeeds even
+  // if the commit is no longer the tip of any branch (e.g. after a force-push
+  // that orphaned the previously-fetched commits, or when the SHA points at
+  // an intermediate commit on a long-lived branch).
+  git(["fetch", "origin", commit], scenarioWorkingDir);
 }
 
 function updateSubmodules(scenarioWorkingDir: string): void {
@@ -112,10 +273,18 @@ function updateSubmodules(scenarioWorkingDir: string): void {
   git(["submodule", "update", "--init", "--recursive"], scenarioWorkingDir);
 }
 
-function checkout(scenarioWorkingDir: string, commit: string): void {
+function checkout(
+  scenarioWorkingDir: string,
+  commit: string,
+  force: ForceCheckout,
+): void {
   logStep(`Checking out ${commit}`);
 
-  git(["checkout", commit], scenarioWorkingDir);
+  const args = ["checkout", commit];
+  if (force === ForceCheckout.Yes) {
+    args.push("--force");
+  }
+  git(args, scenarioWorkingDir);
 }
 
 function clean(scenarioWorkingDir: string): void {


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8275

## Summary

Adds three flags to `pnpm e2e`:

- `--use-local` — bump-and-publish any workspace package changed since its last release tag (via the new `pnpm verdaccio publish --since-release`), then rewrite the scenario's `package.json` to pin `hardhat` / `@nomicfoundation/*` deps to whatever Verdaccio now serves.
- `--force-checkout` — let `git checkout <commit>` overwrite uncommitted changes in the scenario working dir.
- `--force-publish` — opt-in escape hatch for publishing to a Verdaccio instance that's already running.

Together they let local and CI-hosted benchmarks flow through the e2e harness end-to-end without manually crafting changesets or hand-bumping versions. Consumed by `pnpm bench` / `pnpm bench:regression` in later PRs in this stack.

## Why these three flags

### `--use-local`

Without it, `pnpm e2e` runs scenarios against the most-recent **published** versions of Hardhat packages. To benchmark or regression-test against working-tree changes, the runner needs to:

1. Detect what's changed since the last release.
2. Get those changes into the local Verdaccio under a version pnpm will accept.
3. Make the scenario's `package.json` actually pin those bumped versions (otherwise it'd still resolve the npm-cached release version through Verdaccio's proxy).

The first two steps are `sinceReleasePublish()` (added in #8273). Step 3 is the new `upgradeLocalDependencies`: for each `hardhat` / `@nomicfoundation/*` dep in the scenario's `package.json`, query `GET http://127.0.0.1:4873/<pkg>` and rewrite the dep range to the `dist-tags.latest` Verdaccio reports. Because Verdaccio merges locally-published packages with npm-proxied ones, this returns bumped local versions where available and npm versions for everything else — exactly what install would resolve, but pinned so the scenario can't drift.

### `--force-checkout`

`--use-local` patches the scenario's `package.json` in place. On the next run, `git checkout <commit>` would refuse because of the uncommitted edit. `--force-checkout` adds `-f` so the patched file gets blown away and the scenario starts from a clean state. Necessary in CI's regression-benchmark loop where the same clone is reused across runs on our dedicated GitHub runner.

### `--force-publish`

`--use-local` against an already-running Verdaccio is ambiguous — we'd be silently mutating someone else's registry contents. By default this errors out:

```
A Verdaccio instance is already running. Skipping --use-local's bump-and-publish
step — the scenario will use whatever the running registry already contains.
  To force a fresh bump-and-publish to the running instance, pass --force-publish.
  Or stop the running instance first:
    pnpm verdaccio stop
```

`--force-publish` opts back in for cases where overwriting is the intent (e.g. iterating locally on the same Verdaccio across multiple `pnpm e2e` invocations) or when you want to use a locally published version of EDR.

## `init` flow

```
1. if --use-local AND verdaccio running AND NOT --force-publish → log warning, skip publish
2. start Verdaccio if not running
3. if (started or --force-publish):
     if --use-local → sinceReleasePublish()
     else           → verdaccioPublish()
4. setupScenario    (clone / fetch+checkout / clean / submodules / preinstall)
5. if --use-local → upgradeLocalDependencies()
6. installScenarioDeps  (custom install script or installDependencies)
7. if we started Verdaccio → stop it
```

Steps 4–6 used to be a single `initializeScenario`; they're split because `upgradeLocalDependencies` has to run **after** clone/checkout (so it can edit the freshly checked-out `package.json`) but **before** install (so the install resolves against the patched deps).

## Install-time fixes that came along for the ride

`installDependencies` ([scripts/end-to-end/helpers/install.ts](scripts/end-to-end/helpers/install.ts)) gains an `allowLockfileUpdates: boolean` (true when `--use-local`, since the dep-pinning edit drifts the lockfile):

- pnpm / bun → append `--no-frozen-lockfile`
- yarn berry → append `--no-immutable`
- npm → no flag needed (`npm install` never freezes; only `npm ci` does)

Two install-time env vars are now always set:

- `npm_config_minimum_release_age=0` — pnpm 10+ rejects packages published less than 7 days ago by default; `sinceReleasePublish` publishes bumped versions seconds before install runs, so this would otherwise fail.
- `npm_config_registry=<VERDACCIO_URL>` — Yarn Classic doesn't honor project `.yarnrc.yml` for `registry`, so we force it via env (highest-priority npm config source).

`fetch()` also now takes the target commit SHA and fetches it specifically, so checkout succeeds even when the SHA has been orphaned upstream (force-pushed branch, etc.).

## Test plan

- [x] `pnpm test:scripts` — new [scripts/end-to-end/helpers/install.test.ts](scripts/end-to-end/helpers/install.test.ts) covers all 4 package managers × allow/disallow lockfile updates for `getInstallArgs`.
- [x] Manually used all commands extensively while testing performance regression benchmark 

