### PR TITLE
Improved error messages for common migration errors

### DIFF
--- a/.changeset/warm-ravens-listen.md
+++ b/.changeset/warm-ravens-listen.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Improved error messages for common migration errors.

--- a/packages/hardhat/src/internal/cli/error-handler.ts
+++ b/packages/hardhat/src/internal/cli/error-handler.ts
@@ -8,7 +8,6 @@ import {
 } from "@nomicfoundation/hardhat-errors";
 
 import { HARDHAT_NAME, HARDHAT_WEBSITE_URL } from "../constants.js";
-import { UsingHardhat2PluginError } from "../using-hardhat2-plugin-errors.js";
 
 // The classifier may import many unrelated things top-level to do its job, so
 // we load it lazily.
@@ -89,11 +88,6 @@ export async function printErrorMessages(
   shouldShowStackTraces: boolean = false,
   print: (message: string | Error) => void = console.error,
 ): Promise<void> {
-  if (error instanceof UsingHardhat2PluginError) {
-    printUsingHardhat2Error(error, print);
-    return;
-  }
-
   const { category } = await getErrorWithCategory(error);
   const showStackTraces =
     shouldShowStackTraces ||
@@ -220,17 +214,5 @@ async function getErrorMessages(error: Error): Promise<ErrorMessages> {
         ),
         postErrorStackTraceMessage: `If you think this is a bug in Hardhat, please report it here: ${HARDHAT_WEBSITE_URL}report-bug`,
       };
-  }
-}
-function printUsingHardhat2Error(
-  error: UsingHardhat2PluginError,
-  print: (message: string | Error) => void = console.error,
-): void {
-  print(styleText(["red", "bold"], `Hardhat 3 installation error:`));
-  print("");
-  if (error.callerRelativePath !== undefined) {
-    print(error.message);
-  } else {
-    print(error.stack);
   }
 }

--- a/packages/hardhat/src/internal/cli/error-handler.ts
+++ b/packages/hardhat/src/internal/cli/error-handler.ts
@@ -17,8 +17,8 @@ let classifierModule: typeof ClassifierT | undefined;
  * The different categories of errors that can be handled by hardhat cli.
  * Each category has a different way of being formatted and displayed.
  * To add new categories, add a new entry to this enum and update the
