### PR TITLE
fix: prefer env vars for config variables

### DIFF
--- a/.changeset/proud-hats-fetch.md
+++ b/.changeset/proud-hats-fetch.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Prefer environment variables over configuration variable hooks when resolving configuration variables.

--- a/packages/hardhat/src/internal/core/configuration-variables.ts
+++ b/packages/hardhat/src/internal/core/configuration-variables.ts
@@ -115,6 +115,12 @@ export class LazyResolvedConfigurationVariable extends BaseResolvedConfiguration
   }
 
   protected async _getRawValue(): Promise<string> {
+    const envValue = process.env[this.name];
+
+    if (typeof envValue === "string") {
+      return envValue;
+    }
+
     const mutex = LazyResolvedConfigurationVariable.#mutexes.get(this.#hooks);
     assertHardhatInvariant(mutex !== undefined, "Mutex must be defined");
 

--- a/packages/hardhat/test/internal/core/configuration-variables/configuration-variables.ts
+++ b/packages/hardhat/test/internal/core/configuration-variables/configuration-variables.ts
@@ -56,6 +56,30 @@ describe("ResolvedConfigurationVariable", () => {
     delete process.env.foo;
   });
 
+  it("should prefer environment variables over configuration variable hooks", async () => {
+    const isolatedHre = await HardhatRuntimeEnvironmentImplementation.create(
+      {},
+      {},
+    );
+
+    isolatedHre.hooks.registerHandlers("configurationVariables", {
+      fetchValue: async () => "hook value",
+    });
+
+    const variable = new LazyResolvedConfigurationVariable(
+      isolatedHre.hooks,
+      configVariable("foo"),
+    );
+
+    process.env.foo = "env value";
+
+    try {
+      assert.equal(await variable.get(), "env value");
+    } finally {
+      delete process.env.foo;
+    }
+  });
+
   it("should throw if the environment variable is not found", async () => {
     const variable = new LazyResolvedConfigurationVariable(
       hre.hooks,


### PR DESCRIPTION
## Summary
- Makes `LazyResolvedConfigurationVariable` resolve an existing environment variable before invoking configuration variable hooks.
- Adds a regression test covering env-var precedence over hook-provided values.

## Why
Configuration variables can be resolved by plugins such as keystore integrations. Environment variables should consistently take precedence and avoid invoking those hooks when present.

## Changes
- Short-circuit `LazyResolvedConfigurationVariable._getRawValue()` when `process.env[variable.name]` exists.
- Keep the existing hook/default chain for variables not present in the environment.

## Validation
- `pnpm test:file packages/hardhat/test/internal/core/configuration-variables/configuration-variables.ts`
- `pnpm lint:file packages/hardhat/src/internal/core/configuration-variables.ts packages/hardhat/test/internal/core/configuration-variables/configuration-variables.ts`

## Scope
Focused fix for configuration variable resolution precedence.

Closes #7596
