### PR TITLE
refactor(test): make tmp dirs workspace-local and unify the helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ myproject
 
 /node_modules
 /.idea
+/tmp
 *.tsbuildinfo
 
 # VS Code workspace config

--- a/packages/hardhat-test-utils/src/fs.ts
+++ b/packages/hardhat-test-utils/src/fs.ts
@@ -57,9 +57,12 @@ export async function makeWorkspaceTmpDir(nameHint: string): Promise<string> {
 /**
  * Removes a tmp directory previously created by `makeWorkspaceTmpDir`.
  *
- * Restores `process.cwd()` if it currently points inside the directory
- * (required on Windows so `rm` can unlink the tree), then logs and swallows
- * any error so a cleanup failure never fails a test.
+ * If `process.cwd()` currently points inside the directory, moves it to the
+ * directory's parent first (required on Windows so `rm` can unlink the tree).
+ * Note that this does not restore the caller's original cwd — callers that
+ * need a precise cwd restoration must do it themselves before calling.
+ *
+ * Then logs and swallows any error so a cleanup failure never fails a test.
  *
  * Low-level helper used by `createTmpDir` and `useTestProjectTemplate`.
  */

--- a/packages/hardhat-test-utils/src/fs.ts
+++ b/packages/hardhat-test-utils/src/fs.ts
@@ -12,7 +12,6 @@ import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 import {
   ensureDir,
   getRealPath,
-  mkdtemp,
   remove,
 } from "@nomicfoundation/hardhat-utils/fs";
 import { findClosestPackageRoot } from "@nomicfoundation/hardhat-utils/package";
@@ -134,42 +133,4 @@ export function createTmpDir(
   }
 
   return handle;
-}
-
-/**
- * Create a tmp directory.
- * @param nameHint - A hint to use as part of the name of the tmp directory.
- *
- * @deprecated Use {@link createTmpDir} instead. Kept for backwards
- *   compatibility during the migration; will be removed once all callers move
- *   to `createTmpDir`.
- */
-export async function getTmpDir(nameHint: string = "tmp-dir"): Promise<string> {
-  const tmpDir = await mkdtemp(`hardhat-tests-${nameHint}`);
-  return tmpDir;
-}
-
-/**
- * Creates a tmp directory before each test, and removes it after each test.
- * @param nameHint - A hint to use as part of the name of the tmp directory.
- *
- * @deprecated Use {@link createTmpDir} with scope `"test"` instead. Kept for
- *   backwards compatibility during the migration; will be removed once all
- *   callers move to `createTmpDir`.
- */
-export function useTmpDir(nameHint: string = "tmp-dir"): void {
-  let previousWorkingDir: string;
-  let tmpDir: string;
-
-  beforeEach(async function () {
-    previousWorkingDir = process.cwd();
-
-    tmpDir = await getTmpDir(nameHint);
-
-    process.chdir(tmpDir);
-  });
-
-  afterEach(async function () {
-    process.chdir(previousWorkingDir);
-  });
 }

