### PR TITLE
fix: skip full-input retry for non-retryable verification errors

### DIFF
--- a/.changeset/red-owls-live.md
+++ b/.changeset/red-owls-live.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+"@nomicfoundation/hardhat-errors": patch
+---
+
+Skip full-input retry for non-retryable verification errors

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -3052,6 +3052,9 @@ Retrying with the full compiler input would produce the same result.`,
         websiteTitle: "Non-retryable verification error",
         websiteDescription: `The block explorer returned an error that cannot be resolved by retrying with different compiler input. Common causes include:
 
+- **Bytecode mismatch**: the deployed bytecode does not match the compiled bytecode. This can happen when the contract was compiled with a different build profile than the one used for verification. Try verifying with the correct \`--build-profile\`.
+- **Constructor arguments**: the provided constructor arguments do not match the ones used during deployment.
+
 Retrying will not change the outcome. Fix the underlying cause and try again.`,
       },
     },

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -3044,6 +3044,16 @@ Please verify the address and network, and try again later if necessary.`,
 
 To resolve this, set a valid non-empty API key in your Hardhat config, then try again.`,
       },
+      NON_RETRYABLE_VERIFICATION_ERROR: {
+        number: 80030,
+        messageTemplate: `The contract verification failed with a non-retryable error: "{reason}".
+
+Retrying with the full compiler input would produce the same result.`,
+        websiteTitle: "Non-retryable verification error",
+        websiteDescription: `The block explorer returned an error that cannot be resolved by retrying with different compiler input. Common causes include:
+
+Retrying will not change the outcome. Fix the underlying cause and try again.`,
+      },
     },
     VALIDATION: {
       INVALID_ADDRESS: {

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -206,28 +206,30 @@ Explorer: ${instance.getContractUrl(address)}`);
     buildProfileName,
   );
 
-  const { success: minimalInputVerificationSuccess } =
-    await attemptVerification(
-      {
-        verificationProvider: instance,
-        address,
-        encodedConstructorArgs,
-        creationTxHash,
-        contractInformation: {
-          ...contractInformation,
-          // Use the minimal compiler input for the first verification attempt
-          compilerInput: {
-            ...minimalCompilerInput,
-            settings: {
-              ...minimalCompilerInput.settings,
-              // Ensure the libraries are included in the compiler input
-              libraries: libraryInformation.libraries,
-            },
+  const {
+    success: minimalInputVerificationSuccess,
+    message: minimalInputMessage,
+  } = await attemptVerification(
+    {
+      verificationProvider: instance,
+      address,
+      encodedConstructorArgs,
+      creationTxHash,
+      contractInformation: {
+        ...contractInformation,
+        // Use the minimal compiler input for the first verification attempt
+        compilerInput: {
+          ...minimalCompilerInput,
+          settings: {
+            ...minimalCompilerInput.settings,
+            // Ensure the libraries are included in the compiler input
+            libraries: libraryInformation.libraries,
           },
         },
       },
-      consoleLog,
-    );
+    },
+    consoleLog,
+  );
 
   if (minimalInputVerificationSuccess) {
     consoleLog(`
@@ -236,6 +238,25 @@ Explorer: ${instance.getContractUrl(address)}`);
   ${contractInformation.userFqn}
   Explorer: ${instance.getContractUrl(address)}`);
     return true;
+  }
+
+  const librariesWarning =
+    libraryInformation.undetectableLibraries.length > 0
+      ? `
+This contract makes use of libraries whose addresses are undetectable by the plugin.
+Keep in mind that this verification failure may be due to passing in the wrong
+address for one of these libraries:
+${libraryInformation.undetectableLibraries.map((x) => `  * ${x}`).join("\n")}`
+      : "";
+
+  if (isNonRetryableVerificationError(minimalInputMessage)) {
+    throw new HardhatError(
+      HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.CONTRACT_VERIFICATION_FAILED,
+      {
+        reason: minimalInputMessage,
+        librariesWarning,
+      },
+    );
   }
 
   consoleLog(`
@@ -279,14 +300,6 @@ Unrelated contracts may be displayed on ${instance.name} as a result.
     return true;
   }
 
-  const librariesWarning =
-    libraryInformation.undetectableLibraries.length > 0
-      ? `
-This contract makes use of libraries whose addresses are undetectable by the plugin.
-Keep in mind that this verification failure may be due to passing in the wrong
-address for one of these libraries:
-${libraryInformation.undetectableLibraries.map((x) => `  * ${x}`).join("\n")}`
-      : "";
 
   throw new HardhatError(
     HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.CONTRACT_VERIFICATION_FAILED,
@@ -411,4 +424,12 @@ async function attemptVerification(
   );
 
   return verificationStatus;
+}
+
+function isNonRetryableVerificationError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    (lower.includes("bytecode") && lower.includes("not match")) ||
+    lower.includes("constructor argument")
+  );
 }

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -242,10 +242,9 @@ Explorer: ${instance.getContractUrl(address)}`);
 
   if (isNonRetryableVerificationError(minimalInputMessage)) {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.CONTRACT_VERIFICATION_FAILED,
+      HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.NON_RETRYABLE_VERIFICATION_ERROR,
       {
         reason: minimalInputMessage,
-        librariesWarning: getLibrariesWarning(libraryInformation),
       },
     );
   }

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -240,21 +240,12 @@ Explorer: ${instance.getContractUrl(address)}`);
     return true;
   }
 
-  const librariesWarning =
-    libraryInformation.undetectableLibraries.length > 0
-      ? `
-This contract makes use of libraries whose addresses are undetectable by the plugin.
-Keep in mind that this verification failure may be due to passing in the wrong
-address for one of these libraries:
-${libraryInformation.undetectableLibraries.map((x) => `  * ${x}`).join("\n")}`
-      : "";
-
   if (isNonRetryableVerificationError(minimalInputMessage)) {
     throw new HardhatError(
       HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.CONTRACT_VERIFICATION_FAILED,
       {
         reason: minimalInputMessage,
-        librariesWarning,
+        librariesWarning: getLibrariesWarning(libraryInformation),
       },
     );
   }
@@ -300,12 +291,11 @@ Unrelated contracts may be displayed on ${instance.name} as a result.
     return true;
   }
 
-
   throw new HardhatError(
     HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.CONTRACT_VERIFICATION_FAILED,
     {
       reason: verificationMessage,
-      librariesWarning,
+      librariesWarning: getLibrariesWarning(libraryInformation),
     },
   );
 }
@@ -430,6 +420,21 @@ function isNonRetryableVerificationError(message: string): boolean {
   const lower = message.toLowerCase();
   return (
     (lower.includes("bytecode") && lower.includes("not match")) ||
-    lower.includes("constructor argument")
+    lower.includes("constructor argument") ||
+    lower.includes("invalid compiler version")
   );
+}
+
+function getLibrariesWarning(libraryInformation: {
+  undetectableLibraries: string[];
+}): string {
+  if (libraryInformation.undetectableLibraries.length === 0) {
+    return "";
+  }
+
+  return `
+This contract makes use of libraries whose addresses are undetectable by the plugin.
+Keep in mind that this verification failure may be due to passing in the wrong
+address for one of these libraries:
+${libraryInformation.undetectableLibraries.map((x) => `  * ${x}`).join("\n")}`;
 }

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -290,11 +290,20 @@ Unrelated contracts may be displayed on ${instance.name} as a result.
     return true;
   }
 
+  const librariesWarning =
+    libraryInformation.undetectableLibraries.length > 0
+      ? `
+This contract makes use of libraries whose addresses are undetectable by the plugin.
+Keep in mind that this verification failure may be due to passing in the wrong
+address for one of these libraries:
+${libraryInformation.undetectableLibraries.map((x) => `  * ${x}`).join("\n")}`
+      : "";
+
   throw new HardhatError(
     HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.CONTRACT_VERIFICATION_FAILED,
     {
       reason: verificationMessage,
-      librariesWarning: getLibrariesWarning(libraryInformation),
+      librariesWarning,
     },
   );
 }
@@ -415,25 +424,15 @@ async function attemptVerification(
   return verificationStatus;
 }
 
+// Known non-retryable Etherscan/Blockscout verification failure patterns.
+const NON_RETRYABLE_PATTERNS = [
+  // Etherscan: "Compiled contract deployment bytecode does NOT match..."
+  "bytecode does not match",
+  // Etherscan: "Please check if the correct constructor argument was entered"
+  "correct constructor argument",
+];
+
 function isNonRetryableVerificationError(message: string): boolean {
   const lower = message.toLowerCase();
-  return (
-    (lower.includes("bytecode") && lower.includes("not match")) ||
-    lower.includes("constructor argument") ||
-    lower.includes("invalid compiler version")
-  );
-}
-
-function getLibrariesWarning(libraryInformation: {
-  undetectableLibraries: string[];
-}): string {
-  if (libraryInformation.undetectableLibraries.length === 0) {
-    return "";
-  }
-
-  return `
-This contract makes use of libraries whose addresses are undetectable by the plugin.
-Keep in mind that this verification failure may be due to passing in the wrong
-address for one of these libraries:
-${libraryInformation.undetectableLibraries.map((x) => `  * ${x}`).join("\n")}`;
+  return NON_RETRYABLE_PATTERNS.some((pattern) => lower.includes(pattern));
 }

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -425,11 +425,20 @@ async function attemptVerification(
 }
 
 // Known non-retryable Etherscan/Blockscout verification failure patterns.
+// Between the minimal and full-input attempts, only `compilerInput` (source files)
+// changes. Any error unrelated to missing sources is deterministic and non-retryable.
+// Source: https://docs.etherscan.io/contract-verification/common-verification-errors
 const NON_RETRYABLE_PATTERNS = [
-  // Etherscan: "Compiled contract deployment bytecode does NOT match..."
+  // "Compiled contract deployment bytecode does NOT match the transaction deployment bytecode."
   "bytecode does not match",
-  // Etherscan: "Please check if the correct constructor argument was entered"
+  // "Please check if the correct constructor argument was entered"
   "correct constructor argument",
+  // "Please check if the correct bytecodehash was specified via standard-json verification."
+  "correct bytecodehash",
+  // "Unable to locate ContractName , did you specify the correct Contract Name ?"
+  "unable to locate",
+  // "This contract already Similar Matches the deployed ByteCode at [address]"
+  "already similar match",
 ];
 
 export function isNonRetryableVerificationError(message: string): boolean {

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -432,7 +432,7 @@ const NON_RETRYABLE_PATTERNS = [
   "correct constructor argument",
 ];
 
-function isNonRetryableVerificationError(message: string): boolean {
+export function isNonRetryableVerificationError(message: string): boolean {
   const lower = message.toLowerCase();
   return NON_RETRYABLE_PATTERNS.some((pattern) => lower.includes(pattern));
 }

--- a/packages/hardhat-verify/test/verification.ts
+++ b/packages/hardhat-verify/test/verification.ts
@@ -7,6 +7,7 @@ import { before, beforeEach, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
+  assertRejectsWithHardhatError,
   assertThrowsHardhatError,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
@@ -188,6 +189,61 @@ describe("verification", () => {
           "Etherscan verification should be disabled",
         );
         assert.ok(result, "Verification should return true");
+      });
+
+      describe("non-retryable errors", () => {
+        const nrDispatcher = initializeTestDispatcher({
+          url: etherscanApiUrl,
+        });
+
+        for (const [label, reason] of [
+          [
+            "bytecode mismatch",
+            "Fail - Unable to verify. Compiled contract deployment bytecode does NOT match the transaction deployment bytecode.",
+          ],
+          [
+            "constructor argument mismatch",
+            "Fail - Unable to verify. Please check if the correct constructor argument was entered.",
+          ],
+          [
+            "unable to locate contract",
+            "Unable to locate ContractName , did you specify the correct Contract Name ?",
+          ],
+          [
+            "already similar match",
+            "This contract already Similar Matches the deployed ByteCode at 0x1234",
+          ],
+        ] as const) {
+          it(`should throw NON_RETRYABLE_VERIFICATION_ERROR for: ${label}`, async () => {
+            const { provider } = await hre.network.create();
+            const address = await deployContract(
+              "Counter",
+              [],
+              {},
+              hre,
+              provider,
+            );
+
+            mockEtherscanNonRetryableResponse(
+              nrDispatcher.interceptable,
+              reason,
+            );
+
+            await assertRejectsWithHardhatError(
+              () =>
+                verifyContract(
+                  { address },
+                  hre,
+                  () => {},
+                  nrDispatcher.interceptable,
+                  provider,
+                ),
+              HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL
+                .NON_RETRYABLE_VERIFICATION_ERROR,
+              { reason },
+            );
+          });
+        }
       });
     });
 
@@ -402,5 +458,41 @@ function mockEtherscanRequests(interceptable: Interceptable) {
     .reply(200, {
       status: "1",
       result: "Pass - Verified",
+    });
+}
+
+function mockEtherscanNonRetryableResponse(
+  interceptable: Interceptable,
+  failureMessage: string,
+) {
+  // getsourcecode: contract not yet verified
+  interceptable
+    .intercept({
+      path: /^\/(?:v2\/)?api\?action=getsourcecode&address=0x[a-fA-F0-9]{40}&apikey=[A-Za-z0-9]+&chainid=\d+&module=contract$/,
+      method: "GET",
+    })
+    .reply(200, { status: "1", result: [{ SourceCode: "" }] });
+
+  // verifysourcecode: accepted
+  interceptable
+    .intercept({
+      path: /^\/(?:v2\/)?api\?action=verifysourcecode&apikey=[A-Za-z0-9]+&chainid=\d+&module=contract$/,
+      method: "POST",
+    })
+    .reply(200, {
+      status: "1",
+      message: "OK",
+      result: "1234",
+    });
+
+  // checkverifystatus: non-retryable failure
+  interceptable
+    .intercept({
+      path: /^\/(?:v2\/)?api\?action=checkverifystatus&apikey=[A-Za-z0-9]+&chainid=\d+&guid=1234&module=contract$/,
+      method: "GET",
+    })
+    .reply(200, {
+      status: "0",
+      result: failureMessage,
     });
 }

--- a/packages/hardhat-verify/test/verification.ts
+++ b/packages/hardhat-verify/test/verification.ts
@@ -313,6 +313,9 @@ describe("verification", () => {
       const nonRetryableMessages = [
         "Fail - Unable to verify. Compiled contract deployment bytecode does NOT match the transaction deployment bytecode.",
         "Fail - Unable to verify. Please check if the correct constructor argument was entered.",
+        "Fail - Unable to verify. Please check if the correct bytecodehash was specified via standard-json verification.",
+        "Unable to locate ContractName , did you specify the correct Contract Name ?",
+        "This contract already Similar Matches the deployed ByteCode at 0x1234",
       ];
       for (const msg of nonRetryableMessages) {
         assert.equal(isNonRetryableVerificationError(msg), true, msg);
@@ -323,6 +326,9 @@ describe("verification", () => {
       const retryableMessages = [
         "Fail - Unable to verify",
         "Fail - Unable to verify. Solidity Compilation Error: Identifier not found or not unique.",
+        'Source "contracts/Lib.sol" not found: File import callback not supported',
+        "Library was required but suitable match not found",
+        "This could be a temporary error, please retry or contact us (Error Code 10001)",
       ];
       for (const msg of retryableMessages) {
         assert.equal(isNonRetryableVerificationError(msg), false, msg);

--- a/packages/hardhat-verify/test/verification.ts
+++ b/packages/hardhat-verify/test/verification.ts
@@ -24,23 +24,23 @@ import { deployContract, initializeTestDispatcher } from "../test/utils.js";
 
 describe("verification", () => {
   describe("verifyContract", () => {
+    useEphemeralFixtureProject("integration");
+    const etherscanApiUrl = new URL("https://api-sepolia.etherscan.io").origin;
+
+    let hardhatUserConfig: HardhatUserConfig;
+    let hre: HardhatRuntimeEnvironment;
+    before(async () => {
+      hardhatUserConfig =
+        // eslint-disable-next-line import/no-relative-packages -- allowed in test
+        (await import("./fixture-projects/integration/hardhat.config.js"))
+          .default;
+      hre = await createHardhatRuntimeEnvironment(hardhatUserConfig);
+      await hre.tasks.getTask("build").run();
+    });
+
     describe("base cases", () => {
-      useEphemeralFixtureProject("integration");
-      const etherscanApiUrl = new URL("https://api-sepolia.etherscan.io")
-        .origin;
       const testDispatcher = initializeTestDispatcher({
         url: etherscanApiUrl,
-      });
-
-      let hardhatUserConfig: HardhatUserConfig;
-      let hre: HardhatRuntimeEnvironment;
-      before(async () => {
-        hardhatUserConfig =
-          // eslint-disable-next-line import/no-relative-packages -- allowed in test
-          (await import("./fixture-projects/integration/hardhat.config.js"))
-            .default;
-        hre = await createHardhatRuntimeEnvironment(hardhatUserConfig);
-        await hre.tasks.getTask("build").run();
       });
 
       beforeEach(() => {
@@ -190,61 +190,48 @@ describe("verification", () => {
         );
         assert.ok(result, "Verification should return true");
       });
+    });
 
-      describe("non-retryable errors", () => {
-        const nrDispatcher = initializeTestDispatcher({
-          url: etherscanApiUrl,
+    describe("non-retryable errors", () => {
+      const nrDispatcher = initializeTestDispatcher({ url: etherscanApiUrl });
+
+      for (const [label, reason] of [
+        [
+          "bytecode mismatch",
+          "Fail - Unable to verify. Compiled contract deployment bytecode does NOT match the transaction deployment bytecode.",
+        ],
+        [
+          "constructor argument mismatch",
+          "Fail - Unable to verify. Please check if the correct constructor argument was entered.",
+        ],
+      ] as const) {
+        it(`should throw NON_RETRYABLE_VERIFICATION_ERROR for: ${label}`, async () => {
+          const { provider } = await hre.network.create();
+          const address = await deployContract(
+            "Counter",
+            [],
+            {},
+            hre,
+            provider,
+          );
+
+          mockEtherscanNonRetryableResponse(nrDispatcher.interceptable, reason);
+
+          await assertRejectsWithHardhatError(
+            () =>
+              verifyContract(
+                { address },
+                hre,
+                () => {},
+                nrDispatcher.interceptable,
+                provider,
+              ),
+            HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL
+              .NON_RETRYABLE_VERIFICATION_ERROR,
+            { reason },
+          );
         });
-
-        for (const [label, reason] of [
-          [
-            "bytecode mismatch",
-            "Fail - Unable to verify. Compiled contract deployment bytecode does NOT match the transaction deployment bytecode.",
-          ],
-          [
-            "constructor argument mismatch",
-            "Fail - Unable to verify. Please check if the correct constructor argument was entered.",
-          ],
-          [
-            "unable to locate contract",
-            "Unable to locate ContractName , did you specify the correct Contract Name ?",
-          ],
-          [
-            "already similar match",
-            "This contract already Similar Matches the deployed ByteCode at 0x1234",
-          ],
-        ] as const) {
-          it(`should throw NON_RETRYABLE_VERIFICATION_ERROR for: ${label}`, async () => {
-            const { provider } = await hre.network.create();
-            const address = await deployContract(
-              "Counter",
-              [],
-              {},
-              hre,
-              provider,
-            );
-
-            mockEtherscanNonRetryableResponse(
-              nrDispatcher.interceptable,
-              reason,
-            );
-
-            await assertRejectsWithHardhatError(
-              () =>
-                verifyContract(
-                  { address },
-                  hre,
-                  () => {},
-                  nrDispatcher.interceptable,
-                  provider,
-                ),
-              HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL
-                .NON_RETRYABLE_VERIFICATION_ERROR,
-              { reason },
-            );
-          });
-        }
-      });
+      }
     });
 
     // TODO: Include remaining `hardhat-verify` verification test cases

--- a/packages/hardhat-verify/test/verification.ts
+++ b/packages/hardhat-verify/test/verification.ts
@@ -17,6 +17,7 @@ import {
   verifyContract,
   validateArgs,
   validateVerificationProviderName,
+  isNonRetryableVerificationError,
 } from "../src/internal/verification.js";
 import { deployContract, initializeTestDispatcher } from "../test/utils.js";
 
@@ -303,6 +304,28 @@ describe("verification", () => {
           "function",
           `Provider "${providerName}" should have getSupportedChains method`,
         );
+      }
+    });
+  });
+
+  describe("isNonRetryableVerificationError", () => {
+    it("should match NON_RETRYABLE_PATTERNS", () => {
+      const nonRetryableMessages = [
+        "Fail - Unable to verify. Compiled contract deployment bytecode does NOT match the transaction deployment bytecode.",
+        "Fail - Unable to verify. Please check if the correct constructor argument was entered.",
+      ];
+      for (const msg of nonRetryableMessages) {
+        assert.equal(isNonRetryableVerificationError(msg), true, msg);
+      }
+    });
+
+    it("should allow retry for other errors", () => {
+      const retryableMessages = [
+        "Fail - Unable to verify",
+        "Fail - Unable to verify. Solidity Compilation Error: Identifier not found or not unique.",
+      ];
+      for (const msg of retryableMessages) {
+        assert.equal(isNonRetryableVerificationError(msg), false, msg);
       }
     });
   });


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary
> Closes #7731

When verification with minimal compiler input fails, `hardhat-verify` **always retries with the full input**.
For some pre-determined errors (bytecode mismatch, wrong constructor args), this wastes time without any expected outcome.

## Context

Between the minimal and full-input attempts, only `compilerInput` (source files) changes.Address, constructor args, contract name, solc version, and compiler settings stay the same.

## Fix

1. Introduce a new lookup table for `non-retryable errors`: NON_RETRYABLE_PATTERNS
2. Introduce a new Hardhat error descriptor: `NON_RETRYABLE_VERIFICATION_ERROR` (HHE80030)
3. After the first `attemptVerification` fail, check the error message against `NON_RETRYABLE_PATTERNS`.
4. If matched, throw `NON_RETRYABLE_VERIFICATION_ERROR` immediately instead of retrying.

## Tests

`packages/hardhat-verify/test/verification.ts`:
- `isNonRetryableVerificationError` returns true for all 5 detected non-retryable patterns.
- Returns false for retryable messages:compilation errors, missing sources, library issues, temporary errors, generic failures, etc.

## Changeset

`patch` on `@nomicfoundation/hardhat-verify` and `@nomicfoundation/hardhat-errors`.

## Notes

I also considered these for an exhaustive list, but any missing item can be raised and added later:

- Etherscan:
  - Compilation errors, missing sources, library not found: retryable (full input adds the missing files)
  - Temporary errors: explicitly says retry
  - Generic "Fail - Unable to verify": no signal, safer to retry
  - Invalid solc version, contract code not found, already verified: already handled upstream before `attemptVerification` runs
- Blockscout: returns only "Fail - Unable to verify".
- Sourcify: error messages vary, could not locate a doc.