### PR TITLE
feat(bench): add pnpm bench:regression

### DIFF
--- a/end-to-end/ens-contracts/scenario.json
+++ b/end-to-end/ens-contracts/scenario.json
@@ -7,5 +7,8 @@
   "packageManager": "bun",
   "preinstall": "./preinstall.sh",
   "submodules": true,
-  "defaultCommand": "bun run test"
+  "defaultCommand": "bun run test",
+  "benchmark": {
+    "skip": true
+  }
 }

--- a/end-to-end/lidofinance-core/scenario.json
+++ b/end-to-end/lidofinance-core/scenario.json
@@ -6,5 +6,8 @@
   "commit": "ef5307d1b4c6a0373eb897511c8d2d7c3948159b",
   "packageManager": "yarn",
   "submodules": false,
-  "defaultCommand": "yarn run test"
+  "defaultCommand": "yarn run test",
+  "benchmark": {
+    "skip": true
+  }
 }

--- a/end-to-end/openzeppelin-contracts-hh2/scenario.json
+++ b/end-to-end/openzeppelin-contracts-hh2/scenario.json
@@ -6,5 +6,8 @@
   "commit": "45f032d1bcf1a88b7bc90154d7eef76c87bf9d45",
   "packageManager": "npm",
   "submodules": true,
-  "defaultCommand": "npx hardhat test"
+  "defaultCommand": "npx hardhat test",
+  "benchmark": {
+    "skip": true
+  }
 }

--- a/end-to-end/openzeppelin-contracts/scenario.json
+++ b/end-to-end/openzeppelin-contracts/scenario.json
@@ -3,9 +3,17 @@
   "description": "A fork of OpenZeppelin's Hardhat 3 branch including their Mocha test suite.",
   "tags": ["external-repo", "mocha"],
   "repo": "nomicfoundation/openzeppelin-contracts",
-  "commit": "644c6aea5bda410c347637192e5210dcaccff76f",
+  "commit": "a2e6c4f30f5b3f7dfbf451235d16424b0f95abc4",
   "packageManager": "npm",
   "submodules": true,
   "preinstall": "./preinstall.sh",
