### PR TITLE
test(e2e): add 1inch-swap-vm scenario

### DIFF
--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
+  "description": "1inch SwapVM contract fork to Hardhat 3.",
+  "tags": ["external-repo"],
+  "repo": "anaPerezGhiglia/1inch-swap-vm",
+  "commit": "eacd08361caf75431d2b4409136cf4eb10fa63a3",
+  "packageManager": "pnpm",
+  "submodules": false,
+  "defaultCommand": "npx hardhat test solidity",
+  "benchmark": {
+    "runs": {
+      "coldCompile": 3,
+      "warmCompile": 45,
+      "defaultCommand": 29
+    }
+  }
+}


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8280

Adds the `1inch-swap-vm` end-to-end scenario.
