### PR TITLE
fix(solidity-test): skip abstract contracts in test suite discovery

### DIFF
--- a/.changeset/quiet-pandas-dance.md
+++ b/.changeset/quiet-pandas-dance.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed `abstract` contracts being picked up as test suites by the Solidity test runner (#8203).

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -150,7 +150,9 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
 
 export function isTestSuiteArtifact(artifact: Artifact): boolean {
   const bytecode = artifact.contract.bytecode;
-  if (bytecode === "" || bytecode === "0x") {
+
+  // Skip abstract contracts and interfaces i.e. those with no bytecode
+  if (bytecode === "" || bytecode === "0x" || bytecode === undefined) {
     return false;
   }
 
@@ -159,6 +161,7 @@ export function isTestSuiteArtifact(artifact: Artifact): boolean {
     if (type === "function" && typeof name === "string") {
       return name.startsWith("test") || name.startsWith("invariant");
     }
+
     return false;
   });
 }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -149,6 +149,11 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
 }
 
 export function isTestSuiteArtifact(artifact: Artifact): boolean {
+  const bytecode = artifact.contract.bytecode;
+  if (bytecode === "" || bytecode === "0x") {
+    return false;
+  }
+
   const abi: Abi = JSON.parse(artifact.contract.abi);
   return abi.some(({ type, name }) => {
     if (type === "function" && typeof name === "string") {

--- a/packages/hardhat/test/fixture-projects/solidity-test/test/contracts/abstract-and-interface/AbstractAndConcrete.t.sol
+++ b/packages/hardhat/test/fixture-projects/solidity-test/test/contracts/abstract-and-interface/AbstractAndConcrete.t.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+abstract contract AbstractTest {
+  function test_abstract() public pure {
+    require(true, "abstract test should only run via concrete descendant");
+  }
+}
+
+contract ConcreteFromAbstract is AbstractTest {
+  function test_actual() public pure {
+    require(true, "concrete test runs");
+  }
+}

--- a/packages/hardhat/test/fixture-projects/solidity-test/test/contracts/abstract-and-interface/InterfaceAndImpl.t.sol
+++ b/packages/hardhat/test/fixture-projects/solidity-test/test/contracts/abstract-and-interface/InterfaceAndImpl.t.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface ITestInterface {
+  function test_interface() external;
+}
+
+contract InterfaceImpl is ITestInterface {
+  function test_interface() external pure override {
+    require(true, "interface impl runs");
+  }
+}

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
@@ -13,11 +13,15 @@ import {
   l1HardforkToString,
   opHardforkToString,
   opLatestHardfork,
+  Artifact,
 } from "@nomicfoundation/edr";
 
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
 import { resolveSolidityTestForkingConfig } from "../../../../src/internal/builtin-plugins/solidity-test/config.js";
-import { solidityTestConfigToSolidityTestRunnerConfigArgs } from "../../../../src/internal/builtin-plugins/solidity-test/helpers.js";
+import {
+  isTestSuiteArtifact,
+  solidityTestConfigToSolidityTestRunnerConfigArgs,
+} from "../../../../src/internal/builtin-plugins/solidity-test/helpers.js";
 import {
   DEFAULT_VERBOSITY,
   GENERIC_CHAIN_TYPE,
@@ -296,5 +300,49 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
       const expectedHardfork = opHardforkToString(opLatestHardfork());
       assert.equal(args.hardfork, expectedHardfork);
     });
+  });
+});
+
+describe("isTestSuiteArtifact", () => {
+  const testAbi = JSON.stringify([
+    { type: "function", name: "test_foo", inputs: [], outputs: [] },
+  ]);
+
+  it("returns true for a contract with a test_* function", () => {
+    const artifact: Artifact = {
+      id: {
+        name: "ConcreteTest",
+        solcVersion: "0.8.0",
+        source: "test/ConcreteTest.t.sol",
+      },
+      contract: {
+        abi: testAbi,
+        bytecode: "0x6080604052",
+        linkReferences: {},
+        deployedBytecode: "0x6080604052",
+        deployedLinkReferences: {},
+      },
+    };
+
+    assert.equal(isTestSuiteArtifact(artifact), true);
+  });
+
+  it("returns false for abstract contracts with zero bytecode", () => {
+    const artifact: Artifact = {
+      id: {
+        name: "AbstractTest",
+        solcVersion: "0.8.0",
+        source: "test/AbstractTest.t.sol",
+      },
+      contract: {
+        abi: testAbi,
+        bytecode: "",
+        linkReferences: {},
+        deployedBytecode: "",
+        deployedLinkReferences: {},
+      },
+    };
+
+    assert.equal(isTestSuiteArtifact(artifact), false);
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
@@ -1,5 +1,6 @@
 import type { ConfigurationVariableResolver } from "../../../../src/types/config.js";
 import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
+import type { Artifact } from "@nomicfoundation/edr";
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
@@ -13,7 +14,6 @@ import {
   l1HardforkToString,
   opHardforkToString,
   opLatestHardfork,
-  Artifact,
 } from "@nomicfoundation/edr";
 
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
@@ -310,6 +310,9 @@ describe("isTestSuiteArtifact", () => {
   const nonTestFnAbi = JSON.stringify([
     { type: "function", name: "foo", inputs: [], outputs: [] },
   ]);
+  const invariantFnAbi = JSON.stringify([
+    { type: "function", name: "invariant_bar", inputs: [], outputs: [] },
+  ]);
 
   it("returns true for a concrete contract with a test_* function", () => {
     const artifact: Artifact = {
@@ -320,6 +323,26 @@ describe("isTestSuiteArtifact", () => {
       },
       contract: {
         abi: testFnAbi,
+        bytecode: "0x6080604052",
+        linkReferences: {},
+        deployedBytecode: "0x6080604052",
+        deployedLinkReferences: {},
+      },
+    };
+
+    assert.equal(isTestSuiteArtifact(artifact), true);
+  });
+
+
+  it("returns true for a concrete contract with an invariant_* function", () => {
+    const artifact: Artifact = {
+      id: {
+        name: "InvariantTest",
+        solcVersion: "0.8.0",
+        source: "test/InvariantTest.t.sol",
+      },
+      contract: {
+        abi: invariantFnAbi,
         bytecode: "0x6080604052",
         linkReferences: {},
         deployedBytecode: "0x6080604052",
@@ -349,7 +372,7 @@ describe("isTestSuiteArtifact", () => {
     assert.equal(isTestSuiteArtifact(artifact), false);
   });
 
-  it("returns false for a concrete contract with no test ABI entries", () => {
+  it("returns false for a concrete contract with no test/invariant ABI entries", () => {
     const artifact: Artifact = {
       id: {
         name: "Plain",

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
@@ -366,7 +366,7 @@ describe("isTestSuiteArtifact", () => {
     assert.equal(isTestSuiteArtifact(artifact), false);
   });
 
-  it("returns false for abstract contracts with zero/empty-string bytecode, even when ABI has test entries", () => {
+  it("returns false for abstract contracts with zero bytecode, even when ABI has test entries", () => {
     const artifact = artifactFactory({
       name: "AbstractTest",
       abi: abiWith("test_foo"),

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
@@ -304,11 +304,14 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
 });
 
 describe("isTestSuiteArtifact", () => {
-  const testAbi = JSON.stringify([
+  const testFnAbi = JSON.stringify([
     { type: "function", name: "test_foo", inputs: [], outputs: [] },
   ]);
+  const nonTestFnAbi = JSON.stringify([
+    { type: "function", name: "foo", inputs: [], outputs: [] },
+  ]);
 
-  it("returns true for a contract with a test_* function", () => {
+  it("returns true for a concrete contract with a test_* function", () => {
     const artifact: Artifact = {
       id: {
         name: "ConcreteTest",
@@ -316,7 +319,7 @@ describe("isTestSuiteArtifact", () => {
         source: "test/ConcreteTest.t.sol",
       },
       contract: {
-        abi: testAbi,
+        abi: testFnAbi,
         bytecode: "0x6080604052",
         linkReferences: {},
         deployedBytecode: "0x6080604052",
@@ -327,7 +330,7 @@ describe("isTestSuiteArtifact", () => {
     assert.equal(isTestSuiteArtifact(artifact), true);
   });
 
-  it("returns false for abstract contracts with zero bytecode", () => {
+  it("returns false for abstract contracts with zero/empty-string bytecode, even when ABI has test entries", () => {
     const artifact: Artifact = {
       id: {
         name: "AbstractTest",
@@ -335,10 +338,29 @@ describe("isTestSuiteArtifact", () => {
         source: "test/AbstractTest.t.sol",
       },
       contract: {
-        abi: testAbi,
-        bytecode: "",
+        abi: testFnAbi,
+        bytecode: "0x",
         linkReferences: {},
-        deployedBytecode: "",
+        deployedBytecode: "0x",
+        deployedLinkReferences: {},
+      },
+    };
+
+    assert.equal(isTestSuiteArtifact(artifact), false);
+  });
+
+  it("returns false for a concrete contract with no test ABI entries", () => {
+    const artifact: Artifact = {
+      id: {
+        name: "Plain",
+        solcVersion: "0.8.0",
+        source: "src/Plain.sol",
+      },
+      contract: {
+        abi: nonTestFnAbi,
+        bytecode: "0x6080604052",
+        linkReferences: {},
+        deployedBytecode: "0x6080604052",
         deployedLinkReferences: {},
       },
     };

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/helpers.ts
@@ -304,89 +304,74 @@ describe("solidityTestConfigToSolidityTestRunnerConfigArgs", () => {
 });
 
 describe("isTestSuiteArtifact", () => {
-  const testFnAbi = JSON.stringify([
-    { type: "function", name: "test_foo", inputs: [], outputs: [] },
-  ]);
-  const nonTestFnAbi = JSON.stringify([
-    { type: "function", name: "foo", inputs: [], outputs: [] },
-  ]);
-  const invariantFnAbi = JSON.stringify([
-    { type: "function", name: "invariant_bar", inputs: [], outputs: [] },
-  ]);
+  const SOLC_VERSION = "0.8.0";
+  const ZERO_BYTECODE = "0x";
+  const NON_EMPTY_BYTECODE = "0x6080604052";
+
+  const abiWith = (fnName: string): string =>
+    JSON.stringify([
+      { type: "function", name: fnName, inputs: [], outputs: [] },
+    ]);
+
+  const artifactFactory = ({
+    name,
+    abi,
+    bytecode,
+  }: {
+    name: string;
+    abi: string;
+    bytecode: string;
+  }): Artifact => ({
+    id: {
+      name,
+      solcVersion: SOLC_VERSION,
+      source: `test/${name}.t.sol`,
+    },
+    contract: {
+      abi,
+      bytecode,
+      linkReferences: {},
+      deployedBytecode: bytecode,
+      deployedLinkReferences: {},
+    },
+  });
 
   it("returns true for a concrete contract with a test_* function", () => {
-    const artifact: Artifact = {
-      id: {
-        name: "ConcreteTest",
-        solcVersion: "0.8.0",
-        source: "test/ConcreteTest.t.sol",
-      },
-      contract: {
-        abi: testFnAbi,
-        bytecode: "0x6080604052",
-        linkReferences: {},
-        deployedBytecode: "0x6080604052",
-        deployedLinkReferences: {},
-      },
-    };
+    const artifact = artifactFactory({
+      name: "ConcreteTest",
+      abi: abiWith("test_foo"),
+      bytecode: NON_EMPTY_BYTECODE,
+    });
 
     assert.equal(isTestSuiteArtifact(artifact), true);
   });
-
 
   it("returns true for a concrete contract with an invariant_* function", () => {
-    const artifact: Artifact = {
-      id: {
-        name: "InvariantTest",
-        solcVersion: "0.8.0",
-        source: "test/InvariantTest.t.sol",
-      },
-      contract: {
-        abi: invariantFnAbi,
-        bytecode: "0x6080604052",
-        linkReferences: {},
-        deployedBytecode: "0x6080604052",
-        deployedLinkReferences: {},
-      },
-    };
+    const artifact = artifactFactory({
+      name: "InvariantTest",
+      abi: abiWith("invariant_bar"),
+      bytecode: NON_EMPTY_BYTECODE,
+    });
 
     assert.equal(isTestSuiteArtifact(artifact), true);
   });
 
-  it("returns false for abstract contracts with zero/empty-string bytecode, even when ABI has test entries", () => {
-    const artifact: Artifact = {
-      id: {
-        name: "AbstractTest",
-        solcVersion: "0.8.0",
-        source: "test/AbstractTest.t.sol",
-      },
-      contract: {
-        abi: testFnAbi,
-        bytecode: "0x",
-        linkReferences: {},
-        deployedBytecode: "0x",
-        deployedLinkReferences: {},
-      },
-    };
+  it("returns false for a concrete contract with no test/invariant ABI entries", () => {
+    const artifact = artifactFactory({
+      name: "Plain",
+      abi: abiWith("foo"),
+      bytecode: NON_EMPTY_BYTECODE,
+    });
 
     assert.equal(isTestSuiteArtifact(artifact), false);
   });
 
-  it("returns false for a concrete contract with no test/invariant ABI entries", () => {
-    const artifact: Artifact = {
-      id: {
-        name: "Plain",
-        solcVersion: "0.8.0",
-        source: "src/Plain.sol",
-      },
-      contract: {
-        abi: nonTestFnAbi,
-        bytecode: "0x6080604052",
-        linkReferences: {},
-        deployedBytecode: "0x6080604052",
-        deployedLinkReferences: {},
-      },
-    };
+  it("returns false for abstract contracts with zero/empty-string bytecode, even when ABI has test entries", () => {
+    const artifact = artifactFactory({
+      name: "AbstractTest",
+      abi: abiWith("test_foo"),
+      bytecode: ZERO_BYTECODE,
+    });
 
     assert.equal(isTestSuiteArtifact(artifact), false);
   });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -55,6 +55,11 @@ const hardhatConfigHardforkTests = {
   paths: { tests: { solidity: "test/contracts/hardfork" } },
 };
 
+const hardhatConfigAbstractAndInterfaceTests = {
+  ...hardhatConfig,
+  paths: { tests: { solidity: "test/contracts/abstract-and-interface" } },
+};
+
 describe("solidity-test/task-action", function () {
   let hre: HardhatRuntimeEnvironment;
 
@@ -526,4 +531,77 @@ describe("solidity-test/task-action", function () {
     // The test should not throw, which means the precompile exists
     // and works as expected
   });
+
+  describe("abstract contracts and interfaces", () => {
+    // Earlier tests in this file run `build` against narrower test-path
+    // configs, which overwrites the unified `artifacts/` directory. Rebuild
+    // here so the abstract-and-interface fixture artifacts exist on disk.
+    before(async () => {
+      const rebuildHre = await createHardhatRuntimeEnvironment(
+        hardhatConfigAllTestDirs,
+      );
+
+      await rebuildHre.tasks.getTask(["build"]).run({});
+    });
+
+    it("should not report abstract contracts as test suites", async () => {
+      hre = await createHardhatRuntimeEnvironment(
+        hardhatConfigAbstractAndInterfaceTests,
+      );
+
+      const result = await hre.tasks
+        .getTask(["test", "solidity"])
+        .run({ noCompile: true });
+
+      const discoveredSuiteNames = getDiscoveredSuiteNames(result);
+
+      assert.ok(
+        !discoveredSuiteNames.includes("AbstractTest"),
+        `AbstractTest should be filtered out, got suites: ${discoveredSuiteNames.join(", ")}`,
+      );
+      assert.ok(
+        discoveredSuiteNames.includes("ConcreteFromAbstract"),
+        `ConcreteFromAbstract should be discovered, got suites: ${discoveredSuiteNames.join(", ")}`,
+      );
+    });
+
+    it("should not report interfaces as test suites", async () => {
+      hre = await createHardhatRuntimeEnvironment(
+        hardhatConfigAbstractAndInterfaceTests,
+      );
+
+      const result = await hre.tasks
+        .getTask(["test", "solidity"])
+        .run({ noCompile: true });
+
+      const discoveredSuiteNames = getDiscoveredSuiteNames(result);
+
+      assert.ok(
+        !discoveredSuiteNames.includes("ITestInterface"),
+        `ITestInterface should be filtered out, got suites: ${discoveredSuiteNames.join(", ")}`,
+      );
+      assert.ok(
+        discoveredSuiteNames.includes("InterfaceImpl"),
+        `InterfaceImpl should be discovered, got suites: ${discoveredSuiteNames.join(", ")}`,
+      );
+    });
+  });
 });
+
+function getDiscoveredSuiteNames(
+  result:
+    | {
+        success: true;
+        value: { suiteResults: Array<{ id: { name: string } }> };
+      }
+    | {
+        success: false;
+        error: { suiteResults: Array<{ id: { name: string } }> };
+      },
+): string[] {
+  const suiteResults = result.success
+    ? result.value.suiteResults
+    : result.error.suiteResults;
+
+  return suiteResults.map((s) => s.id.name);
+}


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary

This PR addresses a bug:
> Hardhat currently runs test functions from abstract contract as their own test suite. This should not be the case.

## Fix

Prevent abstract contracts (& interfaces) from being reported as their own suite, by filtering out artifacts with zero bytecode.

## Context

`isTestSuiteArtifact` decides whether a compiled contract is a Solidity test suite by checking the ABI for function names starting with `test` or `invariant`. Abstract contracts (and interfaces) compile to no bytecode but can still expose `test*` / `invariant*` ABI entries via inheritance, so they were surfaced as standalone phantom test suites alongside the concrete contracts that inherit from them.

This PR adds an early-exit guard at the top of `isTestSuiteArtifact`: if `artifact.contract.bytecode === "0x"`, the artifact has no deployable form and is skipped.

## Tests
Added tests covering all cases related to `isTestSuiteArtifact` function:

- Concrete contract with `test_*` ABI entries + non-empty bytecode: identified as a test suite.
- Concrete contract with no `test*` / `invariant*` ABI entries: NOT identified.
- Abstract contract (`bytecode: "0x"`) with `test_*` ABI entries: NOT identified (regression test for #8203).

## Changeset

`patch` on `hardhat`.

## Notes

* Closes #8203
