### PR TITLE
test(e2e): add uniswap-x scenario

### DIFF
--- a/end-to-end/uniswap-x/preinstall-foundry.sh
+++ b/end-to-end/uniswap-x/preinstall-foundry.sh
@@ -1,0 +1,17 @@
+# CaliburEntry.sol has `pragma solidity 0.8.29;` (exact) and requires `via_ir`,
+# which conflicts with the main project's pinned 0.8.30 / no-via_ir settings.
+# Build calibur in isolation so CaliburEntry's artifact is produced on disk.
+(cd lib/calibur && forge build)
+
+# Restore the original explicit artifact path for vm.getCode. The upstream
+# fork shortened it to "CaliburEntry.sol" for Hardhat compat, but that form
+# requires CaliburEntry to be in forge test's compile graph — impossible
+# without patching the submodule because of the pragma/via_ir conflicts above.
+# The existing `fs_permissions` entry for `./lib/calibur/out/` already grants
+# read access to the pre-built artifact.
+sed -i 's|vm.getCode("CaliburEntry.sol")|vm.getCode("lib/calibur/out/CaliburEntry.sol/CaliburEntry.json")|' \
+  test/native-input/DelegationHandler.sol
+
+# Drop the default profile's `no_match_path = "*/integration/*"` so `forge test`
+# runs the integration suite — matches EDR's default of running everything.
+sed -i '/^no_match_path *= *"\*\/integration\/\*"$/d' foundry.toml

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
+  "description": "UniswapX contracts fork to Hardhat 3.",
+  "tags": ["external-repo"],
+  "repo": "popescuoctavian/UniswapX",
+  "commit": "e4ed16b4e6894d36b7a19b985333dc254ebbf9d2",
+  "packageManager": "npm",
+  "submodules": true,
+  "env": {
+    "FOUNDRY_RPC_URL": "${localEnv:ALCHEMY_URL}"
+  },
+  "defaultCommand": "npx hardhat test solidity",
+  "benchmark": {
+    "runs": {
+      "coldCompile": 3,
+      "warmCompile": 37,
+      "defaultCommand": 3
+    }
+  }
+}

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -9,6 +9,7 @@
   "env": {
     "FOUNDRY_RPC_URL": "${localEnv:ALCHEMY_URL}"
   },
+  "preinstall": "./preinstall-foundry.sh",
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "runs": {

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -17,5 +17,6 @@
       "warmCompile": 37,
       "defaultCommand": 3
     }
-  }
+  },
+  "disabled": true
 }


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8285

Adds the `uniswap/uniswap-x` end-to-end scenario.

This contains a separate `preinstall` bash script that is required to get the end-to-end scenario to continue working for Foundry. This is useful for performance comparisons.