### PR TITLE
fix: avoid mutating network requests

### DIFF
--- a/.changeset/tidy-requests-copy.md
+++ b/.changeset/tidy-requests-copy.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+fix: avoid mutating network manager JSON-RPC requests

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -59,9 +59,8 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         });
       }
 
-      // We previously cloned here, but the performance impact is significant.
-      // TODO: ensure the passed in request is not mutated by adapting the
-      // handlers being applied here. See https://github.com/NomicFoundation/hardhat/issues/8090
+      // Handlers copy requests when they need to add or update fields, so the
+      // original request received by this hook is not mutated.
       let updatedRequest = jsonRpcRequest;
 
       for (const handler of requestHandlers) {

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/json-rpc.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/json-rpc.ts
@@ -145,3 +145,13 @@ export function getRequestParams(
     HardhatError.ERRORS.CORE.NETWORK.INVALID_REQUEST_PARAMS,
   );
 }
+
+export function updateRequestParams(
+  jsonRpcRequest: JsonRpcRequest,
+  params: unknown[],
+): JsonRpcRequest {
+  return {
+    ...jsonRpcRequest,
+    params,
+  };
+}

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/sender.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/sender.ts
@@ -8,7 +8,7 @@ import type { RequestHandler } from "../../types.js";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { getRequestParams } from "../../../json-rpc.js";
+import { getRequestParams, updateRequestParams } from "../../../json-rpc.js";
 
 /**
  * This class modifies JSON-RPC requests.
@@ -49,7 +49,10 @@ export abstract class SenderHandler implements RequestHandler {
       const senderAccount = await this.getSender();
 
       if (senderAccount !== undefined) {
-        tx.from = senderAccount;
+        const updatedParams = [...params];
+        updatedParams[0] = { ...tx, from: senderAccount };
+
+        return updateRequestParams(jsonRpcRequest, updatedParams);
       } else if (method === "eth_sendTransaction") {
         throw new HardhatError(
           HardhatError.ERRORS.CORE.NETWORK.NO_REMOTE_ACCOUNT_AVAILABLE,

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts
@@ -7,7 +7,7 @@ import type { RequestHandler } from "../../types.js";
 
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { getRequestParams } from "../../../json-rpc.js";
+import { getRequestParams, updateRequestParams } from "../../../json-rpc.js";
 
 import { MultipliedGasEstimation } from "./multiplied-gas-estimation.js";
 
@@ -49,7 +49,13 @@ export class AutomaticGasHandler
     const [tx] = params;
 
     if (isObject(tx) && tx.gas === undefined) {
-      tx.gas = await this.getMultipliedGasEstimation(params);
+      const updatedParams = [...params];
+      updatedParams[0] = {
+        ...tx,
+        gas: await this.getMultipliedGasEstimation(params),
+      };
+
+      return updateRequestParams(jsonRpcRequest, updatedParams);
     }
 
     return jsonRpcRequest;

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts
@@ -12,7 +12,7 @@ import {
 } from "@nomicfoundation/hardhat-utils/hex";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { getRequestParams } from "../../../json-rpc.js";
+import { getRequestParams, updateRequestParams } from "../../../json-rpc.js";
 
 /**
  * This class automatically adjusts transaction requests to include appropriately estimated gas prices.
@@ -72,8 +72,13 @@ export class AutomaticGasPriceHandler implements RequestHandler {
       tx.maxPriorityFeePerGas === undefined &&
       suggestedEip1559Values === undefined
     ) {
-      tx.gasPrice = numberToHexString(await this.#getGasPrice());
-      return jsonRpcRequest;
+      const updatedLegacyParams = [...params];
+      updatedLegacyParams[0] = {
+        ...tx,
+        gasPrice: numberToHexString(await this.#getGasPrice()),
+      };
+
+      return updateRequestParams(jsonRpcRequest, updatedLegacyParams);
     }
 
     // If eth_feeHistory failed, but the user still wants to send an EIP-1559 tx
@@ -101,10 +106,14 @@ export class AutomaticGasPriceHandler implements RequestHandler {
       maxFeePerGas += maxPriorityFeePerGas;
     }
 
-    tx.maxFeePerGas = numberToHexString(maxFeePerGas);
-    tx.maxPriorityFeePerGas = numberToHexString(maxPriorityFeePerGas);
+    const updatedParams = [...params];
+    updatedParams[0] = {
+      ...tx,
+      maxFeePerGas: numberToHexString(maxFeePerGas),
+      maxPriorityFeePerGas: numberToHexString(maxPriorityFeePerGas),
+    };
 
-    return jsonRpcRequest;
+    return updateRequestParams(jsonRpcRequest, updatedParams);
   }
 
   async #getGasPrice(): Promise<bigint> {

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
@@ -7,7 +7,7 @@ import type { PrefixedHexString } from "@nomicfoundation/hardhat-utils/hex";
 
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { getRequestParams } from "../../../json-rpc.js";
+import { getRequestParams, updateRequestParams } from "../../../json-rpc.js";
 
 /**
  * This class ensures that a fixed gas is applied to transaction requests.
@@ -37,7 +37,10 @@ export class FixedGasHandler implements RequestHandler {
     const [tx] = params;
 
     if (isObject(tx) && tx.gas === undefined) {
-      tx.gas = this.#gas;
+      const updatedParams = [...params];
+      updatedParams[0] = { ...tx, gas: this.#gas };
+
+      return updateRequestParams(jsonRpcRequest, updatedParams);
     }
 
     return jsonRpcRequest;

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts
@@ -7,7 +7,7 @@ import type { PrefixedHexString } from "@nomicfoundation/hardhat-utils/hex";
 
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { getRequestParams } from "../../../json-rpc.js";
+import { getRequestParams, updateRequestParams } from "../../../json-rpc.js";
 
 /**
  * This class ensures that a fixed gas price is applied to transaction requests.
@@ -43,7 +43,10 @@ export class FixedGasPriceHandler implements RequestHandler {
       tx.maxFeePerGas === undefined &&
       tx.maxPriorityFeePerGas === undefined
     ) {
-      tx.gasPrice = this.#gasPrice;
+      const updatedParams = [...params];
+      updatedParams[0] = { ...tx, gasPrice: this.#gasPrice };
+
+      return updateRequestParams(jsonRpcRequest, updatedParams);
     }
 
     return jsonRpcRequest;

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -17,6 +17,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { deepClone } from "@nomicfoundation/hardhat-utils/lang";
 
 import factory from "../../../../../src/internal/builtin-plugins/network-manager/hook-handlers/network.js";
 import { EthereumMockedProvider } from "../request-handlers/ethereum-mocked-provider.js";
@@ -36,6 +37,33 @@ describe("network hook handler", () => {
     );
 
     assert.deepEqual(response.id, 99);
+  });
+
+  it("should not mutate the original JSON-RPC request", async () => {
+    const handlers = await createHandlersFromFactory();
+    const { connection, context, next } = setupRequestMocks();
+
+    const request = createRequestWithId(1);
+    const originalParams = await deepClone(request.params);
+
+    const response = await handlers.onRequest(
+      context,
+      connection,
+      request,
+      next,
+    );
+
+    assert.deepEqual(request.params, originalParams);
+
+    assert(
+      isSuccessfulResponse(response),
+      "expected response to be a successful response",
+    );
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- result is typed as unknown, narrowing to the expected shape */
+    const params = response.result as Array<Record<string, string>>;
+    assert.equal(params[0].from, connection.networkConfig.from);
+    assert.equal(params[0].gas, numberToHexString(21_000n));
+    assert.equal(params[0].gasPrice, numberToHexString(1_000n));
   });
 
   it("should reuse cached handlers on subsequent calls with the same connection", async () => {

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
@@ -44,9 +44,10 @@ describe("AutomaticSenderHandler", function () {
   it("should set the from value into the transaction", async () => {
     const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-    await automaticSenderHandler.handle(jsonRpcRequest);
+    const response = await automaticSenderHandler.handle(jsonRpcRequest);
 
-    const [requestTx] = getRequestParams(jsonRpcRequest);
+    assert("method" in response, "expected handler response to be a request");
+    const [requestTx] = getRequestParams(response);
     assert.ok(isObject(requestTx), "tx is not an object");
     assert.equal(requestTx.from, "0x123006d4548a3ac17d72b372ae1e416bf65b8eaf");
   });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/fixed-sender-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/fixed-sender-handler.ts
@@ -43,9 +43,10 @@ describe("FixedSenderHandler", function () {
   it("should set the from value into the transaction", async () => {
     const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-    await fixedSenderHandler.handle(jsonRpcRequest);
+    const response = await fixedSenderHandler.handle(jsonRpcRequest);
 
-    const [requestTx] = getRequestParams(jsonRpcRequest);
+    assert("method" in response, "expected handler response to be a request");
+    const [requestTx] = getRequestParams(response);
     assert.ok(isObject(requestTx), "tx is not an object");
     assert.equal(requestTx.from, "0x2a97a65d5673a2c61e95ce33cecadf24f654f96d");
   });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts
@@ -48,8 +48,9 @@ describe("AutomaticGasHandler", () => {
       },
     ]);
 
-    await automaticGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const response = await automaticGasHandler.handle(jsonRpcRequest);
+    assert("method" in response, "expected handler response to be a request");
+    const [tx] = getRequestParams(response);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(
@@ -74,8 +75,9 @@ describe("AutomaticGasHandler", () => {
       GAS_MULTIPLIER2,
     );
 
-    await automaticGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const response = await automaticGasHandler.handle(jsonRpcRequest);
+    assert("method" in response, "expected handler response to be a request");
+    const [tx] = getRequestParams(response);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(
@@ -95,8 +97,9 @@ describe("AutomaticGasHandler", () => {
 
     automaticGasHandler = new AutomaticGasHandler(mockedProvider);
 
-    await automaticGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const response = await automaticGasHandler.handle(jsonRpcRequest);
+    assert("method" in response, "expected handler response to be a request");
+    const [tx] = getRequestParams(response);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts
@@ -96,8 +96,12 @@ describe("AutomaticGasPriceHandler", () => {
           },
         ]);
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const response = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert(
+          "method" in response,
+          "expected handler response to be a request",
+        );
+        const [tx] = getRequestParams(response);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.maxPriorityFeePerGas, "0x4");
@@ -114,8 +118,12 @@ describe("AutomaticGasPriceHandler", () => {
           },
         ]);
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const response = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert(
+          "method" in response,
+          "expected handler response to be a request",
+        );
+        const [tx] = getRequestParams(response);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.maxPriorityFeePerGas, "0x4");
@@ -140,8 +148,12 @@ describe("AutomaticGasPriceHandler", () => {
               ),
         );
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const response = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert(
+          "method" in response,
+          "expected handler response to be a request",
+        );
+        const [tx] = getRequestParams(response);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.maxPriorityFeePerGas, "0x1");
@@ -185,8 +197,12 @@ describe("AutomaticGasPriceHandler", () => {
               ),
         );
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const response = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert(
+          "method" in response,
+          "expected handler response to be a request",
+        );
+        const [tx] = getRequestParams(response);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.maxPriorityFeePerGas, "0x1");
@@ -232,8 +248,12 @@ describe("AutomaticGasPriceHandler", () => {
               ),
         );
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const response = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert(
+          "method" in response,
+          "expected handler response to be a request",
+        );
+        const [tx] = getRequestParams(response);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.maxPriorityFeePerGas, "0x12");
@@ -282,8 +302,12 @@ describe("AutomaticGasPriceHandler", () => {
           },
         ]);
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const response = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert(
+          "method" in response,
+          "expected handler response to be a request",
+        );
+        const [tx] = getRequestParams(response);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.gasPrice, numberToHexString(FIXED_GAS_PRICE));
@@ -299,8 +323,12 @@ describe("AutomaticGasPriceHandler", () => {
           },
         ]);
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const response = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert(
+          "method" in response,
+          "expected handler response to be a request",
+        );
+        const [tx] = getRequestParams(response);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(
@@ -320,8 +348,12 @@ describe("AutomaticGasPriceHandler", () => {
           },
         ]);
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const response = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert(
+          "method" in response,
+          "expected handler response to be a request",
+        );
+        const [tx] = getRequestParams(response);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
@@ -28,8 +28,9 @@ describe("FixedGasHandler", () => {
       },
     ]);
 
