### PR TITLE
fix(hardhat): return revert data as hex string for code 3 errors

### DIFF
--- a/.changeset/fix-json-rpc-revert-data-hex-string.md
+++ b/.changeset/fix-json-rpc-revert-data-hex-string.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix JSON-RPC `error.data` shape for revert errors (code 3): return the raw revert hex string directly instead of a `{ message, txHash, data }` wrapper object. This matches the geth/anvil/EVM-node convention that client tooling (viem, ethers, web3.js) relies on when decoding custom errors. Closes #8075.

--- a/packages/hardhat/src/internal/builtin-plugins/node/json-rpc/handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/json-rpc/handler.ts
@@ -269,15 +269,8 @@ const _handleError = (error: Error): JsonRpcResponse => {
     error = new InternalError(undefined, error);
   }
 
-  // For revert errors (code 3), the JSON-RPC `data` field must be the hex
-  // revert data as a string — this matches the geth/anvil/EVM-node convention
-  // and is what tooling (viem, ethers, web3.js) expects when decoding custom
-  // errors. Returning the rich `{ message, txHash, data }` wrapper here breaks
-  // clients that call `.slice` on `error.data` (see issue #8075).
-  //
-  // For Hardhat-internal errors (non-revert) we keep the rich object so that
-  // diagnostic info (txHash, message) is preserved — those clients don't
-  // attempt to decode the field as hex revert data.
+  // Revert errors (code 3): return raw hex to match the geth/anvil convention
+  // that viem/ethers/web3.js rely on. Other errors keep the wrapper for diagnostics.
   const data: unknown = isRevertError
     ? returnData
     : { message: error.message, txHash, data: returnData };

--- a/packages/hardhat/src/internal/builtin-plugins/node/json-rpc/handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/json-rpc/handler.ts
@@ -269,6 +269,19 @@ const _handleError = (error: Error): JsonRpcResponse => {
     error = new InternalError(undefined, error);
   }
 
+  // For revert errors (code 3), the JSON-RPC `data` field must be the hex
+  // revert data as a string — this matches the geth/anvil/EVM-node convention
+  // and is what tooling (viem, ethers, web3.js) expects when decoding custom
+  // errors. Returning the rich `{ message, txHash, data }` wrapper here breaks
+  // clients that call `.slice` on `error.data` (see issue #8075).
+  //
+  // For Hardhat-internal errors (non-revert) we keep the rich object so that
+  // diagnostic info (txHash, message) is preserved — those clients don't
+  // attempt to decode the field as hex revert data.
+  const data: unknown = isRevertError
+    ? returnData
+    : { message: error.message, txHash, data: returnData };
+
   const response: FailedJsonRpcResponse = {
     jsonrpc: "2.0",
     id: null,
@@ -278,11 +291,7 @@ const _handleError = (error: Error): JsonRpcResponse => {
           ? error.code
           : InternalError.CODE,
       message: error.message,
-      data: {
-        message: error.message,
-        txHash,
-        data: returnData,
-      },
+      data,
     },
   };
 

--- a/packages/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts
@@ -341,7 +341,13 @@ describe("JSON-RPC handler", async function () {
     assert.equal(rpcRes.error.data.data, "0xcafe");
   });
 
