### PR TITLE
feat(solidity-test): negation filters

### DIFF
--- a/.changeset/negation-test-filters.md
+++ b/.changeset/negation-test-filters.md
@@ -1,0 +1,5 @@
+---
+"hardhat": minor
+---
+
+Add `--no-match-test` and `--no-match-contract` CLI flags to `test solidity` for excluding tests and contracts by pattern

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -165,6 +165,24 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
   };
 }
 
+function parseAbi(artifact: Artifact): Abi {
+  return JSON.parse(artifact.contract.abi);
+}
+
+export function getTestFunctionNames(artifact: Artifact): string[] {
+  const names: string[] = [];
+  for (const { type, name } of parseAbi(artifact)) {
+    if (
+      type === "function" &&
+      typeof name === "string" &&
+      (name.startsWith("test") || name.startsWith("invariant"))
+    ) {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
 export function isTestSuiteArtifact(artifact: Artifact): boolean {
   const bytecode = artifact.contract.bytecode;
 
@@ -173,23 +191,14 @@ export function isTestSuiteArtifact(artifact: Artifact): boolean {
     return false;
   }
 
-  const abi: Abi = JSON.parse(artifact.contract.abi);
-  return abi.some(({ type, name }) => {
-    if (type === "function" && typeof name === "string") {
-      return name.startsWith("test") || name.startsWith("invariant");
-    }
-
-    return false;
-  });
+  return getTestFunctionNames(artifact).length > 0;
 }
 
 export function warnDeprecatedTestFail(
   artifact: Artifact,
   sourceNameToUserSourceName: Map<string, string>,
 ): void {
-  const abi: Abi = JSON.parse(artifact.contract.abi);
-
-  abi.forEach(({ type, name }) => {
+  for (const { type, name } of parseAbi(artifact)) {
     if (
       type === "function" &&
       typeof name === "string" &&
@@ -203,7 +212,7 @@ export function warnDeprecatedTestFail(
 
       console.warn(warningMessage);
     }
-  });
+  }
 }
 
 export function escapeRegExp(s: string): string {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -220,6 +220,13 @@ export function escapeRegExp(s: string): string {
 }
 
 export function buildSafeRegExp(pattern: string, flagName: string): RegExp {
+  if (pattern === "") {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+      { value: pattern, type: "RegExp", name: flagName },
+    );
+  }
+
   try {
     return new RegExp(pattern);
   } catch {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -19,6 +19,7 @@ import {
   opHardforkFromString,
   l1HardforkFromString,
 } from "@nomicfoundation/edr";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { toBigInt } from "@nomicfoundation/hardhat-utils/bigint";
 import { hexStringToBytes } from "@nomicfoundation/hardhat-utils/hex";
 
@@ -203,4 +204,19 @@ export function warnDeprecatedTestFail(
       console.warn(warningMessage);
     }
   });
+}
+
+export function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function buildSafeRegExp(pattern: string, flagName: string): RegExp {
+  try {
+    return new RegExp(pattern);
+  } catch {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+      { value: pattern, type: "RegExp", name: flagName },
+    );
+  }
 }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -33,14 +33,14 @@ const hardhatPlugin: HardhatPlugin = {
       .addOption({
         name: "noMatchTest",
         description:
-          "excludes tests",
+          "Exclude tests matching the given string or regexp",
         type: ArgumentType.STRING_WITHOUT_DEFAULT,
         defaultValue: undefined,
       })
       .addOption({
         name: "noMatchContract",
         description:
-          "exclude test contracts",
+          "Exclude test contracts matching the given string or regexp",
         type: ArgumentType.STRING_WITHOUT_DEFAULT,
         defaultValue: undefined,
       })

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -30,6 +30,20 @@ const hardhatPlugin: HardhatPlugin = {
         type: ArgumentType.STRING_WITHOUT_DEFAULT,
         defaultValue: undefined,
       })
+      .addOption({
+        name: "noMatchTest",
+        description:
+          "excludes tests",
+        type: ArgumentType.STRING_WITHOUT_DEFAULT,
+        defaultValue: undefined,
+      })
+      .addOption({
+        name: "noMatchContract",
+        description:
+          "exclude test contracts",
+        type: ArgumentType.STRING_WITHOUT_DEFAULT,
+        defaultValue: undefined,
+      })
       .addFlag({
         name: "noCompile",
         description: "Don't compile the project before running the tests",

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -32,8 +32,7 @@ const hardhatPlugin: HardhatPlugin = {
       })
       .addOption({
         name: "noMatchTest",
-        description:
-          "Exclude tests matching the given string or regexp",
+        description: "Exclude tests matching the given string or regexp",
         type: ArgumentType.STRING_WITHOUT_DEFAULT,
         defaultValue: undefined,
       })

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -269,14 +269,13 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     const allTestNames: string[] = [];
     for (const { edrArtifact } of testSuiteArtifacts) {
       const abi: Abi = JSON.parse(edrArtifact.contract.abi);
-      for (const entry of abi) {
-        if (entry.type === "function" && typeof entry.name === "string") {
-          if (
-            entry.name.startsWith("test") ||
-            entry.name.startsWith("invariant")
-          ) {
-            allTestNames.push(entry.name);
-          }
+      for (const { type, name } of abi) {
+        if (
+          type === "function" &&
+          typeof name === "string" &&
+          (name.startsWith("test") || name.startsWith("invariant"))
+        ) {
+          allTestNames.push(name);
         }
       }
     }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -272,7 +272,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
       getTestFunctionNames(edrArtifact),
     );
 
-    let survivingTests = allTestNames.filter(
+    let survivingTests = [...new Set(allTestNames)].filter(
       (name) => !noMatchTestRegex.test(name),
     );
 
@@ -281,15 +281,17 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
       survivingTests = survivingTests.filter((name) => grepRegex.test(name));
     }
 
-    const uniqueTests = [...new Set(survivingTests)];
-    if (uniqueTests.length > 0) {
-      effectiveTestPattern = `^(${uniqueTests.map(escapeRegExp).join("|")})$`;
-    } else {
+    if (survivingTests.length === 0) {
       console.warn(
         "Warning: all test functions were excluded by the provided filters. No tests will run.",
       );
-      effectiveTestPattern = "^$";
+      return successfulResult({
+        summary: { failed: 0, passed: 0, skipped: 0, todo: 0, failureOutput: "" },
+        suiteResults: [],
+      });
     }
+
+    effectiveTestPattern = `^(${survivingTests.map(escapeRegExp).join("|")})$`;
   }
 
   const testRunnerConfig =

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -193,23 +193,22 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   );
 
   const testRootPathsSet = new Set(testRootPathsToRun);
-  let testSuiteArtifacts = edrArtifactsWithMetadata
+  const noMatchContractRegex =
+    noMatchContract !== undefined
+      ? buildSafeRegExp(noMatchContract, "--no-match-contract")
+      : undefined;
+  const testSuiteArtifacts = edrArtifactsWithMetadata
     .filter(({ userSourceName }) =>
       testRootPathsSet.has(
         resolveFromRoot(hre.config.paths.root, userSourceName),
       ),
     )
-    .filter(({ edrArtifact }) => isTestSuiteArtifact(edrArtifact));
-
-  if (noMatchContract !== undefined) {
-    const noMatchContractRegex = buildSafeRegExp(
-      noMatchContract,
-      "--no-match-contract",
+    .filter(({ edrArtifact }) => isTestSuiteArtifact(edrArtifact))
+    .filter(
+      ({ edrArtifact }) =>
+        noMatchContractRegex === undefined ||
+        !noMatchContractRegex.test(edrArtifact.id.name),
     );
-    testSuiteArtifacts = testSuiteArtifacts.filter(
-      ({ edrArtifact }) => !noMatchContractRegex.test(edrArtifact.id.name),
-    );
-  }
 
   for (const { edrArtifact } of testSuiteArtifacts) {
     warnDeprecatedTestFail(edrArtifact, sourceNameToUserSourceName);
@@ -282,12 +281,17 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     }
 
     if (survivingTests.length === 0) {
-      const activeFlags = `--no-match-test${grep !== undefined ? ", --grep" : ""}`;
       console.warn(
-        `Warning: all test functions were excluded by ${activeFlags}. No tests will run.`,
+        "Warning: all test functions were excluded by the provided filters. No tests will run.",
       );
       return successfulResult({
-        summary: { failed: 0, passed: 0, skipped: 0, todo: 0, failureOutput: "" },
+        summary: {
+          failed: 0,
+          passed: 0,
+          skipped: 0,
+          todo: 0,
+          failureOutput: "",
+        },
         suiteResults: [],
       });
     }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -38,6 +38,8 @@ import {
 } from "./edr-artifacts.js";
 import { collectEip712CanonicalTypes } from "./eip712/index.js";
 import {
+  buildSafeRegExp,
+  escapeRegExp,
   isTestSuiteArtifact,
   warnDeprecatedTestFail,
   solidityTestConfigToSolidityTestRunnerConfigArgs,
@@ -502,21 +504,6 @@ async function loadArtifacts(
     );
   }
   return { edrArtifactsWithMetadata, allBuildInfosAndOutputs };
-}
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function buildSafeRegExp(pattern: string, flagName: string): RegExp {
-  try {
-    return new RegExp(pattern);
-  } catch {
-    throw new HardhatError(
-      HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
-      { value: pattern, type: "RegExp", name: flagName },
-    );
-  }
 }
 
 export default runSolidityTests;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -306,7 +306,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
       });
     }
 
