### PR TITLE
Introduce `definePlugin`, use it in all the official plugins, and warn about unused plugins

### DIFF
--- a/.changeset/define-plugin.md
+++ b/.changeset/define-plugin.md
@@ -1,0 +1,20 @@
+---
+"hardhat": minor
+---
+
+Added `definePlugin`, a new helper exported from `hardhat/plugins`. Plugin authors should wrap their plugin literal with it so the default export of their `index` module becomes:
+
+```ts
+import type { HardhatPlugin } from "hardhat/types/plugins";
+
+import { definePlugin } from "hardhat/plugins";
+
+const hardhatPlugin: HardhatPlugin = definePlugin({
+  id: "my-plugin",
+  // ...
+});
+
+export default hardhatPlugin;
+```
+
+`definePlugin` returns its argument unchanged and, as a side effect, registers the plugin's id in a process-wide registry of loaded plugins. Hardhat's CLI uses that registry to warn when a plugin is imported but missing from the user's `plugins` array.

--- a/.changeset/hardhat-ethers-chai-matchers-uses-define-plugin.md
+++ b/.changeset/hardhat-ethers-chai-matchers-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers-chai-matchers": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-ethers-uses-define-plugin.md
+++ b/.changeset/hardhat-ethers-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-foundry-uses-define-plugin.md
+++ b/.changeset/hardhat-foundry-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-foundry": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-ignition-ethers-uses-define-plugin.md
+++ b/.changeset/hardhat-ignition-ethers-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition-ethers": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-ignition-uses-define-plugin.md
+++ b/.changeset/hardhat-ignition-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-ignition-viem-uses-define-plugin.md
+++ b/.changeset/hardhat-ignition-viem-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition-viem": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-keystore-uses-define-plugin.md
+++ b/.changeset/hardhat-keystore-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-keystore": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-ledger-uses-define-plugin.md
+++ b/.changeset/hardhat-ledger-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ledger": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-mocha-uses-define-plugin.md
+++ b/.changeset/hardhat-mocha-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-mocha": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-network-helpers-uses-define-plugin.md
+++ b/.changeset/hardhat-network-helpers-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-network-helpers": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-node-test-runner-uses-define-plugin.md
+++ b/.changeset/hardhat-node-test-runner-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-node-test-runner": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-toolbox-mocha-ethers-uses-define-plugin.md
+++ b/.changeset/hardhat-toolbox-mocha-ethers-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-toolbox-mocha-ethers": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-toolbox-viem-uses-define-plugin.md
+++ b/.changeset/hardhat-toolbox-viem-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-toolbox-viem": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-typechain-uses-define-plugin.md
+++ b/.changeset/hardhat-typechain-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-typechain": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-verify-uses-define-plugin.md
+++ b/.changeset/hardhat-verify-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-viem-assertions-uses-define-plugin.md
+++ b/.changeset/hardhat-viem-assertions-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/hardhat-viem-uses-define-plugin.md
+++ b/.changeset/hardhat-viem-uses-define-plugin.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+The plugin now uses `definePlugin` from `hardhat/plugins` in its `index.ts`, so it participates in Hardhat's new "imported but unused plugin" warning when omitted from a project's `plugins` array.

--- a/.changeset/templates-verbatim-module-syntax.md
+++ b/.changeset/templates-verbatim-module-syntax.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+The sample projects initialized with `hardhat --init` now set `verbatimModuleSyntax: true` in their `tsconfig.json`. This ensures that plugin imports in `hardhat.config.ts` are actually evaluated at runtime, which is required for the new "imported but unused plugin" warning to work reliably.

--- a/.changeset/warn-unused-plugins.md
+++ b/.changeset/warn-unused-plugins.md
@@ -1,0 +1,7 @@
+---
+"hardhat": minor
+---
+
+Hardhat now warns when a plugin is imported in `hardhat.config.ts` but missing from the `plugins` array. The warning is printed to stderr after the runtime environment is created, listing the offending plugins and pointing the user at the fix.
+
+For the warning to be reliable, your project's `tsconfig.json` must enable `verbatimModuleSyntax: true`. Without it, TypeScript deletes unused default-value imports, so an unused plugin can't be detected.

--- a/.changeset/warn-unused-plugins.md
+++ b/.changeset/warn-unused-plugins.md
@@ -2,6 +2,6 @@
 "hardhat": minor
 ---
 
-Hardhat now warns when a plugin is imported in `hardhat.config.ts` but missing from the `plugins` array. The warning is printed to stderr after the runtime environment is created, listing the offending plugins and pointing the user at the fix.
+Hardhat now warns when a plugin is imported in your Hardhat config file but missing from the `plugins` array. The warning is printed to stderr after the runtime environment is created, listing the offending plugins and pointing the user at the fix.
 
-For the warning to be reliable, your project's `tsconfig.json` must enable `verbatimModuleSyntax: true`. Without it, TypeScript deletes unused default-value imports, so an unused plugin can't be detected.
+If your Hardhat config file is written in TypeScript, for the warning to be reliable your project's `tsconfig.json` must enable `verbatimModuleSyntax: true`. Without it, TypeScript deletes unused default-value imports, so an unused plugin can't be detected.

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -6,5 +6,101 @@
     "packages/hardhat/templates",
     "packages/config"
   ],
