### PR TITLE
fix: allow optional positional arguments: STRING_WITHOUT_DEFAULT, FILE_WITHOUT_DEFAULT

### DIFF
--- a/.changeset/early-mice-park.md
+++ b/.changeset/early-mice-park.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Allow STRING_WITHOUT_DEFAULT and FILE_WITHOUT_DEFAULT as positional arguments

--- a/packages/hardhat/src/internal/cli/help/utils.ts
+++ b/packages/hardhat/src/internal/cli/help/utils.ts
@@ -7,7 +7,7 @@ import type { Task } from "../../../types/tasks.js";
 
 import { camelToKebabCase } from "@nomicfoundation/hardhat-utils/string";
 
-import { isOptionalArgumentType } from "../../core/tasks/utils.js";
+import { isArgumentRequired } from "../../core/tasks/utils.js";
 
 export const GLOBAL_NAME_PADDING = 6;
 
@@ -95,7 +95,7 @@ export function parseOptions(task: Task): {
     positionalArguments.push({
       name,
       description: trimFullStop(description),
-      isRequired: defaultValue === undefined && !isOptionalArgumentType(type),
+      isRequired: isArgumentRequired(type, defaultValue),
       ...(defaultValue !== undefined && {
         defaultValue: Array.isArray(defaultValue)
           ? defaultValue.join(", ")

--- a/packages/hardhat/src/internal/cli/help/utils.ts
+++ b/packages/hardhat/src/internal/cli/help/utils.ts
@@ -7,6 +7,8 @@ import type { Task } from "../../../types/tasks.js";
 
 import { camelToKebabCase } from "@nomicfoundation/hardhat-utils/string";
 
+import { isOptionalArgumentType } from "../../core/tasks/utils.js";
+
 export const GLOBAL_NAME_PADDING = 6;
 
 interface ArgumentDescriptor {
@@ -84,11 +86,16 @@ export function parseOptions(task: Task): {
     });
   }
 
-  for (const { name, description, defaultValue } of task.positionalArguments) {
+  for (const {
+    name,
+    description,
+    defaultValue,
+    type,
+  } of task.positionalArguments) {
     positionalArguments.push({
       name,
       description: trimFullStop(description),
-      isRequired: defaultValue === undefined,
+      isRequired: defaultValue === undefined && !isOptionalArgumentType(type),
       ...(defaultValue !== undefined && {
         defaultValue: Array.isArray(defaultValue)
           ? defaultValue.join(", ")

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -40,7 +40,7 @@ import { parseArgumentValue } from "../core/arguments.js";
 import { buildGlobalOptionDefinitions } from "../core/global-options.js";
 import { resolveProjectRoot } from "../core/hre.js";
 import { resolvePluginList } from "../core/plugins/resolve-plugin-list.js";
-import { isOptionalArgumentType } from "../core/tasks/utils.js";
+import { isArgumentRequired } from "../core/tasks/utils.js";
 import { setGlobalHardhatRuntimeEnvironment } from "../global-hre-instance.js";
 import { createHardhatRuntimeEnvironment } from "../hre-initialization.js";
 
@@ -769,9 +769,8 @@ function validateRequiredArguments(
 ) {
   const missingRequiredArgument = argumentDefinitions.find(
     ({ defaultValue, name, type }) =>
-      defaultValue === undefined &&
-      taskArguments[name] === undefined &&
-      !isOptionalArgumentType(type),
+      isArgumentRequired(type, defaultValue) &&
+      taskArguments[name] === undefined,
   );
 
   if (missingRequiredArgument === undefined) {

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -40,6 +40,7 @@ import { parseArgumentValue } from "../core/arguments.js";
 import { buildGlobalOptionDefinitions } from "../core/global-options.js";
 import { resolveProjectRoot } from "../core/hre.js";
 import { resolvePluginList } from "../core/plugins/resolve-plugin-list.js";
+import { isOptionalArgumentType } from "../core/tasks/utils.js";
 import { setGlobalHardhatRuntimeEnvironment } from "../global-hre-instance.js";
 import { createHardhatRuntimeEnvironment } from "../hre-initialization.js";
 
@@ -767,8 +768,10 @@ function validateRequiredArguments(
   taskArguments: TaskArguments,
 ) {
   const missingRequiredArgument = argumentDefinitions.find(
-    ({ defaultValue, name }) =>
-      defaultValue === undefined && taskArguments[name] === undefined,
+    ({ defaultValue, name, type }) =>
+      defaultValue === undefined &&
+      taskArguments[name] === undefined &&
+      !isOptionalArgumentType(type),
   );
 
   if (missingRequiredArgument === undefined) {

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -204,20 +204,19 @@ export class ResolvedTask implements Task {
     argument: PositionalArgumentDefinition,
     value: ArgumentValue | ArgumentValue[],
   ) {
-    if (argument.defaultValue === undefined && value === undefined) {
-      const allowsUndefined =
-        argument.type === ArgumentType.STRING_WITHOUT_DEFAULT ||
-        argument.type === ArgumentType.FILE_WITHOUT_DEFAULT;
-
-      if (!allowsUndefined) {
-        throw new HardhatError(
-          HardhatError.ERRORS.CORE.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
-          {
-            argument: argument.name,
-            task: formatTaskId(this.id),
-          },
-        );
-      }
+    if (
+      argument.defaultValue === undefined &&
+      value === undefined &&
+      argument.type !== ArgumentType.STRING_WITHOUT_DEFAULT &&
+      argument.type !== ArgumentType.FILE_WITHOUT_DEFAULT
+    ) {
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
+        {
+          argument: argument.name,
+          task: formatTaskId(this.id),
+        },
+      );
     }
   }
 

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -207,7 +207,7 @@ export class ResolvedTask implements Task {
     if (
       argument.defaultValue === undefined &&
       value === undefined &&
-      !isOptionalArgumentType(argument.type)
+      !ResolvedTask.#isOptionalArgumentType(argument.type)
     ) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
@@ -291,11 +291,11 @@ export class ResolvedTask implements Task {
 
     return resolvedActionFn.default;
   }
-}
 
-function isOptionalArgumentType(type: ArgumentType): boolean {
-  return (
-    type === ArgumentType.STRING_WITHOUT_DEFAULT ||
-    type === ArgumentType.FILE_WITHOUT_DEFAULT
-  );
+  static #isOptionalArgumentType(type: ArgumentType): boolean {
+    return (
+      type === ArgumentType.STRING_WITHOUT_DEFAULT ||
+      type === ArgumentType.FILE_WITHOUT_DEFAULT
+    );
+  }
 }

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -22,7 +22,7 @@ import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
 import { detectPluginNpmDependencyProblems } from "../plugins/detect-plugin-npm-dependency-problems.js";
 
-import { formatTaskId, isOptionalArgumentType } from "./utils.js";
+import { formatTaskId, isArgumentRequired } from "./utils.js";
 import { validateTaskArgumentValue } from "./validations.js";
 
 export class ResolvedTask implements Task {
@@ -204,9 +204,8 @@ export class ResolvedTask implements Task {
     value: ArgumentValue | ArgumentValue[],
   ) {
     if (
-      argument.defaultValue === undefined &&
-      value === undefined &&
-      !isOptionalArgumentType(argument.type)
+      isArgumentRequired(argument.type, argument.defaultValue) &&
+      value === undefined
     ) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -1,5 +1,4 @@
 import type {
-  ArgumentType,
   ArgumentValue,
   OptionDefinition,
   PositionalArgumentDefinition,
@@ -23,7 +22,7 @@ import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
 import { detectPluginNpmDependencyProblems } from "../plugins/detect-plugin-npm-dependency-problems.js";
 
-import { formatTaskId } from "./utils.js";
+import { formatTaskId, isOptionalArgumentType } from "./utils.js";
 import { validateTaskArgumentValue } from "./validations.js";
 
 export class ResolvedTask implements Task {
@@ -207,7 +206,7 @@ export class ResolvedTask implements Task {
     if (
       argument.defaultValue === undefined &&
       value === undefined &&
-      !ResolvedTask.#isOptionalArgumentType(argument.type)
+      !isOptionalArgumentType(argument.type)
     ) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
@@ -290,9 +289,5 @@ export class ResolvedTask implements Task {
     }
 
     return resolvedActionFn.default;
-  }
-
-  static #isOptionalArgumentType(type: ArgumentType): boolean {
-    return type.endsWith("_WITHOUT_DEFAULT");
   }
 }

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -205,10 +205,11 @@ export class ResolvedTask implements Task {
     value: ArgumentValue | ArgumentValue[],
   ) {
     if (argument.defaultValue === undefined && value === undefined) {
-      if (
-        argument.type !== ArgumentType.STRING_WITHOUT_DEFAULT &&
-        argument.type !== ArgumentType.FILE_WITHOUT_DEFAULT
-      ) {
+      const allowsUndefined =
+        argument.type === ArgumentType.STRING_WITHOUT_DEFAULT ||
+        argument.type === ArgumentType.FILE_WITHOUT_DEFAULT;
+
+      if (!allowsUndefined) {
         throw new HardhatError(
           HardhatError.ERRORS.CORE.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
           {

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -20,6 +20,7 @@ import {
 } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
+import { ArgumentType } from "../../../types/arguments.js";
 import { detectPluginNpmDependencyProblems } from "../plugins/detect-plugin-npm-dependency-problems.js";
 
 import { formatTaskId } from "./utils.js";
@@ -204,13 +205,18 @@ export class ResolvedTask implements Task {
     value: ArgumentValue | ArgumentValue[],
   ) {
     if (argument.defaultValue === undefined && value === undefined) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CORE.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
-        {
-          argument: argument.name,
-          task: formatTaskId(this.id),
-        },
-      );
+      if (
+        argument.type !== ArgumentType.STRING_WITHOUT_DEFAULT &&
+        argument.type !== ArgumentType.FILE_WITHOUT_DEFAULT
+      ) {
+        throw new HardhatError(
+          HardhatError.ERRORS.CORE.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
+          {
+            argument: argument.name,
+            task: formatTaskId(this.id),
+          },
+        );
+      }
     }
   }
 

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -1,4 +1,5 @@
 import type {
+  ArgumentType,
   ArgumentValue,
   OptionDefinition,
   PositionalArgumentDefinition,
@@ -20,7 +21,6 @@ import {
 } from "@nomicfoundation/hardhat-errors";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
-import { ArgumentType } from "../../../types/arguments.js";
 import { detectPluginNpmDependencyProblems } from "../plugins/detect-plugin-npm-dependency-problems.js";
 
 import { formatTaskId } from "./utils.js";
@@ -293,9 +293,6 @@ export class ResolvedTask implements Task {
   }
 
   static #isOptionalArgumentType(type: ArgumentType): boolean {
-    return (
-      type === ArgumentType.STRING_WITHOUT_DEFAULT ||
-      type === ArgumentType.FILE_WITHOUT_DEFAULT
-    );
+    return type.endsWith("_WITHOUT_DEFAULT");
   }
 }

--- a/packages/hardhat/src/internal/core/tasks/resolved-task.ts
+++ b/packages/hardhat/src/internal/core/tasks/resolved-task.ts
@@ -207,8 +207,7 @@ export class ResolvedTask implements Task {
     if (
       argument.defaultValue === undefined &&
       value === undefined &&
-      argument.type !== ArgumentType.STRING_WITHOUT_DEFAULT &&
-      argument.type !== ArgumentType.FILE_WITHOUT_DEFAULT
+      !isOptionalArgumentType(argument.type)
     ) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.TASK_DEFINITIONS.MISSING_VALUE_FOR_TASK_ARGUMENT,
@@ -292,4 +291,11 @@ export class ResolvedTask implements Task {
 
     return resolvedActionFn.default;
   }
+}
+
+function isOptionalArgumentType(type: ArgumentType): boolean {
+  return (
+    type === ArgumentType.STRING_WITHOUT_DEFAULT ||
+    type === ArgumentType.FILE_WITHOUT_DEFAULT
+  );
 }

--- a/packages/hardhat/src/internal/core/tasks/utils.ts
+++ b/packages/hardhat/src/internal/core/tasks/utils.ts
@@ -1,3 +1,5 @@
+import type { ArgumentType, ArgumentValue } from "../../../types/arguments.js";
+
 export function formatTaskId(taskId: string | string[]): string {
   if (typeof taskId === "string") {
     return taskId;
@@ -10,13 +12,13 @@ export function getActorFragment(pluginId: string | undefined): string {
   return pluginId !== undefined ? `Plugin ${pluginId} is` : "You are";
 }
 
-export function isOptionalArgumentType(type: string): boolean {
+export function isOptionalArgumentType(type: ArgumentType): boolean {
   return type.endsWith("_WITHOUT_DEFAULT");
 }
 
 export function isArgumentRequired(
-  type: string,
-  defaultValue: unknown,
+  type: ArgumentType,
+  defaultValue: ArgumentValue | ArgumentValue[] | undefined,
 ): boolean {
   return defaultValue === undefined && !isOptionalArgumentType(type);
 }

--- a/packages/hardhat/src/internal/core/tasks/utils.ts
+++ b/packages/hardhat/src/internal/core/tasks/utils.ts
@@ -10,10 +10,13 @@ export function getActorFragment(pluginId: string | undefined): string {
   return pluginId !== undefined ? `Plugin ${pluginId} is` : "You are";
 }
 
+export function isOptionalArgumentType(type: string): boolean {
+  return type.endsWith("_WITHOUT_DEFAULT");
+}
 
 export function isArgumentRequired(
   type: string,
   defaultValue: unknown,
 ): boolean {
-  return defaultValue === undefined && !type.endsWith("_WITHOUT_DEFAULT");
+  return defaultValue === undefined && !isOptionalArgumentType(type);
 }

--- a/packages/hardhat/src/internal/core/tasks/utils.ts
+++ b/packages/hardhat/src/internal/core/tasks/utils.ts
@@ -10,6 +10,10 @@ export function getActorFragment(pluginId: string | undefined): string {
   return pluginId !== undefined ? `Plugin ${pluginId} is` : "You are";
 }
 
-export function isOptionalArgumentType(type: string): boolean {
-  return type.endsWith("_WITHOUT_DEFAULT");
+
+export function isArgumentRequired(
+  type: string,
+  defaultValue: unknown,
+): boolean {
+  return defaultValue === undefined && !type.endsWith("_WITHOUT_DEFAULT");
 }

--- a/packages/hardhat/src/internal/core/tasks/utils.ts
+++ b/packages/hardhat/src/internal/core/tasks/utils.ts
@@ -9,3 +9,7 @@ export function formatTaskId(taskId: string | string[]): string {
 export function getActorFragment(pluginId: string | undefined): string {
   return pluginId !== undefined ? `Plugin ${pluginId} is` : "You are";
 }
+
+export function isOptionalArgumentType(type: string): boolean {
+  return type.endsWith("_WITHOUT_DEFAULT");
+}

--- a/packages/hardhat/src/internal/core/tasks/validations.ts
+++ b/packages/hardhat/src/internal/core/tasks/validations.ts
@@ -19,7 +19,7 @@ import {
   validateArgumentValue,
 } from "../arguments.js";
 
-import { formatTaskId } from "./utils.js";
+import { isArgumentRequired, formatTaskId } from "./utils.js";
 
 export function validateId(id: string | string[]): void {
   if (id.length === 0) {
@@ -133,8 +133,8 @@ export function validatePositionalArgument(
 
   if (
     lastArg !== undefined &&
-    lastArg.defaultValue !== undefined &&
-    defaultValue === undefined
+    !isArgumentRequired(lastArg.type, lastArg.defaultValue) &&
+    isArgumentRequired(type, defaultValue)
   ) {
     throw new HardhatError(
       HardhatError.ERRORS.CORE.TASK_DEFINITIONS.REQUIRED_ARG_AFTER_OPTIONAL,

--- a/packages/hardhat/test/internal/cli/help/utils.ts
+++ b/packages/hardhat/test/internal/cli/help/utils.ts
@@ -360,6 +360,52 @@ describe("utils", function () {
         ],
       });
     });
+
+    for (const argType of [
+      ArgumentType.STRING_WITHOUT_DEFAULT,
+      ArgumentType.FILE_WITHOUT_DEFAULT,
+    ] as const) {
+      it(`should mark ${argType} positional argument as optional`, function () {
+        const task: Task = {
+          id: ["task"],
+          description: "task description",
+          actions: [
+            {
+              pluginId: "task-plugin-id",
+              action: async () => ({
+                default: () => {},
+              }),
+            },
+          ],
+          options: new Map(),
+          positionalArguments: [
+            {
+              name: "posArg",
+              description: "An optional argument",
+              type: argType,
+              isVariadic: false,
+            },
+          ],
+          pluginId: "task-plugin-id",
+          subtasks: new Map(),
+          isEmpty: false,
+          run: async () => {},
+        };
+
+        const result = parseOptions(task);
+
+        assert.deepEqual(result, {
+          options: [],
+          positionalArguments: [
+            {
+              name: "posArg",
+              description: "An optional argument",
+              isRequired: false,
+            },
+          ],
+        });
+      });
+    }
   });
 
   describe("toCommandLineOption", function () {

--- a/packages/hardhat/test/internal/cli/main.ts
+++ b/packages/hardhat/test/internal/cli/main.ts
@@ -1477,6 +1477,65 @@ GLOBAL OPTIONS:
       });
     });
 
+    describe("task with _WITHOUT_DEFAULT positional arguments", function () {
+      for (const argType of [
+        ArgumentType.STRING_WITHOUT_DEFAULT,
+        ArgumentType.FILE_WITHOUT_DEFAULT,
+      ] as const) {
+        describe(argType, function () {
+          before(async function () {
+            tasksBuilders = [
+              task(["task0"]).addPositionalArgument({
+                name: "arg",
+                type: argType,
+              }),
+            ];
+
+            subtasksBuilders = [];
+
+            ({ hre, tasks, subtasks } = await getTasksAndHreEnvironment(
+              tasksBuilders,
+              subtasksBuilders,
+            ));
+          });
+
+          it("should not throw when no value is provided", function () {
+            const command = "npx hardhat task0";
+
+            const cliArguments = command.split(" ").slice(2);
+            const usedCliArguments = [false];
+
+            const res = parseTaskAndArguments(
+              cliArguments,
+              usedCliArguments,
+              hre,
+            );
+
+            assert.ok(!Array.isArray(res), "Result should not be an array");
+            assert.equal(res.task.id, tasks[0].id);
+            assert.deepEqual(res.taskArguments, {});
+          });
+
+          it("should accept a value when one is provided", function () {
+            const command = "npx hardhat task0 myValue";
+
+            const cliArguments = command.split(" ").slice(2);
+            const usedCliArguments = new Array(cliArguments.length).fill(false);
+
+            const res = parseTaskAndArguments(
+              cliArguments,
+              usedCliArguments,
+              hre,
+            );
+
+            assert.ok(!Array.isArray(res), "Result should not be an array");
+            assert.equal(res.task.id, tasks[0].id);
+            assert.deepEqual(res.taskArguments, { arg: "myValue" });
+          });
+        });
+      }
+    });
+
     describe("task and subtask with variadic arguments", function () {
       before(async function () {
         tasksBuilders = [

--- a/packages/hardhat/test/internal/core/tasks/builders.ts
+++ b/packages/hardhat/test/internal/core/tasks/builders.ts
@@ -1059,6 +1059,33 @@ describe("Task builders", () => {
         );
       });
 
+      for (const argType of [
+        ArgumentType.STRING_WITHOUT_DEFAULT,
+        ArgumentType.FILE_WITHOUT_DEFAULT,
+      ] as const) {
+        it(`should throw if trying to add a required positional argument after a ${argType} one`, () => {
+          const builder = new NewTaskDefinitionBuilderImplementation("task-id");
+
+          builder.addPositionalArgument({
+            name: "arg",
+            type: argType,
+          });
+
+          assertThrowsHardhatError(
+            () => builder.addPositionalArgument({ name: "arg2" }),
+            HardhatError.ERRORS.CORE.TASK_DEFINITIONS
+              .REQUIRED_ARG_AFTER_OPTIONAL,
+            { name: "arg2" },
+          );
+          assertThrowsHardhatError(
+            () => builder.addVariadicArgument({ name: "arg3" }),
+            HardhatError.ERRORS.CORE.TASK_DEFINITIONS
+              .REQUIRED_ARG_AFTER_OPTIONAL,
+            { name: "arg3" },
+          );
+        });
+      }
+
       it("should throw if trying to add a positional argument after a variadic one", () => {
         const builder = new NewTaskDefinitionBuilderImplementation("task-id");
 

--- a/packages/hardhat/test/internal/core/tasks/task-manager.ts
+++ b/packages/hardhat/test/internal/core/tasks/task-manager.ts
@@ -2362,6 +2362,68 @@ describe("TaskManagerImplementation", () => {
         );
       });
 
+      it("should not throw for STRING_WITHOUT_DEFAULT positional argument with no value", async () => {
+        let receivedValue: unknown;
+        const hre = await HardhatRuntimeEnvironmentImplementation.create(
+          {
+            plugins: [
+              {
+                id: "plugin1",
+                tasks: [
+                  new NewTaskDefinitionBuilderImplementation("task1")
+                    .addPositionalArgument({
+                      name: "posArg",
+                      type: ArgumentType.STRING_WITHOUT_DEFAULT,
+                    })
+                    .setAction(async () => ({
+                      default: ({ posArg }: { posArg: unknown }) => {
+                        receivedValue = posArg;
+                      },
+                    }))
+                    .build(),
+                ],
+              },
+            ],
+          },
+          {},
+        );
+
+        const task1 = hre.tasks.getTask("task1");
+        await task1.run({});
+        assert.equal(receivedValue, undefined);
+      });
+
+      it("should not throw for FILE_WITHOUT_DEFAULT positional argument with no value", async () => {
+        let receivedValue: unknown;
+        const hre = await HardhatRuntimeEnvironmentImplementation.create(
+          {
+            plugins: [
+              {
+                id: "plugin1",
+                tasks: [
+                  new NewTaskDefinitionBuilderImplementation("task1")
+                    .addPositionalArgument({
+                      name: "posArg",
+                      type: ArgumentType.FILE_WITHOUT_DEFAULT,
+                    })
+                    .setAction(async () => ({
+                      default: ({ posArg }: { posArg: unknown }) => {
+                        receivedValue = posArg;
+                      },
+                    }))
+                    .build(),
+                ],
+              },
+            ],
+          },
+          {},
+        );
+
+        const task1 = hre.tasks.getTask("task1");
+        await task1.run({});
+        assert.equal(receivedValue, undefined);
+      });
+
       it("should throw if the provided value for the argument is not of the correct type", async () => {
         const hre = await HardhatRuntimeEnvironmentImplementation.create(
           {

--- a/packages/hardhat/test/internal/core/tasks/task-manager.ts
+++ b/packages/hardhat/test/internal/core/tasks/task-manager.ts
@@ -2362,67 +2362,41 @@ describe("TaskManagerImplementation", () => {
         );
       });
 
-      it("should not throw for STRING_WITHOUT_DEFAULT positional argument with no value", async () => {
-        let receivedValue: unknown;
-        const hre = await HardhatRuntimeEnvironmentImplementation.create(
-          {
-            plugins: [
-              {
-                id: "plugin1",
-                tasks: [
-                  new NewTaskDefinitionBuilderImplementation("task1")
-                    .addPositionalArgument({
-                      name: "posArg",
-                      type: ArgumentType.STRING_WITHOUT_DEFAULT,
-                    })
-                    .setAction(async () => ({
-                      default: ({ posArg }: { posArg: unknown }) => {
-                        receivedValue = posArg;
-                      },
-                    }))
-                    .build(),
-                ],
-              },
-            ],
-          },
-          {},
-        );
+      for (const argType of [
+        ArgumentType.STRING_WITHOUT_DEFAULT,
+        ArgumentType.FILE_WITHOUT_DEFAULT,
+      ] as const) {
+        it(`should not throw for ${argType} positional argument with no value`, async () => {
+          let receivedValue: unknown;
+          const hre = await HardhatRuntimeEnvironmentImplementation.create(
+            {
+              plugins: [
+                {
+                  id: "plugin1",
+                  tasks: [
+                    new NewTaskDefinitionBuilderImplementation("task1")
+                      .addPositionalArgument({
+                        name: "posArg",
+                        type: argType,
+                      })
+                      .setAction(async () => ({
+                        default: ({ posArg }: { posArg: unknown }) => {
+                          receivedValue = posArg;
+                        },
+                      }))
+                      .build(),
+                  ],
+                },
+              ],
+            },
+            {},
+          );
 
-        const task1 = hre.tasks.getTask("task1");
-        await task1.run({});
-        assert.equal(receivedValue, undefined);
-      });
-
-      it("should not throw for FILE_WITHOUT_DEFAULT positional argument with no value", async () => {
-        let receivedValue: unknown;
-        const hre = await HardhatRuntimeEnvironmentImplementation.create(
-          {
-            plugins: [
-              {
-                id: "plugin1",
-                tasks: [
-                  new NewTaskDefinitionBuilderImplementation("task1")
-                    .addPositionalArgument({
-                      name: "posArg",
-                      type: ArgumentType.FILE_WITHOUT_DEFAULT,
-                    })
-                    .setAction(async () => ({
-                      default: ({ posArg }: { posArg: unknown }) => {
-                        receivedValue = posArg;
-                      },
-                    }))
-                    .build(),
-                ],
-              },
-            ],
-          },
-          {},
-        );
-
-        const task1 = hre.tasks.getTask("task1");
-        await task1.run({});
-        assert.equal(receivedValue, undefined);
-      });
+          const task1 = hre.tasks.getTask("task1");
+          await task1.run({});
+          assert.equal(receivedValue, undefined);
+        });
+      }
 
       it("should throw if the provided value for the argument is not of the correct type", async () => {
         const hre = await HardhatRuntimeEnvironmentImplementation.create(

--- a/packages/hardhat/test/internal/core/tasks/task-manager.ts
+++ b/packages/hardhat/test/internal/core/tasks/task-manager.ts
@@ -2396,6 +2396,37 @@ describe("TaskManagerImplementation", () => {
           await task1.run({});
           assert.equal(receivedValue, undefined);
         });
+
+        it(`should not throw for ${argType} variadic argument with no value`, async () => {
+          let receivedValue: unknown;
+          const hre = await HardhatRuntimeEnvironmentImplementation.create(
+            {
+              plugins: [
+                {
+                  id: "plugin1",
+                  tasks: [
+                    new NewTaskDefinitionBuilderImplementation("task1")
+                      .addVariadicArgument({
+                        name: "posArg",
+                        type: argType,
+                      })
+                      .setAction(async () => ({
+                        default: ({ posArg }: { posArg: unknown }) => {
+                          receivedValue = posArg;
+                        },
+                      }))
+                      .build(),
+                  ],
+                },
+              ],
+            },
+            {},
+          );
+
+          const task1 = hre.tasks.getTask("task1");
+          await task1.run({});
+          assert.equal(receivedValue, undefined);
+        });
       }
 
       it("should throw if the provided value for the argument is not of the correct type", async () => {


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary
>Closes #6683

Using `STRING_WITHOUT_DEFAULT` or `FILE_WITHOUT_DEFAULT` with `addPositionalArgument` throws `HHE505: Missing value for the task argument` at runtime, even though these types define `undefined` as a valid value.

## Context

`#validateRequiredArgument` checks `defaultValue === undefined` to decide if an argument is required. This cannot distinguish "no default provided" (required) from "default is explicitly `undefined`" (optional).

## Fix

The fix extracts an `#isOptionalArgumentType` check that matches any `ArgumentType` ending with `_WITHOUT_DEFAULT`. So, future optional types following the same naming convention are covered automatically.

For all other types, `defaultValue === undefined` still throws an error as "required". 

## Tests

`packages/hardhat/test/internal/core/tasks/task-manager.ts`:
- `STRING_WITHOUT_DEFAULT` positional arg: task runs without error when no value is provided
- `FILE_WITHOUT_DEFAULT` positional arg: same behavior

## Notes

- An alternative approach would be introducing an explicit `--optional` flag on `addPositionalArgument`, but the type system already encodes this information via `_WITHOUT_DEFAULT` types, so this fix seemed to have less friction on UX.

- This is not a breaking change. No existing code could depend on the previous behavior: hard crash (`HHE505`)

## Changeset

Included. `patch` on `hardhat`.
