### PR TITLE
hardhat-solx: emit solx debugInfo for EDR Solidity stack traces

### DIFF
--- a/.changeset/solx-debug-info-output-selection.md
+++ b/.changeset/solx-debug-info-output-selection.md
@@ -1,5 +1,0 @@
----
-"@nomicfoundation/hardhat-solx": minor
----
-
-Introduce support for Solidity stack traces for solx-compiled tests using solx's 0.1.4+ DWARF format. Drops unsupported Solidity version 0.8.33 (solx 0.1.3) due to no debug info.

--- a/.changeset/solx-debug-info-output-selection.md
+++ b/.changeset/solx-debug-info-output-selection.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-solx": minor
+---
+
+Introduce support for Solidity stack traces for solx-compiled tests using solx's 0.1.4+ DWARF format. Drops unsupported Solidity version 0.8.33 (solx 0.1.3) due to no debug info.

--- a/packages/hardhat-solx/README.md
+++ b/packages/hardhat-solx/README.md
@@ -97,7 +97,7 @@ export default defineConfig({
 
 ### Supported Solidity versions
 
-solx maps each Solidity version to a specific solx binary version internally. Currently supported: `0.8.33` (solx 0.1.3), `0.8.34` (solx 0.1.4).
+solx maps each Solidity version to a specific solx binary version internally. Currently supported: `0.8.34` (solx 0.1.4). Earlier solx releases did not emit the DWARF debug info that EDR relies on for Solidity stack traces, so they are not supported by this plugin.
 
 ### EVM version support
 

--- a/packages/hardhat-solx/src/internal/constants.ts
+++ b/packages/hardhat-solx/src/internal/constants.ts
@@ -20,11 +20,7 @@ export const DEFAULT_SOLX_SETTINGS: Record<string, unknown> = {
   LLVMOptimization: "1",
 };
 
-/**
- * Maps Solidity compiler versions to the solx version that embeds them.
- * Only stable solx releases are included.
- */
+/** Maps Solidity versions to the solx version that embeds them. */
 export const SOLIDITY_TO_SOLX_VERSION_MAP: Record<string, string> = {
-  "0.8.33": "0.1.3",
   "0.8.34": "0.1.4",
 };

--- a/packages/hardhat-solx/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-solx/src/internal/hook-handlers/config.ts
@@ -23,6 +23,7 @@ import {
   SOLX_COMPILER_TYPE,
   SUPPORTED_SOLX_EVM_VERSIONS,
 } from "../constants.js";
+import { addSolxDebugInfoSelectors } from "../solx-compiler.js";
 
 const log = createDebug("hardhat:solx:hook-handlers:config");
 
@@ -172,10 +173,17 @@ export async function resolveUserConfig(
 ): Promise<HardhatConfig> {
   const resolvedConfig = await next(userConfig, resolveConfigurationVariable);
 
+  // Add solx debugInfo selectors so the cached solcInput, build-info,
+  // and build-ID hash all include them.
+  const profiles = await augmentSolxOutputSelectionInProfiles(
+    resolvedConfig.solidity.profiles,
+  );
+
   return {
     ...resolvedConfig,
     solidity: {
       ...resolvedConfig.solidity,
+      profiles,
       registeredCompilerTypes:
         resolvedConfig.solidity.registeredCompilerTypes.includes(
           SOLX_COMPILER_TYPE,
@@ -187,6 +195,56 @@ export async function resolveUserConfig(
             ],
     },
     solx: resolveSolxConfig(userConfig.solx),
+  };
+}
+
+/**
+ * For each compiler entry whose `type === "solx"`, augments
+ * `settings.outputSelection` with the solx debugInfo selectors.
+ * Non-solx entries pass through unchanged.
+ */
+async function augmentSolxOutputSelectionInProfiles(
+  profiles: HardhatConfig["solidity"]["profiles"],
+): Promise<HardhatConfig["solidity"]["profiles"]> {
+  const result: Record<string, (typeof profiles)[string]> = {};
+  for (const [profileName, profile] of Object.entries(profiles)) {
+    const augmentedCompilers = await Promise.all(
+      profile.compilers.map((compiler) => augmentIfSolx(compiler)),
+    );
+    const augmentedOverrides: Record<
+      string,
+      (typeof profile.overrides)[string]
+    > = {};
+    for (const [overrideKey, override] of Object.entries(profile.overrides)) {
+      augmentedOverrides[overrideKey] = await augmentIfSolx(override);
+    }
+    result[profileName] = {
+      ...profile,
+      compilers: augmentedCompilers,
+      overrides: augmentedOverrides,
+    };
+  }
+  return result;
+}
+
+// SolidityCompilerConfig.settings is typed `any` upstream (see hardhat's
+// `CommonSolidityCompilerConfig`), so we use the same here — narrowing
+// would require type assertions that the repo's eslint config forbids.
+async function augmentIfSolx<
+  T extends { type?: string; settings?: Record<string, unknown> },
+>(entry: T): Promise<T> {
+  if (entry.type !== SOLX_COMPILER_TYPE) {
+    return entry;
+  }
+  const settings = isObject(entry.settings) ? entry.settings : {};
+  return {
+    ...entry,
+    settings: {
+      ...settings,
+      outputSelection: await addSolxDebugInfoSelectors(
+        entry.settings?.outputSelection,
+      ),
+    },
   };
 }
 

--- a/packages/hardhat-solx/src/internal/platform.ts
+++ b/packages/hardhat-solx/src/internal/platform.ts
@@ -6,11 +6,11 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
  * Returns the platform-specific base name for the solx binary (without version suffix).
  * The full asset name is `${baseName}-v${version}` (or `.exe` on Windows).
  *
- * Actual GitHub release assets (e.g., for v0.1.3):
- *   solx-linux-amd64-gnu-v0.1.3
- *   solx-linux-arm64-gnu-v0.1.3
- *   solx-macosx-v0.1.3           (universal binary)
- *   solx-windows-amd64-gnu-v0.1.3.exe
+ * Actual GitHub release assets (e.g., for v0.1.4):
+ *   solx-linux-amd64-gnu-v0.1.4
+ *   solx-linux-arm64-gnu-v0.1.4
+ *   solx-macosx-v0.1.4           (universal binary)
+ *   solx-windows-amd64-gnu-v0.1.4.exe
  */
 export function getSolxBinaryBaseName(): string {
   const platform = os.platform();

--- a/packages/hardhat-solx/src/internal/solx-compiler.ts
+++ b/packages/hardhat-solx/src/internal/solx-compiler.ts
@@ -7,7 +7,7 @@ import type {
 import { deepClone } from "@nomicfoundation/hardhat-utils/lang";
 import { spawnCompile as defaultSpawnCompile } from "hardhat/internal/solidity";
 
-/** solx 0.1.4+ source-mapping selectors (DWARF in `debugInfo`). */
+// Selectors for enabling DWARF `debugInfo` output
 export const SOLX_DEBUG_INFO_SELECTORS: readonly string[] = [
   "evm.bytecode.debugInfo",
   "evm.deployedBytecode.debugInfo",
@@ -38,8 +38,8 @@ export class SolxCompiler implements Compiler {
   public async compile(input: CompilerInput): Promise<CompilerOutput> {
     const args = ["--standard-json", "--no-import-callback"];
 
-    // outputSelection already includes solx selectors (baked in by resolveUserConfig).
-    // Merge extra solx settings on top.
+    // Merge default solx settings with user settings. User settings take
+    // precedence, allowing overrides of viaIR, LLVMOptimization, etc.
     const modifiedInput: CompilerInput = {
       ...input,
       settings: {

--- a/packages/hardhat-solx/src/internal/solx-compiler.ts
+++ b/packages/hardhat-solx/src/internal/solx-compiler.ts
@@ -4,7 +4,14 @@ import type {
   CompilerOutput,
 } from "hardhat/types/solidity";
 
+import { deepClone } from "@nomicfoundation/hardhat-utils/lang";
 import { spawnCompile as defaultSpawnCompile } from "hardhat/internal/solidity";
+
+/** solx 0.1.4+ source-mapping selectors (DWARF in `debugInfo`). */
+export const SOLX_DEBUG_INFO_SELECTORS: readonly string[] = [
+  "evm.bytecode.debugInfo",
+  "evm.deployedBytecode.debugInfo",
+] as const;
 
 export class SolxCompiler implements Compiler {
   public readonly version: string;
@@ -31,8 +38,8 @@ export class SolxCompiler implements Compiler {
   public async compile(input: CompilerInput): Promise<CompilerOutput> {
     const args = ["--standard-json", "--no-import-callback"];
 
-    // Merge default solx settings with user settings. User settings take
-    // precedence, allowing overrides of viaIR, LLVMOptimization, etc.
+    // outputSelection already includes solx selectors (baked in by resolveUserConfig).
+    // Merge extra solx settings on top.
     const modifiedInput: CompilerInput = {
       ...input,
       settings: {
@@ -43,4 +50,33 @@ export class SolxCompiler implements Compiler {
 
     return await this.#spawnCompile(this.compilerPath, args, modifiedInput);
   }
+}
+
+/**
+ * Returns a new outputSelection with the solx debugInfo selectors at
+ * `["*"]["*"]`. Existing user selectors are preserved; downstream
+ * `#dedupeAndSortOutputSelection` removes duplicates.
+ */
+export async function addSolxDebugInfoSelectors(
+  outputSelection: unknown,
+): Promise<NonNullable<CompilerInput["settings"]>["outputSelection"]> {
+  const seed: Record<
+    string,
+    Record<string, string[]>
+  > = typeof outputSelection === "object" && outputSelection !== null
+    ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- known shape
+      (outputSelection as Record<string, Record<string, string[]>>)
+    : {};
+  const cloned: Record<string, Record<string, string[]>> = await deepClone(
+    seed,
+  );
+
+  // Hardhat normalizes outputSelection to populate `["*"]["*"]` upstream, but
+  // unit tests construct the input directly with `{}`, so make sure the slot
+  // exists before we push.
+  cloned["*"] ??= {};
+  cloned["*"]["*"] ??= [];
+  cloned["*"]["*"].push(...SOLX_DEBUG_INFO_SELECTORS);
+
+  return cloned;
 }

--- a/packages/hardhat-solx/src/type-extensions.ts
+++ b/packages/hardhat-solx/src/type-extensions.ts
@@ -1,3 +1,16 @@
+declare module "hardhat/types/solidity" {
+  /**
+   * solx 0.1.4+ leaves `evm.{deployed,}Bytecode.sourceMap` empty and emits
+   * source-mapping information as a hex-encoded ELF/DWARF blob in
+   * `evm.{deployed,}Bytecode.debugInfo` instead. The plugin opts the user's
+   * `outputSelection` into producing this field on every solx compile, so
+   * declare it here to reflect that contract.
+   */
+  interface CompilerOutputBytecode {
+    debugInfo?: string;
+  }
+}
+
 declare module "hardhat/types/config" {
   export interface SolidityCompilerTypeDefinitions {
     solx: true;

--- a/packages/hardhat-solx/test/config.ts
+++ b/packages/hardhat-solx/test/config.ts
@@ -7,6 +7,7 @@ import {
   validateResolvedConfig,
   validateUserConfig,
 } from "../src/internal/hook-handlers/config.js";
+import { SOLX_DEBUG_INFO_SELECTORS } from "../src/internal/solx-compiler.js";
 
 describe("hardhat-solx plugin config validation", () => {
   it("accepts valid config with dangerouslyAllowSolxInProduction", async () => {
@@ -67,7 +68,7 @@ describe("hardhat-solx plugin config resolution", () => {
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", settings: {} }],
+          compilers: [{ version: "0.8.34", settings: {} }],
           overrides: {},
         },
       }),
@@ -84,7 +85,7 @@ describe("hardhat-solx plugin config resolution", () => {
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", settings: {} }],
+          compilers: [{ version: "0.8.34", settings: {} }],
           overrides: {},
         },
       }),
@@ -101,7 +102,7 @@ describe("hardhat-solx plugin config resolution", () => {
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", settings: {} }],
+          compilers: [{ version: "0.8.34", settings: {} }],
           overrides: {},
         },
       }),
@@ -121,7 +122,7 @@ describe("hardhat-solx plugin config resolution", () => {
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", settings: {} }],
+          compilers: [{ version: "0.8.34", settings: {} }],
           overrides: {},
         },
       }),
@@ -129,6 +130,106 @@ describe("hardhat-solx plugin config resolution", () => {
 
     const profileNames = Object.keys(resolvedConfig.solidity.profiles);
     assert.deepEqual(profileNames, ["default"]);
+  });
+
+  it("adds solx debugInfo selectors to solx-typed compilers in resolved config", async () => {
+    const resolvedConfig = await resolveUserConfig(
+      {},
+      undefined as any,
+      makeNext({
+        solx: {
+          isolated: false,
+          preferWasm: false,
+          compilers: [
+            {
+              version: "0.8.34",
+              type: "solx",
+              settings: { outputSelection: { "*": { "*": ["abi"] } } },
+            },
+          ],
+          overrides: {},
+        },
+      }),
+    );
+
+    const solxCompiler = resolvedConfig.solidity.profiles.solx.compilers[0];
+    const wildcardSelectors = solxCompiler.settings.outputSelection["*"][
+      "*"
+    ] as string[];
+    for (const selector of SOLX_DEBUG_INFO_SELECTORS) {
+      assert.ok(
+        wildcardSelectors.includes(selector),
+        `expected resolved solx compiler config to include "${selector}", got: ${wildcardSelectors.join(", ")}`,
+      );
+    }
+    assert.ok(
+      wildcardSelectors.includes("abi"),
+      "user-provided selectors must be preserved alongside the augmentation",
+    );
+  });
+
+  it("does NOT add solx selectors to non-solx compilers", async () => {
+    const resolvedConfig = await resolveUserConfig(
+      {},
+      undefined as any,
+      makeNext({
+        default: {
+          isolated: false,
+          preferWasm: false,
+          compilers: [
+            {
+              version: "0.8.34",
+              settings: { outputSelection: { "*": { "*": ["abi"] } } },
+            },
+          ],
+          overrides: {},
+        },
+      }),
+    );
+
+    const solcCompiler = resolvedConfig.solidity.profiles.default.compilers[0];
+    const wildcardSelectors = solcCompiler.settings.outputSelection["*"][
+      "*"
+    ] as string[];
+    for (const selector of SOLX_DEBUG_INFO_SELECTORS) {
+      assert.ok(
+        !wildcardSelectors.includes(selector),
+        `solc-typed compiler must NOT receive solx selector "${selector}"; got: ${wildcardSelectors.join(", ")}`,
+      );
+    }
+  });
+
+  it("augments solx-typed override entries too", async () => {
+    const resolvedConfig = await resolveUserConfig(
+      {},
+      undefined as any,
+      makeNext({
+        solx: {
+          isolated: false,
+          preferWasm: false,
+          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+          overrides: {
+            "contracts/Special.sol": {
+              version: "0.8.34",
+              type: "solx",
+              settings: {},
+            },
+          },
+        },
+      }),
+    );
+
+    const override =
+      resolvedConfig.solidity.profiles.solx.overrides["contracts/Special.sol"];
+    const wildcardSelectors = override.settings.outputSelection["*"][
+      "*"
+    ] as string[];
+    for (const selector of SOLX_DEBUG_INFO_SELECTORS) {
+      assert.ok(
+        wildcardSelectors.includes(selector),
+        `expected solx override to include "${selector}", got: ${wildcardSelectors.join(", ")}`,
+      );
+    }
   });
 });
 
@@ -140,7 +241,7 @@ describe("hardhat-solx EVM version validation", () => {
           solx: {
             compilers: [
               {
-                version: "0.8.33",
+                version: "0.8.34",
                 type: "solx",
                 settings: { evmVersion: "paris" },
               },
@@ -163,7 +264,7 @@ describe("hardhat-solx EVM version validation", () => {
           solx: {
             compilers: [
               {
-                version: "0.8.33",
+                version: "0.8.34",
                 type: "solx",
                 settings: { evmVersion: "shanghai" },
               },
@@ -182,7 +283,7 @@ describe("hardhat-solx EVM version validation", () => {
           solx: {
             compilers: [
               {
-                version: "0.8.33",
+                version: "0.8.34",
                 type: "solx",
                 settings: { evmVersion: "cancun" },
               },
@@ -201,7 +302,7 @@ describe("hardhat-solx EVM version validation", () => {
           solx: {
             compilers: [
               {
-                version: "0.8.33",
+                version: "0.8.34",
                 type: "solx",
                 settings: { evmVersion: "prague" },
               },
@@ -220,7 +321,7 @@ describe("hardhat-solx EVM version validation", () => {
           solx: {
             compilers: [
               {
-                version: "0.8.33",
+                version: "0.8.34",
                 type: "solx",
                 settings: { evmVersion: "osaka" },
               },
@@ -237,7 +338,7 @@ describe("hardhat-solx EVM version validation", () => {
       solidity: {
         profiles: {
           solx: {
-            compilers: [{ version: "0.8.33", type: "solx" }],
+            compilers: [{ version: "0.8.34", type: "solx" }],
           },
         },
       },
@@ -252,7 +353,7 @@ describe("hardhat-solx EVM version validation", () => {
           solx: {
             compilers: [
               {
-                version: "0.8.33",
+                version: "0.8.34",
                 settings: { evmVersion: "paris" },
               },
             ],
@@ -269,10 +370,10 @@ describe("hardhat-solx EVM version validation", () => {
       solidity: {
         profiles: {
           solx: {
-            compilers: [{ version: "0.8.33" }],
+            compilers: [{ version: "0.8.34" }],
             overrides: {
               "contracts/Old.sol": {
-                version: "0.8.33",
+                version: "0.8.34",
                 type: "solx",
                 settings: { evmVersion: "london" },
               },
@@ -306,12 +407,12 @@ describe("hardhat-solx Solidity version validation", () => {
     );
   });
 
-  it("accepts type: 'solx' with supported Solidity version 0.8.33", async () => {
+  it("accepts type: 'solx' with supported Solidity version 0.8.34", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
           solx: {
-            compilers: [{ version: "0.8.33", type: "solx" }],
+            compilers: [{ version: "0.8.34", type: "solx" }],
           },
         },
       },
@@ -328,7 +429,7 @@ describe("hardhat-solx Solidity version validation", () => {
         profiles: {
           solx: {
             compilers: [
-              { version: "0.8.33", type: "solx", path: "/tmp/solx-custom" },
+              { version: "0.8.34", type: "solx", path: "/tmp/solx-custom" },
             ],
           },
         },
@@ -402,7 +503,7 @@ describe("hardhat-solx resolved config validation", () => {
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", settings: {} }],
+          compilers: [{ version: "0.8.34", settings: {} }],
           overrides: {},
         },
       }),
@@ -420,13 +521,13 @@ describe("hardhat-solx resolved config validation", () => {
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", settings: {} }],
+          compilers: [{ version: "0.8.34", settings: {} }],
           overrides: {},
         },
         solx: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", type: "solx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
           overrides: {},
         },
       }),
@@ -440,13 +541,13 @@ describe("hardhat-solx resolved config validation", () => {
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", type: "solx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
           overrides: {},
         },
         solx: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", type: "solx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
           overrides: {},
         },
       }),
@@ -469,15 +570,15 @@ describe("hardhat-solx resolved config validation", () => {
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", settings: {} }],
+          compilers: [{ version: "0.8.34", settings: {} }],
           overrides: {
-            "MyContract.sol": { version: "0.8.33", type: "solx", settings: {} },
+            "MyContract.sol": { version: "0.8.34", type: "solx", settings: {} },
           },
         },
         solx: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", type: "solx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
           overrides: {},
         },
       }),
@@ -501,13 +602,13 @@ describe("hardhat-solx resolved config validation", () => {
           default: {
             isolated: false,
             preferWasm: false,
-            compilers: [{ version: "0.8.33", type: "solx", settings: {} }],
+            compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
             overrides: {},
           },
           solx: {
             isolated: false,
             preferWasm: false,
-            compilers: [{ version: "0.8.33", type: "solx", settings: {} }],
+            compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
             overrides: {},
           },
         },
@@ -523,13 +624,13 @@ describe("hardhat-solx resolved config validation", () => {
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", settings: {} }],
+          compilers: [{ version: "0.8.34", settings: {} }],
           overrides: {},
         },
         solx: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.33", type: "solx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
           overrides: {},
         },
       }),
@@ -544,7 +645,7 @@ describe("hardhat-solx resolved config validation", () => {
           default: {
             isolated: false,
             preferWasm: false,
-            compilers: [{ version: "0.8.33", type: "solx", settings: {} }],
+            compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
             overrides: {},
           },
         },

--- a/packages/hardhat-solx/test/fixture-projects/simple/hardhat.config.ts
+++ b/packages/hardhat-solx/test/fixture-projects/simple/hardhat.config.ts
@@ -6,11 +6,11 @@ const config: HardhatUserConfig = {
   solidity: {
     profiles: {
       default: {
-        version: "0.8.33",
+        version: "0.8.34",
       },
       solx: {
         type: "solx",
-        version: "0.8.33",
+        version: "0.8.34",
       },
     },
   },

--- a/packages/hardhat-solx/test/fixture-projects/with-debug-info/.gitignore
+++ b/packages/hardhat-solx/test/fixture-projects/with-debug-info/.gitignore
@@ -1,0 +1,2 @@
+artifacts/
+cache/

--- a/packages/hardhat-solx/test/fixture-projects/with-debug-info/contracts/ConstructorRevert.sol
+++ b/packages/hardhat-solx/test/fixture-projects/with-debug-info/contracts/ConstructorRevert.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+// CREATE-time revert via internal helper. Exercises solx DWARF for the
+// CREATE bytecode (evm.bytecode.debugInfo).
+contract ConstructorRevert {
+    function _check(uint256 v) internal pure {
+        require(v > 0, "constructor helper boom");
+    }
+
+    constructor(uint256 v) {
+        _check(v);
+    }
+}

--- a/packages/hardhat-solx/test/fixture-projects/with-debug-info/contracts/Counter.sol
+++ b/packages/hardhat-solx/test/fixture-projects/with-debug-info/contracts/Counter.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+contract Counter {
+    uint256 public count;
+
+    function set(uint256 v) public {
+        _checkPositive(v);
+        count = v;
+    }
+
+    function _checkPositive(uint256 v) internal pure {
+        require(v > 0, "must be positive");
+    }
+}

--- a/packages/hardhat-solx/test/fixture-projects/with-debug-info/contracts/InlineAsm.sol
+++ b/packages/hardhat-solx/test/fixture-projects/with-debug-info/contracts/InlineAsm.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.34;
+
+// Inline-assembly revert. Sparser DWARF (no per-opcode rows for assembly).
+contract InlineAsm {
+    function boom() external pure {
+        assembly {
+            mstore(0x00, 0x08c379a000000000000000000000000000000000000000000000000000000000)
+            mstore(0x04, 0x20)
+            mstore(0x24, 0x04)
+            mstore(0x44, 0x61736d00000000000000000000000000000000000000000000000000000000)
+            revert(0x00, 0x64)
+        }
+    }
+}

--- a/packages/hardhat-solx/test/fixture-projects/with-debug-info/hardhat.config.ts
+++ b/packages/hardhat-solx/test/fixture-projects/with-debug-info/hardhat.config.ts
@@ -1,0 +1,20 @@
+import type { HardhatUserConfig } from "hardhat/config";
+
+import HardhatSolxPlugin from "../../../src/index.js";
+
+const config: HardhatUserConfig = {
+  solidity: {
+    profiles: {
+      default: {
+        version: "0.8.34",
+      },
+      solx: {
+        type: "solx",
+        version: "0.8.34",
+      },
+    },
+  },
+  plugins: [HardhatSolxPlugin],
+};
+
+export default config;

--- a/packages/hardhat-solx/test/fixture-projects/with-debug-info/package.json
+++ b/packages/hardhat-solx/test/fixture-projects/with-debug-info/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "hardhat-solx-with-debug-info-fixture",
+  "private": true,
+  "type": "module",
+  "version": "0.0.1"
+}

--- a/packages/hardhat-solx/test/hook-handlers/solidity.ts
+++ b/packages/hardhat-solx/test/hook-handlers/solidity.ts
@@ -15,7 +15,7 @@ function createSolidityCompilerConfig(
   overrides: Partial<SolidityCompilerConfig> = {},
 ): SolidityCompilerConfig {
   return {
-    version: "0.8.33",
+    version: "0.8.34",
     settings: {
       optimizer: {},
       outputSelection: {},
@@ -28,8 +28,8 @@ function createSolidityCompilerConfig(
 function createGetCompilerMockNext() {
   let called = false;
   const mockCompiler = {
-    version: "0.8.33",
-    longVersion: "0.8.33+commit.abc123",
+    version: "0.8.34",
+    longVersion: "0.8.34+commit.abc123",
     compilerPath: "/path/to/solc",
     isSolcJs: false,
     compile: async (_input: CompilerInput): Promise<CompilerOutput> => ({
@@ -129,7 +129,7 @@ describe("hardhat-solx solidity hook handler", () => {
       const context = { config: {} } as any;
 
       const configs: SolidityCompilerConfig[] = [
-        createSolidityCompilerConfig({ type: "solx", version: "0.8.33" }),
+        createSolidityCompilerConfig({ type: "solx", version: "0.8.34" }),
       ];
 
       // This will fail to download (no network in tests), but we can
@@ -239,7 +239,7 @@ describe("hardhat-solx solidity hook handler", () => {
       const context = { config: {} } as any;
       const compilerConfig = createSolidityCompilerConfig({
         type: "solx",
-        version: "0.8.33",
+        version: "0.8.34",
         path: "/nonexistent/path/to/solx",
       });
       const mockNext = createGetCompilerMockNext();
@@ -260,7 +260,7 @@ describe("hardhat-solx solidity hook handler", () => {
       const { exists } = await import("@nomicfoundation/hardhat-utils/fs");
 
       // Use the cached solx binary if available, skip otherwise
-      const cachedPath = await getSolxBinaryPath("0.1.3");
+      const cachedPath = await getSolxBinaryPath("0.1.4");
       if (!(await exists(cachedPath))) {
         return;
       }
@@ -273,7 +273,7 @@ describe("hardhat-solx solidity hook handler", () => {
       const context = { config: {} } as any;
       const compilerConfig = createSolidityCompilerConfig({
         type: "solx",
-        version: "0.8.33",
+        version: "0.8.34",
         path: cachedPath,
       });
       const mockNext = createGetCompilerMockNext();
@@ -290,8 +290,8 @@ describe("hardhat-solx solidity hook handler", () => {
       );
       assert.equal(compiler.compilerPath, cachedPath);
       // Version should be parsed from the binary, not from config
-      assert.equal(compiler.version, "0.1.3");
-      assert.equal(compiler.longVersion, "0.1.3+solx");
+      assert.equal(compiler.version, "0.1.4");
+      assert.equal(compiler.longVersion, "0.1.4+solx");
     });
   });
 
@@ -307,7 +307,7 @@ describe("hardhat-solx solidity hook handler", () => {
       const configs: SolidityCompilerConfig[] = [
         createSolidityCompilerConfig({
           type: "solx",
-          version: "0.8.33",
+          version: "0.8.34",
           path: "/custom/path/to/solx",
         }),
       ];

--- a/packages/hardhat-solx/test/integration.ts
+++ b/packages/hardhat-solx/test/integration.ts
@@ -27,11 +27,11 @@ describe("hardhat-solx integration", () => {
       solidity: {
         profiles: {
           default: {
-            version: "0.8.33",
+            version: "0.8.34",
           },
           solx: {
             type: "solx",
-            version: "0.8.33",
+            version: "0.8.34",
           },
         },
       },

--- a/packages/hardhat-solx/test/output-augmentation.ts
+++ b/packages/hardhat-solx/test/output-augmentation.ts
@@ -17,10 +17,6 @@ import {
 // Side-effect-import the type augmentation for `debugInfo`.
 import "../src/type-extensions.js";
 
-// Compiles small contracts with solx (downloads binary on first run) and
-// asserts evm.{deployed,}Bytecode.debugInfo is populated. Gated behind
-// HARDHAT_DISABLE_SLOW_TESTS to mirror other compile-heavy tests.
-
 // `\x7fELF` magic hex-encoded — solx debugInfo is a hex-encoded ELF blob.
 const ELF_MAGIC_HEX = "7f454c46";
 

--- a/packages/hardhat-solx/test/output-augmentation.ts
+++ b/packages/hardhat-solx/test/output-augmentation.ts
@@ -1,0 +1,150 @@
+import type {
+  CompilationJob,
+  CompilerOutputContract,
+} from "hardhat/types/solidity";
+
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { useFixtureProject } from "@nomicfoundation/hardhat-test-utils";
+import {
+  createHardhatRuntimeEnvironment,
+  importUserConfig,
+  resolveHardhatConfigPath,
+} from "hardhat/hre";
+
+// Side-effect-import the type augmentation for `debugInfo`.
+import "../src/type-extensions.js";
+
+// Compiles small contracts with solx (downloads binary on first run) and
+// asserts evm.{deployed,}Bytecode.debugInfo is populated. Gated behind
+// HARDHAT_DISABLE_SLOW_TESTS to mirror other compile-heavy tests.
+
+// `\x7fELF` magic hex-encoded — solx debugInfo is a hex-encoded ELF blob.
+const ELF_MAGIC_HEX = "7f454c46";
+
+describe(
+  "hardhat-solx output augmentation",
+  { skip: process.env.HARDHAT_DISABLE_SLOW_TESTS === "true" },
+  () => {
+    useFixtureProject("with-debug-info");
+
+    async function createHre() {
+      const configPath = await resolveHardhatConfigPath();
+      const userConfig = await importUserConfig(configPath);
+      return await createHardhatRuntimeEnvironment(userConfig);
+    }
+
+    // Each fixture exercises a different bytecode shape: Counter (runtime),
+    // ConstructorRevert (CREATE), InlineAsm (assembly).
+    const FIXTURES: ReadonlyArray<{ source: string; contract: string }> = [
+      { source: "Counter.sol", contract: "Counter" },
+      { source: "ConstructorRevert.sol", contract: "ConstructorRevert" },
+      { source: "InlineAsm.sol", contract: "InlineAsm" },
+    ];
+
+    it("solx-compiled artifacts carry evm.bytecode.debugInfo and evm.deployedBytecode.debugInfo", async () => {
+      const hre = await createHre();
+
+      const rootFilePaths = await hre.solidity.getRootFilePaths({
+        scope: "contracts",
+      });
+      const fixturePaths = FIXTURES.map(({ source }) => {
+        const found = rootFilePaths.find((p) => path.basename(p) === source);
+        assert.ok(
+          found !== undefined,
+          `${source} should be a build root, got: ${rootFilePaths.join(", ")}`,
+        );
+        return found;
+      });
+
+      const jobsResult = await hre.solidity.getCompilationJobs(fixturePaths, {
+        force: true,
+        quiet: true,
+        buildProfile: "solx",
+      });
+      assert.ok(
+        jobsResult.success,
+        "getCompilationJobs should succeed for the solx profile",
+      );
+
+      // The fixtures are independent (no shared imports) so they can land in
+      // separate jobs; run each one and merge outputs by source path.
+      const seenJobs = new Set<CompilationJob>();
+      const mergedContracts: Record<
+        string,
+        Record<string, CompilerOutputContract>
+      > = {};
+      const mergedErrors: Array<{ severity: string; message: string }> = [];
+      for (const job of jobsResult.compilationJobsPerFile.values()) {
+        if (seenJobs.has(job)) continue;
+        seenJobs.add(job);
+        const { output } = await hre.solidity.runCompilationJob(job, {
+          quiet: true,
+          buildProfile: "solx",
+        });
+        for (const e of output.errors ?? []) {
+          mergedErrors.push(e);
+        }
+        for (const [src, contracts] of Object.entries(output.contracts ?? {})) {
+          mergedContracts[src] = {
+            ...(mergedContracts[src] ?? {}),
+            ...contracts,
+          };
+        }
+      }
+
+      const errors = mergedErrors.filter((e) => e.severity === "error");
+      assert.equal(
+        errors.length,
+        0,
+        `solx compilation produced errors: ${errors.map((e) => e.message).join(", ")}`,
+      );
+
+      for (const { source, contract } of FIXTURES) {
+        const sourcePath = `project/contracts/${source}`;
+        const compiled = mergedContracts[sourcePath]?.[contract];
+        assert.ok(
+          compiled !== undefined,
+          `${contract} not found at ${sourcePath}. Sources: ${Object.keys(mergedContracts).join(", ")}`,
+        );
+
+        const evm = compiled.evm;
+        assert.ok(evm !== undefined, `${contract}: expected evm in output`);
+
+        const { bytecode, deployedBytecode } = evm;
+        assert.ok(bytecode !== undefined, `${contract}: expected evm.bytecode`);
+        assert.ok(
+          deployedBytecode !== undefined,
+          `${contract}: expected evm.deployedBytecode`,
+        );
+
+        const { debugInfo: creationDebugInfo } = bytecode;
+        const { debugInfo: runtimeDebugInfo } = deployedBytecode;
+
+        // Core assertion: the plugin must add debugInfo to outputSelection so
+        // EDR can render solx-aware stack traces. solc artifacts wouldn't
+        // carry this field at all; solx artifacts must.
+        assert.ok(
+          creationDebugInfo !== undefined && creationDebugInfo.length > 0,
+          `${contract}: expected evm.bytecode.debugInfo to be a non-empty hex string`,
+        );
+        assert.ok(
+          runtimeDebugInfo !== undefined && runtimeDebugInfo.length > 0,
+          `${contract}: expected evm.deployedBytecode.debugInfo to be a non-empty hex string`,
+        );
+
+        // Sanity-check the blobs are hex-encoded ELFs (EDR's wire format).
+        assert.ok(
+          creationDebugInfo.toLowerCase().startsWith(ELF_MAGIC_HEX),
+          `${contract}: evm.bytecode.debugInfo should start with the ELF magic bytes (${ELF_MAGIC_HEX})`,
+        );
+        assert.ok(
+          runtimeDebugInfo.toLowerCase().startsWith(ELF_MAGIC_HEX),
+          `${contract}: evm.deployedBytecode.debugInfo should start with the ELF magic bytes (${ELF_MAGIC_HEX})`,
+        );
+      }
+    });
+  },
+);

--- a/packages/hardhat-solx/test/platform.ts
+++ b/packages/hardhat-solx/test/platform.ts
@@ -34,9 +34,9 @@ describe("hardhat-solx platform detection", () => {
   });
 
   it("asset name includes version suffix", () => {
-    const assetName = getSolxAssetName("0.1.3");
+    const assetName = getSolxAssetName("0.1.4");
     assert.ok(
-      assetName.includes("-v0.1.3"),
+      assetName.includes("-v0.1.4"),
       `asset name should include version suffix: ${assetName}`,
     );
     assert.ok(

--- a/packages/hardhat-solx/test/solx-compiler.ts
+++ b/packages/hardhat-solx/test/solx-compiler.ts
@@ -3,7 +3,11 @@ import type { CompilerInput, CompilerOutput } from "hardhat/types/solidity";
 import assert from "node:assert/strict";
 import { beforeEach, describe, it } from "node:test";
 
-import { SolxCompiler } from "../src/internal/solx-compiler.js";
+import {
+  SOLX_DEBUG_INFO_SELECTORS,
+  SolxCompiler,
+  addSolxDebugInfoSelectors,
+} from "../src/internal/solx-compiler.js";
 
 // Track calls to the fake spawnCompile
 let spawnCompileCalls: Array<{
@@ -28,17 +32,17 @@ describe("SolxCompiler", () => {
   });
 
   it("implements the Compiler interface", async () => {
-    const compiler = new SolxCompiler("0.1.3", "/path/to/solx");
+    const compiler = new SolxCompiler("0.1.4", "/path/to/solx");
 
-    assert.equal(compiler.version, "0.1.3");
-    assert.equal(compiler.longVersion, "0.1.3+solx");
+    assert.equal(compiler.version, "0.1.4");
+    assert.equal(compiler.longVersion, "0.1.4+solx");
     assert.equal(compiler.compilerPath, "/path/to/solx");
     assert.equal(compiler.isSolcJs, false);
   });
 
   it("calls spawnCompile with correct binary path and args", async () => {
     const compiler = new SolxCompiler(
-      "0.1.3",
+      "0.1.4",
       "/path/to/solx",
       {},
       fakeSpawnCompile,
@@ -59,7 +63,7 @@ describe("SolxCompiler", () => {
 
   it("merges extraSettings into input.settings", async () => {
     const compiler = new SolxCompiler(
-      "0.1.3",
+      "0.1.4",
       "/path/to/solx",
       { LLVMOptimization: "1" },
       fakeSpawnCompile,
@@ -76,6 +80,10 @@ describe("SolxCompiler", () => {
     await compiler.compile(input);
 
     assert.equal(spawnCompileCalls.length, 1);
+    // The outputSelection passes through unchanged: the plugin's
+    // `resolveUserConfig` hook is what adds the solx-specific debugInfo
+    // selectors, so by the time `SolxCompiler.compile` runs they're
+    // already present on whatever the build system constructed.
     assert.deepEqual(spawnCompileCalls[0].input.settings, {
       optimizer: { enabled: true },
       outputSelection: { "*": { "*": ["abi"] } },
@@ -85,7 +93,7 @@ describe("SolxCompiler", () => {
 
   it("does not modify the original input object", async () => {
     const compiler = new SolxCompiler(
-      "0.1.3",
+      "0.1.4",
       "/path/to/solx",
       { LLVMOptimization: "1" },
       fakeSpawnCompile,
@@ -108,7 +116,7 @@ describe("SolxCompiler", () => {
 
   it("returns the output from spawnCompile", async () => {
     const compiler = new SolxCompiler(
-      "0.1.3",
+      "0.1.4",
       "/path/to/solx",
       {},
       fakeSpawnCompile,
@@ -121,5 +129,47 @@ describe("SolxCompiler", () => {
 
     const result = await compiler.compile(input);
     assert.equal(result, fakeOutput);
+  });
+});
+
+describe("addSolxDebugInfoSelectors", () => {
+  it("populates the wildcard slot when the input is empty", async () => {
+    const result = await addSolxDebugInfoSelectors({});
+    assert.deepEqual(result, {
+      "*": { "*": [...SOLX_DEBUG_INFO_SELECTORS] },
+    });
+  });
+
+  it("appends to an existing wildcard selector list without removing user entries", async () => {
+    const result = await addSolxDebugInfoSelectors({
+      "*": { "*": ["abi", "metadata"] },
+    });
+    assert.deepEqual(result, {
+      "*": { "*": ["abi", "metadata", ...SOLX_DEBUG_INFO_SELECTORS] },
+    });
+  });
+
+  it('preserves the file-level `[*][""]` slot for outputs like ast', async () => {
+    const result = await addSolxDebugInfoSelectors({
+      "*": { "": ["ast"] },
+    });
+    // The file-level slot must round-trip unchanged. Selectors are added at
+    // the per-contract slot `["*"]["*"]` instead.
+    assert.ok(result !== undefined, "result should not be undefined");
+    assert.deepEqual(result["*"][""], ["ast"]);
+  });
+
+  it("does not mutate the input object", async () => {
+    const input = { "*": { "*": ["abi"] } };
+    const before = JSON.stringify(input);
+    await addSolxDebugInfoSelectors(input);
+    assert.equal(JSON.stringify(input), before);
+  });
+
+  it("accepts undefined input (sets up the wildcard slot)", async () => {
+    const result = await addSolxDebugInfoSelectors(undefined);
+    assert.deepEqual(result, {
+      "*": { "*": [...SOLX_DEBUG_INFO_SELECTORS] },
+    });
   });
 });


### PR DESCRIPTION
Adds `evm.{deployed,}Bytecode.debugInfo` output selectors to solx compiles in order to output debug info used for stack traces. 
Drops Solidity 0.8.33 / solx 0.1.3 from the supported map (predates DWARF). 

Companion EDR PR: https://github.com/NomicFoundation/edr/pull/1425