### PR TITLE
fix: suppress warnings from the injected coverage library file

### DIFF
--- a/.changeset/suppress-coverage-library-warnings.md
+++ b/.changeset/suppress-coverage-library-warnings.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Suppress Solidity compiler warnings emitted against the synthetic `__NomicFoundationCoverage` library file injected by the coverage hook, so `--coverage` runs no longer surface warnings users cannot fix.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -16,6 +16,13 @@ import { COVERAGE_LIBRARY_FILE_NAME } from "@nomicfoundation/edr";
 //        (e.g., test/contracts/Example.sol)
 //    - Use this for warnings that are acceptable in test code but not in production code
 //      (e.g., missing SPDX license identifiers or pragma statements)
+//
+// 3. scope: 'coverage-library' - Suppress warnings from the injected coverage library file
+//    - The file is identified by source paths containing COVERAGE_LIBRARY_FILE_NAME
+//      (e.g., matches `__NomicFoundationCoverage` and the uuid-suffixed variant)
+//    - Use this for warnings emitted against the file injected by the coverage hook,
+//      since users cannot edit it
+//    - No `message` field: every warning emitted against the file is suppressed
 interface SpecificFileRule {
   message: string;
   scope: "specific-file";

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -16,24 +16,34 @@ import { COVERAGE_LIBRARY_FILE_NAME } from "@nomicfoundation/edr";
 //        (e.g., test/contracts/Example.sol)
 //    - Use this for warnings that are acceptable in test code but not in production code
 //      (e.g., missing SPDX license identifiers or pragma statements)
-export const SPECIFIC_FILE_RULES: Array<{
+type SpecificFileRule = {
   message: string;
-  scope: "file-tag";
+  scope: "specific-file";
   filePath: string;
-}> = [
+};
+
+type TestFilesRule = {
+  message: string;
+  scope: "test-files";
+};
+
+type CoverageLibraryRule = {
+  scope: "coverage-library";
+};
+
+type SuppressionRule = SpecificFileRule | TestFilesRule | CoverageLibraryRule;
+
+export const SPECIFIC_FILE_RULES: SpecificFileRule[] = [
   {
     message:
       "Natspec memory-safe-assembly special comment for inline assembly is deprecated and scheduled for removal. Use the memory-safe block annotation instead.",
-    scope: "file-tag",
+    scope: "specific-file",
     // Normalize to handle different OS path separators
     filePath: path.normalize("hardhat/console.sol"),
   },
 ];
 
-export const TEST_FILE_RULES: Array<{
-  message: string;
-  scope: "test-files";
-}> = [
+export const TEST_FILE_RULES: TestFilesRule[] = [
   {
     message: "SPDX license identifier not provided",
     scope: "test-files",
@@ -44,15 +54,13 @@ export const TEST_FILE_RULES: Array<{
   },
 ];
 
-export const COVERAGE_LIBRARY_RULES: Array<{
-  scope: "coverage-library";
-}> = [
+export const COVERAGE_LIBRARY_RULES: CoverageLibraryRule[] = [
   {
     scope: "coverage-library",
   },
 ];
 
-export const SUPPRESSED_WARNINGS = [
+export const SUPPRESSED_WARNINGS: SuppressionRule[] = [
   ...SPECIFIC_FILE_RULES,
   ...TEST_FILE_RULES,
   ...COVERAGE_LIBRARY_RULES,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -20,9 +20,8 @@ import { COVERAGE_LIBRARY_FILE_NAME } from "@nomicfoundation/edr";
 // 3. scope: 'coverage-library' - Suppress warnings from the injected coverage library file
 //    - The file is identified by source paths containing COVERAGE_LIBRARY_FILE_NAME
 //      (e.g., matches `__NomicFoundationCoverage` and the uuid-suffixed variant)
-//    - Use this for warnings emitted against the file injected by the coverage hook,
-//      since users cannot edit it
-//    - No `message` field: every warning emitted against the file is suppressed
+//    - No `message` field: every warning emitted against the file is suppressed,
+//      since the file is injected by the --coverage hook and users cannot edit it
 interface SpecificFileRule {
   message: string;
   scope: "specific-file";

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -1,7 +1,9 @@
 import path from "node:path";
 
+import { COVERAGE_LIBRARY_FILE_NAME } from "@nomicfoundation/edr";
+
 // Compiler warnings to suppress from build output.
-// Supports two types of suppression rules:
+// Supports three types of suppression rules:
 //
 // 1. scope: 'specific-file' - Suppress warnings from specific file paths
 //    - Use this to suppress known warnings from internal/library files (e.g., console.sol)
@@ -24,6 +26,9 @@ export const SUPPRESSED_WARNINGS: Array<
       message: string;
       scope: "test-files";
     }
+    | {
+      scope: "coverage-library";
+    }
 > = [
   {
     message:
@@ -39,6 +44,9 @@ export const SUPPRESSED_WARNINGS: Array<
   {
     message: "Source file does not specify required compiler version",
     scope: "test-files",
+  },
+  {
+    scope: "coverage-library",
   },
 ];
 
@@ -67,6 +75,10 @@ export function shouldSuppressWarning(
   );
 
   return SUPPRESSED_WARNINGS.some((rule) => {
+    if (rule.scope === "coverage-library") {
+      return errorMessage.includes(COVERAGE_LIBRARY_FILE_NAME);
+    }
+
     if (!errorMessage.includes(rule.message)) {
       return false;
     }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -16,27 +16,24 @@ import { COVERAGE_LIBRARY_FILE_NAME } from "@nomicfoundation/edr";
 //        (e.g., test/contracts/Example.sol)
 //    - Use this for warnings that are acceptable in test code but not in production code
 //      (e.g., missing SPDX license identifiers or pragma statements)
-export const SUPPRESSED_WARNINGS: Array<
-  | {
-      message: string;
-      scope: "specific-file";
-      filePath: string;
-    }
-  | {
-      message: string;
-      scope: "test-files";
-    }
-    | {
-      scope: "coverage-library";
-    }
-> = [
+export const SPECIFIC_FILE_RULES: Array<{
+  message: string;
+  scope: "file-tag";
+  filePath: string;
+}> = [
   {
     message:
       "Natspec memory-safe-assembly special comment for inline assembly is deprecated and scheduled for removal. Use the memory-safe block annotation instead.",
-    scope: "specific-file",
+    scope: "file-tag",
     // Normalize to handle different OS path separators
     filePath: path.normalize("hardhat/console.sol"),
   },
+];
+
+export const TEST_FILE_RULES: Array<{
+  message: string;
+  scope: "test-files";
+}> = [
   {
     message: "SPDX license identifier not provided",
     scope: "test-files",
@@ -45,9 +42,20 @@ export const SUPPRESSED_WARNINGS: Array<
     message: "Source file does not specify required compiler version",
     scope: "test-files",
   },
+];
+
+export const COVERAGE_LIBRARY_RULES: Array<{
+  scope: "coverage-library";
+}> = [
   {
     scope: "coverage-library",
   },
+];
+
+export const SUPPRESSED_WARNINGS = [
+  ...SPECIFIC_FILE_RULES,
+  ...TEST_FILE_RULES,
+  ...COVERAGE_LIBRARY_RULES,
 ];
 
 /**

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -16,20 +16,20 @@ import { COVERAGE_LIBRARY_FILE_NAME } from "@nomicfoundation/edr";
 //        (e.g., test/contracts/Example.sol)
 //    - Use this for warnings that are acceptable in test code but not in production code
 //      (e.g., missing SPDX license identifiers or pragma statements)
-type SpecificFileRule = {
+interface SpecificFileRule {
   message: string;
   scope: "specific-file";
   filePath: string;
-};
+}
 
-type TestFilesRule = {
+interface TestFilesRule {
   message: string;
   scope: "test-files";
-};
+}
 
-type CoverageLibraryRule = {
+interface CoverageLibraryRule {
   scope: "coverage-library";
-};
+}
 
 type SuppressionRule = SpecificFileRule | TestFilesRule | CoverageLibraryRule;
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/warning-filtering.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/warning-filtering.ts
@@ -3,7 +3,10 @@ import type { HardhatUserConfig } from "../../../../../../src/config.js";
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { SUPPRESSED_WARNINGS } from "../../../../../../src/internal/builtin-plugins/solidity/build-system/warning-suppression.js";
+import {
+  SPECIFIC_FILE_RULES,
+  TEST_FILE_RULES,
+} from "../../../../../../src/internal/builtin-plugins/solidity/build-system/warning-suppression.js";
 import { useTestProjectTemplate } from "../resolver/helpers.js";
 
 //
@@ -11,9 +14,9 @@ import { useTestProjectTemplate } from "../resolver/helpers.js";
 // unit tests in warning-suppression.ts
 //
 
-const NATSPEC_MEMORY_SAFE_WARNING = SUPPRESSED_WARNINGS[0].message;
-const SPDX_WARNING = SUPPRESSED_WARNINGS[1].message;
-const PRAGMA_WARNING = SUPPRESSED_WARNINGS[2].message;
+const NATSPEC_MEMORY_SAFE_WARNING = SPECIFIC_FILE_RULES[0].message;
+const SPDX_WARNING = TEST_FILE_RULES[0].message;
+const PRAGMA_WARNING = TEST_FILE_RULES[1].message;
 
 // Project with the warning in a regular contract file (not console.sol)
 const projectWithNatspecWarningInRegularFile = {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -164,30 +164,33 @@ describe("shouldSuppressWarning", () => {
   });
 
   describe("Coverage library warnings (coverage-library scope)", () => {
-    it("should suppress any warning emitted against the bare coverage library file", () => {
-      const message = `Warning: ${NATSPEC_WARNING}\n  --> ${COVERAGE_LIBRARY_FILE_NAME}:11:5:`;
-      assert.equal(
-        shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT),
-        true,
-      );
-    });
+    const scenarios = [
+      {
+        name: "should suppress any warning emitted against the bare coverage library file",
+        path: COVERAGE_LIBRARY_FILE_NAME,
+        expected: true,
+      },
+      {
+        name: "should suppress any warning emitted against the uuid-suffixed coverage library file",
+        path: `${COVERAGE_LIBRARY_FILE_NAME}-1fe87c59-dedc-4831-8918-604bc223bbfa.sol`,
+        expected: true,
+      },
+      {
+        name: "should NOT suppress the same warning emitted against a user-file path",
+        path: path.join("contracts", "MyContract.sol"),
+        expected: false,
+      },
+    ];
 
-    it("should suppress any warning emitted against the uuid-suffixed coverage library file", () => {
-      const message = `Warning: Some other warning text\n  --> ${COVERAGE_LIBRARY_FILE_NAME}-1fe87c59-dedc-4831-8918-604bc223bbfa.sol:11:5:`;
-      assert.equal(
-        shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT),
-        true,
-      );
-    });
-
-    it("should NOT suppress the same warning emitted against a user-file path", () => {
-      const userPath = path.join("contracts", "MyContract.sol");
-      const message = `Warning: ${NATSPEC_WARNING}\n  --> ${userPath}:42:1:`;
-      assert.equal(
-        shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT),
-        false,
-      );
-    });
+    for (const scenario of scenarios) {
+      it(scenario.name, () => {
+        const message = `Warning: ${NATSPEC_WARNING}\n  --> ${scenario.path}:1:1:`;
+        assert.equal(
+          shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT),
+          scenario.expected,
+        );
+      });
+    }
   });
 
   describe("non-matching warnings", () => {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { describe, it } from "node:test";
 
+import { COVERAGE_LIBRARY_FILE_NAME } from "@nomicfoundation/edr";
+
 import {
   shouldSuppressWarning,
   SPECIFIC_FILE_RULES,
@@ -158,6 +160,33 @@ describe("shouldSuppressWarning", () => {
           });
         }
       }
+    });
+  });
+
+  describe("Coverage library warnings (coverage-library scope)", () => {
+    it("should suppress any warning emitted against the bare coverage library file", () => {
+      const message = `Warning: ${NATSPEC_WARNING}\n  --> ${COVERAGE_LIBRARY_FILE_NAME}:11:5:`;
+      assert.equal(
+        shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT),
+        true,
+      );
+    });
+
+    it("should suppress any warning emitted against the uuid-suffixed coverage library file", () => {
+      const message = `Warning: Some other warning text\n  --> ${COVERAGE_LIBRARY_FILE_NAME}-1fe87c59-dedc-4831-8918-604bc223bbfa.sol:11:5:`;
+      assert.equal(
+        shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT),
+        true,
+      );
+    });
+
+    it("should NOT suppress the same warning emitted against a user-file path", () => {
+      const userPath = path.join("contracts", "MyContract.sol");
+      const message = `Warning: ${NATSPEC_WARNING}\n  --> ${userPath}:42:1:`;
+      assert.equal(
+        shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT),
+        false,
+      );
     });
   });
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -4,13 +4,14 @@ import { describe, it } from "node:test";
 
 import {
   shouldSuppressWarning,
-  SUPPRESSED_WARNINGS,
+  SPECIFIC_FILE_RULES,
+  TEST_FILE_RULES,
 } from "../../../../../src/internal/builtin-plugins/solidity/build-system/warning-suppression.js";
 
 describe("shouldSuppressWarning", () => {
-  const NATSPEC_WARNING = SUPPRESSED_WARNINGS[0].message;
-  const SPDX_WARNING = SUPPRESSED_WARNINGS[1].message;
-  const PRAGMA_WARNING = SUPPRESSED_WARNINGS[2].message;
+  const NATSPEC_WARNING = SPECIFIC_FILE_RULES[0].message;
+  const SPDX_WARNING = TEST_FILE_RULES[0].message;
+  const PRAGMA_WARNING = TEST_FILE_RULES[1].message;
 
   // Mock project paths for testing
   const PROJECT_ROOT = path.join("home", "user", "project");

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -166,12 +166,12 @@ describe("shouldSuppressWarning", () => {
   describe("Coverage library warnings (coverage-library scope)", () => {
     const scenarios = [
       {
-        name: "should suppress any warning emitted against the bare coverage library file",
+        name: "should suppress warnings from the bare coverage library file",
         path: COVERAGE_LIBRARY_FILE_NAME,
         expected: true,
       },
       {
-        name: "should suppress any warning emitted against the uuid-suffixed coverage library file",
+        name: "should suppress warnings from the uuid-suffixed coverage library file",
         path: `${COVERAGE_LIBRARY_FILE_NAME}-1fe87c59-dedc-4831-8918-604bc223bbfa.sol`,
         expected: true,
       },


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary

This PR addresses a bug:
> `--coverage` flag surfaces solc warnings emitted against the synthetic `__NomicFoundationCoverage` library. This is injected by the coverage hook. Users cannot fix these issues, so there is no point of polluting with these warnings.

## Context

When the coverage hook runs, EDR's synthetic library is injected into the solc input. solc compiles it alongside user sources and emits warnings against it:
```
Warning: Natspec memory-safe-assembly special comment for inline assembly is deprecated and scheduled for removal. Use the memory-safe block annotation instead.
  --> __NomicFoundationCoverage-1fe87c59-dedc-4831-8918-604bc223bbfa.sol:11:5:
```
The build-system warning pipeline has no rule for this file, so the warnings reach stdout. 

## Fix
* Extended `warning-suppression.ts` with a new `coverage-library` scope that drops any warning whose error text contains `COVERAGE_LIBRARY_FILE_NAME`(i.e., `__NomicFoundationCoverage`).

* Additionally, the rules(`SUPPRESSED_WARNINGS`) are split into three sub-arrays`SPECIFIC_FILE_RULES`, `TEST_FILE_RULES`, `COVERAGE_LIBRARY_RULES` — so each scope keeps a narrow type(TS9017).

## Tests

Unit tests added in `packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts`. Integration test (`integration/warning-filtering.ts`) updated for the new sub-array exports.

All tests confirmed.

## Changeset

`patch` on `hardhat`.

## Notes

* Closes #8251
