### PR TITLE
test(hardhat): create init skill-install workspaces under tmp.path

### DIFF
--- a/packages/hardhat/test/internal/cli/init/init.ts
+++ b/packages/hardhat/test/internal/cli/init/init.ts
@@ -1470,7 +1470,7 @@ describe("assertNoNonInteractiveClashes / copyProjectFilesNonInteractive", () =>
 
   it("should install skills and create CLAUDE.md and .claude for the mocha-ethers template", async () => {
     const [template] = await getTemplate("hardhat-3", "mocha-ethers");
-    const workspace = path.join(process.cwd(), "workspace-mocha-ethers");
+    const workspace = path.join(tmp.path, "workspace-mocha-ethers");
     await ensureDir(workspace);
 
     await copyProjectFilesNonInteractive(workspace, template);
@@ -1526,7 +1526,7 @@ describe("assertNoNonInteractiveClashes / copyProjectFilesNonInteractive", () =>
 
   it("should install skills and create CLAUDE.md and .claude for the node-test-runner-viem template", async () => {
     const [template] = await getTemplate("hardhat-3", "node-test-runner-viem");
-    const workspace = path.join(process.cwd(), "workspace-viem");
+    const workspace = path.join(tmp.path, "workspace-viem");
     await ensureDir(workspace);
 
     await copyProjectFilesNonInteractive(workspace, template);


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This prevents an issue in CI (see [logs](https://github.com/NomicFoundation/hardhat/actions/runs/26337907211/job/77534686121?pr=8324#step:6:6547)) where the regression benchmark job for validating the hardhat build using `pnpm test` at the workspace root directory fails, due to temporary test files being written to `cwd`.

# Analysis of the underlying problem

https://github.com/NomicFoundation/hardhat/commit/f090f3f24 added new tests. There are two problems with these tests:

1. The enclosing `describe("assertNoNonInteractiveClashes / copyProjectFilesNonInteractive", …)` does not call `useTmpDirAsCwd`, so `process.cwd()` is whatever the test process is launched from. When `pnpm test` runs the hardhat package, that cwd is `packages/hardhat/`. So `workspace-mocha-ethers/` and `workspace-viem/` get materialized at `packages/hardhat/workspace-mocha-ethers/` and `packages/hardhat/workspace-viem/`.
2. They never clean them up — there's no `after(...)` removing the directories.

After these tests run, `packages/hardhat/` contains stray `workspace-mocha-ethers/{hardhat.config.ts,test/Counter.ts,scripts/send-op-tx.ts,ignition/modules/Counter.ts,…}` and `workspace-viem/....`. These files import `@nomicfoundation/hardhat-toolbox-mocha-ethers`, `chai`, `@nomicfoundation/hardhat-ignition/modules`, etc. — which aren't dependencies of the hardhat package itself.

When the regression benchmark CI job runs `pnpm test` at the root directory, it tries to recursively execute that command, incl. in these new directories. Given that the dependencies are not part of the workspace, the errors shown in the CI log occur.
