### PR TITLE
Fix/skip retry on non retryable errors

### DIFF
--- a/.changeset/red-owls-live.md
+++ b/.changeset/red-owls-live.md
@@ -1,0 +1,8 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+"@nomicfoundation/hardhat-errors": patch
+---
+
+Improved `hardhat verify` to fail faster when the block explorer reports that the constructor arguments are incorrect.
+
+Thanks to @gultekinmakif for the original idea and implementation in #8333.

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -2999,7 +2999,9 @@ Reason: "{reason}".
         websiteTitle: "Contract verification failed",
         websiteDescription: `Unable to verify the contract on the block explorer.
 
-If your contract uses libraries whose addresses cannot be detected automatically, make sure you are providing the correct address for each undetectable library.`,
+A common cause is incorrect constructor arguments. Please make sure the values you provide match the ones used during deployment.
+
+Another common cause is missing or incorrect library addresses. If your contract uses libraries whose addresses cannot be detected automatically, please make sure you provide the correct address for each undetectable library.`,
       },
       BLOCK_EXPLORER_NOT_CONFIGURED: {
         number: 80027,

--- a/packages/hardhat-verify/src/internal/blockscout.ts
+++ b/packages/hardhat-verify/src/internal/blockscout.ts
@@ -359,6 +359,7 @@ export class Blockscout implements VerificationProvider {
   ): Promise<{
     success: boolean;
     message: string;
+    isRetryable: boolean;
   }> {
     let response: HttpResponse;
     let responseBody: BlockscoutResponse | undefined;
@@ -450,6 +451,7 @@ export class Blockscout implements VerificationProvider {
     return {
       success: blockscoutResponse.isSuccess(),
       message: blockscoutResponse.message,
+      isRetryable: blockscoutResponse.isRetryable(),
     };
   }
 }
@@ -509,5 +511,12 @@ class BlockscoutVerificationStatusResponse
 
   public isOk(): boolean {
     return this.status === 1;
+  }
+
+  public isRetryable(): boolean {
+    // Blockscout's only failure message is the detail-free "Fail - Unable to
+    // verify". We cannot reliably tell whether a retry would help, so we
+    // assume that all failures are retryable.
+    return true;
   }
 }

--- a/packages/hardhat-verify/src/internal/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/etherscan.ts
@@ -371,6 +371,7 @@ export class Etherscan implements VerificationProvider {
   ): Promise<{
     success: boolean;
     message: string;
+    isRetryable: boolean;
   }> {
     let response: HttpResponse;
     let responseBody: EtherscanResponse | undefined;
@@ -450,6 +451,7 @@ export class Etherscan implements VerificationProvider {
       return {
         success: etherscanResponse.isSuccess(),
         message: etherscanResponse.message,
+        isRetryable: etherscanResponse.isRetryable(),
       };
     }
 
@@ -554,6 +556,28 @@ class EtherscanVerificationResponse implements VerificationResponse {
   }
 }
 
+// Etherscan verification failures classified by message as non-retryable.
+//
+// The full-input retry only changes the submitted sources and compiler
+// settings. A wrong-constructor-arguments rejection is independent of both
+// (the arguments are encoded once and reused across attempts), so retrying is
+// pointless.
+//
+// Other documented failures are deliberately excluded here: bytecode and
+// metadata (`bytecodehash`) mismatches are often fixed by the retry, which
+// resubmits with the artifact's real compiler settings; missing-source,
+// compilation, and temporary errors are inherently retryable.
+//
+// TODO: this is not the complete set of non-retryable failures. A bytecode
+// mismatch is also non-retryable when the minimal and full inputs have equal
+// compiler settings (the retry would recompile the target to identical
+// bytecode and fail identically). That case is not detectable from the
+// failure message alone; it requires comparing the two inputs' settings, and
+// will be implemented in a future PR.
+//
+// See: https://docs.etherscan.io/contract-verification/common-verification-errors
+const NON_RETRYABLE_FAILURE_PATTERNS = ["correct constructor argument"];
+
 class EtherscanVerificationStatusResponse
   implements VerificationStatusResponse
 {
@@ -586,6 +610,13 @@ class EtherscanVerificationStatusResponse
 
   public isOk(): boolean {
     return this.status === 1;
+  }
+
+  public isRetryable(): boolean {
+    const message = this.message.toLowerCase();
+    return !NON_RETRYABLE_FAILURE_PATTERNS.some((pattern) =>
+      message.includes(pattern),
+    );
   }
 }
 

--- a/packages/hardhat-verify/src/internal/etherscan.ts
+++ b/packages/hardhat-verify/src/internal/etherscan.ts
@@ -568,12 +568,12 @@ class EtherscanVerificationResponse implements VerificationResponse {
 // resubmits with the artifact's real compiler settings; missing-source,
 // compilation, and temporary errors are inherently retryable.
 //
-// TODO: this is not the complete set of non-retryable failures. A bytecode
-// mismatch is also non-retryable when the minimal and full inputs have equal
-// compiler settings (the retry would recompile the target to identical
-// bytecode and fail identically). That case is not detectable from the
-// failure message alone; it requires comparing the two inputs' settings, and
-// will be implemented in a future PR.
+// Note: a bytecode mismatch is intentionally left retryable even when the
+// minimal and full inputs share the same compiler settings. Older solc
+// versions have known bugs that can produce different bytecode depending on
+// which unrelated files are present in the input, so the full-input retry
+// can still resolve such a mismatch — the non-retryable set can't safely
+// be extended without an actual recompile-and-compare.
 //
 // See: https://docs.etherscan.io/contract-verification/common-verification-errors
 const NON_RETRYABLE_FAILURE_PATTERNS = ["correct constructor argument"];

--- a/packages/hardhat-verify/src/internal/sourcify.ts
+++ b/packages/hardhat-verify/src/internal/sourcify.ts
@@ -255,6 +255,7 @@ export class Sourcify implements VerificationProvider {
   ): Promise<{
     success: boolean;
     message: string;
+    isRetryable: boolean;
   }> {
     let response: HttpResponse;
     let responseBody:
@@ -347,6 +348,7 @@ export class Sourcify implements VerificationProvider {
     return {
       success,
       message,
+      isRetryable: verificationStatus.isRetryable(),
     };
   }
 }
@@ -431,6 +433,13 @@ class SourcifyVerificationStatus implements VerificationStatusResponse {
       this.response.isJobCompleted &&
       this.response.error?.customCode === "contract_not_deployed"
     );
+  }
+
+  public isRetryable(): boolean {
+    // Sourcify error messages vary and have no documented catalogue. We cannot
+    // reliably tell whether a retry would help, so we assume that all failures
+    // are retryable.
+    return true;
   }
 
   public isAlreadyVerified(): boolean {

--- a/packages/hardhat-verify/src/internal/types.ts
+++ b/packages/hardhat-verify/src/internal/types.ts
@@ -15,6 +15,12 @@ export interface VerificationStatusResponse {
   isSuccess(): boolean;
   isAlreadyVerified(): boolean;
   isOk(): boolean;
+  /**
+   * Whether a failed verification could be resolved by retrying with the full
+   * compiler input. Only meaningful when `isFailure()` is true, on success the
+   * value is irrelevant.
+   */
+  isRetryable(): boolean;
 }
 
 export interface VerificationResponse {
@@ -112,5 +118,6 @@ export interface VerificationProvider {
   ): Promise<{
     success: boolean;
     message: string;
+    isRetryable: boolean;
   }>;
 }

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -206,28 +206,31 @@ Explorer: ${instance.getContractUrl(address)}`);
     buildProfileName,
   );
 
