### PR TITLE
fix: return JSON-RPC error instead of crashing on non-array eth_accounts 

### DIFF
--- a/.changeset/safe-geese-flip.md
+++ b/.changeset/safe-geese-flip.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Return a JSON-RPC error instead of crashing when eth_accounts returns a non-array
+Fixed a crash that could occur when a network returned an unexpected response while resolving the default sender account

--- a/.changeset/safe-geese-flip.md
+++ b/.changeset/safe-geese-flip.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Return a JSON-RPC error instead of crashing when eth_accounts returns a non-array

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
@@ -6,6 +6,7 @@ import type {
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
 import { getRequestParams } from "../../../json-rpc.js";
+import { InternalError } from "../../../provider-errors.js";
 
 import { SenderHandler } from "./sender.js";
 
@@ -42,7 +43,7 @@ export class AutomaticSenderHandler extends SenderHandler {
           jsonrpc: "2.0",
           id: jsonRpcRequest.id,
           error: {
-            code: -32603,
+            code: InternalError.CODE,
             message: "eth_accounts did not return an array of accounts",
           },
         };

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
@@ -7,7 +7,8 @@ import { SenderHandler } from "./sender.js";
 
 /**
  * This class automatically retrieves and caches the first available account from the connected provider.
- * If the first account have not been fetched yet, It returns a JSON-RPC error.
+ * On the first supported request, fetches and caches `eth_accounts` so callers don't need to set `from` manually.
+ * If `eth_accounts` responds with a non-array, it returns a JSON-RPC error.
  */
 export class AutomaticSenderHandler extends SenderHandler {
   #alreadyFetchedAccounts = false;

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
@@ -1,4 +1,7 @@
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import type {
+  JsonRpcRequest,
+  JsonRpcResponse,
+} from "../../../../../../types/providers.js";
 
 import { SenderHandler } from "./sender.js";
 
@@ -11,22 +14,37 @@ export class AutomaticSenderHandler extends SenderHandler {
   #alreadyFetchedAccounts = false;
   #firstAccount: string | undefined;
 
-  protected async getSender(): Promise<string | undefined> {
+  public override async handle(
+    jsonRpcRequest: JsonRpcRequest,
+  ): Promise<JsonRpcRequest | JsonRpcResponse> {
+    if (!this.isSupportedMethod(jsonRpcRequest)) {
+      return jsonRpcRequest;
+    }
+
     if (this.#alreadyFetchedAccounts === false) {
       const accounts = await this.provider.request({
         method: "eth_accounts",
       });
 
-      // TODO: This shouldn't be an exception but a failed JSON response!
-      assertHardhatInvariant(
-        Array.isArray(accounts),
-        "eth_accounts response should be an array",
-      );
+      if (!Array.isArray(accounts)) {
+        return {
+          jsonrpc: "2.0",
+          id: jsonRpcRequest.id,
+          error: {
+            code: -32603,
+            message: "eth_accounts did not return an array of accounts",
+          },
+        };
+      }
 
       this.#firstAccount = accounts[0];
       this.#alreadyFetchedAccounts = true;
     }
 
+    return await super.handle(jsonRpcRequest);
+  }
+
+  protected async getSender(): Promise<string | undefined> {
     return this.#firstAccount;
   }
 }

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
@@ -3,6 +3,10 @@ import type {
   JsonRpcResponse,
 } from "../../../../../../types/providers.js";
 
+import { isObject } from "@nomicfoundation/hardhat-utils/lang";
+
+import { getRequestParams } from "../../../json-rpc.js";
+
 import { SenderHandler } from "./sender.js";
 
 /**
@@ -19,6 +23,13 @@ export class AutomaticSenderHandler extends SenderHandler {
   ): Promise<JsonRpcRequest | JsonRpcResponse> {
     if (!this.isSupportedMethod(jsonRpcRequest)) {
       return jsonRpcRequest;
+    }
+
+    const [tx] = getRequestParams(jsonRpcRequest);
+    if (!isObject(tx) || tx.from !== undefined) {
+      // Skip the eth_accounts fetch when we won't need a sender anyway:
+      // the tx isn't an object, or it already carries a `from`.
+      return await super.handle(jsonRpcRequest);
     }
 
     if (this.#alreadyFetchedAccounts === false) {

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
@@ -7,8 +7,7 @@ import { SenderHandler } from "./sender.js";
 
 /**
  * This class automatically retrieves and caches the first available account from the connected provider.
- * It overrides the getSender method of the base class to request the list of accounts if the first account has not been fetched yet,
- * ensuring dynamic selection of the sender for all JSON-RPC requests without requiring manual input.
+ * If the first account have not been fetched yet, It returns a JSON-RPC error.
  */
 export class AutomaticSenderHandler extends SenderHandler {
   #alreadyFetchedAccounts = false;

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
@@ -10,6 +10,7 @@ import {
   isJsonRpcResponse,
   isFailedJsonRpcResponse,
 } from "../../../../../../../src/internal/builtin-plugins/network-manager/json-rpc.js";
+import { InternalError } from "../../../../../../../src/internal/builtin-plugins/network-manager/provider-errors.js";
 import { AutomaticSenderHandler } from "../../../../../../../src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.js";
 import { EthereumMockedProvider } from "../../ethereum-mocked-provider.js";
 
@@ -58,9 +59,51 @@ describe("AutomaticSenderHandler", function () {
 
     const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
+    await automaticSenderHandler.handle(jsonRpcRequest);
+
     const [requestTx] = getRequestParams(jsonRpcRequest);
     assert.ok(isObject(requestTx), "tx is not an object");
     assert.equal(requestTx.from, "0x000006d4548a3ac17d72b372ae1e416bf65b8ead");
+  });
+
+  it("should not fetch eth_accounts when the transaction already has a from", async () => {
+    const provider = new EthereumMockedProvider();
+    provider.setReturnValue("eth_accounts", [
+      "0x123006d4548a3ac17d72b372ae1e416bf65b8eaf",
+    ]);
+
+    const handler = new AutomaticSenderHandler(provider);
+
+    const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [
+      { ...tx, from: "0x000006d4548a3ac17d72b372ae1e416bf65b8ead" },
+    ]);
+
+    await handler.handle(jsonRpcRequest);
+
+    assert.equal(
+      provider.getNumberOfCalls("eth_accounts"),
+      0,
+      "eth_accounts should not be fetched when a sender isn't needed",
+    );
+  });
+
+  it("should not fetch eth_accounts when the params don't carry a transaction object", async () => {
+    const provider = new EthereumMockedProvider();
+    provider.setReturnValue("eth_accounts", [
+      "0x123006d4548a3ac17d72b372ae1e416bf65b8eaf",
+    ]);
+
+    const handler = new AutomaticSenderHandler(provider);
+
+    const jsonRpcRequest = getJsonRpcRequest(1, "eth_call", []);
+
+    await handler.handle(jsonRpcRequest);
+
+    assert.equal(
+      provider.getNumberOfCalls("eth_accounts"),
+      0,
+      "eth_accounts should not be fetched when there's no transaction object",
+    );
   });
 
   it("should not fail on eth_calls if provider doesn't have any accounts", async () => {
@@ -105,7 +148,7 @@ describe("AutomaticSenderHandler", function () {
     );
     assert.equal(
       result.error.code,
-      -32603,
+      InternalError.CODE,
       "error code should be Internal error (-32603)",
     );
     assert.ok(

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
@@ -7,6 +7,8 @@ import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 import {
   getJsonRpcRequest,
   getRequestParams,
+  isJsonRpcResponse,
+  isFailedJsonRpcResponse,
 } from "../../../../../../../src/internal/builtin-plugins/network-manager/json-rpc.js";
 import { AutomaticSenderHandler } from "../../../../../../../src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.js";
 import { EthereumMockedProvider } from "../../ethereum-mocked-provider.js";
@@ -73,5 +75,38 @@ describe("AutomaticSenderHandler", function () {
     const [requestTx] = getRequestParams(jsonRpcRequest);
     assert.ok(isObject(requestTx), "tx is not an object");
     assert.equal(requestTx.value, "asd");
+  });
+
+  it("should return a failed JSON-RPC response if eth_accounts returns a non-array", async () => {
+    const badProvider = new EthereumMockedProvider();
+    badProvider.setReturnValue("eth_accounts", "not-an-array");
+
+    const handler = new AutomaticSenderHandler(badProvider);
+
+    const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [
+      {
+        to: "0xa5bc06d4548a3ac17d72b372ae1e416bf65b8eac",
+        gas: numberToHexString(21000),
+        gasPrice: numberToHexString(678912),
+        nonce: numberToHexString(0),
+        value: numberToHexString(1),
+      },
+    ]);
+
+    const result = await handler.handle(jsonRpcRequest);
+
+    assert.ok(
+      isJsonRpcResponse(result),
+      "expected a JSON-RPC response, not a request",
+    );
+    assert.ok(
+      isFailedJsonRpcResponse(result),
+      "expected a failed JSON-RPC response",
+    );
+    assert.equal(result.error.code, -32603, "error code should be Internal error (-32603)");
+    assert.ok(
+      result.error.message.includes("eth_accounts"),
+      "error message should mention eth_accounts",
+    );
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
@@ -103,7 +103,11 @@ describe("AutomaticSenderHandler", function () {
       isFailedJsonRpcResponse(result),
       "expected a failed JSON-RPC response",
     );
-    assert.equal(result.error.code, -32603, "error code should be Internal error (-32603)");
+    assert.equal(
+      result.error.code,
+      -32603,
+      "error code should be Internal error (-32603)",
+    );
     assert.ok(
       result.error.message.includes("eth_accounts"),
       "error message should mention eth_accounts",


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary

TODO at the call site says: "This shouldn't be an exception but a failed JSON response!", which I agree:
> `AutomaticSenderHandler` crashes with `assertHardhatInvariant` when a remote provider returns a non-array from `eth_accounts`.

## Context

`getSender()` returns `Promise<string | undefined>`, so it cannot return a `FailedJsonRpcResponse`.
The validation had to bemoved up to `handle()` call, which can return `JsonRpcRequest | JsonRpcResponse`.
The handler chain at `network.ts:74` already supports this path, so the fix works

## Fix

Override `handle()`, instead of `getSender()` throwing an exception:
If `eth_accounts` yields a _non-array_, return a `FailedJsonRpcResponse` with code `-32603` (per EIP-1474). 

## Tests

`packages/hardhat/test/.../automatic-sender-handler.ts`:
- [x] Non-array `eth_accounts` response: returns `FailedJsonRpcResponse` with code `-32603`

## Changeset

`patch` on `hardhat`