### PR TITLE
feat(hardhat-verify): precise error for build-profile mismatches

### DIFF
--- a/.changeset/quiet-finches-build.md
+++ b/.changeset/quiet-finches-build.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+"@nomicfoundation/hardhat-errors": patch
+---
+
+`hardhat-verify` now detects when the local artifacts were compiled with a different build profile than the one being used for verification, and shows an error pointing at the correct profile instead of the generic deployed-bytecode-mismatch.

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -3048,20 +3048,22 @@ To resolve this, set a valid non-empty API key in your Hardhat config, then try 
       },
       ARTIFACT_BUILD_PROFILE_MISMATCH: {
         number: 80030,
-        messageTemplate: `The artifact for {contractDescription} was compiled with the "{artifactProfile}" build profile, but verify is using the "{buildProfileName}" build profile.
+        messageTemplate: `The artifact for {contractDescription} was compiled with build profile "{artifactProfile}", but verify is using build profile "{buildProfileName}".
 
-To fix this, recompile with the matching profile and retry verification:
+If your contract was deployed with the "{artifactProfile}" profile, re-run verify with the matching profile:
 
-  npx hardhat compile --force --build-profile {buildProfileName}
-  npx hardhat verify ...
+  npx hardhat verify --build-profile {artifactProfile} ...
 
-If your contract was actually deployed using the "{artifactProfile}" profile, re-run verify with --build-profile {artifactProfile} instead.`,
+Another possibility is that your local artifacts are stale; recompile and retry:
+
+  npx hardhat compile --build-profile {buildProfileName}
+  npx hardhat verify ...`,
         websiteTitle: "Artifact build profile mismatch",
         websiteDescription: `The compiled artifacts on disk were produced by a different configured build profile than the one verify is using.
 
 This typically happens when \`hardhat compile\`, \`hardhat test\`, or another task overwrote the on-disk artifacts between deployment and verification, since most tasks default to the \`default\` profile while \`verify\` defaults to \`production\`.
 
-Recompile with the profile verify uses (or pass --build-profile to match the profile that was used at deploy time), then retry.`,
+Pass --build-profile to match the profile that was used at deploy time, or recompile to regenerate artifacts for the profile verify uses, then retry.`,
       },
     },
     VALIDATION: {

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -3046,6 +3046,23 @@ Please verify the address and network, and try again later if necessary.`,
 
 To resolve this, set a valid non-empty API key in your Hardhat config, then try again.`,
       },
+      ARTIFACT_BUILD_PROFILE_MISMATCH: {
+        number: 80030,
+        messageTemplate: `The artifact for {contractDescription} was compiled with the "{artifactProfile}" build profile, but verify is using the "{buildProfileName}" build profile.
+
+To fix this, recompile with the matching profile and retry verification:
+
+  npx hardhat compile --force --build-profile {buildProfileName}
+  npx hardhat verify ...
+
+If your contract was actually deployed using the "{artifactProfile}" profile, re-run verify with --build-profile {artifactProfile} instead.`,
+        websiteTitle: "Artifact build profile mismatch",
+        websiteDescription: `The compiled artifacts on disk were produced by a different configured build profile than the one verify is using.
+
+This typically happens when \`hardhat compile\`, \`hardhat test\`, or another task overwrote the on-disk artifacts between deployment and verification, since most tasks default to the \`default\` profile while \`verify\` defaults to \`production\`.
+
+Recompile with the profile verify uses (or pass --build-profile to match the profile that was used at deploy time), then retry.`,
+      },
     },
     VALIDATION: {
       INVALID_ADDRESS: {

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -3048,7 +3048,7 @@ To resolve this, set a valid non-empty API key in your Hardhat config, then try 
       },
       ARTIFACT_BUILD_PROFILE_MISMATCH: {
         number: 80030,
-        messageTemplate: `The artifact for {contractDescription} was compiled with build profile "{artifactProfile}", but verify is using build profile "{buildProfileName}".
+        messageTemplate: `The artifacts used to verify {contractDescription} were compiled with build profile "{artifactProfile}", but verify is using build profile "{buildProfileName}".
 
 If your contract was deployed with the "{artifactProfile}" profile, re-run verify with the matching profile:
 

--- a/packages/hardhat-verify/src/internal/build-profile-detection.ts
+++ b/packages/hardhat-verify/src/internal/build-profile-detection.ts
@@ -7,6 +7,7 @@ import type {
 
 import path from "node:path";
 
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 import { deepEqual } from "@nomicfoundation/hardhat-utils/lang";
 
 export interface ArtifactCandidate {
@@ -26,6 +27,10 @@ export function makeArtifactCandidate(
   projectRoot: string,
 ): ArtifactCandidate {
   const inputSourceName = buildInfo.userSourceNameMap[userSourceName];
+  assertHardhatInvariant(
+    inputSourceName !== undefined,
+    `Source name "${userSourceName}" is missing from the build info's userSourceNameMap.`,
+  );
   const rootFilePath = inputSourceName.startsWith("npm/")
     ? `npm:${userSourceName}`
     : path.join(projectRoot, userSourceName);

--- a/packages/hardhat-verify/src/internal/build-profile-detection.ts
+++ b/packages/hardhat-verify/src/internal/build-profile-detection.ts
@@ -1,0 +1,177 @@
+import type { BuildInfo } from "hardhat/types/artifacts";
+import type { SolidityBuildProfileConfig } from "hardhat/types/config";
+
+import { deepEqual } from "@nomicfoundation/hardhat-utils/lang";
+
+interface BytecodeAffectingSettings {
+  optimizer: {
+    enabled: boolean;
+    runs: number;
+    details: unknown;
+  };
+  viaIR: boolean;
+  evmVersion: string | undefined;
+  metadata: unknown;
+}
+
+// Duplicated from packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-info.ts.
+// That module is internal (no public export), and we only need the lookup to
+// backfill `evmVersion` symmetrically when comparing a profile's settings against
+// the artifact's settings.
+const defaultEvmTargets: { [key: string]: string } = {
+  "0.5.1": "byzantium",
+  "0.5.2": "byzantium",
+  "0.5.3": "byzantium",
+  "0.5.4": "byzantium",
+  "0.5.5": "petersburg",
+  "0.5.6": "petersburg",
+  "0.5.7": "petersburg",
+  "0.5.8": "petersburg",
+  "0.5.9": "petersburg",
+  "0.5.10": "petersburg",
+  "0.5.11": "petersburg",
+  "0.5.12": "petersburg",
+  "0.5.13": "petersburg",
+  "0.5.14": "istanbul",
+  "0.5.15": "istanbul",
+  "0.5.16": "istanbul",
+  "0.5.17": "istanbul",
+  "0.6.0": "istanbul",
+  "0.6.1": "istanbul",
+  "0.6.2": "istanbul",
+  "0.6.3": "istanbul",
+  "0.6.4": "istanbul",
+  "0.6.5": "istanbul",
+  "0.6.6": "istanbul",
+  "0.6.7": "istanbul",
+  "0.6.8": "istanbul",
+  "0.6.9": "istanbul",
+  "0.6.10": "istanbul",
+  "0.6.11": "istanbul",
+  "0.6.12": "istanbul",
+  "0.7.0": "istanbul",
+  "0.7.1": "istanbul",
+  "0.7.2": "istanbul",
+  "0.7.3": "istanbul",
+  "0.7.4": "istanbul",
+  "0.7.5": "istanbul",
+  "0.7.6": "istanbul",
+  "0.8.0": "istanbul",
+  "0.8.1": "istanbul",
+  "0.8.2": "istanbul",
+  "0.8.3": "istanbul",
+  "0.8.4": "istanbul",
+  "0.8.5": "berlin",
+  "0.8.6": "berlin",
+  "0.8.7": "london",
+  "0.8.8": "london",
+  "0.8.9": "london",
+  "0.8.10": "london",
+  "0.8.11": "london",
+  "0.8.12": "london",
+  "0.8.13": "london",
+  "0.8.14": "london",
+  "0.8.15": "london",
+  "0.8.16": "london",
+  "0.8.17": "london",
+  "0.8.18": "paris",
+  "0.8.19": "paris",
+  "0.8.20": "shanghai",
+  "0.8.21": "shanghai",
+  "0.8.22": "shanghai",
+  "0.8.23": "shanghai",
+  "0.8.24": "shanghai",
+  "0.8.25": "cancun",
+  "0.8.26": "cancun",
+  "0.8.27": "cancun",
+  "0.8.28": "cancun",
+  "0.8.29": "cancun",
+  "0.8.30": "prague",
+  "0.8.31": "osaka",
+  "0.8.32": "osaka",
+  "0.8.33": "osaka",
+  "0.8.34": "osaka",
+};
+
+function getEvmVersionFromSolcVersion(solcVersion: string): string | undefined {
+  return defaultEvmTargets[solcVersion];
+}
+
+/**
+ * Extracts the bytecode-affecting subset of a settings object, applying
+ * fallbacks so both sides of a comparison are apples-to-apples.
+ *
+ * `outputSelection`, `libraries`, and `remappings` are excluded — they are
+ * framework/dependency-graph-driven and would cause false negatives.
+ */
+export function extractBytecodeAffectingSettings(
+  inputSettings: { [key: string]: any } | undefined,
+  solcVersion: string,
+): BytecodeAffectingSettings {
+  return {
+    optimizer: {
+      enabled: inputSettings?.optimizer?.enabled ?? false,
+      runs: inputSettings?.optimizer?.runs ?? 200,
+      details: inputSettings?.optimizer?.details,
+    },
+    viaIR: inputSettings?.viaIR ?? false,
+    evmVersion:
+      inputSettings?.evmVersion ?? getEvmVersionFromSolcVersion(solcVersion),
+    metadata: inputSettings?.metadata,
+  };
+}
+
+/**
+ * Picks the settings that a profile would use to compile a given user-source
+ * file at a given solc version. Returns `undefined` if the profile has no
+ * compiler matching `solcVersion` (in which case the profile cannot match the
+ * artifact).
+ */
+export function resolveProfileSettingsForSource(
+  profile: SolidityBuildProfileConfig,
+  userSourceName: string,
+  solcVersion: string,
+): { [key: string]: any } | undefined {
+  const override = profile.overrides[userSourceName];
+  if (override !== undefined && override.version === solcVersion) {
+    return override.settings;
+  }
+  const compiler = profile.compilers.find((c) => c.version === solcVersion);
+  return compiler?.settings;
+}
+
+/**
+ * Returns the names of all build profiles whose bytecode-affecting
+ * settings (for the given source file and solc version) match the build
+ * info's settings.
+ */
+export async function getMatchingBuildProfileNames(
+  buildInfo: BuildInfo,
+  userSourceName: string,
+  buildProfiles: Record<string, SolidityBuildProfileConfig>,
+): Promise<string[]> {
+  const artifactBytecodeSettings = extractBytecodeAffectingSettings(
+    buildInfo.input.settings,
+    buildInfo.solcVersion,
+  );
+
+  const results: string[] = [];
+  for (const [name, profile] of Object.entries(buildProfiles)) {
+    const profileInputSettings = resolveProfileSettingsForSource(
+      profile,
+      userSourceName,
+      buildInfo.solcVersion,
+    );
+    if (profileInputSettings === undefined) {
+      continue;
+    }
+    const profileBytecodeSettings = extractBytecodeAffectingSettings(
+      profileInputSettings,
+      buildInfo.solcVersion,
+    );
+    if (await deepEqual(artifactBytecodeSettings, profileBytecodeSettings)) {
+      results.push(name);
+    }
+  }
+  return results;
+}

--- a/packages/hardhat-verify/src/internal/build-profile-detection.ts
+++ b/packages/hardhat-verify/src/internal/build-profile-detection.ts
@@ -1,177 +1,115 @@
 import type { BuildInfo } from "hardhat/types/artifacts";
 import type { SolidityBuildProfileConfig } from "hardhat/types/config";
+import type {
+  CompilerInput,
+  SolidityBuildSystem,
+} from "hardhat/types/solidity";
+
+import path from "node:path";
 
 import { deepEqual } from "@nomicfoundation/hardhat-utils/lang";
 
-interface BytecodeAffectingSettings {
-  optimizer: {
-    enabled: boolean;
-    runs: number;
-    details: unknown;
-  };
-  viaIR: boolean;
-  evmVersion: string | undefined;
-  metadata: unknown;
-}
-
-// Duplicated from packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-info.ts.
-// That module is internal (no public export), and we only need the lookup to
-// backfill `evmVersion` symmetrically when comparing a profile's settings against
-// the artifact's settings.
-const defaultEvmTargets: { [key: string]: string } = {
-  "0.5.1": "byzantium",
-  "0.5.2": "byzantium",
-  "0.5.3": "byzantium",
-  "0.5.4": "byzantium",
-  "0.5.5": "petersburg",
-  "0.5.6": "petersburg",
-  "0.5.7": "petersburg",
-  "0.5.8": "petersburg",
-  "0.5.9": "petersburg",
-  "0.5.10": "petersburg",
-  "0.5.11": "petersburg",
-  "0.5.12": "petersburg",
-  "0.5.13": "petersburg",
-  "0.5.14": "istanbul",
-  "0.5.15": "istanbul",
-  "0.5.16": "istanbul",
-  "0.5.17": "istanbul",
-  "0.6.0": "istanbul",
-  "0.6.1": "istanbul",
-  "0.6.2": "istanbul",
-  "0.6.3": "istanbul",
-  "0.6.4": "istanbul",
-  "0.6.5": "istanbul",
-  "0.6.6": "istanbul",
-  "0.6.7": "istanbul",
-  "0.6.8": "istanbul",
-  "0.6.9": "istanbul",
-  "0.6.10": "istanbul",
-  "0.6.11": "istanbul",
-  "0.6.12": "istanbul",
-  "0.7.0": "istanbul",
-  "0.7.1": "istanbul",
-  "0.7.2": "istanbul",
-  "0.7.3": "istanbul",
-  "0.7.4": "istanbul",
-  "0.7.5": "istanbul",
-  "0.7.6": "istanbul",
-  "0.8.0": "istanbul",
-  "0.8.1": "istanbul",
-  "0.8.2": "istanbul",
-  "0.8.3": "istanbul",
-  "0.8.4": "istanbul",
-  "0.8.5": "berlin",
-  "0.8.6": "berlin",
-  "0.8.7": "london",
-  "0.8.8": "london",
-  "0.8.9": "london",
-  "0.8.10": "london",
-  "0.8.11": "london",
-  "0.8.12": "london",
-  "0.8.13": "london",
-  "0.8.14": "london",
-  "0.8.15": "london",
-  "0.8.16": "london",
-  "0.8.17": "london",
-  "0.8.18": "paris",
-  "0.8.19": "paris",
-  "0.8.20": "shanghai",
-  "0.8.21": "shanghai",
-  "0.8.22": "shanghai",
-  "0.8.23": "shanghai",
-  "0.8.24": "shanghai",
-  "0.8.25": "cancun",
-  "0.8.26": "cancun",
-  "0.8.27": "cancun",
-  "0.8.28": "cancun",
-  "0.8.29": "cancun",
-  "0.8.30": "prague",
-  "0.8.31": "osaka",
-  "0.8.32": "osaka",
-  "0.8.33": "osaka",
-  "0.8.34": "osaka",
-};
-
-function getEvmVersionFromSolcVersion(solcVersion: string): string | undefined {
-  return defaultEvmTargets[solcVersion];
+export interface ArtifactCandidate {
+  contract: string;
+  rootFilePath: string;
+  artifactSettings: CompilerInput["settings"];
 }
 
 /**
- * Extracts the bytecode-affecting subset of a settings object, applying
- * fallbacks so both sides of a comparison are apples-to-apples.
- *
- * `outputSelection`, `libraries`, and `remappings` are excluded — they are
- * framework/dependency-graph-driven and would cause false negatives.
+ * Builds a candidate from an FQN and its build info, ready to be compared
+ * against build profiles by `findArtifactBuildProfile`.
  */
-export function extractBytecodeAffectingSettings(
-  inputSettings: { [key: string]: any } | undefined,
-  solcVersion: string,
-): BytecodeAffectingSettings {
-  return {
-    optimizer: {
-      enabled: inputSettings?.optimizer?.enabled ?? false,
-      runs: inputSettings?.optimizer?.runs ?? 200,
-      details: inputSettings?.optimizer?.details,
-    },
-    viaIR: inputSettings?.viaIR ?? false,
-    evmVersion:
-      inputSettings?.evmVersion ?? getEvmVersionFromSolcVersion(solcVersion),
-    metadata: inputSettings?.metadata,
-  };
-}
-
-/**
- * Picks the settings that a profile would use to compile a given user-source
- * file at a given solc version. Returns `undefined` if the profile has no
- * compiler matching `solcVersion` (in which case the profile cannot match the
- * artifact).
- */
-export function resolveProfileSettingsForSource(
-  profile: SolidityBuildProfileConfig,
+export function makeArtifactCandidate(
+  contract: string,
   userSourceName: string,
-  solcVersion: string,
-): { [key: string]: any } | undefined {
-  const override = profile.overrides[userSourceName];
-  if (override !== undefined && override.version === solcVersion) {
-    return override.settings;
-  }
-  const compiler = profile.compilers.find((c) => c.version === solcVersion);
-  return compiler?.settings;
-}
-
-/**
- * Returns the names of all build profiles whose bytecode-affecting
- * settings (for the given source file and solc version) match the build
- * info's settings.
- */
-export async function getMatchingBuildProfileNames(
   buildInfo: BuildInfo,
-  userSourceName: string,
-  buildProfiles: Record<string, SolidityBuildProfileConfig>,
-): Promise<string[]> {
-  const artifactBytecodeSettings = extractBytecodeAffectingSettings(
-    buildInfo.input.settings,
-    buildInfo.solcVersion,
-  );
+  projectRoot: string,
+): ArtifactCandidate {
+  const inputSourceName = buildInfo.userSourceNameMap[userSourceName];
+  const rootFilePath = inputSourceName.startsWith("npm/")
+    ? `npm:${userSourceName}`
+    : path.join(projectRoot, userSourceName);
+  return {
+    contract,
+    rootFilePath,
+    artifactSettings: buildInfo.input.settings,
+  };
+}
 
-  const results: string[] = [];
-  for (const [name, profile] of Object.entries(buildProfiles)) {
-    const profileInputSettings = resolveProfileSettingsForSource(
-      profile,
-      userSourceName,
-      buildInfo.solcVersion,
-    );
-    if (profileInputSettings === undefined) {
+/**
+ * Returns the first (candidate, profileName) pair where the candidate's
+ * bytecode-affecting compiler settings match a build profile other than
+ * the active one. Returns `undefined` if no such pair exists.
+ *
+ * For each non-active profile we ask the build system to produce the solc
+ * input it would generate for all candidates at once (one `getCompilationJobs`
+ * call per profile), and compare each candidate's `buildInfo.input.settings`
+ * against that. We deliberately compare everything except `outputSelection`,
+ * `libraries`, and `remappings` as those are framework / dependency-graph
+ * driven and would always differ.
+ */
+export async function findArtifactBuildProfile(
+  solidity: SolidityBuildSystem,
+  candidates: ArtifactCandidate[],
+  buildProfiles: Record<string, SolidityBuildProfileConfig>,
+  activeBuildProfileName: string,
+): Promise<{ contract: string; profileName: string } | undefined> {
+  const rootFilePaths = candidates.map((c) => c.rootFilePath);
+
+  for (const profileName of Object.keys(buildProfiles)) {
+    if (profileName === activeBuildProfileName) {
       continue;
     }
-    const profileBytecodeSettings = extractBytecodeAffectingSettings(
-      profileInputSettings,
-      buildInfo.solcVersion,
-    );
-    if (await deepEqual(artifactBytecodeSettings, profileBytecodeSettings)) {
-      results.push(name);
+
+    const jobsResult = await solidity.getCompilationJobs(rootFilePaths, {
+      buildProfile: profileName,
+      quiet: true,
+      force: true,
+    });
+
+    if (!jobsResult.success) {
+      // The profile can't compile these files (e.g. no compatible solc).
+      continue;
+    }
+
+    for (const candidate of candidates) {
+      const job = jobsResult.compilationJobsPerFile.get(candidate.rootFilePath);
+      if (job === undefined) {
+        continue;
+      }
+      const profileInput = await job.getSolcInput();
+      if (
+        await bytecodeAffectingSettingsEqual(
+          candidate.artifactSettings,
+          profileInput.settings,
+        )
+      ) {
+        return { contract: candidate.contract, profileName };
+      }
     }
   }
-  return results;
+
+  return undefined;
+}
+
+async function bytecodeAffectingSettingsEqual(
+  a: CompilerInput["settings"],
+  b: CompilerInput["settings"],
+): Promise<boolean> {
+  return await deepEqual(stripFrameworkSettings(a), stripFrameworkSettings(b));
+}
+
+function stripFrameworkSettings(
+  settings: CompilerInput["settings"],
+): Omit<
+  CompilerInput["settings"],
+  "outputSelection" | "libraries" | "remappings"
+> {
+  const {
+    outputSelection: _outputSelection,
+    libraries: _libraries,
+    remappings: _remappings,
+    ...rest
+  } = settings;
+  return rest;
 }

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -1,6 +1,6 @@
 import type { BuildInfoAndOutput } from "./artifacts.js";
 import type { Bytecode } from "./bytecode.js";
-import type { ArtifactManager, BuildInfo } from "hardhat/types/artifacts";
+import type { ArtifactManager } from "hardhat/types/artifacts";
 import type { SolidityBuildProfileConfig } from "hardhat/types/config";
 import type {
   CompilerInput,
@@ -146,9 +146,7 @@ export class ContractInformationResolver {
       deployedBytecode,
     );
     if (contractInformation === null) {
-      return await this.#throwBytecodeMismatch([
-        { buildInfo: buildInfoAndOutput.buildInfo, contract },
-      ]);
+      return await this.#throwBytecodeMismatch([contract]);
     }
 
     return contractInformation;
@@ -170,10 +168,7 @@ export class ContractInformationResolver {
   ): Promise<ContractInformation> {
     const candidates = await this.#artifacts.getAllFullyQualifiedNames();
     const matches: ContractInformation[] = [];
-    const consideredCandidates: Array<{
-      contract: string;
-      buildInfo: BuildInfo;
-    }> = [];
+    const consideredContracts: string[] = [];
 
     for (const contract of candidates) {
       const buildInfoAndOutput = await getBuildInfoAndOutput(
@@ -192,10 +187,7 @@ export class ContractInformationResolver {
         continue;
       }
 
-      consideredCandidates.push({
-        contract,
-        buildInfo: buildInfoAndOutput.buildInfo,
-      });
+      consideredContracts.push(contract);
 
       const contractInformation = this.#matchAndBuild(
         contract,
@@ -208,7 +200,7 @@ export class ContractInformationResolver {
     }
 
     if (matches.length === 0) {
-      return await this.#throwBytecodeMismatch(consideredCandidates);
+      return await this.#throwBytecodeMismatch(consideredContracts);
     }
 
     if (matches.length > 1) {
@@ -284,18 +276,27 @@ export class ContractInformationResolver {
    * `ARTIFACT_BUILD_PROFILE_MISMATCH`; otherwise throws the generic
    * `DEPLOYED_BYTECODE_MISMATCH`.
    */
-  async #throwBytecodeMismatch(
-    candidates: Array<{ buildInfo: BuildInfo; contract: string }>,
-  ): Promise<never> {
+  async #throwBytecodeMismatch(candidates: string[]): Promise<never> {
     const contractDescription =
       candidates.length === 1
-        ? `the contract "${candidates[0].contract}"`
+        ? `the contract "${candidates[0]}"`
         : "any of your local contracts";
 
-    for (const candidate of candidates) {
-      const { sourceName } = parseFullyQualifiedName(candidate.contract);
+    // We re-fetch build infos here instead of accumulating them in
+    // #resolveByBytecodeLookup to prevent out-of-memory issues.
+    // This is fine as re-reads only happen on the unhappy path
+    // and we bail on the first profile match.
+    for (const contract of candidates) {
+      const buildInfoAndOutput = await getBuildInfoAndOutput(
+        this.#artifacts,
+        contract,
+      );
+      if (buildInfoAndOutput === undefined) {
+        continue;
+      }
+      const { sourceName } = parseFullyQualifiedName(contract);
       const profileMatches = await getMatchingBuildProfileNames(
-        candidate.buildInfo,
+        buildInfoAndOutput.buildInfo,
         sourceName,
         this.#buildProfiles,
       );

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -293,11 +293,6 @@ export class ContractInformationResolver {
    * `DEPLOYED_BYTECODE_MISMATCH`.
    */
   async #throwBytecodeMismatch(candidates: string[]): Promise<never> {
-    const contractDescription =
-      candidates.length === 1
-        ? `the contract "${candidates[0]}"`
-        : "any of your local contracts";
-
     // We re-fetch build infos here instead of accumulating them in
     // #resolveByBytecodeLookup to prevent out-of-memory issues.
     // This is fine as re-reads only happen on the unhappy path.
@@ -331,7 +326,10 @@ export class ContractInformationResolver {
       throw new HardhatError(
         HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.ARTIFACT_BUILD_PROFILE_MISMATCH,
         {
-          contractDescription,
+          contractDescription:
+            candidates.length === 1
+              ? `the contract "${candidates[0]}"`
+              : "one of your local contracts",
           artifactProfile: match.profileName,
           buildProfileName: this.#buildProfileName,
         },
@@ -340,7 +338,12 @@ export class ContractInformationResolver {
 
     throw new HardhatError(
       HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.DEPLOYED_BYTECODE_MISMATCH,
-      { contractDescription },
+      {
+        contractDescription:
+          candidates.length === 1
+            ? `the contract "${candidates[0]}"`
+            : "any of your local contracts",
+      },
     );
   }
 }

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -1,10 +1,13 @@
 import type { BuildInfoAndOutput } from "./artifacts.js";
+import type { ArtifactCandidate } from "./build-profile-detection.js";
 import type { Bytecode } from "./bytecode.js";
 import type { ArtifactManager } from "hardhat/types/artifacts";
 import type { SolidityBuildProfileConfig } from "hardhat/types/config";
+import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
 import type {
   CompilerInput,
   CompilerOutputContract,
+  SolidityBuildSystem,
 } from "hardhat/types/solidity";
 
 import {
@@ -17,7 +20,10 @@ import {
 } from "hardhat/utils/contract-names";
 
 import { getBuildInfoAndOutput } from "./artifacts.js";
-import { getMatchingBuildProfileNames } from "./build-profile-detection.js";
+import {
+  findArtifactBuildProfile,
+  makeArtifactCandidate,
+} from "./build-profile-detection.js";
 import { formatInferredSolcVersion } from "./metadata.js";
 
 export interface ContractInformation {
@@ -41,25 +47,35 @@ export interface ContractInformation {
  *  - zero or multiple matches in inference mode.
  */
 // TODO: add tests once the todos in getBuildInfoAndOutput are resolved.
+export interface ContractInformationResolverOptions {
+  hre: HardhatRuntimeEnvironment;
+  compatibleSolcVersions: string[];
+  networkName: string;
+  buildProfileName: string;
+}
+
 export class ContractInformationResolver {
   readonly #artifacts: ArtifactManager;
   readonly #compatibleSolcVersions: string[];
   readonly #networkName: string;
   readonly #buildProfiles: Record<string, SolidityBuildProfileConfig>;
   readonly #buildProfileName: string;
+  readonly #solidity: SolidityBuildSystem;
+  readonly #projectRoot: string;
 
-  constructor(
-    artifacts: ArtifactManager,
-    compatibleSolcVersions: string[],
-    networkName: string,
-    buildProfiles: Record<string, SolidityBuildProfileConfig>,
-    buildProfileName: string,
-  ) {
-    this.#artifacts = artifacts;
+  constructor({
+    hre,
+    compatibleSolcVersions,
+    networkName,
+    buildProfileName,
+  }: ContractInformationResolverOptions) {
+    this.#artifacts = hre.artifacts;
     this.#compatibleSolcVersions = compatibleSolcVersions;
     this.#networkName = networkName;
-    this.#buildProfiles = buildProfiles;
+    this.#buildProfiles = hre.config.solidity.profiles;
     this.#buildProfileName = buildProfileName;
+    this.#solidity = hre.solidity;
+    this.#projectRoot = hre.config.paths.root;
   }
 
   public async resolve(
@@ -284,8 +300,8 @@ export class ContractInformationResolver {
 
     // We re-fetch build infos here instead of accumulating them in
     // #resolveByBytecodeLookup to prevent out-of-memory issues.
-    // This is fine as re-reads only happen on the unhappy path
-    // and we bail on the first profile match.
+    // This is fine as re-reads only happen on the unhappy path.
+    const artifactCandidates: ArtifactCandidate[] = [];
     for (const contract of candidates) {
       const buildInfoAndOutput = await getBuildInfoAndOutput(
         this.#artifacts,
@@ -295,25 +311,33 @@ export class ContractInformationResolver {
         continue;
       }
       const { sourceName } = parseFullyQualifiedName(contract);
-      const profileMatches = await getMatchingBuildProfileNames(
-        buildInfoAndOutput.buildInfo,
-        sourceName,
-        this.#buildProfiles,
+      artifactCandidates.push(
+        makeArtifactCandidate(
+          contract,
+          sourceName,
+          buildInfoAndOutput.buildInfo,
+          this.#projectRoot,
+        ),
       );
-      const mismatchedProfiles = profileMatches.filter(
-        (p) => p !== this.#buildProfileName,
-      );
-      if (mismatchedProfiles.length > 0) {
-        throw new HardhatError(
-          HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.ARTIFACT_BUILD_PROFILE_MISMATCH,
-          {
-            contractDescription,
-            artifactProfile: mismatchedProfiles[0],
-            buildProfileName: this.#buildProfileName,
-          },
-        );
-      }
     }
+
+    const match = await findArtifactBuildProfile(
+      this.#solidity,
+      artifactCandidates,
+      this.#buildProfiles,
+      this.#buildProfileName,
+    );
+    if (match !== undefined) {
+      throw new HardhatError(
+        HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.ARTIFACT_BUILD_PROFILE_MISMATCH,
+        {
+          contractDescription,
+          artifactProfile: match.profileName,
+          buildProfileName: this.#buildProfileName,
+        },
+      );
+    }
+
     throw new HardhatError(
       HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.DEPLOYED_BYTECODE_MISMATCH,
       { contractDescription },

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -307,7 +307,7 @@ export class ContractInformationResolver {
           HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.ARTIFACT_BUILD_PROFILE_MISMATCH,
           {
             contractDescription,
-            artifactProfile: mismatchedProfiles.join(" or "),
+            artifactProfile: mismatchedProfiles[0],
             buildProfileName: this.#buildProfileName,
           },
         );

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -1,6 +1,7 @@
 import type { BuildInfoAndOutput } from "./artifacts.js";
 import type { Bytecode } from "./bytecode.js";
-import type { ArtifactManager } from "hardhat/types/artifacts";
+import type { ArtifactManager, BuildInfo } from "hardhat/types/artifacts";
+import type { SolidityBuildProfileConfig } from "hardhat/types/config";
 import type {
   CompilerInput,
   CompilerOutputContract,
@@ -16,6 +17,7 @@ import {
 } from "hardhat/utils/contract-names";
 
 import { getBuildInfoAndOutput } from "./artifacts.js";
+import { getMatchingBuildProfileNames } from "./build-profile-detection.js";
 import { formatInferredSolcVersion } from "./metadata.js";
 
 export interface ContractInformation {
@@ -43,15 +45,21 @@ export class ContractInformationResolver {
   readonly #artifacts: ArtifactManager;
   readonly #compatibleSolcVersions: string[];
   readonly #networkName: string;
+  readonly #buildProfiles: Record<string, SolidityBuildProfileConfig>;
+  readonly #buildProfileName: string;
 
   constructor(
     artifacts: ArtifactManager,
     compatibleSolcVersions: string[],
     networkName: string,
+    buildProfiles: Record<string, SolidityBuildProfileConfig>,
+    buildProfileName: string,
   ) {
     this.#artifacts = artifacts;
     this.#compatibleSolcVersions = compatibleSolcVersions;
     this.#networkName = networkName;
+    this.#buildProfiles = buildProfiles;
+    this.#buildProfileName = buildProfileName;
   }
 
   public async resolve(
@@ -138,10 +146,9 @@ export class ContractInformationResolver {
       deployedBytecode,
     );
     if (contractInformation === null) {
-      throw new HardhatError(
-        HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.DEPLOYED_BYTECODE_MISMATCH,
-        { contractDescription: `the contract "${contract}"` },
-      );
+      return await this.#throwBytecodeMismatch([
+        { buildInfo: buildInfoAndOutput.buildInfo, contract },
+      ]);
     }
 
     return contractInformation;
@@ -163,6 +170,10 @@ export class ContractInformationResolver {
   ): Promise<ContractInformation> {
     const candidates = await this.#artifacts.getAllFullyQualifiedNames();
     const matches: ContractInformation[] = [];
+    const consideredCandidates: Array<{
+      contract: string;
+      buildInfo: BuildInfo;
+    }> = [];
 
     for (const contract of candidates) {
       const buildInfoAndOutput = await getBuildInfoAndOutput(
@@ -181,6 +192,11 @@ export class ContractInformationResolver {
         continue;
       }
 
+      consideredCandidates.push({
+        contract,
+        buildInfo: buildInfoAndOutput.buildInfo,
+      });
+
       const contractInformation = this.#matchAndBuild(
         contract,
         buildInfoAndOutput,
@@ -192,10 +208,7 @@ export class ContractInformationResolver {
     }
 
     if (matches.length === 0) {
-      throw new HardhatError(
-        HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.DEPLOYED_BYTECODE_MISMATCH,
-        { contractDescription: "any of your local contracts" },
-      );
+      return await this.#throwBytecodeMismatch(consideredCandidates);
     }
 
     if (matches.length > 1) {
@@ -262,5 +275,47 @@ export class ContractInformationResolver {
     }
 
     return null;
+  }
+
+  /**
+   * Throws the most precise bytecode-mismatch error available for the given
+   * candidates. If any candidate's bytecode-affecting settings match a
+   * configured build profile other than the active one, throws
+   * `ARTIFACT_BUILD_PROFILE_MISMATCH`; otherwise throws the generic
+   * `DEPLOYED_BYTECODE_MISMATCH`.
+   */
+  async #throwBytecodeMismatch(
+    candidates: Array<{ buildInfo: BuildInfo; contract: string }>,
+  ): Promise<never> {
+    const contractDescription =
+      candidates.length === 1
+        ? `the contract "${candidates[0].contract}"`
+        : "any of your local contracts";
+
+    for (const candidate of candidates) {
+      const { sourceName } = parseFullyQualifiedName(candidate.contract);
+      const profileMatches = await getMatchingBuildProfileNames(
+        candidate.buildInfo,
+        sourceName,
+        this.#buildProfiles,
+      );
+      const mismatchedProfiles = profileMatches.filter(
+        (p) => p !== this.#buildProfileName,
+      );
+      if (mismatchedProfiles.length > 0) {
+        throw new HardhatError(
+          HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.ARTIFACT_BUILD_PROFILE_MISMATCH,
+          {
+            contractDescription,
+            artifactProfile: mismatchedProfiles.join(" or "),
+            buildProfileName: this.#buildProfileName,
+          },
+        );
+      }
+    }
+    throw new HardhatError(
+      HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.DEPLOYED_BYTECODE_MISMATCH,
+      { contractDescription },
+    );
   }
 }

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -181,6 +181,8 @@ Explorer: ${instance.getContractUrl(address)}`);
     artifacts,
     compatibleSolcVersions,
     networkName,
+    config.solidity.profiles,
+    buildProfileName,
   );
   const contractInformation = await contractInformationResolver.resolve(
     contract,

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -78,7 +78,6 @@ export async function verifyContract(
   provider?: EthereumProvider,
 ): Promise<boolean> {
   const {
-    artifacts,
     config,
     globalOptions: { buildProfile: buildProfileName = "production" },
     network,
@@ -177,13 +176,12 @@ Explorer: ${instance.getContractUrl(address)}`);
     );
   }
 
-  const contractInformationResolver = new ContractInformationResolver(
-    artifacts,
+  const contractInformationResolver = new ContractInformationResolver({
+    hre,
     compatibleSolcVersions,
     networkName,
-    config.solidity.profiles,
     buildProfileName,
-  );
+  });
   const contractInformation = await contractInformationResolver.resolve(
     contract,
     deployedBytecode,

--- a/packages/hardhat-verify/test/verification.ts
+++ b/packages/hardhat-verify/test/verification.ts
@@ -326,7 +326,7 @@ describe("verification", () => {
           {
             artifactProfile: "default",
             buildProfileName: "production",
-            contractDescription: "any of your local contracts",
+            contractDescription: "one of your local contracts",
           },
         );
       });
@@ -494,7 +494,7 @@ describe("verification", () => {
           {
             artifactProfile: "staging",
             buildProfileName: "production",
-            contractDescription: "any of your local contracts",
+            contractDescription: "one of your local contracts",
           },
         );
       });

--- a/packages/hardhat-verify/test/verification.ts
+++ b/packages/hardhat-verify/test/verification.ts
@@ -269,47 +269,50 @@ describe("verification", () => {
         url: "https://fake-explorer.test",
       });
 
-      let hre: HardhatRuntimeEnvironment;
+      let baseConfig: HardhatUserConfig;
       before(async () => {
-        const hardhatUserConfig =
+        baseConfig =
           // eslint-disable-next-line import/no-relative-packages -- allowed in test
           (await import("./fixture-projects/integration/hardhat.config.js"))
             .default;
-        hre = await createHardhatRuntimeEnvironment(hardhatUserConfig);
       });
 
-      it("should throw ARTIFACT_BUILD_PROFILE_MISMATCH when the artifact was compiled with a different profile than verify is using", async () => {
-        // Only the `isVerified` lookup is mocked. The verifysourcecode POST is
-        // intentionally NOT mocked: if a regression bypasses the new detection
-        // and tries to submit, disableNetConnect() in the test dispatcher will
-        // reject the request noisily.
+      beforeEach(() => {
+        // Mock only the `isVerified` getsourcecode lookup. verifysourcecode is
+        // intentionally NOT mocked — every test in this block must throw
+        // before any verification submission. If a regression submits, the
+        // dispatcher's disableNetConnect() + pending-interceptor check will
+        // surface it loudly.
         testDispatcher.interceptable
           .intercept({
             path: /^\/(?:v2\/)?api\?action=getsourcecode&address=0x[a-fA-F0-9]{40}&apikey=[A-Za-z0-9]+&chainid=\d+&module=contract$/,
             method: "GET",
           })
           .reply(200, { status: "1", result: [{ SourceCode: "" }] });
+      });
 
-        // 1) Build with production → artifacts on disk = production-compiled.
+      it("should throw ARTIFACT_BUILD_PROFILE_MISMATCH when the artifact was compiled with a different profile than verify is using", async () => {
+        const hre = await createHardhatRuntimeEnvironment(baseConfig);
+
+        // Build with production → artifacts on disk = production-compiled.
         await hre.tasks.getTask("build").run({
           defaultBuildProfile: "production",
           force: true,
         });
 
-        // 2) Deploy. On-chain deployedBytecode = production-compiled.
+        // Deploy. On-chain deployedBytecode = production-compiled.
         const { provider } = await hre.network.create();
         const address = await deployContract("Counter", [], {}, hre, provider);
 
-        // 3) Re-build with default → artifacts on disk = default-compiled,
-        //    while the on-chain bytecode is still production.
+        // Re-build with default → artifacts on disk = default-compiled,
+        // while the on-chain bytecode is still production.
         await hre.tasks.getTask("build").run({
           defaultBuildProfile: "default",
           force: true,
         });
 
-        // 4) Verify. globalOptions.buildProfile is undefined, so verifyContract
-        //    defaults to "production". The artifact matches "default"; detection
-        //    should throw the precise error before any verifysourcecode call.
+        // Verify defaults to "production". The artifact matches "default" —
+        // detection should throw the precise error before any submission.
         await assertRejectsWithHardhatError(
           verifyContract(
             { address },
@@ -324,6 +327,242 @@ describe("verification", () => {
             artifactProfile: "default",
             buildProfileName: "production",
             contractDescription: "any of your local contracts",
+          },
+        );
+      });
+
+      it("should fall back to the generic DEPLOYED_BYTECODE_MISMATCH when the artifact matches the active build profile", async () => {
+        const hre = await createHardhatRuntimeEnvironment(baseConfig);
+
+        // Build with production → every artifact reflects production settings,
+        // which is also what verify will use (the active profile).
+        await hre.tasks.getTask("build").run({
+          defaultBuildProfile: "production",
+          force: true,
+        });
+
+        // Deploy Counter, but verify with CounterWithArgs's FQN at Counter's
+        // address. #resolveByFqn re-compiles CounterWithArgs's artifact (also
+        // production-compiled) against Counter's on-chain bytecode → bytecode
+        // mismatch. Profile detection then sees the artifact matches the
+        // active profile and must fall back to the generic error.
+        const { provider } = await hre.network.create();
+        const address = await deployContract("Counter", [], {}, hre, provider);
+
+        await assertRejectsWithHardhatError(
+          verifyContract(
+            {
+              address,
+              contract: "contracts/CounterWithArgs.sol:CounterWithArgs",
+            },
+            hre,
+            () => {},
+            testDispatcher.interceptable,
+            provider,
+          ),
+          HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.DEPLOYED_BYTECODE_MISMATCH,
+          {
+            contractDescription:
+              'the contract "contracts/CounterWithArgs.sol:CounterWithArgs"',
+          },
+        );
+      });
+
+      it("should fall back to the generic DEPLOYED_BYTECODE_MISMATCH when no configured profile matches the artifact", async () => {
+        // Build via an HRE that has an extra "weird" profile (runs: 1). After
+        // this build, the on-disk artifacts reflect runs: 1.
+        const buildConfig: HardhatUserConfig = {
+          ...baseConfig,
+          solidity: {
+            profiles: {
+              default: {
+                compilers: [{ version: "0.8.28" }, { version: "0.8.33" }],
+              },
+              production: {
+                compilers: [{ version: "0.8.28" }, { version: "0.8.33" }],
+              },
+              weird: {
+                compilers: [
+                  {
+                    version: "0.8.28",
+                    settings: { optimizer: { enabled: true, runs: 1 } },
+                  },
+                  {
+                    version: "0.8.33",
+                    settings: { optimizer: { enabled: true, runs: 1 } },
+                  },
+                ],
+              },
+            },
+          },
+        };
+        const buildHre = await createHardhatRuntimeEnvironment(buildConfig);
+        await buildHre.tasks.getTask("build").run({
+          defaultBuildProfile: "weird",
+          force: true,
+        });
+
+        const { provider } = await buildHre.network.create();
+        const address = await deployContract(
+          "Counter",
+          [],
+          {},
+          buildHre,
+          provider,
+        );
+
+        // Verify with an HRE that does NOT have `weird` in its config. The
+        // local CounterWithArgs artifact (runs: 1) doesn't match the verify
+        // HRE's `default` (no optimizer); `production` is active and skipped.
+        // No profile matches → fall back to the generic error.
+        const verifyHre = await createHardhatRuntimeEnvironment(baseConfig);
+
+        await assertRejectsWithHardhatError(
+          verifyContract(
+            {
+              address,
+              contract: "contracts/CounterWithArgs.sol:CounterWithArgs",
+            },
+            verifyHre,
+            () => {},
+            testDispatcher.interceptable,
+            provider,
+          ),
+          HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.DEPLOYED_BYTECODE_MISMATCH,
+          {
+            contractDescription:
+              'the contract "contracts/CounterWithArgs.sol:CounterWithArgs"',
+          },
+        );
+      });
+
+      it("should identify the artifact profile when it is the third (non-default, non-production) configured profile", async () => {
+        const configWithStaging: HardhatUserConfig = {
+          ...baseConfig,
+          solidity: {
+            profiles: {
+              default: {
+                compilers: [{ version: "0.8.28" }, { version: "0.8.33" }],
+              },
+              production: {
+                compilers: [{ version: "0.8.28" }, { version: "0.8.33" }],
+              },
+              staging: {
+                compilers: [
+                  {
+                    version: "0.8.28",
+                    settings: { optimizer: { enabled: true, runs: 999 } },
+                  },
+                  {
+                    version: "0.8.33",
+                    settings: { optimizer: { enabled: true, runs: 999 } },
+                  },
+                ],
+              },
+            },
+          },
+        };
+        const hre = await createHardhatRuntimeEnvironment(configWithStaging);
+
+        // Build with `default`. Deploy. On-chain = default-compiled.
+        await hre.tasks.getTask("build").run({
+          defaultBuildProfile: "default",
+          force: true,
+        });
+        const { provider } = await hre.network.create();
+        const address = await deployContract("Counter", [], {}, hre, provider);
+
+        // Rebuild with `staging` so the on-disk artifacts reflect runs: 999.
+        await hre.tasks.getTask("build").run({
+          defaultBuildProfile: "staging",
+          force: true,
+        });
+
+        // Verify defaults to `production`. The artifact matches neither
+        // `default` nor `production`, but matches `staging` — the loop must
+        // iterate past `default` to find the match.
+        await assertRejectsWithHardhatError(
+          verifyContract(
+            { address },
+            hre,
+            () => {},
+            testDispatcher.interceptable,
+            provider,
+          ),
+          HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL
+            .ARTIFACT_BUILD_PROFILE_MISMATCH,
+          {
+            artifactProfile: "staging",
+            buildProfileName: "production",
+            contractDescription: "any of your local contracts",
+          },
+        );
+      });
+
+      it("should identify the artifact profile when the match comes from a per-source override", async () => {
+        // `production-counter-override` overrides Counter.sol to use runs: 1.
+        // Other contracts in the profile compile with the compiler-level
+        // settings (no optimizer here).
+        const configWithOverride: HardhatUserConfig = {
+          ...baseConfig,
+          solidity: {
+            profiles: {
+              default: {
+                compilers: [{ version: "0.8.28" }, { version: "0.8.33" }],
+              },
+              production: {
+                compilers: [{ version: "0.8.28" }, { version: "0.8.33" }],
+              },
+              "production-counter-override": {
+                compilers: [{ version: "0.8.28" }, { version: "0.8.33" }],
+                overrides: {
+                  "contracts/Counter.sol": {
+                    version: "0.8.33",
+                    settings: { optimizer: { enabled: true, runs: 1 } },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const hre = await createHardhatRuntimeEnvironment(configWithOverride);
+
+        // Build with `default`. Deploy Counter. On-chain Counter = no optimizer.
+        await hre.tasks.getTask("build").run({
+          defaultBuildProfile: "default",
+          force: true,
+        });
+        const { provider } = await hre.network.create();
+        const address = await deployContract("Counter", [], {}, hre, provider);
+
+        // Rebuild with `production-counter-override` → local Counter artifact
+        // reflects runs: 1 (via the override). Other artifacts get the
+        // compiler-level settings (no optimizer).
+        await hre.tasks.getTask("build").run({
+          defaultBuildProfile: "production-counter-override",
+          force: true,
+        });
+
+        // Use the FQN path so we constrain detection to Counter and exercise
+        // override resolution unambiguously. The artifact (runs: 1) only
+        // matches `production-counter-override` via the Counter.sol override.
+        await assertRejectsWithHardhatError(
+          verifyContract(
+            {
+              address,
+              contract: "contracts/Counter.sol:Counter",
+            },
+            hre,
+            () => {},
+            testDispatcher.interceptable,
+            provider,
+          ),
+          HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL
+            .ARTIFACT_BUILD_PROFILE_MISMATCH,
+          {
+            artifactProfile: "production-counter-override",
+            buildProfileName: "production",
+            contractDescription: 'the contract "contracts/Counter.sol:Counter"',
           },
         );
       });

--- a/packages/hardhat-verify/test/verification.ts
+++ b/packages/hardhat-verify/test/verification.ts
@@ -263,6 +263,72 @@ describe("verification", () => {
       });
     });
 
+    describe("build profile mismatch", () => {
+      useEphemeralFixtureProject("integration");
+      const testDispatcher = initializeTestDispatcher({
+        url: "https://fake-explorer.test",
+      });
+
+      let hre: HardhatRuntimeEnvironment;
+      before(async () => {
+        const hardhatUserConfig =
+          // eslint-disable-next-line import/no-relative-packages -- allowed in test
+          (await import("./fixture-projects/integration/hardhat.config.js"))
+            .default;
+        hre = await createHardhatRuntimeEnvironment(hardhatUserConfig);
+      });
+
+      it("should throw ARTIFACT_BUILD_PROFILE_MISMATCH when the artifact was compiled with a different profile than verify is using", async () => {
+        // Only the `isVerified` lookup is mocked. The verifysourcecode POST is
+        // intentionally NOT mocked: if a regression bypasses the new detection
+        // and tries to submit, disableNetConnect() in the test dispatcher will
+        // reject the request noisily.
+        testDispatcher.interceptable
+          .intercept({
+            path: /^\/(?:v2\/)?api\?action=getsourcecode&address=0x[a-fA-F0-9]{40}&apikey=[A-Za-z0-9]+&chainid=\d+&module=contract$/,
+            method: "GET",
+          })
+          .reply(200, { status: "1", result: [{ SourceCode: "" }] });
+
+        // 1) Build with production → artifacts on disk = production-compiled.
+        await hre.tasks.getTask("build").run({
+          defaultBuildProfile: "production",
+          force: true,
+        });
+
+        // 2) Deploy. On-chain deployedBytecode = production-compiled.
+        const { provider } = await hre.network.create();
+        const address = await deployContract("Counter", [], {}, hre, provider);
+
+        // 3) Re-build with default → artifacts on disk = default-compiled,
+        //    while the on-chain bytecode is still production.
+        await hre.tasks.getTask("build").run({
+          defaultBuildProfile: "default",
+          force: true,
+        });
+
+        // 4) Verify. globalOptions.buildProfile is undefined, so verifyContract
+        //    defaults to "production". The artifact matches "default"; detection
+        //    should throw the precise error before any verifysourcecode call.
+        await assertRejectsWithHardhatError(
+          verifyContract(
+            { address },
+            hre,
+            () => {},
+            testDispatcher.interceptable,
+            provider,
+          ),
+          HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL
+            .ARTIFACT_BUILD_PROFILE_MISMATCH,
+          {
+            artifactProfile: "default",
+            buildProfileName: "production",
+            contractDescription: "any of your local contracts",
+          },
+        );
+      });
+    });
+
     // TODO: Include remaining `hardhat-verify` verification test cases
     describe.todo("all cases", () => {
       it("should throw an error when etherscan is not enabled in the hardhat config", async () => {});


### PR DESCRIPTION
`hardhat-verify` now detects when the local artifacts were compiled with a different build profile than the one being used for verification, and shows an error pointing at the correct profile instead of the generic deployed-bytecode-mismatch.