-  const { success: minimalInputVerificationSuccess } =
-    await attemptVerification(
-      {
-        verificationProvider: instance,
-        address,
-        encodedConstructorArgs,
-        creationTxHash,
-        contractInformation: {
-          ...contractInformation,
-          // Use the minimal compiler input for the first verification attempt
-          compilerInput: {
-            ...minimalCompilerInput,
-            settings: {
-              ...minimalCompilerInput.settings,
-              // Ensure the libraries are included in the compiler input
-              libraries: libraryInformation.libraries,
-            },
+  const {
+    success: minimalInputVerificationSuccess,
+    message: minimalInputMessage,
+    isRetryable,
+  } = await attemptVerification(
+    {
+      verificationProvider: instance,
+      address,
+      encodedConstructorArgs,
+      creationTxHash,
+      contractInformation: {
+        ...contractInformation,
+        // Use the minimal compiler input for the first verification attempt
+        compilerInput: {
+          ...minimalCompilerInput,
+          settings: {
+            ...minimalCompilerInput.settings,
+            // Ensure the libraries are included in the compiler input
+            libraries: libraryInformation.libraries,
           },
         },
       },
-      consoleLog,
-    );
+    },
+    consoleLog,
+  );
 
   if (minimalInputVerificationSuccess) {
     consoleLog(`
@@ -238,45 +241,51 @@ Explorer: ${instance.getContractUrl(address)}`);
     return true;
   }
 
-  consoleLog(`
+  let failureReason = minimalInputMessage;
+
+  if (isRetryable) {
+    consoleLog(`
 The initial verification attempt for ${contractInformation.userFqn} failed using the minimal compiler input.
 
 Trying again with the full solc input used to compile and deploy the contract.
 Unrelated contracts may be displayed on ${instance.name} as a result.
 `);
 
-  // If verifying with the minimal input failed, try again with the full compiler input
-  const {
-    success: fullCompilerInputVerificationSuccess,
-    message: verificationMessage,
-  } = await attemptVerification(
-    {
-      verificationProvider: instance,
-      address,
-      encodedConstructorArgs,
-      creationTxHash,
-      contractInformation: {
-        ...contractInformation,
-        compilerInput: {
-          ...contractInformation.compilerInput,
-          settings: {
-            ...contractInformation.compilerInput.settings,
-            // Ensure the libraries are included in the compiler input
-            libraries: libraryInformation.libraries,
+    // If verifying with the minimal input failed, try again with the full compiler input
+    const {
+      success: fullCompilerInputVerificationSuccess,
+      message: fullInputMessage,
+    } = await attemptVerification(
+      {
+        verificationProvider: instance,
+        address,
+        encodedConstructorArgs,
+        creationTxHash,
+        contractInformation: {
+          ...contractInformation,
+          compilerInput: {
+            ...contractInformation.compilerInput,
+            settings: {
+              ...contractInformation.compilerInput.settings,
+              // Ensure the libraries are included in the compiler input
+              libraries: libraryInformation.libraries,
+            },
           },
         },
       },
-    },
-    consoleLog,
-  );
+      consoleLog,
+    );
 
-  if (fullCompilerInputVerificationSuccess) {
-    consoleLog(`
+    if (fullCompilerInputVerificationSuccess) {
+      consoleLog(`
 ✅ Contract verified successfully on ${instance.name}!
 
   ${contractInformation.userFqn}
   Explorer: ${instance.getContractUrl(address)}`);
-    return true;
+      return true;
+    }
+
+    failureReason = fullInputMessage;
   }
 
   const librariesWarning =
@@ -291,7 +300,7 @@ ${libraryInformation.undetectableLibraries.map((x) => `  * ${x}`).join("\n")}`
   throw new HardhatError(
     HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.CONTRACT_VERIFICATION_FAILED,
     {
-      reason: verificationMessage,
+      reason: failureReason,
       librariesWarning,
     },
   );
@@ -383,6 +392,7 @@ async function attemptVerification(
 ): Promise<{
   success: boolean;
   message: string;
+  isRetryable: boolean;
 }> {
   const guid = await verificationProvider.verify({
     contractAddress: address,

--- a/packages/hardhat-verify/test/etherscan.ts
+++ b/packages/hardhat-verify/test/etherscan.ts
@@ -866,6 +866,50 @@ describe("etherscan", () => {
         }
       });
 
+      it("should flag only constructor-argument failures as non-retryable", async () => {
+        const etherscan = new Etherscan({
+          ...etherscanConfig,
+          dispatcher: testDispatcher.interceptable,
+        });
+
+        const cases: Array<{ result: string; isRetryable: boolean }> = [
+          {
+            result:
+              "Fail - Unable to verify. Please check if the correct constructor argument was entered.",
+            isRetryable: false,
+          },
+          {
+            // Settings-dependent: the full-input retry can fix it, so retryable.
+            result:
+              "Fail - Unable to verify. Compiled contract deployment bytecode does NOT match the transaction deployment bytecode.",
+            isRetryable: true,
+          },
+          {
+            // Metadata is a compiler setting, so the retry can fix it too.
+            result:
+              "Fail - Unable to verify. Please check if the correct bytecodehash was specified via standard-json verification.",
+            isRetryable: true,
+          },
+          { result: "Fail - Unable to verify", isRetryable: true },
+        ];
+
+        for (const { result, isRetryable } of cases) {
+          pollVerificationStatusInterceptor.reply(200, {
+            status: "0",
+            result,
+          });
+
+          const response = await etherscan.pollVerificationStatus(
+            guid,
+            address,
+            contract,
+          );
+
+          assert.equal(response.success, false, result);
+          assert.equal(response.isRetryable, isRetryable, result);
+        }
+      });
+
       it("should poll the verification status until it is successful or fails", async () => {
         const etherscan = new Etherscan({
           ...etherscanConfig,

--- a/packages/hardhat-verify/test/verification.ts
+++ b/packages/hardhat-verify/test/verification.ts
@@ -7,6 +7,7 @@ import { before, beforeEach, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
+  assertRejectsWithHardhatError,
   assertThrowsHardhatError,
   useEphemeralFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
@@ -187,6 +188,78 @@ describe("verification", () => {
           "Etherscan verification should be disabled",
         );
         assert.ok(result, "Verification should return true");
+      });
+    });
+
+    describe("retry behavior", () => {
+      useEphemeralFixtureProject("integration");
+      const etherscanApiUrl = new URL("https://api-sepolia.etherscan.io")
+        .origin;
+      const testDispatcher = initializeTestDispatcher({
+        url: etherscanApiUrl,
+      });
+
+      let hre: HardhatRuntimeEnvironment;
+      before(async () => {
+        const hardhatUserConfig =
+          // eslint-disable-next-line import/no-relative-packages -- allowed in test
+          (await import("./fixture-projects/integration/hardhat.config.js"))
+            .default;
+        hre = await createHardhatRuntimeEnvironment(hardhatUserConfig);
+        await hre.tasks.getTask("build").run();
+      });
+
+      it("should skip the full-input retry when the explorer rejects the constructor arguments", async () => {
+        const { provider } = await hre.network.create();
+        const address = await deployContract("Counter", [], {}, hre, provider);
+
+        // Only a single verification attempt is mocked. If the code retried with
+        // the full input it would issue a second verifysourcecode request with no
+        // interceptor, which disableNetConnect() rejects, and the dispatcher's
+        // afterEach pending-interceptor check would also fail.
+        mockEtherscanVerificationFlow(testDispatcher.interceptable, [
+          "Fail - Unable to verify. Please check if the correct constructor argument was entered.",
+        ]);
+
+        await assertRejectsWithHardhatError(
+          verifyContract(
+            { address },
+            hre,
+            () => {},
+            testDispatcher.interceptable,
+            provider,
+          ),
+          HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL
+            .CONTRACT_VERIFICATION_FAILED,
+          {
+            reason:
+              "Fail - Unable to verify. Please check if the correct constructor argument was entered.",
+            librariesWarning: "",
+          },
+        );
+      });
+
+      it("should retry with the full input when the minimal attempt fails with a bytecode mismatch", async () => {
+        const { provider } = await hre.network.create();
+        const address = await deployContract("Counter", [], {}, hre, provider);
+
+        // Two attempts: the minimal input fails with a bytecode mismatch (which
+        // the retry can fix by resubmitting with the artifact's settings), then
+        // the full input succeeds.
+        mockEtherscanVerificationFlow(testDispatcher.interceptable, [
+          "Fail - Unable to verify. Compiled contract deployment bytecode does NOT match the transaction deployment bytecode.",
+          "Pass - Verified",
+        ]);
+
+        const result = await verifyContract(
+          { address },
+          hre,
+          () => {},
+          testDispatcher.interceptable,
+          provider,
+        );
+
+        assert.ok(result, "Verification should return true after the retry");
       });
     });
 
@@ -374,4 +447,35 @@ function mockEtherscanRequests(interceptable: Interceptable) {
       status: "1",
       result: "Pass - Verified",
     });
+}
+
+// Mocks a full Etherscan verification flow: the initial isVerified() lookup
+// (reported as not verified), followed by one verifysourcecode + checkverifystatus
+// pair per entry in `statusResults` (one per verification attempt).
+function mockEtherscanVerificationFlow(
+  interceptable: Interceptable,
+  statusResults: string[],
+) {
+  interceptable
+    .intercept({
+      path: /^\/(?:v2\/)?api\?action=getsourcecode&address=0x[a-fA-F0-9]{40}&apikey=[A-Za-z0-9]+&chainid=\d+&module=contract$/,
+      method: "GET",
+    })
+    .reply(200, { status: "1", result: [{ SourceCode: "" }] });
+
+  for (const result of statusResults) {
+    interceptable
+      .intercept({
+        path: /^\/(?:v2\/)?api\?action=verifysourcecode&apikey=[A-Za-z0-9]+&chainid=\d+&module=contract$/,
+        method: "POST",
+      })
+      .reply(200, { status: "1", message: "OK", result: "1234" });
+
+    interceptable
+      .intercept({
+        path: /^\/(?:v2\/)?api\?action=checkverifystatus&apikey=[A-Za-z0-9]+&chainid=\d+&guid=1234&module=contract$/,
+        method: "GET",
+      })
+      .reply(200, { status: "1", result });
+  }
 }


### PR DESCRIPTION
Closes #7731. Replaces #8333. Thanks @gultekinmakif for working on the original PR!

`hardhat-verify` now fails immediately when the block explorer rejects the constructor arguments, instead of repeating the verification with the full compiler input (which would fail for the same reason). Other failures still retry as before.

A follow-up PR will generalize the skip to any failure where the minimal and full inputs share the same compiler settings.