-    await fixedGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const response = await fixedGasHandler.handle(jsonRpcRequest);
+    assert("method" in response, "expected handler response to be a request");
+    const [tx] = getRequestParams(response);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(tx.gas, numberToHexString(FIXED_GAS_LIMIT));

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts
@@ -30,8 +30,9 @@ describe("FixedGasPriceHandler", () => {
       },
     ]);
 
-    await fixedGasPriceHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const response = await fixedGasPriceHandler.handle(jsonRpcRequest);
+    assert("method" in response, "expected handler response to be a request");
+    const [tx] = getRequestParams(response);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(tx.gasPrice, numberToHexString(FIXED_GAS_PRICE));


### PR DESCRIPTION
## Summary
- Updates network-manager request handlers to return copied JSON-RPC requests when adding sender, gas, or gas price fields.
- Keeps the hook-handler request pipeline non-mutating without cloning every incoming request.
- Adds a regression test for preserving the original JSON-RPC request and updates handler tests to assert returned requests.

## Why
Network hook handlers should not mutate the JSON-RPC request object they receive. The hook previously had a TODO for this after removing an unconditional clone for performance reasons.

## Changes
- Adds a small `updateRequestParams` helper for returning copied request objects.
- Copies transaction params in sender, gas, and gas-price handlers before adding defaults.
- Removes the stale TODO in the network hook handler.
- Adds a changeset for the Hardhat patch release.

## Validation
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/network.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/fixed-sender-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts`
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/network-manager/json-rpc.ts packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/sender.ts packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/network.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/fixed-sender-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts`

## Scope
Focused network-manager request immutability fix.

Closes #8090