-  "defaultCommand": "npx hardhat test mocha"
+  "defaultCommand": "npx hardhat test mocha",
+  "benchmark": {
+    "skip": true,
+    "runs": {
+      "coldCompile": 3,
+      "warmCompile": 19,
+      "defaultCommand": 3
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "spellcheck:file": "node ./scripts/spellcheck-file.ts",
     "verdaccio": "node ./scripts/verdaccio/main.ts",
     "e2e": "node ./scripts/end-to-end/main.ts",
-    "bench": "node ./scripts/benchmark/main.ts"
+    "bench": "node ./scripts/benchmark/main.ts",
+    "bench:regression": "node ./scripts/benchmark/regression.ts"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -13,6 +13,8 @@ import {
   UseLocal,
   init as e2eInit,
 } from "../end-to-end/subcommands/init.ts";
+import { isScenarioDefinition } from "../end-to-end/schema/scenario-schema.ts";
+import type { ScenarioDefinition } from "../end-to-end/types.ts";
 import { isVerdaccioRunning } from "../verdaccio/helpers/shell.ts";
 import {
   publish as verdaccioPublish,
@@ -81,21 +83,7 @@ interface RegressionArgs {
 interface ScenarioEntry {
   id: string;
   scenarioJsonPath: string;
-  definition: ScenarioDefinitionLike;
-}
-
-interface ScenarioDefinitionLike {
-  defaultCommand?: string;
-  tags?: string[];
-  disabled?: boolean;
-  benchmark?: {
-    skip?: boolean;
-    runs?: {
-      defaultCommand?: number;
-      coldCompile?: number;
-      warmCompile?: number;
-    };
-  };
+  definition: ScenarioDefinition;
 }
 
 interface BenchmarkEntry {
@@ -271,6 +259,7 @@ function resolveArgs(argv: string[]): RegressionArgs | undefined {
 
 function collectScenarios(args: RegressionArgs): ScenarioEntry[] {
   const entries: ScenarioEntry[] = [];
+  const invalid: string[] = [];
 
   for (const entry of readdirSync(END_TO_END_DIR, { withFileTypes: true })) {
     if (!entry.isDirectory()) {
@@ -291,15 +280,35 @@ function collectScenarios(args: RegressionArgs): ScenarioEntry[] {
       continue;
     }
 
-    const definition = JSON.parse(raw) as ScenarioDefinitionLike;
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      invalid.push(
+        `${entry.name}: invalid JSON — ${error instanceof Error ? error.message : String(error)}`,
+      );
+
+      continue;
+    }
+
+    if (!isScenarioDefinition(parsed)) {
+      invalid.push(`${entry.name}: does not match scenario schema`);
+
+      continue;
+    }
+
+    const definition = parsed;
 
     if (definition.disabled === true) {
       logWarning(`Skipping "${entry.name}" (scenario is disabled)`);
+
       continue;
     }
 
     if (definition.benchmark?.skip === true) {
       logWarning(`Skipping "${entry.name}" (benchmark.skip is set)`);
+
       continue;
     }
 
@@ -307,7 +316,7 @@ function collectScenarios(args: RegressionArgs): ScenarioEntry[] {
       continue;
     }
 
-    if (args.tag !== undefined && !(definition.tags ?? []).includes(args.tag)) {
+    if (args.tag !== undefined && !definition.tags.includes(args.tag)) {
       continue;
     }
 
@@ -316,6 +325,18 @@ function collectScenarios(args: RegressionArgs): ScenarioEntry[] {
       scenarioJsonPath,
       definition,
     });
+  }
+
+  if (invalid.length > 0) {
+    logError(
+      "Invalid scenario.json files (must be fixed before bench:regression can run):",
+    );
+
+    for (const line of invalid) {
+      console.error(`  - ${line}`);
+    }
+
+    process.exit(1);
   }
 
   return entries;

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -1,0 +1,557 @@
+// cSpell:ignore cacache <-- NPM's content-addressable cache
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { runBenchmark } from "./main.ts";
+import type { BenchArgs } from "./helpers/args.ts";
+import { DEFAULT_CLONE_DIR } from "../end-to-end/helpers/args.ts";
+import { fmt, log, logError, logStep, logWarning } from "./helpers/log.ts";
+import {
+  ForceCheckout,
+  ForcePublish,
+  UseLocal,
+  init as e2eInit,
+} from "../end-to-end/subcommands/init.ts";
+import { isVerdaccioRunning } from "../verdaccio/helpers/shell.ts";
+import {
+  publish as verdaccioPublish,
+  sinceReleasePublish,
+} from "../verdaccio/publish.ts";
+import { start as verdaccioStart } from "../verdaccio/start.ts";
+import { stop as verdaccioStop } from "../verdaccio/stop.ts";
+
+const USAGE = `
+scripts/benchmark/regression.ts — Multi-scenario regression benchmark
+
+DESCRIPTION
+  For each scenario under end-to-end/ that is not disabled and does not opt
+  out via "benchmark": { "skip": true }, runs three hyperfine phases:
+
+    1. Cold compile  — "npx hardhat compile" with the compile cache cleared
+                       before each run (via --prepare "npx hardhat clean").
+    2. Warm compile  — "npx hardhat compile" against the warm cache.
+    3. Default cmd   — the scenario's defaultCommand, against a compiled
+                       project.
+
+  Run counts (N, M, L) are required per scenario in scenario.json under
+  "benchmark": { "runs": { "coldCompile": N, "warmCompile": M,
+                            "defaultCommand": L } }.
+  Missing fields fail pre-flight with a summary of every offending scenario.
+
+  Writes a flat JSON array in benchmark-action/github-action-benchmark's
+  customSmallerIsBetter format. Per-run times are preserved in the "extra"
+  field as a JSON-stringified object.
+
+OPTIONS
+  --output <path>       Required. Aggregated JSON destination
+  --scenarios <csv>     Filter by scenario id (directory basename)
+  --tag <tag>           Filter by a tag present in scenario.json tags
+  --use-local           Detect packages changed since their release tag, bump
+                        versions, publish to Verdaccio, and pin scenario deps to
+                        the published versions.
+                        If Verdaccio is already running, an error is thrown unless
+                        --force-publish is also passed.
+  --force-checkout      Force git checkouts even if there are uncommitted changes
+                        in the scenario working directory
+  --force-publish       Allow publishing to an already-running Verdaccio instance,
+                        potentially overwriting its current contents
+  --e2e-clone-dir <p>   Override clone directory (default: same as pnpm e2e)
+  --fail-fast           Abort on the first scenario failure
+
+EXAMPLES
+  pnpm bench:regression --output /tmp/regression.json
+  pnpm bench:regression --scenarios uniswap-v4-core,aave-v4 --output /tmp/r.json
+`;
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..");
+const END_TO_END_DIR = path.join(REPO_ROOT, "end-to-end");
+
+interface RegressionArgs {
+  output: string;
+  scenarios: string[] | undefined;
+  tag: string | undefined;
+  useLocal: UseLocal;
+  forceCheckout: ForceCheckout;
+  forcePublish: ForcePublish;
+  e2eCloneDirectory: string;
+  failFast: boolean;
+}
+
+interface ScenarioEntry {
+  id: string;
+  scenarioJsonPath: string;
+  definition: ScenarioDefinitionLike;
+}
+
+interface ScenarioDefinitionLike {
+  defaultCommand?: string;
+  tags?: string[];
+  disabled?: boolean;
+  benchmark?: {
+    skip?: boolean;
+    runs?: {
+      defaultCommand?: number;
+      coldCompile?: number;
+      warmCompile?: number;
+    };
+  };
+}
+
+interface BenchmarkEntry {
+  name: string;
+  unit: string;
+  value: number;
+  range: string;
+  extra: string;
+}
+
+interface HyperfineResult {
+  mean: number;
+  stddev: number;
+  min: number;
+  max: number;
+  median: number;
+  times: number[];
+}
+
+async function main(): Promise<void> {
+  const args = resolveArgs(process.argv.slice(2));
+
+  if (args === undefined) {
+    console.log(USAGE);
+    return;
+  }
+
+  const scenarios = collectScenarios(args);
+
+  if (scenarios.length === 0) {
+    logError("No scenarios matched the provided filters");
+    process.exit(1);
+  }
+
+  const missing = findMissingRunCounts(scenarios);
+
+  if (missing.length > 0) {
+    printMissingRunCountsError(missing);
+    process.exit(1);
+  }
+
+  const results: BenchmarkEntry[] = [];
+  const failures: string[] = [];
+
+  // Launch Verdaccio once so that:
+  // 1. all scenarios share the same registry contents — bumped versions
+  //    remain available throughout the run, and
+  // 2. pacote's metadata cache (`~/.npm/_cacache`, keyed by registry URL)
+  //    never gets out of sync with the registry's actual contents.
+  //
+  // Per-scenario init() detects the already-running Verdaccio and skips
+  // its own start/publish/stop.
+  const verdaccioAlreadyRunning = isVerdaccioRunning();
+
+  if (
+    verdaccioAlreadyRunning &&
+    args.useLocal === UseLocal.Yes &&
+    args.forcePublish === ForcePublish.No
+  ) {
+    throw new Error(
+      "A Verdaccio instance is already running. Using --use-local would\n" +
+        "  override packages in the running registry.\n\n" +
+        "  Add --force-publish to proceed, or stop the running instance first:\n" +
+        "    pnpm verdaccio stop",
+    );
+  }
+
+  if (!verdaccioAlreadyRunning) {
+    await verdaccioStart(true);
+  }
+
+  const startedVerdaccio = !verdaccioAlreadyRunning;
+  let failFastExit = false;
+
+  try {
+    if (startedVerdaccio || args.forcePublish === ForcePublish.Yes) {
+      if (args.useLocal === UseLocal.Yes) {
+        sinceReleasePublish();
+      } else {
+        verdaccioPublish(false, true);
+      }
+    }
+
+    for (const scenario of scenarios) {
+      logStep(`Scenario: ${fmt.pkg(scenario.id)}`);
+
+      try {
+        const entries = await runScenario(scenario, args);
+        results.push(...entries);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logError(`Scenario "${scenario.id}" failed: ${message}`);
+        failures.push(scenario.id);
+
+        if (args.failFast) {
+          failFastExit = true;
+          break;
+        }
+      }
+    }
+  } finally {
+    if (startedVerdaccio) {
+      verdaccioStop();
+    }
+  }
+
+  if (failFastExit) {
+    process.exit(1);
+  }
+
+  writeOutput(args.output, results);
+
+  if (failures.length > 0) {
+    logError(
+      `${failures.length} scenario(s) failed: ${failures.join(", ")}. Partial results written to ${args.output}`,
+    );
+    process.exit(1);
+  }
+
+  log(
+    fmt.success(
+      `Regression benchmark complete — wrote ${results.length} entries to ${args.output}`,
+    ),
+  );
+}
+
+function resolveArgs(argv: string[]): RegressionArgs | undefined {
+  const output = getArgValue(argv, "--output");
+
+  if (output === undefined) {
+    return undefined;
+  }
+
+  const scenariosRaw = getArgValue(argv, "--scenarios");
+  const scenarios =
+    scenariosRaw !== undefined
+      ? scenariosRaw
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      : undefined;
+
+  const tag = getArgValue(argv, "--tag");
+
+  const useLocal = argv.includes("--use-local") ? UseLocal.Yes : UseLocal.No;
+
+  const forceCheckout = argv.includes("--force-checkout")
+    ? ForceCheckout.Yes
+    : ForceCheckout.No;
+
+  const forcePublish = argv.includes("--force-publish")
+    ? ForcePublish.Yes
+    : ForcePublish.No;
+
+  const failFast = argv.includes("--fail-fast");
+
+  const e2eCloneDirectory =
+    getArgValue(argv, "--e2e-clone-dir") ??
+    process.env.E2E_CLONE_DIR ??
+    DEFAULT_CLONE_DIR;
+
+  return {
+    output: path.resolve(output),
+    scenarios,
+    tag,
+    useLocal,
+    forceCheckout,
+    forcePublish,
+    e2eCloneDirectory,
+    failFast,
+  };
+}
+
+function collectScenarios(args: RegressionArgs): ScenarioEntry[] {
+  const entries: ScenarioEntry[] = [];
+
+  for (const entry of readdirSync(END_TO_END_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const scenarioJsonPath = path.join(
+      END_TO_END_DIR,
+      entry.name,
+      "scenario.json",
+    );
+
+    let raw: string;
+
+    try {
+      raw = readFileSync(scenarioJsonPath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const definition = JSON.parse(raw) as ScenarioDefinitionLike;
+
+    if (definition.disabled === true) {
+      logWarning(`Skipping "${entry.name}" (scenario is disabled)`);
+      continue;
+    }
+
+    if (definition.benchmark?.skip === true) {
+      logWarning(`Skipping "${entry.name}" (benchmark.skip is set)`);
+      continue;
+    }
+
+    if (args.scenarios !== undefined && !args.scenarios.includes(entry.name)) {
+      continue;
+    }
+
+    if (args.tag !== undefined && !(definition.tags ?? []).includes(args.tag)) {
+      continue;
+    }
+
+    entries.push({
+      id: entry.name,
+      scenarioJsonPath,
+      definition,
+    });
+  }
+
+  return entries;
+}
+
+function findMissingRunCounts(
+  scenarios: ScenarioEntry[],
+): Array<{ id: string; missing: string[] }> {
+  const missing: Array<{ id: string; missing: string[] }> = [];
+
+  for (const scenario of scenarios) {
+    const runs = scenario.definition.benchmark?.runs;
+    const absent: string[] = [];
+
+    if (runs?.coldCompile === undefined) {
+      absent.push("coldCompile");
+    }
+
+    if (runs?.warmCompile === undefined) {
+      absent.push("warmCompile");
+    }
+
+    if (runs?.defaultCommand === undefined) {
+      absent.push("defaultCommand");
+    }
+
+    if (absent.length > 0) {
+      missing.push({ id: scenario.id, missing: absent });
+    }
+  }
+
+  return missing;
+}
+
+function printMissingRunCountsError(
+  missing: Array<{ id: string; missing: string[] }>,
+): void {
+  logError(
+    "Regression benchmark requires benchmark.runs.{coldCompile,warmCompile,defaultCommand} in every scenario.json.",
+  );
+  console.error("Missing fields:");
+
+  for (const { id, missing: fields } of missing) {
+    console.error(`  - end-to-end/${id}/scenario.json: ${fields.join(", ")}`);
+  }
+
+  console.error(
+    'Add them to scenario.json or set "benchmark": { "skip": true } to opt out.',
+  );
+}
+
+async function runScenario(
+  scenario: ScenarioEntry,
+  args: RegressionArgs,
+): Promise<BenchmarkEntry[]> {
+  const runs = scenario.definition.benchmark?.runs;
+
+  if (
+    runs?.coldCompile === undefined ||
+    runs.warmCompile === undefined ||
+    runs.defaultCommand === undefined
+  ) {
+    throw new Error(
+      `Missing benchmark.runs.* fields for "${scenario.id}" — pre-flight should have caught this`,
+    );
+  }
+
+  const scenarioTmpDir = path.join(tmpdir(), "hardhat-regression", scenario.id);
+  mkdirSync(scenarioTmpDir, { recursive: true });
+
+  const coldExport = path.join(scenarioTmpDir, "cold.json");
+  const warmExport = path.join(scenarioTmpDir, "warm.json");
+  const defaultExport = path.join(scenarioTmpDir, "default.json");
+
+  logStep("Initializing scenario");
+  await e2eInit(
+    args.e2eCloneDirectory,
+    scenario.scenarioJsonPath,
+    args.useLocal,
+    args.forceCheckout,
+    // always skip per-scenario publish — we publish once globally up-front
+    ForcePublish.No,
+  );
+
+  await runPhase(
+    "compile (cold)",
+    buildBenchArgs(scenario.scenarioJsonPath, args, {
+      command: "npx hardhat compile",
+      prepare: "npx hardhat clean",
+      runs: runs.coldCompile,
+      exportJson: coldExport,
+    }),
+  );
+
+  await runPhase(
+    "compile (warm)",
+    buildBenchArgs(scenario.scenarioJsonPath, args, {
+      command: "npx hardhat compile",
+      prepare: undefined,
+      runs: runs.warmCompile,
+      exportJson: warmExport,
+    }),
+  );
+
+  await runPhase(
+    "default command",
+    buildBenchArgs(scenario.scenarioJsonPath, args, {
+      command: undefined,
+      prepare: undefined,
+      runs: runs.defaultCommand,
+      exportJson: defaultExport,
+    }),
+  );
+
+  return [
+    toEntry(scenario.id, "compile (cold)", readHyperfineResult(coldExport)),
+    toEntry(scenario.id, "compile (warm)", readHyperfineResult(warmExport)),
+    toEntry(scenario.id, "default command", readHyperfineResult(defaultExport)),
+  ];
+}
+
+async function runPhase(label: string, benchArgs: BenchArgs): Promise<void> {
+  try {
+    await runBenchmark(benchArgs);
+  } catch (error) {
+    const original = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `${label} phase failed: ${original}\n  Reproduce with: ${buildReproCommand(benchArgs)}`,
+    );
+  }
+}
+
+function buildReproCommand(benchArgs: BenchArgs): string {
+  const parts: string[] = [
+    "pnpm bench",
+    "--scenario",
+    shellQuote(benchArgs.scenarioPath),
+  ];
+
+  if (benchArgs.command !== undefined) {
+    parts.push("--command", shellQuote(benchArgs.command));
+  }
+
+  if (benchArgs.prepare !== undefined) {
+    parts.push("--prepare", shellQuote(benchArgs.prepare));
+  }
+
+  if (benchArgs.runs !== undefined) {
+    parts.push("--runs", String(benchArgs.runs));
+  }
+
+  parts.push(
+    "--e2e-clone-dir",
+    shellQuote(benchArgs.e2eCloneDirectory),
+    "--show-output",
+  );
+
+  return parts.join(" ");
+}
+
+function shellQuote(value: string): string {
+  if (/^[\w@./:=-]+$/.test(value)) {
+    return value;
+  }
+
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function buildBenchArgs(
+  scenarioPath: string,
+  args: RegressionArgs,
+  phase: {
+    command: string | undefined;
+    prepare: string | undefined;
+    runs: number;
+    exportJson: string;
+  },
+): BenchArgs {
+  return {
+    scenarioPath,
+    command: phase.command,
+    init: false,
+    useLocal: UseLocal.No,
+    forcePublish: ForcePublish.No,
+    forceCheckout: ForceCheckout.No,
+    precompile: false,
+    prepare: phase.prepare,
+    ignoreFailure: false,
+    showOutput: false,
+    warmup: 0,
+    runs: phase.runs,
+    exportJson: phase.exportJson,
+    e2eCloneDirectory: args.e2eCloneDirectory,
+  };
+}
+
+function readHyperfineResult(exportPath: string): HyperfineResult {
+  const raw = JSON.parse(readFileSync(exportPath, "utf-8")) as {
+    results: HyperfineResult[];
+  };
+
+  if (!Array.isArray(raw.results) || raw.results.length === 0) {
+    throw new Error(`Hyperfine export at ${exportPath} has no results`);
+  }
+
+  return raw.results[0];
+}
+
+function toEntry(
+  scenarioId: string,
+  phaseLabel: string,
+  result: HyperfineResult,
+): BenchmarkEntry {
+  return {
+    name: `${scenarioId} / ${phaseLabel}`,
+    unit: "s",
+    value: result.mean,
+    range: `± ${result.stddev}`,
+    extra: JSON.stringify({
+      times: result.times,
+      min: result.min,
+      max: result.max,
+      median: result.median,
+    }),
+  };
+}
+
+function writeOutput(outputPath: string, entries: BenchmarkEntry[]): void {
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, JSON.stringify(entries, null, 2));
+}
+
+function getArgValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+
+  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}
+
+await main();

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -190,11 +190,14 @@ async function main(): Promise<void> {
     }
   }
 
+  writeOutput(args.output, results);
+
   if (failFastExit) {
+    logError(
+      `Aborted on first failure (--fail-fast). Partial results (${results.length} entries) written to ${args.output}`,
+    );
     process.exit(1);
   }
-
-  writeOutput(args.output, results);
 
   if (failures.length > 0) {
     logError(

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -465,6 +465,7 @@ async function runPhase(label: string, benchArgs: BenchArgs): Promise<void> {
     const original = error instanceof Error ? error.message : String(error);
     throw new Error(
       `${label} phase failed: ${original}\n  Reproduce with: ${buildReproCommand(benchArgs)}`,
+      { cause: error },
     );
   }
 }


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8277 

## Summary

Adds `pnpm bench:regression`: a multi-scenario regression driver that iterates every benchmarkable scenario under `end-to-end/`, runs three hyperfine phases per scenario (cold compile / warm compile / default command), and emits a single JSON report in the format [`benchmark-action/github-action-benchmark`](https://github.com/benchmark-action/github-action-benchmark) expects (`customSmallerIsBetter`).

Also opts four existing scenarios out of regression via the new `benchmark.skip: true` — currently fail or are for an older version of Hardhat :

- `ens-contracts`
- `lidofinance-core`
- `openzeppelin-contracts-hh2
- `openzeppelin-contracts`

I also updated the commit SHA of `openzeppelin-contracts`. When I originally made this change, the commit SHA committed to the scenario could not be found in the repositories history, so I updated it to the latest commit in @kanej's branch—at the time.

The CI workflow that drives this (label-gated PR runs + baseline tracking) lands in the final PR in the stack.

## What runs per scenario

For each non-disabled, non-`benchmark.skip` scenario:

1. **Init** — `e2eInit` once (clone / fetch / checkout / clean / preinstall / install). Reused across the three phases.
2. **Cold compile** — `hyperfine --prepare 'npx hardhat clean' --runs <coldCompile> 'npx hardhat compile'`. Cache cleared between runs.
3. **Warm compile** — `hyperfine --runs <warmCompile> 'npx hardhat compile'`. Cache from the previous phase persists.
4. **Default command** — `hyperfine --runs <defaultCommand> '<scenario.defaultCommand>'`. Run against the warm-compiled project.

Run counts are required per scenario.

## Motivation for design

Three requirements when designing the implementation of `pnpm bench:regression`:

1. **Single shared Verdaccio across the whole run.** When `--use-local` is passed, the driver starts Verdaccio once, calls `sinceReleasePublish` once, and reuses the registry across every scenario. This is load-bearing for two reasons:
   - Bumped package versions stay available throughout the run (a per-scenario start/stop would lose them).
   - pacote's metadata cache (`~/.npm/_cacache`, keyed by registry URL) never desyncs from registry contents — which it can if Verdaccio restarts mid-run and republishes under the same versions.
2. **Pre-flight failure.** Before running any phase, the driver collects every scenario that's missing one of `benchmark.runs.{coldCompile, warmCompile, defaultCommand}` and exits non-zero with the full list (rather than failing partway through after wasting wall-clock).
3. **Per-scenario failure isolation.** A failure in one scenario's phase is caught, logged with a `pnpm bench` reproduction command, and added to a `failures[]` list. The driver continues with the next scenario and still writes a partial JSON report. Exit code is non-zero if any scenario failed. `--fail-fast` opts back into abort-on-first-failure.

## Output format

Flat array of `{ name, unit, value, range, extra }` entries — three per scenario (one per phase). `value` is hyperfine's mean (seconds); per-run times are JSON-stringified into `extra`:

```json
[
  {
    "name": "uniswap-v4-core / compile (cold)",
    "unit": "s",
    "value": 12.34,
    "range": "± 0.42",
    "extra": "{\"times\":[12.3,12.5,12.2],\"min\":12.2,\"max\":12.5,\"median\":12.3}"
  },
  ...
]
```

This is the only shape `customSmallerIsBetter` accepts. Encoding `<scenario-id> / <phase-label>` into `name` is what lets the GitHub-Pages chart split into per-scenario, per-phase series.

## CLI

| Flag | Purpose |
|---|---|
| `--output <path>` | Aggregated JSON destination (required) |
| `--scenarios <csv>` | Filter by scenario id (directory basename) |
| `--tag <tag>` | Filter by `tags` in `scenario.json` |
| `--use-local` / `--force-checkout` / `--force-publish` | Same semantics as `pnpm e2e --use-local` etc. (preceding PR) |
| `--e2e-clone-dir <p>` | Override clone directory |
| `--fail-fast` | Abort on the first scenario failure |

No CLI overrides for run counts: the contract is that run counts live in `scenario.json` so reviewers can reason about a scenario's expected cost from its definition alone.

## Pre-flight validation

```
$ pnpm bench:regression --output /tmp/r.json
[bench] Error: Regression benchmark requires benchmark.runs.{coldCompile,warmCompile,defaultCommand}
        in every scenario.json.
Missing fields:
  - end-to-end/lidofinance-core/scenario.json: coldCompile, warmCompile, defaultCommand
  - end-to-end/aave-v4/scenario.json: coldCompile, warmCompile
Add them to scenario.json or set "benchmark": { "skip": true } to opt out.
```

Each scenario must either provide all three run counts or opt out. This is intentionally strict — accidentally regressing a scenario into having 1 run isn't visible in the chart, and CI would silently lose meaningful coverage.

## Test plan

- [x] `pnpm test:scripts` — schema validation covers the `benchmark` block parsing (no behavioral tests for the driver itself; it's I/O-heavy and orchestrates real subprocess invocations).
- [x] Manual: `pnpm bench:regression --output /tmp/r.json` against a scenario that's missing run counts → expect pre-flight error listing it.
- [x] Manually ran `pnpm bench:regression` for all scenarios to get performance regression benchmarks working, locally and on our dedicated CI runner

## Future work

In the future, we can convert the scenario's `benchmark` field to be a map of `benchmarkName -> benchmarkDescription` that allows per-scenario benchmarks to be added, rather than strictly adhering to the current three hardcoded phases.