### PR TITLE
fix(hardhat-viem-assertions): compare addresses case-insensitively in withArgs / revertWithCustomErrorWithArgs

### DIFF
--- a/.changeset/fix-viem-assertions-address-case.md
+++ b/.changeset/fix-viem-assertions-address-case.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+fix(hardhat-viem-assertions): compare addresses case-insensitively in withArgs / revertWithCustomErrorWithArgs

--- a/.changeset/fix-viem-assertions-address-case.md
+++ b/.changeset/fix-viem-assertions-address-case.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-viem-assertions": patch
 ---
 
-fix(hardhat-viem-assertions): compare addresses case-insensitively in withArgs / revertWithCustomErrorWithArgs
+Compare addresses case-insensitively in withArgs / revertWithCustomErrorWithArgs

--- a/packages/hardhat-viem-assertions/src/internal/predicates.ts
+++ b/packages/hardhat-viem-assertions/src/internal/predicates.ts
@@ -3,6 +3,13 @@ import assert from "node:assert/strict";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { deepEqual } from "@nomicfoundation/hardhat-utils/lang";
 
+// EIP-55 addresses are 0x-prefixed 40 hex chars; case carries only checksum info.
+const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
+
+function isAddressLike(value: unknown): value is string {
+  return typeof value === "string" && ADDRESS_REGEX.test(value);
+}
+
 export function anyValue() {
   return true;
 }
@@ -30,6 +37,10 @@ export async function isArgumentMatch(
         assert.fail(
           `The predicate of index ${index} threw when called: ${e.message}`,
         );
+      }
+    } else if (isAddressLike(emittedArg) && isAddressLike(expectedArg)) {
+      if (emittedArg.toLowerCase() !== expectedArg.toLowerCase()) {
+        return false;
       }
     } else {
       if (!(await deepEqual(emittedArg, expectedArg))) {

--- a/packages/hardhat-viem-assertions/src/internal/predicates.ts
+++ b/packages/hardhat-viem-assertions/src/internal/predicates.ts
@@ -39,6 +39,10 @@ export async function isArgumentMatch(
         );
       }
     } else if (isAddressLike(emittedArg) && isAddressLike(expectedArg)) {
+      if (emittedArg === expectedArg) {
+        continue;
+      }
+
       if (emittedArg.toLowerCase() !== expectedArg.toLowerCase()) {
         return false;
       }

--- a/packages/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Events.sol
+++ b/packages/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Events.sol
@@ -19,6 +19,7 @@ contract Events {
   event WithString(string s);
   event WithArray(uint[] a);
   event WithStruct(TestStruct a);
+  event WithAddress(address a);
 
   constructor() {}
 
@@ -70,5 +71,9 @@ contract Events {
 
   function emitStruct(TestStruct memory a) public {
     emit WithStruct(a);
+  }
+
+  function emitAddress(address a) public {
+    emit WithAddress(a);
   }
 }

--- a/packages/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Revert.sol
+++ b/packages/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Revert.sol
@@ -16,6 +16,7 @@ contract Revert {
   error CustomErrorWithUintAndStringNamedParam(uint u, uint v, string s);
   error CustomErrorWithArray(uint[]);
   error CustomErrorWithStruct(TestStruct);
+  error CustomErrorWithAddress(address);
 
   function alwaysRevert() external pure {
     revert("Intentional revert for testing purposes");
@@ -56,6 +57,10 @@ contract Revert {
 
   function revertWithCustomErrorWithStruct(TestStruct memory a) external pure {
     revert CustomErrorWithStruct(a);
+  }
+
+  function revertWithCustomErrorWithAddress(address a) external pure {
+    revert CustomErrorWithAddress(a);
   }
 }
 

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
@@ -180,6 +180,40 @@ describe("emitWithArgs", () => {
     });
   });
 
+  it("should compare address arguments case-insensitively", async () => {
+    const contract = await viem.deployContract("Events");
+    const checksummed = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+
+    await viem.assertions.emitWithArgs(
+      contract.write.emitAddress([checksummed]),
+      contract,
+      "WithAddress",
+      [checksummed.toLowerCase()],
+    );
+  });
+
+  it("should throw when address arguments do not match even case-insensitively", async () => {
+    const contract = await viem.deployContract("Events");
+    const addr1 = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+    const addr2 = "0x0000000000000000000000000000000000000001";
+
+    await assertRejects(
+      viem.assertions.emitWithArgs(
+        contract.write.emitAddress([addr1]),
+        contract,
+        "WithAddress",
+        [addr2],
+      ),
+      (error) =>
+        isExpectedError(
+          error,
+          "The event arguments do not match the expected ones.",
+          [addr1.toLowerCase()],
+          [addr2],
+        ),
+    );
+  });
+
   it("should not throw if no args are passed and nothing is emitted", async () => {
     const contract = await viem.deployContract("Events");
 

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
@@ -208,7 +208,7 @@ describe("emitWithArgs", () => {
         isExpectedError(
           error,
           "The event arguments do not match the expected ones.",
-          [addr1.toLowerCase()],
+          [addr1],
           [addr2],
         ),
     );

--- a/packages/hardhat-viem-assertions/test/internal/assertions/revert/revert-with-custom-error-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/revert/revert-with-custom-error-with-args.ts
@@ -95,6 +95,18 @@ describe("revertWithCustomErrorWithArgs", () => {
     );
   });
 
+  it("should compare address error arguments case-insensitively", async () => {
+    const contract = await viem.deployContract("Revert");
+    const checksummed = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+
+    await viem.assertions.revertWithCustomErrorWithArgs(
+      contract.read.revertWithCustomErrorWithAddress([checksummed]),
+      contract,
+      "CustomErrorWithAddress",
+      [checksummed.toLowerCase()],
+    );
+  });
+
   it("should check that the function reverts when called within nested contracts", async () => {
     const contract = await viem.deployContract("Revert");
     const contractThatThrows = await viem.deployContract("Revert");


### PR DESCRIPTION
## Summary

Closes #8256.

viem normalises decoded addresses to EIP-55 checksum form, so an emitted address and a user-supplied address for the same account may differ only in case (`0xAbCd…` vs `0xabcd…`). The previous `deepEqual` path treated these as unequal, surfacing as confusing test failures whenever a caller passed a lowercase or differently-cased address to `withArgs` / `revertWithCustomErrorWithArgs`.

## What changed

**`src/internal/predicates.ts`**

Added an `isAddressLike` helper that matches the `0x` + 40-hex-char pattern, and a new branch in `isArgumentMatch`:

- When both the emitted and expected values look like addresses → compare with `.toLowerCase()`.
- Everything else (including strings that happen to be 40 hex chars but lack a `0x` prefix) → existing `deepEqual` path, unchanged.

**Fixture contracts**

- `Events.sol` — `WithAddress(address a)` event + `emitAddress(address)` function.
- `Revert.sol` — `CustomErrorWithAddress(address)` error + `revertWithCustomErrorWithAddress(address)` function.

**Tests**

- `emit-with-args.ts` — two new cases: checksummed address matches its lowercase form; two distinct addresses do not match.
- `revert-with-custom-error-with-args.ts` — one new case mirroring the happy-path emit test for custom errors.

## Test plan

- [ ] `pnpm --filter @nomicfoundation/hardhat-viem-assertions test` passes (new cases green, no regressions).
- [ ] `pnpm --filter @nomicfoundation/hardhat-viem-assertions lint` clean.