-    effectiveTestPattern = `^(${survivingTests.map(escapeRegExp).join("|")})$`;
+    effectiveTestPattern = `^(${survivingTests.map(escapeRegExp).join("|")})(\\(\\))?$`;
   }
 
   const testRunnerConfig =

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -1,3 +1,4 @@
+import type { Abi } from "../../../types/artifacts.js";
 import type {
   BuildInfoAndOutput,
   EdrArtifactWithMetadata,
@@ -50,6 +51,8 @@ interface TestActionArguments {
   testFiles: string[];
   chainType: string;
   grep?: string;
+  noMatchTest?: string;
+  noMatchContract?: string;
   noCompile: boolean;
   testSummaryIndex: number;
 }
@@ -59,7 +62,7 @@ export interface SolidityTestRunResult extends TestRunResult {
 }
 
 const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
-  { testFiles, chainType, grep, noCompile, testSummaryIndex },
+  { testFiles, chainType, grep, noMatchTest, noMatchContract, noCompile, testSummaryIndex },
   hre,
 ): Promise<Result<SolidityTestRunResult, SolidityTestRunResult>> => {
   // Set an environment variable that plugins can use to detect when a process is running tests
@@ -180,13 +183,20 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   );
 
   const testRootPathsSet = new Set(testRootPathsToRun);
