### PR TITLE
ci: remove limit on benchmark history items

### DIFF
--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -117,4 +117,3 @@ jobs:
           # Only fail on PRs; don't break CI on main
           fail-on-alert: ${{ github.event_name == 'pull_request' }}
           summary-always: true
-          max-items-in-chart: 50


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Removes the data limit on the number of historic benchmark runs that can be stored. This is a trade-off between retaining the full history vs making the chart less legible due to the amount of data points.