-  "bumps": []
+  "bumps": [
+    {
+      "package": "@nomicfoundation/hardhat-typechain",
+      "peer": "hardhat",
+      "reason": "It uses the new processArtifactsAfterSuccessfulBuild hook"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-ethers",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-ethers-chai-matchers",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-foundry",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-ignition",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-ignition-ethers",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-ignition-viem",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-keystore",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-ledger",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-mocha",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-network-helpers",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-node-test-runner",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-solx",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-toolbox-mocha-ethers",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-toolbox-viem",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-typechain",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-verify",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-viem",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    },
+    {
+      "package": "@nomicfoundation/hardhat-viem-assertions",
+      "peer": "hardhat",
+      "reason": "It uses `definePlugin` from `hardhat/plugins`"
+    }
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Use `await import` only if one of these conditions is met:
 5. The import has to happen at a certain point in time (mostly used for import side-effects, e.g. `await import(...)` without doing anything with the imported module)
 6. If there's a comment justifying it, and the imported module is cached (i.e. not running `await import(...)` every time, but instead doing something like `if (cachedModule === undefined) { cachedModule = await import(...) }`). Some code duplication in this case is acceptable if that avoids adding unnecessary async logic (e.g. avoid `const module = await getModule()` to avoid repeating just a few conditionals).
 
-The only accepted imports in the `index.ts` file of plugins (both built-in and external) are their `type-extension`, types and `enums` from `hardhat`, and `hardhat/config`, and potentially a simple file with constants. They can also import files that follow these same rules and restrictions. Everything else should be imported by a callback registered in the plugin object.
+The only accepted imports in the `index.ts` file of plugins (both built-in and external) are their `type-extension`, types and `enums` from `hardhat`, `hardhat/config`, `hardhat/plugins` (for `definePlugin`), and potentially a simple file with constants. They can also import files that follow these same rules and restrictions. Everything else should be imported by a callback registered in the plugin object.
 
 Test files are free to use `await import` freely.
 

--- a/docs/engineering-guidelines.md
+++ b/docs/engineering-guidelines.md
@@ -14,7 +14,7 @@ The intention behind the current separation of part of `hardhat` into the `core/
 
 The entry-point of the plugins are meant to only export a description of the plugin, and not implement any functionality. Please don’t import anything in those files.
 
-The only accepted imports in the `index.ts` file of plugins (both built-in and external) are their `type-extension`, types and `enums` from `hardhat`, and `hardhat/config`, and potentially a simple file with constants. They can also import files that follow these same rules and restrictions. Everything else should be imported by a callback registered in the plugin object.
+The only accepted imports in the `index.ts` file of plugins (both built-in and external) are their `type-extension`, types and `enums` from `hardhat`, `hardhat/config`, `hardhat/plugins` (for `definePlugin`), and potentially a simple file with constants. They can also import files that follow these same rules and restrictions. Everything else should be imported by a callback registered in the plugin object.
 
 ## A3: Always initialize the HRE using the `hre-initialization` module inside of `hardhat`
 

--- a/packages/example-project/test/node/example-test-of-assertions.ts
+++ b/packages/example-project/test/node/example-test-of-assertions.ts
@@ -1,6 +1,6 @@
 import { describe, it, before } from "node:test";
 import hre from "hardhat";
-import { ContractReturnType } from "@nomicfoundation/hardhat-viem/types";
+import type { ContractReturnType } from "@nomicfoundation/hardhat-viem/types";
 
 const { viem } = await hre.network.create();
 

--- a/packages/example-project/tsconfig.json
+++ b/packages/example-project/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../config/tsconfig.base.json",
   "compilerOptions": {
     "isolatedDeclarations": false,
+    "verbatimModuleSyntax": true,
     "types": ["node", "mocha"]
   },
   "references": [

--- a/packages/hardhat-ethers-chai-matchers/src/index.ts
+++ b/packages/hardhat-ethers-chai-matchers/src/index.ts
@@ -1,14 +1,16 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 export type * from "./type-extensions.js";
 
-const hardhatChaiMatchersPlugin: HardhatPlugin = {
+const hardhatChaiMatchersPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-ethers-chai-matchers",
   hookHandlers: {
     network: () => import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ethers-chai-matchers",
   dependencies: () => [import("@nomicfoundation/hardhat-ethers")],
-};
+});
 
 export default hardhatChaiMatchersPlugin;

--- a/packages/hardhat-ethers/src/index.ts
+++ b/packages/hardhat-ethers/src/index.ts
@@ -1,13 +1,15 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 export type * from "./type-extensions.js";
 
-const hardhatEthersPlugin: HardhatPlugin = {
+const hardhatEthersPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-ethers",
   hookHandlers: {
     network: () => import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ethers",
-};
+});
 
 export default hardhatEthersPlugin;

--- a/packages/hardhat-foundry/src/index.ts
+++ b/packages/hardhat-foundry/src/index.ts
@@ -1,10 +1,12 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
-const hardhatFoundry: HardhatPlugin = {
+import { definePlugin } from "hardhat/plugins";
+
+const hardhatFoundry: HardhatPlugin = definePlugin({
   id: "@nomicfoundation/hardhat-foundry",
   hookHandlers: {
     solidity: () => import("./internal/hook-handlers/solidity.js"),
   },
-};
+});
 
 export default hardhatFoundry;

--- a/packages/hardhat-ignition-ethers/src/index.ts
+++ b/packages/hardhat-ignition-ethers/src/index.ts
@@ -1,8 +1,10 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 export type * from "./type-extensions.js";
 
-const hardhatIgnitionEthersPlugin: HardhatPlugin = {
+const hardhatIgnitionEthersPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-ignition-ethers",
   dependencies: () => [
     import("@nomicfoundation/hardhat-ignition"),
@@ -12,6 +14,6 @@ const hardhatIgnitionEthersPlugin: HardhatPlugin = {
     network: () => import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ignition-ethers",
-};
+});
 
 export default hardhatIgnitionEthersPlugin;

--- a/packages/hardhat-ignition-viem/src/index.ts
+++ b/packages/hardhat-ignition-viem/src/index.ts
@@ -1,8 +1,10 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 export type * from "./type-extensions.js";
 
-const hardhatIgnitionViemPlugin: HardhatPlugin = {
+const hardhatIgnitionViemPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-ignition-viem",
   dependencies: () => [
     import("@nomicfoundation/hardhat-ignition"),
@@ -12,6 +14,6 @@ const hardhatIgnitionViemPlugin: HardhatPlugin = {
     network: () => import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ignition-viem",
-};
+});
 
 export default hardhatIgnitionViemPlugin;

--- a/packages/hardhat-ignition/src/index.ts
+++ b/packages/hardhat-ignition/src/index.ts
@@ -1,13 +1,14 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
 import { emptyTask, task } from "hardhat/config";
+import { definePlugin } from "hardhat/plugins";
 import { ArgumentType } from "hardhat/types/arguments";
 
 import { PLUGIN_ID } from "./internal/constants.js";
 
 export type * from "./type-extensions.js";
 
-const hardhatIgnitionPlugin: HardhatPlugin = {
+const hardhatIgnitionPlugin: HardhatPlugin = definePlugin({
   id: PLUGIN_ID,
   npmPackage: "@nomicfoundation/hardhat-ignition",
   hookHandlers: {
@@ -156,6 +157,6 @@ const hardhatIgnitionPlugin: HardhatPlugin = {
       .setAction(() => import("./internal/tasks/migrate.js"))
       .build(),
   ],
-};
+});
 
 export default hardhatIgnitionPlugin;

--- a/packages/hardhat-keystore/src/index.ts
+++ b/packages/hardhat-keystore/src/index.ts
@@ -3,11 +3,12 @@ import type { HardhatPlugin } from "hardhat/types/plugins";
 export type * from "./internal/type-extensions.js";
 
 import { emptyTask, task } from "hardhat/config";
+import { definePlugin } from "hardhat/plugins";
 import { ArgumentType } from "hardhat/types/arguments";
 
 import { PLUGIN_ID } from "./internal/constants.js";
 
-const hardhatKeystorePlugin: HardhatPlugin = {
+const hardhatKeystorePlugin: HardhatPlugin = definePlugin({
   id: PLUGIN_ID,
   hookHandlers: {
     config: () => import("./internal/hook-handlers/config.js"),
@@ -125,6 +126,6 @@ const hardhatKeystorePlugin: HardhatPlugin = {
       .build(),
   ],
   npmPackage: "@nomicfoundation/hardhat-keystore",
-};
+});
 
 export default hardhatKeystorePlugin;

--- a/packages/hardhat-ledger/src/index.ts
+++ b/packages/hardhat-ledger/src/index.ts
@@ -2,15 +2,17 @@ import type { HardhatPlugin } from "hardhat/types/plugins";
 
 export type * from "./type-extensions.js";
 
+import { definePlugin } from "hardhat/plugins";
+
 import { PLUGIN_NAME } from "./internal/plugin-name.js";
 
-const hardhatLedgerPlugin: HardhatPlugin = {
+const hardhatLedgerPlugin: HardhatPlugin = definePlugin({
   id: PLUGIN_NAME,
   hookHandlers: {
     config: () => import("./internal/hook-handlers/config.js"),
     network: () => import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-ledger",
-};
+});
 
 export default hardhatLedgerPlugin;

--- a/packages/hardhat-mocha/src/index.ts
+++ b/packages/hardhat-mocha/src/index.ts
@@ -1,11 +1,12 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
 import { task } from "hardhat/config";
+import { definePlugin } from "hardhat/plugins";
 import { ArgumentType } from "hardhat/types/arguments";
 
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-mocha",
   tasks: [
     task(["test", "mocha"], "Runs tests using the Mocha test runner")
@@ -36,6 +37,6 @@ const hardhatPlugin: HardhatPlugin = {
     test: () => import("./hookHandlers/test.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-mocha",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat-network-helpers/src/index.ts
+++ b/packages/hardhat-network-helpers/src/index.ts
@@ -1,13 +1,15 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 export type * from "./type-extensions.js";
 
-const hardhatNetworkHelpersPlugin: HardhatPlugin = {
+const hardhatNetworkHelpersPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-network-helpers",
   hookHandlers: {
     network: () => import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-network-helpers",
-};
+});
 
 export default hardhatNetworkHelpersPlugin;

--- a/packages/hardhat-node-test-runner/src/index.ts
+++ b/packages/hardhat-node-test-runner/src/index.ts
@@ -1,11 +1,12 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
 import { task } from "hardhat/config";
+import { definePlugin } from "hardhat/plugins";
 import { ArgumentType } from "hardhat/types/arguments";
 
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-node-test-runner",
   tasks: [
     task(["test", "nodejs"], "Runs tests using the NodeJS test runner")
@@ -44,6 +45,6 @@ const hardhatPlugin: HardhatPlugin = {
     test: () => import("./hookHandlers/test.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-node-test-runner",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat-solx/src/index.ts
+++ b/packages/hardhat-solx/src/index.ts
@@ -1,14 +1,16 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 export type * from "./type-extensions.js";
 
-const hardhatSolxPlugin: HardhatPlugin = {
+const hardhatSolxPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-solx",
   npmPackage: "@nomicfoundation/hardhat-solx",
   hookHandlers: {
     config: () => import("./internal/hook-handlers/config.js"),
     solidity: () => import("./internal/hook-handlers/solidity.js"),
   },
-};
+});
 
 export default hardhatSolxPlugin;

--- a/packages/hardhat-toolbox-mocha-ethers/src/index.ts
+++ b/packages/hardhat-toolbox-mocha-ethers/src/index.ts
@@ -1,8 +1,10 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 export type * from "./type-extensions.js";
 
-const hardhatToolboxMochaEthersPlugin: HardhatPlugin = {
+const hardhatToolboxMochaEthersPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-toolbox-mocha-ethers",
   dependencies: () => [
     import("@nomicfoundation/hardhat-ethers"),
@@ -15,6 +17,6 @@ const hardhatToolboxMochaEthersPlugin: HardhatPlugin = {
     import("@nomicfoundation/hardhat-verify"),
   ],
   npmPackage: "@nomicfoundation/hardhat-toolbox-mocha-ethers",
-};
+});
 
 export default hardhatToolboxMochaEthersPlugin;

--- a/packages/hardhat-toolbox-viem/src/index.ts
+++ b/packages/hardhat-toolbox-viem/src/index.ts
@@ -1,8 +1,10 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 export type * from "./type-extensions.js";
 
-const hardhatToolboxViemPlugin: HardhatPlugin = {
+const hardhatToolboxViemPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-toolbox-viem",
   dependencies: () => [
     import("@nomicfoundation/hardhat-ignition-viem"),
@@ -14,6 +16,6 @@ const hardhatToolboxViemPlugin: HardhatPlugin = {
     import("@nomicfoundation/hardhat-verify"),
   ],
   npmPackage: "@nomicfoundation/hardhat-toolbox-viem",
-};
+});
 
 export default hardhatToolboxViemPlugin;

--- a/packages/hardhat-typechain/src/index.ts
+++ b/packages/hardhat-typechain/src/index.ts
@@ -1,10 +1,11 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
 import { globalFlag } from "hardhat/config";
+import { definePlugin } from "hardhat/plugins";
 
 export type * from "./type-extensions.js";
 
-const hardhatTypechain: HardhatPlugin = {
+const hardhatTypechain: HardhatPlugin = definePlugin({
   id: "hardhat-typechain",
   hookHandlers: {
     config: () => import("./internal/hook-handlers/config.js"),
@@ -19,6 +20,6 @@ const hardhatTypechain: HardhatPlugin = {
       description: "Disables the typechain type generation",
     }),
   ],
-};
+});
 
 export default hardhatTypechain;

--- a/packages/hardhat-verify/src/index.ts
+++ b/packages/hardhat-verify/src/index.ts
@@ -1,5 +1,7 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 import verifyBlockscoutTask from "./internal/tasks/verify/blockscout/index.js";
 import verifyEtherscanTask from "./internal/tasks/verify/etherscan/index.js";
 import verifyTask from "./internal/tasks/verify/index.js";
@@ -7,7 +9,7 @@ import verifySourcifyTask from "./internal/tasks/verify/sourcify/index.js";
 
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-verify",
   hookHandlers: {
     config: () => import("./internal/hook-handlers/config.js"),
@@ -20,6 +22,6 @@ const hardhatPlugin: HardhatPlugin = {
     verifySourcifyTask,
   ],
   npmPackage: "@nomicfoundation/hardhat-verify",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat-viem-assertions/src/index.ts
+++ b/packages/hardhat-viem-assertions/src/index.ts
@@ -1,14 +1,16 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-viem-assertions",
   dependencies: () => [import("@nomicfoundation/hardhat-viem")],
   hookHandlers: {
     network: () => import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-viem-assertions",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat-viem/src/index.ts
+++ b/packages/hardhat-viem/src/index.ts
@@ -1,13 +1,15 @@
 import type { HardhatPlugin } from "hardhat/types/plugins";
 
+import { definePlugin } from "hardhat/plugins";
+
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "hardhat-viem",
   hookHandlers: {
     network: () => import("./internal/hook-handlers/network.js"),
   },
   npmPackage: "@nomicfoundation/hardhat-viem",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/cli.ts
+++ b/packages/hardhat/src/cli.ts
@@ -24,4 +24,7 @@ function isTsxRequired(): boolean {
 }
 
 // eslint-disable-next-line no-restricted-syntax -- We do want TLA here
-await main(process.argv.slice(2), { registerTsx: isTsxRequired() });
+await main(process.argv.slice(2), {
+  registerTsx: isTsxRequired(),
+  warnAboutUnusedPlugins: true,
+});

--- a/packages/hardhat/src/internal/builtin-plugins/artifacts/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/artifacts/index.ts
@@ -1,12 +1,15 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
+
+import { definePlugin } from "../../../plugins.js";
+
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:artifacts",
   hookHandlers: {
     hre: () => import("./hook-handlers/hre.js"),
   },
   npmPackage: "hardhat",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/clean/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/clean/index.ts
@@ -1,10 +1,11 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { task } from "../../core/config.js";
 
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:clean",
   tasks: [
     task("clean", "Clear the cache and delete all artifacts")
@@ -16,6 +17,6 @@ const hardhatPlugin: HardhatPlugin = {
       .build(),
   ],
   npmPackage: "hardhat",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/console/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/console/index.ts
@@ -1,8 +1,9 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { task } from "../../core/config.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:console",
   tasks: [
     task("console", "Open a hardhat console")
@@ -25,6 +26,6 @@ const hardhatPlugin: HardhatPlugin = {
   ],
   dependencies: () => [import("../solidity/index.js")],
   npmPackage: "hardhat",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/index.ts
@@ -1,10 +1,11 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { globalFlag } from "../../core/config.js";
 
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:coverage",
   tasks: [],
   globalOptions: [
@@ -20,6 +21,6 @@ const hardhatPlugin: HardhatPlugin = {
     test: () => import("./hook-handlers/test.js"),
   },
   npmPackage: "hardhat",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/flatten/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/flatten/index.ts
@@ -1,9 +1,10 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { ArgumentType } from "../../../types/arguments.js";
 import { task } from "../../core/config.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:flatten",
   tasks: [
     task("flatten")
@@ -17,6 +18,6 @@ const hardhatPlugin: HardhatPlugin = {
       .setAction(async () => await import("./task-action.js"))
       .build(),
   ],
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/gas-analytics/index.ts
@@ -1,11 +1,12 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { ArgumentType } from "../../../types/arguments.js";
 import { globalFlag, globalOption, overrideTask } from "../../core/config.js";
 
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:gas-analytics",
   tasks: [
     overrideTask("test")
@@ -63,6 +64,6 @@ const hardhatPlugin: HardhatPlugin = {
     import("../solidity-test/index.js"),
   ],
   npmPackage: "hardhat",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/index.ts
@@ -1,5 +1,6 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { ArgumentType } from "../../../types/arguments.js";
 import { globalOption } from "../../core/config.js";
 
@@ -8,7 +9,7 @@ export type * from "./type-extensions/global-options.js";
 export type * from "./type-extensions/hooks.js";
 export type * from "./type-extensions/hre.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:network-manager",
   hookHandlers: {
     config: () => import("./hook-handlers/config.js"),
@@ -25,6 +26,6 @@ const hardhatPlugin: HardhatPlugin = {
   ],
   npmPackage: "hardhat",
   dependencies: () => [import("../artifacts/index.js")],
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/node/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/index.ts
@@ -1,9 +1,10 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { ArgumentType } from "../../../types/arguments.js";
 import { task } from "../../core/config.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:node",
   tasks: [
     task("node", "Start a JSON-RPC server on top of Hardhat Network")
@@ -50,6 +51,6 @@ const hardhatPlugin: HardhatPlugin = {
       .build(),
   ],
   dependencies: () => [import("../network-manager/index.js")],
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/run/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/run/index.ts
@@ -1,8 +1,9 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { task } from "../../core/config.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:run",
   tasks: [
     task("run", "Run a user-defined script after compiling the project")
@@ -19,6 +20,6 @@ const hardhatPlugin: HardhatPlugin = {
   ],
   dependencies: () => [import("../solidity/index.js")],
   npmPackage: "hardhat",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -2,11 +2,12 @@ import type { HardhatPlugin } from "../../../types/plugins.js";
 
 import { ArgumentType } from "hardhat/types/arguments";
 
+import { definePlugin } from "../../../plugins.js";
 import { task } from "../../core/config.js";
 
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:solidity-tests",
   hookHandlers: {
     config: () => import("./hook-handlers/config.js"),
@@ -51,6 +52,6 @@ const hardhatPlugin: HardhatPlugin = {
     import("../coverage/index.js"),
   ],
   npmPackage: "hardhat",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/index.ts
@@ -1,5 +1,6 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { ArgumentType } from "../../../types/arguments.js";
 import { globalOption, task } from "../../core/config.js";
 
@@ -35,7 +36,7 @@ const buildTask = task("build", "Build project")
   .setAction(async () => await import("./tasks/build.js"))
   .build();
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:solidity",
   dependencies: () => [import("../artifacts/index.js")],
   hookHandlers: {
@@ -65,6 +66,6 @@ const hardhatPlugin: HardhatPlugin = {
     }),
   ],
   npmPackage: "hardhat",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/telemetry/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/telemetry/index.ts
@@ -1,8 +1,9 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { task } from "../../core/config.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:telemetry",
   tasks: [
     task("telemetry", "Display and modify telemetry settings")
@@ -18,6 +19,6 @@ const hardhatPlugin: HardhatPlugin = {
       .build(),
   ],
   npmPackage: "hardhat",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/index.ts
@@ -1,11 +1,12 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { definePlugin } from "../../../plugins.js";
 import { ArgumentType } from "../../../types/arguments.js";
 import { task } from "../../core/config.js";
 
 export type * from "./type-extensions.js";
 
-const hardhatPlugin: HardhatPlugin = {
+const hardhatPlugin: HardhatPlugin = definePlugin({
   id: "builtin:test",
   hookHandlers: {
     config: () => import("./hook-handlers/config.js"),
@@ -37,6 +38,6 @@ const hardhatPlugin: HardhatPlugin = {
   ],
   dependencies: () => [import("../solidity/index.js")],
   npmPackage: "hardhat",
-};
+});
 
 export default hardhatPlugin;

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -40,6 +40,7 @@ import { parseArgumentValue } from "../core/arguments.js";
 import { buildGlobalOptionDefinitions } from "../core/global-options.js";
 import { resolveProjectRoot } from "../core/hre.js";
 import { resolvePluginList } from "../core/plugins/resolve-plugin-list.js";
+import { warnAboutUnusedLoadedPlugins } from "../core/plugins/unused-plugins-warning.js";
 import { isArgumentRequired } from "../core/tasks/utils.js";
 import { setGlobalHardhatRuntimeEnvironment } from "../global-hre-instance.js";
 import { createHardhatRuntimeEnvironment } from "../hre-initialization.js";
@@ -233,6 +234,8 @@ export async function main(
       projectRoot,
       { resolvedPlugins, globalOptionDefinitions },
     );
+
+    warnAboutUnusedLoadedPlugins(hre.config.plugins);
 
     // This must be the first time we set it, otherwise we let it crash
     setGlobalHardhatRuntimeEnvironment(hre);

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -61,6 +61,7 @@ export interface MainOptions {
   registerTsx?: boolean;
   rethrowErrors?: true;
   allowNonlocalHardhatInstallation?: true;
+  warnAboutUnusedPlugins?: true;
 }
 
 export async function main(
@@ -235,7 +236,9 @@ export async function main(
       { resolvedPlugins, globalOptionDefinitions },
     );
 
-    warnAboutUnusedLoadedPlugins(hre.config.plugins);
+    if (options.warnAboutUnusedPlugins) {
+      warnAboutUnusedLoadedPlugins(hre.config.plugins);
+    }
 
     // This must be the first time we set it, otherwise we let it crash
     setGlobalHardhatRuntimeEnvironment(hre);

--- a/packages/hardhat/src/internal/core/plugins/loaded-plugins-registry.ts
+++ b/packages/hardhat/src/internal/core/plugins/loaded-plugins-registry.ts
@@ -1,0 +1,11 @@
+import type { HardhatPlugin } from "../../../types/plugins.js";
+
+const loadedPlugins = new Map<string, HardhatPlugin>();
+
+export function registerLoadedPlugin(plugin: HardhatPlugin): void {
+  loadedPlugins.set(plugin.id, plugin);
+}
+
+export function getLoadedPlugins(): ReadonlyMap<string, HardhatPlugin> {
+  return loadedPlugins;
+}

--- a/packages/hardhat/src/internal/core/plugins/unused-plugins-warning.ts
+++ b/packages/hardhat/src/internal/core/plugins/unused-plugins-warning.ts
@@ -1,0 +1,42 @@
+import type { HardhatPlugin } from "../../../types/plugins.js";
+
+import { getLoadedPlugins } from "./loaded-plugins-registry.js";
+
+export function warnAboutUnusedLoadedPlugins(
+  resolvedPlugins: HardhatPlugin[],
+  printError: (message: string) => void = (message) => console.error(message),
+  loadedPlugins: Iterable<HardhatPlugin> = getLoadedPlugins().values(),
+): void {
+  const resolvedIds = new Set(resolvedPlugins.map((p) => p.id));
+
+  const unused: HardhatPlugin[] = [];
+  for (const plugin of loadedPlugins) {
+    if (!resolvedIds.has(plugin.id)) {
+      unused.push(plugin);
+    }
+  }
+
+  if (unused.length === 0) {
+    return;
+  }
+
+  const lines: string[] = [
+    "Warning: the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:",
+    "",
+  ];
+
+  for (const plugin of unused) {
+    const name =
+      plugin.npmPackage !== undefined && plugin.npmPackage !== null
+        ? `${plugin.npmPackage}  (id: ${plugin.id})`
+        : plugin.id;
+    lines.push(`  - ${name}`);
+  }
+
+  lines.push(
+    "",
+    "Add them to `plugins: [...]` in your config to enable them, or remove the import if intentional.",
+  );
+
+  printError(lines.join("\n"));
+}

--- a/packages/hardhat/src/internal/core/plugins/unused-plugins-warning.ts
+++ b/packages/hardhat/src/internal/core/plugins/unused-plugins-warning.ts
@@ -25,7 +25,7 @@ export function warnAboutUnusedLoadedPlugins(
   const lines: string[] = [
     "",
     styleText(["bold", "yellow"], "Warning:") +
-      " the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:",
+      " the following plugins were imported but are not present in the `plugins` array of your config:",
     "",
   ];
 
@@ -39,7 +39,7 @@ export function warnAboutUnusedLoadedPlugins(
 
   lines.push(
     "",
-    "  Add them to `plugins: [...]` in your config to enable them, or remove the import(s) to remove this warning.",
+    "  Add them to the `plugins` array, or remove the unused plugin import(s) to silence this warning.",
     "",
   );
 

--- a/packages/hardhat/src/internal/core/plugins/unused-plugins-warning.ts
+++ b/packages/hardhat/src/internal/core/plugins/unused-plugins-warning.ts
@@ -1,5 +1,7 @@
 import type { HardhatPlugin } from "../../../types/plugins.js";
 
+import { styleText } from "node:util";
+
 import { getLoadedPlugins } from "./loaded-plugins-registry.js";
 
 export function warnAboutUnusedLoadedPlugins(
@@ -21,7 +23,9 @@ export function warnAboutUnusedLoadedPlugins(
   }
 
   const lines: string[] = [
-    "Warning: the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:",
+    "",
+    styleText(["bold", "yellow"], "Warning:") +
+      " the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:",
     "",
   ];
 
@@ -35,7 +39,8 @@ export function warnAboutUnusedLoadedPlugins(
 
   lines.push(
     "",
-    "Add them to `plugins: [...]` in your config to enable them, or remove the import if intentional.",
+    "  Add them to `plugins: [...]` in your config to enable them, or remove the import(s) to remove this warning.",
+    "",
   );
 
   printError(lines.join("\n"));

--- a/packages/hardhat/src/plugins.ts
+++ b/packages/hardhat/src/plugins.ts
@@ -1,6 +1,25 @@
 export { HardhatPluginError } from "@nomicfoundation/hardhat-errors";
 
+import type { HardhatPlugin } from "./types/plugins.js";
+
+import { registerLoadedPlugin } from "./internal/core/plugins/loaded-plugins-registry.js";
 import { throwUsingHardhat2PluginError } from "./internal/using-hardhat2-plugin-errors.js";
+
+/**
+ * Defines a Hardhat plugin.
+ *
+ * Plugin authors should use this helper as the default export of their
+ * plugin's `index` module. It registers the plugin's `id` in a process-wide
+ * registry of loaded plugins, which the Hardhat CLI uses to detect plugins
+ * that are imported but not included in the user's `plugins` array.
+ *
+ * @param plugin The plugin definition.
+ * @returns The same plugin definition, unchanged.
+ */
+export function definePlugin(plugin: HardhatPlugin): HardhatPlugin {
+  registerLoadedPlugin(plugin);
+  return plugin;
+}
 
 /**
  * @deprecated This function is part of the Hardhat 2 plugin API.

--- a/packages/hardhat/templates/hardhat-3/01-node-test-runner-viem/tsconfig.json
+++ b/packages/hardhat/templates/hardhat-3/01-node-test-runner-viem/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2023",
     "skipLibCheck": true,
     "outDir": "dist",
-    "types": ["node"]
+    "types": ["node"],
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/hardhat/templates/hardhat-3/02-mocha-ethers/tsconfig.json
+++ b/packages/hardhat/templates/hardhat-3/02-mocha-ethers/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2023",
     "skipLibCheck": true,
     "outDir": "dist",
-    "types": ["node", "mocha"]
+    "types": ["node", "mocha"],
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/hardhat/templates/hardhat-3/03-minimal/tsconfig.json
+++ b/packages/hardhat/templates/hardhat-3/03-minimal/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2023",
     "skipLibCheck": true,
     "outDir": "dist",
-    "types": ["node"]
+    "types": ["node"],
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -5,6 +5,7 @@ import { describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
+
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 
 describe("config validation", () => {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -5,7 +5,6 @@ import { describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
-
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 
 describe("config validation", () => {

--- a/packages/hardhat/test/internal/core/plugins/loaded-plugins-registry.ts
+++ b/packages/hardhat/test/internal/core/plugins/loaded-plugins-registry.ts
@@ -1,0 +1,49 @@
+import type { HardhatPlugin } from "../../../../src/types/plugins.js";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  getLoadedPlugins,
+  registerLoadedPlugin,
+} from "../../../../src/internal/core/plugins/loaded-plugins-registry.js";
+import { definePlugin } from "../../../../src/plugins.js";
+
+describe("loaded plugins registry", () => {
+  it("definePlugin returns its argument unchanged", () => {
+    const plugin: HardhatPlugin = {
+      id: "test:returns-arg",
+      npmPackage: "test-pkg",
+    };
+
+    assert.equal(definePlugin(plugin), plugin);
+  });
+
+  it("definePlugin registers the plugin id in the loaded set", () => {
+    const plugin: HardhatPlugin = {
+      id: "test:register-id",
+    };
+
+    definePlugin(plugin);
+
+    assert.equal(getLoadedPlugins().get(plugin.id), plugin);
+  });
+
+  it("dedupes by id when called twice with the same id", () => {
+    const first: HardhatPlugin = { id: "test:dedupe", npmPackage: "first" };
+    const second: HardhatPlugin = { id: "test:dedupe", npmPackage: "second" };
+
+    definePlugin(first);
+    definePlugin(second);
+
+    assert.equal(getLoadedPlugins().get("test:dedupe"), second);
+  });
+
+  it("registerLoadedPlugin behaves like the side effect of definePlugin", () => {
+    const plugin: HardhatPlugin = { id: "test:register-direct" };
+
+    registerLoadedPlugin(plugin);
+
+    assert.equal(getLoadedPlugins().get(plugin.id), plugin);
+  });
+});

--- a/packages/hardhat/test/internal/core/plugins/unused-plugins-warning.ts
+++ b/packages/hardhat/test/internal/core/plugins/unused-plugins-warning.ts
@@ -19,10 +19,10 @@ function captureErrors(): {
 
 const WARNING_HEADER =
   styleText(["bold", "yellow"], "Warning:") +
-  " the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:";
+  " the following plugins were imported but are not present in the `plugins` array of your config:";
 
 const WARNING_FOOTER =
-  "  Add them to `plugins: [...]` in your config to enable them, or remove the import(s) to remove this warning.";
+  "  Add them to the `plugins` array, or remove the unused plugin import(s) to silence this warning.";
 
 describe("warnAboutUnusedLoadedPlugins", () => {
   it("emits a warning listing plugins that are loaded but not resolved", () => {

--- a/packages/hardhat/test/internal/core/plugins/unused-plugins-warning.ts
+++ b/packages/hardhat/test/internal/core/plugins/unused-plugins-warning.ts
@@ -1,0 +1,100 @@
+import type { HardhatPlugin } from "../../../../src/types/plugins.js";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { warnAboutUnusedLoadedPlugins } from "../../../../src/internal/core/plugins/unused-plugins-warning.js";
+
+function captureErrors(): {
+  printError: (message: string) => void;
+  messages: string[];
+} {
+  const messages: string[] = [];
+  return {
+    printError: (message) => messages.push(message),
+    messages,
+  };
+}
+
+describe("warnAboutUnusedLoadedPlugins", () => {
+  it("emits a warning listing plugins that are loaded but not resolved", () => {
+    const orphan: HardhatPlugin = {
+      id: "hardhat-orphan",
+      npmPackage: "@nomicfoundation/hardhat-orphan",
+    };
+
+    const { printError, messages } = captureErrors();
+    warnAboutUnusedLoadedPlugins([], printError, [orphan]);
+
+    assert.deepEqual(messages, [
+      [
+        "Warning: the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:",
+        "",
+        "  - @nomicfoundation/hardhat-orphan  (id: hardhat-orphan)",
+        "",
+        "Add them to `plugins: [...]` in your config to enable them, or remove the import if intentional.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("does not warn when the loaded plugin is in the resolved list", () => {
+    const inConfig: HardhatPlugin = { id: "hardhat-in-config" };
+
+    const { printError, messages } = captureErrors();
+    warnAboutUnusedLoadedPlugins([inConfig], printError, [inConfig]);
+
+    assert.deepEqual(messages, []);
+  });
+
+  it("does not warn when the loaded plugin is in the resolved list as a transitive dep", () => {
+    const dep: HardhatPlugin = { id: "hardhat-transitive-dep" };
+    const parent: HardhatPlugin = {
+      id: "hardhat-transitive-parent",
+      dependencies: () => [Promise.resolve({ default: dep })],
+    };
+
+    const { printError, messages } = captureErrors();
+    warnAboutUnusedLoadedPlugins([parent, dep], printError, [parent, dep]);
+
+    assert.deepEqual(messages, []);
+  });
+
+  it("falls back to id only when npmPackage is missing", () => {
+    const noPackage: HardhatPlugin = { id: "hardhat-no-pkg" };
+
+    const { printError, messages } = captureErrors();
+    warnAboutUnusedLoadedPlugins([], printError, [noPackage]);
+
+    assert.deepEqual(messages, [
+      [
+        "Warning: the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:",
+        "",
+        "  - hardhat-no-pkg",
+        "",
+        "Add them to `plugins: [...]` in your config to enable them, or remove the import if intentional.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("lists every orphan in a single warning block", () => {
+    const orphanA: HardhatPlugin = {
+      id: "hardhat-orphan-a",
+      npmPackage: "@nomicfoundation/hardhat-orphan-a",
+    };
+    const orphanB: HardhatPlugin = { id: "hardhat-orphan-b" };
+
+    const { printError, messages } = captureErrors();
+    warnAboutUnusedLoadedPlugins([], printError, [orphanA, orphanB]);
+
+    assert.deepEqual(messages, [
+      [
+        "Warning: the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:",
+        "",
+        "  - @nomicfoundation/hardhat-orphan-a  (id: hardhat-orphan-a)",
+        "  - hardhat-orphan-b",
+        "",
+        "Add them to `plugins: [...]` in your config to enable them, or remove the import if intentional.",
+      ].join("\n"),
+    ]);
+  });
+});

--- a/packages/hardhat/test/internal/core/plugins/unused-plugins-warning.ts
+++ b/packages/hardhat/test/internal/core/plugins/unused-plugins-warning.ts
@@ -2,6 +2,7 @@ import type { HardhatPlugin } from "../../../../src/types/plugins.js";
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { styleText } from "node:util";
 
 import { warnAboutUnusedLoadedPlugins } from "../../../../src/internal/core/plugins/unused-plugins-warning.js";
 
@@ -16,6 +17,13 @@ function captureErrors(): {
   };
 }
 
+const WARNING_HEADER =
+  styleText(["bold", "yellow"], "Warning:") +
+  " the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:";
+
+const WARNING_FOOTER =
+  "  Add them to `plugins: [...]` in your config to enable them, or remove the import(s) to remove this warning.";
+
 describe("warnAboutUnusedLoadedPlugins", () => {
   it("emits a warning listing plugins that are loaded but not resolved", () => {
     const orphan: HardhatPlugin = {
@@ -28,11 +36,13 @@ describe("warnAboutUnusedLoadedPlugins", () => {
 
     assert.deepEqual(messages, [
       [
-        "Warning: the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:",
+        "",
+        WARNING_HEADER,
         "",
         "  - @nomicfoundation/hardhat-orphan  (id: hardhat-orphan)",
         "",
-        "Add them to `plugins: [...]` in your config to enable them, or remove the import if intentional.",
+        WARNING_FOOTER,
+        "",
       ].join("\n"),
     ]);
   });
@@ -67,11 +77,13 @@ describe("warnAboutUnusedLoadedPlugins", () => {
 
     assert.deepEqual(messages, [
       [
-        "Warning: the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:",
+        "",
+        WARNING_HEADER,
         "",
         "  - hardhat-no-pkg",
         "",
-        "Add them to `plugins: [...]` in your config to enable them, or remove the import if intentional.",
+        WARNING_FOOTER,
+        "",
       ].join("\n"),
     ]);
   });
@@ -88,12 +100,14 @@ describe("warnAboutUnusedLoadedPlugins", () => {
 
     assert.deepEqual(messages, [
       [
-        "Warning: the following plugins were imported but are not present in your `plugins` array in hardhat.config.ts:",
+        "",
+        WARNING_HEADER,
         "",
         "  - @nomicfoundation/hardhat-orphan-a  (id: hardhat-orphan-a)",
         "  - hardhat-orphan-b",
         "",
-        "Add them to `plugins: [...]` in your config to enable them, or remove the import if intentional.",
+        WARNING_FOOTER,
+        "",
       ].join("\n"),
     ]);
   });


### PR DESCRIPTION
This PR introduces a new `definePlugin` api, used to create plugins. It's similar to `defineConfig`, but it registers the plugin in a global store of "loaded" plugins. That enables Hardhat's CLI to detect any loaded-but-unused plugin, and print a warning.

The result of these changes look like this

<img width="1860" height="1214" alt="image" src="https://github.com/user-attachments/assets/22d0c4d6-cf0f-4751-a888-97cf1e123020" />