-  it("should preserve code 3, revert data, and txHash for revert errors over HTTP", async function () {
+  it("should expose revert data as a hex string for code 3 errors (geth/anvil convention)", async function () {
+    // Revert errors (code 3) MUST return `error.data` as a hex string, not
+    // a wrapper object. This matches the geth/anvil/sepolia convention and is
+    // what client tooling (viem, ethers, web3.js) expects to decode custom
+    // errors. See issue #8075 — viem's `ContractFunctionRevertedError` calls
+    // `.slice()` on `error.data` and fails with `data2?.slice is not a function`
+    // when the field is an object.
     const rpcReq: JsonRpcRequest = {
       jsonrpc: "2.0",
       method: "revertWithDataAndTxHash",
@@ -360,16 +366,16 @@ describe("JSON-RPC handler", async function () {
       "execution reverted",
       "Revert error must not be wrapped as InternalError",
     );
-    assert.ok(
-      isObject(rpcRes.error.data),
-      "Expected error data to be an object",
+    assert.equal(
+      typeof rpcRes.error.data,
+      "string",
+      "error.data must be a hex string for revert errors (matches geth/anvil)",
     );
     assert.equal(
-      rpcRes.error.data.data,
+      rpcRes.error.data,
       "0xdeadbeef",
-      "error.data.data must contain the raw revert hex",
+      "error.data must contain the raw revert hex directly",
     );
-    assert.equal(rpcRes.error.data.txHash, "0xabc123");
   });
 });
 

--- a/packages/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts
@@ -342,12 +342,8 @@ describe("JSON-RPC handler", async function () {
   });
 
   it("should expose revert data as a hex string for code 3 errors (geth/anvil convention)", async function () {
-    // Revert errors (code 3) MUST return `error.data` as a hex string, not
-    // a wrapper object. This matches the geth/anvil/sepolia convention and is
-    // what client tooling (viem, ethers, web3.js) expects to decode custom
-    // errors. See issue #8075 — viem's `ContractFunctionRevertedError` calls
-    // `.slice()` on `error.data` and fails with `data2?.slice is not a function`
-    // when the field is an object.
+    // For revert errors (code 3), error.data must be the raw hex string,
+    // matching the geth/anvil convention viem/ethers/web3.js expect. See #8075.
     const rpcReq: JsonRpcRequest = {
       jsonrpc: "2.0",
       method: "revertWithDataAndTxHash",


### PR DESCRIPTION
## Summary

Fixes #8075 — when a contract reverts on the local Hardhat node, viem
fails with `data2?.slice is not a function` while the identical
transaction works fine on Sepolia.

The JSON-RPC handler currently wraps `error.data` in a
`{ message, txHash, data }` object for **every** failure response,
including execution-revert (code 3). That diverges from the
geth/anvil/EVM-node convention where `error.data` is the raw revert
hex string, and breaks client tooling (viem, ethers, web3.js) that
decodes custom errors by reading and slicing that field directly.

### Before
```jsonc
// hardhat node response
{
  "error": {
    "code": 3,
    "message": "execution reverted",
    "data": { "message": "...", "txHash": "0x...", "data": "0x256d9840" }
  }
}
```

### After
```jsonc
// hardhat node response (matches geth/anvil/sepolia)
{
  "error": {
    "code": 3,
    "message": "execution reverted",
    "data": "0x256d9840"
  }
}
```

## Scope

- **Revert errors only** (`error.code === 3`) get the hex-string shape.
- Hardhat-internal errors (non-revert) keep the rich
  `{ message, txHash, data }` diagnostic wrapper — tooling does not try
  to decode those as revert data, and the wrapper is still useful for
  surfacing internal failures.
- `http-provider.ts` already handles either shape correctly because
  `extractReturnData` checks `typeof error.data === \"string\"` first,
  so upstream revert responses (now hex strings) flow through unchanged.

## Test plan
- [x] Updated the existing `revertWithDataAndTxHash` test in
  `packages/hardhat/test/internal/builtin-plugins/node/json-rpc/handler.ts`
  to assert the new shape and explain the rationale (links back to #8075).
- [x] `node --import tsx/esm --test test/internal/builtin-plugins/node/json-rpc/handler.ts`
  → all 13 tests pass, including the updated revert-shape test.
- [x] `pnpm lint:file` clean (prettier + eslint) on both changed files.
- [x] Manual re-trace through `_handleError` for non-revert paths
  (`plainError`, `methodNotFound`, `topLevelTxHash`, `dataAsString`,
  `dataWithTxHash`, `dataWithData`, `dataWithBoth`,
  `nonProviderErrorWithDataButNoCode3`) — all still produce the rich
  `{ message, txHash, data }` wrapper as before; no behavior change for
  those.

A changeset entry (`patch` to `hardhat`) is included.