### PR TITLE
fix: environment variables should take precedence over keystore

### DIFF
--- a/.changeset/gold-snails-snap.md
+++ b/.changeset/gold-snails-snap.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-keystore": patch
+---
+
+Environment variables take precedence over keystore values

--- a/packages/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
+++ b/packages/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
@@ -26,6 +26,11 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
       variable: ConfigurationVariable,
       next,
     ) => {
+      // Environment variables should take precedence over keystore
+      if (process.env[variable.name] !== undefined) {
+        return await next(context, variable);
+      }
+
       // If we are in CI, the keystore should not be used
       // or even initialized
       if (isCi()) {

--- a/packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts
+++ b/packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts
@@ -343,6 +343,35 @@ describe("hook-handlers - configuration variables - fetchValue", () => {
       });
     });
 
+    describe("when an environment variable is set for the same key", () => {
+      let resultValue: string;
+
+      beforeEach(async () => {
+        process.env.key1 = "value-from-env";
+
+        resultValue = await hre.hooks.runHandlerChain(
+          "configurationVariables",
+          "fetchValue",
+          [exampleConfigurationVariable],
+          async (_context, _configVar) => {
+            return process.env[_configVar.name] ?? "unexpected-default-value";
+          },
+        );
+      });
+
+      afterEach(() => {
+        delete process.env.key1;
+      });
+
+      it("should return the environment variable value instead of the keystore value", async () => {
+        assert.equal(
+          resultValue,
+          "value-from-env",
+          "env var should take precedence over keystore",
+        );
+      });
+    });
+
     describe("where the key is not in the development and production keystore", () => {
       let resultValue: string;
 

--- a/packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts
+++ b/packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts
@@ -1,5 +1,6 @@
 import type { ConfigurationVariable } from "hardhat/types/config";
 import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
+import type { HardhatPlugin } from "hardhat/types/plugins";
 
 import assert from "node:assert/strict";
 import path from "node:path";
@@ -344,31 +345,112 @@ describe("hook-handlers - configuration variables - fetchValue", () => {
     });
 
     describe("when an environment variable is set for the same key", () => {
-      let resultValue: string;
+      let passwordRequestCount: number;
 
       beforeEach(async () => {
-        process.env.key1 = "value-from-env";
+        passwordRequestCount = 0;
 
-        resultValue = await hre.hooks.runHandlerChain(
-          "configurationVariables",
-          "fetchValue",
-          [exampleConfigurationVariable],
-          async (_context, _configVar) => {
-            return process.env[_configVar.name] ?? "unexpected-default-value";
+        const trackingPasswordPlugin: HardhatPlugin = {
+          id: "tracking-keystore-password",
+          hookHandlers: {
+            userInterruptions: async () => ({
+              default: async () => ({
+                requestSecretInput: async () => {
+                  passwordRequestCount++;
+                  return TEST_PASSWORD_PROD;
+                },
+              }),
+            }),
           },
-        );
+        };
+
+        hre = await createHardhatRuntimeEnvironment({
+          plugins: [
+            hardhatKeystorePlugin,
+            setupKeystoreFileLocationOverrideAt(
+              configurationVariableProdKeystoreFilePath,
+              configurationVariableDevKeystoreFilePath,
+              configurationVariableDevKeystorePasswordFilePath,
+            ),
+            trackingPasswordPlugin,
+          ],
+        });
       });
 
-      afterEach(() => {
-        delete process.env.key1;
+      describe("with a non-empty value", () => {
+        let resultValue: string;
+
+        // `key4-prod` only exists in the production keystore, so resolving it
+        // through the keystore would prompt for the production password.
+        beforeEach(async () => {
+          process.env["key4-prod"] = "value-from-env";
+
+          resultValue = await hre.hooks.runHandlerChain(
+            "configurationVariables",
+            "fetchValue",
+            [exampleConfigurationVariable4],
+            async (_context, _configVar) => {
+              return process.env[_configVar.name] ?? "unexpected-default-value";
+            },
+          );
+        });
+
+        afterEach(() => {
+          delete process.env["key4-prod"];
+        });
+
+        it("should return the environment variable value instead of the keystore value", async () => {
+          assert.equal(
+            resultValue,
+            "value-from-env",
+            "env var should take precedence over keystore",
+          );
+        });
+
+        it("should not prompt for the keystore password", async () => {
+          assert.equal(
+            passwordRequestCount,
+            0,
+            "keystore should not be opened when env var is set",
+          );
+        });
       });
 
-      it("should return the environment variable value instead of the keystore value", async () => {
-        assert.equal(
-          resultValue,
-          "value-from-env",
-          "env var should take precedence over keystore",
-        );
+      describe("with an empty string value", () => {
+        let resultValue: string;
+
+        beforeEach(async () => {
+          process.env["key4-prod"] = "";
+
+          resultValue = await hre.hooks.runHandlerChain(
+            "configurationVariables",
+            "fetchValue",
+            [exampleConfigurationVariable4],
+            async (_context, _configVar) => {
+              return process.env[_configVar.name] ?? "unexpected-default-value";
+            },
+          );
+        });
+
+        afterEach(() => {
+          delete process.env["key4-prod"];
+        });
+
+        it("should return the empty environment variable value", async () => {
+          assert.equal(
+            resultValue,
+            "",
+            "an empty env var should still take precedence over keystore",
+          );
+        });
+
+        it("should not prompt for the keystore password", async () => {
+          assert.equal(
+            passwordRequestCount,
+            0,
+            "keystore should not be opened when env var is set",
+          );
+        });
       });
     });
 


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary
> Closes #7596

> "The keystore shouldn't be even checked if the envvar exists."

Environment variables should take precedence over keystore values when resolving configuration variables.

## Context

The keystore's `fetchValue` hook checks both keystores before calling `next()`, which is where `process.env` is read.
If the key exists in a keystore, the handler returns early and the env var is never consulted.

## Fix
This PR adds a `process.env[variable.name]` check at the top of the handler.
If the env var is defined, **skip keystore lookup entirely**.

## Tests

`packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts`:
- Added relevant test.

## Changeset

`patch` on `@nomicfoundation/hardhat-keystore`