### PR TITLE
`hardhat-viem-assertions`: Accept `Promise`s or awaited calls, and fix a bug related to it

### DIFF
--- a/.changeset/viem-assertions-tx-hash-or-promise.md
+++ b/.changeset/viem-assertions-tx-hash-or-promise.md
@@ -1,0 +1,9 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": minor
+---
+
+`balancesHaveChanged`, `emit`, and `emitWithArgs` now accept either a promise or its already-awaited value, so `await contract.write.foo()` can be passed directly. The `revert*` assertions still require an un-awaited promise because they need to catch the rejection.
+
+`emit` and `emitWithArgs` now only look at logs produced by the specific transaction passed in (via its receipt) instead of every log ever emitted by the contract address. Tests that previously passed by matching events from other transactions on the same contract will now correctly fail.
+
+The `contractFn` parameter of `emit` and `emitWithArgs` has been narrowed accordingly: it no longer accepts `ReadContractReturnType` (reads don't produce a receipt). Existing code passing a read result was already a no-op against the contract's logs and would not have produced a meaningful assertion.

--- a/.changeset/viem-assertions-tx-hash-or-promise.md
+++ b/.changeset/viem-assertions-tx-hash-or-promise.md
@@ -2,7 +2,7 @@
 "@nomicfoundation/hardhat-viem-assertions": minor
 ---
 
-`balancesHaveChanged`, `emit`, and `emitWithArgs` now accept either a promise or its already-awaited value, so `await contract.write.foo()` can be passed directly. The `revert*` assertions still require an un-awaited promise because they need to catch the rejection.
+The assertions `balancesHaveChanged`, `emit`, and `emitWithArgs` now accept either a promise or its already-awaited value, so `await contract.write.foo()` can be passed directly.
 
 `emit` and `emitWithArgs` now only look at logs produced by the specific transaction passed in (via its receipt) instead of every log ever emitted by the contract address. Tests that previously passed by matching events from other transactions on the same contract will now correctly fail.
 

--- a/packages/hardhat-viem-assertions/README.md
+++ b/packages/hardhat-viem-assertions/README.md
@@ -219,7 +219,7 @@ Type:
 
 ```ts
 emit<TContract extends AbiHolder<Abi>>(
-  txHash: MaybePromise<Hash>,
+  txHash: Hash | Promise<Hash>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<void>;
@@ -265,7 +265,7 @@ emitWithArgs<
   TContract extends AbiHolder<Abi>,
   TEventName extends ContractEventName<TContract["abi"]>,
 >(
-  txHash: MaybePromise<Hash>,
+  txHash: Hash | Promise<Hash>,
   contract: TContract,
   eventName: TEventName,
   args: EventArgsOf<TContract["abi"], TEventName>,
@@ -328,7 +328,7 @@ Type:
 
 ```ts
 balancesHaveChanged(
-  txHash: MaybePromise<Hash>,
+  txHash: Hash | Promise<Hash>,
   changes: Array<{
     address: Address;
     amount: bigint;

--- a/packages/hardhat-viem-assertions/README.md
+++ b/packages/hardhat-viem-assertions/README.md
@@ -209,7 +209,7 @@ await viem.assertions.revertWithCustomErrorWithArgs(
 
 ### Events
 
-These assertions can be used to check that a transaction emits specific events and their arguments. Each one accepts either an un-awaited viem write call or its already-awaited result, and looks at the receipt of that specific transaction.
+These assertions can be used to check that a transaction emits specific events and their arguments. Each one accepts a transaction hash or a promise resolving to one (e.g. a viem write call) and looks at the receipt of that specific transaction.
 
 #### `emit`
 
@@ -219,7 +219,7 @@ Type:
 
 ```ts
 emit<TContract extends AbiHolder<Abi>>(
-  contractFn: MaybePromise<WriteContractReturnType>,
+  txHash: MaybePromise<Hash>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<void>;
@@ -227,7 +227,7 @@ emit<TContract extends AbiHolder<Abi>>(
 
 Parameters:
 
-- `contractFn`: A viem write contract call, or its already-awaited result.
+- `txHash`: The transaction hash returned by a viem write call or `sendTransaction`, or a promise that resolves to it.
 - `contract`: The viem contract instance whose ABI is used to parse logs.
 - `eventName`: The event name to assert. Autocompleted from `contract.abi`.
 
@@ -265,7 +265,7 @@ emitWithArgs<
   TContract extends AbiHolder<Abi>,
   TEventName extends ContractEventName<TContract["abi"]>,
 >(
-  contractFn: MaybePromise<WriteContractReturnType>,
+  txHash: MaybePromise<Hash>,
   contract: TContract,
   eventName: TEventName,
   args: EventArgsOf<TContract["abi"], TEventName>,
@@ -274,7 +274,7 @@ emitWithArgs<
 
 Parameters:
 
-- `contractFn`: A viem write contract call, or its already-awaited result.
+- `txHash`: The transaction hash returned by a viem write call or `sendTransaction`, or a promise that resolves to it.
 - `contract`: The viem contract instance whose ABI is used to parse logs.
 - `eventName`: The event name to assert. Autocompleted from `contract.abi`.
 - `args`: Expected event arguments, typed against the matching ABI input tuple. Each position can be a concrete value or a `(value) => boolean` predicate.

--- a/packages/hardhat-viem-assertions/README.md
+++ b/packages/hardhat-viem-assertions/README.md
@@ -209,7 +209,7 @@ await viem.assertions.revertWithCustomErrorWithArgs(
 
 ### Events
 
-These assertions can be used to check that a transaction emits specific events and their arguments.
+These assertions can be used to check that a transaction emits specific events and their arguments. Each one accepts either an un-awaited viem write call or its already-awaited result, and looks at the receipt of that specific transaction.
 
 #### `emit`
 
@@ -219,7 +219,7 @@ Type:
 
 ```ts
 emit<TContract extends AbiHolder<Abi>>(
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+  contractFn: MaybePromise<WriteContractReturnType>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<void>;
@@ -227,7 +227,7 @@ emit<TContract extends AbiHolder<Abi>>(
 
 Parameters:
 
-- `contractFn`: A promise returned by a viem read or write contract call.
+- `contractFn`: A viem write contract call, or its already-awaited result.
 - `contract`: The viem contract instance whose ABI is used to parse logs.
 - `eventName`: The event name to assert. Autocompleted from `contract.abi`.
 
@@ -245,6 +245,15 @@ await viem.assertions.emit(
 );
 ```
 
+The contract call can also be awaited first, which is helpful if you want to assert several events against the same transaction:
+
+```ts
+const hash = await rocketContract.write.launch();
+
+await viem.assertions.emit(hash, rocketContract, "LaunchEvent");
+await viem.assertions.emit(hash, rocketContract, "FuelBurnedEvent");
+```
+
 #### `emitWithArgs`
 
 Assert that executing a contract function emits a specific event with the given arguments.
@@ -256,7 +265,7 @@ emitWithArgs<
   TContract extends AbiHolder<Abi>,
   TEventName extends ContractEventName<TContract["abi"]>,
 >(
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+  contractFn: MaybePromise<WriteContractReturnType>,
   contract: TContract,
   eventName: TEventName,
   args: EventArgsOf<TContract["abi"], TEventName>,
@@ -265,7 +274,7 @@ emitWithArgs<
 
 Parameters:
 
-- `contractFn`: A promise returned by a viem read or write contract call.
+- `contractFn`: A viem write contract call, or its already-awaited result.
 - `contract`: The viem contract instance whose ABI is used to parse logs.
 - `eventName`: The event name to assert. Autocompleted from `contract.abi`.
 - `args`: Expected event arguments, typed against the matching ABI input tuple. Each position can be a concrete value or a `(value) => boolean` predicate.
@@ -313,13 +322,13 @@ These assertions can be used to check how a given transaction affects the ether 
 
 #### `balancesHaveChanged`
 
-Assert that a transaction changes the ether balance of the given addresses by the specified amounts.
+Assert that a transaction changes the ether balance of the given addresses by the specified amounts. The transaction can be provided as an un-awaited promise from `sendTransaction` or a viem write call, or as the already-awaited result.
 
 Type:
 
 ```ts
 balancesHaveChanged(
-  resolvedTxHash: Promise<Hash>,
+  txHash: MaybePromise<Hash>,
   changes: Array<{
     address: Address;
     amount: bigint;
@@ -329,7 +338,7 @@ balancesHaveChanged(
 
 Parameters:
 
-- `resolvedTxHash`: A promise that resolves to the transaction hash returned by `sendTransaction`.
+- `txHash`: The transaction hash returned by `sendTransaction` (or a viem write call), or a promise that resolves to it.
 - `changes`: The expected balance deltas, in wei, for each address. Negative values are allowed.
 
 Returns:
@@ -355,4 +364,15 @@ await viem.assertions.balancesHaveChanged(
     },
   ],
 );
+```
+
+The transaction can also be awaited first:
+
+```ts
+const hash = await vault.write.deposit([], { value: 1000n });
+
+await viem.assertions.balancesHaveChanged(hash, [
+  { address: vault.address, amount: 1000n },
+  { address: bobWalletClient.account.address, amount: -1000n },
+]);
 ```

--- a/packages/hardhat-viem-assertions/src/internal/assertions/balances-have-changed.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/balances-have-changed.ts
@@ -1,4 +1,3 @@
-import type { MaybePromise } from "../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
 import type { Address, Hash } from "viem";
@@ -11,7 +10,7 @@ export async function balancesHaveChanged<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  txHash: MaybePromise<Hash>,
+  txHash: Hash | Promise<Hash>,
   changes: Array<{
     address: Address;
     amount: bigint;

--- a/packages/hardhat-viem-assertions/src/internal/assertions/balances-have-changed.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/balances-have-changed.ts
@@ -21,7 +21,7 @@ export async function balancesHaveChanged<
 
   assert.ok(
     isHash(resolvedTxHash),
-    `The promise should return a transaction hash, but it returned: ${String(resolvedTxHash)}`,
+    `txHash must be a transaction hash or a promise resolving to one, but got: ${String(resolvedTxHash)}`,
   );
 
   const publicClient = await viem.getPublicClient();

--- a/packages/hardhat-viem-assertions/src/internal/assertions/balances-have-changed.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/balances-have-changed.ts
@@ -1,3 +1,4 @@
+import type { MaybePromise } from "../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
 import type { Address, Hash } from "viem";
@@ -10,7 +11,7 @@ export async function balancesHaveChanged<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  txHash: Promise<Hash>,
+  txHash: MaybePromise<Hash>,
   changes: Array<{
     address: Address;
     amount: bigint;

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
@@ -1,4 +1,5 @@
 import type { AbiHolder } from "../../../abi-types.js";
+import type { MaybePromise } from "../../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
 import type {
@@ -19,7 +20,7 @@ export async function handleEmit<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  contractFn: Promise<WriteContractReturnType>,
+  contractFn: MaybePromise<WriteContractReturnType>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<Array<{ args?: Record<string, any> }>> {

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
@@ -1,5 +1,4 @@
 import type { AbiHolder } from "../../../abi-types.js";
-import type { MaybePromise } from "../../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
 import type { Abi, AbiEvent, ContractEventName, Hash } from "viem";
@@ -15,7 +14,7 @@ export async function handleEmit<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  txHash: MaybePromise<Hash>,
+  txHash: Hash | Promise<Hash>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<Array<{ args?: Record<string, any> }>> {

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
@@ -44,14 +44,14 @@ export async function handleEmit<
 
   const publicClient = await viem.getPublicClient();
 
-  const logs = await publicClient.getLogs({
-    address: contract.address,
+  const receipt = await publicClient.getTransactionReceipt({
+    hash: contractFnResult.value,
   });
 
   const parsedLogs = parseEventLogs({
     abi: contract.abi,
     eventName,
-    logs,
+    logs: receipt.logs,
   });
 
   assert.ok(

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
@@ -11,7 +11,7 @@ import type {
 
 import assert from "node:assert/strict";
 
-import { parseEventLogs } from "viem";
+import { parseEventLogs, isHash } from "viem";
 
 import { settle } from "../../helpers.js";
 
@@ -27,6 +27,15 @@ export async function handleEmit<
   // Settle `contractFn` first so the tx doesn't leak into the next test, but
   // defer rethrowing so ABI errors still take precedence over tx reverts.
   const contractFnResult = await settle(contractFn);
+
+  if (contractFnResult.ok === true) {
+    assert.ok(
+      isHash(contractFnResult.value),
+      `Expected contract function to return a transaction hash, but got: ${String(
+        contractFnResult.value,
+      )}`,
+    );
+  }
 
   const abiEvents: AbiEvent[] = contract.abi.filter(
     (item): item is AbiEvent =>

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
@@ -5,7 +5,6 @@ import type {
   Abi,
   AbiEvent,
   ContractEventName,
-  ReadContractReturnType,
   WriteContractReturnType,
 } from "viem";
 
@@ -20,7 +19,7 @@ export async function handleEmit<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+  contractFn: Promise<WriteContractReturnType>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<Array<{ args?: Record<string, any> }>> {

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
@@ -45,14 +45,22 @@ export async function handleEmit<
 
   const publicClient = await viem.getPublicClient();
 
-  const receipt = await publicClient.getTransactionReceipt({
+  const receipt = await publicClient.waitForTransactionReceipt({
     hash: contractFnResult.value,
   });
+
+  // `receipt.logs` includes logs from every contract touched by the tx; keep
+  // only the ones emitted by the contract under test so an event with a
+  // colliding signature from a different contract can't satisfy the assertion.
+  const contractAddress = contract.address.toLowerCase();
+  const ownLogs = receipt.logs.filter(
+    (log) => log.address.toLowerCase() === contractAddress,
+  );
 
   const parsedLogs = parseEventLogs({
     abi: contract.abi,
     eventName,
-    logs: receipt.logs,
+    logs: ownLogs,
   });
 
   assert.ok(

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/core.ts
@@ -2,12 +2,7 @@ import type { AbiHolder } from "../../../abi-types.js";
 import type { MaybePromise } from "../../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
-import type {
-  Abi,
-  AbiEvent,
-  ContractEventName,
-  WriteContractReturnType,
-} from "viem";
+import type { Abi, AbiEvent, ContractEventName, Hash } from "viem";
 
 import assert from "node:assert/strict";
 
@@ -20,19 +15,19 @@ export async function handleEmit<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  contractFn: MaybePromise<WriteContractReturnType>,
+  txHash: MaybePromise<Hash>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<Array<{ args?: Record<string, any> }>> {
-  // Settle `contractFn` first so the tx doesn't leak into the next test, but
+  // Settle `txHash` first so the tx doesn't leak into the next test, but
   // defer rethrowing so ABI errors still take precedence over tx reverts.
-  const contractFnResult = await settle(contractFn);
+  const txHashResult = await settle(txHash);
 
-  if (contractFnResult.ok === true) {
+  if (txHashResult.ok === true) {
     assert.ok(
-      isHash(contractFnResult.value),
-      `Expected contract function to return a transaction hash, but got: ${String(
-        contractFnResult.value,
+      isHash(txHashResult.value),
+      `txHash must be a transaction hash or a promise resolving to one, but got: ${String(
+        txHashResult.value,
       )}`,
     );
   }
@@ -47,15 +42,15 @@ export async function handleEmit<
     `Event "${eventName}" not found in the contract ABI`,
   );
 
-  if (contractFnResult.ok === false) {
+  if (txHashResult.ok === false) {
     // eslint-disable-next-line no-restricted-syntax -- propagate the original tx-revert error
-    throw contractFnResult.error;
+    throw txHashResult.error;
   }
 
   const publicClient = await viem.getPublicClient();
 
   const receipt = await publicClient.waitForTransactionReceipt({
-    hash: contractFnResult.value,
+    hash: txHashResult.value,
   });
 
   // `receipt.logs` includes logs from every contract touched by the tx; keep

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
@@ -1,5 +1,4 @@
 import type { AbiHolder, EventArgsOf } from "../../../abi-types.js";
-import type { MaybePromise } from "../../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
 import type { Abi, AbiEvent, ContractEventName, Hash } from "viem";
@@ -17,7 +16,7 @@ export async function emitWithArgs<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  txHash: MaybePromise<Hash>,
+  txHash: Hash | Promise<Hash>,
   contract: TContract,
   eventName: TEventName,
   expectedArgs: EventArgsOf<TContract["abi"], TEventName>,

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
@@ -2,12 +2,7 @@ import type { AbiHolder, EventArgsOf } from "../../../abi-types.js";
 import type { MaybePromise } from "../../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
-import type {
-  Abi,
-  AbiEvent,
-  ContractEventName,
-  WriteContractReturnType,
-} from "viem";
+import type { Abi, AbiEvent, ContractEventName, Hash } from "viem";
 
 import assert from "node:assert/strict";
 
@@ -22,14 +17,14 @@ export async function emitWithArgs<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  contractFn: MaybePromise<WriteContractReturnType>,
+  txHash: MaybePromise<Hash>,
   contract: TContract,
   eventName: TEventName,
   expectedArgs: EventArgsOf<TContract["abi"], TEventName>,
 ): Promise<void> {
-  // Settle `contractFn` first so the tx doesn't leak into the next test, but
+  // Settle `txHash` first so the tx doesn't leak into the next test, but
   // defer rethrowing so ABI errors still take precedence over tx reverts.
-  const contractFnResult = await settle(contractFn);
+  const txHashResult = await settle(txHash);
 
   const abiEvents: AbiEvent[] = contract.abi.filter(
     (item): item is AbiEvent =>
@@ -48,18 +43,18 @@ export async function emitWithArgs<
     `There are multiple events named "${eventName}" that accepts ${expectedArgs.length} input arguments. This scenario is currently not supported.`,
   );
 
-  if (contractFnResult.ok === false) {
+  if (txHashResult.ok === false) {
     // eslint-disable-next-line no-restricted-syntax -- propagate the original tx-revert error
-    throw contractFnResult.error;
+    throw txHashResult.error;
   }
 
   const expectedAbiEvent = abiEvents[0];
 
-  // contractFn has already been awaited above; pass an already-resolved promise
+  // txHash has already been awaited above; pass an already-resolved promise
   // so handleEmit's internal await is a no-op and we don't double-submit.
   const parsedLogs = await handleEmit(
     viem,
-    Promise.resolve(contractFnResult.value),
+    Promise.resolve(txHashResult.value),
     contract,
     eventName,
   );

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
@@ -1,4 +1,5 @@
 import type { AbiHolder, EventArgsOf } from "../../../abi-types.js";
+import type { MaybePromise } from "../../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
 import type {
@@ -21,7 +22,7 @@ export async function emitWithArgs<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  contractFn: Promise<WriteContractReturnType>,
+  contractFn: MaybePromise<WriteContractReturnType>,
   contract: TContract,
   eventName: TEventName,
   expectedArgs: EventArgsOf<TContract["abi"], TEventName>,

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit-with-args.ts
@@ -5,7 +5,6 @@ import type {
   Abi,
   AbiEvent,
   ContractEventName,
-  ReadContractReturnType,
   WriteContractReturnType,
 } from "viem";
 
@@ -22,7 +21,7 @@ export async function emitWithArgs<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+  contractFn: Promise<WriteContractReturnType>,
   contract: TContract,
   eventName: TEventName,
   expectedArgs: EventArgsOf<TContract["abi"], TEventName>,

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit.ts
@@ -1,4 +1,5 @@
 import type { AbiHolder } from "../../../abi-types.js";
+import type { MaybePromise } from "../../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
 import type { Abi, ContractEventName, WriteContractReturnType } from "viem";
@@ -10,7 +11,7 @@ export async function emit<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  contractFn: Promise<WriteContractReturnType>,
+  contractFn: MaybePromise<WriteContractReturnType>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<void> {

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit.ts
@@ -1,12 +1,7 @@
 import type { AbiHolder } from "../../../abi-types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
-import type {
-  Abi,
-  ContractEventName,
-  ReadContractReturnType,
-  WriteContractReturnType,
-} from "viem";
+import type { Abi, ContractEventName, WriteContractReturnType } from "viem";
 
 import { handleEmit } from "./core.js";
 
@@ -15,7 +10,7 @@ export async function emit<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+  contractFn: Promise<WriteContractReturnType>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<void> {

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit.ts
@@ -2,7 +2,7 @@ import type { AbiHolder } from "../../../abi-types.js";
 import type { MaybePromise } from "../../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
-import type { Abi, ContractEventName, WriteContractReturnType } from "viem";
+import type { Abi, ContractEventName, Hash } from "viem";
 
 import { handleEmit } from "./core.js";
 
@@ -11,9 +11,9 @@ export async function emit<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  contractFn: MaybePromise<WriteContractReturnType>,
+  txHash: MaybePromise<Hash>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<void> {
-  await handleEmit(viem, contractFn, contract, eventName);
+  await handleEmit(viem, txHash, contract, eventName);
 }

--- a/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/emit/emit.ts
@@ -1,5 +1,4 @@
 import type { AbiHolder } from "../../../abi-types.js";
-import type { MaybePromise } from "../../../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
 import type { Abi, ContractEventName, Hash } from "viem";
@@ -11,7 +10,7 @@ export async function emit<
   ChainTypeT extends ChainType | string = "generic",
 >(
   viem: HardhatViemHelpers<ChainTypeT>,
-  txHash: MaybePromise<Hash>,
+  txHash: Hash | Promise<Hash>,
   contract: TContract,
   eventName: ContractEventName<TContract["abi"]>,
 ): Promise<void> {

--- a/packages/hardhat-viem-assertions/src/internal/helpers.ts
+++ b/packages/hardhat-viem-assertions/src/internal/helpers.ts
@@ -1,3 +1,5 @@
+import type { MaybePromise } from "../types.js";
+
 /**
  * This is a JSON.stringify function with a custom replacer that stringifies bigints as strings.
  */
@@ -8,14 +10,14 @@ export function stringifyArgs(obj: any): string {
 }
 
 /**
- * Awaits `promise` and returns a tagged result so callers can decide when to
- * surface a rejection.
+ * Awaits `value` (which may already be a resolved value) and returns a tagged
+ * result so callers can decide when to surface a rejection.
  */
 export async function settle<T>(
-  promise: Promise<T>,
+  value: MaybePromise<T>,
 ): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> {
-  return await promise.then(
-    (value) => ({ ok: true, value }) as const,
+  return await Promise.resolve(value).then(
+    (v) => ({ ok: true, value: v }) as const,
     (error: unknown) => ({ ok: false, error }) as const,
   );
 }

--- a/packages/hardhat-viem-assertions/src/internal/helpers.ts
+++ b/packages/hardhat-viem-assertions/src/internal/helpers.ts
@@ -1,5 +1,3 @@
-import type { MaybePromise } from "../types.js";
-
 /**
  * This is a JSON.stringify function with a custom replacer that stringifies bigints as strings.
  */
@@ -14,7 +12,7 @@ export function stringifyArgs(obj: any): string {
  * result so callers can decide when to surface a rejection.
  */
 export async function settle<T>(
-  value: MaybePromise<T>,
+  value: T | Promise<T>,
 ): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> {
   return await Promise.resolve(value).then(
     (v) => ({ ok: true, value: v }) as const,

--- a/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
+++ b/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
@@ -41,7 +41,7 @@ export class HardhatViemAssertionsImpl<
   }
 
   public async emit<TContract extends AbiHolder<Abi>>(
-    contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+    contractFn: Promise<WriteContractReturnType>,
     contract: TContract,
     eventName: ContractEventName<TContract["abi"]>,
   ): Promise<void> {
@@ -52,7 +52,7 @@ export class HardhatViemAssertionsImpl<
     TContract extends AbiHolder<Abi>,
     TEventName extends ContractEventName<TContract["abi"]>,
   >(
-    contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+    contractFn: Promise<WriteContractReturnType>,
     contract: TContract,
     eventName: TEventName,
     args: EventArgsOf<TContract["abi"], TEventName>,

--- a/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
+++ b/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
@@ -1,5 +1,5 @@
 import type { AbiHolder, ErrorArgsOf, EventArgsOf } from "../abi-types.js";
-import type { HardhatViemAssertions } from "../types.js";
+import type { HardhatViemAssertions, MaybePromise } from "../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
 import type {
@@ -31,17 +31,17 @@ export class HardhatViemAssertionsImpl<
   }
 
   public async balancesHaveChanged(
-    resolvedTxHash: Promise<Hash>,
+    txHash: MaybePromise<Hash>,
     changes: Array<{
       address: Address;
       amount: bigint;
     }>,
   ): Promise<void> {
-    return await balancesHaveChanged(this.#viem, resolvedTxHash, changes);
+    return await balancesHaveChanged(this.#viem, txHash, changes);
   }
 
   public async emit<TContract extends AbiHolder<Abi>>(
-    contractFn: Promise<WriteContractReturnType>,
+    contractFn: MaybePromise<WriteContractReturnType>,
     contract: TContract,
     eventName: ContractEventName<TContract["abi"]>,
   ): Promise<void> {
@@ -52,7 +52,7 @@ export class HardhatViemAssertionsImpl<
     TContract extends AbiHolder<Abi>,
     TEventName extends ContractEventName<TContract["abi"]>,
   >(
-    contractFn: Promise<WriteContractReturnType>,
+    contractFn: MaybePromise<WriteContractReturnType>,
     contract: TContract,
     eventName: TEventName,
     args: EventArgsOf<TContract["abi"], TEventName>,

--- a/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
+++ b/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
@@ -1,5 +1,5 @@
 import type { AbiHolder, ErrorArgsOf, EventArgsOf } from "../abi-types.js";
-import type { HardhatViemAssertions, MaybePromise } from "../types.js";
+import type { HardhatViemAssertions } from "../types.js";
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { ChainType } from "hardhat/types/network";
 import type {
@@ -31,7 +31,7 @@ export class HardhatViemAssertionsImpl<
   }
 
   public async balancesHaveChanged(
-    txHash: MaybePromise<Hash>,
+    txHash: Hash | Promise<Hash>,
     changes: Array<{
       address: Address;
       amount: bigint;
@@ -41,7 +41,7 @@ export class HardhatViemAssertionsImpl<
   }
 
   public async emit<TContract extends AbiHolder<Abi>>(
-    txHash: MaybePromise<Hash>,
+    txHash: Hash | Promise<Hash>,
     contract: TContract,
     eventName: ContractEventName<TContract["abi"]>,
   ): Promise<void> {
@@ -52,7 +52,7 @@ export class HardhatViemAssertionsImpl<
     TContract extends AbiHolder<Abi>,
     TEventName extends ContractEventName<TContract["abi"]>,
   >(
-    txHash: MaybePromise<Hash>,
+    txHash: Hash | Promise<Hash>,
     contract: TContract,
     eventName: TEventName,
     args: EventArgsOf<TContract["abi"], TEventName>,

--- a/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
+++ b/packages/hardhat-viem-assertions/src/internal/viem-assertions.ts
@@ -41,29 +41,23 @@ export class HardhatViemAssertionsImpl<
   }
 
   public async emit<TContract extends AbiHolder<Abi>>(
-    contractFn: MaybePromise<WriteContractReturnType>,
+    txHash: MaybePromise<Hash>,
     contract: TContract,
     eventName: ContractEventName<TContract["abi"]>,
   ): Promise<void> {
-    return await emit(this.#viem, contractFn, contract, eventName);
+    return await emit(this.#viem, txHash, contract, eventName);
   }
 
   public async emitWithArgs<
     TContract extends AbiHolder<Abi>,
     TEventName extends ContractEventName<TContract["abi"]>,
   >(
-    contractFn: MaybePromise<WriteContractReturnType>,
+    txHash: MaybePromise<Hash>,
     contract: TContract,
     eventName: TEventName,
     args: EventArgsOf<TContract["abi"], TEventName>,
   ): Promise<void> {
-    return await emitWithArgs(
-      this.#viem,
-      contractFn,
-      contract,
-      eventName,
-      args,
-    );
+    return await emitWithArgs(this.#viem, txHash, contract, eventName, args);
   }
 
   public async revert(

--- a/packages/hardhat-viem-assertions/src/types.ts
+++ b/packages/hardhat-viem-assertions/src/types.ts
@@ -49,12 +49,12 @@ export interface HardhatViemAssertions {
    * passes if at least one matching event is found in that transaction.
    *
    * @typeParam TContract - The viem contract instance whose ABI is used to parse logs.
-   * @param contractFn - A viem write contract call, or its already-awaited transaction hash.
+   * @param txHash - The transaction hash returned by a viem write call or `sendTransaction`, or a promise that resolves to it.
    * @param contract - The viem contract instance whose ABI is used to parse logs.
    * @param eventName - The event name to assert.
    */
   emit<TContract extends AbiHolder<Abi>>(
-    contractFn: MaybePromise<WriteContractReturnType>,
+    txHash: MaybePromise<Hash>,
     contract: TContract,
     eventName: ContractEventName<TContract["abi"]>,
   ): Promise<void>;
@@ -68,7 +68,7 @@ export interface HardhatViemAssertions {
    *
    * @typeParam TContract - The viem contract instance whose ABI is used to parse logs.
    * @typeParam TEventName - The name of the event to check, constrained to events declared in `TContract`'s ABI.
-   * @param contractFn - A viem write contract call, or its already-awaited transaction hash.
+   * @param txHash - The transaction hash returned by a viem write call or `sendTransaction`, or a promise that resolves to it.
    * @param contract - The viem contract instance whose ABI is used to parse logs.
    * @param eventName - The event name to assert.
    * @param args - Expected event arguments. Each item can be a concrete value or a predicate function `(value) => boolean`.
@@ -77,7 +77,7 @@ export interface HardhatViemAssertions {
     TContract extends AbiHolder<Abi>,
     TEventName extends ContractEventName<TContract["abi"]>,
   >(
-    contractFn: MaybePromise<WriteContractReturnType>,
+    txHash: MaybePromise<Hash>,
     contract: TContract,
     eventName: TEventName,
     args: EventArgsOf<TContract["abi"], TEventName>,

--- a/packages/hardhat-viem-assertions/src/types.ts
+++ b/packages/hardhat-viem-assertions/src/types.ts
@@ -42,12 +42,12 @@ export interface HardhatViemAssertions {
    * matching event is found.
    *
    * @typeParam TContract - The viem contract instance whose ABI is used to parse logs.
-   * @param contractFn - A promise returned by a viem read or write contract call.
+   * @param contractFn - A promise returned by a viem write contract call.
    * @param contract - The viem contract instance whose ABI is used to parse logs.
    * @param eventName - The event name to assert.
    */
   emit<TContract extends AbiHolder<Abi>>(
-    contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+    contractFn: Promise<WriteContractReturnType>,
     contract: TContract,
     eventName: ContractEventName<TContract["abi"]>,
   ): Promise<void>;
@@ -61,7 +61,7 @@ export interface HardhatViemAssertions {
    *
    * @typeParam TContract - The viem contract instance whose ABI is used to parse logs.
    * @typeParam TEventName - The name of the event to check, constrained to events declared in `TContract`'s ABI.
-   * @param contractFn - A promise returned by a viem read or write contract call.
+   * @param contractFn - A promise returned by a viem write contract call.
    * @param contract - The viem contract instance whose ABI is used to parse logs.
    * @param eventName - The event name to assert.
    * @param args - Expected event arguments. Each item can be a concrete value or a predicate function `(value) => boolean`.
@@ -70,7 +70,7 @@ export interface HardhatViemAssertions {
     TContract extends AbiHolder<Abi>,
     TEventName extends ContractEventName<TContract["abi"]>,
   >(
-    contractFn: Promise<ReadContractReturnType | WriteContractReturnType>,
+    contractFn: Promise<WriteContractReturnType>,
     contract: TContract,
     eventName: TEventName,
     args: EventArgsOf<TContract["abi"], TEventName>,

--- a/packages/hardhat-viem-assertions/src/types.ts
+++ b/packages/hardhat-viem-assertions/src/types.ts
@@ -44,9 +44,9 @@ export interface HardhatViemAssertions {
   /**
    * Assert that executing a contract function emits a specific event.
    *
-   * The function is awaited, then logs are fetched for the contract address and parsed
-   * against the contract ABI for the given event name. The assertion passes if at least one
-   * matching event is found.
+   * The transaction is awaited and its receipt is fetched; the logs in the receipt that were
+   * emitted by `contract` are parsed against its ABI for the given event name. The assertion
+   * passes if at least one matching event is found in that transaction.
    *
    * @typeParam TContract - The viem contract instance whose ABI is used to parse logs.
    * @param contractFn - A viem write contract call, or its already-awaited transaction hash.

--- a/packages/hardhat-viem-assertions/src/types.ts
+++ b/packages/hardhat-viem-assertions/src/types.ts
@@ -10,6 +10,13 @@ import type {
 } from "viem";
 
 /**
+ * A value that may be either resolved synchronously or wrapped in a promise.
+ * Used so assertions can accept either `contract.write.foo()` directly or its
+ * already-awaited result.
+ */
+export type MaybePromise<T> = T | Promise<T>;
+
+/**
  * Ethereum-specific test assertions that integrate with viem.
  *
  * These assertions help validate: reverted transactions, emitted events, and
@@ -23,11 +30,11 @@ export interface HardhatViemAssertions {
    * For the transaction sender, the effective gas fee is accounted for so the expected amount reflects the
    * pure value transfer effect.
    *
-   * @param resolvedTxHash - A promise that resolves to the transaction hash returned by `sendTransaction`.
+   * @param txHash - The transaction hash returned by `sendTransaction`, or a promise that resolves to it.
    * @param changes - The expected balance deltas, in wei, for each address. Negative values are allowed.
    */
   balancesHaveChanged: (
-    resolvedTxHash: Promise<Hash>,
+    txHash: MaybePromise<Hash>,
     changes: Array<{
       address: Address;
       amount: bigint;
@@ -42,12 +49,12 @@ export interface HardhatViemAssertions {
    * matching event is found.
    *
    * @typeParam TContract - The viem contract instance whose ABI is used to parse logs.
-   * @param contractFn - A promise returned by a viem write contract call.
+   * @param contractFn - A viem write contract call, or its already-awaited transaction hash.
    * @param contract - The viem contract instance whose ABI is used to parse logs.
    * @param eventName - The event name to assert.
    */
   emit<TContract extends AbiHolder<Abi>>(
-    contractFn: Promise<WriteContractReturnType>,
+    contractFn: MaybePromise<WriteContractReturnType>,
     contract: TContract,
     eventName: ContractEventName<TContract["abi"]>,
   ): Promise<void>;
@@ -61,7 +68,7 @@ export interface HardhatViemAssertions {
    *
    * @typeParam TContract - The viem contract instance whose ABI is used to parse logs.
    * @typeParam TEventName - The name of the event to check, constrained to events declared in `TContract`'s ABI.
-   * @param contractFn - A promise returned by a viem write contract call.
+   * @param contractFn - A viem write contract call, or its already-awaited transaction hash.
    * @param contract - The viem contract instance whose ABI is used to parse logs.
    * @param eventName - The event name to assert.
    * @param args - Expected event arguments. Each item can be a concrete value or a predicate function `(value) => boolean`.
@@ -70,7 +77,7 @@ export interface HardhatViemAssertions {
     TContract extends AbiHolder<Abi>,
     TEventName extends ContractEventName<TContract["abi"]>,
   >(
-    contractFn: Promise<WriteContractReturnType>,
+    contractFn: MaybePromise<WriteContractReturnType>,
     contract: TContract,
     eventName: TEventName,
     args: EventArgsOf<TContract["abi"], TEventName>,

--- a/packages/hardhat-viem-assertions/src/types.ts
+++ b/packages/hardhat-viem-assertions/src/types.ts
@@ -10,13 +10,6 @@ import type {
 } from "viem";
 
 /**
- * A value that may be either resolved synchronously or wrapped in a promise.
- * Used so assertions can accept either `contract.write.foo()` directly or its
- * already-awaited result.
- */
-export type MaybePromise<T> = T | Promise<T>;
-
-/**
  * Ethereum-specific test assertions that integrate with viem.
  *
  * These assertions help validate: reverted transactions, emitted events, and
@@ -34,7 +27,7 @@ export interface HardhatViemAssertions {
    * @param changes - The expected balance deltas, in wei, for each address. Negative values are allowed.
    */
   balancesHaveChanged: (
-    txHash: MaybePromise<Hash>,
+    txHash: Hash | Promise<Hash>,
     changes: Array<{
       address: Address;
       amount: bigint;
@@ -54,7 +47,7 @@ export interface HardhatViemAssertions {
    * @param eventName - The event name to assert.
    */
   emit<TContract extends AbiHolder<Abi>>(
-    txHash: MaybePromise<Hash>,
+    txHash: Hash | Promise<Hash>,
     contract: TContract,
     eventName: ContractEventName<TContract["abi"]>,
   ): Promise<void>;
@@ -77,7 +70,7 @@ export interface HardhatViemAssertions {
     TContract extends AbiHolder<Abi>,
     TEventName extends ContractEventName<TContract["abi"]>,
   >(
-    txHash: MaybePromise<Hash>,
+    txHash: Hash | Promise<Hash>,
     contract: TContract,
     eventName: TEventName,
     args: EventArgsOf<TContract["abi"], TEventName>,

--- a/packages/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Counter.sol
+++ b/packages/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Counter.sol
@@ -13,6 +13,8 @@ contract Counter {
   function divideBy(uint8 by) public {
     x /= by;
   }
+
+  function deposit() public payable {}
 }
 
 contract CounterNestedPanicError {

--- a/packages/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Events.sol
+++ b/packages/hardhat-viem-assertions/test/fixture-projects/hardhat-project/contracts/Events.sol
@@ -41,6 +41,14 @@ contract Events {
     emit WithTwoUintArgs(u, v);
   }
 
+  function emitMultipleTwoUints() public {
+    emit WithoutArgs();
+    emit WithTwoUintArgs(1, 2);
+    emit WithTwoUintArgs(3, 4);
+    emit WithTwoUintArgs(5, 6);
+    emit WithoutArgs();
+  }
+
   function emitTwoUintsNoParamName(uint u, uint v) public {
     emit WithTwoUintArgsNoParamName(u, v);
   }

--- a/packages/hardhat-viem-assertions/test/internal/assertion-typings.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertion-typings.ts
@@ -1,6 +1,10 @@
 import type { HardhatViemAssertions } from "../../src/types.js";
 import type { GetContractReturnType } from "@nomicfoundation/hardhat-viem/types";
-import type { ReadContractReturnType, WriteContractReturnType } from "viem";
+import type {
+  Hash,
+  ReadContractReturnType,
+  WriteContractReturnType,
+} from "viem";
 
 import { describe, it } from "node:test";
 
@@ -58,11 +62,20 @@ declare const assertions: HardhatViemAssertions;
 declare const contract: GetContractReturnType<typeof _abi>;
 declare const fn: Promise<ReadContractReturnType | WriteContractReturnType>;
 declare const writeFn: Promise<WriteContractReturnType>;
+declare const writeResult: WriteContractReturnType;
 declare const readFn: Promise<ReadContractReturnType>;
+declare const hash: Hash;
+declare const hashPromise: Promise<Hash>;
 
 describe("assertion typings", () => {
-  it("emit rejects read calls (only write calls have a receipt)", () => {
+  it("balancesHaveChanged accepts either a hash or a promise of a hash", () => {
+    void (() => assertions.balancesHaveChanged(hashPromise, []));
+    void (() => assertions.balancesHaveChanged(hash, []));
+  });
+
+  it("emit accepts a write call or its already-awaited hash, and rejects reads", () => {
     void (() => assertions.emit(writeFn, contract, "WithoutArgs"));
+    void (() => assertions.emit(writeResult, contract, "WithoutArgs"));
 
     void (() =>
       assertions.emit(
@@ -73,8 +86,10 @@ describe("assertion typings", () => {
       ));
   });
 
-  it("emitWithArgs rejects read calls (only write calls have a receipt)", () => {
+  it("emitWithArgs accepts a write call or its already-awaited hash, and rejects reads", () => {
     void (() => assertions.emitWithArgs(writeFn, contract, "WithoutArgs", []));
+    void (() =>
+      assertions.emitWithArgs(writeResult, contract, "WithoutArgs", []));
 
     void (() =>
       assertions.emitWithArgs(

--- a/packages/hardhat-viem-assertions/test/internal/assertion-typings.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertion-typings.ts
@@ -57,14 +57,41 @@ const _abi = [
 declare const assertions: HardhatViemAssertions;
 declare const contract: GetContractReturnType<typeof _abi>;
 declare const fn: Promise<ReadContractReturnType | WriteContractReturnType>;
+declare const writeFn: Promise<WriteContractReturnType>;
+declare const readFn: Promise<ReadContractReturnType>;
 
 describe("assertion typings", () => {
-  it("emit accepts only event names declared on the contract ABI", () => {
-    void (() => assertions.emit(fn, contract, "WithoutArgs"));
+  it("emit rejects read calls (only write calls have a receipt)", () => {
+    void (() => assertions.emit(writeFn, contract, "WithoutArgs"));
 
     void (() =>
       assertions.emit(
-        fn,
+        // @ts-expect-error -- read results are not accepted: reads don't produce a tx receipt
+        readFn,
+        contract,
+        "WithoutArgs",
+      ));
+  });
+
+  it("emitWithArgs rejects read calls (only write calls have a receipt)", () => {
+    void (() => assertions.emitWithArgs(writeFn, contract, "WithoutArgs", []));
+
+    void (() =>
+      assertions.emitWithArgs(
+        // @ts-expect-error -- read results are not accepted: reads don't produce a tx receipt
+        readFn,
+        contract,
+        "WithoutArgs",
+        [],
+      ));
+  });
+
+  it("emit accepts only event names declared on the contract ABI", () => {
+    void (() => assertions.emit(writeFn, contract, "WithoutArgs"));
+
+    void (() =>
+      assertions.emit(
+        writeFn,
         contract,
         // @ts-expect-error -- "ForeignEvent" is not in the ABI
         "ForeignEvent",
@@ -73,14 +100,14 @@ describe("assertion typings", () => {
 
   it("emitWithArgs narrows expectedArgs to the event's input tuple", () => {
     void (() =>
-      assertions.emitWithArgs(fn, contract, "WithTwoUintArgs", [
+      assertions.emitWithArgs(writeFn, contract, "WithTwoUintArgs", [
         1n,
         (v: bigint) => v > 0n,
       ]));
 
     void (() =>
       assertions.emitWithArgs(
-        fn,
+        writeFn,
         contract,
         "WithTwoUintArgs",
         // @ts-expect-error -- second arg is a string, not a bigint or predicate
@@ -89,7 +116,7 @@ describe("assertion typings", () => {
 
     void (() =>
       assertions.emitWithArgs(
-        fn,
+        writeFn,
         contract,
         "WithTwoUintArgs",
         // @ts-expect-error -- only one arg, ABI declares two
@@ -97,7 +124,7 @@ describe("assertion typings", () => {
       ));
 
     void (() =>
-      assertions.emitWithArgs(fn, contract, "WithTwoUintArgs", [
+      assertions.emitWithArgs(writeFn, contract, "WithTwoUintArgs", [
         1n,
         // @ts-expect-error -- predicate types its arg as string, ABI says bigint
         (v: string) => v.length > 0,

--- a/packages/hardhat-viem-assertions/test/internal/assertions/balances-have-changed.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/balances-have-changed.ts
@@ -1,8 +1,12 @@
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
+import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
 
-import { beforeEach, describe, it } from "node:test";
+import { before, beforeEach, describe, it } from "node:test";
 
-import { assertRejects } from "@nomicfoundation/hardhat-test-utils";
+import {
+  assertRejects,
+  useEphemeralFixtureProject,
+} from "@nomicfoundation/hardhat-test-utils";
 import hardhatViem from "@nomicfoundation/hardhat-viem";
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 
@@ -99,5 +103,50 @@ describe("balancesHaveChanged", () => {
           10n,
         ),
     );
+  });
+});
+
+describe("balancesHaveChanged with contract write calls", () => {
+  let hre: HardhatRuntimeEnvironment;
+  let viem: HardhatViemHelpers;
+
+  useEphemeralFixtureProject("hardhat-project");
+
+  before(async () => {
+    hre = await createHardhatRuntimeEnvironment({
+      solidity: "0.8.24",
+      plugins: [hardhatViem, hardhatViemAssertions],
+    });
+
+    await hre.tasks.getTask("build").run({});
+  });
+
+  beforeEach(async () => {
+    ({ viem } = await hre.network.create());
+  });
+
+  it("should check balance changes when passed a contract write call promise", async () => {
+    const counter = await viem.deployContract("Counter");
+    const [bobWalletClient] = await viem.getWalletClients();
+
+    await viem.assertions.balancesHaveChanged(
+      counter.write.deposit([], { value: 1000n }),
+      [
+        { address: counter.address, amount: 1000n },
+        { address: bobWalletClient.account.address, amount: -1000n },
+      ],
+    );
+  });
+
+  it("should check balance changes when passed an already-awaited contract write call", async () => {
+    const counter = await viem.deployContract("Counter");
+    const [bobWalletClient] = await viem.getWalletClients();
+
+    const txHash = await counter.write.deposit([], { value: 1000n });
+
+    await viem.assertions.balancesHaveChanged(txHash, [
+      { address: counter.address, amount: 1000n },
+      { address: bobWalletClient.account.address, amount: -1000n },
+    ]);
   });
 });

--- a/packages/hardhat-viem-assertions/test/internal/assertions/balances-have-changed.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/balances-have-changed.ts
@@ -58,6 +58,22 @@ describe("balancesHaveChanged", () => {
     );
   });
 
+  it("should accept an already-awaited tx hash", async () => {
+    const [bobWalletClient, aliceWalletClient] = await viem.getWalletClients();
+
+    const txHash = await bobWalletClient.sendTransaction({
+      to: aliceWalletClient.account.address,
+      value: 3333333333333333n,
+    });
+
+    await viem.assertions.balancesHaveChanged(txHash, [
+      {
+        address: aliceWalletClient.account.address,
+        amount: 3333333333333333n,
+      },
+    ]);
+  });
+
   it("should throw an error when the balance changes to a value different from the expected one", async () => {
     const [bobWalletClient, aliceWalletClient] = await viem.getWalletClients();
 

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
@@ -10,6 +10,7 @@ import {
 } from "@nomicfoundation/hardhat-test-utils";
 import hardhatViem from "@nomicfoundation/hardhat-viem";
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+import { encodeFunctionData } from "viem";
 
 import hardhatViemAssertions from "../../../../src/index.js";
 import { anyValue } from "../../../../src/internal/predicates.js";
@@ -54,6 +55,41 @@ describe("emitWithArgs", () => {
     await viem.assertions.emitWithArgs(writeResult, contract, "WithIntArg", [
       1n,
     ]);
+  });
+
+  it("should check that the event was emitted when given a sendTransaction promise", async () => {
+    const contract = await viem.deployContract("Events");
+    const [walletClient] = await viem.getWalletClients();
+
+    await viem.assertions.emitWithArgs(
+      walletClient.sendTransaction({
+        to: contract.address,
+        data: encodeFunctionData({
+          abi: contract.abi,
+          functionName: "emitInt",
+          args: [1n],
+        }),
+      }),
+      contract,
+      "WithIntArg",
+      [1n],
+    );
+  });
+
+  it("should check that the event was emitted when given an already-awaited sendTransaction hash", async () => {
+    const contract = await viem.deployContract("Events");
+    const [walletClient] = await viem.getWalletClients();
+
+    const hash = await walletClient.sendTransaction({
+      to: contract.address,
+      data: encodeFunctionData({
+        abi: contract.abi,
+        functionName: "emitInt",
+        args: [1n],
+      }),
+    });
+
+    await viem.assertions.emitWithArgs(hash, contract, "WithIntArg", [1n]);
   });
 
   it("should check that the event was emitted with the correct multiple arguments", async () => {

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
@@ -1,6 +1,5 @@
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
-import type { EthereumProvider } from "hardhat/types/providers";
 
 import assert from "node:assert/strict";
 import { before, beforeEach, describe, it } from "node:test";
@@ -20,7 +19,6 @@ import { isExpectedError } from "../../../helpers/is-expected-error.js";
 describe("emitWithArgs", () => {
   let hre: HardhatRuntimeEnvironment;
   let viem: HardhatViemHelpers;
-  let provider: EthereumProvider;
 
   useEphemeralFixtureProject("hardhat-project");
 
@@ -34,7 +32,7 @@ describe("emitWithArgs", () => {
   });
 
   beforeEach(async () => {
-    ({ provider, viem } = await hre.network.create());
+    ({ viem } = await hre.network.create());
   });
 
   it("should check that the event was emitted with the correct single argument", async () => {
@@ -59,41 +57,15 @@ describe("emitWithArgs", () => {
     );
   });
 
-  it("should check that the event was emitted when multiple events are emitted", async () => {
+  it("should check that the event was emitted when the transaction emits multiple events", async () => {
     const contract = await viem.deployContract("Events");
 
-    // Temporarily disable auto mine to ensure all events are emitted within the same block
-    await provider.request({
-      method: "evm_setAutomine",
-      params: [false],
-    });
-
     await viem.assertions.emitWithArgs(
-      (async () => {
-        await contract.write.emitWithoutArgs();
-        await contract.write.emitTwoUints([1n, 2n]);
-        const hash = await contract.write.emitTwoUints([3n, 4n]);
-        await contract.write.emitTwoUints([5n, 6n]);
-        await contract.write.emitWithoutArgs();
-
-        // Mine a block that will contain multiple events
-        await provider.request({
-          method: "hardhat_mine",
-          params: ["0x1"],
-        });
-
-        return hash;
-      })(),
+      contract.write.emitMultipleTwoUints(),
       contract,
       "WithTwoUintArgs",
       [3n, 4n],
     );
-
-    // Re-enable auto mine
-    await provider.request({
-      method: "evm_setAutomine",
-      params: [true],
-    });
   });
 
   it("should check that the event was emitted with the correct multiple arguments, one with param name, one without", async () => {

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
@@ -78,6 +78,38 @@ describe("emitWithArgs", () => {
     );
   });
 
+  it("should make multiple assertions against the same awaited tx, including one not emitted", async () => {
+    const contract = await viem.deployContract("Events");
+
+    const hash = await contract.write.emitMultipleTwoUints();
+
+    await viem.assertions.emit(hash, contract, "WithoutArgs");
+
+    await viem.assertions.emitWithArgs(hash, contract, "WithTwoUintArgs", [
+      1n,
+      2n,
+    ]);
+    await viem.assertions.emitWithArgs(hash, contract, "WithTwoUintArgs", [
+      3n,
+      4n,
+    ]);
+    await viem.assertions.emitWithArgs(hash, contract, "WithTwoUintArgs", [
+      5n,
+      6n,
+    ]);
+
+    await assertRejects(
+      viem.assertions.emit(hash, contract, "WithIntArg"),
+      (error) =>
+        isExpectedError(
+          error,
+          `No events were emitted for contract with address "${contract.address}" and event name "WithIntArg"`,
+          false,
+          true,
+        ),
+    );
+  });
+
   it("should check that the event was emitted with the correct multiple arguments, one with param name, one without", async () => {
     const contract = await viem.deployContract("Events");
 

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
@@ -46,6 +46,16 @@ describe("emitWithArgs", () => {
     );
   });
 
+  it("should check that the event was emitted when given an already-awaited write result", async () => {
+    const contract = await viem.deployContract("Events");
+
+    const writeResult = await contract.write.emitInt([1n]);
+
+    await viem.assertions.emitWithArgs(writeResult, contract, "WithIntArg", [
+      1n,
+    ]);
+  });
+
   it("should check that the event was emitted with the correct multiple arguments", async () => {
     const contract = await viem.deployContract("Events");
 

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit-with-args.ts
@@ -72,7 +72,7 @@ describe("emitWithArgs", () => {
       (async () => {
         await contract.write.emitWithoutArgs();
         await contract.write.emitTwoUints([1n, 2n]);
-        await contract.write.emitTwoUints([3n, 4n]);
+        const hash = await contract.write.emitTwoUints([3n, 4n]);
         await contract.write.emitTwoUints([5n, 6n]);
         await contract.write.emitWithoutArgs();
 
@@ -81,6 +81,8 @@ describe("emitWithArgs", () => {
           method: "hardhat_mine",
           params: ["0x1"],
         });
+
+        return hash;
       })(),
       contract,
       "WithTwoUintArgs",

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
@@ -10,6 +10,7 @@ import {
 } from "@nomicfoundation/hardhat-test-utils";
 import hardhatViem from "@nomicfoundation/hardhat-viem";
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+import { encodeFunctionData } from "viem";
 
 import hardhatViemAssertions from "../../../../src/index.js";
 import { errorIncludesTestFile } from "../../../helpers/error-includes-test-file.js";
@@ -50,6 +51,38 @@ describe("emit", () => {
     const writeResult = await contract.write.emitWithoutArgs();
 
     await viem.assertions.emit(writeResult, contract, "WithoutArgs");
+  });
+
+  it("should check that the event was emitted when given a sendTransaction promise", async () => {
+    const contract = await viem.deployContract("Events");
+    const [walletClient] = await viem.getWalletClients();
+
+    await viem.assertions.emit(
+      walletClient.sendTransaction({
+        to: contract.address,
+        data: encodeFunctionData({
+          abi: contract.abi,
+          functionName: "emitWithoutArgs",
+        }),
+      }),
+      contract,
+      "WithoutArgs",
+    );
+  });
+
+  it("should check that the event was emitted when given an already-awaited sendTransaction hash", async () => {
+    const contract = await viem.deployContract("Events");
+    const [walletClient] = await viem.getWalletClients();
+
+    const hash = await walletClient.sendTransaction({
+      to: contract.address,
+      data: encodeFunctionData({
+        abi: contract.abi,
+        functionName: "emitWithoutArgs",
+      }),
+    });
+
+    await viem.assertions.emit(hash, contract, "WithoutArgs");
   });
 
   it("should throw because the event does not exists in the ABI", async () => {

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
@@ -1,5 +1,6 @@
 import type { HardhatViemHelpers } from "@nomicfoundation/hardhat-viem/types";
 import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
+import type { EthereumProvider } from "hardhat/types/providers";
 
 import assert from "node:assert/strict";
 import { before, beforeEach, describe, it } from "node:test";
@@ -19,6 +20,7 @@ import { isExpectedError } from "../../../helpers/is-expected-error.js";
 describe("emit", () => {
   let hre: HardhatRuntimeEnvironment;
   let viem: HardhatViemHelpers;
+  let provider: EthereumProvider;
 
   useEphemeralFixtureProject("hardhat-project");
 
@@ -32,7 +34,7 @@ describe("emit", () => {
   });
 
   beforeEach(async () => {
-    ({ viem } = await hre.network.create());
+    ({ provider, viem } = await hre.network.create());
   });
 
   it("should check that the event was emitted", async () => {
@@ -105,6 +107,32 @@ describe("emit", () => {
 
     await assertRejects(
       viem.assertions.emit(contract.write.doNotEmit(), contract, "WithoutArgs"),
+      (error) =>
+        isExpectedError(
+          error,
+          `No events were emitted for contract with address "${contract.address}" and event name "WithoutArgs"`,
+          false,
+          true,
+        ),
+    );
+  });
+
+  it("should not match an event emitted by a different tx in the same block", async () => {
+    const contract = await viem.deployContract("Events");
+
+    // Disable auto-mine so the two txs share one block, exercising the case
+    // where the old `getLogs({ address })` implementation would surface tx1's
+    // log when asserting against tx2.
+    await provider.request({ method: "evm_setAutomine", params: [false] });
+
+    await contract.write.emitWithoutArgs();
+    const tx2Hash = await contract.write.doNotEmit();
+
+    await provider.request({ method: "hardhat_mine", params: ["0x1"] });
+    await provider.request({ method: "evm_setAutomine", params: [true] });
+
+    await assertRejects(
+      viem.assertions.emit(tx2Hash, contract, "WithoutArgs"),
       (error) =>
         isExpectedError(
           error,

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
@@ -87,6 +87,26 @@ describe("emit", () => {
     await viem.assertions.emit(hash, contract, "WithoutArgs");
   });
 
+  it("should throw when contractFn does not resolve to a transaction hash", async () => {
+    const contract = await viem.deployContract("Events");
+
+    await assertRejects(
+      viem.assertions.emit(
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentionally passing a non-hash value to exercise the validation
+        "not-a-hash" as `0x${string}`,
+        contract,
+        "WithoutArgs",
+      ),
+      (error) =>
+        isExpectedError(
+          error,
+          `Expected contract function to return a transaction hash, but got: not-a-hash`,
+          false,
+          true,
+        ),
+    );
+  });
+
   it("should throw because the event does not exists in the ABI", async () => {
     const contract = await viem.deployContract("Events");
 

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
@@ -87,7 +87,7 @@ describe("emit", () => {
     await viem.assertions.emit(hash, contract, "WithoutArgs");
   });
 
-  it("should throw when contractFn does not resolve to a transaction hash", async () => {
+  it("should throw when txHash does not resolve to a transaction hash", async () => {
     const contract = await viem.deployContract("Events");
 
     await assertRejects(
@@ -100,7 +100,7 @@ describe("emit", () => {
       (error) =>
         isExpectedError(
           error,
-          `Expected contract function to return a transaction hash, but got: not-a-hash`,
+          `txHash must be a transaction hash or a promise resolving to one, but got: not-a-hash`,
           false,
           true,
         ),

--- a/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/emit/emit.ts
@@ -44,6 +44,14 @@ describe("emit", () => {
     );
   });
 
+  it("should check that the event was emitted when given an already-awaited write result", async () => {
+    const contract = await viem.deployContract("Events");
+
+    const writeResult = await contract.write.emitWithoutArgs();
+
+    await viem.assertions.emit(writeResult, contract, "WithoutArgs");
+  });
+
   it("should throw because the event does not exists in the ABI", async () => {
     const contract = await viem.deployContract("Events");
 


### PR DESCRIPTION
This PR makes `balancesHaveChanged`, `emit`, and `emitWithArgs` work with `contract.write.foo()` and `await contract.write.foo()`, so the user can choose to await the calls or not, before calling the assertion.

While doing that, I found that `emit` and `emitWithArgs` also received read operation return values, which doesn't work, because `eth_call`s ignore any `log`.

Also, the way they were implemented queried any past event emitted, instead of focusing on the transaction being asserted, which was incorrect and slower.