### PR TITLE
fix: scope EIP-712 duplicate checks to included sources

### DIFF
--- a/.changeset/gentle-orders-include.md
+++ b/.changeset/gentle-orders-include.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed Solidity Test EIP-712 type collection so unselected sources don't trigger duplicate struct-name errors.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/canonicalize.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/canonicalize.ts
@@ -25,14 +25,17 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
  * constructs and propagates `None` through the dep graph so dependents are
  * also dropped.
  *
- * Only names in `selectedNames` are emitted; non-selected structs still
+ * Only names from `selectedSourcePaths` are emitted; non-selected structs still
  * participate in dep resolution so cross-file deps inline correctly.
  */
 export function canonicalizeStructs(
   structs: CollectedStruct[],
   selectedNames: Set<string>,
+  selectedSourcePaths: Set<string> = new Set<string>(
+    structs.filter((s) => selectedNames.has(s.name)).map((s) => s.sourcePath),
+  ),
 ): string[] {
-  const byName = indexByName(structs, selectedNames);
+  const byName = indexByName(structs, selectedNames, selectedSourcePaths);
   const knownNames = new Set(byName.keys());
   const encodable = computeEncodable(byName, knownNames);
   const result: string[] = [];
@@ -199,6 +202,7 @@ function transitiveDeps(
 function indexByName(
   structs: CollectedStruct[],
   selectedNames: Set<string>,
+  selectedSourcePaths: Set<string>,
 ): Map<string, CollectedStruct> {
   const byName = new Map<string, CollectedStruct>();
   const fingerprintByName = new Map<string, string>();
@@ -209,8 +213,8 @@ function indexByName(
   >();
 
   const ordered = [
-    ...structs.filter((s) => selectedNames.has(s.name)),
-    ...structs.filter((s) => !selectedNames.has(s.name)),
+    ...structs.filter((s) => selectedSourcePaths.has(s.sourcePath)),
+    ...structs.filter((s) => !selectedSourcePaths.has(s.sourcePath)),
   ];
 
   for (const struct of ordered) {
@@ -228,7 +232,7 @@ function indexByName(
       continue;
     }
 
-    if (!selectedNames.has(struct.name)) {
+    if (!selectedSourcePaths.has(struct.sourcePath)) {
       if (!deferredConflicts.has(struct.name)) {
         deferredConflicts.set(struct.name, {
           firstSource: sourceByName.get(struct.name) ?? "<unknown>",

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -53,6 +53,7 @@ export function collectEip712CanonicalTypes(
 
   const collected: CollectedStruct[] = [];
   const selectedNames = new Set<string>();
+  const selectedSourcePaths = new Set<string>();
 
   for (const { buildInfo, output } of buildInfosAndOutputs) {
     // Byte-level fast path: a build info whose source bytes don't contain
@@ -109,6 +110,7 @@ export function collectEip712CanonicalTypes(
       collected.push(...structs);
 
       if (isPathSelected(userSourceName, include, exclude)) {
+        selectedSourcePaths.add(userSourceName);
         for (const s of structs) {
           selectedNames.add(s.name);
         }
@@ -116,5 +118,5 @@ export function collectEip712CanonicalTypes(
     }
   }
 
-  return canonicalizeStructs(collected, selectedNames);
+  return canonicalizeStructs(collected, selectedNames, selectedSourcePaths);
 }

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -220,6 +220,40 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(excludeTests, ["Foo(uint256 x)"]);
   });
 
+  it("ignores conflicting same-named structs from unselected sources", () => {
+    const sources: FakeSource[] = [
+      {
+        inputSourceName: "project/contracts/A.sol",
+        userSourceName: "contracts/A.sol",
+        ast: sourceUnit([
+          structAst("Order", [
+            { type: "address", name: "user" },
+            { type: "uint256", name: "amount" },
+          ]),
+        ]),
+      },
+      {
+        inputSourceName: "project/contracts/B.sol",
+        userSourceName: "contracts/B.sol",
+        ast: sourceUnit([
+          structAst("Order", [
+            { type: "bytes32", name: "id" },
+            { type: "bool", name: "active" },
+          ]),
+        ]),
+      },
+    ];
+    const buildInfo = makeBuildInfo("solc-0_8_23-bbbbcccc", sources);
+
+    const result = collectEip712CanonicalTypes(
+      [buildInfo],
+      inputToUserSourceMap(sources),
+      { include: ["contracts/A.sol"], exclude: [] },
+    );
+
+    assert.deepEqual(result, ["Order(address user,uint256 amount)"]);
+  });
+
   it("dedupes the same struct seen across multiple build infos", () => {
     const ast = sourceUnit([
       structAst("Person", [


### PR DESCRIPTION
## Summary
- Fixes Solidity Test EIP-712 type collection so a same-named struct in an unselected source doesn't trigger a duplicate-name error.
- Keeps duplicate checks for selected structs and for non-selected structs that are reachable dependencies of selected types.
- Adds a regression test for include-scoped duplicate struct names.

## Why
The `test.solidity.eip712Types.include` setting should bound which source files contribute selected struct definitions. A file outside the include set should not fail the run just because it defines a struct with the same name as a selected struct.

## Changes
- Tracks selected source paths separately from selected struct names.
- Uses selected source paths when ordering and classifying conflicting definitions.
- Adds a changeset for the Hardhat patch release.

## Validation
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts`
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/canonicalize.ts`
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/canonicalize.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts`

## Scope
Focused Solidity Test EIP-712 collector fix.

Closes #8344
