### PR TITLE
feat(bench): add pnpm bench (single-scenario hyperfine wrapper)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test:file": "node ./scripts/test-file.ts",
     "spellcheck:file": "node ./scripts/spellcheck-file.ts",
     "verdaccio": "node ./scripts/verdaccio/main.ts",
-    "e2e": "node ./scripts/end-to-end/main.ts"
+    "e2e": "node ./scripts/end-to-end/main.ts",
+    "bench": "node ./scripts/benchmark/main.ts"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/scripts/benchmark/helpers/args.ts
+++ b/scripts/benchmark/helpers/args.ts
@@ -1,0 +1,106 @@
+import { log } from "node:console";
+import { normalizeScenarioPath } from "../../end-to-end/helpers/directory.ts";
+import { DEFAULT_CLONE_DIR } from "../../end-to-end/helpers/args.ts";
+import {
+  ForceCheckout,
+  ForcePublish,
+  UseLocal,
+} from "../../end-to-end/subcommands/init.ts";
+
+export interface BenchArgs {
+  scenarioPath: string;
+  command: string | undefined;
+  init: boolean;
+  useLocal: UseLocal;
+  forceCheckout: ForceCheckout;
+  forcePublish: ForcePublish;
+  precompile: boolean;
+  prepare: string | undefined;
+  ignoreFailure: boolean;
+  showOutput: boolean;
+  warmup: number;
+  runs: number | undefined;
+  exportJson: string | undefined;
+  e2eCloneDirectory: string;
+}
+
+export function resolveAndValidateArgs(args: string[]): BenchArgs | undefined {
+  const scenarioPathRaw =
+    getArgValue(args, "--scenario") ?? process.env.E2E_SCENARIO;
+
+  if (scenarioPathRaw === undefined) {
+    return undefined;
+  }
+
+  const scenarioPath = normalizeScenarioPath(scenarioPathRaw);
+  const command = getArgValue(args, "--command");
+  const init = args.includes("--init");
+  const useLocal = args.includes("--use-local") ? UseLocal.Yes : UseLocal.No;
+
+  const forceCheckout = args.includes("--force-checkout")
+    ? ForceCheckout.Yes
+    : ForceCheckout.No;
+
+  const forcePublish = args.includes("--force-publish")
+    ? ForcePublish.Yes
+    : ForcePublish.No;
+
+  const precompile = args.includes("--precompile");
+  const prepare = getArgValue(args, "--prepare");
+  const ignoreFailure = args.includes("--ignore-failure");
+  const showOutput = args.includes("--show-output");
+
+  const warmupRaw = getArgValue(args, "--warmup");
+  const warmup = warmupRaw !== undefined ? parseInt(warmupRaw, 10) : 0;
+
+  if (warmupRaw !== undefined && (isNaN(warmup) || warmup < 0)) {
+    throw new Error("--warmup must be a non-negative integer");
+  }
+
+  const runsRaw = getArgValue(args, "--runs");
+  const runs = runsRaw !== undefined ? parseInt(runsRaw, 10) : undefined;
+
+  if (
+    runsRaw !== undefined &&
+    (runs === undefined || isNaN(runs) || runs < 1)
+  ) {
+    throw new Error("--runs must be a positive integer");
+  }
+
+  const exportJson = getArgValue(args, "--export-json");
+
+  let e2eCloneDirectory =
+    getArgValue(args, "--e2e-clone-dir") ?? process.env.E2E_CLONE_DIR;
+
+  if (e2eCloneDirectory === undefined) {
+    e2eCloneDirectory = DEFAULT_CLONE_DIR;
+
+    log(
+      `No --e2e-clone-dir argument or E2E_CLONE_DIR environment variable provided, defaulting to:`,
+    );
+    log(`  ${DEFAULT_CLONE_DIR}`);
+  }
+
+  return {
+    scenarioPath,
+    command,
+    init,
+    useLocal,
+    forceCheckout,
+    forcePublish,
+    precompile,
+    prepare,
+    ignoreFailure,
+    showOutput,
+    warmup,
+    runs,
+    exportJson,
+    e2eCloneDirectory,
+  };
+}
+
+function getArgValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+
+  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}

