### PR TITLE
test(e2e): enable aave-v4 scenario

### DIFF
--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -7,5 +7,21 @@
   "packageManager": "yarn",
   "submodules": true,
   "defaultCommand": "npx hardhat test solidity",
-  "disabled": true
+  "benchmark": {
+    "commands": {
+      "cold compile": {
+        "runs": 3,
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile"
+      },
+      "warm compile": {
+        "runs": 39,
+        "command": "npx hardhat compile"
+      },
+      "test solidity": {
+        "runs": 3,
+        "command": "npx hardhat test solidity --no-compile"
+      }
+    }
+  }
 }


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

The latest version of Hardhat fixes broken tests in aave-v4, allowing us to enable the scenario file and add it to the regression benchmark harness.

The number of runs was calculated based on locally run benchmark times.
