### PR TITLE
fix: parse large Solidity Test build info outputs

### DIFF
--- a/.changeset/large-build-info-solidity-test.md
+++ b/.changeset/large-build-info-solidity-test.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix Solidity Test inline-config and EIP-712 collectors with very large build-info outputs.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/build-info-output.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/build-info-output.ts
@@ -1,0 +1,308 @@
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import { bytesToUtf8String } from "@nomicfoundation/hardhat-utils/bytes";
+
+export interface SolidityBuildInfoOutputForSolidityTests {
+  output: {
+    sources: Record<string, { ast: any }>;
+    contracts?: Record<
+      string,
+      Record<string, { evm?: { methodIdentifiers?: Record<string, string> } }>
+    >;
+  };
+}
+
+/**
+ * Parses the parts of a build-info output needed by Solidity Test without
+ * decoding the entire JSON payload into a single string.
+ *
+ * Real projects can produce build-info outputs that are larger than V8's max
+ * string length. The full output mostly consists of contract bytecode and
+ * metadata, while Solidity Test only needs source ASTs and method identifiers.
+ * This parser scans the JSON bytes and parses those smaller subtrees only.
+ */
+export function parseSolidityTestBuildInfoOutput(
+  output: Uint8Array,
+): SolidityBuildInfoOutputForSolidityTests {
+  const rootRange = getValueRange(output, skipWhitespace(output, 0));
+  const outputRange = findObjectPropertyRange(output, rootRange, "output");
+
+  if (outputRange === undefined) {
+    return { output: { sources: {} } };
+  }
+
+  const sourcesRange = findObjectPropertyRange(output, outputRange, "sources");
+  const contractsRange = findObjectPropertyRange(
+    output,
+    outputRange,
+    "contracts",
+  );
+
+  const parsedOutput: SolidityBuildInfoOutputForSolidityTests = {
+    output: {
+      sources:
+        sourcesRange !== undefined ? parseSources(output, sourcesRange) : {},
+      contracts:
+        contractsRange !== undefined
+          ? parseContractsMethodIdentifiers(output, contractsRange)
+          : undefined,
+    },
+  };
+
+  return parsedOutput;
+}
+
+function parseSources(
+  bytes: Uint8Array,
+  sourcesRange: ValueRange,
+): NonNullable<SolidityBuildInfoOutputForSolidityTests["output"]["sources"]> {
+  const sources: NonNullable<
+    SolidityBuildInfoOutputForSolidityTests["output"]["sources"]
+  > = {};
+
+  for (const { key, valueRange } of iterateObjectProperties(
+    bytes,
+    sourcesRange,
+  )) {
+    sources[key] = parseJsonRange(bytes, valueRange);
+  }
+
+  return sources;
+}
+
+function parseContractsMethodIdentifiers(
+  bytes: Uint8Array,
+  contractsRange: ValueRange,
+): NonNullable<SolidityBuildInfoOutputForSolidityTests["output"]["contracts"]> {
+  const contracts: NonNullable<
+    SolidityBuildInfoOutputForSolidityTests["output"]["contracts"]
+  > = {};
+
+  for (const {
+    key: sourceName,
+    valueRange: sourceContractsRange,
+  } of iterateObjectProperties(bytes, contractsRange)) {
+    const parsedContracts: NonNullable<
+      SolidityBuildInfoOutputForSolidityTests["output"]["contracts"]
+    >[string] = {};
+
+    for (const {
+      key: contractName,
+      valueRange: contractRange,
+    } of iterateObjectProperties(bytes, sourceContractsRange)) {
+      const evmRange = findObjectPropertyRange(bytes, contractRange, "evm");
+      const methodIdentifiersRange =
+        evmRange !== undefined
+          ? findObjectPropertyRange(bytes, evmRange, "methodIdentifiers")
+          : undefined;
+
+      parsedContracts[contractName] = {
+        evm:
+          methodIdentifiersRange !== undefined
+            ? {
+                methodIdentifiers: parseJsonRange(
+                  bytes,
+                  methodIdentifiersRange,
+                ),
+              }
+            : undefined,
+      };
+    }
+
+    contracts[sourceName] = parsedContracts;
+  }
+
+  return contracts;
+}
+
+interface ValueRange {
+  start: number;
+  end: number;
+}
+
+function findObjectPropertyRange(
+  bytes: Uint8Array,
+  objectRange: ValueRange,
+  propertyName: string,
+): ValueRange | undefined {
+  for (const { key, valueRange } of iterateObjectProperties(
+    bytes,
+    objectRange,
+  )) {
+    if (key === propertyName) {
+      return valueRange;
+    }
+  }
+
+  return undefined;
+}
+
+function* iterateObjectProperties(
+  bytes: Uint8Array,
+  objectRange: ValueRange,
+): Generator<{ key: string; valueRange: ValueRange }> {
+  let cursor = skipWhitespace(bytes, objectRange.start);
+  if (bytes[cursor] !== ASCII.LEFT_BRACE) {
+    return;
+  }
+
+  cursor = skipWhitespace(bytes, cursor + 1);
+  while (cursor < objectRange.end && bytes[cursor] !== ASCII.RIGHT_BRACE) {
+    const keyRange = readStringRange(bytes, cursor);
+    const key = parseJsonRange<string>(bytes, keyRange);
+
+    cursor = skipWhitespace(bytes, keyRange.end);
+    if (bytes[cursor] !== ASCII.COLON) {
+      fail("Invalid JSON object: missing ':' after key");
+    }
+
+    const valueRange = getValueRange(bytes, skipWhitespace(bytes, cursor + 1));
+    yield { key, valueRange };
+
+    cursor = skipWhitespace(bytes, valueRange.end);
+    if (bytes[cursor] === ASCII.COMMA) {
+      cursor = skipWhitespace(bytes, cursor + 1);
+    } else if (bytes[cursor] !== ASCII.RIGHT_BRACE) {
+      fail("Invalid JSON object: missing ',' or '}'");
+    }
+  }
+}
+
+function getValueRange(bytes: Uint8Array, start: number): ValueRange {
+  const firstByte = bytes[start];
+
+  if (firstByte === ASCII.LEFT_BRACE) {
+    return readCompositeRange(
+      bytes,
+      start,
+      ASCII.LEFT_BRACE,
+      ASCII.RIGHT_BRACE,
+    );
+  }
+
+  if (firstByte === ASCII.LEFT_BRACKET) {
+    return readCompositeRange(
+      bytes,
+      start,
+      ASCII.LEFT_BRACKET,
+      ASCII.RIGHT_BRACKET,
+    );
+  }
+
+  if (firstByte === ASCII.DOUBLE_QUOTE) {
+    return readStringRange(bytes, start);
+  }
+
+  let end = start;
+  while (
+    end < bytes.length &&
+    bytes[end] !== ASCII.COMMA &&
+    bytes[end] !== ASCII.RIGHT_BRACE &&
+    bytes[end] !== ASCII.RIGHT_BRACKET &&
+    !isWhitespace(bytes[end])
+  ) {
+    end += 1;
+  }
+
+  return { start, end };
+}
+
+function readCompositeRange(
+  bytes: Uint8Array,
+  start: number,
+  left: number,
+  right: number,
+): ValueRange {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < bytes.length; i++) {
+    const byte = bytes[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (byte === ASCII.BACKSLASH) {
+        escaped = true;
+      } else if (byte === ASCII.DOUBLE_QUOTE) {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (byte === ASCII.DOUBLE_QUOTE) {
+      inString = true;
+    } else if (byte === left) {
+      depth += 1;
+    } else if (byte === right) {
+      depth -= 1;
+      if (depth === 0) {
+        return { start, end: i + 1 };
+      }
+    }
+  }
+
+  fail("Invalid JSON: unterminated composite value");
+}
+
+function readStringRange(bytes: Uint8Array, start: number): ValueRange {
+  if (bytes[start] !== ASCII.DOUBLE_QUOTE) {
+    fail("Invalid JSON: expected string");
+  }
+
+  let escaped = false;
+  for (let i = start + 1; i < bytes.length; i++) {
+    const byte = bytes[i];
+
+    if (escaped) {
+      escaped = false;
+    } else if (byte === ASCII.BACKSLASH) {
+      escaped = true;
+    } else if (byte === ASCII.DOUBLE_QUOTE) {
+      return { start, end: i + 1 };
+    }
+  }
+
+  fail("Invalid JSON: unterminated string");
+}
+
+function fail(message: string): never {
+  assertHardhatInvariant(false, message);
+}
+
+function parseJsonRange<T>(bytes: Uint8Array, range: ValueRange): T {
+  return JSON.parse(bytesToUtf8String(bytes.subarray(range.start, range.end)));
+}
+
+function skipWhitespace(bytes: Uint8Array, start: number): number {
+  let cursor = start;
+  while (cursor < bytes.length && isWhitespace(bytes[cursor])) {
+    cursor += 1;
+  }
+
+  return cursor;
+}
+
+function isWhitespace(byte: number): boolean {
+  return (
+    byte === ASCII.SPACE ||
+    byte === ASCII.LINE_FEED ||
+    byte === ASCII.CARRIAGE_RETURN ||
+    byte === ASCII.TAB
+  );
+}
+
+const ASCII = {
+  BACKSLASH: 0x5c,
+  COLON: 0x3a,
+  COMMA: 0x2c,
+  CARRIAGE_RETURN: 0x0d,
+  DOUBLE_QUOTE: 0x22,
+  LEFT_BRACE: 0x7b,
+  LEFT_BRACKET: 0x5b,
+  LINE_FEED: 0x0a,
+  RIGHT_BRACE: 0x7d,
+  RIGHT_BRACKET: 0x5d,
+  SPACE: 0x20,
+  TAB: 0x09,
+} as const;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -1,13 +1,10 @@
 import type { CollectedStruct } from "./ast-walker.js";
-import type { SolidityBuildInfoOutput } from "../../../../types/solidity/solidity-artifacts.js";
 import type { BuildInfoAndOutput } from "../edr-artifacts.js";
 
-import {
-  bytesIncludesUtf8String,
-  bytesToUtf8String,
-} from "@nomicfoundation/hardhat-utils/bytes";
+import { bytesIncludesUtf8String } from "@nomicfoundation/hardhat-utils/bytes";
 
 import { HARDHAT_PROJECT_INPUT_SOURCE_NAME_ROOT } from "../../solidity/constants.js";
+import { parseSolidityTestBuildInfoOutput } from "../build-info-output.js";
 
 import {
   buildUserDefinedValueTypeIndex,
@@ -61,9 +58,7 @@ export function collectEip712CanonicalTypes(
       continue;
     }
 
-    const parsedOutput: SolidityBuildInfoOutput = JSON.parse(
-      bytesToUtf8String(output),
-    );
+    const parsedOutput = parseSolidityTestBuildInfoOutput(output);
 
     const sources = parsedOutput.output.sources;
     if (sources === undefined) {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -1,4 +1,3 @@
-import type { SolidityBuildInfoOutput } from "../../../../types/solidity/solidity-artifacts.js";
 import type {
   BuildInfoAndOutput,
   EdrArtifactWithMetadata,
@@ -10,9 +9,9 @@ import {
   HardhatError,
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
-import { bytesToUtf8String } from "@nomicfoundation/hardhat-utils/bytes";
 
 import { getFullyQualifiedName } from "../../../../utils/contract-names.js";
+import { parseSolidityTestBuildInfoOutput } from "../build-info-output.js";
 
 import {
   buildInfoContainsInlineConfig,
@@ -153,8 +152,8 @@ function collectRawOverrides(
       continue;
     }
 
-    const buildInfoOutput: SolidityBuildInfoOutput = JSON.parse(
-      bytesToUtf8String(buildInfoAndOutput.output),
+    const buildInfoOutput = parseSolidityTestBuildInfoOutput(
+      buildInfoAndOutput.output,
     );
 
     for (const [

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/build-info-output.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/build-info-output.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { utf8StringToBytes } from "@nomicfoundation/hardhat-utils/bytes";
+
+import { parseSolidityTestBuildInfoOutput } from "../../../../src/internal/builtin-plugins/solidity-test/build-info-output.js";
+
+describe("parseSolidityTestBuildInfoOutput", () => {
+  it("extracts source ASTs and method identifiers from build-info output bytes", () => {
+    const output = {
+      _format: "hh3-sol-build-info-output-1",
+      id: "solc-0_8_23-aaaaaaaa",
+      output: {
+        contracts: {
+          "project/test/Foo.sol": {
+            Foo: {
+              abi: [],
+              evm: {
+                bytecode: { object: "ab".repeat(1_000_000) },
+                deployedBytecode: { object: "cd".repeat(1_000_000) },
+                methodIdentifiers: {
+                  "testExample()": "abcdef01",
+                },
+              },
+              metadata: "{}",
+            },
+          },
+        },
+        sources: {
+          "project/test/Foo.sol": {
+            id: 0,
+            ast: {
+              nodeType: "SourceUnit",
+              nodes: [],
+            },
+          },
+        },
+      },
+    };
+
+    const parsed = parseSolidityTestBuildInfoOutput(
+      utf8StringToBytes(JSON.stringify(output)),
+    );
+
+    assert.deepEqual(parsed.output.sources?.["project/test/Foo.sol"].ast, {
+      nodeType: "SourceUnit",
+      nodes: [],
+    });
+    assert.deepEqual(
+      parsed.output.contracts?.["project/test/Foo.sol"].Foo.evm
+        ?.methodIdentifiers,
+      { "testExample()": "abcdef01" },
+    );
+    const evm = parsed.output.contracts?.["project/test/Foo.sol"].Foo.evm;
+    assert.notEqual(evm, undefined);
+    assert.equal("bytecode" in evm, false);
+  });
+
+  it("handles escaped property names while scanning JSON bytes", () => {
+    const inputSourceName = "project/test/With\\Escape.sol";
+    const output = {
+      output: {
+        sources: {
+          [inputSourceName]: {
+            ast: { nodeType: "SourceUnit", nodes: [] },
+          },
+        },
+        contracts: {},
+      },
+    };
+
+    const parsed = parseSolidityTestBuildInfoOutput(
+      utf8StringToBytes(JSON.stringify(output)),
+    );
+
+    assert.deepEqual(parsed.output.sources?.[inputSourceName].ast, {
+      nodeType: "SourceUnit",
+      nodes: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes Solidity Test build-info output parsing for very large outputs that can exceed V8's max string length
- Adds a byte scanner that extracts only source ASTs and contract method identifiers needed by inline-config and EIP-712 collectors
- Adds focused parser coverage for large bytecode-heavy outputs and escaped source names

## Why
Large projects can produce build-info output JSON files over Node's maximum string length. The Solidity Test inline-config and EIP-712 collectors only need small subtrees from those outputs, but previously decoded and parsed the full JSON string.

## Changes
- Add `parseSolidityTestBuildInfoOutput` for selective build-info output parsing from bytes
- Use it in the inline-config and EIP-712 collectors
- Add a changeset for `hardhat`

## Validation
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/build-info-output.ts`
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts`
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts`
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity-test/build-info-output.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/build-info-output.ts`

## Scope
Refs #8341
