### PR TITLE
fix(reporter): display viem error causes

### DIFF
--- a/.changeset/mad-bears-rule.md
+++ b/.changeset/mad-bears-rule.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-reporter": patch
+---
+
+Surfaced Solidity stack traces from `SolidityError` causes in the node test reporter. Failures from viem and ethers contract calls now render a dedicated `Solidity stack trace:` section instead of a deeply nested viem cause chain.

--- a/packages/hardhat-node-test-reporter/src/error-formatting.ts
+++ b/packages/hardhat-node-test-reporter/src/error-formatting.ts
@@ -8,6 +8,7 @@ import { isCi } from "./ci.js";
 import { indent } from "./formatting.js";
 import {
   cleanupTestFailError,
+  findSolidityErrorInChain,
   isTestFileExecutionFailureError,
 } from "./node-test-error-utils.js";
 
@@ -188,6 +189,20 @@ export function formatSingleError(
       );
     }
   }
+
+  // Build the `Solidity stack trace:` section through intermediate viem/ethers wrapper layers.
+  const solidityStackSection =
+    depth === 0 ? formatSolidityStackSection(error) : "";
+
+  // Strip .sol frames from the top-level stack — they render in the section.
+  // So, the Solidity frames don't render twice when appeared in the top-level stack.
+  if (solidityStackSection !== "") {
+    stackLines = stackLines.filter(
+      (line) =>
+        line.reference === undefined ||
+        !line.reference.location.endsWith(".sol"),
+    );
+  }
   const stack = stackLines.map(formatStackLine).join("\n");
 
   let formattedError =