--- a/scripts/benchmark/helpers/log.ts
+++ b/scripts/benchmark/helpers/log.ts
@@ -1,0 +1,27 @@
+import { styleText } from "node:util";
+
+const PREFIX = "[bench]";
+
+export const fmt = {
+  pkg: (name: string) => styleText("bold", name),
+  version: (v: string) => styleText("green", v),
+  deemphasize: (text: string) => styleText("dim", text),
+  success: (text: string) => styleText("green", text),
+  fail: (text: string) => styleText("red", text),
+};
+
+export function log(msg: string): void {
+  console.log(`${styleText("cyan", PREFIX)} ${msg}`);
+}
+
+export function logStep(step: string): void {
+  console.log(styleText(["bold", "yellow"], `${PREFIX} === ${step} ===`));
+}
+
+export function logWarning(msg: string): void {
+  console.warn(styleText("yellow", `${PREFIX} Warning: ${msg}`));
+}
+
+export function logError(msg: string): void {
+  console.error(styleText("red", `${PREFIX} Error: ${msg}`));
+}

--- a/scripts/benchmark/main.ts
+++ b/scripts/benchmark/main.ts
@@ -1,0 +1,191 @@
+import { init as e2eInit } from "../end-to-end/subcommands/init.ts";
+import { exec as e2eExec } from "../end-to-end/subcommands/exec.ts";
+import { loadScenario } from "../end-to-end/helpers/directory.ts";
+import { resolveAndValidateArgs, type BenchArgs } from "./helpers/args.ts";
+import { fmt, log, logStep, logError, logWarning } from "./helpers/log.ts";
+
+const USAGE = `
+scripts/benchmark/main.ts — Benchmark Hardhat scenarios with hyperfine
+
+DESCRIPTION
+  Initializes an e2e scenario and benchmarks a command using hyperfine.
+  Use --use-local to detect changed packages, publish them to Verdaccio,
+  and pin the scenario to those versions before benchmarking.
+
+OPTIONS
+  --scenario <path>     Scenario folder or scenario.json (required)
+  --command <cmd>       Command to benchmark (default: scenario's defaultCommand)
+  --init                Force (re-)initialization of the scenario even if it is
+                        already set up. Without this flag, an existing scenario
+                        setup is reused and only (re-)initialized on demand
+  --use-local           Detect packages changed since their release tag, bump
+                        versions, publish to Verdaccio, and pin scenario deps to
+                        the published versions. If Verdaccio is already running,
+                        publish is skipped (the existing registry contents are
+                        reused) unless --force-publish is also passed.
+                        Only applies when init runs
+  --force-checkout      Force git checkouts even if there are uncommitted changes in the scenario working directory
+  --force-publish       Force publishing to an already-running Verdaccio instance,
+                        potentially overwriting its current contents.
+                        Only applies when init runs
+  --precompile          Run "npx hardhat compile" in the scenario before
+                        benchmarking (useful for warming up compilation caches)
+  --prepare <cmd>       Execute CMD before each timing run. Forwarded to
+                        hyperfine's --prepare flag. Useful for clearing disk
+                        caches or resetting state between runs
+  --warmup <n>          Warmup runs before benchmarking (default: 0). Forwarded
+                        to hyperfine's --warmup flag. Useful for filling disk
+                        caches for I/O-heavy programs
+  --runs <n>            Number of benchmark runs (default: scenario's
+                        benchmark.runs.defaultCommand or 10). Forwarded to
+                        hyperfine's --runs flag
+  --ignore-failure      Ignore non-zero exit codes of the benchmarked command.
+                        Forwarded to hyperfine's --ignore-failure flag
+  --show-output         Print stdout and stderr of the benchmarked command.
+                        Forwarded to hyperfine's --show-output flag
+  --export-json <path>  Write hyperfine's JSON report to PATH. Forwarded to
+                        hyperfine's --export-json flag
+  --e2e-clone-dir <p>   Override clone directory (default: same as pnpm e2e)
+
+EXAMPLES
+  pnpm bench --scenario ./end-to-end/uniswap-v4-core --runs 1
+  pnpm bench --scenario ./end-to-end/uniswap-v4-core --use-local --precompile
+  pnpm bench --scenario ./end-to-end/openzeppelin-contracts --command "npx hardhat compile"
+`;
+
+export async function runBenchmark(benchArgs: BenchArgs): Promise<void> {
+  const {
+    scenarioPath,
+    command,
+    init,
+    useLocal,
+    forceCheckout,
+    forcePublish,
+    precompile,
+    prepare,
+    ignoreFailure,
+    showOutput,
+    warmup,
+    exportJson,
+    e2eCloneDirectory,
+  } = benchArgs;
+
+  const scenario = loadScenario(e2eCloneDirectory, scenarioPath);
+
+  if (scenario.definition.disabled === true) {
+    logWarning(`Scenario "${scenario.id}" is disabled`);
+    return;
+  }
+
+  const benchCommand = command ?? scenario.definition.defaultCommand;
+  const runs =
+    benchArgs.runs ?? scenario.definition.benchmark?.runs?.defaultCommand ?? 10;
+
+  if (init) {
+    logStep("Initializing scenario");
+    await e2eInit(
+      e2eCloneDirectory,
+      scenarioPath,
+      useLocal,
+      forceCheckout,
+      forcePublish,
+    );
+  }
+
+  if (precompile) {
+    logStep("Precompiling (npx hardhat compile)");
+    await e2eExec(
+      e2eCloneDirectory,
+      scenarioPath,
+      "npx hardhat compile",
+      useLocal,
+      forceCheckout,
+      forcePublish,
+    );
+  }
+
+  logStep("Running benchmark");
+  const hyperfineCommand = buildHyperfineCommand(
+    benchCommand,
+    warmup,
+    runs,
+    prepare,
+    ignoreFailure,
+    showOutput,
+    exportJson,
+  );
+
+  log(`Benchmarking: ${fmt.pkg(benchCommand)}`);
+  log(`Warmup: ${warmup}, Runs: ${runs}`);
+
+  await e2eExec(
+    e2eCloneDirectory,
+    scenarioPath,
+    hyperfineCommand,
+    useLocal,
+    forceCheckout,
+    forcePublish,
+  );
+
+  log(fmt.success("Benchmark complete"));
+}
+
+async function cliMain(): Promise<void> {
+  const benchArgs = resolveAndValidateArgs(process.argv.slice(2));
+
+  if (benchArgs === undefined) {
+    console.log(USAGE);
+    return;
+  }
+
+  try {
+    await runBenchmark(benchArgs);
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
+
+    logError(error.message);
+    process.exit(1);
+  }
+}
+
+function buildHyperfineCommand(
+  command: string,
+  warmup: number,
+  runs: number,
+  prepare: string | undefined,
+  ignoreFailure: boolean,
+  showOutput: boolean,
+  exportJson: string | undefined,
+): string {
+  const parts: string[] = ["hyperfine"];
+
+  if (warmup > 0) {
+    parts.push("--warmup", String(warmup));
+  }
+
+  parts.push("--runs", String(runs));
+
+  if (prepare !== undefined) {
+    parts.push("--prepare", `'${prepare}'`);
+  }
+
+  if (ignoreFailure) {
+    parts.push("--ignore-failure");
+  }
+
+  if (showOutput) {
+    parts.push("--show-output");
+  }
+
+  if (exportJson !== undefined) {
+    parts.push("--export-json", `'${exportJson}'`);
+  }
+
+  parts.push(`'${command}'`);
+
+  return parts.join(" ");
+}
+
+await cliMain();