- *  {@link getErrorWithCategory} and {@link getErrorMessages} functions
- * accordingly.
+ *  {@link getErrorWithCategory} function and the switch inside
+ * {@link printErrorMessages} accordingly.
  */
 enum ErrorCategory {
   HARDHAT = "HARDHAT",
@@ -56,22 +56,14 @@ type ErrorWithCategory =
     };
 
 /**
- * The different messages that can be displayed for each category of errors.
- *  - `formattedErrorMessage`: the main error message that is always displayed.
- *  - `showMoreInfoMessage`: an optional message that can be displayed to
- * provide more information about the error. It is only displayed when stack
- * traces are hidden.
- *  - `postErrorStackTraceMessage` an optional message that can be displayed
- * after the stack trace. It is only displayed when stack traces are shown.
- */
-interface ErrorMessages {
-  formattedErrorMessage: string;
-  showMoreInfoMessage?: string;
-  postErrorStackTraceMessage?: string;
-}
-
-/**
  * Formats and logs error messages based on the category the error belongs to.
+ *
+ * For each category, we produce up to three pieces:
+ *  - `formattedErrorMessage`: the main error message that is always displayed.
+ *  - `showMoreInfoMessage`: an optional message that points the user at more
+ *    info. It is only displayed when the stack trace is hidden.
+ *  - `postErrorStackTraceMessage`: an optional message that is displayed after
+ *    the stack trace.
  *
  * @param error the error to handle. Supported categories are defined in
  * {@link ErrorCategory}.
@@ -88,17 +80,53 @@ export async function printErrorMessages(
   shouldShowStackTraces: boolean = false,
   print: (message: string | Error) => void = console.error,
 ): Promise<void> {
-  const { category } = await getErrorWithCategory(error);
+  const { category, categorizedError } = await getErrorWithCategory(error);
+
+  let formattedErrorMessage: string;
+  let showMoreInfoMessage: string | undefined;
+  let postErrorStackTraceMessage: string | undefined;
+
+  switch (category) {
+    case ErrorCategory.HARDHAT:
+      formattedErrorMessage = `${styleText(["red", "bold"], `Error ${categorizedError.errorCode}:`)} ${categorizedError.formattedMessage}`;
+      showMoreInfoMessage = `For more info go to ${HARDHAT_WEBSITE_URL}${categorizedError.errorCode} or run ${HARDHAT_NAME} with --show-stack-traces`;
+      break;
+    case ErrorCategory.PLUGIN:
+      formattedErrorMessage = `${styleText(["red", "bold"], `Error ${categorizedError.errorCode} in plugin ${categorizedError.pluginId}:`)} ${categorizedError.formattedMessage}`;
+      showMoreInfoMessage = `For more info go to ${HARDHAT_WEBSITE_URL}${categorizedError.errorCode} or run ${HARDHAT_NAME} with --show-stack-traces`;
+      break;
+    case ErrorCategory.COMMUNITY_PLUGIN:
+      formattedErrorMessage = `${styleText(["red", "bold"], `Error in community plugin ${categorizedError.pluginId}:`)} ${categorizedError.message}`;
+      showMoreInfoMessage = `For more info run ${HARDHAT_NAME} with --show-stack-traces`;
+      break;
+    case ErrorCategory.HH2_TO_HH3_MIGRATION:
+      formattedErrorMessage = styleText(
+        ["red", "bold"],
+        `Hardhat 3 migration error:`,
+      );
+      postErrorStackTraceMessage = `It looks like you are migrating from Hardhat 2 to Hardhat 3. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/migrate-from-hardhat2 to learn how to migrate your project to Hardhat 3.`;
+      break;
+    case ErrorCategory.CJS_TO_ESM_MIGRATION:
+      formattedErrorMessage = styleText(
+        ["red", "bold"],
+        `Hardhat 3 migration error:`,
+      );
+      postErrorStackTraceMessage = `It looks like you are migrating from CommonJS to ESM. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/migrate-to-esm to learn how to migrate your project to ESM.`;
+      break;
+    case ErrorCategory.OTHER:
+      formattedErrorMessage = styleText(
+        ["red", "bold"],
+        `An unexpected error occurred:`,
+      );
+      postErrorStackTraceMessage = `If you think this is a bug in Hardhat, please report it here: ${HARDHAT_WEBSITE_URL}report-bug`;
+      break;
+  }
+
   const showStackTraces =
     shouldShowStackTraces ||
     category === ErrorCategory.OTHER ||
     category === ErrorCategory.HH2_TO_HH3_MIGRATION ||
     category === ErrorCategory.CJS_TO_ESM_MIGRATION;
-  const {
-    formattedErrorMessage,
-    showMoreInfoMessage,
-    postErrorStackTraceMessage,
-  } = await getErrorMessages(error);
 
   print(formattedErrorMessage);
 
@@ -170,49 +198,4 @@ async function getErrorWithCategory(error: Error): Promise<ErrorWithCategory> {
     category: ErrorCategory.OTHER,
     categorizedError: error,
   };
-}
-
-async function getErrorMessages(error: Error): Promise<ErrorMessages> {
-  const { category, categorizedError } = await getErrorWithCategory(error);
-  switch (category) {
-    case ErrorCategory.HARDHAT:
-      return {
-        formattedErrorMessage: `${styleText(["red", "bold"], `Error ${categorizedError.errorCode}:`)} ${categorizedError.formattedMessage}`,
-        showMoreInfoMessage: `For more info go to ${HARDHAT_WEBSITE_URL}${categorizedError.errorCode} or run ${HARDHAT_NAME} with --show-stack-traces`,
-      };
-    case ErrorCategory.PLUGIN:
-      return {
-        formattedErrorMessage: `${styleText(["red", "bold"], `Error ${categorizedError.errorCode} in plugin ${categorizedError.pluginId}:`)} ${categorizedError.formattedMessage}`,
-        showMoreInfoMessage: `For more info go to ${HARDHAT_WEBSITE_URL}${categorizedError.errorCode} or run ${HARDHAT_NAME} with --show-stack-traces`,
-      };
-    case ErrorCategory.COMMUNITY_PLUGIN:
-      return {
-        formattedErrorMessage: `${styleText(["red", "bold"], `Error in community plugin ${categorizedError.pluginId}:`)} ${categorizedError.message}`,
-        showMoreInfoMessage: `For more info run ${HARDHAT_NAME} with --show-stack-traces`,
-      };
-    case ErrorCategory.HH2_TO_HH3_MIGRATION:
-      return {
-        formattedErrorMessage: styleText(
-          ["red", "bold"],
-          `Hardhat 3 migration error:`,
-        ),
-        postErrorStackTraceMessage: `It looks like you are migrating from Hardhat 2 to Hardhat 3. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/migrate-from-hardhat2 to learn how to migrate your project to Hardhat 3.`,
-      };
-    case ErrorCategory.CJS_TO_ESM_MIGRATION:
-      return {
-        formattedErrorMessage: styleText(
-          ["red", "bold"],
-          `Hardhat 3 migration error:`,
-        ),
-        postErrorStackTraceMessage: `It looks like you are migrating from CommonJS to ESM. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/migrate-to-esm to learn how to migrate your project to ESM.`,
-      };
-    case ErrorCategory.OTHER:
-      return {
-        formattedErrorMessage: styleText(
-          ["red", "bold"],
-          `An unexpected error occurred:`,
-        ),
-        postErrorStackTraceMessage: `If you think this is a bug in Hardhat, please report it here: ${HARDHAT_WEBSITE_URL}report-bug`,
-      };
-  }
 }

--- a/packages/hardhat/src/internal/cli/error-handler.ts
+++ b/packages/hardhat/src/internal/cli/error-handler.ts
@@ -210,7 +210,7 @@ async function getErrorMessages(error: Error): Promise<ErrorMessages> {
           ["red", "bold"],
           `Hardhat 3 migration error:`,
         ),
-        postErrorStackTraceMessage: `It looks like you are migrating from CommonJS to ESM. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/docs/migrate-from-hardhat2/guides/mocha-tests#esm to learn how to migrate your project to ESM.`,
+        postErrorStackTraceMessage: `It looks like you are migrating from CommonJS to ESM. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/migrate-to-esm to learn how to migrate your project to ESM.`,
       };
     case ErrorCategory.OTHER:
       return {

--- a/packages/hardhat/src/internal/cli/error-handler.ts
+++ b/packages/hardhat/src/internal/cli/error-handler.ts
@@ -1,3 +1,5 @@
+import type * as ClassifierT from "./telemetry/error-classification/classifier.js";
+
 import { styleText } from "node:util";
 
 import {
@@ -7,6 +9,10 @@ import {
 
 import { HARDHAT_NAME, HARDHAT_WEBSITE_URL } from "../constants.js";
 import { UsingHardhat2PluginError } from "../using-hardhat2-plugin-errors.js";
+
+// The classifier may import many unrelated things top-level to do its job, so
+// we load it lazily.
+let classifierModule: typeof ClassifierT | undefined;
 
 /**
  * The different categories of errors that can be handled by hardhat cli.
@@ -19,6 +25,8 @@ enum ErrorCategory {
   HARDHAT = "HARDHAT",
   PLUGIN = "PLUGIN",
   COMMUNITY_PLUGIN = "COMMUNITY_PLUGIN",
+  HH2_TO_HH3_MIGRATION = "HH2_TO_HH3_MIGRATION",
+  CJS_TO_ESM_MIGRATION = "CJS_TO_ESM_MIGRATION",
   OTHER = "OTHER",
 }
 
@@ -34,6 +42,14 @@ type ErrorWithCategory =
   | {
       category: ErrorCategory.COMMUNITY_PLUGIN;
       categorizedError: HardhatPluginError;
+    }
+  | {
+      category: ErrorCategory.HH2_TO_HH3_MIGRATION;
+      categorizedError: Error;
+    }
+  | {
+      category: ErrorCategory.CJS_TO_ESM_MIGRATION;
+      categorizedError: Error;
     }
   | {
       category: ErrorCategory.OTHER;
@@ -62,28 +78,33 @@ interface ErrorMessages {
  * {@link ErrorCategory}.
  * @param shouldShowStackTraces whether to show stack traces or not. If true,
  * the stack trace is always shown. If false, the stack trace is only shown for
- * errors of category {@link ErrorCategory.OTHER}.
+ * errors of category {@link ErrorCategory.OTHER},
+ * {@link ErrorCategory.HH2_TO_HH3_MIGRATION}, and
+ * {@link ErrorCategory.CJS_TO_ESM_MIGRATION}.
  * @param print the function used to print the error message, defaults to
  * `console.error`. Useful for testing to capture error messages.
  */
