### PR TITLE
test: upgrade aave-v4 dry-run migration

### DIFF
--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -3,7 +3,7 @@
   "description": "Aave v4 fork to Hardhat 3.",
   "tags": ["external-repo"],
   "repo": "anaPerezGhiglia/aave-v4",
-  "commit": "95534d58cf54d60c6415c0efd7fb3a0eac6539d1",
+  "commit": "f729aeff7cc61d576e8f89e818e05265ec9f65e9",
   "packageManager": "yarn",
   "submodules": true,
   "defaultCommand": "npx hardhat test solidity",


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

@anaPerezGhiglia upgraded the dry-run migration of aave-v4 to Hardhat v3.5: https://github.com/anaPerezGhiglia/aave-v4/pull/3. This bumps the regression benchmark to that commit.

More tests were enabled as part of the upgrade to HH v3.5, so it's possible that the Solidity test benchmark takes longer.