--- a/scripts/benchmark/main.ts
+++ b/scripts/benchmark/main.ts
@@ -188,4 +188,6 @@ function buildHyperfineCommand(
   return parts.join(" ");
 }
 
-await cliMain();
+if (import.meta.main) {
+  await cliMain();
+}

--- a/scripts/end-to-end/schema/scenario-schema.ts
+++ b/scripts/end-to-end/schema/scenario-schema.ts
@@ -24,7 +24,53 @@ export function isScenarioDefinition(
     (obj.preinstall === undefined || typeof obj.preinstall === "string") &&
     (obj.install === undefined || typeof obj.install === "string") &&
     (obj.submodules === undefined || typeof obj.submodules === "boolean") &&
-    (obj.disabled === undefined || obj.disabled === true)
+    (obj.disabled === undefined || obj.disabled === true) &&
+    (obj.benchmark === undefined || isBenchmarkConfig(obj.benchmark))
+  );
+}
+
+function isBenchmarkConfig(value: unknown): value is {
+  skip?: true;
+  runs?: {
+    defaultCommand?: number;
+    coldCompile?: number;
+    warmCompile?: number;
+  };
+} {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  return (
+    (obj.skip === undefined || obj.skip === true) &&
+    (obj.runs === undefined || isBenchmarkRunsConfig(obj.runs))
+  );
+}
+
+function isBenchmarkRunsConfig(value: unknown): value is {
+  defaultCommand?: number;
+  coldCompile?: number;
+  warmCompile?: number;
+} {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  return (
+    isPositiveIntegerOrUndefined(obj.defaultCommand) &&
+    isPositiveIntegerOrUndefined(obj.coldCompile) &&
+    isPositiveIntegerOrUndefined(obj.warmCompile)
+  );
+}
+
+function isPositiveIntegerOrUndefined(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (typeof value === "number" && Number.isInteger(value) && value >= 1)
   );
 }
 

