### PR TITLE
test(e2e): add 1inch-aqua scenario

### DIFF
--- a/end-to-end/1inch-aqua/scenario.json
+++ b/end-to-end/1inch-aqua/scenario.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
+  "description": "1inch Aqua Protocol fork to Hardhat 3.",
+  "tags": ["external-repo"],
+  "repo": "anaPerezGhiglia/aqua",
+  "commit": "19277969b5e67b5b55968422b4cba4029544807c",
+  "packageManager": "yarn",
+  "submodules": false,
+  "defaultCommand": "npx hardhat test solidity",
+  "benchmark": {
+    "runs": {
+      "coldCompile": 5,
+      "warmCompile": 55,
+      "defaultCommand": 83
+    }
+  }
+}


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8278

Adds the `1inch-aqua` end-to-end scenario.
