### PR TITLE
test(e2e): add aave-v4 scenario (disabled)

### DIFF
--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
+  "description": "Aave v4 fork to Hardhat 3.",
+  "tags": ["external-repo"],
+  "repo": "anaPerezGhiglia/aave-v4",
+  "commit": "95534d58cf54d60c6415c0efd7fb3a0eac6539d1",
+  "packageManager": "yarn",
+  "submodules": true,
+  "defaultCommand": "npx hardhat test solidity --no-compile",
+  "disabled": true
+}

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -6,6 +6,6 @@
   "commit": "95534d58cf54d60c6415c0efd7fb3a0eac6539d1",
   "packageManager": "yarn",
   "submodules": true,
-  "defaultCommand": "npx hardhat test solidity --no-compile",
+  "defaultCommand": "npx hardhat test solidity",
   "disabled": true
 }


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8281

Adds the `aave-v4` end-to-end scenario. For now it's disabled, as there are still some failures with the snapshot cheatcodes.
