### PR TITLE
fix(coverage): stream coverage data json to disk

### DIFF
--- a/.changeset/loud-pumas-jump.md
+++ b/.changeset/loud-pumas-jump.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed `--coverage` runs failing with `RangeError: Invalid string length` when coverage data exceeds Node's `JSON.stringify` string-length ceiling.

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -130,7 +130,7 @@ export class CoverageManagerImplementation implements CoverageManager {
     const dataPath = await this.#getDataPath(id);
     const filePath = path.join(dataPath, `${crypto.randomUUID()}.json`);
     const data = Object.fromEntries(this.data);
-    // NOTE: We use writeJsonFileAsStream here because the coverage data for large runs 
+    // NOTE: We use writeJsonFileAsStream here because the coverage data for large runs
     // can exceed the maximum string length when calling JSON.stringify.
     await writeJsonFileAsStream(filePath, data);
     log("Saved data", id, filePath);
@@ -179,8 +179,8 @@ export class CoverageManagerImplementation implements CoverageManager {
       const filePaths = await getAllFilesMatching(dataPath);
 
       for (const filePath of filePaths) {
-        // NOTE: We use writeJsonFileAsStream here because the coverage data for large runs 
-        // can exceed the maximum string length when calling JSON.stringify.
+        // NOTE: We use readJsonFileAsStream here because the coverage data for large runs
+        // can exceed the maximum string length when calling JSON.parse.
         const entries =
           await readJsonFileAsStream<Record<string, number>>(filePath);
 

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -17,7 +17,7 @@ import {
   readJsonFile,
   readUtf8File,
   remove,
-  writeJsonFile,
+  writeJsonFileAsStream,
   writeUtf8File,
 } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -130,7 +130,9 @@ export class CoverageManagerImplementation implements CoverageManager {
     const dataPath = await this.#getDataPath(id);
     const filePath = path.join(dataPath, `${crypto.randomUUID()}.json`);
     const data = Object.fromEntries(this.data);
-    await writeJsonFile(filePath, data);
+    // NOTE: We use writeJsonFileAsStream here because the coverage data for large runs 
+    // can exceed the maximum string length when calling JSON.stringify.
+    await writeJsonFileAsStream(filePath, data);
     log("Saved data", id, filePath);
   }
 

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -14,7 +14,7 @@ import { formatTable } from "@nomicfoundation/hardhat-utils/format";
 import {
   ensureDir,
   getAllFilesMatching,
-  readJsonFile,
+  readJsonFileAsStream,
   readUtf8File,
   remove,
   writeJsonFileAsStream,
@@ -179,7 +179,10 @@ export class CoverageManagerImplementation implements CoverageManager {
       const filePaths = await getAllFilesMatching(dataPath);
 
       for (const filePath of filePaths) {
-        const entries = await readJsonFile<Record<string, number>>(filePath);
+        // NOTE: We use writeJsonFileAsStream here because the coverage data for large runs 
+        // can exceed the maximum string length when calling JSON.stringify.
+        const entries =
+          await readJsonFileAsStream<Record<string, number>>(filePath);
 
         for (const [tag, count] of Object.entries(entries)) {
           this.data.set(tag, (this.data.get(tag) ?? 0) + count);


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary

This PR addresses a bug:
> Large `--coverage` runs fail with `RangeError: Invalid string length` when the serialized coverage map exceeds Node's `JSON.stringify` / `JSON.parse` string-length ceiling.

## Fix

Both `saveData` and `loadData` now use `writeJsonFileAsStream` / `readJsonFileAsStream` instead of their non-streaming counterparts. The rationale comment mirrors [`build-system.ts:1035`](https://github.com/NomicFoundation/hardhat/blob/8f38e42e1eef9bf210807b47d23f2386cc49cec4/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts#L1035).

## Tests

Introducing any regression tests would not make any sense, so I tested the behaviour change locally.

I ran a small Node script that builds a `Record<string, number>` of 5,000,000 coverage-tag-shaped entries (~520 MB serialized, same order of magnitude as the failure on the linked issue).

<img width="630" height="234" alt="poc" src="https://github.com/user-attachments/assets/9a942317-d950-4cca-a168-7feae77639cb" />

The script confirms that this PR is able to stream large files, while the main branch fails.

## Changeset

`patch` on `hardhat`.

## Notes

* Other `writeJsonFile` call sites that might exhibit similar behavior on sufficiently large inputs:
    * [`build-system.ts:1027`](https://github.com/NomicFoundation/hardhat/blob/8f38e42e1eef9bf210807b47d23f2386cc49cec4/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts#L1027)
    * [`gas-analytics-manager.ts:109`](https://github.com/NomicFoundation/hardhat/blob/8f38e42e1eef9bf210807b47d23f2386cc49cec4/packages/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts#L109)
    * [`gas-analytics-manager.ts:151`](https://github.com/NomicFoundation/hardhat/blob/8f38e42e1eef9bf210807b47d23f2386cc49cec4/packages/hardhat/src/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts#L151)
    * [`snapshot-cheatcodes.ts:224`](https://github.com/NomicFoundation/hardhat/blob/8f38e42e1eef9bf210807b47d23f2386cc49cec4/packages/hardhat/src/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts#L224)
* Closes #8071
