### PR TITLE
ci: add regression benchmark workflow

### DIFF
--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -58,6 +58,7 @@ jobs:
     #
     # The fork-safety guard keeps untrusted forks off the self-hosted runner.
     if: >
+      !cancelled() && !failure() &&
       (github.event_name != 'pull_request' ||
         contains(github.event.pull_request.labels.*.name, 'ci:perf')) &&
       (github.ref == 'refs/heads/main' ||

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -1,0 +1,113 @@
+name: Regression Benchmark
+
+on:
+  # Deliberately do not run on merge_group
+  push:
+    branches:
+      - "main"
+  pull_request:
+    # Include `labeled` so the workflow fires when the `ci:perf`
+    # label is added.
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - "**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Don't cancel in-progress jobs on main so baselines aren't lost mid-run
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  tests:
+    name: Validate Hardhat works correctly
+    runs-on: ubuntu-latest
+    # Run validation tests for non-main branches to ensure that the branch is
+    # in a valid state before running the expensive regression benchmark.
+    # We assume that the main branch is always in a good state.
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
+
+      # cspell:disable-next-line
+      - uses: socketdev/action@4337a545deecc20f19a909e52db7a2f6ba292f42 # v1
+        with:
+          mode: firewall
+
+      - uses: ./.github/actions/setup-env
+
+      - name: Install packages
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm test
+
+  regression-benchmark:
+    name: Regression benchmark
+    environment: github-action-benchmark
+    # Use a self-hosted runner for stable benchmark measurements; the shared
+    # GitHub runners produce noisy results that will generate false positives
+    # against the configured alert-threshold.
+    runs-on: hardhat-linux-amd64-self-hosted
+    # Only run for pushes to main, workflow_dispatch, or PRs that carry the
+    # `ci:perf` label.
+    #
+    # The fork-safety guard keeps untrusted forks off the self-hosted runner.
+    if: >
+      (github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'ci:perf')) &&
+      (github.ref == 'refs/heads/main' ||
+        github.repository == github.event.pull_request.head.repo.full_name)
+
+    needs: tests
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
+
+      # cspell:disable-next-line
+      - uses: socketdev/action@4337a545deecc20f19a909e52db7a2f6ba292f42 # v1
+        with:
+          mode: firewall
+
+      - uses: ./.github/actions/setup-env
+
+      - name: Install hyperfine
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y hyperfine
+
+      - name: Install packages
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run regression benchmark
+        env:
+          ALCHEMY_URL: ${{ secrets.ALCHEMY_URL }}
+        run: pnpm bench:regression --use-local --force-checkout --output regression-report.json
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: regression-report.json
+          gh-repository: github.com/nomic-foundation-automation/hardhat-benchmark-results
+          gh-pages-branch: main
+          benchmark-data-dir-path: hardhat3
+          github-token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
+          # Only push baseline on main-branch pushes; PRs only compare
+          auto-push: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+          alert-threshold: "110%"
+          # Only fail on PRs; don't break CI on main
+          fail-on-alert: ${{ github.event_name == 'pull_request' }}
+          summary-always: true
+          max-items-in-chart: 50

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -21,10 +21,16 @@ jobs:
   tests:
     name: Validate Hardhat works correctly
     runs-on: ubuntu-latest
-    # Run validation tests for non-main branches to ensure that the branch is
-    # in a valid state before running the expensive regression benchmark.
-    # We assume that the main branch is always in a good state.
-    if: github.ref != 'refs/heads/main'
+    # Gate validation on the same conditions as the regression-benchmark
+    # job that depends on it: this is a PR event, carries the `ci:perf`
+    # label, and isn't from a fork. Main pushes skip this gate entirely
+    # (main is assumed-green); see the regression-benchmark `if:` for the
+    # corresponding propagation guard.
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'ci:perf') &&
+      github.repository == github.event.pull_request.head.repo.full_name
+
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
@@ -57,7 +63,7 @@ jobs:
     # `ci:perf` label.
     #
     # The fork-safety guard keeps untrusted forks off the self-hosted runner.
-    if: >
+    if: |
       !cancelled() && !failure() &&
       (github.event_name != 'pull_request' ||
         contains(github.event.pull_request.labels.*.name, 'ci:perf')) &&


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

> ℹ️ **NOTE**
> This is part of a chain of PRs to implement performance regression benchmarks. They are split up into smaller PRs to make reviewing easier.
>
> This PR was preceded by #8276 

## Summary

Adds `.github/workflows/regression-benchmark.yml`, the CI side of the regression-benchmark stack. Runs `pnpm bench:regression` on a self-hosted runner and ships the results to [benchmark-action/github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) for baseline tracking and PR alerts.

## Motivation

This CI workflow allows us to do two things:

1. An automated guardrail: PRs that touch performance-sensitive code should be prevented from merging using an objective measurement.
2. Historical trends are tracked on `main` to detect cumulative small performance regressions over time; the so-called “death by a thousand cuts”.

Every push to `main` writes results to a separate repo (`nomic-foundation-automation/hardhat-benchmark-results`, `hardhat3` directory). PRs compare against that baseline. This uses the same dependency as EDR.

### Stable runner

Shared GitHub runners have enough variance to trigger false positives at the 110 % alert threshold we want. The job runs on `hardhat-linux-amd64-self-hosted`.

### Opt-in trigger

Running on every PR push is expensive (three hyperfine phases × every scenario). PRs only run when the `ci:perf` label is present.

## Behavior

| Event | What runs |
|---|---|
| `push` to `main` | Skip the validation job; run regression; **push** new baseline to the results repo |
| PR opened/synced/relabeled with `ci:perf` | Run `pnpm test` first (validate the branch isn't broken before burning a lot of runner time), then regression; compare against baseline; **fail the job** on regressions ≥ 110 % |
| PR without `ci:perf` | Skipped entirely |
| Fork PR (any) | Skipped — fork-safety guard keeps untrusted code off the self-hosted runner |

`concurrency` cancels in-progress runs for non-main refs; main runs are never cancelled so baselines aren't lost mid-publish.

## Worth noting

- **Validation gate** — non-main runs gate the benchmark on a green `pnpm test`. Main is assumed-green; skipping the gate there shaves ~15 min off baseline runs.
- **`sfw` (socket firewall)** — wraps `pnpm install` and is set up via `socketdev/action`. Same pattern other workflows in this repo use.
- **Alert threshold 110 %, `fail-on-alert` only on PRs** — regressions fail PR jobs but never break `main`, so an alert never blocks a release.
- **`BENCHMARK_GITHUB_TOKEN`** — PAT with write access to the results repo. Required the `main` branch doesn't have a `GITHUB_TOKEN`, so we wouldn't be able to push to the benchmark result repository.

## Future work

Once this PR is merged to `main`, the first benchmark results should be pushed to the [nomic-foundation-automation/hardhat-benchmark-results/](https://github.com/nomic-foundation-automation/hardhat-benchmark-results/) repo. Afterwards, I'll do a manual run on the dedicated CI runner for Foundry and upload those numbers as the baseline.