### PR TITLE
Add `--allow-build=esbuild` when installing dependencies with pnpm 11

### DIFF
--- a/.changeset/fifty-zoos-hunt.md
+++ b/.changeset/fifty-zoos-hunt.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix `hardhat --init` when used with pnpm 11

--- a/packages/hardhat/src/internal/cli/init/init.ts
+++ b/packages/hardhat/src/internal/cli/init/init.ts
@@ -35,6 +35,7 @@ import { sendErrorTelemetry } from "../telemetry/error-reporter/reporter.js";
 import {
   getDevDependenciesInstallationCommand,
   getPackageManager,
+  getVersion,
   installsPeerDependenciesByDefault,
 } from "./package-manager.js";
 import {
@@ -694,6 +695,8 @@ export async function installProjectDependencies({
   );
 
   const packageManager = getPackageManager();
+  const packageManagerVersion = await getVersion(workspace, packageManager);
+  const packageManagerMajorVersion = packageManagerVersion?.[0];
 
   // Find the template dev dependencies that are not already installed
   const templateDependencies = template.packageJson.devDependencies ?? {};
@@ -730,6 +733,7 @@ export async function installProjectDependencies({
     const command = getDevDependenciesInstallationCommand(
       packageManager,
       dependenciesToInstall,
+      packageManagerMajorVersion,
     );
     const commandString = command.join(" ");
 
@@ -788,6 +792,7 @@ export async function installProjectDependencies({
     const command = getDevDependenciesInstallationCommand(
       packageManager,
       dependenciesToUpdate,
+      packageManagerMajorVersion,
     );
     const commandString = command.join(" ");
 

--- a/packages/hardhat/src/internal/cli/init/package-manager.ts
+++ b/packages/hardhat/src/internal/cli/init/package-manager.ts
@@ -104,11 +104,16 @@ export function getPackageManager(): PackageManager {
  *
  * @param packageManager The package manager to use.
  * @param dependencies The dependencies to install.
+ * @param packageManagerMajorVersion The major version of the package manager,
+ * if known. Used to opt into version-specific flags (e.g. pnpm 11's
+ * `--allow-build=esbuild`, required because `tsx` ships `esbuild` whose
+ * postinstall script is otherwise blocked).
  * @returns The installation command.
  */
 export function getDevDependenciesInstallationCommand(
   packageManager: PackageManager,
   dependencies: string[],
+  packageManagerMajorVersion?: number,
 ): string[] {
   const packageManagerToCommand: Record<PackageManager, string[]> = {
     npm: ["npm", "install", "--save-dev"],
@@ -118,6 +123,18 @@ export function getDevDependenciesInstallationCommand(
     bun: ["bun", "add", "--dev"],
   };
   const command = packageManagerToCommand[packageManager];
+
+  // NOTE: adding an unnecessary flag doesn't result in an error
+  // nor warning, so we don't check if hardhat or tsx are being
+  // installed.
+  if (
+    packageManager === "pnpm" &&
+    packageManagerMajorVersion !== undefined &&
+    packageManagerMajorVersion >= 11
+  ) {
+    command.push("--allow-build=esbuild");
+  }
+
   // We quote all the dependency identifiers so that they can be run on a shell
   // without semver symbols interfering with the command
   command.push(
@@ -205,7 +222,7 @@ export async function installsPeerDependenciesByDefault(
   }
 }
 
-async function getVersion(
+export async function getVersion(
   workspace: string,
   packageManager: PackageManager,
   version?: string,

--- a/packages/hardhat/test/internal/cli/init/package-manager.ts
+++ b/packages/hardhat/test/internal/cli/init/package-manager.ts
@@ -187,8 +187,50 @@ describe("getDevDependenciesInstallationCommand", () => {
     assert.equal(command.join(" "), 'pnpm add --save-dev "a" "b"');
   });
 
+  it("should return the correct command for pnpm 10", async () => {
+    const command = getDevDependenciesInstallationCommand(
+      "pnpm",
+      ["a", "b"],
+      10,
+    );
+    assert.equal(command.join(" "), 'pnpm add --save-dev "a" "b"');
+  });
+
+  it("should include --allow-build=esbuild for pnpm 11+", async () => {
+    const command = getDevDependenciesInstallationCommand(
+      "pnpm",
+      ["a", "b"],
+      11,
+    );
+    assert.equal(
+      command.join(" "),
+      'pnpm add --save-dev --allow-build=esbuild "a" "b"',
+    );
+  });
+
+  it("should include --allow-build=esbuild for pnpm 12+", async () => {
+    const command = getDevDependenciesInstallationCommand(
+      "pnpm",
+      ["a", "b"],
+      12,
+    );
+    assert.equal(
+      command.join(" "),
+      'pnpm add --save-dev --allow-build=esbuild "a" "b"',
+    );
+  });
+
   it("should return the correct command for npm", async () => {
     const command = getDevDependenciesInstallationCommand("npm", ["a", "b"]);
+    assert.equal(command.join(" "), 'npm install --save-dev "a" "b"');
+  });
+
+  it("should not add --allow-build for npm even at v11", async () => {
+    const command = getDevDependenciesInstallationCommand(
+      "npm",
+      ["a", "b"],
+      11,
+    );
     assert.equal(command.join(" "), 'npm install --save-dev "a" "b"');
   });
 
@@ -197,13 +239,40 @@ describe("getDevDependenciesInstallationCommand", () => {
     assert.equal(command.join(" "), 'yarn add --dev "a" "b"');
   });
 
+  it("should not add --allow-build for yarn even at v11", async () => {
+    const command = getDevDependenciesInstallationCommand(
+      "yarn",
+      ["a", "b"],
+      11,
+    );
+    assert.equal(command.join(" "), 'yarn add --dev "a" "b"');
+  });
+
   it("should return the correct command for bun", async () => {
     const command = getDevDependenciesInstallationCommand("bun", ["a", "b"]);
     assert.equal(command.join(" "), 'bun add --dev "a" "b"');
   });
 
+  it("should not add --allow-build for bun even at v11", async () => {
+    const command = getDevDependenciesInstallationCommand(
+      "bun",
+      ["a", "b"],
+      11,
+    );
+    assert.equal(command.join(" "), 'bun add --dev "a" "b"');
+  });
+
   it("should return the correct command for deno", async () => {
     const command = getDevDependenciesInstallationCommand("deno", ["a", "b"]);
+    assert.equal(command.join(" "), 'deno add "npm:a" "npm:b"');
+  });
+
+  it("should not add --allow-build for deno even at v11", async () => {
+    const command = getDevDependenciesInstallationCommand(
+      "deno",
+      ["a", "b"],
+      11,
+    );
     assert.equal(command.join(" "), 'deno add "npm:a" "npm:b"');
   });
 });


### PR DESCRIPTION
This is a quickfix to get `hardhat --init` working in pnpm 11, and not a definite "pnpm 11" support PR