@@ -218,6 +233,10 @@ export function formatSingleError(
   }
 
   if (error.cause instanceof Error) {
+    if (solidityStackSection !== "") {
+      return `${formattedError}\n${solidityStackSection}`;
+    }
+
     let cause = error.cause;
     if (depth + 1 >= MAX_ERROR_CHAIN_LENGTH) {
       cause = new Error(
@@ -232,7 +251,48 @@ export function formatSingleError(
     return `${formattedError}\n${formattedCause}`;
   }
 
+  if (solidityStackSection !== "") {
+    return `${formattedError}\n${solidityStackSection}`;
+  }
+
   return formattedError;
+}
+
+/** Formats the `Solidity stack trace:` section, or `""` if no SolidityError is in the chain. */
+function formatSolidityStackSection(error: Error): string {
+  const solidityError = findSolidityErrorInChain(error);
+  if (solidityError === undefined) {
+    return "";
+  }
+
+  const parsedLines = (solidityError.stack?.split("\n") ?? []).map(
+    parseStackLine,
+  );
+  const firstReferenceIndex = parsedLines.findIndex(
+    (line) => line.reference !== undefined,
+  );
+  if (firstReferenceIndex === -1) {
+    return "";
+  }
+
+  const solidityLines: StackLine[] = [];
+  for (let i = firstReferenceIndex; i < parsedLines.length; i++) {
+    const { reference } = parsedLines[i];
+    if (reference === undefined || !reference.location.endsWith(".sol")) {
+      break;
+    }
+    solidityLines.push(parsedLines[i]);
+  }
+
+  if (solidityLines.length === 0) {
+    return "";
+  }
+
+  const formattedFrames = solidityLines.map(formatStackLine).join("\n");
+  return styleText(
+    "gray",
+    `Solidity stack trace:\n${indent(formattedFrames, ERROR_STACK_INDENT)}`,
+  );
 }
 
 function isAggregateError(error: Error): error is Error & { errors: Error[] } {

--- a/packages/hardhat-node-test-reporter/src/error-formatting.ts
+++ b/packages/hardhat-node-test-reporter/src/error-formatting.ts
@@ -279,7 +279,15 @@ function formatSolidityStackSection(error: Error): string {
   const solidityLines: StackLine[] = [];
   for (let i = firstReferenceIndex; i < parsedLines.length; i++) {
     const { reference } = parsedLines[i];
-    if (reference === undefined || !reference.location.endsWith(".sol")) {
+    if (reference === undefined) {
+      break;
+    }
+    // Accept ".sol" AND "unknown" frames. EDR's SolidityCallSite emits "unknown" 
+    // for certain stack-trace entry types: precompile / unrecognized-create entries
+    if (
+      !reference.location.endsWith(".sol") &&
+      reference.location !== "unknown"
+    ) {
       break;
     }
     solidityLines.push(parsedLines[i]);

--- a/packages/hardhat-node-test-reporter/src/error-formatting.ts
+++ b/packages/hardhat-node-test-reporter/src/error-formatting.ts
@@ -229,14 +229,19 @@ export function formatSingleError(
         ),
       )
       .join("\n");
+
+    // Append the section if a SolidityError sits in the aggregate's own
+    // cause chain. Inner sections come from the recursive map above.
+    if (solidityStackSection !== "") {
+      return `${formattedError}\n${formattedErrors}\n${solidityStackSection}`;
+    }
     return `${formattedError}\n${formattedErrors}`;
   }
 
+  if (solidityStackSection !== "") {
+    return `${formattedError}\n${solidityStackSection}`;
+  }
   if (error.cause instanceof Error) {
-    if (solidityStackSection !== "") {
-      return `${formattedError}\n${solidityStackSection}`;
-    }
-
     let cause = error.cause;
     if (depth + 1 >= MAX_ERROR_CHAIN_LENGTH) {
       cause = new Error(
@@ -249,10 +254,6 @@ export function formatSingleError(
       ERROR_CAUSE_INDENT,
     );
     return `${formattedError}\n${formattedCause}`;
-  }
-
-  if (solidityStackSection !== "") {
-    return `${formattedError}\n${solidityStackSection}`;
   }
 
   return formattedError;

--- a/packages/hardhat-node-test-reporter/src/error-formatting.ts
+++ b/packages/hardhat-node-test-reporter/src/error-formatting.ts
@@ -194,8 +194,8 @@ export function formatSingleError(
   const solidityStackSection =
     depth === 0 ? formatSolidityStackSection(error) : "";
 
-  // Strip .sol frames from the top-level stack — they render in the section.
-  // So, the Solidity frames don't render twice when appeared in the top-level stack.
+  // Strip .sol frames from the top-level stack.
+  // So, the Solidity frames don't render twice when rendered in the section.
   if (solidityStackSection !== "") {
     stackLines = stackLines.filter(
       (line) =>

--- a/packages/hardhat-node-test-reporter/src/node-test-error-utils.ts
+++ b/packages/hardhat-node-test-reporter/src/node-test-error-utils.ts
@@ -59,7 +59,7 @@ export function cleanupTestFailError(error: Error): Error {
 }
 
 /**
- * First `SolidityError` in the `.cause` chain, or `undefined`.
+ * Returns the first SolidityError in the '.cause' chain, or 'undefined'
  */
 export function findSolidityErrorInChain(error: Error): Error | undefined {
   let current: Error | undefined = error;

--- a/packages/hardhat-node-test-reporter/src/node-test-error-utils.ts
+++ b/packages/hardhat-node-test-reporter/src/node-test-error-utils.ts
@@ -57,3 +57,17 @@ export function cleanupTestFailError(error: Error): Error {
 
   return error;
 }
+
+/**
+ * First `SolidityError` in the `.cause` chain, or `undefined`.
+ */
+export function findSolidityErrorInChain(error: Error): Error | undefined {
+  let current: Error | undefined = error;
+  while (current !== undefined) {
+    if (current.name === "SolidityError") {
+      return current;
+    }
+    current = current.cause instanceof Error ? current.cause : undefined;
+  }
+  return undefined;
+}

--- a/packages/hardhat-node-test-reporter/test/error-formatting.ts
+++ b/packages/hardhat-node-test-reporter/test/error-formatting.ts
@@ -536,3 +536,77 @@ describe("Removing the diff from the error message", () => {
     });
   });
 });
+
+describe("SolidityError handling in the cause chain", () => {
+
+  function makeSolidityError(): Error {
+    const solidityError = new Error(
+      "VM Exception while processing transaction: reverted with reason string ''",
+    );
+    solidityError.name = "SolidityError";
+    solidityError.stack = [
+      "SolidityError: VM Exception while processing transaction: reverted with reason string ''",
+      "    at Revert.toss (contracts/Revert.sol:11)",
+      "    at contracts/Revert.sol:8",
+      "    at EdrProvider.request (/repo/node_modules/hardhat/dist/edr-provider.js:120:9)",
+      "    at async runMicrotasks (node:internal/process/task_queues:96:5)",
+    ].join("\n");
+    return solidityError;
+  }
+
+  it("renders a `Solidity stack trace:` section for a viem-style wrapper chain and skips the intermediate `[cause]:` layers", () => {
+    const solidityError = makeSolidityError();
+
+    const callExecutionError = new Error("An unknown RPC error occurred.", {
+      cause: solidityError,
+    });
+    callExecutionError.name = "CallExecutionError";
+
+    const topError = new Error(
+      'The contract function "boom" reverted with the following reason:\nBoom',
+      { cause: callExecutionError },
+    );
+    topError.name = "ContractFunctionExecutionError";
+
+    const formatted = stripVTControlCharacters(formatSingleError(topError));
+
+    assert.ok(
+      formatted.includes("Solidity stack trace:"),
+      `Expected output to contain 'Solidity stack trace:' header.\nGot:\n${formatted}`,
+    );
+    assert.ok(
+      formatted.includes("Revert.toss (contracts/Revert.sol:11)"),
+      `Expected output to contain the Solidity frame.\nGot:\n${formatted}`,
+    );
+    assert.ok(
+      !formatted.includes("[cause]: CallExecutionError"),
+      `Expected output to NOT contain the intermediate '[cause]: CallExecutionError' layer.\nGot:\n${formatted}`,
+    );
+    assert.ok(
+      !formatted.includes("[cause]: SolidityError"),
+      `Expected output to NOT contain '[cause]: SolidityError' (the dedicated section replaces it).\nGot:\n${formatted}`,
+    );
+  });
+
+  it("does NOT alter formatting for error chains that contain no SolidityError", () => {
+    const inner = new Error("inner cause");
+    inner.name = "InnerError";
+    inner.stack =
+      "InnerError: inner cause\n    at innerFn (/repo/inner.js:3:5)";
+
+    const top = new Error("top error", { cause: inner });
+    top.name = "TopError";
+    top.stack = "TopError: top error\n    at topFn (/repo/top.js:7:9)";
+
+    const formatted = stripVTControlCharacters(formatSingleError(top));
+
+    assert.ok(
+      formatted.includes("[cause]: InnerError: inner cause"),
+      `Expected the existing '[cause]:' recursion to still happen for non-SolidityError chains.\nGot:\n${formatted}`,
+    );
+    assert.ok(
+      !formatted.includes("Solidity stack trace:"),
+      `Expected no Solidity stack trace section for non-SolidityError chains.\nGot:\n${formatted}`,
+    );
+  });
+});

--- a/packages/hardhat-node-test-reporter/test/error-formatting.ts
+++ b/packages/hardhat-node-test-reporter/test/error-formatting.ts
@@ -538,7 +538,6 @@ describe("Removing the diff from the error message", () => {
 });
 
 describe("SolidityError handling in the cause chain", () => {
-
   function makeSolidityError(): Error {
     const solidityError = new Error(
       "VM Exception while processing transaction: reverted with reason string ''",
@@ -585,6 +584,31 @@ describe("SolidityError handling in the cause chain", () => {
     assert.ok(
       !formatted.includes("[cause]: SolidityError"),
       `Expected output to NOT contain '[cause]: SolidityError' (the dedicated section replaces it).\nGot:\n${formatted}`,
+    );
+  });
+
+  it("renders the Solidity section even when the top-level error itself is the SolidityError", () => {
+    const solidityError = makeSolidityError();
+
+    const formatted = stripVTControlCharacters(
+      formatSingleError(solidityError),
+    );
+
+    assert.ok(
+      formatted.includes("Solidity stack trace:"),
+      `Expected output to contain 'Solidity stack trace:' header.\nGot:\n${formatted}`,
+    );
+    assert.ok(
+      formatted.includes("Revert.toss (contracts/Revert.sol:11)"),
+      `Expected output to contain the Solidity frame.\nGot:\n${formatted}`,
+    );
+
+    const occurrences =
+      formatted.split("Revert.toss (contracts/Revert.sol:11)").length - 1;
+    assert.equal(
+      occurrences,
+      1,
+      `Expected 'Revert.toss (contracts/Revert.sol:11)' to appear exactly once (only inside the 'Solidity stack trace:' section), got ${occurrences}.\nGot:\n${formatted}`,
     );
   });
 


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary
This PR addresses a bug:
> When a viem contract call reverts, the node test reporter prints viem's full wrapper cause chain without surfacing the underlying Solidity stack trace as its own section.

The reporter now detects a `SolidityError` anywhere in an error's cause chain and renders a dedicated `Solidity stack trace:` section, replacing the noisy wrapper layers, matching the **After** screenshot in the linked issue.

## Fix

`formatSingleError` in `hardhat-node-test-reporter` now:

1. Walks the `.cause` chain looking for an error with `name === "SolidityError"`.
2. When found, extracts the Solidity-side frames from that error's `.stack` (the leading callsites prepended by EDR's `Error.prepareStackTrace`) and renders them as a `Solidity stack trace:` section.
3. Suppresses the recursive `[cause]:` rendering of intermediate viem/ethers wrapper layers.
4. Strips `.sol`-location frames from the top-level stack when the section will be emitted, so they don't double-render in the ethers case (where the top-level thrown error is itself the `SolidityError`).

Subsequent commits address edge cases initially missed.

## Tests
Relevant unit tests are added in `test/error-formatting.ts`.

## Notes
* Closes #8237