-export function printErrorMessages(
+export async function printErrorMessages(
   error: Error,
   shouldShowStackTraces: boolean = false,
   print: (message: string | Error) => void = console.error,
-): void {
+): Promise<void> {
   if (error instanceof UsingHardhat2PluginError) {
     printUsingHardhat2Error(error, print);
     return;
   }
 
+  const { category } = await getErrorWithCategory(error);
   const showStackTraces =
     shouldShowStackTraces ||
-    getErrorWithCategory(error).category === ErrorCategory.OTHER;
+    category === ErrorCategory.OTHER ||
+    category === ErrorCategory.HH2_TO_HH3_MIGRATION ||
+    category === ErrorCategory.CJS_TO_ESM_MIGRATION;
   const {
     formattedErrorMessage,
     showMoreInfoMessage,
     postErrorStackTraceMessage,
-  } = getErrorMessages(error);
+  } = await getErrorMessages(error);
 
   print(formattedErrorMessage);
 
@@ -100,7 +121,7 @@ export function printErrorMessages(
   }
 }
 
-function getErrorWithCategory(error: Error): ErrorWithCategory {
+async function getErrorWithCategory(error: Error): Promise<ErrorWithCategory> {
   if (HardhatError.isHardhatError(error)) {
     if (error.pluginId === undefined) {
       return {
@@ -122,14 +143,43 @@ function getErrorWithCategory(error: Error): ErrorWithCategory {
     };
   }
 
+  if (classifierModule === undefined) {
+    classifierModule = await import(
+      "./telemetry/error-classification/classifier.js"
+    );
+  }
+
+  // Pass `ignoreDevelopmentTimeFilter=true` so the migration footer also shows
+  // when hardhat is run from inside its own monorepo — the dev-time filter is
+  // a telemetry concern (don't report to Sentry), unrelated to display routing.
+  const classifierCategory = classifierModule.classifyError(error, true);
+  if (
+    classifierCategory ===
+    classifierModule.ErrorCategory.HH2_TO_HH3_MIGRATION_ERROR
+  ) {
+    return {
+      category: ErrorCategory.HH2_TO_HH3_MIGRATION,
+      categorizedError: error,
+    };
+  }
+  if (
+    classifierCategory ===
+    classifierModule.ErrorCategory.CJS_TO_ESM_MIGRATION_ERROR
+  ) {
+    return {
+      category: ErrorCategory.CJS_TO_ESM_MIGRATION,
+      categorizedError: error,
+    };
+  }
+
   return {
     category: ErrorCategory.OTHER,
     categorizedError: error,
   };
 }
 
-function getErrorMessages(error: Error): ErrorMessages {
-  const { category, categorizedError } = getErrorWithCategory(error);
+async function getErrorMessages(error: Error): Promise<ErrorMessages> {
+  const { category, categorizedError } = await getErrorWithCategory(error);
   switch (category) {
     case ErrorCategory.HARDHAT:
       return {
@@ -145,6 +195,22 @@ function getErrorMessages(error: Error): ErrorMessages {
       return {
         formattedErrorMessage: `${styleText(["red", "bold"], `Error in community plugin ${categorizedError.pluginId}:`)} ${categorizedError.message}`,
         showMoreInfoMessage: `For more info run ${HARDHAT_NAME} with --show-stack-traces`,
+      };
+    case ErrorCategory.HH2_TO_HH3_MIGRATION:
+      return {
+        formattedErrorMessage: styleText(
+          ["red", "bold"],
+          `Hardhat 3 migration error:`,
+        ),
+        postErrorStackTraceMessage: `It looks like you are migrating from Hardhat 2 to Hardhat 3. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/migrate-from-hardhat2 to learn how to migrate your project to Hardhat 3.`,
+      };
+    case ErrorCategory.CJS_TO_ESM_MIGRATION:
+      return {
+        formattedErrorMessage: styleText(
+          ["red", "bold"],
+          `Hardhat 3 migration error:`,
+        ),
+        postErrorStackTraceMessage: `It looks like you are migrating from CommonJS to ESM. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/docs/migrate-from-hardhat2/guides/mocha-tests#esm to learn how to migrate your project to ESM.`,
       };
     case ErrorCategory.OTHER:
       return {

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -318,7 +318,7 @@ export async function main(
     }
   } catch (error) {
     ensureError(error);
-    printErrorMessages(error, builtinGlobalOptions?.showStackTraces);
+    await printErrorMessages(error, builtinGlobalOptions?.showStackTraces);
 
     try {
       await sendErrorTelemetry(error);

--- a/packages/hardhat/src/internal/cli/telemetry/error-classification/classifier.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/error-classification/classifier.ts
@@ -70,7 +70,8 @@ import {
  * @param error The error to classify.
  * @param ignoreDevelopmentTimeFilter If true, the classifier will ignore the
  * development-time filter, which is used to exclude errors that happen during
- * development of Hardhat itself. This is only meant to be used for testing.
+ * development of Hardhat itself. Set this from display-side callers (where the
+ * dev-time skip is irrelevant) and from tests.
  * @returns The error category.
  */
 export function classifyError(

--- a/packages/hardhat/src/internal/using-hardhat2-plugin-errors.ts
+++ b/packages/hardhat/src/internal/using-hardhat2-plugin-errors.ts
@@ -13,21 +13,18 @@ export class UsingHardhat2PluginError extends CustomError {
     if (callerPath !== undefined) {
       message = `You are trying to use a Hardhat 2 plugin in a Hardhat 3 project.
 
-This file is part of a Hardhat 2 plugin calling an API that was removed in Hardhat 3: ${styleText("bold", callerPath)}
-
-Please read https://hardhat.org/migrate-from-hardhat2 to learn how to migrate your project to Hardhat 3.
-`;
+This file is part of a Hardhat 2 plugin calling an API that was removed in Hardhat 3: ${styleText("bold", callerPath)}`;
     } else {
-      message = `You are trying to use a Hardhat 2 plugin in a Hardhat 3 project.
-      
-Check the stack trace below to identify which plugin is causing this.
-
-Please read https://hardhat.org/migrate-from-hardhat2 to learn how to migrate your project to Hardhat 3.
-`;
+      message = `You are trying to use a Hardhat 2 plugin in a Hardhat 3 project.`;
     }
 
     super(message);
-    this.callerRelativePath = callerPath;
+    // Use a non-enumerable property so that `console.error(error)` does not
+    // print `{ callerRelativePath: '…' }` after the stack trace.
+    Object.defineProperty(this, "callerRelativePath", {
+      value: callerPath,
+      enumerable: false,
+    });
   }
 }
 

--- a/packages/hardhat/test/internal/cli/error-handler.ts
+++ b/packages/hardhat/test/internal/cli/error-handler.ts
@@ -267,8 +267,10 @@ describe("error-handler", () => {
       });
     });
 
-    describe("with a UsingHardhat2PluginError: independent of shouldShowStackTraces and the rest of the handling logic", () => {
-      it("should print the error message when callerRelativePath is available", async () => {
+    describe("with a UsingHardhat2PluginError", () => {
+      // Regression check: the classifier routes UsingHardhat2PluginError to
+      // the HH2_TO_HH3_MIGRATION branch, so the output should match it.
+      it("is treated as a Hardhat 2 to Hardhat 3 migration error", async () => {
         const lines: Array<string | Error> = [];
         const error = new UsingHardhat2PluginError();
 
@@ -276,54 +278,16 @@ describe("error-handler", () => {
           lines.push(msg);
         });
 
-        assert.equal(lines.length, 3);
+        assert.equal(lines.length, 5);
         assert.equal(
           lines[0],
-          styleText(["red", "bold"], `Hardhat 3 installation error:`),
+          styleText(["red", "bold"], `Hardhat 3 migration error:`),
         );
-        assert.equal(lines[1], "");
-        assert.equal(lines[2], error.message);
-      });
-
-      it("should not print the stack trace even when shouldShowStackTraces is true", async () => {
-        const lines: Array<string | Error> = [];
-        const error = new UsingHardhat2PluginError();
-
-        await printErrorMessages(error, true, (msg: string | Error) => {
-          lines.push(msg);
-        });
-
-        // UsingHardhat2PluginError is handled separately and always prints
-        // the same output regardless of shouldShowStackTraces
-        assert.equal(lines.length, 3);
+        assert.equal(lines[2], error);
         assert.equal(
-          lines[0],
-          styleText(["red", "bold"], `Hardhat 3 installation error:`),
+          lines[4],
+          `It looks like you are migrating from Hardhat 2 to Hardhat 3. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/migrate-from-hardhat2 to learn how to migrate your project to Hardhat 3.`,
         );
-        assert.equal(lines[1], "");
-        assert.equal(lines[2], error.message);
-      });
-
-      it("should print the stack trace when the callerRelativePath is not available", async () => {
-        const lines: Array<string | Error> = [];
-        const error = new UsingHardhat2PluginError();
-
-        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          -- Casting for testing purposes, as generating a failure of the logic
-          that gets the callerRelativePath is not trivial */
-        (error as any).callerRelativePath = undefined;
-
-        await printErrorMessages(error, true, (msg: string | Error) => {
-          lines.push(msg);
-        });
-
-        assert.equal(lines.length, 3);
-        assert.equal(
-          lines[0],
-          styleText(["red", "bold"], `Hardhat 3 installation error:`),
-        );
-        assert.equal(lines[1], "");
-        assert.equal(lines[2], error.stack);
       });
     });
   });

--- a/packages/hardhat/test/internal/cli/error-handler.ts
+++ b/packages/hardhat/test/internal/cli/error-handler.ts
@@ -243,7 +243,7 @@ describe("error-handler", () => {
         assert.equal(lines[3], "");
         assert.equal(
           lines[4],
-          `It looks like you are migrating from CommonJS to ESM. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/docs/migrate-from-hardhat2/guides/mocha-tests#esm to learn how to migrate your project to ESM.`,
+          `It looks like you are migrating from CommonJS to ESM. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/migrate-to-esm to learn how to migrate your project to ESM.`,
         );
       });
 

--- a/packages/hardhat/test/internal/cli/error-handler.ts
+++ b/packages/hardhat/test/internal/cli/error-handler.ts
@@ -31,11 +31,11 @@ const mockPluginErrorDescriptor = {
 describe("error-handler", () => {
   describe("printErrorMessages", () => {
     describe("with a Hardhat error", () => {
-      it("should print the error message", () => {
+      it("should print the error message", async () => {
         const lines: Array<string | Error> = [];
         const error = new HardhatError(mockCoreErrorDescriptor);
 
-        printErrorMessages(error, false, (msg: string | Error) => {
+        await printErrorMessages(error, false, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -51,11 +51,11 @@ describe("error-handler", () => {
         );
       });
 
-      it("should print the stack trace", () => {
+      it("should print the stack trace", async () => {
         const lines: Array<string | Error> = [];
         const error = new HardhatError(mockCoreErrorDescriptor);
 
-        printErrorMessages(error, true, (msg: string | Error) => {
+        await printErrorMessages(error, true, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -70,11 +70,11 @@ describe("error-handler", () => {
     });
 
     describe("with a Hardhat plugin error", () => {
-      it("should print the error message", () => {
+      it("should print the error message", async () => {
         const lines: Array<string | Error> = [];
         const error = new HardhatError(mockPluginErrorDescriptor);
 
-        printErrorMessages(error, false, (msg: string | Error) => {
+        await printErrorMessages(error, false, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -90,11 +90,11 @@ describe("error-handler", () => {
         );
       });
 
-      it("should print the stack trace", () => {
+      it("should print the stack trace", async () => {
         const lines: Array<string | Error> = [];
         const error = new HardhatError(mockPluginErrorDescriptor);
 
-        printErrorMessages(error, true, (msg: string | Error) => {
+        await printErrorMessages(error, true, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -109,14 +109,14 @@ describe("error-handler", () => {
     });
 
     describe("with a Hardhat community plugin error", () => {
-      it("should print the error message", () => {
+      it("should print the error message", async () => {
         const lines: Array<string | Error> = [];
         const error = new HardhatPluginError(
           "community-plugin",
           "error message",
         );
 
-        printErrorMessages(error, false, (msg: string | Error) => {
+        await printErrorMessages(error, false, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -132,14 +132,14 @@ describe("error-handler", () => {
         );
       });
 
-      it("should print the stack trace", () => {
+      it("should print the stack trace", async () => {
         const lines: Array<string | Error> = [];
         const error = new HardhatPluginError(
           "community-plugin",
           "error message",
         );
 
-        printErrorMessages(error, true, (msg: string | Error) => {
+        await printErrorMessages(error, true, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -154,11 +154,11 @@ describe("error-handler", () => {
     });
 
     describe("with an unknown error", () => {
-      it("should print the error message with the stack traces for an instance of Error", () => {
+      it("should print the error message with the stack traces for an instance of Error", async () => {
         const lines: Array<string | Error> = [];
         const error = new Error("error message");
 
-        printErrorMessages(error, false, (msg: string | Error) => {
+        await printErrorMessages(error, false, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -177,12 +177,102 @@ describe("error-handler", () => {
       });
     });
 
+    describe("with a Hardhat 2 to Hardhat 3 migration error", () => {
+      it("should print the error message", async () => {
+        const lines: Array<string | Error> = [];
+        const error = new Error(
+          "class extends value undefined is not a constructor or null",
+        );
+
+        await printErrorMessages(error, false, (msg: string | Error) => {
+          lines.push(msg);
+        });
+
+        assert.equal(lines.length, 5);
+        assert.equal(
+          lines[0],
+          styleText(["red", "bold"], `Hardhat 3 migration error:`),
+        );
+        assert.equal(lines[1], "");
+        assert.equal(lines[2], error);
+        assert.equal(lines[3], "");
+        assert.equal(
+          lines[4],
+          `It looks like you are migrating from Hardhat 2 to Hardhat 3. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/migrate-from-hardhat2 to learn how to migrate your project to Hardhat 3.`,
+        );
+      });
+
+      it("should always print the stack trace", async () => {
+        const error = new Error(
+          "class extends value undefined is not a constructor or null",
+        );
+
+        for (const shouldShowStackTraces of [false, true]) {
+          const lines: Array<string | Error> = [];
+          await printErrorMessages(
+            error,
+            shouldShowStackTraces,
+            (msg: string | Error) => {
+              lines.push(msg);
+            },
+          );
+          assert.ok(
+            lines.includes(error),
+            `error stack should be printed (shouldShowStackTraces=${shouldShowStackTraces})`,
+          );
+        }
+      });
+    });
+
+    describe("with a CommonJS to ESM migration error", () => {
+      it("should print the error message", async () => {
+        const lines: Array<string | Error> = [];
+        const error = new Error("Cannot use import statement outside a module");
+
+        await printErrorMessages(error, false, (msg: string | Error) => {
+          lines.push(msg);
+        });
+
+        assert.equal(lines.length, 5);
+        assert.equal(
+          lines[0],
+          styleText(["red", "bold"], `Hardhat 3 migration error:`),
+        );
+        assert.equal(lines[1], "");
+        assert.equal(lines[2], error);
+        assert.equal(lines[3], "");
+        assert.equal(
+          lines[4],
+          `It looks like you are migrating from CommonJS to ESM. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/docs/migrate-from-hardhat2/guides/mocha-tests#esm to learn how to migrate your project to ESM.`,
+        );
+      });
+
+      it("should always print the stack trace", async () => {
+        const error = new Error("Cannot use import statement outside a module");
+
+        for (const shouldShowStackTraces of [false, true]) {
+          const lines: Array<string | Error> = [];
+          await printErrorMessages(
+            error,
+            shouldShowStackTraces,
+            (msg: string | Error) => {
+              lines.push(msg);
+            },
+          );
+          assert.ok(
+            lines.includes(error),
+            `error stack should be printed (shouldShowStackTraces=${shouldShowStackTraces})`,
+          );
+        }
+      });
+    });
+
     describe("with a UsingHardhat2PluginError: independent of shouldShowStackTraces and the rest of the handling logic", () => {
-      it("should print the error message when callerRelativePath is available", () => {
+      it("should print the error message when callerRelativePath is available", async () => {
         const lines: Array<string | Error> = [];
         const error = new UsingHardhat2PluginError();
 
-        printErrorMessages(error, false, (msg: string | Error) => {
+        await printErrorMessages(error, false, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -195,11 +285,11 @@ describe("error-handler", () => {
         assert.equal(lines[2], error.message);
       });
 
-      it("should not print the stack trace even when shouldShowStackTraces is true", () => {
+      it("should not print the stack trace even when shouldShowStackTraces is true", async () => {
         const lines: Array<string | Error> = [];
         const error = new UsingHardhat2PluginError();
 
-        printErrorMessages(error, true, (msg: string | Error) => {
+        await printErrorMessages(error, true, (msg: string | Error) => {
           lines.push(msg);
         });
 
@@ -214,16 +304,16 @@ describe("error-handler", () => {
         assert.equal(lines[2], error.message);
       });
 
-      it("should print the stack trace when the callerRelativePath is not available", () => {
+      it("should print the stack trace when the callerRelativePath is not available", async () => {
         const lines: Array<string | Error> = [];
         const error = new UsingHardhat2PluginError();
 
-        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions 
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           -- Casting for testing purposes, as generating a failure of the logic
           that gets the callerRelativePath is not trivial */
         (error as any).callerRelativePath = undefined;
 
-        printErrorMessages(error, true, (msg: string | Error) => {
+        await printErrorMessages(error, true, (msg: string | Error) => {
           lines.push(msg);
         });
 


### PR DESCRIPTION
Improved the error messages for common migration errors, pointing to the migration guide for troubleshooting. Adapted the Hardhat 2 plugin error to be in line with the other migration errors. The ESM migration link was added to the docs, but it temporarily points to the ESM section in the Mocha guide. A new guide should be created later, and the redirect should be updated on the website.

Docs (redirect): https://github.com/NomicFoundation/hardhat-website/pull/265

## Screenshots

### Hardhat 2 -> Hardhat 3 migration error

```typescript
// hardhat.config.ts
import { task } from "hardhat";
task("scenario-a-placeholder", "placeholder").setAction(async () => {});
```
 
<img width="1650" alt="image" src="https://github.com/user-attachments/assets/7b9ec8cb-a4eb-4afd-af3e-2c1d36099318" />

### CJS -> ESM migration error

```typescript
// scripts/cjs-to-esm-scenario.cjs
import { ethers } from "ethers";
console.log(ethers);
```

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/ca8879f3-f53a-4588-ac54-393a1bee1689" />

### Hardhat 2 plugin migration error

```typescript
// hardhat.config.ts
import { extendConfig } from "hardhat/config";
extendConfig(() => {});
```

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/1d9a5041-4974-4487-8641-46f20507f509" />