--- a/scripts/end-to-end/schema/scenario.schema.json
+++ b/scripts/end-to-end/schema/scenario.schema.json
@@ -62,6 +62,39 @@
       "type": "boolean",
       "const": true,
       "description": "Set to true to skip this scenario during end-to-end runs"
+    },
+    "benchmark": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "skip": {
+          "type": "boolean",
+          "const": true,
+          "description": "Set to true to skip this scenario in the regression benchmark"
+        },
+        "runs": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "defaultCommand": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of hyperfine runs for the scenario's defaultCommand"
+            },
+            "coldCompile": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of hyperfine runs for `npx hardhat compile` with the cache cleared before each run"
+            },
+            "warmCompile": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of hyperfine runs for `npx hardhat compile` against a warm cache"
+            }
+          }
+        }
+      },
+      "description": "Benchmark configuration for pnpm bench and pnpm bench:regression"
     }
   }
 }

--- a/scripts/end-to-end/types.ts
+++ b/scripts/end-to-end/types.ts
@@ -17,4 +17,12 @@ export interface ScenarioDefinition {
   env?: Record<string, string>;
   submodules?: boolean;
   disabled?: true;
+  benchmark?: {
+    skip?: true;
+    runs?: {
+      defaultCommand?: number;
+      coldCompile?: number;
+      warmCompile?: number;
+    };
+  };
 }


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8276

## Summary

Adds `pnpm bench`: a thin wrapper that initializes an e2e scenario and runs a single command under [hyperfine](https://github.com/sharkdp/hyperfine). Foundation for `pnpm bench:regression` (next PR in the stack), which orchestrates the same machinery across every benchmarkable scenario.

Also extends `scenario.json` with a `benchmark` config block:

```json
"benchmark": {
  "skip": true,                              // opt out of regression sweeps
  "runs": {
    "defaultCommand": 10,                    // hyperfine --runs for the scenario's default command
    "coldCompile":    3,                     // hyperfine --runs for `npx hardhat compile` with --prepare 'npx hardhat clean'
    "warmCompile":   20                      // hyperfine --runs for `npx hardhat compile` against a warm cache
  }
}
```

`pnpm bench` only reads `runs.defaultCommand` (falling back to `10` when missing). The `skip` and `coldCompile` / `warmCompile` fields are consumed by `pnpm bench:regression` in the follow-up PR — defining them here lets each scenario's run counts live with the scenario rather than in a separate config.

## Motivation

### Re-use the existing verdaccio & E2E infrastructure

`pnpm bench` merely forms a thin wrapper around the existing `pnpm e2e` and `pnpm verdaccio` scripts, to maximise reuse.

### Hyperfine

We are reusing `hyperfine` for benchmarking as it includes end-to-end startup time of Node, incl. native startup, import resolution, file loading, etc. This provides the most accurate wall-clock time for a user running a command in Hardhat.

### Per-scenario run counts

Different scenarios have wildly different per-run latencies. Pinning sensible defaults per scenario avoids excessive benchmark run times.

## Skip-init behavior

Without `--init`, an existing scenario clone is reused and the benchmark runs immediately. With `--init`, the full clone/fetch/checkout/clean/preinstall/install cycle runs first.

## Examples

```
# Benchmark the default command, 1 run
pnpm bench --scenario ./end-to-end/uniswap-v4-core --runs 1

# Benchmark `npx hardhat compile` against a freshly cleared cache
pnpm bench --scenario ./end-to-end/openzeppelin-contracts \
  --command "npx hardhat compile" --prepare "npx hardhat clean"

# Local working-tree changes, full init
pnpm bench --scenario ./end-to-end/uniswap-v4-core --use-local --init
```

## Test plan

- [x] `pnpm test:scripts` — schema-validation tests confirm the new `benchmark` block (`skip` + nested `runs`) parses correctly via `isScenarioDefinition`.
- [x] Manually ran `pnpm bench` for numerous scenarios to get performance regression benchmarks working