### PR TITLE
Fix hardhat viem assertions bug

### DIFF
--- a/.changeset/gentle-buckets-draw.md
+++ b/.changeset/gentle-buckets-draw.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+Fix an error in revertWithCustomErrorWithArgs

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
@@ -11,8 +11,6 @@ import type {
 
 import assert from "node:assert/strict";
 
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
-
 import { settle, stringifyArgs } from "../../helpers.js";
 import { isArgumentMatch } from "../../predicates.js";
 
@@ -87,7 +85,7 @@ export async function emitWithArgs<
       // They must be mapped into a sorted array that matches the order of the ABI event parameters.
       // Example: event EventY(uint u, uint v) -> mapped to -> { u: bigint, v: bigint }
       for (const [index, param] of expectedAbiEvent.inputs.entries()) {
-        assertHardhatInvariant(
+        assert.ok(
           param.name !== undefined,
           `The event parameter at index ${index} does not have a name`,
         );

--- a/packages/hardhat-viem-assertions/src/internal/assertions/revert/extract-revert-error.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/revert/extract-revert-error.ts
@@ -1,6 +1,7 @@
 import type { Hex } from "viem";
 
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import assert from "node:assert/strict";
+
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { isPrefixedHexString } from "@nomicfoundation/hardhat-utils/hex";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
@@ -57,7 +58,7 @@ export function extractRevertError(error: unknown): {
     current = current.cause as Error | undefined;
   }
 
-  assertHardhatInvariant(
+  assert.ok(
     dataReason !== undefined,
     `No revert data found on error.\nError name: "${error.name}", message: ${error.message}`,
   );

--- a/packages/hardhat-viem-assertions/src/internal/assertions/revert/extract-revert-error.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/revert/extract-revert-error.ts
@@ -3,6 +3,7 @@ import type { Hex } from "viem";
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { isPrefixedHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
 /**
  * Recursively extracts, if it exists, the revert data hex string from an error.
@@ -36,6 +37,17 @@ export function extractRevertError(error: unknown): {
 
       if (typeof data === "string" && isPrefixedHexString(data)) {
         dataReason = data;
+        message = current.message;
+      }
+
+      // We also support the data.data format used by some Hardhat versions.
+      if (
+        isObject(data) &&
+        "data" in data &&
+        typeof data.data === "string" &&
+        isPrefixedHexString(data.data)
+      ) {
+        dataReason = data.data;
         message = current.message;
       }
     }

--- a/packages/hardhat-viem-assertions/src/internal/assertions/revert/handle-revert-with-custom-error.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/revert/handle-revert-with-custom-error.ts
@@ -8,7 +8,6 @@ import type {
 
 import assert from "node:assert/strict";
 
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import { panicErrorCodeToMessage } from "@nomicfoundation/hardhat-utils/panic-errors";
 import { decodeErrorResult } from "viem";
@@ -43,10 +42,7 @@ export async function handleRevertWithCustomError<
       });
 
       if (isKnownErrorSelector(rawError.data)) {
-        assertHardhatInvariant(
-          Array.isArray(args),
-          "Expected args to be an array",
-        );
+        assert.ok(Array.isArray(args), "Expected args to be an array");
 
         if (isPanicErrorSelector(rawError.data)) {
           assert.fail(
@@ -61,8 +57,9 @@ export async function handleRevertWithCustomError<
         );
       }
 
-      assertHardhatInvariant(
-        abiItem.type === "error",
+      assert.equal(
+        abiItem.type,
+        "error",
         `Expected a custom error, but the error type is "${abiItem.type}".`,
       );
 

--- a/packages/hardhat-viem-assertions/test/fixture-projects/missing-contract-error/contracts/GenericReverter.sol
+++ b/packages/hardhat-viem-assertions/test/fixture-projects/missing-contract-error/contracts/GenericReverter.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+contract GenericReverter {
+    error GenericError(address account);
+
+    function check(address account) external pure returns (bool) {
+        require(false, GenericError(account));
+        return true;
+    }
+
+    function doNotRevert() external pure returns (bool) {
+        return true;
+    }
+}

--- a/packages/hardhat-viem-assertions/test/fixture-projects/missing-contract-error/hardhat.config.ts
+++ b/packages/hardhat-viem-assertions/test/fixture-projects/missing-contract-error/hardhat.config.ts
@@ -1,0 +1,21 @@
+import type { HardhatUserConfig } from "hardhat/config";
+
+import hardhatViem from "@nomicfoundation/hardhat-viem";
+import hardhatViemAssertions from "../../../src/index.js";
+
+const config: HardhatUserConfig = {
+  plugins: [hardhatViem, hardhatViemAssertions],
+  solidity: {
+    version: "0.8.33",
+    settings: {
+      evmVersion: "osaka",
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+      viaIR: true,
+    },
+  },
+};
+
+export default config;

--- a/packages/hardhat-viem-assertions/test/fixture-projects/missing-contract-error/package.json
+++ b/packages/hardhat-viem-assertions/test/fixture-projects/missing-contract-error/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "hardhat-project",
+  "private": "true",
+  "type": "module",
+  "dependencies": {
+    "hardhat": "workspace:*"
+  }
+}

--- a/packages/hardhat-viem-assertions/test/internal/assertions/revert/revert-with-custom-error-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/revert/revert-with-custom-error-with-args.ts
@@ -8,7 +8,11 @@ import {
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import hardhatViem from "@nomicfoundation/hardhat-viem";
-import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+import {
+  resolveHardhatConfigPath,
+  createHardhatRuntimeEnvironment,
+  importUserConfig,
+} from "hardhat/hre";
 
 import hardhatViemAssertions from "../../../../src/index.js";
 import { anyValue } from "../../../../src/predicates.js";
@@ -232,5 +236,30 @@ describe("revertWithCustomErrorWithArgs", () => {
           ].every((msg) => error.message.includes(msg)),
       );
     });
+  });
+});
+
+describe("revertWithCustomErrorWithArgs: regressuin tests", () => {
+  useEphemeralFixtureProject("missing-contract-error");
+
+  it("Should correctly find the custom error", async () => {
+    const configPath = await resolveHardhatConfigPath();
+    const config = await importUserConfig(configPath);
+    const hre = await createHardhatRuntimeEnvironment(config, {
+      config: configPath,
+    });
+
+    await hre.tasks.getTask("build").run({});
+    const { viem } = await hre.network.create();
+    const account = "0x0000000000000000000000000000000000000001";
+
+    const contract = await viem.deployContract("GenericReverter");
+
+    await viem.assertions.revertWithCustomErrorWithArgs(
+      contract.read.check([account]),
+      contract,
+      "GenericError",
+      [account],
+    );
   });
 });

--- a/packages/hardhat-viem-assertions/test/internal/assertions/revert/revert-with-custom-error-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/revert/revert-with-custom-error-with-args.ts
@@ -239,7 +239,7 @@ describe("revertWithCustomErrorWithArgs", () => {
   });
 });
 
-describe("revertWithCustomErrorWithArgs: regressuin tests", () => {
+describe("revertWithCustomErrorWithArgs: regression tests", () => {
   useEphemeralFixtureProject("missing-contract-error");
 
   it("Should correctly find the custom error", async () => {


### PR DESCRIPTION
This PR introduces a regression test to the viem assertion package, fixes it, and then makes sure that we use `node:assert` instead of `assertHardhatInvariant` in the rest of the assertions.