--- a/packages/hardhat-test-utils/src/fs.ts
+++ b/packages/hardhat-test-utils/src/fs.ts
@@ -29,6 +29,12 @@ async function getWorkspaceRoot(): Promise<string> {
  * tools that resolve config by walking up from `cwd` — corepack, package
  * managers, `.npmrc`, and similar — see the workspace's settings.
  *
+ * Note that the workspace's `package.json` sets `"type": "module"`, so any
+ * `.js` file written into the tmp dir is treated as ESM by default. Tests
+ * that download third-party CJS `.js` blobs into their tmp dir (e.g. solc's
+ * WASM bundle) need to plant a `package.json` with `{"type":"commonjs"}`
+ * inside their own tmp dir to opt out.
+ *
  * Low-level helper used by `createTmpDir` and `useTestProjectTemplate`. Most
  * tests should use `createTmpDir` instead.
  */

--- a/packages/hardhat-test-utils/src/fs.ts
+++ b/packages/hardhat-test-utils/src/fs.ts
@@ -1,3 +1,9 @@
+// IMPORTANT: this file is duplicated almost verbatim at
+// `packages/hardhat-utils/test/helpers/fs.ts` because `hardhat-test-utils`
+// depends on `hardhat-utils`, so the latter can't import from here. Any change
+// to `createTmpDir` / `makeWorkspaceTmpDir` / `safeRemoveTmpDir` should be
+// mirrored in that file.
+
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { after, afterEach, before, beforeEach } from "node:test";
@@ -43,6 +49,9 @@ export async function makeWorkspaceTmpDir(nameHint: string): Promise<string> {
   const tmpBase = path.join(root, "tmp");
   await ensureDir(tmpBase);
   const tmpDir = await fsPromises.mkdtemp(path.join(tmpBase, `${nameHint}-`));
+  // `mkdtemp` creates dirs with mode 0o700 (owner-only). Widen to the
+  // conventional 0o755 directory mode so other users can traverse the tree.
+  await fsPromises.chmod(tmpDir, 0o755);
   return await getRealPath(tmpDir);
 }
 

--- a/packages/hardhat-test-utils/src/fs.ts
+++ b/packages/hardhat-test-utils/src/fs.ts
@@ -1,10 +1,133 @@
-import { beforeEach, afterEach } from "node:test";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import { after, afterEach, before, beforeEach } from "node:test";
 
-import { mkdtemp } from "@nomicfoundation/hardhat-utils/fs";
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import {
+  ensureDir,
+  getRealPath,
+  mkdtemp,
+  remove,
+} from "@nomicfoundation/hardhat-utils/fs";
+import { findClosestPackageRoot } from "@nomicfoundation/hardhat-utils/package";
+
+let workspaceRootCache: string | undefined;
+
+async function getWorkspaceRoot(): Promise<string> {
+  if (workspaceRootCache === undefined) {
+    const testUtilsRoot = await findClosestPackageRoot(import.meta.url);
+    workspaceRootCache = path.resolve(testUtilsRoot, "..", "..");
+  }
+  return workspaceRootCache;
+}
+
+/**
+ * Creates a tmp directory inside `<workspace-root>/tmp/` and returns its
+ * absolute (real) path.
+ *
+ * Putting tmp dirs inside the workspace (instead of `os.tmpdir()`) means
+ * tools that resolve config by walking up from `cwd` — corepack, package
+ * managers, `.npmrc`, and similar — see the workspace's settings.
+ *
+ * Low-level helper used by `createTmpDir` and `useTestProjectTemplate`. Most
+ * tests should use `createTmpDir` instead.
+ */
+export async function makeWorkspaceTmpDir(nameHint: string): Promise<string> {
+  const root = await getWorkspaceRoot();
+  const tmpBase = path.join(root, "tmp");
+  await ensureDir(tmpBase);
+  const tmpDir = await fsPromises.mkdtemp(path.join(tmpBase, `${nameHint}-`));
+  return await getRealPath(tmpDir);
+}
+
+/**
+ * Removes a tmp directory previously created by `makeWorkspaceTmpDir`.
+ *
+ * Restores `process.cwd()` if it currently points inside the directory
+ * (required on Windows so `rm` can unlink the tree), then logs and swallows
+ * any error so a cleanup failure never fails a test.
+ *
+ * Low-level helper used by `createTmpDir` and `useTestProjectTemplate`.
+ */
+export async function safeRemoveTmpDir(tmpPath: string): Promise<void> {
+  try {
+    const cwd = process.cwd();
+    if (cwd === tmpPath || cwd.startsWith(tmpPath + path.sep)) {
+      process.chdir(path.dirname(tmpPath));
+    }
+    await remove(tmpPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`Failed to remove temporary directory ${tmpPath}: ${message}`);
+  }
+}
+
+/**
+ * Creates a tmp directory inside `<workspace-root>/tmp/`, registers the
+ * appropriate Node test-runner hooks to clean it up, and returns a handle
+ * whose `.path` getter is valid inside `it`/`before`/`after`/`beforeEach`/
+ * `afterEach` (it throws if accessed before the relevant hook has run).
+ *
+ * @param nameHint - A short string used as a prefix for the tmp directory
+ *   name. Helps when reading on-disk paths during debugging.
+ * @param scope - `"test"`: fresh dir per `it` via `beforeEach`/`afterEach`.
+ *   `"describe"`: one shared dir for the whole describe via `before`/`after`.
+ *
+ * @example
+ * ```ts
+ * describe("foo", () => {
+ *   const tmp = createTmpDir("foo", "test");
+ *   it("writes a file", async () => {
+ *     await writeUtf8File(path.join(tmp.path, "x"), "y");
+ *   });
+ * });
+ * ```
+ */
+export function createTmpDir(
+  nameHint: string,
+  scope: "test" | "describe",
+): { readonly path: string } {
+  let tmpPath: string | undefined;
+
+  const handle = {
+    get path(): string {
+      assertHardhatInvariant(
+        tmpPath !== undefined,
+        `createTmpDir("${nameHint}"): .path accessed before the dir was created. It is available inside it()/before()/after()/beforeEach()/afterEach() blocks.`,
+      );
+      return tmpPath;
+    },
+  };
+
+  const create = async () => {
+    tmpPath = await makeWorkspaceTmpDir(nameHint);
+  };
+  const cleanup = async () => {
+    if (tmpPath !== undefined) {
+      const toRemove = tmpPath;
+      tmpPath = undefined;
+      await safeRemoveTmpDir(toRemove);
+    }
+  };
+
+  if (scope === "test") {
+    beforeEach(create);
+    afterEach(cleanup);
+  } else {
+    before(create);
+    after(cleanup);
+  }
+
+  return handle;
+}
 
 /**
  * Create a tmp directory.
  * @param nameHint - A hint to use as part of the name of the tmp directory.
+ *
+ * @deprecated Use {@link createTmpDir} instead. Kept for backwards
+ *   compatibility during the migration; will be removed once all callers move
+ *   to `createTmpDir`.
  */
 export async function getTmpDir(nameHint: string = "tmp-dir"): Promise<string> {
   const tmpDir = await mkdtemp(`hardhat-tests-${nameHint}`);
@@ -14,6 +137,10 @@ export async function getTmpDir(nameHint: string = "tmp-dir"): Promise<string> {
 /**
  * Creates a tmp directory before each test, and removes it after each test.
  * @param nameHint - A hint to use as part of the name of the tmp directory.
+ *
+ * @deprecated Use {@link createTmpDir} with scope `"test"` instead. Kept for
+ *   backwards compatibility during the migration; will be removed once all
+ *   callers move to `createTmpDir`.
  */
 export function useTmpDir(nameHint: string = "tmp-dir"): void {
   let previousWorkingDir: string;

--- a/packages/hardhat-test-utils/test/fs.ts
+++ b/packages/hardhat-test-utils/test/fs.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { after, before, describe, it } from "node:test";
+
+import { findClosestPackageRoot } from "@nomicfoundation/hardhat-utils/package";
+
+import {
+  createTmpDir,
+  makeWorkspaceTmpDir,
+  safeRemoveTmpDir,
+} from "../src/fs.js";
+
+describe("fs", () => {
+  describe("makeWorkspaceTmpDir", () => {
+    let workspaceRoot: string;
+    before(async () => {
+      const pkgRoot = await findClosestPackageRoot(import.meta.url);
+      workspaceRoot = path.resolve(pkgRoot, "..", "..");
+    });
+
+    it("creates a directory inside <workspace-root>/tmp/", async () => {
+      const dir = await makeWorkspaceTmpDir("unit");
+      try {
+        assert.ok(existsSync(dir), `expected ${dir} to exist`);
+        const expectedParent = path.join(workspaceRoot, "tmp");
+        assert.equal(path.dirname(dir), expectedParent);
+        assert.match(path.basename(dir), /^unit-/);
+      } finally {
+        await safeRemoveTmpDir(dir);
+      }
+    });
+
+    it("returns distinct paths for repeated calls with the same name hint", async () => {
+      const a = await makeWorkspaceTmpDir("unit");
+      const b = await makeWorkspaceTmpDir("unit");
+      try {
+        assert.notEqual(a, b);
+      } finally {
+        await safeRemoveTmpDir(a);
+        await safeRemoveTmpDir(b);
+      }
+    });
+  });
+
+  describe("safeRemoveTmpDir", () => {
+    it("removes an existing directory", async () => {
+      const dir = await makeWorkspaceTmpDir("safe-remove");
+      assert.ok(existsSync(dir), `expected ${dir} to exist before removal`);
+
+      await safeRemoveTmpDir(dir);
+
+      assert.ok(!existsSync(dir), `expected ${dir} to be removed`);
+    });
+
+    it("does not throw when called on a non-existent path", async () => {
+      const dir = await makeWorkspaceTmpDir("safe-remove-nonexistent");
+      await safeRemoveTmpDir(dir);
+
+      await safeRemoveTmpDir(dir);
+    });
+
+    it("restores cwd before removing if cwd is inside the directory", async () => {
+      const dir = await makeWorkspaceTmpDir("safe-remove-cwd");
+      const originalCwd = process.cwd();
+
+      try {
+        process.chdir(dir);
+        assert.equal(process.cwd(), dir);
+
+        await safeRemoveTmpDir(dir);
+
+        assert.notEqual(process.cwd(), dir);
+        assert.ok(!existsSync(dir), `expected ${dir} to be removed`);
+      } finally {
+        if (process.cwd() !== originalCwd) {
+          process.chdir(originalCwd);
+        }
+      }
+    });
+  });
+
+  describe("createTmpDir", () => {
+    describe('scope "test"', () => {
+      const tmp = createTmpDir("scope-test-fresh", "test");
+      const seenPaths: string[] = [];
+
+      it("creates a dir before the first test runs", () => {
+        assert.ok(existsSync(tmp.path), `expected ${tmp.path} to exist`);
+        seenPaths.push(tmp.path);
+      });
+
+      it("creates a different dir for the second test, and removed the previous one", () => {
+        assert.ok(existsSync(tmp.path), `expected ${tmp.path} to exist`);
+        assert.ok(
+          !seenPaths.includes(tmp.path),
+          `expected a fresh path, got the previous one: ${tmp.path}`,
+        );
+        assert.ok(
+          !existsSync(seenPaths[0]),
+          `expected the previous test's dir ${seenPaths[0]} to be cleaned up`,
+        );
+        seenPaths.push(tmp.path);
+      });
+
+      after(() => {
+        for (const p of seenPaths) {
+          assert.ok(!existsSync(p), `${p} should have been cleaned up`);
+        }
+      });
+    });
+
+    describe('scope "describe"', () => {
+      let sharedPath: string;
+
+      describe("inner describe", () => {
+        const tmp = createTmpDir("scope-describe-shared", "describe");
+
+        it("creates one dir for the whole describe", () => {
+          sharedPath = tmp.path;
+          assert.ok(existsSync(sharedPath), `expected ${sharedPath} to exist`);
+        });
+
+        it("reuses the same dir across sibling tests", () => {
+          assert.equal(tmp.path, sharedPath);
+          assert.ok(
+            existsSync(sharedPath),
+            `expected ${sharedPath} to still exist`,
+          );
+        });
+      });
+
+      it("removes the shared dir after the inner describe completes", () => {
+        assert.ok(
+          !existsSync(sharedPath),
+          `expected the shared dir ${sharedPath} to be cleaned up`,
+        );
+      });
+    });
+
+    describe(".path getter", () => {
+      it("throws when accessed before the create hook has run", () => {
+        const tmp = createTmpDir("never-run", "test");
+
+        assert.throws(
+          () => tmp.path,
+          /accessed before the dir was created/,
+          ".path should refuse access before beforeEach has populated it",
+        );
+      });
+    });
+  });
+});

--- a/packages/hardhat-test-utils/test/fs.ts
+++ b/packages/hardhat-test-utils/test/fs.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { after, before, describe, it } from "node:test";
 
@@ -60,7 +60,7 @@ describe("fs", () => {
       await safeRemoveTmpDir(dir);
     });
 
-    it("restores cwd before removing if cwd is inside the directory", async () => {
+    it("moves cwd out before removing if cwd is the directory itself", async () => {
       const dir = await makeWorkspaceTmpDir("safe-remove-cwd");
       const originalCwd = process.cwd();
 
@@ -71,6 +71,30 @@ describe("fs", () => {
         await safeRemoveTmpDir(dir);
 
         assert.notEqual(process.cwd(), dir);
+        assert.ok(!existsSync(dir), `expected ${dir} to be removed`);
+      } finally {
+        if (process.cwd() !== originalCwd) {
+          process.chdir(originalCwd);
+        }
+      }
+    });
+
+    it("moves cwd out before removing if cwd is a subdirectory of the directory", async () => {
+      const dir = await makeWorkspaceTmpDir("safe-remove-cwd-subdir");
+      const subdir = path.join(dir, "nested", "deeper");
+      mkdirSync(subdir, { recursive: true });
+      const originalCwd = process.cwd();
+
+      try {
+        process.chdir(subdir);
+        assert.equal(process.cwd(), subdir);
+
+        await safeRemoveTmpDir(dir);
+
+        assert.ok(
+          !process.cwd().startsWith(dir + path.sep) && process.cwd() !== dir,
+          `expected cwd to be outside ${dir}, got ${process.cwd()}`,
+        );
         assert.ok(!existsSync(dir), `expected ${dir} to be removed`);
       } finally {
         if (process.cwd() !== originalCwd) {

--- a/packages/hardhat-utils/test/fs.ts
+++ b/packages/hardhat-utils/test/fs.ts
@@ -39,7 +39,7 @@ import {
   readdirOrEmpty,
 } from "../src/fs.js";
 
-import { useTmpDir } from "./helpers/fs.js";
+import { createTmpDir } from "./helpers/fs.js";
 
 function withUnknownDirentType(dirent: Dirent): Dirent {
   const cloned: Dirent = Object.create(dirent);
@@ -66,30 +66,30 @@ function withKnownFileDirentType(dirent: Dirent): Dirent {
 }
 
 describe("File system utils", () => {
-  const getTmpDir = useTmpDir("fs");
+  const tmp = createTmpDir("fs", "test");
 
   describe("getRealPath", () => {
     it("Should resolve symlinks", async () => {
-      const actualPath = path.join(getTmpDir(), "mixedCasingFile");
+      const actualPath = path.join(tmp.path, "mixedCasingFile");
       await createFile(actualPath);
 
-      const linkPath = path.join(getTmpDir(), "link");
+      const linkPath = path.join(tmp.path, "link");
       await fsPromises.symlink(actualPath, linkPath);
 
       assert.equal(await getRealPath(linkPath), actualPath);
     });
 
     it("Should normalize the path", async () => {
-      const actualPath = path.join(getTmpDir(), "file");
+      const actualPath = path.join(tmp.path, "file");
       await createFile(actualPath);
 
-      const filePath = path.join(getTmpDir(), "a", "..", ".", "", "file");
+      const filePath = path.join(tmp.path, "a", "..", ".", "", "file");
 
       assert.equal(await getRealPath(filePath), actualPath);
     });
 
     it("Should throw FileNotFoundError if not found", async () => {
-      const actualPath = path.join(getTmpDir(), "not-exists");
+      const actualPath = path.join(tmp.path, "not-exists");
 
       await assert.rejects(getRealPath(actualPath), {
         name: "FileNotFoundError",
@@ -98,7 +98,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileSystemAccessError if a different error is thrown", async () => {
-      const linkPath = path.join(getTmpDir(), "link");
+      const linkPath = path.join(tmp.path, "link");
       await fsPromises.symlink(linkPath, linkPath);
 
       await assert.rejects(getRealPath(linkPath), {
@@ -109,40 +109,40 @@ describe("File system utils", () => {
 
   describe("getAllFilesMatching", () => {
     beforeEach(async () => {
-      await mkdir(path.join(getTmpDir(), "dir-empty"));
-      await mkdir(path.join(getTmpDir(), "dir-with-files", "dir-within-dir"));
-      await mkdir(path.join(getTmpDir(), "dir-with-extension.txt"));
-      await mkdir(path.join(getTmpDir(), "dir-WithCasing"));
+      await mkdir(path.join(tmp.path, "dir-empty"));
+      await mkdir(path.join(tmp.path, "dir-with-files", "dir-within-dir"));
+      await mkdir(path.join(tmp.path, "dir-with-extension.txt"));
+      await mkdir(path.join(tmp.path, "dir-WithCasing"));
 
       // root files
-      await createFile(path.join(getTmpDir(), "file-1.txt"));
-      await createFile(path.join(getTmpDir(), "file-2.txt"));
-      await createFile(path.join(getTmpDir(), "file-3.json"));
+      await createFile(path.join(tmp.path, "file-1.txt"));
+      await createFile(path.join(tmp.path, "file-2.txt"));
+      await createFile(path.join(tmp.path, "file-3.json"));
 
       // dir-with-files files
       await createFile(
-        path.join(getTmpDir(), "dir-with-files", "inner-file-1.json"),
+        path.join(tmp.path, "dir-with-files", "inner-file-1.json"),
       );
       await createFile(
-        path.join(getTmpDir(), "dir-with-files", "inner-file-2.txt"),
+        path.join(tmp.path, "dir-with-files", "inner-file-2.txt"),
       );
 
       // dir-with-files/dir-within-dir files
       await createFile(
-        path.join(getTmpDir(), "dir-with-files", "dir-within-dir", "file-deep"),
+        path.join(tmp.path, "dir-with-files", "dir-within-dir", "file-deep"),
       );
 
       // dir-with-extension.txt files
       await createFile(
-        path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-3.txt"),
+        path.join(tmp.path, "dir-with-extension.txt", "inner-file-3.txt"),
       );
       await createFile(
-        path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-4.json"),
+        path.join(tmp.path, "dir-with-extension.txt", "inner-file-4.json"),
       );
 
       // dir-WithCasing files
       await createFile(
-        path.join(getTmpDir(), "dir-WithCasing", "file-WithCASING"),
+        path.join(tmp.path, "dir-WithCasing", "file-WithCASING"),
       );
     });
 
@@ -159,7 +159,7 @@ describe("File system utils", () => {
 
     it("Should return an empty array if the dir doesn't exist", async () => {
       await assertGetAllFilesMatching(
-        path.join(getTmpDir(), "not-in-fs"),
+        path.join(tmp.path, "not-in-fs"),
         undefined,
         [],
       );
@@ -167,74 +167,74 @@ describe("File system utils", () => {
 
     it("Should return an empty array if the dir is empty", async () => {
       await assertGetAllFilesMatching(
-        path.join(getTmpDir(), "dir-empty"),
+        path.join(tmp.path, "dir-empty"),
         undefined,
         [],
       );
     });
 
     it("Should return an empty array if no file matches", async () => {
-      await assertGetAllFilesMatching(getTmpDir(), () => false, []);
+      await assertGetAllFilesMatching(tmp.path, () => false, []);
     });
 
     it("Should return every file by default, recursively", async () => {
-      await assertGetAllFilesMatching(getTmpDir(), undefined, [
-        path.join(getTmpDir(), "file-1.txt"),
-        path.join(getTmpDir(), "file-2.txt"),
-        path.join(getTmpDir(), "file-3.json"),
-        path.join(getTmpDir(), "dir-with-files", "inner-file-1.json"),
-        path.join(getTmpDir(), "dir-with-files", "inner-file-2.txt"),
-        path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-3.txt"),
-        path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-4.json"),
-        path.join(getTmpDir(), "dir-WithCasing", "file-WithCASING"),
-        path.join(getTmpDir(), "dir-with-files", "dir-within-dir", "file-deep"),
+      await assertGetAllFilesMatching(tmp.path, undefined, [
+        path.join(tmp.path, "file-1.txt"),
+        path.join(tmp.path, "file-2.txt"),
+        path.join(tmp.path, "file-3.json"),
+        path.join(tmp.path, "dir-with-files", "inner-file-1.json"),
+        path.join(tmp.path, "dir-with-files", "inner-file-2.txt"),
+        path.join(tmp.path, "dir-with-extension.txt", "inner-file-3.txt"),
+        path.join(tmp.path, "dir-with-extension.txt", "inner-file-4.json"),
+        path.join(tmp.path, "dir-WithCasing", "file-WithCASING"),
+        path.join(tmp.path, "dir-with-files", "dir-within-dir", "file-deep"),
       ]);
 
       await assertGetAllFilesMatching(
-        path.join(getTmpDir(), "dir-WithCasing"),
+        path.join(tmp.path, "dir-WithCasing"),
         undefined,
-        [path.join(getTmpDir(), "dir-WithCasing", "file-WithCASING")],
+        [path.join(tmp.path, "dir-WithCasing", "file-WithCASING")],
       );
     });
 
     it("Should filter files and not dirs", async () => {
-      await assertGetAllFilesMatching(getTmpDir(), (f) => f.endsWith(".txt"), [
-        path.join(getTmpDir(), "file-1.txt"),
-        path.join(getTmpDir(), "file-2.txt"),
-        path.join(getTmpDir(), "dir-with-files", "inner-file-2.txt"),
-        path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-3.txt"),
+      await assertGetAllFilesMatching(tmp.path, (f) => f.endsWith(".txt"), [
+        path.join(tmp.path, "file-1.txt"),
+        path.join(tmp.path, "file-2.txt"),
+        path.join(tmp.path, "dir-with-files", "inner-file-2.txt"),
+        path.join(tmp.path, "dir-with-extension.txt", "inner-file-3.txt"),
       ]);
 
-      await assertGetAllFilesMatching(getTmpDir(), (f) => !f.endsWith(".txt"), [
-        path.join(getTmpDir(), "file-3.json"),
-        path.join(getTmpDir(), "dir-with-files", "inner-file-1.json"),
-        path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-4.json"),
-        path.join(getTmpDir(), "dir-WithCasing", "file-WithCASING"),
-        path.join(getTmpDir(), "dir-with-files", "dir-within-dir", "file-deep"),
+      await assertGetAllFilesMatching(tmp.path, (f) => !f.endsWith(".txt"), [
+        path.join(tmp.path, "file-3.json"),
+        path.join(tmp.path, "dir-with-files", "inner-file-1.json"),
+        path.join(tmp.path, "dir-with-extension.txt", "inner-file-4.json"),
+        path.join(tmp.path, "dir-WithCasing", "file-WithCASING"),
+        path.join(tmp.path, "dir-with-files", "dir-within-dir", "file-deep"),
       ]);
     });
 
     it("Should filter files asynchronously", async () => {
-      await writeUtf8File(path.join(getTmpDir(), "file-1.txt"), "skip");
+      await writeUtf8File(path.join(tmp.path, "file-1.txt"), "skip");
 
       await assertGetAllFilesMatching(
-        getTmpDir(),
+        tmp.path,
         async (f) => {
           return f.endsWith(".txt") && (await readUtf8File(f)) !== "skip";
         },
         [
-          path.join(getTmpDir(), "file-2.txt"),
-          path.join(getTmpDir(), "dir-with-files", "inner-file-2.txt"),
-          path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-3.txt"),
+          path.join(tmp.path, "file-2.txt"),
+          path.join(tmp.path, "dir-with-files", "inner-file-2.txt"),
+          path.join(tmp.path, "dir-with-extension.txt", "inner-file-3.txt"),
         ],
       );
     });
 
     it("Should preserve the true casing of the files, except for the dir's path", async () => {
       await assertGetAllFilesMatching(
-        getTmpDir(),
+        tmp.path,
         (f) => f.toLowerCase().endsWith("withcasing"),
-        [path.join(getTmpDir(), "dir-WithCasing", "file-WithCASING")],
+        [path.join(tmp.path, "dir-WithCasing", "file-WithCASING")],
       );
     });
 
@@ -242,8 +242,8 @@ describe("File system utils", () => {
       const originalReaddir = fsPromises.readdir;
       const originalLstat = fsPromises.lstat;
 
-      const unknownDirPath = path.join(getTmpDir(), "dir-with-files");
-      const knownFilePath = path.join(getTmpDir(), "file-1.txt");
+      const unknownDirPath = path.join(tmp.path, "dir-with-files");
+      const knownFilePath = path.join(tmp.path, "file-1.txt");
       const lstatPaths: string[] = [];
 
       t.mock.method(fsPromises, "readdir", async (...args: any[]) => {
@@ -254,10 +254,7 @@ describe("File system utils", () => {
           args,
         );
 
-        if (
-          absolutePathToDir !== getTmpDir() ||
-          options?.withFileTypes !== true
-        ) {
+        if (absolutePathToDir !== tmp.path || options?.withFileTypes !== true) {
           return dirents;
         }
 
@@ -279,25 +276,20 @@ describe("File system utils", () => {
         return await Reflect.apply(originalLstat, fsPromises, args);
       });
 
-      const files = await getAllFilesMatching(getTmpDir());
+      const files = await getAllFilesMatching(tmp.path);
 
       assert.deepEqual(
         new Set(files),
         new Set([
-          path.join(getTmpDir(), "file-1.txt"),
-          path.join(getTmpDir(), "file-2.txt"),
-          path.join(getTmpDir(), "file-3.json"),
-          path.join(getTmpDir(), "dir-with-files", "inner-file-1.json"),
-          path.join(getTmpDir(), "dir-with-files", "inner-file-2.txt"),
-          path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-3.txt"),
-          path.join(getTmpDir(), "dir-with-extension.txt", "inner-file-4.json"),
-          path.join(getTmpDir(), "dir-WithCasing", "file-WithCASING"),
-          path.join(
-            getTmpDir(),
-            "dir-with-files",
-            "dir-within-dir",
-            "file-deep",
-          ),
+          path.join(tmp.path, "file-1.txt"),
+          path.join(tmp.path, "file-2.txt"),
+          path.join(tmp.path, "file-3.json"),
+          path.join(tmp.path, "dir-with-files", "inner-file-1.json"),
+          path.join(tmp.path, "dir-with-files", "inner-file-2.txt"),
+          path.join(tmp.path, "dir-with-extension.txt", "inner-file-3.txt"),
+          path.join(tmp.path, "dir-with-extension.txt", "inner-file-4.json"),
+          path.join(tmp.path, "dir-WithCasing", "file-WithCASING"),
+          path.join(tmp.path, "dir-with-files", "dir-within-dir", "file-deep"),
         ]),
       );
       assert.ok(
@@ -311,10 +303,10 @@ describe("File system utils", () => {
     });
 
     it("Should throw NotADirectoryError if the path is not a directory", async () => {
-      const dirPath = path.join(getTmpDir(), "file-1.txt");
+      const dirPath = path.join(tmp.path, "file-1.txt");
 
       await assert.rejects(
-        getAllFilesMatching(path.join(getTmpDir(), "file-1.txt")),
+        getAllFilesMatching(path.join(tmp.path, "file-1.txt")),
         {
           name: "NotADirectoryError",
           message: `Path ${dirPath} is not a directory`,
@@ -323,7 +315,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileSystemAccessError if a different error is thrown", async () => {
-      const linkPath = path.join(getTmpDir(), "link");
+      const linkPath = path.join(tmp.path, "link");
       await fsPromises.symlink(linkPath, linkPath);
 
       await assert.rejects(getAllFilesMatching(linkPath), {
@@ -333,7 +325,7 @@ describe("File system utils", () => {
 
     describe("With directoryFilter", () => {
       it("Should return an empty array if directoryFilter returns false", async () => {
-        const from = path.join(getTmpDir(), "from");
+        const from = path.join(tmp.path, "from");
 
         const skipPath = path.join(from, "skip");
         await mkdir(skipPath);
@@ -360,7 +352,7 @@ describe("File system utils", () => {
       });
 
       it("Should filter directories asynchronously", async () => {
-        const from = path.join(getTmpDir(), "from");
+        const from = path.join(tmp.path, "from");
 
         const dirPath = path.join(from, "dir");
         await mkdir(dirPath);
@@ -391,13 +383,13 @@ describe("File system utils", () => {
 
   describe("getAllDirectoriesMatching", () => {
     beforeEach(async () => {
-      await mkdir(path.join(getTmpDir(), "dir-empty"));
-      await mkdir(path.join(getTmpDir(), "dir-with-files"));
-      await mkdir(path.join(getTmpDir(), "dir-with-subdir", "dir-within-dir"));
-      await mkdir(path.join(getTmpDir(), "dir-with-extension.txt"));
-      await mkdir(path.join(getTmpDir(), "dir-WithCasing"));
+      await mkdir(path.join(tmp.path, "dir-empty"));
+      await mkdir(path.join(tmp.path, "dir-with-files"));
+      await mkdir(path.join(tmp.path, "dir-with-subdir", "dir-within-dir"));
+      await mkdir(path.join(tmp.path, "dir-with-extension.txt"));
+      await mkdir(path.join(tmp.path, "dir-WithCasing"));
 
-      await createFile(path.join(getTmpDir(), "dir-with-files", "file-1.txt"));
+      await createFile(path.join(tmp.path, "dir-with-files", "file-1.txt"));
     });
 
     async function assertGetAllDirectoriesMatching(
@@ -413,7 +405,7 @@ describe("File system utils", () => {
 
     it("Should return an empty array if the dir doesn't exist", async () => {
       await assertGetAllDirectoriesMatching(
-        path.join(getTmpDir(), "not-in-fs"),
+        path.join(tmp.path, "not-in-fs"),
         undefined,
         [],
       );
@@ -421,45 +413,45 @@ describe("File system utils", () => {
 
     it("Should return an empty array if the dir is empty", async () => {
       await assertGetAllDirectoriesMatching(
-        path.join(getTmpDir(), "dir-empty"),
+        path.join(tmp.path, "dir-empty"),
         undefined,
         [],
       );
     });
 
     it("Should return an empty array if no file matches", async () => {
-      await assertGetAllDirectoriesMatching(getTmpDir(), () => false, []);
+      await assertGetAllDirectoriesMatching(tmp.path, () => false, []);
     });
 
     it("Should return every dir by default, recursively, except for subdirs of matched dirs", async () => {
-      await assertGetAllDirectoriesMatching(getTmpDir(), undefined, [
-        path.join(getTmpDir(), "dir-empty"),
-        path.join(getTmpDir(), "dir-with-files"),
-        path.join(getTmpDir(), "dir-with-subdir"),
-        path.join(getTmpDir(), "dir-with-extension.txt"),
-        path.join(getTmpDir(), "dir-WithCasing"),
+      await assertGetAllDirectoriesMatching(tmp.path, undefined, [
+        path.join(tmp.path, "dir-empty"),
+        path.join(tmp.path, "dir-with-files"),
+        path.join(tmp.path, "dir-with-subdir"),
+        path.join(tmp.path, "dir-with-extension.txt"),
+        path.join(tmp.path, "dir-WithCasing"),
       ]);
 
       await assertGetAllDirectoriesMatching(
-        path.join(getTmpDir(), "dir-with-subdir"),
+        path.join(tmp.path, "dir-with-subdir"),
         undefined,
-        [path.join(getTmpDir(), "dir-with-subdir", "dir-within-dir")],
+        [path.join(tmp.path, "dir-with-subdir", "dir-within-dir")],
       );
     });
 
     it("Should filter dirs", async () => {
       await assertGetAllDirectoriesMatching(
-        getTmpDir(),
+        tmp.path,
         (d) => d.endsWith(".txt"),
-        [path.join(getTmpDir(), "dir-with-extension.txt")],
+        [path.join(tmp.path, "dir-with-extension.txt")],
       );
     });
 
     it("Should filter dirs asynchronously", async () => {
       await assertGetAllDirectoriesMatching(
-        getTmpDir(),
+        tmp.path,
         async (d) => (await getAllFilesMatching(d)).length !== 0,
-        [path.join(getTmpDir(), "dir-with-files")],
+        [path.join(tmp.path, "dir-with-files")],
       );
     });
 
@@ -467,7 +459,7 @@ describe("File system utils", () => {
       const originalReaddir = fsPromises.readdir;
       const originalLstat = fsPromises.lstat;
 
-      const unknownDirPath = path.join(getTmpDir(), "dir-with-files");
+      const unknownDirPath = path.join(tmp.path, "dir-with-files");
       const lstatPaths: string[] = [];
 
       t.mock.method(fsPromises, "readdir", async (...args: any[]) => {
@@ -478,10 +470,7 @@ describe("File system utils", () => {
           args,
         );
 
-        if (
-          absolutePathToDir !== getTmpDir() ||
-          options?.withFileTypes !== true
-        ) {
+        if (absolutePathToDir !== tmp.path || options?.withFileTypes !== true) {
           return dirents;
         }
 
@@ -497,16 +486,16 @@ describe("File system utils", () => {
         return await Reflect.apply(originalLstat, fsPromises, args);
       });
 
-      const dirs = await getAllDirectoriesMatching(getTmpDir());
+      const dirs = await getAllDirectoriesMatching(tmp.path);
 
       assert.deepEqual(
         new Set(dirs),
         new Set([
-          path.join(getTmpDir(), "dir-empty"),
-          path.join(getTmpDir(), "dir-with-files"),
-          path.join(getTmpDir(), "dir-with-subdir"),
-          path.join(getTmpDir(), "dir-with-extension.txt"),
-          path.join(getTmpDir(), "dir-WithCasing"),
+          path.join(tmp.path, "dir-empty"),
+          path.join(tmp.path, "dir-with-files"),
+          path.join(tmp.path, "dir-with-subdir"),
+          path.join(tmp.path, "dir-with-extension.txt"),
+          path.join(tmp.path, "dir-WithCasing"),
         ]),
       );
       assert.ok(
@@ -518,8 +507,8 @@ describe("File system utils", () => {
 
   describe("getFileTrueCase", () => {
     it("Should return the true case of files and dirs", async () => {
-      const mixedCaseFilePath = path.join(getTmpDir(), "mixedCaseFile");
-      const mixedCaseDirPath = path.join(getTmpDir(), "mixedCaseDir");
+      const mixedCaseFilePath = path.join(tmp.path, "mixedCaseFile");
+      const mixedCaseDirPath = path.join(tmp.path, "mixedCaseDir");
       const mixedCaseFile2Path = path.join(mixedCaseDirPath, "mixedCaseFile2");
 
       await createFile(mixedCaseFilePath);
@@ -528,53 +517,53 @@ describe("File system utils", () => {
 
       // We test mixedCaseFilePath from tmpdir
       assert.equal(
-        await getFileTrueCase(getTmpDir(), "mixedCaseFile"),
-        path.relative(getTmpDir(), mixedCaseFilePath),
+        await getFileTrueCase(tmp.path, "mixedCaseFile"),
+        path.relative(tmp.path, mixedCaseFilePath),
       );
       assert.equal(
-        await getFileTrueCase(getTmpDir(), "mixedcasefile"),
-        path.relative(getTmpDir(), mixedCaseFilePath),
+        await getFileTrueCase(tmp.path, "mixedcasefile"),
+        path.relative(tmp.path, mixedCaseFilePath),
       );
       assert.equal(
-        await getFileTrueCase(getTmpDir(), "MIXEDCASEFILE"),
-        path.relative(getTmpDir(), mixedCaseFilePath),
+        await getFileTrueCase(tmp.path, "MIXEDCASEFILE"),
+        path.relative(tmp.path, mixedCaseFilePath),
       );
 
       // We test mixedCaseDirPath from tmpdir
       assert.equal(
-        await getFileTrueCase(getTmpDir(), "mixedCaseDir"),
-        path.relative(getTmpDir(), mixedCaseDirPath),
+        await getFileTrueCase(tmp.path, "mixedCaseDir"),
+        path.relative(tmp.path, mixedCaseDirPath),
       );
       assert.equal(
-        await getFileTrueCase(getTmpDir(), "mixedcasedir"),
-        path.relative(getTmpDir(), mixedCaseDirPath),
+        await getFileTrueCase(tmp.path, "mixedcasedir"),
+        path.relative(tmp.path, mixedCaseDirPath),
       );
       assert.equal(
-        await getFileTrueCase(getTmpDir(), "MIXEDCASEDIR"),
-        path.relative(getTmpDir(), mixedCaseDirPath),
+        await getFileTrueCase(tmp.path, "MIXEDCASEDIR"),
+        path.relative(tmp.path, mixedCaseDirPath),
       );
 
       // We test mixedCaseFilePath2 from tmpdir
       assert.equal(
         await getFileTrueCase(
-          getTmpDir(),
+          tmp.path,
           path.join("mixedCaseDir", "mixedCaseFile2"),
         ),
-        path.relative(getTmpDir(), mixedCaseFile2Path),
+        path.relative(tmp.path, mixedCaseFile2Path),
       );
       assert.equal(
         await getFileTrueCase(
-          getTmpDir(),
+          tmp.path,
           path.join("mixedcasedir", "MIXEDCASEFILE2"),
         ),
-        path.relative(getTmpDir(), mixedCaseFile2Path),
+        path.relative(tmp.path, mixedCaseFile2Path),
       );
       assert.equal(
         await getFileTrueCase(
-          getTmpDir(),
+          tmp.path,
           path.join("MIXEDCASEDIR", "mixedcasefile2"),
         ),
-        path.relative(getTmpDir(), mixedCaseFile2Path),
+        path.relative(tmp.path, mixedCaseFile2Path),
       );
 
       // We test mixedCaseFilePath2 from mixedCaseDir
@@ -593,26 +582,26 @@ describe("File system utils", () => {
     });
 
     it("Should NOT resolve symlinks", async () => {
-      const actualPath = path.join(getTmpDir(), "mixedCasingFile");
+      const actualPath = path.join(tmp.path, "mixedCasingFile");
       await createFile(actualPath);
 
-      const linkPath = path.join(getTmpDir(), "lInK");
+      const linkPath = path.join(tmp.path, "lInK");
       await fsPromises.symlink(actualPath, linkPath);
 
-      assert.equal(await getFileTrueCase(getTmpDir(), "link"), "lInK");
+      assert.equal(await getFileTrueCase(tmp.path, "link"), "lInK");
     });
 
     it("Should throw FileNotFoundError if not found", async () => {
-      const actualPath = path.join(getTmpDir(), "not-exists");
+      const actualPath = path.join(tmp.path, "not-exists");
 
-      await assert.rejects(getFileTrueCase(getTmpDir(), "not-exists"), {
+      await assert.rejects(getFileTrueCase(tmp.path, "not-exists"), {
         name: "FileNotFoundError",
         message: `File ${actualPath} not found`,
       });
     });
 
     it("Should throw NotADirectoryError if the starting directory is not a directory", async () => {
-      const filePath = path.join(getTmpDir(), "file");
+      const filePath = path.join(tmp.path, "file");
       await createFile(filePath);
 
       await assert.rejects(getFileTrueCase(filePath, "asd"), {
@@ -622,7 +611,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileSystemAccessError if a different error is thrown", async () => {
-      const linkPath = path.join(getTmpDir(), "link");
+      const linkPath = path.join(tmp.path, "link");
       await fsPromises.symlink(linkPath, linkPath);
 
       await assert.rejects(getFileTrueCase(linkPath, "file"), {
@@ -633,8 +622,8 @@ describe("File system utils", () => {
 
   describe("TrueCasePathResolver", () => {
     it("Should return the true case of files and directories", async () => {
-      const mixedCaseFilePath = path.join(getTmpDir(), "mixedCaseFile");
-      const mixedCaseDirPath = path.join(getTmpDir(), "mixedCaseDir");
+      const mixedCaseFilePath = path.join(tmp.path, "mixedCaseFile");
+      const mixedCaseDirPath = path.join(tmp.path, "mixedCaseDir");
       const mixedCaseFile2Path = path.join(mixedCaseDirPath, "mixedCaseFile2");
 
       await createFile(mixedCaseFilePath);
@@ -644,16 +633,16 @@ describe("File system utils", () => {
       const resolver = new TrueCasePathResolver();
 
       assert.equal(
-        await resolver.getFileTrueCase(getTmpDir(), "mixedcasefile"),
+        await resolver.getFileTrueCase(tmp.path, "mixedcasefile"),
         "mixedCaseFile",
       );
       assert.equal(
-        await resolver.getFileTrueCase(getTmpDir(), "MIXEDCASEDIR"),
+        await resolver.getFileTrueCase(tmp.path, "MIXEDCASEDIR"),
         "mixedCaseDir",
       );
       assert.equal(
         await resolver.getFileTrueCase(
-          getTmpDir(),
+          tmp.path,
           path.join("mixedcasedir", "MIXEDCASEFILE2"),
         ),
         path.join("mixedCaseDir", "mixedCaseFile2"),
@@ -663,17 +652,17 @@ describe("File system utils", () => {
     it("Should return an empty path when resolving the starting directory itself", async () => {
       const resolver = new TrueCasePathResolver();
 
-      assert.equal(await resolver.getFileTrueCase(getTmpDir(), ""), "");
-      assert.equal(await resolver.getFileTrueCase(getTmpDir(), "."), "");
+      assert.equal(await resolver.getFileTrueCase(tmp.path, ""), "");
+      assert.equal(await resolver.getFileTrueCase(tmp.path, "."), "");
       assert.equal(
-        await resolver.getFileTrueCase(getTmpDir(), path.join("dir", "..")),
+        await resolver.getFileTrueCase(tmp.path, path.join("dir", "..")),
         "",
       );
     });
 
     it("Should resolve relative paths with parent segments that stay within the starting directory", async () => {
-      const mixedCaseFilePath = path.join(getTmpDir(), "mixedCaseFile");
-      const mixedCaseDirPath = path.join(getTmpDir(), "mixedCaseDir");
+      const mixedCaseFilePath = path.join(tmp.path, "mixedCaseFile");
+      const mixedCaseDirPath = path.join(tmp.path, "mixedCaseDir");
 
       await createFile(mixedCaseFilePath);
       await mkdir(mixedCaseDirPath);
@@ -682,7 +671,7 @@ describe("File system utils", () => {
 
       assert.equal(
         await resolver.getFileTrueCase(
-          getTmpDir(),
+          tmp.path,
           path.join("mixedCaseDir", "..", "mixedcasefile"),
         ),
         "mixedCaseFile",
@@ -690,9 +679,9 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the resolved path escapes the starting directory", async () => {
-      const rootPath = path.join(getTmpDir(), "root");
+      const rootPath = path.join(tmp.path, "root");
       const nestedPath = path.join(rootPath, "nested");
-      const secretPath = path.join(getTmpDir(), "secret");
+      const secretPath = path.join(tmp.path, "secret");
 
       await mkdir(nestedPath);
       await createFile(secretPath);
@@ -712,13 +701,13 @@ describe("File system utils", () => {
     });
 
     it("Should cache directory listings across calls to the same resolver", async () => {
-      const filePath = path.join(getTmpDir(), "cachedFile");
+      const filePath = path.join(tmp.path, "cachedFile");
       await createFile(filePath);
 
       const resolver = new TrueCasePathResolver();
 
       assert.equal(
-        await resolver.getFileTrueCase(getTmpDir(), "cachedFile"),
+        await resolver.getFileTrueCase(tmp.path, "cachedFile"),
         "cachedFile",
       );
 
@@ -728,24 +717,23 @@ describe("File system utils", () => {
       await remove(filePath);
 
       assert.equal(
-        await resolver.getFileTrueCase(getTmpDir(), "cachedFile"),
+        await resolver.getFileTrueCase(tmp.path, "cachedFile"),
         "cachedFile",
       );
       assert.equal(
-        await resolver.getFileTrueCase(getTmpDir(), "CACHEDFILE"),
+        await resolver.getFileTrueCase(tmp.path, "CACHEDFILE"),
         "cachedFile",
       );
 
       resolver.clear();
 
-      await assert.rejects(
-        resolver.getFileTrueCase(getTmpDir(), "cachedFile"),
-        { name: "FileNotFoundError" },
-      );
+      await assert.rejects(resolver.getFileTrueCase(tmp.path, "cachedFile"), {
+        name: "FileNotFoundError",
+      });
     });
 
     it("Should cache resolutions separately for different trusted starting directories", async (t) => {
-      const root = path.join(getTmpDir(), "root");
+      const root = path.join(tmp.path, "root");
       const trustedFrom = path.join(root, "B"); // Note that it's uppercase
 
       // We mock `readdir` so that it mimics a case-insensitive filesystem where
@@ -791,7 +779,7 @@ describe("File system utils", () => {
     });
 
     it("Should not resolve the true casing of the trusted starting directory", async (t) => {
-      const trustedFrom = path.join(getTmpDir(), "a", "B");
+      const trustedFrom = path.join(tmp.path, "a", "B");
 
       // We mock `readdir` so that only the trusted starting directory can be
       // read. If the resolver tries to read any ancestor of `from`, this test
@@ -823,24 +811,22 @@ describe("File system utils", () => {
     it("Should not throw when a previous call threw and the path now exists", async () => {
       const resolver = new TrueCasePathResolver();
 
-      await assert.rejects(
-        resolver.getFileTrueCase(getTmpDir(), "laterCreated"),
-        { name: "FileNotFoundError" },
-      );
+      await assert.rejects(resolver.getFileTrueCase(tmp.path, "laterCreated"), {
+        name: "FileNotFoundError",
+      });
 
-      await createFile(path.join(getTmpDir(), "laterCreated"));
+      await createFile(path.join(tmp.path, "laterCreated"));
 
       // The directory listing from the first call is cached, so without
       // `clear()` the new file is invisible.
-      await assert.rejects(
-        resolver.getFileTrueCase(getTmpDir(), "laterCreated"),
-        { name: "FileNotFoundError" },
-      );
+      await assert.rejects(resolver.getFileTrueCase(tmp.path, "laterCreated"), {
+        name: "FileNotFoundError",
+      });
 
       resolver.clear();
 
       assert.equal(
-        await resolver.getFileTrueCase(getTmpDir(), "laterCreated"),
+        await resolver.getFileTrueCase(tmp.path, "laterCreated"),
         "laterCreated",
       );
     });
@@ -853,35 +839,29 @@ describe("File system utils", () => {
         return;
       }
 
-      await createFile(path.join(getTmpDir(), "ambig"));
-      await createFile(path.join(getTmpDir(), "AMBIG"));
+      await createFile(path.join(tmp.path, "ambig"));
+      await createFile(path.join(tmp.path, "AMBIG"));
 
       const resolver = new TrueCasePathResolver();
 
       // Exact matches still work.
-      assert.equal(
-        await resolver.getFileTrueCase(getTmpDir(), "ambig"),
-        "ambig",
-      );
-      assert.equal(
-        await resolver.getFileTrueCase(getTmpDir(), "AMBIG"),
-        "AMBIG",
-      );
+      assert.equal(await resolver.getFileTrueCase(tmp.path, "ambig"), "ambig");
+      assert.equal(await resolver.getFileTrueCase(tmp.path, "AMBIG"), "AMBIG");
 
       // A spelling that folds to the ambiguous key is rejected.
-      await assert.rejects(resolver.getFileTrueCase(getTmpDir(), "Ambig"), {
+      await assert.rejects(resolver.getFileTrueCase(tmp.path, "Ambig"), {
         name: "FileNotFoundError",
       });
     });
 
     it("Should throw NotADirectoryError if an intermediate segment is not a directory", async () => {
-      const filePath = path.join(getTmpDir(), "file");
+      const filePath = path.join(tmp.path, "file");
       await createFile(filePath);
 
       const resolver = new TrueCasePathResolver();
 
       await assert.rejects(
-        resolver.getFileTrueCase(getTmpDir(), path.join("file", "child.ts")),
+        resolver.getFileTrueCase(tmp.path, path.join("file", "child.ts")),
         {
           name: "NotADirectoryError",
           message: `Path ${filePath} is not a directory`,
@@ -890,7 +870,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw NotADirectoryError if the starting directory is not a directory", async () => {
-      const filePath = path.join(getTmpDir(), "file");
+      const filePath = path.join(tmp.path, "file");
       await createFile(filePath);
 
       const resolver = new TrueCasePathResolver();
@@ -901,7 +881,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError when relativePath is '.' and the starting directory doesn't exist", async () => {
-      const missingDir = path.join(getTmpDir(), "missing");
+      const missingDir = path.join(tmp.path, "missing");
 
       const resolver = new TrueCasePathResolver();
 
@@ -914,7 +894,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw NotADirectoryError when relativePath is '.' and the starting directory is a file", async () => {
-      const filePath = path.join(getTmpDir(), "fileAsFrom");
+      const filePath = path.join(tmp.path, "fileAsFrom");
       await createFile(filePath);
 
       const resolver = new TrueCasePathResolver();
@@ -925,7 +905,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileSystemAccessError if a different error is thrown", async () => {
-      const linkPath = path.join(getTmpDir(), "link");
+      const linkPath = path.join(tmp.path, "link");
       await fsPromises.symlink(linkPath, linkPath);
 
       const resolver = new TrueCasePathResolver();
@@ -938,7 +918,7 @@ describe("File system utils", () => {
 
   describe("isDirectory", () => {
     it("Should return true if the path is a directory", async () => {
-      const dirPath = path.join(getTmpDir(), "dir");
+      const dirPath = path.join(tmp.path, "dir");
       await mkdir(dirPath);
 
       assert.ok(
@@ -948,7 +928,7 @@ describe("File system utils", () => {
     });
 
     it("Should return false if the path is not a directory", async () => {
-      const filePath = path.join(getTmpDir(), "file");
+      const filePath = path.join(tmp.path, "file");
       await createFile(filePath);
 
       assert.ok(
@@ -958,7 +938,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the path doesn't exist", async () => {
-      const actualPath = path.join(getTmpDir(), "not-exists");
+      const actualPath = path.join(tmp.path, "not-exists");
 
       await assert.rejects(isDirectory(actualPath), {
         name: "FileNotFoundError",
@@ -980,7 +960,7 @@ describe("File system utils", () => {
   describe("readJsonFile", () => {
     it("Should read and parse a JSON file", async () => {
       const expectedObject = { a: 1, b: 2 };
-      const filePath = path.join(getTmpDir(), "file.json");
+      const filePath = path.join(tmp.path, "file.json");
       await writeUtf8File(filePath, JSON.stringify(expectedObject));
 
       assert.deepEqual(await readJsonFile(filePath), expectedObject);
@@ -991,7 +971,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw InvalidFileFormatError if the file is not valid JSON", async () => {
-      const filePath = path.join(getTmpDir(), "file.json");
+      const filePath = path.join(tmp.path, "file.json");
       await writeUtf8File(filePath, "not-json");
 
       await assert.rejects(readJsonFile(filePath), {
@@ -1001,7 +981,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the file doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists.json");
+      const filePath = path.join(tmp.path, "not-exists.json");
 
       await assert.rejects(readJsonFile(filePath), {
         name: "FileNotFoundError",
@@ -1021,7 +1001,7 @@ describe("File system utils", () => {
   describe("writeJsonFile", () => {
     it("Should write an object to a JSON file", async () => {
       const expectedObject = { a: 1, b: 2 };
-      const filePath = path.join(getTmpDir(), "file.json");
+      const filePath = path.join(tmp.path, "file.json");
 
       await writeJsonFile(filePath, expectedObject);
 
@@ -1036,7 +1016,7 @@ describe("File system utils", () => {
 
     it("Should write an object tto a JSON file even if part of the path doesn't exist", async () => {
       const expectedObject = { a: 1, b: 2 };
-      const filePath = path.join(getTmpDir(), "not-exists", "file.json");
+      const filePath = path.join(tmp.path, "not-exists", "file.json");
 
       await writeJsonFile(filePath, expectedObject);
 
@@ -1047,7 +1027,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw JsonSerializationError if the object can't be serialized to JSON", async () => {
-      const filePath = path.join(getTmpDir(), "file.json");
+      const filePath = path.join(tmp.path, "file.json");
       // create an object with a circular reference
       const circularObject: { self?: {} } = {};
       circularObject.self = circularObject;
@@ -1060,7 +1040,7 @@ describe("File system utils", () => {
 
     it("Should throw FileSystemAccessError if a different error is thrown", async () => {
       // Use a path that will cause a file system error (invalid characters in filename)
-      const filePath = path.join(getTmpDir(), "invalid\0filename.json");
+      const filePath = path.join(tmp.path, "invalid\0filename.json");
 
       await assert.rejects(writeJsonFile(filePath, {}), {
         name: "FileSystemAccessError",
@@ -1071,7 +1051,7 @@ describe("File system utils", () => {
   describe("readJsonFileAsStream", () => {
     it("Should read and parse a JSON file", async () => {
       const expectedObject = { a: 1, b: 2 };
-      const filePath = path.join(getTmpDir(), "file.json");
+      const filePath = path.join(tmp.path, "file.json");
       await writeUtf8File(filePath, JSON.stringify(expectedObject));
 
       assert.deepEqual(await readJsonFileAsStream(filePath), expectedObject);
@@ -1082,7 +1062,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw InvalidFileFormatError if the file is not valid JSON", async () => {
-      const filePath = path.join(getTmpDir(), "file.json");
+      const filePath = path.join(tmp.path, "file.json");
       await writeUtf8File(filePath, "not-json");
 
       await assert.rejects(readJsonFileAsStream(filePath), {
@@ -1092,7 +1072,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw InvalidFileFormatError if the file is empty", async () => {
-      const filePath = path.join(getTmpDir(), "file.json");
+      const filePath = path.join(tmp.path, "file.json");
       await writeUtf8File(filePath, "");
 
       await assert.rejects(readJsonFileAsStream(filePath), {
@@ -1102,7 +1082,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the file doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists.json");
+      const filePath = path.join(tmp.path, "not-exists.json");
 
       await assert.rejects(readJsonFileAsStream(filePath), {
         name: "FileNotFoundError",
@@ -1111,7 +1091,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw IsDirectoryError if the file is a directory", async () => {
-      const filePath = path.join(getTmpDir());
+      const filePath = path.join(tmp.path);
 
       await assert.rejects(readJsonFileAsStream(filePath), {
         name: "IsDirectoryError",
@@ -1131,7 +1111,7 @@ describe("File system utils", () => {
   describe("writeJsonFileAsStream", () => {
     it("Should write an object to a JSON file", async () => {
       const expectedObject = { a: 1, b: 2 };
-      const filePath = path.join(getTmpDir(), "file.json");
+      const filePath = path.join(tmp.path, "file.json");
 
       await writeJsonFileAsStream(filePath, expectedObject);
 
@@ -1146,7 +1126,7 @@ describe("File system utils", () => {
 
     it("Should write an object tto a JSON file even if part of the path doesn't exist", async () => {
       const expectedObject = { a: 1, b: 2 };
-      const filePath = path.join(getTmpDir(), "not-exists", "file.json");
+      const filePath = path.join(tmp.path, "not-exists", "file.json");
 
       await writeJsonFileAsStream(filePath, expectedObject);
 
@@ -1157,7 +1137,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw JsonSerializationError if the object can't be serialized to JSON", async () => {
-      const filePath = path.join(getTmpDir(), "file.json");
+      const filePath = path.join(tmp.path, "file.json");
       // create an object with a circular reference
       const circularObject: { self?: {} } = {};
       circularObject.self = circularObject;
@@ -1170,7 +1150,7 @@ describe("File system utils", () => {
 
     it("Should throw FileSystemAccessError if a different error is thrown", async () => {
       // Use a path that will cause a file system error (invalid characters in filename)
-      const filePath = path.join(getTmpDir(), "invalid\0filename.json");
+      const filePath = path.join(tmp.path, "invalid\0filename.json");
 
       await assert.rejects(writeJsonFileAsStream(filePath, {}), {
         name: "FileSystemAccessError",
@@ -1178,7 +1158,7 @@ describe("File system utils", () => {
     });
 
     it("Should remove the part of the path that didn't exist before if an error is thrown", async () => {
-      const dirPath = path.join(getTmpDir(), "not-exists");
+      const dirPath = path.join(tmp.path, "not-exists");
       const filePath = path.join(dirPath, "protected-file.json");
       // create an object with a circular reference
       const circularObject: { self?: {} } = {};
@@ -1196,7 +1176,7 @@ describe("File system utils", () => {
   describe("readUtf8File", () => {
     it("Should read a file and return its content as a string", async () => {
       const content = "hello";
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
       await writeUtf8File(filePath, content);
 
       assert.equal(await readUtf8File(filePath), content);
@@ -1204,7 +1184,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw IsDirectoryError if the path is a dir and not a file", async () => {
-      const dirPath = path.join(getTmpDir(), "dir-name");
+      const dirPath = path.join(tmp.path, "dir-name");
       await mkdir(dirPath);
 
       await assert.rejects(readUtf8File(dirPath), {
@@ -1214,7 +1194,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the file doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists.txt");
+      const filePath = path.join(tmp.path, "not-exists.txt");
 
       await assert.rejects(readUtf8File(filePath), {
         name: "FileNotFoundError",
@@ -1223,7 +1203,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw IsDirectoryError if the path is a dir and not a file", async () => {
-      const dirPath = path.join(getTmpDir(), "dir-name");
+      const dirPath = path.join(tmp.path, "dir-name");
       await mkdir(dirPath);
 
       await assert.rejects(readUtf8File(dirPath), {
@@ -1244,7 +1224,7 @@ describe("File system utils", () => {
   describe("writeUtf8File", () => {
     it("Should write a string to a file", async () => {
       const content = "hello";
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
 
       await writeUtf8File(filePath, content);
 
@@ -1253,7 +1233,7 @@ describe("File system utils", () => {
 
     it("Should write a string to a file even if part of the path doesn't exist", async () => {
       const content = "hello";
-      const filePath = path.join(getTmpDir(), "not-exists", "file.txt");
+      const filePath = path.join(tmp.path, "not-exists", "file.txt");
 
       await writeUtf8File(filePath, content);
 
@@ -1262,7 +1242,7 @@ describe("File system utils", () => {
 
     it("Should allow setting the flag", async () => {
       const content = "hello";
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
 
       await writeUtf8File(filePath, content);
       await writeUtf8File(filePath, content, "a");
@@ -1271,7 +1251,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileAlreadyExistsError if the file already exists and the flag 'x' is used", async () => {
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
       await writeUtf8File(filePath, "hello");
 
       await assert.rejects(writeUtf8File(filePath, "hello", "wx"), {
@@ -1282,7 +1262,7 @@ describe("File system utils", () => {
 
     it("Should throw FileSystemAccessError if a different error is thrown", async () => {
       // Use a path that will cause a file system error (invalid characters in filename)
-      const filePath = path.join(getTmpDir(), "invalid\0filename.txt");
+      const filePath = path.join(tmp.path, "invalid\0filename.txt");
 
       await assert.rejects(writeUtf8File(filePath, "hello"), {
         name: "FileSystemAccessError",
@@ -1293,7 +1273,7 @@ describe("File system utils", () => {
   describe("readBinaryFile", () => {
     it("Should read a file and return its content as a string", async () => {
       const content = "hello";
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
 
       await writeUtf8File(filePath, content);
 
@@ -1305,7 +1285,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw IsDirectoryError if the path is a dir and not a file", async () => {
-      const dirPath = path.join(getTmpDir(), "dir-name");
+      const dirPath = path.join(tmp.path, "dir-name");
 
       await mkdir(dirPath);
 
@@ -1316,7 +1296,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the file doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists.txt");
+      const filePath = path.join(tmp.path, "not-exists.txt");
 
       await assert.rejects(readBinaryFile(filePath), {
         name: "FileNotFoundError",
@@ -1325,7 +1305,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw IsDirectoryError if the path is a dir and not a file", async () => {
-      const dirPath = path.join(getTmpDir(), "dir-name");
+      const dirPath = path.join(tmp.path, "dir-name");
 
       await mkdir(dirPath);
 
@@ -1346,7 +1326,7 @@ describe("File system utils", () => {
 
   describe("readdir", () => {
     it("Should return the files in a directory", async () => {
-      const dirPath = path.join(getTmpDir(), "dir");
+      const dirPath = path.join(tmp.path, "dir");
       await mkdir(dirPath);
 
       const files = ["file1.txt", "file2.txt", "file3.json"];
@@ -1366,7 +1346,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the directory doesn't exist", async () => {
-      const dirPath = path.join(getTmpDir(), "not-exists");
+      const dirPath = path.join(tmp.path, "not-exists");
 
       await assert.rejects(readdir(dirPath), {
         name: "FileNotFoundError",
@@ -1375,7 +1355,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw NotADirectoryError if the path is not a directory", async () => {
-      const filePath = path.join(getTmpDir(), "file");
+      const filePath = path.join(tmp.path, "file");
       await createFile(filePath);
 
       await assert.rejects(readdir(filePath), {
@@ -1395,7 +1375,7 @@ describe("File system utils", () => {
 
   describe("readdirOrEmpty", () => {
     it("Should return the files in a directory", async () => {
-      const dirPath = path.join(getTmpDir(), "dir");
+      const dirPath = path.join(tmp.path, "dir");
       await mkdir(dirPath);
 
       const files = ["file1.txt", "file2.txt", "file3.json"];
@@ -1415,13 +1395,13 @@ describe("File system utils", () => {
     });
 
     it("Should return an empty array if the directory doesn't exist", async () => {
-      const dirPath = path.join(getTmpDir(), "not-exists");
+      const dirPath = path.join(tmp.path, "not-exists");
 
       assert.deepEqual(await readdirOrEmpty(dirPath), []);
     });
 
     it("Should throw NotADirectoryError if the path is not a directory", async () => {
-      const filePath = path.join(getTmpDir(), "file");
+      const filePath = path.join(tmp.path, "file");
       await createFile(filePath);
 
       await assert.rejects(readdirOrEmpty(filePath), {
@@ -1441,7 +1421,7 @@ describe("File system utils", () => {
 
   describe("mkdir", () => {
     it("Should create a directory", async () => {
-      const dirPath = path.join(getTmpDir(), "dir");
+      const dirPath = path.join(tmp.path, "dir");
 
       await mkdir(dirPath);
 
@@ -1449,7 +1429,7 @@ describe("File system utils", () => {
     });
 
     it("Should create a directory and any necessary directories along the way", async () => {
-      const dirPath = path.join(getTmpDir(), "dir", "subdir");
+      const dirPath = path.join(tmp.path, "dir", "subdir");
 
       await mkdir(dirPath);
 
@@ -1457,7 +1437,7 @@ describe("File system utils", () => {
     });
 
     it("Should do nothing if the directory already exists", async () => {
-      const dirPath = path.join(getTmpDir(), "dir");
+      const dirPath = path.join(tmp.path, "dir");
 
       await mkdir(dirPath);
       await mkdir(dirPath);
@@ -1495,7 +1475,7 @@ describe("File system utils", () => {
 
   describe("getChangeTime", () => {
     it("Should return the change time of a file", async () => {
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
       await createFile(filePath);
 
       const stats = await fsPromises.stat(filePath);
@@ -1507,7 +1487,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the file doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists.txt");
+      const filePath = path.join(tmp.path, "not-exists.txt");
 
       await assert.rejects(getChangeTime(filePath), {
         name: "FileNotFoundError",
@@ -1526,7 +1506,7 @@ describe("File system utils", () => {
 
   describe("getAccessTime", () => {
     it("Should return the access time of a file", async () => {
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
       await createFile(filePath);
 
       const stats = await fsPromises.stat(filePath);
@@ -1538,7 +1518,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the file doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists.txt");
+      const filePath = path.join(tmp.path, "not-exists.txt");
 
       await assert.rejects(getAccessTime(filePath), {
         name: "FileNotFoundError",
@@ -1557,7 +1537,7 @@ describe("File system utils", () => {
 
   describe("getSize", () => {
     it("Should return the size of a file", async () => {
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
       await createFile(filePath);
 
       const stats = await fsPromises.stat(filePath);
@@ -1566,7 +1546,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the file doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists.txt");
+      const filePath = path.join(tmp.path, "not-exists.txt");
 
       await assert.rejects(getFileSize(filePath), {
         name: "FileNotFoundError",
@@ -1585,7 +1565,7 @@ describe("File system utils", () => {
 
   describe("exists", () => {
     it("Should return true if the file exists", async () => {
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
       await createFile(filePath);
 
       assert.ok(
@@ -1595,7 +1575,7 @@ describe("File system utils", () => {
     });
 
     it("Should return false if the file doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists.txt");
+      const filePath = path.join(tmp.path, "not-exists.txt");
 
       assert.ok(
         !(await exists(filePath)),
@@ -1606,8 +1586,8 @@ describe("File system utils", () => {
 
   describe("copy", () => {
     it("Should copy a file", async () => {
-      const srcPath = path.join(getTmpDir(), "src.txt");
-      const destPath = path.join(getTmpDir(), "dest.txt");
+      const srcPath = path.join(tmp.path, "src.txt");
+      const destPath = path.join(tmp.path, "dest.txt");
 
       await writeUtf8File(srcPath, "hello");
       await copy(srcPath, destPath);
@@ -1616,8 +1596,8 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the source file doesn't exist", async () => {
-      const srcPath = path.join(getTmpDir(), "not-exists.txt");
-      const destPath = path.join(getTmpDir(), "dest.txt");
+      const srcPath = path.join(tmp.path, "not-exists.txt");
+      const destPath = path.join(tmp.path, "dest.txt");
 
       await assert.rejects(copy(srcPath, destPath), {
         name: "FileNotFoundError",
@@ -1626,8 +1606,8 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the destination path doesn't exist", async () => {
-      const srcPath = path.join(getTmpDir(), "src.txt");
-      const destPath = path.join(getTmpDir(), "not-exists", "dest.txt");
+      const srcPath = path.join(tmp.path, "src.txt");
+      const destPath = path.join(tmp.path, "not-exists", "dest.txt");
 
       await createFile(srcPath);
 
@@ -1638,8 +1618,8 @@ describe("File system utils", () => {
     });
 
     it("Should throw IsDirectoryError if the source path is a directory", async () => {
-      const srcPath = path.join(getTmpDir(), "dir");
-      const destPath = path.join(getTmpDir(), "dest.txt");
+      const srcPath = path.join(tmp.path, "dir");
+      const destPath = path.join(tmp.path, "dest.txt");
 
       await mkdir(srcPath);
 
@@ -1650,8 +1630,8 @@ describe("File system utils", () => {
     });
 
     it("Should throw IsDirectoryError if the destination path is a directory", async () => {
-      const srcPath = path.join(getTmpDir(), "src.txt");
-      const destPath = path.join(getTmpDir(), "dir");
+      const srcPath = path.join(tmp.path, "src.txt");
+      const destPath = path.join(tmp.path, "dir");
 
       await createFile(srcPath);
       await mkdir(destPath);
@@ -1664,7 +1644,7 @@ describe("File system utils", () => {
 
     it("Should throw FileSystemAccessError if a different error is thrown", async () => {
       const invalidPath = "\0";
-      const destPath = path.join(getTmpDir(), "dest.txt");
+      const destPath = path.join(tmp.path, "dest.txt");
 
       await assert.rejects(copy(invalidPath, destPath), {
         name: "FileSystemAccessError",
@@ -1674,7 +1654,7 @@ describe("File system utils", () => {
 
   describe("remove", () => {
     it("Should remove a file", async () => {
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
       await createFile(filePath);
 
       await remove(filePath);
@@ -1683,7 +1663,7 @@ describe("File system utils", () => {
     });
 
     it("Should remove an empty directory", async () => {
-      const dirPath = path.join(getTmpDir(), "dir");
+      const dirPath = path.join(tmp.path, "dir");
       await mkdir(dirPath);
 
       await remove(dirPath);
@@ -1692,7 +1672,7 @@ describe("File system utils", () => {
     });
 
     it("Should remove a directory and its content", async () => {
-      const dirPath = path.join(getTmpDir(), "dir");
+      const dirPath = path.join(tmp.path, "dir");
       await mkdir(dirPath);
 
       const files = ["file1.txt", "file2.txt", "file3.json"];
@@ -1710,7 +1690,7 @@ describe("File system utils", () => {
     });
 
     it("Should not throw if the path doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists.txt");
+      const filePath = path.join(tmp.path, "not-exists.txt");
 
       await remove(filePath);
     });
@@ -1724,7 +1704,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw busy error on windows platform", async () => {
-      const dirPath = path.join(getTmpDir(), "lockTest");
+      const dirPath = path.join(tmp.path, "lockTest");
       await mkdir(dirPath);
       const filePath = path.join(dirPath, "file.txt");
       await createFile(filePath);
@@ -1749,7 +1729,7 @@ describe("File system utils", () => {
 
   describe("chmod", () => {
     it("Should change the mode of a file", async () => {
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
       await createFile(filePath);
 
       await chmod(filePath, 0o666);
@@ -1761,7 +1741,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the file doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists.txt");
+      const filePath = path.join(tmp.path, "not-exists.txt");
 
       await assert.rejects(chmod(filePath, 0o666), {
         name: "FileNotFoundError",
@@ -1780,8 +1760,8 @@ describe("File system utils", () => {
 
   describe("move", () => {
     it("Should move a file", async () => {
-      const srcPath = path.join(getTmpDir(), "src.txt");
-      const destPath = path.join(getTmpDir(), "dest.txt");
+      const srcPath = path.join(tmp.path, "src.txt");
+      const destPath = path.join(tmp.path, "dest.txt");
 
       await writeUtf8File(srcPath, "hello");
       await move(srcPath, destPath);
@@ -1791,8 +1771,8 @@ describe("File system utils", () => {
     });
 
     it("Should move a directory", async () => {
-      const srcPath = path.join(getTmpDir(), "dir");
-      const destPath = path.join(getTmpDir(), "dest");
+      const srcPath = path.join(tmp.path, "dir");
+      const destPath = path.join(tmp.path, "dest");
 
       await mkdir(srcPath);
       await createFile(path.join(srcPath, "file.txt"));
@@ -1811,8 +1791,8 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the source file doesn't exist", async () => {
-      const srcPath = path.join(getTmpDir(), "not-exists.txt");
-      const destPath = path.join(getTmpDir(), "dest.txt");
+      const srcPath = path.join(tmp.path, "not-exists.txt");
+      const destPath = path.join(tmp.path, "dest.txt");
 
       await assert.rejects(move(srcPath, destPath), {
         name: "FileNotFoundError",
@@ -1821,8 +1801,8 @@ describe("File system utils", () => {
     });
 
     it("Should throw FileNotFoundError if the destination path doesn't exist", async () => {
-      const srcPath = path.join(getTmpDir(), "src.txt");
-      const destPath = path.join(getTmpDir(), "not-exists", "dest.txt");
+      const srcPath = path.join(tmp.path, "src.txt");
+      const destPath = path.join(tmp.path, "not-exists", "dest.txt");
 
       await createFile(srcPath);
 
@@ -1833,8 +1813,8 @@ describe("File system utils", () => {
     });
 
     it("Should throw DirectoryNotEmptyError if the source path is a directory and the destination path is a directory that is not empty", async () => {
-      const srcPath = path.join(getTmpDir(), "dir");
-      const destPath = path.join(getTmpDir(), "dest");
+      const srcPath = path.join(tmp.path, "dir");
+      const destPath = path.join(tmp.path, "dest");
 
       await mkdir(srcPath);
       await mkdir(destPath);
@@ -1848,7 +1828,7 @@ describe("File system utils", () => {
 
     it("Should throw FileSystemAccessError if a different error is thrown", async () => {
       const invalidPath = "\0";
-      const destPath = path.join(getTmpDir(), "dest.txt");
+      const destPath = path.join(tmp.path, "dest.txt");
 
       await assert.rejects(move(invalidPath, destPath), {
         name: "FileSystemAccessError",
@@ -1858,7 +1838,7 @@ describe("File system utils", () => {
 
   describe("createFile", () => {
     it("Should create a file", async () => {
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
 
       await createFile(filePath);
 
@@ -1866,7 +1846,7 @@ describe("File system utils", () => {
     });
 
     it("Should create a file even if part of the path doesn't exist", async () => {
-      const filePath = path.join(getTmpDir(), "not-exists", "file.txt");
+      const filePath = path.join(tmp.path, "not-exists", "file.txt");
 
       await createFile(filePath);
 
@@ -1884,7 +1864,7 @@ describe("File system utils", () => {
 
   describe("emptyDir", () => {
     it("Should empty a directory", async () => {
-      const dirPath = path.join(getTmpDir(), "dir");
+      const dirPath = path.join(tmp.path, "dir");
       await mkdir(dirPath);
 
       const files = ["file1.txt", "file2.txt", "file3.json"];
@@ -1899,7 +1879,7 @@ describe("File system utils", () => {
     });
 
     it("Should preserve the directory permissions", async () => {
-      const dirPath = path.join(getTmpDir(), "dir");
+      const dirPath = path.join(tmp.path, "dir");
       await mkdir(dirPath);
       await chmod(dirPath, 0o666);
 
@@ -1910,7 +1890,7 @@ describe("File system utils", () => {
     });
 
     it("Should create the directory if it doesn't exist", async () => {
-      const dirPath = path.join(getTmpDir(), "not-exists");
+      const dirPath = path.join(tmp.path, "not-exists");
 
       await emptyDir(dirPath);
 
@@ -1919,7 +1899,7 @@ describe("File system utils", () => {
     });
 
     it("Should throw NotADirectoryError if the path is not a directory", async () => {
-      const filePath = path.join(getTmpDir(), "file");
+      const filePath = path.join(tmp.path, "file");
       await createFile(filePath);
 
       await assert.rejects(emptyDir(filePath), {
@@ -1939,18 +1919,18 @@ describe("File system utils", () => {
 
   describe("findUp", () => {
     it("Should find a file in the current directory", async () => {
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
       await createFile(filePath);
 
-      assert.equal(await findUp("file.txt", getTmpDir()), filePath);
+      assert.equal(await findUp("file.txt", tmp.path), filePath);
     });
 
     it("Should find a file in a parent directory", async () => {
-      const filePath = path.join(getTmpDir(), "file.txt");
+      const filePath = path.join(tmp.path, "file.txt");
       await createFile(filePath);
 
       assert.equal(
-        await findUp("file.txt", path.join(getTmpDir(), "subdir")),
+        await findUp("file.txt", path.join(tmp.path, "subdir")),
         filePath,
       );
     });

--- a/packages/hardhat-utils/test/helpers/fs.ts
+++ b/packages/hardhat-utils/test/helpers/fs.ts
@@ -8,7 +8,7 @@ import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { after, afterEach, before, beforeEach } from "node:test";
 
-import { ensureDir, getRealPath, mkdtemp, remove } from "../../src/fs.js";
+import { ensureDir, getRealPath, remove } from "../../src/fs.js";
 import { findClosestPackageRoot } from "../../src/package.js";
 
 // Local shim of `assertHardhatInvariant` from `@nomicfoundation/hardhat-errors`.
@@ -142,42 +142,4 @@ export function createTmpDir(
   }
 
   return handle;
-}
-
-/**
- * Create a tmp directory.
- * @param nameHint - A hint to use as part of the name of the tmp directory.
- *
- * @deprecated Use {@link createTmpDir} instead. Kept for backwards
- *   compatibility during the migration; will be removed once all callers move
- *   to `createTmpDir`.
- */
-export async function getTmpDir(nameHint: string = "tmp-dir"): Promise<string> {
-  const tmpDir = await mkdtemp(`hardhat-tests-${nameHint}`);
-  return tmpDir;
-}
-
-/**
- * Creates a tmp directory before each test, and removes it after each test.
- * @param nameHint - A hint to use as part of the name of the tmp directory.
- *
- * @deprecated Use {@link createTmpDir} with scope `"test"` instead. Kept for
- *   backwards compatibility during the migration; will be removed once all
- *   callers move to `createTmpDir`.
- */
-export function useTmpDir(nameHint: string = "tmp-dir"): void {
-  let previousWorkingDir: string;
-  let tmpDir: string;
-
-  beforeEach(async function () {
-    previousWorkingDir = process.cwd();
-
-    tmpDir = await getTmpDir(nameHint);
-
-    process.chdir(tmpDir);
-  });
-
-  afterEach(async function () {
-    process.chdir(previousWorkingDir);
-  });
 }

--- a/packages/hardhat-utils/test/helpers/fs.ts
+++ b/packages/hardhat-utils/test/helpers/fs.ts
@@ -66,9 +66,12 @@ export async function makeWorkspaceTmpDir(nameHint: string): Promise<string> {
 /**
  * Removes a tmp directory previously created by `makeWorkspaceTmpDir`.
  *
- * Restores `process.cwd()` if it currently points inside the directory
- * (required on Windows so `rm` can unlink the tree), then logs and swallows
- * any error so a cleanup failure never fails a test.
+ * If `process.cwd()` currently points inside the directory, moves it to the
+ * directory's parent first (required on Windows so `rm` can unlink the tree).
+ * Note that this does not restore the caller's original cwd — callers that
+ * need a precise cwd restoration must do it themselves before calling.
+ *
+ * Then logs and swallows any error so a cleanup failure never fails a test.
  *
  * Low-level helper used by `createTmpDir` and `useTestProjectTemplate`.
  */

--- a/packages/hardhat-utils/test/helpers/fs.ts
+++ b/packages/hardhat-utils/test/helpers/fs.ts
@@ -1,26 +1,183 @@
-import os from "node:os";
+// IMPORTANT: this file mirrors `packages/hardhat-test-utils/src/fs.ts`.
+// `hardhat-test-utils` depends on `hardhat-utils`, so we can't import from
+// there here — this would be a circular dependency. Any change to
+// `createTmpDir` / `makeWorkspaceTmpDir` / `safeRemoveTmpDir` should be
+// mirrored in the canonical file.
+
+import fsPromises from "node:fs/promises";
 import path from "node:path";
-import { beforeEach } from "node:test";
+import { after, afterEach, before, beforeEach } from "node:test";
 
-import { getRealPath, mkdir, remove } from "../../src/fs.js";
+import { ensureDir, getRealPath, mkdtemp, remove } from "../../src/fs.js";
+import { findClosestPackageRoot } from "../../src/package.js";
 
-async function getEmptyTmpDir(nameHint: string) {
-  const tmpDirContainer = await getRealPath(os.tmpdir());
+// Local shim of `assertHardhatInvariant` from `@nomicfoundation/hardhat-errors`.
+// We can't import that package here because it depends on `hardhat-utils`,
+// which would form a circular dependency. The function body below uses this
+// shim instead — that is the only intentional divergence from the canonical
+// helper in `packages/hardhat-test-utils/src/fs.ts`.
+function assertHardhatInvariant(
+  invariant: boolean,
+  message: string,
+): asserts invariant {
+  if (!invariant) {
+    throw new Error(message);
+  }
+}
 
-  const tmpDir = path.join(tmpDirContainer, `hardhat-utils-tests-${nameHint}`);
-  await remove(tmpDir);
-  await mkdir(tmpDir);
+let workspaceRootCache: string | undefined;
 
+async function getWorkspaceRoot(): Promise<string> {
+  if (workspaceRootCache === undefined) {
+    const testUtilsRoot = await findClosestPackageRoot(import.meta.url);
+    workspaceRootCache = path.resolve(testUtilsRoot, "..", "..");
+  }
+  return workspaceRootCache;
+}
+
+/**
+ * Creates a tmp directory inside `<workspace-root>/tmp/` and returns its
+ * absolute (real) path.
+ *
+ * Putting tmp dirs inside the workspace (instead of `os.tmpdir()`) means
+ * tools that resolve config by walking up from `cwd` — corepack, package
+ * managers, `.npmrc`, and similar — see the workspace's settings.
+ *
+ * Note that the workspace's `package.json` sets `"type": "module"`, so any
+ * `.js` file written into the tmp dir is treated as ESM by default. Tests
+ * that download third-party CJS `.js` blobs into their tmp dir (e.g. solc's
+ * WASM bundle) need to plant a `package.json` with `{"type":"commonjs"}`
+ * inside their own tmp dir to opt out.
+ *
+ * Low-level helper used by `createTmpDir` and `useTestProjectTemplate`. Most
+ * tests should use `createTmpDir` instead.
+ */
+export async function makeWorkspaceTmpDir(nameHint: string): Promise<string> {
+  const root = await getWorkspaceRoot();
+  const tmpBase = path.join(root, "tmp");
+  await ensureDir(tmpBase);
+  const tmpDir = await fsPromises.mkdtemp(path.join(tmpBase, `${nameHint}-`));
+  // `mkdtemp` creates dirs with mode 0o700 (owner-only). Widen to the
+  // conventional 0o755 directory mode so other users can traverse the tree.
+  await fsPromises.chmod(tmpDir, 0o755);
+  return await getRealPath(tmpDir);
+}
+
+/**
+ * Removes a tmp directory previously created by `makeWorkspaceTmpDir`.
+ *
+ * Restores `process.cwd()` if it currently points inside the directory
+ * (required on Windows so `rm` can unlink the tree), then logs and swallows
+ * any error so a cleanup failure never fails a test.
+ *
+ * Low-level helper used by `createTmpDir` and `useTestProjectTemplate`.
+ */
+export async function safeRemoveTmpDir(tmpPath: string): Promise<void> {
+  try {
+    const cwd = process.cwd();
+    if (cwd === tmpPath || cwd.startsWith(tmpPath + path.sep)) {
+      process.chdir(path.dirname(tmpPath));
+    }
+    await remove(tmpPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`Failed to remove temporary directory ${tmpPath}: ${message}`);
+  }
+}
+
+/**
+ * Creates a tmp directory inside `<workspace-root>/tmp/`, registers the
+ * appropriate Node test-runner hooks to clean it up, and returns a handle
+ * whose `.path` getter is valid inside `it`/`before`/`after`/`beforeEach`/
+ * `afterEach` (it throws if accessed before the relevant hook has run).
+ *
+ * @param nameHint - A short string used as a prefix for the tmp directory
+ *   name. Helps when reading on-disk paths during debugging.
+ * @param scope - `"test"`: fresh dir per `it` via `beforeEach`/`afterEach`.
+ *   `"describe"`: one shared dir for the whole describe via `before`/`after`.
+ *
+ * @example
+ * ```ts
+ * describe("foo", () => {
+ *   const tmp = createTmpDir("foo", "test");
+ *   it("writes a file", async () => {
+ *     await writeUtf8File(path.join(tmp.path, "x"), "y");
+ *   });
+ * });
+ * ```
+ */
+export function createTmpDir(
+  nameHint: string,
+  scope: "test" | "describe",
+): { readonly path: string } {
+  let tmpPath: string | undefined;
+
+  const handle = {
+    get path(): string {
+      assertHardhatInvariant(
+        tmpPath !== undefined,
+        `createTmpDir("${nameHint}"): .path accessed before the dir was created. It is available inside it()/before()/after()/beforeEach()/afterEach() blocks.`,
+      );
+      return tmpPath;
+    },
+  };
+
+  const create = async () => {
+    tmpPath = await makeWorkspaceTmpDir(nameHint);
+  };
+  const cleanup = async () => {
+    if (tmpPath !== undefined) {
+      const toRemove = tmpPath;
+      tmpPath = undefined;
+      await safeRemoveTmpDir(toRemove);
+    }
+  };
+
+  if (scope === "test") {
+    beforeEach(create);
+    afterEach(cleanup);
+  } else {
+    before(create);
+    after(cleanup);
+  }
+
+  return handle;
+}
+
+/**
+ * Create a tmp directory.
+ * @param nameHint - A hint to use as part of the name of the tmp directory.
+ *
+ * @deprecated Use {@link createTmpDir} instead. Kept for backwards
+ *   compatibility during the migration; will be removed once all callers move
+ *   to `createTmpDir`.
+ */
+export async function getTmpDir(nameHint: string = "tmp-dir"): Promise<string> {
+  const tmpDir = await mkdtemp(`hardhat-tests-${nameHint}`);
   return tmpDir;
 }
 
-export function useTmpDir(nameHint: string) {
-  nameHint = nameHint.replace(/\s+/, "-");
+/**
+ * Creates a tmp directory before each test, and removes it after each test.
+ * @param nameHint - A hint to use as part of the name of the tmp directory.
+ *
+ * @deprecated Use {@link createTmpDir} with scope `"test"` instead. Kept for
+ *   backwards compatibility during the migration; will be removed once all
+ *   callers move to `createTmpDir`.
+ */
+export function useTmpDir(nameHint: string = "tmp-dir"): void {
+  let previousWorkingDir: string;
   let tmpDir: string;
 
   beforeEach(async function () {
-    tmpDir = await getEmptyTmpDir(nameHint);
+    previousWorkingDir = process.cwd();
+
+    tmpDir = await getTmpDir(nameHint);
+
+    process.chdir(tmpDir);
   });
 
-  return (): string => tmpDir;
+  afterEach(async function () {
+    process.chdir(previousWorkingDir);
+  });
 }

--- a/packages/hardhat-utils/test/package.ts
+++ b/packages/hardhat-utils/test/package.ts
@@ -1,7 +1,6 @@
 import type { PackageJson } from "../src/package.js";
 
 import assert from "node:assert/strict";
-import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
 
@@ -11,6 +10,8 @@ import {
   createFile,
   getRealPath,
   mkdir,
+  mkdtemp,
+  remove,
   writeJsonFile,
   writeUtf8File,
 } from "../src/fs.js";
@@ -67,20 +68,21 @@ describe("package", () => {
     });
 
     it("Should throw PackageJsonNotFoundError if no package.json is found", async () => {
-      // Walk up from an OS-level tmp path that has no enclosing package.json.
-      // We can't use the workspace-local tmp dir here because the workspace
-      // itself has a `package.json` above it.
-      const fromPath = path.join(
-        os.tmpdir(),
-        "no-package-json-test",
-        "subdir",
-        "subsubdir",
-      );
+      // We use `mkdtemp` (which creates the dir under `os.tmpdir()`) instead
+      // of `createTmpDir`, because `createTmpDir` would put the dir inside
+      // the workspace, and the workspace itself has a `package.json` above
+      // it, which would make `findClosestPackageJson` succeed.
+      const uniqueParent = await mkdtemp("no-package-json-test-");
+      const fromPath = path.join(uniqueParent, "subdir", "subsubdir");
 
-      await assert.rejects(findClosestPackageJson(fromPath), {
-        name: "PackageJsonNotFoundError",
-        message: `No package.json found for ${fromPath}`,
-      });
+      try {
+        await assert.rejects(findClosestPackageJson(fromPath), {
+          name: "PackageJsonNotFoundError",
+          message: `No package.json found for ${fromPath}`,
+        });
+      } finally {
+        await remove(uniqueParent);
+      }
     });
 
     it("Should throw PackageJsonNotFoundError if the file url is malformed", async () => {
@@ -128,18 +130,21 @@ describe("package", () => {
     });
 
     it("Should throw PackageJsonNotFoundError if no package.json is found", async () => {
-      // See related explanation in the `findClosestPackageJson` test above.
-      const fromPath = path.join(
-        os.tmpdir(),
-        "no-package-json-test",
-        "subdir",
-        "subsubdir",
-      );
+      // We use `mkdtemp` (which creates the dir under `os.tmpdir()`) instead
+      // of `createTmpDir`, because `createTmpDir` would put the dir inside
+      // the workspace, and the workspace itself has a `package.json` above
+      // it, which would make `readClosestPackageJson` succeed.
+      const uniqueParent = await mkdtemp("no-package-json-test-");
+      const fromPath = path.join(uniqueParent, "subdir", "subsubdir");
 
-      await assert.rejects(readClosestPackageJson(fromPath), {
-        name: "PackageJsonNotFoundError",
-        message: `No package.json found for ${fromPath}`,
-      });
+      try {
+        await assert.rejects(readClosestPackageJson(fromPath), {
+          name: "PackageJsonNotFoundError",
+          message: `No package.json found for ${fromPath}`,
+        });
+      } finally {
+        await remove(uniqueParent);
+      }
     });
 
     it("Should throw PackageJsonNotFoundError if the file url is malformed", async () => {
@@ -195,18 +200,21 @@ describe("package", () => {
     });
 
     it("Should throw PackageJsonNotFoundError if no package.json is found", async () => {
-      // See related explanation in the `findClosestPackageJson` test above.
-      const fromPath = path.join(
-        os.tmpdir(),
-        "no-package-json-test",
-        "subdir",
-        "subsubdir",
-      );
+      // We use `mkdtemp` (which creates the dir under `os.tmpdir()`) instead
+      // of `createTmpDir`, because `createTmpDir` would put the dir inside
+      // the workspace, and the workspace itself has a `package.json` above
+      // it, which would make `findClosestPackageRoot` succeed.
+      const uniqueParent = await mkdtemp("no-package-json-test-");
+      const fromPath = path.join(uniqueParent, "subdir", "subsubdir");
 
-      await assert.rejects(findClosestPackageRoot(fromPath), {
-        name: "PackageJsonNotFoundError",
-        message: `No package.json found for ${fromPath}`,
-      });
+      try {
+        await assert.rejects(findClosestPackageRoot(fromPath), {
+          name: "PackageJsonNotFoundError",
+          message: `No package.json found for ${fromPath}`,
+        });
+      } finally {
+        await remove(uniqueParent);
+      }
     });
   });
 

--- a/packages/hardhat-utils/test/package.ts
+++ b/packages/hardhat-utils/test/package.ts
@@ -1,6 +1,7 @@
 import type { PackageJson } from "../src/package.js";
 
 import assert from "node:assert/strict";
+import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
 
@@ -20,10 +21,10 @@ import {
   findDependencyPackageJson,
 } from "../src/package.js";
 
-import { useTmpDir } from "./helpers/fs.js";
+import { createTmpDir } from "./helpers/fs.js";
 
 describe("package", () => {
-  const getTmpDir = useTmpDir("package");
+  const tmp = createTmpDir("package", "test");
 
   describe("findClosestPackageJson", () => {
     it("Should find the closest package.json relative to import.meta.url", async () => {
@@ -34,8 +35,8 @@ describe("package", () => {
     });
 
     it("Should find the closest package.json relative to a file", async () => {
-      const expectedPath = path.join(getTmpDir(), "package.json");
-      const fromPath = path.join(getTmpDir(), "subdir", "subsubdir", "file.js");
+      const expectedPath = path.join(tmp.path, "package.json");
+      const fromPath = path.join(tmp.path, "subdir", "subsubdir", "file.js");
       await createFile(expectedPath);
       await createFile(fromPath);
 
@@ -45,8 +46,8 @@ describe("package", () => {
     });
 
     it("Should find the closest package.json relative to a directory", async () => {
-      const expectedPath = path.join(getTmpDir(), "package.json");
-      const fromPath = path.join(getTmpDir(), "subdir", "subsubdir");
+      const expectedPath = path.join(tmp.path, "package.json");
+      const fromPath = path.join(tmp.path, "subdir", "subsubdir");
       await createFile(expectedPath);
       await mkdir(fromPath);
 
@@ -56,8 +57,8 @@ describe("package", () => {
     });
 
     it("Should find the closest package.json relative to a directory when its within that directory", async () => {
-      const expectedPath = path.join(getTmpDir(), "package.json");
-      const fromPath = getTmpDir();
+      const expectedPath = path.join(tmp.path, "package.json");
+      const fromPath = tmp.path;
       await createFile(expectedPath);
 
       const actualPath = await findClosestPackageJson(fromPath);
@@ -66,7 +67,15 @@ describe("package", () => {
     });
 
     it("Should throw PackageJsonNotFoundError if no package.json is found", async () => {
-      const fromPath = path.join(getTmpDir(), "subdir", "subsubdir");
+      // Walk up from an OS-level tmp path that has no enclosing package.json.
+      // We can't use the workspace-local tmp dir here because the workspace
+      // itself has a `package.json` above it.
+      const fromPath = path.join(
+        os.tmpdir(),
+        "no-package-json-test",
+        "subdir",
+        "subsubdir",
+      );
 
       await assert.rejects(findClosestPackageJson(fromPath), {
         name: "PackageJsonNotFoundError",
@@ -91,8 +100,8 @@ describe("package", () => {
     });
 
     it("Should read the closest package.json relative to a file", async () => {
-      const packageJsonPath = path.join(getTmpDir(), "package.json");
-      const fromPath = path.join(getTmpDir(), "subdir", "subsubdir", "file.js");
+      const packageJsonPath = path.join(tmp.path, "package.json");
+      const fromPath = path.join(tmp.path, "subdir", "subsubdir", "file.js");
       await writeJsonFile(packageJsonPath, {
         name: "test-package",
       });
@@ -105,8 +114,8 @@ describe("package", () => {
     });
 
     it("Should read the closest package.json relative to a directory", async () => {
-      const packageJsonPath = path.join(getTmpDir(), "package.json");
-      const fromPath = path.join(getTmpDir(), "subdir", "subsubdir");
+      const packageJsonPath = path.join(tmp.path, "package.json");
+      const fromPath = path.join(tmp.path, "subdir", "subsubdir");
       await writeJsonFile(packageJsonPath, {
         name: "test-package",
       });
@@ -119,7 +128,13 @@ describe("package", () => {
     });
 
     it("Should throw PackageJsonNotFoundError if no package.json is found", async () => {
-      const fromPath = path.join(getTmpDir(), "subdir", "subsubdir");
+      // See related explanation in the `findClosestPackageJson` test above.
+      const fromPath = path.join(
+        os.tmpdir(),
+        "no-package-json-test",
+        "subdir",
+        "subsubdir",
+      );
 
       await assert.rejects(readClosestPackageJson(fromPath), {
         name: "PackageJsonNotFoundError",
@@ -135,8 +150,8 @@ describe("package", () => {
     });
 
     it("Should throw PackageJsonReadError if the package.json is malformed", async () => {
-      const packageJsonPath = path.join(getTmpDir(), "package.json");
-      const fromPath = path.join(getTmpDir(), "subdir", "subsubdir", "file.js");
+      const packageJsonPath = path.join(tmp.path, "package.json");
+      const fromPath = path.join(tmp.path, "subdir", "subsubdir", "file.js");
       await writeUtf8File(packageJsonPath, "{");
 
       await assert.rejects(readClosestPackageJson(fromPath), {
@@ -154,8 +169,8 @@ describe("package", () => {
     });
 
     it("Should find the package root relative to a file", async () => {
-      const packageJsonPath = path.join(getTmpDir(), "package.json");
-      const fromPath = path.join(getTmpDir(), "subdir", "subsubdir", "file.js");
+      const packageJsonPath = path.join(tmp.path, "package.json");
+      const fromPath = path.join(tmp.path, "subdir", "subsubdir", "file.js");
       await writeJsonFile(packageJsonPath, {
         name: "test-package",
       });
@@ -163,12 +178,12 @@ describe("package", () => {
 
       const packageRoot = await findClosestPackageRoot(fromPath);
 
-      assert.equal(packageRoot, getTmpDir());
+      assert.equal(packageRoot, tmp.path);
     });
 
     it("Should find the package root relative to a directory", async () => {
-      const packageJsonPath = path.join(getTmpDir(), "package.json");
-      const fromPath = path.join(getTmpDir(), "subdir", "subsubdir");
+      const packageJsonPath = path.join(tmp.path, "package.json");
+      const fromPath = path.join(tmp.path, "subdir", "subsubdir");
       await writeJsonFile(packageJsonPath, {
         name: "test-package",
       });
@@ -176,11 +191,17 @@ describe("package", () => {
 
       const packageRoot = await findClosestPackageRoot(fromPath);
 
-      assert.equal(packageRoot, getTmpDir());
+      assert.equal(packageRoot, tmp.path);
     });
 
     it("Should throw PackageJsonNotFoundError if no package.json is found", async () => {
-      const fromPath = path.join(getTmpDir(), "subdir", "subsubdir");
+      // See related explanation in the `findClosestPackageJson` test above.
+      const fromPath = path.join(
+        os.tmpdir(),
+        "no-package-json-test",
+        "subdir",
+        "subsubdir",
+      );
 
       await assert.rejects(findClosestPackageRoot(fromPath), {
         name: "PackageJsonNotFoundError",

--- a/packages/hardhat-utils/test/request.ts
+++ b/packages/hardhat-utils/test/request.ts
@@ -29,7 +29,7 @@ import {
   getProxyUrl,
 } from "../src/request.js";
 
-import { useTmpDir } from "./helpers/fs.js";
+import { createTmpDir } from "./helpers/fs.js";
 import { initializeTestDispatcher } from "./helpers/request.js";
 
 describe("Requests util", () => {
@@ -515,7 +515,7 @@ describe("Requests util", () => {
 
   describe("download", async () => {
     const interceptor = await initializeTestDispatcher();
-    const getTmpDir = useTmpDir("request");
+    const tmp = createTmpDir("request", "test");
     const url = "http://localhost";
     const baseInterceptorOptions = {
       path: "/",
@@ -526,7 +526,7 @@ describe("Requests util", () => {
     };
 
     it("Should download a file", async () => {
-      const destination = path.join(getTmpDir(), "file.txt");
+      const destination = path.join(tmp.path, "file.txt");
       interceptor.intercept(baseInterceptorOptions).reply(200, "file content");
       await download(url, destination, undefined, interceptor);
 
@@ -535,7 +535,7 @@ describe("Requests util", () => {
     });
 
     it("Should throw if the request fails", async () => {
-      const destination = path.join(getTmpDir(), "file.txt");
+      const destination = path.join(tmp.path, "file.txt");
       interceptor
         .intercept(baseInterceptorOptions)
         .reply(500, "Internal Server Error");
@@ -547,7 +547,7 @@ describe("Requests util", () => {
     });
 
     it("Should not leave temp files after a failed download", async () => {
-      const tmpDir = getTmpDir();
+      const tmpDir = tmp.path;
       const destination = path.join(tmpDir, "file.txt");
       interceptor
         .intercept(baseInterceptorOptions)
@@ -566,10 +566,10 @@ describe("Requests util", () => {
   });
 
   describe("generateTempFilePath", () => {
-    const getTmpDir = useTmpDir("generateTempFilePath");
+    const tmp = createTmpDir("generateTempFilePath", "test");
 
     it("Should produce unique paths for the same input", async () => {
-      const filePath = path.join(getTmpDir(), "list.json");
+      const filePath = path.join(tmp.path, "list.json");
       const result1 = await generateTempFilePath(filePath);
       const result2 = await generateTempFilePath(filePath);
 
@@ -581,7 +581,7 @@ describe("Requests util", () => {
     });
 
     it("Should preserve directory and extension", async () => {
-      const dir = getTmpDir();
+      const dir = tmp.path;
       const filePath = path.join(dir, "list.json");
       const result = await generateTempFilePath(filePath);
       const parsed = path.parse(result);
@@ -591,7 +591,7 @@ describe("Requests util", () => {
     });
 
     it("Should have a name starting with tmp-<originalName>-", async () => {
-      const filePath = path.join(getTmpDir(), "list.json");
+      const filePath = path.join(tmp.path, "list.json");
       const result = await generateTempFilePath(filePath);
       const parsed = path.parse(result);
 

--- a/packages/hardhat-utils/test/synchronization.ts
+++ b/packages/hardhat-utils/test/synchronization.ts
@@ -21,7 +21,7 @@ import {
   StaleMultiProcessMutexError,
 } from "../src/synchronization.js";
 
-import { useTmpDir } from "./helpers/fs.js";
+import { createTmpDir } from "./helpers/fs.js";
 
 /**
  * Creates a file within a lock directory that blocks the process of deleting
@@ -127,10 +127,10 @@ function dropRootPrivileges(): () => void {
 }
 
 describe("MultiProcessMutex", () => {
-  const getTmpDir = useTmpDir("multi-process-mutex");
+  const tmp = createTmpDir("multi-process-mutex", "test");
 
   it("should execute all the functions in a sequential order, not in parallel", async () => {
-    const lockPath = path.join(getTmpDir(), "test.lock");
+    const lockPath = path.join(tmp.path, "test.lock");
     const mutex = new MultiProcessMutex(lockPath);
     const start = performance.now();
 
@@ -157,7 +157,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should get the mutex lock because the first function to own it failed", async () => {
-    const lockPath = path.join(getTmpDir(), "test.lock");
+    const lockPath = path.join(tmp.path, "test.lock");
     const mutex = new MultiProcessMutex(lockPath);
 
     const start = performance.now();
@@ -198,7 +198,7 @@ describe("MultiProcessMutex", () => {
     "should acquire the mutex lock after the first owner was cancelled due to a process crash",
     { timeout: 10_000 },
     async () => {
-      const lockPath = path.join(getTmpDir(), "crash.lock");
+      const lockPath = path.join(tmp.path, "crash.lock");
       const fixtureScript = path.resolve(
         import.meta.dirname,
         "fixture-projects/lock/lock-holder.ts",
@@ -256,7 +256,7 @@ describe("MultiProcessMutex", () => {
   );
 
   it("should acquire and release a lock", async () => {
-    const lockPath = path.join(getTmpDir(), "test.lock");
+    const lockPath = path.join(tmp.path, "test.lock");
     const mutex = new MultiProcessMutex(lockPath);
 
     const result = await mutex.use(async () => {
@@ -274,7 +274,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should recover a stale lock with a dead PID", async () => {
-    const lockPath = path.join(getTmpDir(), "stale.lock");
+    const lockPath = path.join(tmp.path, "stale.lock");
     // Create a fake lock file with metadata pointing to a non-existent PID
     writeFakeMetadata(lockPath, {
       pid: 999999999, // Very unlikely to exist
@@ -298,7 +298,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should recover a stale lock without sleeping (skip backoff)", async () => {
-    const lockPath = path.join(getTmpDir(), "stale-no-sleep.lock");
+    const lockPath = path.join(tmp.path, "stale-no-sleep.lock");
     writeFakeMetadata(lockPath, {
       pid: 999999999, // Very unlikely to exist
       hostname: os.hostname(),
@@ -322,7 +322,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should throw MultiProcessMutexTimeoutError when lock is held by a live process", async () => {
-    const lockPath = path.join(getTmpDir(), "timeout.lock");
+    const lockPath = path.join(tmp.path, "timeout.lock");
     // Create a lock owned by THIS process (which is alive)
     writeFakeMetadata(lockPath, {
       pid: process.pid,
@@ -352,7 +352,7 @@ describe("MultiProcessMutex", () => {
     "should wait for a child process to release the lock",
     { timeout: 10_000 },
     async () => {
-      const lockPath = path.join(getTmpDir(), "cross-process.lock");
+      const lockPath = path.join(tmp.path, "cross-process.lock");
       const fixtureScript = path.resolve(
         import.meta.dirname,
         "fixture-projects/lock/lock-holder.ts",
@@ -396,7 +396,7 @@ describe("MultiProcessMutex", () => {
   );
 
   it("should throw IncompatibleHostnameMultiProcessMutexError for a lock from a different hostname", async () => {
-    const lockPath = path.join(getTmpDir(), "hostname.lock");
+    const lockPath = path.join(tmp.path, "hostname.lock");
     writeFakeMetadata(lockPath, {
       pid: 1,
       hostname: "some-other-host",
@@ -427,7 +427,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should treat corrupt metadata as stale", async () => {
-    const lockPath = path.join(getTmpDir(), "corrupt.lock");
+    const lockPath = path.join(tmp.path, "corrupt.lock");
     fs.writeFileSync(lockPath, "NOT VALID JSON {{{", "utf8");
 
     const mutex = new MultiProcessMutex(lockPath);
@@ -436,7 +436,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should treat empty lock file as stale", async () => {
-    const lockPath = path.join(getTmpDir(), "empty.lock");
+    const lockPath = path.join(tmp.path, "empty.lock");
     fs.writeFileSync(lockPath, "", "utf8");
 
     const mutex = new MultiProcessMutex(lockPath);
@@ -445,13 +445,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should auto-create parent directories", async () => {
-    const lockPath = path.join(
-      getTmpDir(),
-      "deep",
-      "nested",
-      "dir",
-      "test.lock",
-    );
+    const lockPath = path.join(tmp.path, "deep", "nested", "dir", "test.lock");
 
     const mutex = new MultiProcessMutex(lockPath);
     const result = await mutex.use(async () => "acquired");
@@ -463,7 +457,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should throw IncompatiblePlatformMultiProcessMutexError for a lock from a different platform", async () => {
-    const lockPath = path.join(getTmpDir(), "platform.lock");
+    const lockPath = path.join(tmp.path, "platform.lock");
     const fakePlatform = process.platform === "linux" ? "win32" : "linux";
     writeFakeMetadata(lockPath, {
       pid: process.pid, // Even if PID matches, different platform = incompatible
@@ -500,7 +494,7 @@ describe("MultiProcessMutex", () => {
     "should throw IncompatibleUidMultiProcessMutexError when lock has a different uid",
     { skip: process.getuid === undefined },
     async () => {
-      const lockPath = path.join(getTmpDir(), "uid.lock");
+      const lockPath = path.join(tmp.path, "uid.lock");
       // Create a stale lock (dead PID) with a different uid
       writeFakeMetadata(lockPath, {
         pid: 999999999, // Very unlikely to exist
@@ -538,7 +532,7 @@ describe("MultiProcessMutex", () => {
     "should throw StaleMultiProcessMutexError with cause when stale lock cannot be removed",
     { skip: process.platform === "win32" },
     async () => {
-      const parentDir = path.join(getTmpDir(), "permission-denied");
+      const parentDir = path.join(tmp.path, "permission-denied");
       fs.mkdirSync(parentDir);
       const lockPath = path.join(parentDir, "user.lock");
       // Create a stale lock (dead PID) with same uid so it passes the uid check
@@ -584,7 +578,7 @@ describe("MultiProcessMutex", () => {
     "should throw StaleMultiProcessMutexError with cause when stale lock cannot be removed (Windows)",
     { skip: process.platform !== "win32" },
     async () => {
-      const lockPath = path.join(getTmpDir(), "permission-denied-win.lock");
+      const lockPath = path.join(tmp.path, "permission-denied-win.lock");
       // Create a stale lock (dead PID) so tryUnlockingStaleLock runs
       writeFakeMetadata(lockPath, {
         pid: 999999999, // Very unlikely to exist — makes the lock stale
@@ -621,7 +615,7 @@ describe("MultiProcessMutex", () => {
 
   describe("acquire", () => {
     it("should acquire and release a lock", async () => {
-      const lockPath = path.join(getTmpDir(), "acquire.lock");
+      const lockPath = path.join(tmp.path, "acquire.lock");
       const mutex = new MultiProcessMutex(lockPath);
 
       const release = await mutex.acquire();
@@ -637,7 +631,7 @@ describe("MultiProcessMutex", () => {
     });
 
     it("should allow manual lock lifecycle around work", async () => {
-      const lockPath = path.join(getTmpDir(), "manual.lock");
+      const lockPath = path.join(tmp.path, "manual.lock");
       const mutex = new MultiProcessMutex(lockPath);
 
       const release = await mutex.acquire();
@@ -657,7 +651,7 @@ describe("MultiProcessMutex", () => {
     });
 
     it("should enforce mutual exclusion via acquire()", async () => {
-      const lockPath = path.join(getTmpDir(), "exclusion.lock");
+      const lockPath = path.join(tmp.path, "exclusion.lock");
       const mutex = new MultiProcessMutex(lockPath);
 
       const order: number[] = [];
@@ -679,7 +673,7 @@ describe("MultiProcessMutex", () => {
     });
 
     it("should release the lock even if the caller's work throws", async () => {
-      const lockPath = path.join(getTmpDir(), "throw.lock");
+      const lockPath = path.join(tmp.path, "throw.lock");
       const mutex = new MultiProcessMutex(lockPath);
 
       await assert.rejects(async () => {
@@ -698,7 +692,7 @@ describe("MultiProcessMutex", () => {
     });
 
     it("should allow calling release multiple times without error", async () => {
-      const lockPath = path.join(getTmpDir(), "double-release.lock");
+      const lockPath = path.join(tmp.path, "double-release.lock");
       const mutex = new MultiProcessMutex(lockPath);
 
       const release = await mutex.acquire();
@@ -707,7 +701,7 @@ describe("MultiProcessMutex", () => {
     });
 
     it("should throw MultiProcessMutexTimeoutError from acquire()", async () => {
-      const lockPath = path.join(getTmpDir(), "timeout-acquire.lock");
+      const lockPath = path.join(tmp.path, "timeout-acquire.lock");
       // Create a lock owned by THIS process (which is alive)
       writeFakeMetadata(lockPath, {
         pid: process.pid,
@@ -745,7 +739,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should treat metadata with invalid field types as stale", async () => {
-    const lockPath = path.join(getTmpDir(), "invalid-fields.lock");
+    const lockPath = path.join(tmp.path, "invalid-fields.lock");
     writeFakeMetadata(lockPath, {
       pid: "not-a-number",
       hostname: "h",
@@ -759,7 +753,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should treat metadata with invalid uid type as stale", async () => {
-    const lockPath = path.join(getTmpDir(), "invalid-uid.lock");
+    const lockPath = path.join(tmp.path, "invalid-uid.lock");
     writeFakeMetadata(lockPath, {
       pid: process.pid,
       hostname: os.hostname(),
@@ -774,7 +768,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should treat metadata with non-safe-integer uid as stale", async () => {
-    const lockPath = path.join(getTmpDir(), "unsafe-uid.lock");
+    const lockPath = path.join(tmp.path, "unsafe-uid.lock");
     writeFakeMetadata(lockPath, {
       pid: process.pid,
       hostname: os.hostname(),
@@ -789,7 +783,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should treat metadata with non-positive createdAt as stale", async () => {
-    const lockPath = path.join(getTmpDir(), "non-positive-created-at.lock");
+    const lockPath = path.join(tmp.path, "non-positive-created-at.lock");
 
     writeFakeMetadata(lockPath, {
       pid: process.pid,
@@ -809,7 +803,7 @@ describe("MultiProcessMutex", () => {
     "should treat a process returning EPERM on kill(pid,0) as alive",
     { skip: process.platform === "win32" },
     async () => {
-      const lockPath = path.join(getTmpDir(), "eperm.lock");
+      const lockPath = path.join(tmp.path, "eperm.lock");
       writeFakeMetadata(lockPath, {
         pid: 1, // init/systemd, owned by root — kill(1, 0) throws EPERM for non-root
         hostname: os.hostname(),
@@ -836,7 +830,7 @@ describe("MultiProcessMutex", () => {
   );
 
   it("should handle ENOENT gracefully when lock is already removed during release", async () => {
-    const lockPath = path.join(getTmpDir(), "already-removed.lock");
+    const lockPath = path.join(tmp.path, "already-removed.lock");
     const mutex = new MultiProcessMutex(lockPath);
     const release = await mutex.acquire();
 
@@ -852,7 +846,7 @@ describe("MultiProcessMutex", () => {
     "should throw MultiProcessMutexError when release fails with non-ENOENT error",
     { skip: process.platform === "win32" },
     async () => {
-      const parentDir = path.join(getTmpDir(), "release-error");
+      const parentDir = path.join(tmp.path, "release-error");
       fs.mkdirSync(parentDir);
       const lockPath = path.join(parentDir, "test.lock");
       const mutex = new MultiProcessMutex(lockPath);
@@ -884,7 +878,7 @@ describe("MultiProcessMutex", () => {
     "should throw MultiProcessMutexError when release fails with non-ENOENT error (Windows)",
     { skip: process.platform !== "win32" },
     async () => {
-      const lockPath = path.join(getTmpDir(), "release-error-win.lock");
+      const lockPath = path.join(tmp.path, "release-error-win.lock");
       const mutex = new MultiProcessMutex(lockPath);
 
       const release = await mutex.acquire();
@@ -911,7 +905,7 @@ describe("MultiProcessMutex", () => {
     "should throw StaleMultiProcessMutexError without uid info when metadata is corrupt",
     { skip: process.platform === "win32" },
     async () => {
-      const parentDir = path.join(getTmpDir(), "stale-no-uid");
+      const parentDir = path.join(tmp.path, "stale-no-uid");
       fs.mkdirSync(parentDir);
       const lockPath = path.join(parentDir, "user.lock");
       // Create lock file with corrupt content — treated as stale with metadata=undefined
@@ -952,7 +946,7 @@ describe("MultiProcessMutex", () => {
     "should throw StaleMultiProcessMutexError without uid info when metadata is corrupt (Windows)",
     { skip: process.platform !== "win32" },
     async () => {
-      const lockPath = path.join(getTmpDir(), "stale-no-uid-win.lock");
+      const lockPath = path.join(tmp.path, "stale-no-uid-win.lock");
       // Create lock file with corrupt content — treated as stale with metadata=undefined
       fs.writeFileSync(lockPath, "corrupt", "utf8");
 
@@ -987,7 +981,7 @@ describe("MultiProcessMutex", () => {
     "should handle ENOENT when parent directory disappears between polls",
     { timeout: 10_000 },
     async () => {
-      const parentDir = path.join(getTmpDir(), "vanishing");
+      const parentDir = path.join(tmp.path, "vanishing");
       fs.mkdirSync(parentDir);
       const lockPath = path.join(parentDir, "test.lock");
 
@@ -1016,7 +1010,7 @@ describe("MultiProcessMutex", () => {
   );
 
   it("should accept old-format metadata without sessionId", async () => {
-    const lockPath = path.join(getTmpDir(), "old-format.lock");
+    const lockPath = path.join(tmp.path, "old-format.lock");
     // Old-format metadata: no sessionId field
     writeFakeMetadata(lockPath, {
       pid: 999999999, // Very unlikely to exist — stale
@@ -1031,7 +1025,7 @@ describe("MultiProcessMutex", () => {
   });
 
   it("should treat metadata with invalid sessionId type as stale", async () => {
-    const lockPath = path.join(getTmpDir(), "invalid-sessionid.lock");
+    const lockPath = path.join(tmp.path, "invalid-sessionid.lock");
     writeFakeMetadata(lockPath, {
       pid: process.pid,
       hostname: os.hostname(),
@@ -1049,7 +1043,7 @@ describe("MultiProcessMutex", () => {
     const DEAD_PID = 999999999;
 
     it("should clean up orphaned temp files from dead PIDs after acquisition", async () => {
-      const lockPath = path.join(getTmpDir(), "cleanup.lock");
+      const lockPath = path.join(tmp.path, "cleanup.lock");
       const dir = path.dirname(lockPath);
       const baseName = path.basename(lockPath);
 
@@ -1073,7 +1067,7 @@ describe("MultiProcessMutex", () => {
     });
 
     it("should NOT clean up temp files from live PIDs", async () => {
-      const lockPath = path.join(getTmpDir(), "live-pid.lock");
+      const lockPath = path.join(tmp.path, "live-pid.lock");
       const dir = path.dirname(lockPath);
       const baseName = path.basename(lockPath);
 
@@ -1110,7 +1104,7 @@ describe("MultiProcessMutex", () => {
     });
 
     it("should clean orphans during stale lock recovery with corrupt metadata", async () => {
-      const lockPath = path.join(getTmpDir(), "corrupt.lock");
+      const lockPath = path.join(tmp.path, "corrupt.lock");
       const dir = path.dirname(lockPath);
       const baseName = path.basename(lockPath);
 
@@ -1135,7 +1129,7 @@ describe("MultiProcessMutex", () => {
     });
 
     it("should not touch unrelated files or other locks' temp files", async () => {
-      const lockPath = path.join(getTmpDir(), "mylock.lock");
+      const lockPath = path.join(tmp.path, "mylock.lock");
       const dir = path.dirname(lockPath);
 
       // Create an unrelated file
@@ -1165,7 +1159,7 @@ describe("MultiProcessMutex", () => {
     });
 
     it("should skip temp files with malformed/unparseable PIDs", async () => {
-      const lockPath = path.join(getTmpDir(), "malformed.lock");
+      const lockPath = path.join(tmp.path, "malformed.lock");
       const dir = path.dirname(lockPath);
       const baseName = path.basename(lockPath);
 

--- a/packages/hardhat/test/internal/builtin-plugins/clean/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/clean/task-action.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { after, before, beforeEach, describe, it, mock } from "node:test";
 
 import {
-  getTmpDir,
+  createTmpDir,
   useFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import {
@@ -28,9 +28,6 @@ let hre: HardhatRuntimeEnvironment;
 let globalCacheDir: string;
 let cacheDir: string;
 let artifactsDir: string;
-
-// Variable for isolating the global cache during tests
-let testGlobalCacheRoot: string;
 
 const onClean = mock.fn(async () => {});
 
@@ -71,11 +68,11 @@ function assertCleanBehavior(global: boolean) {
 describe("clean/task-action", () => {
   describe("cleanAction", () => {
     useFixtureProject("loaded-config");
+    const tmp = createTmpDir("clean-task-global-cache", "describe");
 
     before(async function () {
       // Set up isolated cache directory to avoid deleting the real global cache
-      testGlobalCacheRoot = await getTmpDir("clean-task-global-cache");
-      setMockCacheDir(testGlobalCacheRoot);
+      setMockCacheDir(tmp.path);
 
       globalCacheDir = await getCacheDir();
       cacheDir = path.join(process.cwd(), "cache");
@@ -89,12 +86,8 @@ describe("clean/task-action", () => {
       });
     });
 
-    after(async function () {
-      // Reset mock cache directory
+    after(function () {
       resetMockCacheDir();
-
-      // Clean up temp directory
-      await remove(testGlobalCacheRoot);
     });
 
     beforeEach(async () => {

--- a/packages/hardhat/test/internal/builtin-plugins/console/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/console/task-action.ts
@@ -4,21 +4,18 @@ import type repl from "node:repl";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { PassThrough } from "node:stream";
-import { afterEach, before, beforeEach, describe, it } from "node:test";
+import { before, beforeEach, describe, it } from "node:test";
 
 import {
-  getTmpDir,
+  createTmpDir,
   useFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
-import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
-import { exists, remove } from "@nomicfoundation/hardhat-utils/fs";
+import { exists } from "@nomicfoundation/hardhat-utils/fs";
 
 import { overrideTask } from "../../../../src/config.js";
 import consoleAction from "../../../../src/internal/builtin-plugins/console/task-action.js";
 import { createHardhatRuntimeEnvironment } from "../../../../src/internal/hre-initialization.js";
-
-const log = createDebug("hardhat:core:tasks:console:test");
 
 describe("console/task-action", function () {
   let hre: HardhatRuntimeEnvironment;
@@ -219,25 +216,13 @@ describe("console/task-action", function () {
   });
 
   describe("history", function () {
-    let cacheDir: string;
+    // We use a temporary cache dir to avoid conflicts with other tests
+    // and global user settings.
+    const tmp = createTmpDir("console-action-test", "test");
     let history: string;
 
-    beforeEach(async function () {
-      // We use a temporary cache dir to avoid conflicts with other tests
-      // and global user settings.
-      cacheDir = await getTmpDir("console-action-test");
-      history = path.resolve(cacheDir, "console-history.txt");
-    });
-
-    afterEach(async function () {
-      // We try to remove the temporary cache dir after each test, but we don't
-      // fail the test if it fails. For example, we have observed that in GHA
-      // on Windows, the temp dir cannot be removed due to permission issues.
-      try {
-        await remove(cacheDir);
-      } catch (error) {
-        log("Failed to remove temporary cache dir", error);
-      }
+    beforeEach(() => {
+      history = path.resolve(tmp.path, "console-history.txt");
     });
 
     it("should create a history file", async function () {

--- a/packages/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/coverage/coverage-manager.ts
@@ -12,9 +12,9 @@ import { after, before, beforeEach, describe, it } from "node:test";
 import { stripVTControlCharacters } from "node:util";
 
 import {
+  createTmpDir,
   disableConsole,
   useFixtureProject,
-  useTmpDir,
 } from "@nomicfoundation/hardhat-test-utils";
 import {
   getAllFilesMatching,
@@ -103,11 +103,11 @@ describe("CoverageManagerImplementation", () => {
 
   let coverageManager: CoverageManagerImplementation;
 
-  useTmpDir();
+  const tmp = createTmpDir("coverage-manager", "test");
   disableConsole();
 
   beforeEach(async () => {
-    coverageManager = new CoverageManagerImplementation(process.cwd());
+    coverageManager = new CoverageManagerImplementation(tmp.path);
   });
 
   it("should load all the saved data", async () => {
@@ -127,8 +127,8 @@ describe("CoverageManagerImplementation", () => {
 
     await coverageManager.addMetadata(allMetadata);
 
-    const coverageManager1 = new CoverageManagerImplementation(process.cwd());
-    const coverageManager2 = new CoverageManagerImplementation(process.cwd());
+    const coverageManager1 = new CoverageManagerImplementation(tmp.path);
+    const coverageManager2 = new CoverageManagerImplementation(tmp.path);
 
     await coverageManager1.addData(data1);
     await coverageManager1.saveData(id);
@@ -171,7 +171,7 @@ describe("CoverageManagerImplementation", () => {
       });
     }
 
-    const coverageManager1 = new CoverageManagerImplementation(process.cwd());
+    const coverageManager1 = new CoverageManagerImplementation(tmp.path);
     await coverageManager1.addData(data1);
     await coverageManager1.saveData(id);
 
@@ -192,8 +192,8 @@ describe("CoverageManagerImplementation", () => {
   });
 
   it("should sum counts across saved shards on load", async () => {
-    const cm1 = new CoverageManagerImplementation(process.cwd());
-    const cm2 = new CoverageManagerImplementation(process.cwd());
+    const cm1 = new CoverageManagerImplementation(tmp.path);
+    const cm2 = new CoverageManagerImplementation(tmp.path);
 
     await cm1.addData(["a", "a", "b"]);
     await cm1.saveData(id);
@@ -268,13 +268,13 @@ describe("CoverageManagerImplementation", () => {
     await coverageManager.addData(data);
     await coverageManager.saveData(id);
 
-    let allData = await getAllFilesMatching(process.cwd());
+    let allData = await getAllFilesMatching(tmp.path);
 
     assert.ok(allData.length !== 0, "The data should be saved to disk");
 
     await coverageManager.clearData(id);
 
-    allData = await getAllFilesMatching(process.cwd());
+    allData = await getAllFilesMatching(tmp.path);
 
     assert.ok(allData.length === 0, "The data should be cleared from disk");
   });

--- a/packages/hardhat/test/internal/builtin-plugins/gas-analytics/function-gas-snapshots.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/gas-analytics/function-gas-snapshots.ts
@@ -7,14 +7,15 @@ import type {
 } from "../../../../src/internal/builtin-plugins/gas-analytics/function-gas-snapshots.js";
 
 import assert from "node:assert/strict";
-import { afterEach, before, describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
 import {
-  emptyDir,
+  assertThrowsHardhatError,
+  createTmpDir,
+} from "@nomicfoundation/hardhat-test-utils";
+import {
   FileNotFoundError,
-  mkdtemp,
   readUtf8File,
 } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -197,15 +198,7 @@ describe("function-gas-snapshots", () => {
   });
 
   describe("writeFunctionGasSnapshots", () => {
-    let tmpDir: string;
-
-    before(async () => {
-      tmpDir = await mkdtemp("gas-snapshots-test-");
-    });
-
-    afterEach(async () => {
-      await emptyDir(tmpDir);
-    });
+    const tmp = createTmpDir("gas-snapshots-test", "test");
 
     it("should save snapshots to .gas-snapshot file", async () => {
       const snapshots: FunctionGasSnapshot[] = [
@@ -227,9 +220,9 @@ describe("function-gas-snapshots", () => {
         },
       ];
 
-      await writeFunctionGasSnapshots(tmpDir, snapshots);
+      await writeFunctionGasSnapshots(tmp.path, snapshots);
 
-      const snapshotPath = getFunctionGasSnapshotsPath(tmpDir);
+      const snapshotPath = getFunctionGasSnapshotsPath(tmp.path);
       const savedContent = await readUtf8File(snapshotPath);
 
       const expected = `MyContract#testApprove (gas: 30000)
@@ -259,10 +252,10 @@ MyContract#testTransfer (gas: 25000)`;
         },
       ];
 
-      await writeFunctionGasSnapshots(tmpDir, firstSnapshots);
-      await writeFunctionGasSnapshots(tmpDir, secondSnapshots);
+      await writeFunctionGasSnapshots(tmp.path, firstSnapshots);
+      await writeFunctionGasSnapshots(tmp.path, secondSnapshots);
 
-      const snapshotPath = getFunctionGasSnapshotsPath(tmpDir);
+      const snapshotPath = getFunctionGasSnapshotsPath(tmp.path);
       const savedContent = await readUtf8File(snapshotPath);
 
       assert.equal(savedContent, "MyContract#testB (gas: 20000)");
@@ -271,9 +264,9 @@ MyContract#testTransfer (gas: 25000)`;
     it("should save empty snapshots", async () => {
       const emptySnapshots: FunctionGasSnapshot[] = [];
 
-      await writeFunctionGasSnapshots(tmpDir, emptySnapshots);
+      await writeFunctionGasSnapshots(tmp.path, emptySnapshots);
 
-      const snapshotPath = getFunctionGasSnapshotsPath(tmpDir);
+      const snapshotPath = getFunctionGasSnapshotsPath(tmp.path);
       const savedContent = await readUtf8File(snapshotPath);
 
       assert.equal(savedContent, "");
@@ -281,15 +274,7 @@ MyContract#testTransfer (gas: 25000)`;
   });
 
   describe("readFunctionGasSnapshots", () => {
-    let tmpDir: string;
-
-    before(async () => {
-      tmpDir = await mkdtemp("gas-snapshots-test-");
-    });
-
-    afterEach(async () => {
-      await emptyDir(tmpDir);
-    });
+    const tmp = createTmpDir("gas-snapshots-test", "test");
 
     it("should read snapshots from file", async () => {
       const snapshots: FunctionGasSnapshot[] = [
@@ -303,8 +288,8 @@ MyContract#testTransfer (gas: 25000)`;
         },
       ];
 
-      await writeFunctionGasSnapshots(tmpDir, snapshots);
-      const readSnapshots = await readFunctionGasSnapshots(tmpDir);
+      await writeFunctionGasSnapshots(tmp.path, snapshots);
+      const readSnapshots = await readFunctionGasSnapshots(tmp.path);
 
       assert.deepEqual(readSnapshots, snapshots);
     });
@@ -312,7 +297,7 @@ MyContract#testTransfer (gas: 25000)`;
     it("should throw FileNotFoundError when file doesn't exist", async () => {
       try {
         // file does not exist
-        await readFunctionGasSnapshots(tmpDir);
+        await readFunctionGasSnapshots(tmp.path);
         assert.fail("Expected FileNotFoundError to be thrown");
       } catch (error) {
         assert.ok(

--- a/packages/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/gas-analytics/gas-analytics-manager.ts
@@ -5,18 +5,18 @@ import type {
 
 import assert from "node:assert/strict";
 import path from "node:path";
-import { afterEach, before, describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import { styleText } from "node:util";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
   assertRejectsWithHardhatError,
+  createTmpDir,
   disableConsole,
 } from "@nomicfoundation/hardhat-test-utils";
 import {
   emptyDir,
   getAllFilesMatching,
-  mkdtemp,
   readJsonFile,
 } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -36,21 +36,18 @@ describe("gas-analytics-manager", () => {
   disableConsole();
 
   describe("GasAnalyticsManager", () => {
-    let tmpDir: string;
-    before(async () => {
-      tmpDir = await mkdtemp("gas-stats-test-");
-    });
+    const tmp = createTmpDir("gas-stats-test", "describe");
 
     describe("constructor", () => {
       it("should initialize with empty gasMeasurements array", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         assert.deepEqual(manager.gasMeasurements, []);
       });
     });
 
     describe("addGasMeasurement", () => {
       it("should add function gas measurement to the array", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const functionMeasurement: GasMeasurement = {
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -66,7 +63,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should add deployment gas measurement to the array", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const deploymentMeasurement: GasMeasurement = {
           type: "deployment",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -83,7 +80,7 @@ describe("gas-analytics-manager", () => {
 
     describe("saveGasMeasurements", () => {
       it("should save gas measurements in memory", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const measurement1: GasMeasurement = {
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -109,7 +106,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should save gas measurements in disk", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const measurement1: GasMeasurement = {
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -130,7 +127,7 @@ describe("gas-analytics-manager", () => {
         await manager.saveGasMeasurements("test-id");
 
         const gasMeasurementsPath = await getAllFilesMatching(
-          path.join(tmpDir, "gas-stats", "test-id"),
+          path.join(tmp.path, "gas-stats", "test-id"),
         );
 
         assert.ok(
@@ -149,7 +146,7 @@ describe("gas-analytics-manager", () => {
 
     describe("clearGasMeasurements", () => {
       it("should clear gas measurements in memory", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const measurement1: GasMeasurement = {
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -175,7 +172,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should clear gas measurements in disk", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const measurement1: GasMeasurement = {
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -198,7 +195,7 @@ describe("gas-analytics-manager", () => {
         await manager.clearGasMeasurements("test-id");
 
         const gasMeasurementsPath = await getAllFilesMatching(
-          path.join(tmpDir, "gas-stats", "test-id"),
+          path.join(tmp.path, "gas-stats", "test-id"),
         );
 
         assert.ok(
@@ -210,11 +207,11 @@ describe("gas-analytics-manager", () => {
 
     describe("_loadGasMeasurements", () => {
       afterEach(async () => {
-        await emptyDir(tmpDir);
+        await emptyDir(tmp.path);
       });
 
       it("should load gas measurements from disk", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const measurement1: GasMeasurement = {
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -233,7 +230,7 @@ describe("gas-analytics-manager", () => {
 
         await manager.saveGasMeasurements("test-id");
 
-        const newManager = new GasAnalyticsManagerImplementation(tmpDir);
+        const newManager = new GasAnalyticsManagerImplementation(tmp.path);
         await newManager._loadGasMeasurements("test-id");
 
         assert.equal(newManager.gasMeasurements.length, 2);
@@ -242,7 +239,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should load gas measurements from multiple IDs", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const measurement1: GasMeasurement = {
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -265,7 +262,7 @@ describe("gas-analytics-manager", () => {
         manager.addGasMeasurement(measurement2);
         await manager.saveGasMeasurements("runner-2");
 
-        const newManager = new GasAnalyticsManagerImplementation(tmpDir);
+        const newManager = new GasAnalyticsManagerImplementation(tmp.path);
         await newManager._loadGasMeasurements("runner-1", "runner-2");
 
         assert.equal(newManager.gasMeasurements.length, 2);
@@ -274,7 +271,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should load gas measurements from multiple files", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const measurement1: GasMeasurement = {
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -295,7 +292,7 @@ describe("gas-analytics-manager", () => {
         // Save again to create a second file
         await manager.saveGasMeasurements("test-id");
 
-        const newManager = new GasAnalyticsManagerImplementation(tmpDir);
+        const newManager = new GasAnalyticsManagerImplementation(tmp.path);
         await newManager._loadGasMeasurements("test-id");
 
         assert.equal(newManager.gasMeasurements.length, 4);
@@ -308,12 +305,12 @@ describe("gas-analytics-manager", () => {
 
     describe("reportGasStats", () => {
       afterEach(async () => {
-        await emptyDir(tmpDir);
+        await emptyDir(tmp.path);
       });
 
       it("should not generate output when report is disabled", async (t) => {
         const consoleMock = t.mock.method(console, "log");
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -331,7 +328,7 @@ describe("gas-analytics-manager", () => {
 
       it("should generate output after enableReport is called", async (t) => {
         const consoleMock = t.mock.method(console, "log");
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -360,7 +357,7 @@ describe("gas-analytics-manager", () => {
 
       it("should aggregate data from multiple runner IDs", async (t) => {
         const consoleMock = t.mock.method(console, "log");
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
 
         manager.addGasMeasurement({
           type: "function",
@@ -395,7 +392,7 @@ describe("gas-analytics-manager", () => {
 
     describe("_aggregateGasMeasurements", () => {
       it("should return empty map for no measurements", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
 
         const result = manager._aggregateGasMeasurements();
 
@@ -403,7 +400,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should aggregate function measurements for single contract", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -443,7 +440,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should aggregate deployment measurement for single contract", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -467,7 +464,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should aggregate both deployment and function measurements", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -523,7 +520,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should aggregate measurements for multiple contracts", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/TokenA.sol:TokenA",
@@ -586,7 +583,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should aggregate multiple measurements for same function", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -632,7 +629,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should handle overloaded function signatures", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -680,7 +677,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should aggregate deployment measurements per contract", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -709,7 +706,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should group proxied function calls separately from direct calls", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const proxyChain = [
           "project/contracts/Proxies.sol:Proxy",
           "project/contracts/Impl.sol:Impl",
@@ -754,7 +751,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should group different proxy chains separately", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/Impl.sol:Impl",
@@ -785,7 +782,7 @@ describe("gas-analytics-manager", () => {
 
     describe("_calculateGasStats", () => {
       it("should calculate stats for a single function with multiple gas measurements", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -833,7 +830,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should calculate stats for deployment gas measurements", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -876,7 +873,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should calculate stats for multiple contracts", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/TokenA.sol:TokenA",
@@ -914,7 +911,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should handle overloaded functions by using full signature", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -970,7 +967,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should handle empty gas measurements", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
 
         const gasStats = manager._calculateGasStats();
 
@@ -978,7 +975,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should round average and median to 2 decimal places", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -1024,7 +1021,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should duplicate deployment stats to proxied groups", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const proxyChain = [
           "project/contracts/Proxies.sol:Proxy",
           "project/contracts/Impl.sol:Impl",
@@ -1082,7 +1079,7 @@ describe("gas-analytics-manager", () => {
 
     describe("_generateGasStatsReport", () => {
       it("should generate an empty report for no gas stats", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
 
         const report = manager._generateGasStatsReport(new Map());
 
@@ -1090,7 +1087,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should generate a report", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const gasStats = new Map();
         // Contracts are added in non-alphabetical order to test sorting
         gasStats.set("project/contracts/TokenA.sol:TokenA", {
@@ -1191,7 +1188,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should sort overloads with same parameter count correctly", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const gasStats = new Map();
         gasStats.set("project/contracts/TestContract.sol:TestContract", {
           proxyChain: [],
@@ -1237,7 +1234,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should sort overloads with different parameter counts correctly", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const gasStats = new Map();
         gasStats.set("project/contracts/TestContract.sol:TestContract", {
           proxyChain: [],
@@ -1285,13 +1282,13 @@ describe("gas-analytics-manager", () => {
 
     describe("_generateGasStatsJson", () => {
       it("should return empty contracts object when no measurements", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         const result = manager._generateGasStatsJson(new Map());
         assert.deepEqual(result, { contracts: {} });
       });
 
       it("should include both deployment and functions stats", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -1332,7 +1329,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should set deployment to null when contract has only function calls", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/Token.sol:Token",
@@ -1350,7 +1347,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should set functions to null when contract has only deployments", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: "project/contracts/Factory.sol:Factory",
@@ -1370,7 +1367,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should sort contracts alphabetically by user-friendly FQN", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: "project/contracts/ZContract.sol:ZContract",
@@ -1392,7 +1389,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should sort functions alphabetically within a contract", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/Token.sol:Token",
@@ -1422,7 +1419,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should use full signatures as keys for overloaded functions", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/Token.sol:Token",
@@ -1458,7 +1455,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should strip project/ prefix from contract keys via getUserFqn", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -1479,7 +1476,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should strip npm package version from contract keys", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn:
@@ -1507,7 +1504,7 @@ describe("gas-analytics-manager", () => {
         const contractName = "MyToken";
         const internalFqn = `project/${sourceName}:${contractName}`;
 
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: internalFqn,
@@ -1529,7 +1526,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should include proxyChain in JSON output and use display key", () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: "project/contracts/Impl.sol:Impl",
@@ -1583,20 +1580,20 @@ describe("gas-analytics-manager", () => {
 
     describe("writeGasStatsJson", () => {
       afterEach(async () => {
-        await emptyDir(tmpDir);
+        await emptyDir(tmp.path);
       });
 
       it("should throw if outputPath is a directory", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         await assertRejectsWithHardhatError(
-          manager.writeGasStatsJson(tmpDir, "test-id"),
+          manager.writeGasStatsJson(tmp.path, "test-id"),
           HardhatError.ERRORS.CORE.BUILTIN_TASKS.INVALID_FILE_PATH,
-          { path: tmpDir },
+          { path: tmp.path },
         );
       });
 
       it("should write JSON file at the specified path", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -1606,7 +1603,7 @@ describe("gas-analytics-manager", () => {
         });
         await manager.saveGasMeasurements("test-id");
 
-        const outputPath = path.join(tmpDir, "gas-output.json");
+        const outputPath = path.join(tmp.path, "gas-output.json");
         await manager.writeGasStatsJson(outputPath, "test-id");
 
         const json = await readJsonFile<GasStatsJson>(outputPath);
@@ -1634,7 +1631,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should create parent directories if they do not exist", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "deployment",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -1644,7 +1641,7 @@ describe("gas-analytics-manager", () => {
         await manager.saveGasMeasurements("test-id");
 
         const outputPath = path.join(
-          tmpDir,
+          tmp.path,
           "nested",
           "deep",
           "gas-output.json",
@@ -1659,7 +1656,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should resolve a relative path against process.cwd()", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -1670,14 +1667,14 @@ describe("gas-analytics-manager", () => {
         await manager.saveGasMeasurements("test-id");
 
         const originalCwd = process.cwd();
-        process.chdir(tmpDir);
+        process.chdir(tmp.path);
         try {
           await manager.writeGasStatsJson("relative-output.json", "test-id");
         } finally {
           process.chdir(originalCwd);
         }
 
-        const expectedPath = path.join(tmpDir, "relative-output.json");
+        const expectedPath = path.join(tmp.path, "relative-output.json");
         const json = await readJsonFile<GasStatsJson>(expectedPath);
         assert.ok(
           "contracts/MyContract.sol:MyContract" in json.contracts,
@@ -1686,7 +1683,7 @@ describe("gas-analytics-manager", () => {
       });
 
       it("should not write file when report is disabled", async () => {
-        const manager = new GasAnalyticsManagerImplementation(tmpDir);
+        const manager = new GasAnalyticsManagerImplementation(tmp.path);
         manager.addGasMeasurement({
           type: "function",
           contractFqn: "project/contracts/MyContract.sol:MyContract",
@@ -1697,10 +1694,10 @@ describe("gas-analytics-manager", () => {
         await manager.saveGasMeasurements("test-id");
 
         manager.disableReport();
-        const outputPath = path.join(tmpDir, "should-not-exist.json");
+        const outputPath = path.join(tmp.path, "should-not-exist.json");
         await manager.writeGasStatsJson(outputPath, "test-id");
 
-        const files = await getAllFilesMatching(tmpDir, (f) =>
+        const files = await getAllFilesMatching(tmp.path, (f) =>
           f.endsWith("should-not-exist.json"),
         );
         assert.equal(files.length, 0, "file should not have been written");

--- a/packages/hardhat/test/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/gas-analytics/snapshot-cheatcodes.ts
@@ -8,15 +8,16 @@ import type {
 
 import assert from "node:assert/strict";
 import path from "node:path";
-import { afterEach, before, describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
 import {
-  emptyDir,
+  assertThrowsHardhatError,
+  createTmpDir,
+} from "@nomicfoundation/hardhat-test-utils";
+import {
   exists,
   FileNotFoundError,
-  mkdtemp,
   readJsonFile,
 } from "@nomicfoundation/hardhat-utils/fs";
 
@@ -266,15 +267,7 @@ describe("snapshot-cheatcodes", () => {
   });
 
   describe("writeSnapshotCheatcodes", () => {
-    let tmpDir: string;
-
-    before(async () => {
-      tmpDir = await mkdtemp("snapshot-cheatcodes-test-");
-    });
-
-    afterEach(async () => {
-      await emptyDir(tmpDir);
-    });
+    const tmp = createTmpDir("snapshot-cheatcodes-test", "test");
 
     it("should write single snapshot group to JSON file", async () => {
       const snapshots = new Map([
@@ -297,10 +290,10 @@ describe("snapshot-cheatcodes", () => {
         ],
       ]);
 
-      await writeSnapshotCheatcodes(tmpDir, snapshots);
+      await writeSnapshotCheatcodes(tmp.path, snapshots);
 
       const snapshotPath = getSnapshotCheatcodesPath(
-        tmpDir,
+        tmp.path,
         "CalculatorTest.json",
       );
       const savedContent = await readJsonFile(snapshotPath);
@@ -340,13 +333,13 @@ describe("snapshot-cheatcodes", () => {
         ],
       ]);
 
-      await writeSnapshotCheatcodes(tmpDir, snapshots);
+      await writeSnapshotCheatcodes(tmp.path, snapshots);
 
-      const groupAPath = getSnapshotCheatcodesPath(tmpDir, "GroupA.json");
+      const groupAPath = getSnapshotCheatcodesPath(tmp.path, "GroupA.json");
       const groupAContent = await readJsonFile(groupAPath);
       assert.deepEqual(groupAContent, { "entry-a": "100" });
 
-      const groupBPath = getSnapshotCheatcodesPath(tmpDir, "GroupB.json");
+      const groupBPath = getSnapshotCheatcodesPath(tmp.path, "GroupB.json");
       const groupBContent = await readJsonFile(groupBPath);
       assert.deepEqual(groupBContent, {
         "entry-b": "200",
@@ -378,10 +371,13 @@ describe("snapshot-cheatcodes", () => {
         ],
       ]);
 
-      await writeSnapshotCheatcodes(tmpDir, firstSnapshots);
-      await writeSnapshotCheatcodes(tmpDir, secondSnapshots);
+      await writeSnapshotCheatcodes(tmp.path, firstSnapshots);
+      await writeSnapshotCheatcodes(tmp.path, secondSnapshots);
 
-      const snapshotPath = getSnapshotCheatcodesPath(tmpDir, "TestGroup.json");
+      const snapshotPath = getSnapshotCheatcodesPath(
+        tmp.path,
+        "TestGroup.json",
+      );
       const savedContent = await readJsonFile(snapshotPath);
 
       assert.deepEqual(savedContent, { "new-entry": "200" });
@@ -390,9 +386,9 @@ describe("snapshot-cheatcodes", () => {
     it("should handle empty snapshots map", async () => {
       const emptySnapshots = new Map();
 
-      await writeSnapshotCheatcodes(tmpDir, emptySnapshots);
+      await writeSnapshotCheatcodes(tmp.path, emptySnapshots);
 
-      const snapshotsDir = path.join(tmpDir, SNAPSHOT_CHEATCODES_DIR);
+      const snapshotsDir = path.join(tmp.path, SNAPSHOT_CHEATCODES_DIR);
       const dirExists = await exists(snapshotsDir);
       assert.equal(
         dirExists,
@@ -426,11 +422,11 @@ describe("snapshot-cheatcodes", () => {
           },
         ],
       ]);
-      await writeSnapshotCheatcodes(tmpDir, firstSnapshots);
+      await writeSnapshotCheatcodes(tmp.path, firstSnapshots);
 
       // Verify both files exist
-      const groupAPath = getSnapshotCheatcodesPath(tmpDir, "GroupA.json");
-      const groupBPath = getSnapshotCheatcodesPath(tmpDir, "GroupB.json");
+      const groupAPath = getSnapshotCheatcodesPath(tmp.path, "GroupA.json");
+      const groupBPath = getSnapshotCheatcodesPath(tmp.path, "GroupB.json");
       assert.equal(await exists(groupAPath), true, "GroupA.json should exist");
       assert.equal(await exists(groupBPath), true, "GroupB.json should exist");
 
@@ -449,7 +445,7 @@ describe("snapshot-cheatcodes", () => {
           },
         ],
       ]);
-      await writeSnapshotCheatcodes(tmpDir, secondSnapshots);
+      await writeSnapshotCheatcodes(tmp.path, secondSnapshots);
 
       // GroupA should still exist, GroupB should be deleted
       assert.equal(
@@ -466,15 +462,7 @@ describe("snapshot-cheatcodes", () => {
   });
 
   describe("readSnapshotCheatcodes", () => {
-    let tmpDir: string;
-
-    before(async () => {
-      tmpDir = await mkdtemp("snapshot-cheatcodes-test-");
-    });
-
-    afterEach(async () => {
-      await emptyDir(tmpDir);
-    });
+    const tmp = createTmpDir("snapshot-cheatcodes-test", "test");
 
     it("should read single snapshot group from JSON file", async () => {
       const snapshots: SnapshotCheatcodesWithMetadataMap = new Map([
@@ -497,8 +485,8 @@ describe("snapshot-cheatcodes", () => {
         ],
       ]);
 
-      await writeSnapshotCheatcodes(tmpDir, snapshots);
-      const readSnapshots = await readSnapshotCheatcodes(tmpDir);
+      await writeSnapshotCheatcodes(tmp.path, snapshots);
+      const readSnapshots = await readSnapshotCheatcodes(tmp.path);
 
       assert.equal(readSnapshots.size, 1);
       const calculatorTest = readSnapshots.get("CalculatorTest");
@@ -539,8 +527,8 @@ describe("snapshot-cheatcodes", () => {
         ],
       ]);
 
-      await writeSnapshotCheatcodes(tmpDir, snapshots);
-      const readSnapshots = await readSnapshotCheatcodes(tmpDir);
+      await writeSnapshotCheatcodes(tmp.path, snapshots);
+      const readSnapshots = await readSnapshotCheatcodes(tmp.path);
 
       assert.equal(readSnapshots.size, 2);
       const groupA = readSnapshots.get("GroupA");
@@ -554,7 +542,7 @@ describe("snapshot-cheatcodes", () => {
 
     it("should throw FileNotFoundError when snapshots directory doesn't exist", async () => {
       try {
-        await readSnapshotCheatcodes(tmpDir);
+        await readSnapshotCheatcodes(tmp.path);
         assert.fail("Expected FileNotFoundError to be thrown");
       } catch (error) {
         assert.ok(
@@ -993,15 +981,7 @@ ZGroup#entry-z: 300`;
   });
 
   describe("sanitizeSnapshotCheatcodes", () => {
-    let tmpDir: string;
-
-    before(async () => {
-      tmpDir = await mkdtemp("snapshot-cheatcodes-sanitize-test-");
-    });
-
-    afterEach(async () => {
-      await emptyDir(tmpDir);
-    });
+    const tmp = createTmpDir("snapshot-cheatcodes-sanitize-test", "test");
 
     it("should rekey groups whose names need sanitization and report renames", () => {
       const input: SnapshotCheatcodesWithMetadataMap = new Map([
@@ -1149,9 +1129,9 @@ ZGroup#entry-z: 300`;
       ]);
 
       const { snapshotCheatcodes } = sanitizeSnapshotCheatcodes(input);
-      await writeSnapshotCheatcodes(tmpDir, snapshotCheatcodes);
+      await writeSnapshotCheatcodes(tmp.path, snapshotCheatcodes);
 
-      const previous = await readSnapshotCheatcodes(tmpDir);
+      const previous = await readSnapshotCheatcodes(tmp.path);
       const comparison = compareSnapshotCheatcodes(
         previous,
         snapshotCheatcodes,

--- a/packages/hardhat/test/internal/builtin-plugins/gas-analytics/tasks/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/gas-analytics/tasks/solidity-test/task-action.ts
@@ -1,12 +1,11 @@
 import assert from "node:assert/strict";
-import { afterEach, before, describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 
+import { createTmpDir } from "@nomicfoundation/hardhat-test-utils";
 import {
-  emptyDir,
   exists,
   readJsonFile,
   readUtf8File,
-  mkdtemp,
 } from "@nomicfoundation/hardhat-utils/fs";
 
 import { getFunctionGasSnapshotsPath } from "../../../../../../src/internal/builtin-plugins/gas-analytics/function-gas-snapshots.js";
@@ -25,15 +24,7 @@ import {
 
 describe("solidity-test/task-action (override in gas-analytics/index)", () => {
   describe("handleSnapshot", () => {
-    let tmpDir: string;
-
-    before(async () => {
-      tmpDir = await mkdtemp("snapshots-handler-test-");
-    });
-
-    afterEach(async () => {
-      await emptyDir(tmpDir);
-    });
+    const tmp = createTmpDir("snapshots-handler-test", "test");
 
     it("should write function gas snapshots when tests pass", async () => {
       const suiteResults = [
@@ -42,11 +33,11 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         ]),
       ];
 
-      const result = await handleSnapshot(tmpDir, suiteResults, true);
+      const result = await handleSnapshot(tmp.path, suiteResults, true);
 
       assert.equal(result.functionGasSnapshotsWritten, true);
 
-      const snapshotPath = getFunctionGasSnapshotsPath(tmpDir);
+      const snapshotPath = getFunctionGasSnapshotsPath(tmp.path);
       const savedContent = await readUtf8File(snapshotPath);
       assert.equal(savedContent, "MyContract#testA (gas: 10000)");
     });
@@ -58,11 +49,11 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         ]),
       ];
 
-      const result = await handleSnapshot(tmpDir, suiteResults, false);
+      const result = await handleSnapshot(tmp.path, suiteResults, false);
 
       assert.equal(result.functionGasSnapshotsWritten, false);
 
-      const snapshotPath = getFunctionGasSnapshotsPath(tmpDir);
+      const snapshotPath = getFunctionGasSnapshotsPath(tmp.path);
       const fileExists = await exists(snapshotPath);
       assert.equal(fileExists, false);
     });
@@ -79,9 +70,12 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         ]),
       ];
 
-      await handleSnapshot(tmpDir, suiteResults, true);
+      await handleSnapshot(tmp.path, suiteResults, true);
 
-      const cheatcodePath = getSnapshotCheatcodesPath(tmpDir, "TestGroup.json");
+      const cheatcodePath = getSnapshotCheatcodesPath(
+        tmp.path,
+        "TestGroup.json",
+      );
       const cheatcodeContent = await readJsonFile(cheatcodePath);
       assert.deepEqual(cheatcodeContent, { "test-entry": "42" });
     });
@@ -98,9 +92,12 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         ]),
       ];
 
-      await handleSnapshot(tmpDir, suiteResults, false);
+      await handleSnapshot(tmp.path, suiteResults, false);
 
-      const cheatcodePath = getSnapshotCheatcodesPath(tmpDir, "TestGroup.json");
+      const cheatcodePath = getSnapshotCheatcodesPath(
+        tmp.path,
+        "TestGroup.json",
+      );
       const cheatcodeContent = await readJsonFile(cheatcodePath);
       assert.deepEqual(cheatcodeContent, { "test-entry": "42" });
     });
@@ -118,13 +115,16 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         ]),
       ];
 
-      await handleSnapshot(tmpDir, suiteResults, true);
+      await handleSnapshot(tmp.path, suiteResults, true);
 
-      const snapshotPath = getFunctionGasSnapshotsPath(tmpDir);
+      const snapshotPath = getFunctionGasSnapshotsPath(tmp.path);
       const functionContent = await readUtf8File(snapshotPath);
       assert.equal(functionContent, "MyContract#testA (gas: 10000)");
 
-      const cheatcodePath = getSnapshotCheatcodesPath(tmpDir, "TestGroup.json");
+      const cheatcodePath = getSnapshotCheatcodesPath(
+        tmp.path,
+        "TestGroup.json",
+      );
       const cheatcodeContent = await readJsonFile(cheatcodePath);
       assert.deepEqual(cheatcodeContent, { "test-entry": "42" });
     });
@@ -160,15 +160,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
   });
 
   describe("handleSnapshotCheck", () => {
-    let tmpDir: string;
-
-    before(async () => {
-      tmpDir = await mkdtemp("snapshots-check-test-");
-    });
-
-    afterEach(async () => {
-      await emptyDir(tmpDir);
-    });
+    const tmp = createTmpDir("snapshots-check-test", "test");
 
     describe("function gas snapshots", () => {
       it("should write function gas snapshots on first run (no existing file)", async () => {
@@ -179,7 +171,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         ];
 
         const { functionGasSnapshotsCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           suiteResults,
         );
 
@@ -188,7 +180,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         assert.equal(functionGasSnapshotsCheck.comparison.added.length, 0);
         assert.equal(functionGasSnapshotsCheck.comparison.removed.length, 0);
         assert.equal(functionGasSnapshotsCheck.comparison.changed.length, 0);
-        const snapshotPath = getFunctionGasSnapshotsPath(tmpDir);
+        const snapshotPath = getFunctionGasSnapshotsPath(tmp.path);
         const savedContent = await readUtf8File(snapshotPath);
         assert.equal(savedContent, "MyContract#testA (gas: 10000)");
       });
@@ -200,10 +192,10 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           ]),
         ];
 
-        await handleSnapshot(tmpDir, suiteResults, true);
+        await handleSnapshot(tmp.path, suiteResults, true);
 
         const { functionGasSnapshotsCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           suiteResults,
         );
 
@@ -226,10 +218,10 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           ]),
         ];
 
-        await handleSnapshot(tmpDir, initialResults, true);
+        await handleSnapshot(tmp.path, initialResults, true);
 
         const { functionGasSnapshotsCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           changedResults,
         );
 
@@ -253,10 +245,10 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           ]),
         ];
 
-        await handleSnapshot(tmpDir, initialResults, true);
+        await handleSnapshot(tmp.path, initialResults, true);
 
         const { functionGasSnapshotsCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           withAddedResults,
         );
 
@@ -266,7 +258,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         assert.equal(functionGasSnapshotsCheck.comparison.removed.length, 0);
         assert.equal(functionGasSnapshotsCheck.comparison.changed.length, 0);
 
-        const snapshotPath = getFunctionGasSnapshotsPath(tmpDir);
+        const snapshotPath = getFunctionGasSnapshotsPath(tmp.path);
         const savedContent = await readUtf8File(snapshotPath);
         assert.match(savedContent, /MyContract#testB \(gas: 20000\)/);
       });
@@ -284,10 +276,10 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           ]),
         ];
 
-        await handleSnapshot(tmpDir, initialResults, true);
+        await handleSnapshot(tmp.path, initialResults, true);
 
         const { functionGasSnapshotsCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           withRemovedResults,
         );
 
@@ -297,7 +289,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         assert.equal(functionGasSnapshotsCheck.comparison.removed.length, 1);
         assert.equal(functionGasSnapshotsCheck.comparison.changed.length, 0);
 
-        const snapshotPath = getFunctionGasSnapshotsPath(tmpDir);
+        const snapshotPath = getFunctionGasSnapshotsPath(tmp.path);
         const savedContent = await readUtf8File(snapshotPath);
         assert.doesNotMatch(savedContent, /testB/);
       });
@@ -317,7 +309,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         ];
 
         const { snapshotCheatcodesCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           suiteResults,
         );
 
@@ -328,7 +320,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         assert.equal(snapshotCheatcodesCheck.comparison.changed.length, 0);
 
         const cheatcodePath = getSnapshotCheatcodesPath(
-          tmpDir,
+          tmp.path,
           "TestGroup.json",
         );
         const cheatcodeContent = await readJsonFile(cheatcodePath);
@@ -343,7 +335,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         ];
 
         const { snapshotCheatcodesCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           suiteResults,
         );
 
@@ -366,10 +358,10 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           ]),
         ];
 
-        await handleSnapshot(tmpDir, suiteResults, true);
+        await handleSnapshot(tmp.path, suiteResults, true);
 
         const { snapshotCheatcodesCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           suiteResults,
         );
 
@@ -402,10 +394,10 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           ]),
         ];
 
-        await handleSnapshot(tmpDir, initialResults, true);
+        await handleSnapshot(tmp.path, initialResults, true);
 
         const { snapshotCheatcodesCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           changedResults,
         );
 
@@ -441,10 +433,10 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           ]),
         ];
 
-        await handleSnapshot(tmpDir, initialResults, true);
+        await handleSnapshot(tmp.path, initialResults, true);
 
         const { snapshotCheatcodesCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           withAddedResults,
         );
 
@@ -455,7 +447,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         assert.equal(snapshotCheatcodesCheck.comparison.changed.length, 0);
 
         const cheatcodePath = getSnapshotCheatcodesPath(
-          tmpDir,
+          tmp.path,
           "TestGroup.json",
         );
         const cheatcodeContent = await readJsonFile(cheatcodePath);
@@ -490,10 +482,10 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
           ]),
         ];
 
-        await handleSnapshot(tmpDir, initialResults, true);
+        await handleSnapshot(tmp.path, initialResults, true);
 
         const { snapshotCheatcodesCheck } = await handleSnapshotCheck(
-          tmpDir,
+          tmp.path,
           withRemovedResults,
         );
 
@@ -504,7 +496,7 @@ describe("solidity-test/task-action (override in gas-analytics/index)", () => {
         assert.equal(snapshotCheatcodesCheck.comparison.changed.length, 0);
 
         const cheatcodePath = getSnapshotCheatcodesPath(
-          tmpDir,
+          tmp.path,
           "TestGroup.json",
         );
         const cheatcodeContent = await readJsonFile(cheatcodePath);

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -1,9 +1,5 @@
-import type {
-  EdrNetworkHDAccountsConfig,
-  NetworkConfig,
-} from "../../../../../src/types/config.js";
+import type { EdrNetworkHDAccountsConfig } from "../../../../../src/types/config.js";
 import type { HardhatRuntimeEnvironment } from "../../../../../src/types/hre.js";
-import type { RequireField } from "../../../../../src/types/utils.js";
 import type {
   LocalConfig,
   ProviderConfig,
@@ -18,8 +14,10 @@ import {
   assertHardhatInvariant,
   HardhatError,
 } from "@nomicfoundation/hardhat-errors";
-import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
-import { mkdtemp } from "@nomicfoundation/hardhat-utils/fs";
+import {
+  assertRejectsWithHardhatError,
+  createTmpDir,
+} from "@nomicfoundation/hardhat-test-utils";
 import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
 
 import { createHardhatRuntimeEnvironment } from "../../../../../src/hre.js";
@@ -217,11 +215,7 @@ describe("edr-provider", () => {
     });
 
     describe("eth_getProof", () => {
-      let tmpCacheDir: string;
-
-      before(async () => {
-        tmpCacheDir = await mkdtemp("edr-provider-eth-getProof");
-      });
+      const tmp = createTmpDir("edr-provider-eth-getProof", "describe");
 
       it("should return account proof on local network", async () => {
         const { provider } = await hre.network.create();
@@ -319,7 +313,7 @@ describe("edr-provider", () => {
         // cause eth_getProof to fail with a "proof not supported in fork mode" error.
 
         const forkedHre = await createHardhatRuntimeEnvironment({
-          paths: { cache: tmpCacheDir },
+          paths: { cache: tmp.path },
           networks: {
             edrOptimism: {
               type: "edr-simulated",
@@ -366,7 +360,7 @@ describe("edr-provider", () => {
         // "proof not supported in fork mode" error.
 
         const forkedHre = await createHardhatRuntimeEnvironment({
-          paths: { cache: tmpCacheDir },
+          paths: { cache: tmp.path },
           networks: {
             edrOptimism: {
               type: "edr-simulated",
@@ -580,33 +574,41 @@ describe("edr-provider", () => {
     });
   });
 
-  describe("getProviderConfig", async () => {
-    const networkConfigStub: RequireField<NetworkConfig, "chainType"> = {
-      type: "edr-simulated",
-      chainType: "l1",
-      accounts: [],
-      allowBlocksWithSameTimestamp: true,
-      allowUnlimitedContractSize: true,
-      blockGasLimit: 60_000_000n,
-      chainId: 31337,
-      coinbase: Buffer.from("0000000000000000000000000000000000000000", "hex"),
-      gas: "auto",
-      gasMultiplier: 1,
-      gasPrice: "auto",
-      hardfork: "osaka",
-      initialDate: new Date(),
-      loggingEnabled: false,
-      minGasPrice: 0n,
-      mining: { auto: true, interval: 0, mempool: { order: "fifo" } },
-      networkId: 31337,
-      throwOnCallFailures: true,
-      throwOnTransactionFailures: true,
-      forking: {
-        enabled: true,
-        url: new FixedValueConfigurationVariable("http://example.com"),
-        cacheDir: await mkdtemp("getProviderConfigTest"),
-      },
-    };
+  describe("getProviderConfig", () => {
+    const tmp = createTmpDir("getProviderConfigTest", "describe");
+    let networkConfigStub: Parameters<typeof getProviderConfig>[0];
+
+    before(() => {
+      networkConfigStub = {
+        type: "edr-simulated",
+        chainType: "l1",
+        accounts: [],
+        allowBlocksWithSameTimestamp: true,
+        allowUnlimitedContractSize: true,
+        blockGasLimit: 60_000_000n,
+        chainId: 31337,
+        coinbase: Buffer.from(
+          "0000000000000000000000000000000000000000",
+          "hex",
+        ),
+        gas: "auto",
+        gasMultiplier: 1,
+        gasPrice: "auto",
+        hardfork: "osaka",
+        initialDate: new Date(),
+        loggingEnabled: false,
+        minGasPrice: 0n,
+        mining: { auto: true, interval: 0, mempool: { order: "fifo" } },
+        networkId: 31337,
+        throwOnCallFailures: true,
+        throwOnTransactionFailures: true,
+        forking: {
+          enabled: true,
+          url: new FixedValueConfigurationVariable("http://example.com"),
+          cacheDir: tmp.path,
+        },
+      };
+    });
 
     it("should not include hardfork history if not present in the chain descriptor", async () => {
       const providerConfig = await getProviderConfig(

--- a/packages/hardhat/test/internal/builtin-plugins/node/artifacts/build-info-watcher.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/node/artifacts/build-info-watcher.ts
@@ -1,19 +1,13 @@
 import assert from "node:assert/strict";
 import path from "node:path";
-import { beforeEach, describe, it, mock } from "node:test";
+import { describe, it, mock } from "node:test";
 
-import { useTmpDir } from "@nomicfoundation/hardhat-test-utils";
+import { createTmpDir } from "@nomicfoundation/hardhat-test-utils";
 
 import { listener } from "../../../../../src/internal/builtin-plugins/node/artifacts/build-info-watcher.js";
 
 describe("build-info-watcher", function () {
-  useTmpDir();
-
-  let buildInfoDirPath: string;
-
-  beforeEach(async () => {
-    buildInfoDirPath = process.cwd();
-  });
+  const tmp = createTmpDir("build-info-watcher", "test");
 
   describe("listener", async () => {
     it("should not call the handler when a build info output file is added", async function () {
@@ -21,10 +15,7 @@ describe("build-info-watcher", function () {
 
       const handler = mock.fn(async () => {});
 
-      await listener(
-        handler,
-        path.join(buildInfoDirPath, `${buildId}.output.json`),
-      );
+      await listener(handler, path.join(tmp.path, `${buildId}.output.json`));
 
       assert.equal(handler.mock.callCount(), 0);
     });
@@ -34,7 +25,7 @@ describe("build-info-watcher", function () {
 
       const handler = mock.fn(async () => {});
 
-      await listener(handler, path.join(buildInfoDirPath, `${buildId}.json`));
+      await listener(handler, path.join(tmp.path, `${buildId}.json`));
 
       assert.equal(handler.mock.callCount(), 1);
     });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -14,7 +14,7 @@ import { before, beforeEach, describe, it, mock } from "node:test";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
   assertRejectsWithHardhatError,
-  getTmpDir,
+  createTmpDir,
   useFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import {
@@ -80,6 +80,7 @@ describe(
     let solidity: SolidityBuildSystemImplementation;
 
     useFixtureProject("solidity/example-project");
+    const tmp = createTmpDir("solidity-build-system-implementation", "test");
 
     const solidityConfig: SolidityConfig = {
       profiles: {
@@ -130,9 +131,8 @@ describe(
     });
 
     beforeEach(async () => {
-      const tmpDir = await getTmpDir("solidity-build-system-implementation");
-      actualArtifactsPath = path.join(tmpDir, "artifacts");
-      actualCachePath = path.join(tmpDir, "cache");
+      actualArtifactsPath = path.join(tmp.path, "artifacts");
+      actualCachePath = path.join(tmp.path, "cache");
       const hooks = new HookManagerImplementation(process.cwd(), []);
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We don't care about hooks in this context
       hooks.setContext({} as HookContext);
@@ -523,8 +523,10 @@ describe("SolidityBuildSystemImplementation.getScope", () => {
 });
 
 describe("SolidityBuildSystemImplementation.getRootFilePaths", () => {
+  const tmp = createTmpDir("solidity-build-system-root-files", "test");
+
   it("Regression test: walks each sources path only once in unified mode", async () => {
-    const projectRoot = await getTmpDir("solidity-build-system-root-files");
+    const projectRoot = tmp.path;
     const contractsPath = path.join(projectRoot, "contracts");
     const testsPath = path.join(projectRoot, "tests");
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, it } from "node:test";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
   assertRejectsWithHardhatError,
-  useTmpDir,
+  createTmpDir,
 } from "@nomicfoundation/hardhat-test-utils";
 import { sha256 } from "@nomicfoundation/hardhat-utils/crypto";
 import * as fs from "@nomicfoundation/hardhat-utils/fs";
@@ -23,7 +23,7 @@ describe(
     skip: process.env.HARDHAT_DISABLE_SLOW_TESTS === "true",
   },
   function () {
-    useTmpDir("compiler-downloader");
+    const tmp = createTmpDir("compiler-downloader", "test");
 
     describe("isCompilerDownloaded (WASM)", function () {
       let wasmDownloader: CompilerDownloader;
@@ -31,7 +31,7 @@ describe(
       beforeEach(async function () {
         wasmDownloader = new CompilerDownloader(
           CompilerPlatform.WASM,
-          process.cwd(),
+          tmp.path,
         );
 
         await wasmDownloader.updateCompilerListIfNeeded(new Set([]));
@@ -72,7 +72,7 @@ describe(
 
       beforeEach(async function () {
         const platform = CompilerDownloader.getCompilerPlatform();
-        downloader = new CompilerDownloader(platform, process.cwd());
+        downloader = new CompilerDownloader(platform, tmp.path);
 
         await downloader.updateCompilerListIfNeeded(new Set([]));
       });
@@ -112,7 +112,7 @@ describe(
 
       beforeEach(async function () {
         const platform = CompilerDownloader.getCompilerPlatform();
-        downloader = new CompilerDownloader(platform, process.cwd());
+        downloader = new CompilerDownloader(platform, tmp.path);
 
         await downloader.updateCompilerListIfNeeded(new Set([]));
       });
@@ -142,7 +142,7 @@ describe(
       it("Should throw the right error if the list fails to be downloaded", async function () {
         const mockDownloader = new CompilerDownloader(
           CompilerPlatform.WASM,
-          process.cwd(),
+          tmp.path,
           (_url, _destination, _requestOptions, _dispatcherOptions) => {
             throw new Error("download failed");
           },
@@ -160,7 +160,7 @@ describe(
         let downloadAttempts = 0;
         const mockDownloader = new CompilerDownloader(
           CompilerPlatform.WASM,
-          process.cwd(),
+          tmp.path,
           (url, destination, requestOptions, dispatcherOptions) => {
             if (!hasDownloadedOnce) {
               hasDownloadedOnce = true;
@@ -197,7 +197,7 @@ describe(
         let downloads = 0;
         const mockDownloader = new CompilerDownloader(
           CompilerPlatform.WASM,
-          process.cwd(),
+          tmp.path,
           (url, destination, requestOptions, dispatcherOptions) => {
             downloads++;
             return download(
@@ -227,7 +227,7 @@ describe(
         let compilerPath: string | undefined;
         const mockDownloader = new CompilerDownloader(
           CompilerPlatform.WASM,
-          process.cwd(),
+          tmp.path,
           async (url, destination, requestOptions, dispatcherOptions) => {
             if (stopMocking) {
               return await download(
@@ -292,7 +292,7 @@ describe(
           let downloads = 0;
           const mockDownloader = new CompilerDownloader(
             CompilerPlatform.WASM,
-            process.cwd(),
+            tmp.path,
             (url, destination, requestOptions, dispatcherOptions) => {
               downloads++;
               return download(
@@ -328,7 +328,7 @@ describe(
           let downloads = 0;
           const mockDownloader = new CompilerDownloader(
             CompilerPlatform.WASM,
-            process.cwd(),
+            tmp.path,
             (url, destination, requestOptions, dispatcherOptions) => {
               downloads++;
               return download(
@@ -368,7 +368,7 @@ describe(
 
       beforeEach(async function () {
         const platform = CompilerDownloader.getCompilerPlatform();
-        downloader = new CompilerDownloader(platform, process.cwd());
+        downloader = new CompilerDownloader(platform, tmp.path);
 
         await downloader.updateCompilerListIfNeeded(new Set([]));
       });
@@ -406,7 +406,7 @@ describe(
         const platform = CompilerDownloader.getCompilerPlatform();
         const mockDownloader = new CompilerDownloader(
           platform,
-          process.cwd(),
+          tmp.path,
           async (_url, destination, _requestOptions, _dispatcherOptions) => {
             if (!hasDownloadedOnce) {
               hasDownloadedOnce = true;
@@ -501,7 +501,7 @@ describe(
       beforeEach(async () => {
         downloader = new CompilerDownloader(
           CompilerPlatform.LINUX_ARM64,
-          process.cwd(),
+          tmp.path,
         );
       });
 
@@ -510,7 +510,7 @@ describe(
           await downloader.updateCompilerListIfNeeded(new Set(["0.8.28"]));
 
           const compilerList: any = await fs.readJsonFile(
-            path.join(process.cwd(), "linux-arm64", "list.json"),
+            path.join(tmp.path, "linux-arm64", "list.json"),
           );
 
           const build = compilerList.builds.find(
@@ -533,11 +533,7 @@ describe(
           await downloader.updateCompilerListIfNeeded(new Set(["0.8.28"]));
           await downloader.downloadCompiler("0.8.28");
 
-          const binaryPath = path.join(
-            process.cwd(),
-            "linux-arm64",
-            "solc-v0.8.28",
-          );
+          const binaryPath = path.join(tmp.path, "linux-arm64", "solc-v0.8.28");
           // Check the binary exists
           assert(await fs.exists(binaryPath), "binary should exist");
 
@@ -555,11 +551,7 @@ describe(
           await downloader.downloadCompiler("0.8.28");
 
           // Trick the system by deleting the .does.not.work file, because this test might not be running on an arm64 linux machine
-          const binaryPath = path.join(
-            process.cwd(),
-            "linux-arm64",
-            "solc-v0.8.28",
-          );
+          const binaryPath = path.join(tmp.path, "linux-arm64", "solc-v0.8.28");
           await fs.remove(`${binaryPath}.does.not.work`);
 
           const compiler = await downloader.getCompiler("0.8.28");

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/compiler/index.ts
@@ -1,10 +1,11 @@
 import type { CompilerInput } from "../../../../../../src/types/solidity.js";
 
 import assert from "node:assert/strict";
+import path from "node:path";
 import { after, before, beforeEach, describe, it } from "node:test";
 
-import { getTmpDir, useTmpDir } from "@nomicfoundation/hardhat-test-utils";
-import { remove } from "@nomicfoundation/hardhat-utils/fs";
+import { createTmpDir } from "@nomicfoundation/hardhat-test-utils";
+import { writeJsonFile } from "@nomicfoundation/hardhat-utils/fs";
 import {
   resetMockCacheDir,
   setMockCacheDir,
@@ -38,7 +39,7 @@ describe(
   },
   () => {
     describe("native", function () {
-      useTmpDir("native-compiler-execution");
+      const tmp = createTmpDir("native-compiler-execution", "test");
 
       let downloader: CompilerDownloader;
       let optimizerConfig: CompilerInput["settings"]["optimizer"];
@@ -54,7 +55,7 @@ describe(
       beforeEach(async function () {
         downloader = new CompilerDownloader(
           CompilerDownloader.getCompilerPlatform(),
-          process.cwd(),
+          tmp.path,
         );
         await downloader.updateCompilerListIfNeeded(new Set([solcVersion]));
         await downloader.downloadCompiler(solcVersion);
@@ -157,7 +158,7 @@ contract A {}
     });
 
     describe("solcjs", function () {
-      useTmpDir("solcjs-compiler-execution");
+      const tmp = createTmpDir("solcjs-compiler-execution", "test");
 
       let downloader: CompilerDownloader;
       let optimizerConfig: any;
@@ -171,10 +172,15 @@ contract A {}
       });
 
       beforeEach(async function () {
-        downloader = new CompilerDownloader(
-          CompilerPlatform.WASM,
-          process.cwd(),
-        );
+        // The workspace's package.json sets `"type": "module"`, which would
+        // cascade into this tmp dir and make Node try to load solc's
+        // downloaded WASM bundle (a `.js` CJS file using `__dirname`) as ESM.
+        // Plant a package.json that opts this subtree out.
+        await writeJsonFile(path.join(tmp.path, "package.json"), {
+          type: "commonjs",
+        });
+
+        downloader = new CompilerDownloader(CompilerPlatform.WASM, tmp.path);
         await downloader.updateCompilerListIfNeeded(new Set([solcVersion]));
         await downloader.downloadCompiler(solcVersion);
         const compilerPathResult = await downloader.getCompiler(solcVersion);
@@ -187,7 +193,7 @@ contract A {}
         // We need to install the tsx dependency in the temporary workspace
         // for the compilation to succeed.
         await spawn("npm", ["install", "tsx", "--no-save"], {
-          cwd: process.cwd(),
+          cwd: tmp.path,
           shell: true,
           stdio: undefined,
         });
@@ -341,16 +347,14 @@ contract A {}
           CompilerPlatform.LINUX_ARM64,
       },
       function () {
-        let testCacheDir: string;
+        const tmp = createTmpDir("arm64-wasm-fallback", "describe");
 
-        before(async function () {
-          testCacheDir = await getTmpDir("arm64-wasm-fallback");
-          setMockCacheDir(testCacheDir);
+        before(function () {
+          setMockCacheDir(tmp.path);
         });
 
-        after(async function () {
+        after(function () {
           resetMockCacheDir();
-          await remove(testCacheDir);
         });
 
         it("should fall back to WASM when no native ARM64 build exists for 0.4.x", async () => {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/custom-compiler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/integration/custom-compiler.ts
@@ -13,9 +13,9 @@ import { after, before, beforeEach, describe, it } from "node:test";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
   assertRejectsWithHardhatError,
-  getTmpDir,
+  createTmpDir,
 } from "@nomicfoundation/hardhat-test-utils";
-import { remove } from "@nomicfoundation/hardhat-utils/fs";
+import { writeJsonFile } from "@nomicfoundation/hardhat-utils/fs";
 import {
   resetMockCacheDir,
   setMockCacheDir,
@@ -39,7 +39,7 @@ describe(
   function () {
     let nativeCompiler: Compiler;
     let wasmCompiler: Compiler;
-    let testGlobalCacheRoot: string;
+    const tmp = createTmpDir("custom-compiler-test-cache", "describe");
 
     const basicProjectTemplate = {
       name: "test",
@@ -81,8 +81,15 @@ describe(
     // We download a specific version of native and WASM solc and use it for the tests
     before(async function () {
       // Set up isolated cache directory to avoid using/affecting the real global cache
-      testGlobalCacheRoot = await getTmpDir("custom-compiler-test-cache");
-      setMockCacheDir(testGlobalCacheRoot);
+      setMockCacheDir(tmp.path);
+
+      // The workspace's package.json sets `"type": "module"`, which would
+      // cascade into this tmp dir and make Node try to load solc's downloaded
+      // WASM bundle (a `.js` CJS file using `__dirname`) as ESM. Plant a
+      // package.json that opts this subtree out.
+      await writeJsonFile(path.join(tmp.path, "package.json"), {
+        type: "commonjs",
+      });
 
       await downloadSolcCompilers(new Set(["0.8.26"]), true);
 
@@ -103,12 +110,8 @@ describe(
       }
     });
 
-    after(async function () {
-      // Reset mock cache directory
+    after(function () {
       resetMockCacheDir();
-
-      // Clean up temp directory
-      await remove(testGlobalCacheRoot);
     });
 
     for (const compilerType of ["native", "wasm"]) {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/helpers.ts
@@ -108,8 +108,8 @@ export async function useTestProjectTemplate(
       }
 
       // Restore the previous cwd before removal — `safeRemoveTmpDir` also
-      // chdirs out if cwd is inside the tmp dir, but going back to whatever
-      // the caller had before is a more accurate restoration.
+      // changes cwd if it points inside the tmp dir, but going back to
+      // whatever the caller had before is a more accurate restoration.
       process.chdir(oldCwd);
       await safeRemoveTmpDir(projectPath);
       cleaned = true;

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/helpers.ts
@@ -6,9 +6,11 @@ import type { PackageJson } from "@nomicfoundation/hardhat-utils/package";
 import path from "node:path";
 
 import {
+  makeWorkspaceTmpDir,
+  safeRemoveTmpDir,
+} from "@nomicfoundation/hardhat-test-utils";
+import {
   ensureDir,
-  mkdtemp,
-  remove,
   writeJsonFile,
   writeUtf8File,
 } from "@nomicfoundation/hardhat-utils/fs";
@@ -91,8 +93,8 @@ export interface TestProject {
 export async function useTestProjectTemplate(
   template: TestProjectTemplate,
 ): Promise<TestProject> {
-  const projectPath = await mkdtemp(
-    "hh3-solidity-resolver-test" + template.name,
+  const projectPath = await makeWorkspaceTmpDir(
+    `hh3-solidity-resolver-test-${template.name}`,
   );
 
   let cleaned = false;
@@ -105,8 +107,11 @@ export async function useTestProjectTemplate(
         return;
       }
 
-      process.chdir(oldCwd); // return to old cwd, otherwise windows doesn't allow deleting the directory
-      await remove(projectPath);
+      // Restore the previous cwd before removal — `safeRemoveTmpDir` also
+      // chdirs out if cwd is inside the tmp dir, but going back to whatever
+      // the caller had before is a more accurate restoration.
+      process.chdir(oldCwd);
+      await safeRemoveTmpDir(projectPath);
       cleaned = true;
     },
     getHRE: async (

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
@@ -406,7 +406,7 @@ invalid syntax`,
             },
           };
 
-          const project = await useTestProjectTemplate(template);
+          await using project = await useTestProjectTemplate(template);
           const graph = await RemappedNpmPackagesGraphImplementation.create(
             project.path,
           );
@@ -648,7 +648,7 @@ invalid syntax`,
           },
         };
 
-        const project = await useTestProjectTemplate(template);
+        await using project = await useTestProjectTemplate(template);
         const graph = await RemappedNpmPackagesGraphImplementation.create(
           project.path,
         );
@@ -845,7 +845,7 @@ invalid syntax`,
       };
 
       it("Should generate a remapping into a npm file, as provided in the args", async () => {
-        const project = await useTestProjectTemplate(template);
+        await using project = await useTestProjectTemplate(template);
         const graph = await RemappedNpmPackagesGraphImplementation.create(
           project.path,
         );
@@ -884,7 +884,7 @@ invalid syntax`,
       });
 
       it("Should reuse the same remapping object if run twice", async () => {
-        const project = await useTestProjectTemplate(template);
+        await using project = await useTestProjectTemplate(template);
         const graph = await RemappedNpmPackagesGraphImplementation.create(
           project.path,
         );
@@ -906,7 +906,7 @@ invalid syntax`,
       });
 
       it("Should validate that the target matches if run twice", async () => {
-        const project = await useTestProjectTemplate(template);
+        await using project = await useTestProjectTemplate(template);
         const graph = await RemappedNpmPackagesGraphImplementation.create(
           project.path,
         );
@@ -1065,7 +1065,7 @@ invalid syntax`,
             },
           };
 
-          const project = await useTestProjectTemplate(template);
+          await using project = await useTestProjectTemplate(template);
           const graph = await RemappedNpmPackagesGraphImplementation.create(
             project.path,
           );
@@ -1565,7 +1565,7 @@ contr:to-npm=node_modules/dep/contracts`,
               },
             };
 
-            const project = await useTestProjectTemplate(template);
+            await using project = await useTestProjectTemplate(template);
             const graph = await RemappedNpmPackagesGraphImplementation.create(
               project.path,
             );

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts
@@ -12,16 +12,14 @@ import type {
 import assert from "node:assert/strict";
 import { symlink } from "node:fs/promises";
 import path from "node:path";
-import { after, before, describe, it } from "node:test";
+import { before, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 import {
-  ensureDir,
-  mkdtemp,
-  remove,
-  writeJsonFile,
-} from "@nomicfoundation/hardhat-utils/fs";
+  assertRejectsWithHardhatError,
+  createTmpDir,
+} from "@nomicfoundation/hardhat-test-utils";
+import { ensureDir, writeJsonFile } from "@nomicfoundation/hardhat-utils/fs";
 
 import {
   getNormalizeNodeModulesPath,
@@ -712,14 +710,16 @@ invalid syntax`,
       });
 
       describe("Monorepo support", () => {
-        let monorepoPath: string;
+        const tmp = createTmpDir(
+          "hh3-solidity-resolver-test-monorepo",
+          "describe",
+        );
         let hhProjectPath: string;
         let monorepoDependencyPath: string;
         before(async () => {
-          monorepoPath = await mkdtemp("hh3-solidity-resolver-test-monorepo");
-          hhProjectPath = path.join(monorepoPath, "packages", "hh-project");
+          hhProjectPath = path.join(tmp.path, "packages", "hh-project");
           monorepoDependencyPath = path.join(
-            monorepoPath,
+            tmp.path,
             "packages",
             "monorepo-dependency",
           );
@@ -755,10 +755,6 @@ invalid syntax`,
             hhProjectPath,
             path.join(monorepoDependencyPath, "node_modules", "main"),
           );
-        });
-
-        after(async () => {
-          await remove(monorepoPath);
         });
 
         it("Should use `local` as version numbers of monorepo packages when creating their input source name roots", async () => {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/utils.ts
@@ -2,11 +2,10 @@ import type { ResolvedNpmPackage } from "../../../../../../src/types/solidity.js
 
 import assert from "node:assert/strict";
 import path from "node:path";
-import { after, before, describe, it } from "node:test";
+import { describe, it } from "node:test";
 
+import { createTmpDir } from "@nomicfoundation/hardhat-test-utils";
 import {
-  mkdtemp,
-  remove,
   TrueCasePathResolver,
   writeUtf8File,
 } from "@nomicfoundation/hardhat-utils/fs";
@@ -19,20 +18,17 @@ import {
 
 describe("Resolver utils", () => {
   describe("validateFsPath", () => {
-    let dir: string;
-    before(async () => {
-      dir = await mkdtemp("hardhat-test-validate-fs-path");
-    });
-
-    after(async () => {
-      await remove(dir);
-    });
+    const tmp = createTmpDir("hardhat-test-validate-fs-path", "describe");
 
     it("Should return an error if the path doesn't exist", async () => {
       const relativePath = "nope";
 
       assert.deepEqual(
-        await validateFsPath(new TrueCasePathResolver(), dir, relativePath),
+        await validateFsPath(
+          new TrueCasePathResolver(),
+          tmp.path,
+          relativePath,
+        ),
         {
           success: false,
           error: {
@@ -44,13 +40,13 @@ describe("Resolver utils", () => {
 
     it("Should return an error if the path traverses through a file", async () => {
       const fileName = "not-a-dir.txt";
-      const absolutePath = path.join(dir, fileName);
+      const absolutePath = path.join(tmp.path, fileName);
       await writeUtf8File(absolutePath, "txt");
 
       assert.deepEqual(
         await validateFsPath(
           new TrueCasePathResolver(),
-          dir,
+          tmp.path,
           path.join(fileName, "child.sol"),
         ),
         {
@@ -65,13 +61,13 @@ describe("Resolver utils", () => {
     it("Should return an error if the path exists with a different casing", async () => {
       const relativePathIncorrect = "FILE.txt";
       const relativePathCorrect = "file.txt";
-      const absolutePath = path.join(dir, relativePathCorrect);
+      const absolutePath = path.join(tmp.path, relativePathCorrect);
       await writeUtf8File(absolutePath, "txt");
 
       assert.deepEqual(
         await validateFsPath(
           new TrueCasePathResolver(),
-          dir,
+          tmp.path,
           relativePathIncorrect,
         ),
         {
@@ -86,11 +82,15 @@ describe("Resolver utils", () => {
 
     it("Should return success if the path exists with the correct casing", async () => {
       const relativePath = "FILE2.txt";
-      const absolutePath = path.join(dir, relativePath);
+      const absolutePath = path.join(tmp.path, relativePath);
       await writeUtf8File(absolutePath, "txt");
 
       assert.deepEqual(
-        await validateFsPath(new TrueCasePathResolver(), dir, relativePath),
+        await validateFsPath(
+          new TrueCasePathResolver(),
+          tmp.path,
+          relativePath,
+        ),
         {
           success: true,
           value: undefined,

--- a/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
@@ -4,8 +4,7 @@ import type { HardhatPlugin } from "../../../../src/types/plugins.js";
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 
-import { getTmpDir } from "@nomicfoundation/hardhat-test-utils";
-import { remove } from "@nomicfoundation/hardhat-utils/fs";
+import { createTmpDir } from "@nomicfoundation/hardhat-test-utils";
 
 import { overrideTask, task } from "../../../../src/config.js";
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
@@ -360,13 +359,12 @@ describe("test/task-action", function () {
   });
 
   describe("gas stats reporting only includes data from subtasks that ran", function () {
+    const tmp = createTmpDir("gas-stats", "test");
+
     it("should not include stale data from a skipped runner in the gas stats report", async (t) => {
       const consoleMock = t.mock.method(console, "log", () => {});
 
-      const cacheDir = await getTmpDir("gas-stats");
-      t.after(async () => {
-        await remove(cacheDir);
-      });
+      const cacheDir = tmp.path;
 
       // Plugin that maps "runner-a-test.ts" → "runner-a", leaving "runner-b" unregistered
       const fileMapperPlugin: HardhatPlugin = {

--- a/packages/hardhat/test/internal/cli/banner-manager.ts
+++ b/packages/hardhat/test/internal/cli/banner-manager.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { after, afterEach, before, beforeEach, describe, it } from "node:test";
 
-import { getTmpDir } from "@nomicfoundation/hardhat-test-utils";
+import { createTmpDir } from "@nomicfoundation/hardhat-test-utils";
 import {
   readJsonFile,
   writeJsonFile,
@@ -40,7 +40,7 @@ function makeValidConfig({
 }
 
 describe("BannerManager", () => {
-  let testCacheRoot: string;
+  const tmp = createTmpDir("banner-manager-test-cache", "describe");
   let cacheDir: string;
   let printed: string[];
   let mockAgent: TestDispatcher;
@@ -55,14 +55,12 @@ describe("BannerManager", () => {
   };
 
   before(async () => {
-    testCacheRoot = await getTmpDir("banner-manager-test-cache");
-    setMockCacheDir(testCacheRoot);
+    setMockCacheDir(tmp.path);
     cacheDir = await getCacheDir();
   });
 
-  after(async () => {
+  after(() => {
     resetMockCacheDir();
-    await remove(testCacheRoot);
   });
 
   beforeEach(async () => {

--- a/packages/hardhat/test/internal/cli/init/init.ts
+++ b/packages/hardhat/test/internal/cli/init/init.ts
@@ -724,7 +724,7 @@ describe("installProjectDependencies", async () => {
 
 describe("initHardhat", async () => {
   describe("templates", async () => {
-    const tmp = createTmpDir("initHardhat", "test");
+    const tmp = createTmpDir("initHardhat-templates", "test");
 
     disableConsole();
 
@@ -763,7 +763,7 @@ describe("initHardhat", async () => {
   });
 
   describe("folder creation when non existent", async () => {
-    const tmp = createTmpDir("initHardhat", "test");
+    const tmp = createTmpDir("initHardhat-folder-creation", "test");
 
     disableConsole();
 

--- a/packages/hardhat/test/internal/cli/init/init.ts
+++ b/packages/hardhat/test/internal/cli/init/init.ts
@@ -10,8 +10,8 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
   assertRejects,
   assertRejectsWithHardhatError,
+  createTmpDir,
   disableConsole,
-  useTmpDir,
 } from "@nomicfoundation/hardhat-test-utils";
 import {
   ensureDir,
@@ -19,7 +19,6 @@ import {
   createFile,
   readJsonFile,
   readUtf8File,
-  remove,
   writeJsonFile,
   writeUtf8File,
 } from "@nomicfoundation/hardhat-utils/fs";
@@ -49,6 +48,41 @@ const skipNetworkSlowTests =
   process.env.GITHUB_EVENT_NAME === "merge_group" ||
   process.env.GITHUB_HEAD_REF?.startsWith("changeset-release/") === true;
 
+// initHardhat3NonInteractive reads `process.cwd()` internally, and several
+// tests below write/read files via relative paths. This helper combines a
+// per-test tmp dir with a `chdir` into it.
+function useTmpDirAsCwd(name: string): { readonly path: string } {
+  const tmp = createTmpDir(name, "test");
+  let previousCwd: string;
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    process.chdir(tmp.path);
+  });
+  afterEach(() => {
+    process.chdir(previousCwd);
+  });
+  return tmp;
+}
+
+// Writes the standard config files needed for tests that run `pnpm add` from
+// inside a tmp dir.
+//
+// `.npmrc` re-introduces `minimum-release-age-exclude` because we run tests
+// under `pnpm`, and the root `.npmrc`'s array setting gets lost on its way to
+// the subprocess.
+//
+// `pnpm-workspace.yaml` makes pnpm treat the tmp dir as its own workspace
+// root. Without it, pnpm would walk up to the repo's `pnpm-workspace.yaml`
+// and record this test's install under `tmp/<name>:` in the workspace's
+// `pnpm-lock.yaml`.
+async function setUpPnpmTmpDir(dir: string): Promise<void> {
+  await writeUtf8File(
+    path.join(dir, ".npmrc"),
+    'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
+  );
+  await writeUtf8File(path.join(dir, "pnpm-workspace.yaml"), "packages: []\n");
+}
+
 // NOTE: This uses network to access the npm registry
 describe("printWelcomeMessage", () => {
   disableConsole();
@@ -59,13 +93,13 @@ describe("printWelcomeMessage", () => {
 });
 
 describe("getWorkspace", () => {
-  useTmpDir("getWorkspace");
+  const tmp = createTmpDir("getWorkspace", "test");
 
   describe("workspace is not a directory", async () => {
-    useTmpDir("invalidDirectory");
+    const innerTmp = createTmpDir("invalidDirectory", "test");
 
     it("should throw if the provided workspace is not a directory", async () => {
-      const filePath = path.join(process.cwd(), "file.txt");
+      const filePath = path.join(innerTmp.path, "file.txt");
 
       await writeUtf8File(filePath, "some content");
 
@@ -80,13 +114,13 @@ describe("getWorkspace", () => {
   });
 
   it("should throw if the provided workspace is within an already initialized hardhat project", async () => {
-    await ensureDir("hardhat-project");
-    await writeUtf8File("hardhat.config.ts", "");
+    await ensureDir(path.join(tmp.path, "hardhat-project"));
+    await writeUtf8File(path.join(tmp.path, "hardhat.config.ts"), "");
     await assertRejectsWithHardhatError(
-      async () => await getWorkspace("hardhat-project"),
+      async () => await getWorkspace(path.join(tmp.path, "hardhat-project")),
       HardhatError.ERRORS.CORE.GENERAL.HARDHAT_PROJECT_ALREADY_CREATED,
       {
-        hardhatProjectRootPath: path.join(process.cwd(), "hardhat.config.ts"),
+        hardhatProjectRootPath: path.join(tmp.path, "hardhat.config.ts"),
       },
     );
   });
@@ -110,16 +144,17 @@ describe("getTemplate", () => {
 });
 
 describe("validatePackageJson", () => {
-  useTmpDir("validatePackageJson");
+  const tmp = createTmpDir("validatePackageJson", "test");
+  const packageJsonPath = () => path.join(tmp.path, "package.json");
 
   it("should create the package.json file if it does not exist", async () => {
     assert.ok(
-      !(await exists("package.json")),
+      !(await exists(packageJsonPath())),
       "package.json should not exist before ensuring it exists",
     );
 
     await validatePackageJson(
-      process.cwd(),
+      tmp.path,
       {
         name: "package-name",
         version: "0.0.1",
@@ -128,7 +163,7 @@ describe("validatePackageJson", () => {
       false,
     );
 
-    assert.ok(await exists("package.json"), "package.json should exist");
+    assert.ok(await exists(packageJsonPath()), "package.json should exist");
   });
 
   it("should not create the package.json file if it already exists", async () => {
@@ -137,10 +172,10 @@ describe("validatePackageJson", () => {
       type: "module",
     };
 
-    await writeJsonFile("package.json", before);
+    await writeJsonFile(packageJsonPath(), before);
 
     await validatePackageJson(
-      process.cwd(),
+      tmp.path,
       {
         name: "package-name",
         version: "0.0.1",
@@ -149,18 +184,18 @@ describe("validatePackageJson", () => {
       false,
     );
 
-    const after = await readJsonFile("package.json");
+    const after = await readJsonFile(packageJsonPath());
 
     assert.deepEqual(before, after);
   });
 
   it("should throw if the package.json is not for an esm package", async () => {
-    await writeJsonFile("package.json", {});
+    await writeJsonFile(packageJsonPath(), {});
 
     await assertRejectsWithHardhatError(
       async () =>
         await validatePackageJson(
-          process.cwd(),
+          tmp.path,
           {
             name: "package-name",
             version: "0.0.1",
@@ -174,10 +209,10 @@ describe("validatePackageJson", () => {
   });
 
   it("should migrate package.json to esm if the user opts-in to it", async () => {
-    await writeJsonFile("package.json", {});
+    await writeJsonFile(packageJsonPath(), {});
 
     await validatePackageJson(
-      process.cwd(),
+      tmp.path,
       {
         name: "package-name",
         version: "0.0.1",
@@ -186,18 +221,16 @@ describe("validatePackageJson", () => {
       true,
     );
 
-    const pkg: PackageJson = await readJsonFile(
-      path.join(process.cwd(), "package.json"),
-    );
+    const pkg: PackageJson = await readJsonFile(packageJsonPath());
 
     assert.equal(pkg.type, "module");
   });
 
   it("should not migrate package.json to esm when shouldUseEsm is false and type is not set", async () => {
-    await writeJsonFile("package.json", {});
+    await writeJsonFile(packageJsonPath(), {});
 
     await validatePackageJson(
-      process.cwd(),
+      tmp.path,
       {
         name: "package-name",
         version: "0.0.1",
@@ -205,9 +238,7 @@ describe("validatePackageJson", () => {
       false,
     );
 
-    const pkg: PackageJson = await readJsonFile(
-      path.join(process.cwd(), "package.json"),
-    );
+    const pkg: PackageJson = await readJsonFile(packageJsonPath());
 
     assert.equal(pkg.type, undefined);
   });
@@ -218,10 +249,10 @@ describe("validatePackageJson", () => {
       type: "commonjs",
     };
 
-    await writeJsonFile("package.json", before);
+    await writeJsonFile(packageJsonPath(), before);
 
     await validatePackageJson(
-      process.cwd(),
+      tmp.path,
       {
         name: "package-name",
         version: "0.0.1",
@@ -229,23 +260,19 @@ describe("validatePackageJson", () => {
       false,
     );
 
-    const after: PackageJson = await readJsonFile(
-      path.join(process.cwd(), "package.json"),
-    );
+    const after: PackageJson = await readJsonFile(packageJsonPath());
 
     assert.deepEqual(before, after);
   });
 
   it("should not migrate package.json to esm when shouldUseEsm is false and no package.json exists", async () => {
-    await remove(path.join(process.cwd(), "package.json"));
-
     assert.ok(
-      !(await exists("package.json")),
+      !(await exists(packageJsonPath())),
       "package.json should not exist before ensuring it exists",
     );
 
     await validatePackageJson(
-      process.cwd(),
+      tmp.path,
       {
         name: "package-name",
         version: "0.0.1",
@@ -253,9 +280,7 @@ describe("validatePackageJson", () => {
       false,
     );
 
-    const after: PackageJson = await readJsonFile(
-      path.join(process.cwd(), "package.json"),
-    );
+    const after: PackageJson = await readJsonFile(packageJsonPath());
 
     assert.equal(after.type, undefined);
   });
@@ -292,7 +317,7 @@ describe("relativeTemplateToWorkspacePath", () => {
 });
 
 describe("copyProjectFiles", () => {
-  useTmpDir("copyProjectFiles");
+  const tmp = createTmpDir("copyProjectFiles", "test");
 
   disableConsole();
 
@@ -304,29 +329,29 @@ describe("copyProjectFiles", () => {
         relativeTemplateToWorkspacePath,
       );
       for (const file of workspaceFiles) {
-        const pathToFile = path.join(process.cwd(), file);
+        const pathToFile = path.join(tmp.path, file);
         await ensureDir(path.dirname(pathToFile));
         await writeUtf8File(pathToFile, "some content");
       }
       // Copy the template files to the workspace
-      await copyProjectFiles(process.cwd(), template, true);
+      await copyProjectFiles(tmp.path, template, true);
       // Check that the template files in the workspace have been overwritten
       for (const file of workspaceFiles) {
-        const pathToFile = path.join(process.cwd(), file);
+        const pathToFile = path.join(tmp.path, file);
         assert.notEqual(await readUtf8File(pathToFile), "some content");
       }
     });
     it("should copy the .gitignore file correctly", async () => {
       const [template] = await getTemplate("hardhat-3", "mocha-ethers");
       // Copy the template files to the workspace
-      await copyProjectFiles(process.cwd(), template, true);
+      await copyProjectFiles(tmp.path, template, true);
       // Check that the .gitignore exists but gitignore does not
       assert.ok(
-        await exists(path.join(process.cwd(), ".gitignore")),
+        await exists(path.join(tmp.path, ".gitignore")),
         ".gitignore should exist",
       );
       assert.ok(
-        !(await exists(path.join(process.cwd(), "gitignore"))),
+        !(await exists(path.join(tmp.path, "gitignore"))),
         "gitignore should NOT exist",
       );
     });
@@ -339,36 +364,36 @@ describe("copyProjectFiles", () => {
         relativeTemplateToWorkspacePath,
       );
       for (const file of workspaceFiles) {
-        const pathToFile = path.join(process.cwd(), file);
+        const pathToFile = path.join(tmp.path, file);
         await ensureDir(path.dirname(pathToFile));
         await writeUtf8File(pathToFile, "some content");
       }
       // Copy the template files to the workspace
-      await copyProjectFiles(process.cwd(), template, false);
+      await copyProjectFiles(tmp.path, template, false);
       // Check that the template files in the workspace have not been overwritten
       for (const file of workspaceFiles) {
-        const pathToFile = path.join(process.cwd(), file);
+        const pathToFile = path.join(tmp.path, file);
         assert.equal(await readUtf8File(pathToFile), "some content");
       }
     });
     it("should copy the .gitignore file correctly", async () => {
       const [template] = await getTemplate("hardhat-3", "mocha-ethers");
       // Copy the template files to the workspace
-      await copyProjectFiles(process.cwd(), template, false);
+      await copyProjectFiles(tmp.path, template, false);
       // Check that the .gitignore exists but gitignore does not
       assert.ok(
-        await exists(path.join(process.cwd(), ".gitignore")),
+        await exists(path.join(tmp.path, ".gitignore")),
         ".gitignore should exist",
       );
       assert.ok(
-        !(await exists(path.join(process.cwd(), "gitignore"))),
+        !(await exists(path.join(tmp.path, "gitignore"))),
         "gitignore should NOT exist",
       );
     });
 
     it("Regression test: should not scan unrelated workspace files to detect overwrites", async () => {
       const [template] = await getTemplate("hardhat-3", "mocha-ethers");
-      const unrelatedDirPath = path.join(process.cwd(), "unrelated");
+      const unrelatedDirPath = path.join(tmp.path, "unrelated");
       const unrelatedFilePath = path.join(unrelatedDirPath, "ignored.txt");
       await ensureDir(unrelatedDirPath);
       await createFile(unrelatedFilePath);
@@ -378,7 +403,7 @@ describe("copyProjectFiles", () => {
         fsPromises,
         "readdir",
         async (...args: Parameters<typeof originalReaddir>) => {
-          if (args[0] === process.cwd() && args[1]?.withFileTypes === true) {
+          if (args[0] === tmp.path && args[1]?.withFileTypes === true) {
             throw new Error(
               "copyProjectFiles should not scan the workspace recursively",
             );
@@ -389,10 +414,10 @@ describe("copyProjectFiles", () => {
       );
 
       try {
-        await copyProjectFiles(process.cwd(), template, false);
+        await copyProjectFiles(tmp.path, template, false);
 
         const oneCopiedTemplateFile = path.join(
-          process.cwd(),
+          tmp.path,
           relativeTemplateToWorkspacePath(template.files[0]),
         );
         assert.ok(
@@ -406,15 +431,12 @@ describe("copyProjectFiles", () => {
 
     it("Regression test: should still throw if a directory clashes with a destination file", async () => {
       const [template] = await getTemplate("hardhat-3", "mocha-ethers");
-      const pathWithDirectoryClash = path.join(
-        process.cwd(),
-        "hardhat.config.ts",
-      );
+      const pathWithDirectoryClash = path.join(tmp.path, "hardhat.config.ts");
 
       await ensureDir(pathWithDirectoryClash);
 
       await assertRejects(
-        copyProjectFiles(process.cwd(), template, false),
+        copyProjectFiles(tmp.path, template, false),
         (error) => error.name === "IsDirectoryError",
         "expected copyProjectFiles to reject with IsDirectoryError",
       );
@@ -423,7 +445,7 @@ describe("copyProjectFiles", () => {
 });
 
 describe("installProjectDependencies", async () => {
-  useTmpDir("installProjectDependencies");
+  const tmp = createTmpDir("installProjectDependencies", "test");
 
   disableConsole();
 
@@ -439,29 +461,27 @@ describe("installProjectDependencies", async () => {
         skip: skipNetworkSlowTests,
       },
       async () => {
-        await writeUtf8File("package.json", JSON.stringify({ type: "module" }));
-        // NOTE: Because we run tests under `pnpm`, the config setting in
-        // the root `./npmrc` file make it to the subprocesses.
-        // Unfortunately the `minimum-release-age-exclude` because it is an
-        // array can get lost.
-        // We explicitly add the `minimum-release-age-exclude` in as a
-        // `.npmrc` file in the temporary folder to re-introduce this exclude.
         await writeUtf8File(
-          ".npmrc",
-          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
+          path.join(tmp.path, "package.json"),
+          JSON.stringify({ type: "module" }),
         );
+        await setUpPnpmTmpDir(tmp.path);
         await installProjectDependencies({
-          workspace: process.cwd(),
+          workspace: tmp.path,
           template,
           install: true,
           update: false,
         });
-        assert.ok(await exists("node_modules"), "node_modules should exist");
+        assert.ok(
+          await exists(path.join(tmp.path, "node_modules")),
+          "node_modules should exist",
+        );
         const dependencies = Object.keys(
           template.packageJson.devDependencies ?? {},
         );
         for (const dependency of dependencies) {
           const nodeModulesPath = path.join(
+            tmp.path,
             "node_modules",
             ...dependency.split("/"),
           );
@@ -476,14 +496,20 @@ describe("installProjectDependencies", async () => {
 
   it("should not install any template dependencies if the user opts-out of the installation", async () => {
     const [template] = await getTemplate("hardhat-3", "mocha-ethers");
-    await writeUtf8File("package.json", JSON.stringify({ type: "module" }));
+    await writeUtf8File(
+      path.join(tmp.path, "package.json"),
+      JSON.stringify({ type: "module" }),
+    );
     await installProjectDependencies({
-      workspace: process.cwd(),
+      workspace: tmp.path,
       template,
       install: false,
       update: false,
     });
-    assert.ok(!(await exists("node_modules")), "node_modules should not exist");
+    assert.ok(
+      !(await exists(path.join(tmp.path, "node_modules"))),
+      "node_modules should not exist",
+    );
   });
 
   it(
@@ -494,29 +520,29 @@ describe("installProjectDependencies", async () => {
     async () => {
       const [template] = await getTemplate("hardhat-3", "mocha-ethers");
       await writeUtf8File(
-        "package.json",
+        path.join(tmp.path, "package.json"),
         JSON.stringify({
           type: "module",
           devDependencies: { hardhat: "0.0.0" },
         }),
       );
-      // NOTE: See related explanation in the `should install all the ${template.name} ...` test
-      await writeUtf8File(
-        ".npmrc",
-        'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
-      );
+      await setUpPnpmTmpDir(tmp.path);
       await installProjectDependencies({
-        workspace: process.cwd(),
+        workspace: tmp.path,
         template,
         install: false,
         update: true,
       });
-      assert.ok(await exists("node_modules"), "node_modules should exist");
+      assert.ok(
+        await exists(path.join(tmp.path, "node_modules")),
+        "node_modules should exist",
+      );
       const dependencies = Object.keys(
         template.packageJson.devDependencies ?? {},
       );
       for (const dependency of dependencies) {
         const nodeModulesPath = path.join(
+          tmp.path,
           "node_modules",
           ...dependency.split("/"),
         );
@@ -548,26 +574,26 @@ describe("installProjectDependencies", async () => {
           version: "0.0.1",
           devDependencies: { "fake-dependency": "^1.2.3" }, // <-- required version
         },
-        path: process.cwd(),
+        path: tmp.path,
         files: [],
       };
 
       await writeUtf8File(
-        "package.json",
+        path.join(tmp.path, "package.json"),
         JSON.stringify({
           type: "module",
           devDependencies: { "fake-dependency": "1.2.3" }, // <-- specific version
         }),
       );
       await installProjectDependencies({
-        workspace: process.cwd(),
+        workspace: tmp.path,
         template,
         install: false,
         update: true,
       });
 
       assert.ok(
-        !(await exists("node_modules")),
+        !(await exists(path.join(tmp.path, "node_modules"))),
         "no modules should have been installed",
       );
     },
@@ -586,26 +612,26 @@ describe("installProjectDependencies", async () => {
           version: "0.0.1",
           devDependencies: { "fake-dependency": ">=1.2.3" }, // <-- required version
         },
-        path: process.cwd(),
+        path: tmp.path,
         files: [],
       };
 
       await writeUtf8File(
-        "package.json",
+        path.join(tmp.path, "package.json"),
         JSON.stringify({
           type: "module",
           devDependencies: { "fake-dependency": "^1.2.3" }, // <-- version range
         }),
       );
       await installProjectDependencies({
-        workspace: process.cwd(),
+        workspace: tmp.path,
         template,
         install: false,
         update: true,
       });
 
       assert.ok(
-        !(await exists("node_modules")),
+        !(await exists(path.join(tmp.path, "node_modules"))),
         "no modules should have been installed",
       );
     },
@@ -627,7 +653,7 @@ describe("installProjectDependencies", async () => {
         // Put a fake `npm` that always exits non-zero first in PATH so the
         // installation spawn fails deterministically, without needing the
         // network or a real package manager.
-        const fakeBinDir = path.join(process.cwd(), "fake-bin");
+        const fakeBinDir = path.join(tmp.path, "fake-bin");
         await ensureDir(fakeBinDir);
         const fakeNpmPath = path.join(fakeBinDir, "npm");
         await writeUtf8File(fakeNpmPath, "#!/bin/sh\nexit 1\n");
@@ -654,11 +680,14 @@ describe("installProjectDependencies", async () => {
 
       it("should wrap installation failures in a HardhatError", async () => {
         const [template] = await getTemplate("hardhat-3", "mocha-ethers");
-        await writeUtf8File("package.json", JSON.stringify({ type: "module" }));
+        await writeUtf8File(
+          path.join(tmp.path, "package.json"),
+          JSON.stringify({ type: "module" }),
+        );
 
         await assertRejectsWithHardhatError(
           installProjectDependencies({
-            workspace: process.cwd(),
+            workspace: tmp.path,
             template,
             install: true,
             update: false,
@@ -671,7 +700,7 @@ describe("installProjectDependencies", async () => {
       it("should wrap update failures in a HardhatError", async () => {
         const [template] = await getTemplate("hardhat-3", "mocha-ethers");
         await writeUtf8File(
-          "package.json",
+          path.join(tmp.path, "package.json"),
           JSON.stringify({
             type: "module",
             devDependencies: { hardhat: "0.0.0" },
@@ -680,7 +709,7 @@ describe("installProjectDependencies", async () => {
 
         await assertRejectsWithHardhatError(
           installProjectDependencies({
-            workspace: process.cwd(),
+            workspace: tmp.path,
             template,
             install: false,
             update: true,
@@ -695,7 +724,7 @@ describe("installProjectDependencies", async () => {
 
 describe("initHardhat", async () => {
   describe("templates", async () => {
-    useTmpDir("initHardhat");
+    const tmp = createTmpDir("initHardhat", "test");
 
     disableConsole();
 
@@ -712,17 +741,20 @@ describe("initHardhat", async () => {
           await initHardhat({
             hardhatVersion: "hardhat-3",
             template: template.name,
-            workspace: process.cwd(),
+            workspace: tmp.path,
             migrateToEsm: false,
             force: false,
             install: false,
           });
-          assert.ok(await exists("package.json"), "package.json should exist");
+          assert.ok(
+            await exists(path.join(tmp.path, "package.json")),
+            "package.json should exist",
+          );
           const workspaceFiles = template.files.map(
             relativeTemplateToWorkspacePath,
           );
           for (const file of workspaceFiles) {
-            const pathToFile = path.join(process.cwd(), file);
+            const pathToFile = path.join(tmp.path, file);
             assert.ok(await exists(pathToFile), `File ${file} should exist`);
           }
         },
@@ -731,7 +763,7 @@ describe("initHardhat", async () => {
   });
 
   describe("folder creation when non existent", async () => {
-    useTmpDir("initHardhat");
+    const tmp = createTmpDir("initHardhat", "test");
 
     disableConsole();
 
@@ -749,7 +781,7 @@ describe("initHardhat", async () => {
           skip: process.env.HARDHAT_DISABLE_SLOW_TESTS === "true",
         },
         async () => {
-          const workspacePath = path.join(process.cwd(), folderPath);
+          const workspacePath = path.join(tmp.path, folderPath);
 
           await initHardhat({
             hardhatVersion: "hardhat-3",
@@ -941,7 +973,7 @@ describe("shouldUpdateDependency", () => {
 
 describe("initHardhat3NonInteractive", async () => {
   describe("templates", async () => {
-    useTmpDir("initHardhat3NonInteractiveTemplates");
+    const tmp = useTmpDirAsCwd("initHardhat3NonInteractiveTemplates");
 
     disableConsole();
 
@@ -955,10 +987,7 @@ describe("initHardhat3NonInteractive", async () => {
           skip: skipNetworkSlowTests,
         },
         async () => {
-          await writeUtf8File(
-            ".npmrc",
-            'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
-          );
+          await setUpPnpmTmpDir(tmp.path);
           await initHardhat3NonInteractive({ template: template.name });
           assert.ok(await exists("package.json"), "package.json should exist");
           const pkg: PackageJson = await readJsonFile(
@@ -982,7 +1011,7 @@ describe("initHardhat3NonInteractive", async () => {
   });
 
   describe("unknown template", () => {
-    useTmpDir("initHardhat3NonInteractiveUnknownTemplate");
+    useTmpDirAsCwd("initHardhat3NonInteractiveUnknownTemplate");
 
     it("should throw with the list of available templates", async () => {
       const templates = await getTemplates("hardhat-3");
@@ -1004,7 +1033,7 @@ describe("initHardhat3NonInteractive", async () => {
   });
 
   describe("overwrite protection", () => {
-    useTmpDir("initHardhat3NonInteractiveOverwrite");
+    useTmpDirAsCwd("initHardhat3NonInteractiveOverwrite");
 
     disableConsole();
 
@@ -1043,7 +1072,7 @@ describe("initHardhat3NonInteractive", async () => {
   });
 
   describe("exceptions to overwrite protection", () => {
-    useTmpDir("initHardhat3NonInteractiveExceptions");
+    const tmp = useTmpDirAsCwd("initHardhat3NonInteractiveExceptions");
 
     disableConsole();
 
@@ -1057,10 +1086,7 @@ describe("initHardhat3NonInteractive", async () => {
           name: "user-chosen-name",
           type: "module",
         });
-        await writeUtf8File(
-          ".npmrc",
-          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
-        );
+        await setUpPnpmTmpDir(tmp.path);
 
         await initHardhat3NonInteractive({ template: "mocha-ethers" });
 
@@ -1079,10 +1105,7 @@ describe("initHardhat3NonInteractive", async () => {
       },
       async () => {
         await writeUtf8File(".gitignore", "user-gitignore-marker");
-        await writeUtf8File(
-          ".npmrc",
-          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
-        );
+        await setUpPnpmTmpDir(tmp.path);
 
         await initHardhat3NonInteractive({ template: "mocha-ethers" });
 
@@ -1101,10 +1124,7 @@ describe("initHardhat3NonInteractive", async () => {
       },
       async () => {
         await writeUtf8File("README.md", "user readme");
-        await writeUtf8File(
-          ".npmrc",
-          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
-        );
+        await setUpPnpmTmpDir(tmp.path);
 
         const [template] = await getTemplate("hardhat-3", "mocha-ethers");
         const templateReadme = await readUtf8File(
@@ -1127,10 +1147,7 @@ describe("initHardhat3NonInteractive", async () => {
       async () => {
         await writeUtf8File("README.md", "user readme");
         await writeUtf8File("HARDHAT.md", "user hardhat md");
-        await writeUtf8File(
-          ".npmrc",
-          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
-        );
+        await setUpPnpmTmpDir(tmp.path);
 
         await initHardhat3NonInteractive({ template: "mocha-ethers" });
 
@@ -1141,7 +1158,7 @@ describe("initHardhat3NonInteractive", async () => {
   });
 
   describe("progress output", () => {
-    useTmpDir("initHardhat3NonInteractiveOutput");
+    const tmp = useTmpDirAsCwd("initHardhat3NonInteractiveOutput");
 
     it(
       "should print the progress sequence on success",
@@ -1149,10 +1166,7 @@ describe("initHardhat3NonInteractive", async () => {
         skip: skipNetworkSlowTests,
       },
       async () => {
-        await writeUtf8File(
-          ".npmrc",
-          'minimum-release-age-exclude[]="hardhat"\nminimum-release-age-exclude[]="@nomicfoundation/*"',
-        );
+        await setUpPnpmTmpDir(tmp.path);
 
         const logLines: string[] = [];
         const originalLog = console.log;
@@ -1179,10 +1193,10 @@ describe("initHardhat3NonInteractive", async () => {
 });
 
 describe("assertNoNonInteractiveClashes / copyProjectFilesNonInteractive", () => {
-  useTmpDir("copyProjectFilesNonInteractive");
+  const tmp = createTmpDir("copyProjectFilesNonInteractive", "test");
 
   async function buildFixtureTemplate(): Promise<Template> {
-    const templateDir = path.join(process.cwd(), "__template_fixture__");
+    const templateDir = path.join(tmp.path, "__template_fixture__");
     await ensureDir(templateDir);
     await writeUtf8File(
       path.join(templateDir, "hardhat.config.ts"),
@@ -1204,7 +1218,7 @@ describe("assertNoNonInteractiveClashes / copyProjectFilesNonInteractive", () =>
 
   it("should copy all files in an empty workspace", async () => {
     const template = await buildFixtureTemplate();
-    const workspace = path.join(process.cwd(), "workspace");
+    const workspace = path.join(tmp.path, "workspace");
     await ensureDir(workspace);
 
     await assertNoNonInteractiveClashes(workspace, template);
@@ -1230,7 +1244,7 @@ describe("assertNoNonInteractiveClashes / copyProjectFilesNonInteractive", () =>
 
   it("should preserve a pre-existing .gitignore", async () => {
     const template = await buildFixtureTemplate();
-    const workspace = path.join(process.cwd(), "workspace-gitignore");
+    const workspace = path.join(tmp.path, "workspace-gitignore");
     await ensureDir(workspace);
     await writeUtf8File(path.join(workspace, ".gitignore"), "user-gitignore");
 
@@ -1245,7 +1259,7 @@ describe("assertNoNonInteractiveClashes / copyProjectFilesNonInteractive", () =>
 
   it("should redirect README.md to HARDHAT.md when README.md pre-exists", async () => {
     const template = await buildFixtureTemplate();
-    const workspace = path.join(process.cwd(), "workspace-readme");
+    const workspace = path.join(tmp.path, "workspace-readme");
     await ensureDir(workspace);
     await writeUtf8File(path.join(workspace, "README.md"), "user-readme");
 
@@ -1264,7 +1278,7 @@ describe("assertNoNonInteractiveClashes / copyProjectFilesNonInteractive", () =>
 
   it("should skip README copy when both README.md and HARDHAT.md pre-exist", async () => {
     const template = await buildFixtureTemplate();
-    const workspace = path.join(process.cwd(), "workspace-both");
+    const workspace = path.join(tmp.path, "workspace-both");
     await ensureDir(workspace);
     await writeUtf8File(path.join(workspace, "README.md"), "user-readme");
     await writeUtf8File(path.join(workspace, "HARDHAT.md"), "user-hardhat-md");
@@ -1284,7 +1298,7 @@ describe("assertNoNonInteractiveClashes / copyProjectFilesNonInteractive", () =>
 
   it("should throw a clash error for a pre-existing non-exempt file", async () => {
     const template = await buildFixtureTemplate();
-    const workspace = path.join(process.cwd(), "workspace-clash");
+    const workspace = path.join(tmp.path, "workspace-clash");
     await ensureDir(workspace);
     await writeUtf8File(
       path.join(workspace, "hardhat.config.ts"),

--- a/packages/hardhat/test/internal/cli/init/subprocess.ts
+++ b/packages/hardhat/test/internal/cli/init/subprocess.ts
@@ -1,26 +1,31 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import { describe, it } from "node:test";
 
-import { useTmpDir } from "@nomicfoundation/hardhat-test-utils";
+import { createTmpDir } from "@nomicfoundation/hardhat-test-utils";
 import { exists } from "@nomicfoundation/hardhat-utils/fs";
 
 import { spawn } from "../../../../src/internal/cli/init/subprocess.js";
 
 describe("spawn", () => {
-  useTmpDir("spawn");
+  const tmp = createTmpDir("spawn", "test");
 
   it("should execute the command and wait for it to finish", async () => {
     // We delay the test.txt creation and then check if it exists. If spawn
     // didn't wait for the command to finish, test.txt wouldn't exist yet
     await spawn("sleep", ["0.01", "&&", "touch", "test.txt"], {
       shell: true,
+      cwd: tmp.path,
     });
-    assert.ok(await exists("test.txt"), "test.txt should exist already");
+    assert.ok(
+      await exists(path.join(tmp.path, "test.txt")),
+      "test.txt should exist already",
+    );
   });
   it("should throw if the command exits with a non-zero exit code", async () => {
     // eslint-disable-next-line no-restricted-syntax -- We expect a generic error here
     await assert.rejects(async () => {
-      await spawn("test", ["-f", "test.txt"], {});
+      await spawn("test", ["-f", "test.txt"], { cwd: tmp.path });
     });
   });
 });

--- a/packages/hardhat/test/internal/cli/telemetry/telemetry-permissions.ts
+++ b/packages/hardhat/test/internal/cli/telemetry/telemetry-permissions.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
-import { useTmpDir } from "@nomicfoundation/hardhat-test-utils";
+import { createTmpDir } from "@nomicfoundation/hardhat-test-utils";
 import { writeJsonFile } from "@nomicfoundation/hardhat-utils/fs";
 
 import { isTelemetryAllowed } from "../../../../src/internal/cli/telemetry/telemetry-permissions.js";
@@ -11,9 +12,8 @@ async function setTelemetryConfigFile(filePath: string, enabled: boolean) {
 }
 
 describe("telemetry-permissions", () => {
-  // We use a tmp dir and store the telemetry config file there, using a relative path
-  useTmpDir("telemetry-permissions");
-  const CONFIG_FILE_PATH = "./telemetry-config.json";
+  const tmp = createTmpDir("telemetry-permissions", "test");
+  const configFilePath = () => path.join(tmp.path, "telemetry-config.json");
 
   beforeEach(async () => {
     delete process.env.HARDHAT_TEST_INTERACTIVE_ENV;
@@ -25,32 +25,32 @@ describe("telemetry-permissions", () => {
 
   describe("isTelemetryAllowed", () => {
     it("should return false because not an interactive environment", async () => {
-      await setTelemetryConfigFile(CONFIG_FILE_PATH, true);
+      await setTelemetryConfigFile(configFilePath(), true);
 
-      const res = await isTelemetryAllowed(CONFIG_FILE_PATH);
+      const res = await isTelemetryAllowed(configFilePath());
       assert.equal(res, false);
     });
 
     it("should return false because the user explicitly opted out of telemetry", async () => {
       process.env.HARDHAT_TEST_INTERACTIVE_ENV = "true";
-      await setTelemetryConfigFile(CONFIG_FILE_PATH, false);
+      await setTelemetryConfigFile(configFilePath(), false);
 
-      const res = await isTelemetryAllowed(CONFIG_FILE_PATH);
+      const res = await isTelemetryAllowed(configFilePath());
       assert.equal(res, false);
     });
 
     it("should return true because the user did not explicitly opt out of telemetry", async () => {
       process.env.HARDHAT_TEST_INTERACTIVE_ENV = "true";
 
-      const res = await isTelemetryAllowed(CONFIG_FILE_PATH);
+      const res = await isTelemetryAllowed(configFilePath());
       assert.equal(res, true);
     });
 
     it("should return true because the user explicitly opted in to telemetry", async () => {
       process.env.HARDHAT_TEST_INTERACTIVE_ENV = "true";
-      await setTelemetryConfigFile(CONFIG_FILE_PATH, true);
+      await setTelemetryConfigFile(configFilePath(), true);
 
-      const res = await isTelemetryAllowed(CONFIG_FILE_PATH);
+      const res = await isTelemetryAllowed(configFilePath());
       assert.equal(res, true);
     });
   });


### PR DESCRIPTION
## Summary

Tests were creating temp dirs in `/tmp`. Tools that resolve config by walking up from `cwd`, like package managers choosing the right pnpm/npm version or `.npmrc` resolution, never reach the workspace from there. As a result, subprocesses spawned inside those tmp dirs use whatever is on `PATH` instead of what the repo pins.

I hit this because 13 init tests were failing locally when my global pnpm was 11 while the repo pins 10.28.2, but the same kind of problem can affect any tool that walks up looking for workspace settings.

This PR moves tmp dirs to `<workspace-root>/tmp/` and replaces the previous patterns (`mkdtemp` directly, `getTmpDir`, and two copies of `useTmpDir`) with one helper:

```typescript
const tmp = createTmpDir("foo", "test"); // or "describe"
// inside it()/before()/after(): tmp.path
```

Most of the diff is mechanical: `process.cwd()` to `tmp.path`, `getTmpDir()` to `tmp.path`, and `useTmpDir(name)` to `createTmpDir(name, "test")`.

The parts worth looking at more carefully are:
- `packages/hardhat-test-utils/src/fs.ts` and `packages/hardhat-utils/test/helpers/fs.ts`: the new helper. It's copied into `hardhat-utils` to avoid a circular dependency, and both files have a "keep in sync" header.
- `packages/hardhat/test/internal/cli/init/init.ts`: the new `setUpPnpmTmpDir` writes `.npmrc` and `pnpm-workspace.yaml` into tmp dirs that use pnpm, so they don't pollute the workspace's `pnpm-lock.yaml`. There's an inline comment with more context.
- `packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/helpers.ts`: `useTestProjectTemplate` keeps its `await using` shape, so the 260 call sites don't need to change, but it now uses the shared workspace-local helper.
- `packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/remapped-npm-packages-graph.ts`: fixes a pre-existing leak. Seven call sites were using `useTestProjectTemplate` without `await using`, so they never cleaned up. That was mostly hidden when the dirs lived in `/tmp`, but not once they live inside the workspace.
- The per-test `package.json` files in `custom-compiler.ts` and the `solcjs` describe block in `compiler/index.ts`: the workspace's `"type": "module"` reaches the tmp dirs and breaks solc's CJS WASM `.js` bundle. These tests now write `{"type":"commonjs"}` into their own tmp dirs. The comments explain why.

Some notes:
- This PR doesn't have a related issue, but it can be considered a pre-step for https://github.com/NomicFoundation/hardhat/issues/8245. It came up because of the new pnpm version release combined with local environment setup.
- No changeset, since all changes are in tests or internal utils.
- As @alcuadrado noted, this also helps with a separate issue: in some environments, like VMs, `/tmp` can get very large if it isn't cleaned up and use all the assigned disk space. These dirs should still clean themselves up after the tests, but if something goes wrong and `<workspace-root>/tmp/` is left with files, it's easy to clean manually. That's not as safe with the OS tmp dir, since it usually contains unrelated files.