### PR TITLE
fix: tolerate indexed dynamic siblings when decoding event args

### DIFF
--- a/.changeset/young-lines-design.md
+++ b/.changeset/young-lines-design.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/ignition-core": patch
+---
+
+Fixed `m.readEventArgument` by tolerating indexed dynamic siblings when decoding event args ([#8338](https://github.com/NomicFoundation/hardhat/issues/8338))

--- a/packages/ignition-core/src/internal/execution/abi.ts
+++ b/packages/ignition-core/src/internal/execution/abi.ts
@@ -574,6 +574,21 @@ function ethersValueIntoEvmValue(
     return ethersResultIntoEvmTuple(ethersValue, paramType.components);
   }
 
+  // Indexed dynamic params (string/bytes/array/tuple) aren't stored in the log
+  // — only their keccak256 lives in a topic — so ethers v6 returns an `Indexed`
+  // placeholder for them. Reading the value itself is rejected upstream by
+  // `validateArtifactEventArgumentParams`, so this branch only fires for
+  // sibling params during tuple decoding; returning the topic hash lets the
+  // surrounding event decode without poisoning reads of other args.
+  if (ethers.Indexed.isIndexed(ethersValue)) {
+    assertIgnitionInvariant(
+      ethersValue.hash !== null,
+      "ethers.Indexed.hash must be set for placeholders produced by decodeEventLog",
+    );
+
+    return ethersValue.hash;
+  }
+
   throw new HardhatError(
     HardhatError.ERRORS.IGNITION.GENERAL.UNSUPPORTED_DECODE,
     {

--- a/packages/ignition-core/test/execution/abi.ts
+++ b/packages/ignition-core/test/execution/abi.ts
@@ -1,6 +1,7 @@
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
 import { assert } from "chai";
+import { ethers } from "ethers";
 import type { Artifact } from "../../src/types/artifact.js";
 
 import type { SolidityParameterType } from "../../src/index.js";
@@ -10,10 +11,15 @@ import {
   decodeError,
   encodeArtifactDeploymentData,
   encodeArtifactFunctionCall,
+  getEventArgumentFromReceipt,
   validateArtifactFunctionName,
 } from "../../src/internal/execution/abi.js";
 import { linkLibraries } from "../../src/internal/execution/libraries.js";
 import { EvmExecutionResultTypes } from "../../src/internal/execution/types/evm-execution.js";
+import {
+  type TransactionReceipt,
+  TransactionReceiptStatus,
+} from "../../src/internal/execution/types/jsonrpc.js";
 import { assertValidationError } from "../helpers.js";
 import {
   callEncodingFixtures,
@@ -345,6 +351,77 @@ describe("abi", () => {
       it("Should throw if a result type is a function", () => {});
       it("Should throw if a result type is a fixed<M>x<N>", () => {});
       it("Should throw if a result type is a ufixed<M>x<N>", () => {});
+    });
+  });
+
+  describe("getEventArgumentFromReceipt", () => {
+    // Regression test for https://github.com/NomicFoundation/hardhat/issues/8338
+    it("Should decode a non-indexed sibling arg even when the event has an indexed dynamic param", () => {
+      const emitterAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
+
+      const artifact: Artifact = {
+        _format: "hh3-artifact-1",
+        contractName: "Repro8338",
+        sourceName: "contracts/Repro8338.sol",
+        abi: [
+          {
+            anonymous: false,
+            type: "event",
+            name: "SuiteDeployed",
+            inputs: [
+              {
+                indexed: true,
+                internalType: "address",
+                name: "token",
+                type: "address",
+              },
+              {
+                indexed: true,
+                internalType: "string",
+                name: "salt",
+                type: "string",
+              },
+            ],
+          },
+        ],
+        bytecode: "0x",
+        linkReferences: {},
+        deployedBytecode: "0x",
+        deployedLinkReferences: {},
+      };
+
+      const receipt: TransactionReceipt = {
+        blockHash: `0x${"11".repeat(32)}`,
+        blockNumber: 1,
+        status: TransactionReceiptStatus.SUCCESS,
+        logs: [
+          {
+            address: emitterAddress,
+            logIndex: 0,
+            data: "0x",
+            topics: [
+              ethers.id("SuiteDeployed(address,string)"),
+              ethers.zeroPadValue(emitterAddress, 32),
+              ethers.keccak256(ethers.toUtf8Bytes("my-salt")),
+            ],
+          },
+        ],
+      };
+
+      const token = getEventArgumentFromReceipt(
+        receipt,
+        artifact,
+        emitterAddress,
+        "SuiteDeployed",
+        0,
+        "token",
+      );
+
+      assert.equal(
+        token,
+        emitterAddress,
+        "The decoded `token` arg should equal the emitter address",
+      );
     });
   });
 


### PR DESCRIPTION
In Ignition, we ban at validation stage the reading of indexed dynamic params (string/bytes/array/tuple `indexed`), as only their hashes are stored in the log, not their values. However, we also decode the entire event tuple even when reading a single arg, so while we do not read indexed dynamic events we do have to handle them during event decoding.

The #8338 bug was that we were not doing this, specifically Ethers v6 returns an `Indexed` placeholder for them and our decoder did not deal with that placeholder, throwing HHE10001.

We now detect the placeholder with `ethers.Indexed.isIndexed` in `ethersValueIntoEvmValue` and return its `.hash`. Reading the indexed- dynamic arg itself is still blocked by validation, so the hash only ever appears as an intermediate value for sibling decoding, but it no longer blocks reads of allowed siblings.

Fixes #8338.

## Reproducing the 8338 locally

Add two files in the example project:

```solidity
// contracts/Repro8338.sol

// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.0;

// Minimal reproduction of https://github.com/NomicFoundation/hardhat/issues/8338
// `m.readEventArgument` on `token` decodes the whole event, and the
// `string indexed salt` placeholder (`{ _isIndexed: true, hash }`) returned by
// ethers v6 makes ignition-core's value decoder throw HHE10001.
contract Repro8338 {
  event SuiteDeployed(address indexed token, string indexed salt);

  function emitEvent() external {
    emit SuiteDeployed(address(this), "my-salt");
  }
}
```

```ts
// ignition/modules/Repro8338.ts
import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";

// Minimal reproduction of https://github.com/NomicFoundation/hardhat/issues/8338
//
// Run with:
//   pnpm hardhat ignition deploy ignition/modules/Repro8338.ts
//
// Expected: deploys cleanly and `token` resolves to the contract address.
// Actual:   fails at Repro8338#ReadToken with
//   Error HHE10001: Hardhat Ignition can't decode ethers.js value of type
//   string: { "_isIndexed": true }
export default buildModule("Repro8338", (m) => {
  const repro = m.contract("Repro8338");
  const call = m.call(repro, "emitEvent");

  // Reading any arg decodes the whole event, so the `string indexed salt`
  // placeholder is what trips the decoder — not the `token` we're reading.
  const token = m.readEventArgument(call, "SuiteDeployed", "token", {
    id: "ReadToken",
  });

  // Consume the read so the future actually executes.
  m.contractAt("Repro8338", token, { id: "ReproAt" });

  return { repro };
});
```

Finally run:

```
pnpm hardhat ignition deploy ./ignition/modules/Repro8338.ts
```