-  const testSuiteArtifacts = edrArtifactsWithMetadata
+  let testSuiteArtifacts = edrArtifactsWithMetadata
     .filter(({ userSourceName }) =>
       testRootPathsSet.has(
         resolveFromRoot(hre.config.paths.root, userSourceName),
       ),
     )
     .filter(({ edrArtifact }) => isTestSuiteArtifact(edrArtifact));
+
+  if (noMatchContract !== undefined) {
+    const noMatchContractRegex = new RegExp(noMatchContract);
+    testSuiteArtifacts = testSuiteArtifacts.filter(
+      ({ edrArtifact }) => !noMatchContractRegex.test(edrArtifact.id.name),
+    );
+  }
 
   for (const { edrArtifact } of testSuiteArtifacts) {
     warnDeprecatedTestFail(edrArtifact, sourceNameToUserSourceName);
@@ -242,6 +252,34 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     eip712Types,
   );
 
+  let effectiveTestPattern = grep;
+  if (noMatchTest !== undefined) {
+    const noMatchTestRegex = new RegExp(noMatchTest);
+    const allTestNames: string[] = [];
+    for (const { edrArtifact } of testSuiteArtifacts) {
+      const abi: Abi = JSON.parse(edrArtifact.contract.abi);
+      for (const entry of abi) {
+        if (entry.type === "function" && typeof entry.name === "string") {
+          if (entry.name.startsWith("test") ||entry.name.startsWith("invariant") ) {
+            allTestNames.push(entry.name);
+          }
+        }
+      }
+    }
+
+    let survivingTests = allTestNames.filter(
+      (name) => !noMatchTestRegex.test(name),
+    );
+
+    if (grep !== undefined) {
+      const grepRegex = new RegExp(grep);
+      survivingTests = survivingTests.filter((name) => grepRegex.test(name));
+    }
+
+    const uniqueTests = [...new Set(survivingTests)];
+    effectiveTestPattern = `^(${uniqueTests.map(s=>s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})$`;
+  }
+
   const testRunnerConfig =
     await solidityTestConfigToSolidityTestRunnerConfigArgs({
       chainType,
@@ -250,7 +288,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
       config: solidityTestConfig,
       verbosity,
       observability: observabilityConfig,
-      testPattern: grep,
+      testPattern: effectiveTestPattern,
       generateGasReport:
         hre.globalOptions.gasStats ||
         hre.globalOptions.gasStatsJson !== undefined,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -204,7 +204,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   if (noMatchContract !== undefined) {
     const noMatchContractRegex = buildSafeRegExp(
       noMatchContract,
-      "noMatchContract",
+      "--no-match-contract",
     );
     testSuiteArtifacts = testSuiteArtifacts.filter(
       ({ edrArtifact }) => !noMatchContractRegex.test(edrArtifact.id.name),
@@ -267,7 +267,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
 
   let effectiveTestPattern = grep;
   if (noMatchTest !== undefined) {
-    const noMatchTestRegex = buildSafeRegExp(noMatchTest, "noMatchTest");
+    const noMatchTestRegex = buildSafeRegExp(noMatchTest, "--no-match-test");
     const allTestNames = testSuiteArtifacts.flatMap(({ edrArtifact }) =>
       getTestFunctionNames(edrArtifact),
     );
@@ -277,13 +277,14 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     );
 
     if (grep !== undefined) {
-      const grepRegex = buildSafeRegExp(grep, "grep");
+      const grepRegex = buildSafeRegExp(grep, "--grep");
       survivingTests = survivingTests.filter((name) => grepRegex.test(name));
     }
 
     if (survivingTests.length === 0) {
+      const activeFlags = `--no-match-test${grep !== undefined ? ", --grep" : ""}`;
       console.warn(
-        "Warning: all test functions were excluded by the provided filters. No tests will run.",
+        `Warning: all test functions were excluded by ${activeFlags}. No tests will run.`,
       );
       return successfulResult({
         summary: { failed: 0, passed: 0, skipped: 0, todo: 0, failureOutput: "" },

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -1,4 +1,3 @@
-import type { Abi } from "../../../types/artifacts.js";
 import type {
   BuildInfoAndOutput,
   EdrArtifactWithMetadata,
@@ -40,6 +39,7 @@ import { collectEip712CanonicalTypes } from "./eip712/index.js";
 import {
   buildSafeRegExp,
   escapeRegExp,
+  getTestFunctionNames,
   isTestSuiteArtifact,
   warnDeprecatedTestFail,
   solidityTestConfigToSolidityTestRunnerConfigArgs,
@@ -268,19 +268,9 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   let effectiveTestPattern = grep;
   if (noMatchTest !== undefined) {
     const noMatchTestRegex = buildSafeRegExp(noMatchTest, "noMatchTest");
-    const allTestNames: string[] = [];
-    for (const { edrArtifact } of testSuiteArtifacts) {
-      const abi: Abi = JSON.parse(edrArtifact.contract.abi);
-      for (const { type, name } of abi) {
-        if (
-          type === "function" &&
-          typeof name === "string" &&
-          (name.startsWith("test") || name.startsWith("invariant"))
-        ) {
-          allTestNames.push(name);
-        }
-      }
-    }
+    const allTestNames = testSuiteArtifacts.flatMap(({ edrArtifact }) =>
+      getTestFunctionNames(edrArtifact),
+    );
 
     let survivingTests = allTestNames.filter(
       (name) => !noMatchTestRegex.test(name),

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -210,6 +210,16 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
         !noMatchContractRegex.test(edrArtifact.id.name),
     );
 
+  if (testSuiteArtifacts.length === 0 && noMatchContractRegex !== undefined) {
+    console.warn(
+      "Warning: all test contracts were excluded by --no-match-contract. No tests will run.",
+    );
+    return successfulResult({
+      summary: { failed: 0, passed: 0, skipped: 0, todo: 0, failureOutput: "" },
+      suiteResults: [],
+    });
+  }
+
   for (const { edrArtifact } of testSuiteArtifacts) {
     warnDeprecatedTestFail(edrArtifact, sourceNameToUserSourceName);
   }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -62,7 +62,15 @@ export interface SolidityTestRunResult extends TestRunResult {
 }
 
 const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
-  { testFiles, chainType, grep, noMatchTest, noMatchContract, noCompile, testSummaryIndex },
+  {
+    testFiles,
+    chainType,
+    grep,
+    noMatchTest,
+    noMatchContract,
+    noCompile,
+    testSummaryIndex,
+  },
   hre,
 ): Promise<Result<SolidityTestRunResult, SolidityTestRunResult>> => {
   // Set an environment variable that plugins can use to detect when a process is running tests
@@ -192,7 +200,10 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     .filter(({ edrArtifact }) => isTestSuiteArtifact(edrArtifact));
 
   if (noMatchContract !== undefined) {
-    const noMatchContractRegex = new RegExp(noMatchContract);
+    const noMatchContractRegex = buildSafeRegExp(
+      noMatchContract,
+      "noMatchContract",
+    );
     testSuiteArtifacts = testSuiteArtifacts.filter(
       ({ edrArtifact }) => !noMatchContractRegex.test(edrArtifact.id.name),
     );
@@ -254,13 +265,16 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
 
   let effectiveTestPattern = grep;
   if (noMatchTest !== undefined) {
-    const noMatchTestRegex = new RegExp(noMatchTest);
+    const noMatchTestRegex = buildSafeRegExp(noMatchTest, "noMatchTest");
     const allTestNames: string[] = [];
     for (const { edrArtifact } of testSuiteArtifacts) {
       const abi: Abi = JSON.parse(edrArtifact.contract.abi);
       for (const entry of abi) {
         if (entry.type === "function" && typeof entry.name === "string") {
-          if (entry.name.startsWith("test") ||entry.name.startsWith("invariant") ) {
+          if (
+            entry.name.startsWith("test") ||
+            entry.name.startsWith("invariant")
+          ) {
             allTestNames.push(entry.name);
           }
         }
@@ -272,12 +286,19 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     );
 
     if (grep !== undefined) {
-      const grepRegex = new RegExp(grep);
+      const grepRegex = buildSafeRegExp(grep, "grep");
       survivingTests = survivingTests.filter((name) => grepRegex.test(name));
     }
 
     const uniqueTests = [...new Set(survivingTests)];
-    effectiveTestPattern = `^(${uniqueTests.map(s=>s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})$`;
+    if (uniqueTests.length > 0) {
+      effectiveTestPattern = `^(${uniqueTests.map(escapeRegExp).join("|")})$`;
+    } else {
+      console.warn(
+        "Warning: all test functions were excluded by the provided filters. No tests will run.",
+      );
+      effectiveTestPattern = "^$";
+    }
   }
 
   const testRunnerConfig =
@@ -482,6 +503,21 @@ async function loadArtifacts(
     );
   }
   return { edrArtifactsWithMetadata, allBuildInfosAndOutputs };
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildSafeRegExp(pattern: string, flagName: string): RegExp {
+  try {
+    return new RegExp(pattern);
+  } catch {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+      { value: pattern, type: "RegExp", name: flagName },
+    );
+  }
 }
 
 export default runSolidityTests;

--- a/packages/hardhat/test/fixture-projects/solidity-test/test/contracts/all/Counter-1.t.sol
+++ b/packages/hardhat/test/fixture-projects/solidity-test/test/contracts/all/Counter-1.t.sol
@@ -13,4 +13,9 @@ contract CounterTest1 {
   function testInitialValue() public view {
     require(counter.x() == 0, "Initial value should be 0");
   }
+
+  function testIncrement() public {
+    counter.inc();
+    require(counter.x() == 1, "Value should be 1 after increment");
+  }
 }

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -742,96 +742,59 @@ describe("solidity-test/task-action", function () {
   });
 
   describe("negation filters", () => {
-    it("should exclude contracts matching --no-match-contract", async () => {
+    before(async () => {
       hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
+    });
 
-      const result = await hre.tasks
+    async function runWithFilters(filters: Record<string, unknown>) {
+      return hre.tasks
         .getTask(["test", "solidity"])
-        .run({ noCompile: true, noMatchContract: "CounterTest1" });
+        .run({ noCompile: true, ...filters });
+    }
+
+    it("should exclude contracts matching --no-match-contract", async () => {
+      const result = await runWithFilters({ noMatchContract: "CounterTest1" });
 
       assert.equal(result.success, true);
       const suiteNames = getDiscoveredSuiteNames(result);
-      assert.ok(
-        !suiteNames.includes("CounterTest1"),
-        `CounterTest1 should be excluded, got: ${suiteNames.join(", ")}`,
-      );
-      assert.ok(
-        suiteNames.includes("CounterTest2"),
-        `CounterTest2 should still run, got: ${suiteNames.join(", ")}`,
-      );
+      assert.ok(!suiteNames.includes("CounterTest1"));
+      assert.ok(suiteNames.includes("CounterTest2"));
     });
 
     it("should exclude all contracts and return success with zero results", async () => {
-      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
-
-      const result = await hre.tasks
-        .getTask(["test", "solidity"])
-        .run({ noCompile: true, noMatchContract: "Counter" });
+      const result = await runWithFilters({ noMatchContract: "Counter" });
 
       assert.equal(result.success, true);
-      const suiteNames = getDiscoveredSuiteNames(result);
-      assert.equal(suiteNames.length, 0);
+      assert.equal(getDiscoveredSuiteNames(result).length, 0);
     });
 
     it("should return early when --no-match-test excludes all test functions", async () => {
-      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
-
-      const result = await hre.tasks
-        .getTask(["test", "solidity"])
-        .run({ noCompile: true, noMatchTest: "test" });
+      const result = await runWithFilters({ noMatchTest: "test" });
 
       assert.equal(result.success, true);
-      assert.deepEqual(result.value.summary, {
-        failed: 0,
-        passed: 0,
-        skipped: 0,
-        todo: 0,
-        failureOutput: "",
-      });
       assert.deepEqual(result.value.suiteResults, []);
     });
 
-    it("should throw HardhatError for invalid --no-match-contract regex", async () => {
-      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
+    for (const [flag, key] of [
+      ["--no-match-contract", "noMatchContract"],
+      ["--no-match-test", "noMatchTest"],
+    ] as const) {
+      it(`should throw HardhatError for invalid ${flag} regex`, async () => {
+        await assertRejectsWithHardhatError(
+          () => runWithFilters({ [key]: "[unclosed" }),
+          HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+          { value: "[unclosed", type: "RegExp", name: flag },
+        );
+      });
 
-      await assertRejectsWithHardhatError(
-        () =>
-          hre.tasks.getTask(["test", "solidity"]).run({
-            noCompile: true,
-            noMatchContract: "[unclosed",
-          }),
-        HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
-        { value: "[unclosed", type: "RegExp", name: "--no-match-contract" },
-      );
-    });
-
-    it("should throw HardhatError for invalid --no-match-test regex", async () => {
-      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
-
-      await assertRejectsWithHardhatError(
-        () =>
-          hre.tasks.getTask(["test", "solidity"]).run({
-            noCompile: true,
-            noMatchTest: "[unclosed",
-          }),
-        HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
-        { value: "[unclosed", type: "RegExp", name: "--no-match-test" },
-      );
-    });
-
-    it("should throw HardhatError for empty --no-match-test pattern", async () => {
-      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
-
-      await assertRejectsWithHardhatError(
-        () =>
-          hre.tasks.getTask(["test", "solidity"]).run({
-            noCompile: true,
-            noMatchTest: "",
-          }),
-        HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
-        { value: "", type: "RegExp", name: "--no-match-test" },
-      );
-    });
+      it(`should throw HardhatError for empty ${flag} pattern`, async () => {
+        await assertRejectsWithHardhatError(
+          () => runWithFilters({ [key]: "" }),
+          HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+          { value: "", type: "RegExp", name: flag },
+        );
+      });
+    }
   });
 });
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -747,7 +747,7 @@ describe("solidity-test/task-action", function () {
     });
 
     async function runWithFilters(filters: Record<string, unknown>) {
-      return hre.tasks
+      return await hre.tasks
         .getTask(["test", "solidity"])
         .run({ noCompile: true, ...filters });
     }
@@ -757,8 +757,14 @@ describe("solidity-test/task-action", function () {
 
       assert.equal(result.success, true);
       const suiteNames = getDiscoveredSuiteNames(result);
-      assert.ok(!suiteNames.includes("CounterTest1"));
-      assert.ok(suiteNames.includes("CounterTest2"));
+      assert.ok(
+        !suiteNames.includes("CounterTest1"),
+        "CounterTest1 should be excluded",
+      );
+      assert.ok(
+        suiteNames.includes("CounterTest2"),
+        "CounterTest2 should still run",
+      );
     });
 
     it("should exclude all contracts and return success with zero results", async () => {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -774,6 +774,17 @@ describe("solidity-test/task-action", function () {
       assert.equal(getDiscoveredSuiteNames(result).length, 0);
     });
 
+    it("should exclude tests matching --no-match-test and run the rest", async () => {
+      const result = await runWithFilters({ noMatchTest: "Increment" });
+
+      assert.equal(result.success, true);
+      const suiteNames = getDiscoveredSuiteNames(result);
+      assert.ok(
+        suiteNames.includes("CounterTest1"),
+        "CounterTest1 should still run with non-excluded tests",
+      );
+    });
+
     it("should return early when --no-match-test excludes all test functions", async () => {
       const result = await runWithFilters({ noMatchTest: "test" });
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -740,6 +740,99 @@ describe("solidity-test/task-action", function () {
       );
     });
   });
+
+  describe("negation filters", () => {
+    it("should exclude contracts matching --no-match-contract", async () => {
+      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
+
+      const result = await hre.tasks
+        .getTask(["test", "solidity"])
+        .run({ noCompile: true, noMatchContract: "CounterTest1" });
+
+      assert.equal(result.success, true);
+      const suiteNames = getDiscoveredSuiteNames(result);
+      assert.ok(
+        !suiteNames.includes("CounterTest1"),
+        `CounterTest1 should be excluded, got: ${suiteNames.join(", ")}`,
+      );
+      assert.ok(
+        suiteNames.includes("CounterTest2"),
+        `CounterTest2 should still run, got: ${suiteNames.join(", ")}`,
+      );
+    });
+
+    it("should exclude all contracts and return success with zero results", async () => {
+      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
+
+      const result = await hre.tasks
+        .getTask(["test", "solidity"])
+        .run({ noCompile: true, noMatchContract: "Counter" });
+
+      assert.equal(result.success, true);
+      const suiteNames = getDiscoveredSuiteNames(result);
+      assert.equal(suiteNames.length, 0);
+    });
+
+    it("should return early when --no-match-test excludes all test functions", async () => {
+      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
+
+      const result = await hre.tasks
+        .getTask(["test", "solidity"])
+        .run({ noCompile: true, noMatchTest: "test" });
+
+      assert.equal(result.success, true);
+      assert.deepEqual(result.value.summary, {
+        failed: 0,
+        passed: 0,
+        skipped: 0,
+        todo: 0,
+        failureOutput: "",
+      });
+      assert.deepEqual(result.value.suiteResults, []);
+    });
+
+    it("should throw HardhatError for invalid --no-match-contract regex", async () => {
+      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
+
+      await assertRejectsWithHardhatError(
+        () =>
+          hre.tasks.getTask(["test", "solidity"]).run({
+            noCompile: true,
+            noMatchContract: "[unclosed",
+          }),
+        HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+        { value: "[unclosed", type: "RegExp", name: "--no-match-contract" },
+      );
+    });
+
+    it("should throw HardhatError for invalid --no-match-test regex", async () => {
+      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
+
+      await assertRejectsWithHardhatError(
+        () =>
+          hre.tasks.getTask(["test", "solidity"]).run({
+            noCompile: true,
+            noMatchTest: "[unclosed",
+          }),
+        HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+        { value: "[unclosed", type: "RegExp", name: "--no-match-test" },
+      );
+    });
+
+    it("should throw HardhatError for empty --no-match-test pattern", async () => {
+      hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
+
+      await assertRejectsWithHardhatError(
+        () =>
+          hre.tasks.getTask(["test", "solidity"]).run({
+            noCompile: true,
+            noMatchTest: "",
+          }),
+        HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+        { value: "", type: "RegExp", name: "--no-match-test" },
+      );
+    });
+  });
 });
 
 function getDiscoveredSuiteNames(


### PR DESCRIPTION
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.

---
## Summary

Adds `--no-match-test` and `--no-match-contract` CLI flags to the `test solidity` task, enabling Foundry-style negation filters for Solidity tests.

## Context

Hardhat 3's `--grep` option filters tests by a regex, but EDR's regex crate does not support look-around, so there is no way to express "everything except X."

Foundry solves this with dedicated `--no-match-test` and `--no-match-contract` flags. This PR brings the same capability to Hardhat.

### Foundry parity

| Foundry | Hardhat | Notes |
|---------|-------------------|-------|
| `--match-test` | `--grep` (existing) | Same concept, different name |
| `--match-contract` | (not in scope) | `--grep` already filters by test name; contract-level positive matching could be a follow-up |
| `--no-match-test` | `--no-match-test` | **New(this PR)** |
| `--no-match-contract` | `--no-match-contract` | **New(this PR)** |

## Fix

- `--no-match-contract <regex>`: Filters out test contracts whose name matches the regex before passing them to EDR.

- `--no-match-test <regex>`: Collects all test function names from surviving contract ABIs, removes those matching the regex, intersects with `--grep` if present, then constructs a positive `testPattern` regex to pass to EDR.

- Invalid or empty patterns throw `HardhatError`.

- When all tests or contracts are excluded, a warning is printed and the task returns early with zero results.

## Example usage

```shell
# Run everything except fork tests
npx hardhat test solidity --no-match-test "^testFork_"

# Run everything except the ForkTest contract
npx hardhat test solidity --no-match-contract "ForkTest"

# Combine with --grep
npx hardhat test solidity --grep "^test" --no-match-test "Fork"
```

## Notes

- Added 8 test cases covering partial exclusion, total exclusion (both flags), invalid regex, and empty pattern cases.
- Closes #8184 (Support negation of test name filters in Solidity Test)
- Adresses #8309 (Reduce gaps in Solidity Test features)
