### PR TITLE
fix: suppress warnings from coverage-generated files

### DIFF
--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -55,6 +55,10 @@ export function shouldSuppressWarning(
   absoluteSolidityTestsPath: string,
   absoluteProjectRoot: string,
 ): boolean {
+  if (errorMessage.includes("__NomicFoundationCoverage")) {
+    return true;
+  }
+
   // Compute relative path from project root to test directory.
   // Example:
   // absoluteSolidityTestsPath: /workspaces/hardhat-4/packages/example-project/test/contracts

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -160,6 +160,26 @@ describe("shouldSuppressWarning", () => {
     });
   });
 
+  describe("Coverage generated files", () => {
+    it("should suppress any warning from files whose path contains __NomicFoundationCoverage", () => {
+      const message =
+        "Warning: Some arbitrary warning message\n  --> src/__NomicFoundationCoverage-contracts/MyContract.sol:10:1:";
+      assert.equal(
+        shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT),
+        true,
+      );
+    });
+
+    it("should NOT suppress warnings from paths that do not contain __NomicFoundationCoverage", () => {
+      const message =
+        "Warning: Some arbitrary warning message\n  --> src/MyContract.sol:10:1:";
+      assert.equal(
+        shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT),
+        false,
+      );
+    });
+  });
+
   describe("non-matching warnings", () => {
     it("should NOT suppress warnings that don't match any rule", () => {
       const message = `Warning: Some other warning message\n  --> ./test/contracts/Example.sol:1:1:`;


### PR DESCRIPTION
* [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

Resolves #8251

This PR suppresses Solidity compiler warnings originating from coverage-generated files whose paths contain `__NomicFoundationCoverage`.

The implementation adds a minimal early-return check inside `shouldSuppressWarning` in `warning-suppression.ts`, avoiding changes to the existing typed suppression rule structure.

### Changes

* Added suppression for warnings whose paths include `__NomicFoundationCoverage`
* Added positive and negative tests covering the new suppression behavior

### Verification

* `pnpm lint`
* `pnpm build`
* targeted warning-suppression test suite
