### PR TITLE
test: add "edit & compile" benchmark commands to scenarios

### DIFF
--- a/end-to-end/1inch-aqua/scenario.json
+++ b/end-to-end/1inch-aqua/scenario.json
@@ -9,15 +9,17 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "compile sequence": {
-        "runs": 3,
+      "cold compile": {
+        "runs": 2,
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile"
+      },
+      "edit & compile sequence": {
+        "runs": 2,
         "steps": {
-          "reset files & cache": {
-            "command": "git checkout -- test/AquaLifecycle.t.sol test/AquaStorageTest.t.sol src/Aqua.sol && npx hardhat clean",
+          "reset files": {
+            "command": "git checkout -- test/AquaLifecycle.t.sol test/AquaStorageTest.t.sol src/Aqua.sol",
             "measure": false
-          },
-          "cold compile": {
-            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/AquaLifecycle.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaLifecycle.t.sol && npx hardhat compile"
@@ -31,11 +33,11 @@
         }
       },
       "warm compile": {
-        "runs": 9,
+        "runs": 2,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 11,
+        "runs": 2,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/1inch-aqua/scenario.json
+++ b/end-to-end/1inch-aqua/scenario.json
@@ -21,6 +21,16 @@
       "test solidity": {
         "runs": 83,
         "command": "npx hardhat test solidity --no-compile"
+      },
+      "hardhat compile edit test/AquaLifecycle.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/AquaLifecycle.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaLifecycle.t.sol && npx hardhat compile"
+      },
+      "hardhat compile edit src/Aqua.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- src/Aqua.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/Aqua.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/1inch-aqua/scenario.json
+++ b/end-to-end/1inch-aqua/scenario.json
@@ -9,10 +9,26 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
+      "compile sequence": {
         "runs": 5,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
+        "steps": {
+          "reset files & cache": {
+            "command": "git checkout -- test/AquaLifecycle.t.sol test/AquaStorageTest.t.sol src/Aqua.sol && npx hardhat clean",
+            "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
+          },
+          "edit & compile Solidity test with min deps: test/AquaLifecycle.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaLifecycle.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity test with max deps: test/AquaStorageTest.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaStorageTest.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity contract: src/Aqua.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/Aqua.sol && npx hardhat compile"
+          }
+        }
       },
       "warm compile": {
         "runs": 55,
@@ -21,21 +37,6 @@
       "test solidity": {
         "runs": 83,
         "command": "npx hardhat test solidity --no-compile"
-      },
-      "edit & compile Solidity test with min deps: test/AquaLifecycle.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/AquaLifecycle.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaLifecycle.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity test with max deps: test/AquaStorageTest.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/AquaStorageTest.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaStorageTest.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity contract: src/Aqua.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- src/Aqua.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/Aqua.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/1inch-aqua/scenario.json
+++ b/end-to-end/1inch-aqua/scenario.json
@@ -9,17 +9,15 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
-        "runs": 2,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
-      },
-      "edit & compile sequence": {
+      "compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files": {
-            "command": "git checkout -- test/AquaLifecycle.t.sol test/AquaStorageTest.t.sol src/Aqua.sol",
+          "reset files & cache": {
+            "command": "git checkout -- test/AquaLifecycle.t.sol test/AquaStorageTest.t.sol src/Aqua.sol && npx hardhat clean",
             "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/AquaLifecycle.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaLifecycle.t.sol && npx hardhat compile"

--- a/end-to-end/1inch-aqua/scenario.json
+++ b/end-to-end/1inch-aqua/scenario.json
@@ -22,12 +22,17 @@
         "runs": 83,
         "command": "npx hardhat test solidity --no-compile"
       },
-      "hardhat compile edit test/AquaLifecycle.t.sol": {
+      "edit & compile Solidity test with min deps: test/AquaLifecycle.t.sol": {
         "runs": 3,
         "prepare": "git checkout -- test/AquaLifecycle.t.sol && npx hardhat compile",
         "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaLifecycle.t.sol && npx hardhat compile"
       },
-      "hardhat compile edit src/Aqua.sol": {
+      "edit & compile Solidity test with max deps: test/AquaStorageTest.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/AquaStorageTest.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaStorageTest.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity contract: src/Aqua.sol": {
         "runs": 3,
         "prepare": "git checkout -- src/Aqua.sol && npx hardhat compile",
         "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/Aqua.sol && npx hardhat compile"

--- a/end-to-end/1inch-cross-chain-swap/scenario.json
+++ b/end-to-end/1inch-cross-chain-swap/scenario.json
@@ -12,15 +12,17 @@
   },
   "benchmark": {
     "commands": {
-      "compile sequence": {
+      "cold compile": {
+        "runs": 2,
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile"
+      },
+      "edit & compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files & cache": {
-            "command": "git checkout -- test/libraries/FeeCalcLib.t.sol test/integration/ResolverMock.t.sol contracts/BaseEscrow.sol && npx hardhat clean",
+          "reset files": {
+            "command": "git checkout -- test/libraries/FeeCalcLib.t.sol test/integration/ResolverMock.t.sol contracts/BaseEscrow.sol",
             "measure": false
-          },
-          "cold compile": {
-            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/libraries/FeeCalcLib.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/FeeCalcLib.t.sol && npx hardhat compile"
@@ -34,11 +36,11 @@
         }
       },
       "warm compile": {
-        "runs": 11,
+        "runs": 2,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 14,
+        "runs": 15,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/1inch-cross-chain-swap/scenario.json
+++ b/end-to-end/1inch-cross-chain-swap/scenario.json
@@ -12,17 +12,15 @@
   },
   "benchmark": {
     "commands": {
-      "cold compile": {
-        "runs": 2,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
-      },
-      "edit & compile sequence": {
+      "compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files": {
-            "command": "git checkout -- test/libraries/FeeCalcLib.t.sol test/integration/ResolverMock.t.sol contracts/BaseEscrow.sol",
+          "reset files & cache": {
+            "command": "git checkout -- test/libraries/FeeCalcLib.t.sol test/integration/ResolverMock.t.sol contracts/BaseEscrow.sol && npx hardhat clean",
             "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/libraries/FeeCalcLib.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/FeeCalcLib.t.sol && npx hardhat compile"

--- a/end-to-end/1inch-cross-chain-swap/scenario.json
+++ b/end-to-end/1inch-cross-chain-swap/scenario.json
@@ -24,6 +24,16 @@
       "test solidity": {
         "runs": 9,
         "command": "npx hardhat test solidity --no-compile"
+      },
+      "hardhat compile edit test/unit/Escrow.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/unit/Escrow.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/unit/Escrow.t.sol && npx hardhat compile"
+      },
+      "hardhat compile edit contracts/BaseEscrow.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- contracts/BaseEscrow.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/BaseEscrow.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/1inch-cross-chain-swap/scenario.json
+++ b/end-to-end/1inch-cross-chain-swap/scenario.json
@@ -13,7 +13,7 @@
   "benchmark": {
     "commands": {
       "compile sequence": {
-        "runs": 3,
+        "runs": 2,
         "steps": {
           "reset files & cache": {
             "command": "git checkout -- test/libraries/FeeCalcLib.t.sol test/integration/ResolverMock.t.sol contracts/BaseEscrow.sol && npx hardhat clean",
@@ -38,7 +38,7 @@
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 9,
+        "runs": 14,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/1inch-cross-chain-swap/scenario.json
+++ b/end-to-end/1inch-cross-chain-swap/scenario.json
@@ -25,12 +25,17 @@
         "runs": 9,
         "command": "npx hardhat test solidity --no-compile"
       },
-      "hardhat compile edit test/unit/Escrow.t.sol": {
+      "edit & compile Solidity test with min deps: test/libraries/FeeCalcLib.t.sol": {
         "runs": 3,
-        "prepare": "git checkout -- test/unit/Escrow.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/unit/Escrow.t.sol && npx hardhat compile"
+        "prepare": "git checkout -- test/libraries/FeeCalcLib.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/FeeCalcLib.t.sol && npx hardhat compile"
       },
-      "hardhat compile edit contracts/BaseEscrow.sol": {
+      "edit & compile Solidity test with max deps: test/integration/ResolverMock.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/integration/ResolverMock.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/integration/ResolverMock.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity contract: contracts/BaseEscrow.sol": {
         "runs": 3,
         "prepare": "git checkout -- contracts/BaseEscrow.sol && npx hardhat compile",
         "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/BaseEscrow.sol && npx hardhat compile"

--- a/end-to-end/1inch-cross-chain-swap/scenario.json
+++ b/end-to-end/1inch-cross-chain-swap/scenario.json
@@ -12,10 +12,26 @@
   },
   "benchmark": {
     "commands": {
-      "cold compile": {
+      "compile sequence": {
         "runs": 3,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
+        "steps": {
+          "reset files & cache": {
+            "command": "git checkout -- test/libraries/FeeCalcLib.t.sol test/integration/ResolverMock.t.sol contracts/BaseEscrow.sol && npx hardhat clean",
+            "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
+          },
+          "edit & compile Solidity test with min deps: test/libraries/FeeCalcLib.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/FeeCalcLib.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity test with max deps: test/integration/ResolverMock.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/integration/ResolverMock.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity contract: contracts/BaseEscrow.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/BaseEscrow.sol && npx hardhat compile"
+          }
+        }
       },
       "warm compile": {
         "runs": 97,
@@ -24,21 +40,6 @@
       "test solidity": {
         "runs": 9,
         "command": "npx hardhat test solidity --no-compile"
-      },
-      "edit & compile Solidity test with min deps: test/libraries/FeeCalcLib.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/libraries/FeeCalcLib.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/FeeCalcLib.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity test with max deps: test/integration/ResolverMock.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/integration/ResolverMock.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/integration/ResolverMock.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity contract: contracts/BaseEscrow.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- contracts/BaseEscrow.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/BaseEscrow.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -9,17 +9,15 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
-        "runs": 2,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
-      },
-      "edit & compile sequence": {
+      "compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files": {
-            "command": "git checkout -- test/ProtocolFeeProviderMock.t.sol test/TransferModesCombinations.t.sol src/SwapVM.sol",
+          "reset files & cache": {
+            "command": "git checkout -- test/ProtocolFeeProviderMock.t.sol test/TransferModesCombinations.t.sol src/SwapVM.sol && npx hardhat clean",
             "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/ProtocolFeeProviderMock.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/ProtocolFeeProviderMock.t.sol && npx hardhat compile"

--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -9,15 +9,17 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "compile sequence": {
+      "cold compile": {
+        "runs": 2,
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile"
+      },
+      "edit & compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files & cache": {
-            "command": "git checkout -- test/ProtocolFeeProviderMock.t.sol test/TransferModesCombinations.t.sol src/SwapVM.sol && npx hardhat clean",
+          "reset files": {
+            "command": "git checkout -- test/ProtocolFeeProviderMock.t.sol test/TransferModesCombinations.t.sol src/SwapVM.sol",
             "measure": false
-          },
-          "cold compile": {
-            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/ProtocolFeeProviderMock.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/ProtocolFeeProviderMock.t.sol && npx hardhat compile"
@@ -31,11 +33,11 @@
         }
       },
       "warm compile": {
-        "runs": 5,
+        "runs": 2,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 5,
+        "runs": 4,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -21,6 +21,16 @@
       "test solidity": {
         "runs": 29,
         "command": "npx hardhat test solidity --no-compile"
+      },
+      "hardhat compile edit test/Fee.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/Fee.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/Fee.t.sol && npx hardhat compile"
+      },
+      "hardhat compile edit src/SwapVM.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- src/SwapVM.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/SwapVM.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -10,7 +10,7 @@
   "benchmark": {
     "commands": {
       "compile sequence": {
-        "runs": 3,
+        "runs": 2,
         "steps": {
           "reset files & cache": {
             "command": "git checkout -- test/ProtocolFeeProviderMock.t.sol test/TransferModesCombinations.t.sol src/SwapVM.sol && npx hardhat clean",
@@ -35,7 +35,7 @@
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 15,
+        "runs": 5,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -22,12 +22,17 @@
         "runs": 29,
         "command": "npx hardhat test solidity --no-compile"
       },
-      "hardhat compile edit test/Fee.t.sol": {
+      "edit & compile Solidity test with min deps: test/ProtocolFeeProviderMock.t.sol": {
         "runs": 3,
-        "prepare": "git checkout -- test/Fee.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/Fee.t.sol && npx hardhat compile"
+        "prepare": "git checkout -- test/ProtocolFeeProviderMock.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/ProtocolFeeProviderMock.t.sol && npx hardhat compile"
       },
-      "hardhat compile edit src/SwapVM.sol": {
+      "edit & compile Solidity test with max deps: test/TransferModesCombinations.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/TransferModesCombinations.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/TransferModesCombinations.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity contract: src/SwapVM.sol": {
         "runs": 3,
         "prepare": "git checkout -- src/SwapVM.sol && npx hardhat compile",
         "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/SwapVM.sol && npx hardhat compile"

--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -9,10 +9,26 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
+      "compile sequence": {
         "runs": 3,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
+        "steps": {
+          "reset files & cache": {
+            "command": "git checkout -- test/ProtocolFeeProviderMock.t.sol test/TransferModesCombinations.t.sol src/SwapVM.sol && npx hardhat clean",
+            "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
+          },
+          "edit & compile Solidity test with min deps: test/ProtocolFeeProviderMock.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/ProtocolFeeProviderMock.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity test with max deps: test/TransferModesCombinations.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/TransferModesCombinations.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity contract: src/SwapVM.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/SwapVM.sol && npx hardhat compile"
+          }
+        }
       },
       "warm compile": {
         "runs": 45,
@@ -21,21 +37,6 @@
       "test solidity": {
         "runs": 29,
         "command": "npx hardhat test solidity --no-compile"
-      },
-      "edit & compile Solidity test with min deps: test/ProtocolFeeProviderMock.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/ProtocolFeeProviderMock.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/ProtocolFeeProviderMock.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity test with max deps: test/TransferModesCombinations.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/TransferModesCombinations.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/TransferModesCombinations.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity contract: src/SwapVM.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- src/SwapVM.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/SwapVM.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -10,7 +10,7 @@
   "benchmark": {
     "commands": {
       "compile sequence": {
-        "runs": 3,
+        "runs": 2,
         "steps": {
           "reset files & cache": {
             "command": "git checkout -- tests/unit/WadRayMath.t.sol tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol src/libraries/math/MathUtils.sol && npx hardhat clean",
@@ -31,11 +31,11 @@
         }
       },
       "warm compile": {
-        "runs": 17,
+        "runs": 5,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 3,
+        "runs": 5,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -9,10 +9,26 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
+      "compile sequence": {
         "runs": 3,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
+        "steps": {
+          "reset files & cache": {
+            "command": "git checkout -- tests/unit/WadRayMath.t.sol tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol src/libraries/math/MathUtils.sol && npx hardhat clean",
+            "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
+          },
+          "edit & compile Solidity test with min deps: tests/unit/WadRayMath.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/WadRayMath.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity test with max deps: tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity contract: src/libraries/math/MathUtils.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/libraries/math/MathUtils.sol && npx hardhat compile"
+          }
+        }
       },
       "warm compile": {
         "runs": 39,
@@ -21,21 +37,6 @@
       "test solidity": {
         "runs": 3,
         "command": "npx hardhat test solidity --no-compile"
-      },
-      "edit & compile Solidity test with min deps: tests/unit/WadRayMath.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- tests/unit/WadRayMath.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/WadRayMath.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity test with max deps: tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity contract: src/libraries/math/MathUtils.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- src/libraries/math/MathUtils.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/libraries/math/MathUtils.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -9,17 +9,15 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
-        "runs": 2,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
-      },
-      "edit & compile sequence": {
+      "compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files": {
-            "command": "git checkout -- tests/unit/WadRayMath.t.sol tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol src/libraries/math/MathUtils.sol",
+          "reset files & cache": {
+            "command": "git checkout -- tests/unit/WadRayMath.t.sol tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol src/libraries/math/MathUtils.sol && npx hardhat clean",
             "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: tests/unit/WadRayMath.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/WadRayMath.t.sol && npx hardhat compile"

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -9,15 +9,17 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "compile sequence": {
+      "cold compile": {
+        "runs": 2,
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile"
+      },
+      "edit & compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files & cache": {
-            "command": "git checkout -- tests/unit/WadRayMath.t.sol tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol src/libraries/math/MathUtils.sol && npx hardhat clean",
+          "reset files": {
+            "command": "git checkout -- tests/unit/WadRayMath.t.sol tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol src/libraries/math/MathUtils.sol",
             "measure": false
-          },
-          "cold compile": {
-            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: tests/unit/WadRayMath.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/WadRayMath.t.sol && npx hardhat compile"
@@ -31,7 +33,7 @@
         }
       },
       "warm compile": {
-        "runs": 5,
+        "runs": 2,
         "command": "npx hardhat compile"
       },
       "test solidity": {

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -21,6 +21,21 @@
       "test solidity": {
         "runs": 3,
         "command": "npx hardhat test solidity --no-compile"
+      },
+      "edit & compile Solidity test with min deps: tests/unit/WadRayMath.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- tests/unit/WadRayMath.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/WadRayMath.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity test with max deps: tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity contract: src/libraries/math/MathUtils.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- src/libraries/math/MathUtils.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/libraries/math/MathUtils.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/ens-verifiable-factory/scenario.json
+++ b/end-to-end/ens-verifiable-factory/scenario.json
@@ -9,17 +9,15 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
-        "runs": 2,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
-      },
-      "edit & compile sequence": {
+      "compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files": {
-            "command": "git checkout -- test/UUPSProxy.t.sol test/VerifiableFactory.t.sol src/VerifiableFactory.sol",
+          "reset files & cache": {
+            "command": "git checkout -- test/UUPSProxy.t.sol test/VerifiableFactory.t.sol src/VerifiableFactory.sol && npx hardhat clean",
             "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/UUPSProxy.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/UUPSProxy.t.sol && npx hardhat compile"

--- a/end-to-end/ens-verifiable-factory/scenario.json
+++ b/end-to-end/ens-verifiable-factory/scenario.json
@@ -22,12 +22,17 @@
         "runs": 69,
         "command": "npx hardhat test solidity --no-compile"
       },
-      "hardhat compile edit test/VerifiableFactory.t.sol": {
+      "edit & compile Solidity test with min deps: test/UUPSProxy.t.sol": {
+        "runs": 7,
+        "prepare": "git checkout -- test/UUPSProxy.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/UUPSProxy.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity test with max deps: test/VerifiableFactory.t.sol": {
         "runs": 7,
         "prepare": "git checkout -- test/VerifiableFactory.t.sol && npx hardhat compile",
         "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/VerifiableFactory.t.sol && npx hardhat compile"
       },
-      "hardhat compile edit src/VerifiableFactory.sol": {
+      "edit & compile Solidity contract: src/VerifiableFactory.sol": {
         "runs": 7,
         "prepare": "git checkout -- src/VerifiableFactory.sol && npx hardhat compile",
         "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/VerifiableFactory.sol && npx hardhat compile"

--- a/end-to-end/ens-verifiable-factory/scenario.json
+++ b/end-to-end/ens-verifiable-factory/scenario.json
@@ -21,6 +21,16 @@
       "test solidity": {
         "runs": 69,
         "command": "npx hardhat test solidity --no-compile"
+      },
+      "hardhat compile edit test/VerifiableFactory.t.sol": {
+        "runs": 7,
+        "prepare": "git checkout -- test/VerifiableFactory.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/VerifiableFactory.t.sol && npx hardhat compile"
+      },
+      "hardhat compile edit src/VerifiableFactory.sol": {
+        "runs": 7,
+        "prepare": "git checkout -- src/VerifiableFactory.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/VerifiableFactory.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/ens-verifiable-factory/scenario.json
+++ b/end-to-end/ens-verifiable-factory/scenario.json
@@ -31,11 +31,11 @@
         }
       },
       "warm compile": {
-        "runs": 7,
+        "runs": 5,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 3,
+        "runs": 5,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/ens-verifiable-factory/scenario.json
+++ b/end-to-end/ens-verifiable-factory/scenario.json
@@ -9,10 +9,26 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
+      "compile sequence": {
         "runs": 13,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
+        "steps": {
+          "reset files & cache": {
+            "command": "git checkout -- test/UUPSProxy.t.sol test/VerifiableFactory.t.sol src/VerifiableFactory.sol && npx hardhat clean",
+            "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
+          },
+          "edit & compile Solidity test with min deps: test/UUPSProxy.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/UUPSProxy.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity test with max deps: test/VerifiableFactory.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/VerifiableFactory.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity contract: src/VerifiableFactory.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/VerifiableFactory.sol && npx hardhat compile"
+          }
+        }
       },
       "warm compile": {
         "runs": 77,
@@ -21,21 +37,6 @@
       "test solidity": {
         "runs": 69,
         "command": "npx hardhat test solidity --no-compile"
-      },
-      "edit & compile Solidity test with min deps: test/UUPSProxy.t.sol": {
-        "runs": 7,
-        "prepare": "git checkout -- test/UUPSProxy.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/UUPSProxy.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity test with max deps: test/VerifiableFactory.t.sol": {
-        "runs": 7,
-        "prepare": "git checkout -- test/VerifiableFactory.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/VerifiableFactory.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity contract: src/VerifiableFactory.sol": {
-        "runs": 7,
-        "prepare": "git checkout -- src/VerifiableFactory.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/VerifiableFactory.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/ens-verifiable-factory/scenario.json
+++ b/end-to-end/ens-verifiable-factory/scenario.json
@@ -9,15 +9,17 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "compile sequence": {
-        "runs": 3,
+      "cold compile": {
+        "runs": 2,
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile"
+      },
+      "edit & compile sequence": {
+        "runs": 2,
         "steps": {
-          "reset files & cache": {
-            "command": "git checkout -- test/UUPSProxy.t.sol test/VerifiableFactory.t.sol src/VerifiableFactory.sol && npx hardhat clean",
+          "reset files": {
+            "command": "git checkout -- test/UUPSProxy.t.sol test/VerifiableFactory.t.sol src/VerifiableFactory.sol",
             "measure": false
-          },
-          "cold compile": {
-            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/UUPSProxy.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/UUPSProxy.t.sol && npx hardhat compile"
@@ -31,11 +33,11 @@
         }
       },
       "warm compile": {
-        "runs": 5,
+        "runs": 2,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 5,
+        "runs": 2,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/lidofinance-dual-governance/scenario.json
+++ b/end-to-end/lidofinance-dual-governance/scenario.json
@@ -12,17 +12,15 @@
   "defaultCommand": "npx hardhat test solidity --grep=\"^(test_|testFuzz_)\"",
   "benchmark": {
     "commands": {
-      "cold compile": {
-        "runs": 2,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
-      },
-      "edit & compile sequence": {
+      "compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files": {
-            "command": "git checkout -- test/unit/scripts/launch/TimeConstraints.t.sol test/scenario/mainnet-launch.t.sol contracts/types/Timestamp.sol",
+          "reset files & cache": {
+            "command": "git checkout -- test/unit/scripts/launch/TimeConstraints.t.sol test/scenario/mainnet-launch.t.sol contracts/types/Timestamp.sol && npx hardhat clean",
             "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/unit/scripts/launch/TimeConstraints.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/unit/scripts/launch/TimeConstraints.t.sol && npx hardhat compile"

--- a/end-to-end/lidofinance-dual-governance/scenario.json
+++ b/end-to-end/lidofinance-dual-governance/scenario.json
@@ -12,15 +12,17 @@
   "defaultCommand": "npx hardhat test solidity --grep=\"^(test_|testFuzz_)\"",
   "benchmark": {
     "commands": {
-      "compile sequence": {
+      "cold compile": {
+        "runs": 2,
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile"
+      },
+      "edit & compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files & cache": {
-            "command": "git checkout -- test/unit/scripts/launch/TimeConstraints.t.sol test/scenario/mainnet-launch.t.sol contracts/types/Timestamp.sol && npx hardhat clean",
+          "reset files": {
+            "command": "git checkout -- test/unit/scripts/launch/TimeConstraints.t.sol test/scenario/mainnet-launch.t.sol contracts/types/Timestamp.sol",
             "measure": false
-          },
-          "cold compile": {
-            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/unit/scripts/launch/TimeConstraints.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/unit/scripts/launch/TimeConstraints.t.sol && npx hardhat compile"
@@ -34,11 +36,11 @@
         }
       },
       "warm compile": {
-        "runs": 5,
+        "runs": 2,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 7,
+        "runs": 15,
         "command": "npx hardhat test solidity --no-compile --grep=\"^(test_|testFuzz_)\""
       }
     }

--- a/end-to-end/lidofinance-dual-governance/scenario.json
+++ b/end-to-end/lidofinance-dual-governance/scenario.json
@@ -13,7 +13,7 @@
   "benchmark": {
     "commands": {
       "compile sequence": {
-        "runs": 3,
+        "runs": 2,
         "steps": {
           "reset files & cache": {
             "command": "git checkout -- test/unit/scripts/launch/TimeConstraints.t.sol test/scenario/mainnet-launch.t.sol contracts/types/Timestamp.sol && npx hardhat clean",
@@ -34,11 +34,11 @@
         }
       },
       "warm compile": {
-        "runs": 9,
+        "runs": 5,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 3,
+        "runs": 7,
         "command": "npx hardhat test solidity --no-compile --grep=\"^(test_|testFuzz_)\""
       }
     }

--- a/end-to-end/lidofinance-dual-governance/scenario.json
+++ b/end-to-end/lidofinance-dual-governance/scenario.json
@@ -12,10 +12,26 @@
   "defaultCommand": "npx hardhat test solidity --grep=\"^(test_|testFuzz_)\"",
   "benchmark": {
     "commands": {
-      "cold compile": {
+      "compile sequence": {
         "runs": 3,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
+        "steps": {
+          "reset files & cache": {
+            "command": "git checkout -- test/unit/scripts/launch/TimeConstraints.t.sol test/scenario/mainnet-launch.t.sol contracts/types/Timestamp.sol && npx hardhat clean",
+            "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
+          },
+          "edit & compile Solidity test with min deps: test/unit/scripts/launch/TimeConstraints.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/unit/scripts/launch/TimeConstraints.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity test with max deps: test/scenario/mainnet-launch.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/scenario/mainnet-launch.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity contract: contracts/types/Timestamp.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/types/Timestamp.sol && npx hardhat compile"
+          }
+        }
       },
       "warm compile": {
         "runs": 83,
@@ -24,21 +40,6 @@
       "test solidity": {
         "runs": 3,
         "command": "npx hardhat test solidity --no-compile --grep=\"^(test_|testFuzz_)\""
-      },
-      "edit & compile Solidity test with min deps: test/unit/scripts/launch/TimeConstraints.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/unit/scripts/launch/TimeConstraints.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/unit/scripts/launch/TimeConstraints.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity test with max deps: test/scenario/mainnet-launch.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/scenario/mainnet-launch.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/scenario/mainnet-launch.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity contract: contracts/types/Timestamp.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- contracts/types/Timestamp.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/types/Timestamp.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/lidofinance-dual-governance/scenario.json
+++ b/end-to-end/lidofinance-dual-governance/scenario.json
@@ -24,6 +24,21 @@
       "test solidity": {
         "runs": 3,
         "command": "npx hardhat test solidity --no-compile --grep=\"^(test_|testFuzz_)\""
+      },
+      "edit & compile Solidity test with min deps: test/unit/scripts/launch/TimeConstraints.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/unit/scripts/launch/TimeConstraints.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/unit/scripts/launch/TimeConstraints.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity test with max deps: test/scenario/mainnet-launch.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/scenario/mainnet-launch.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/scenario/mainnet-launch.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity contract: contracts/types/Timestamp.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- contracts/types/Timestamp.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/types/Timestamp.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/uniswap-v4-core/scenario.json
+++ b/end-to-end/uniswap-v4-core/scenario.json
@@ -10,7 +10,7 @@
   "benchmark": {
     "commands": {
       "compile sequence": {
-        "runs": 3,
+        "runs": 2,
         "steps": {
           "reset files & cache": {
             "command": "git checkout -- test/libraries/BitMath.t.sol test/PoolManager.t.sol src/types/Currency.sol && npx hardhat clean",
@@ -31,11 +31,11 @@
         }
       },
       "warm compile": {
-        "runs": 15,
+        "runs": 5,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 7,
+        "runs": 9,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/uniswap-v4-core/scenario.json
+++ b/end-to-end/uniswap-v4-core/scenario.json
@@ -21,6 +21,16 @@
       "test solidity": {
         "runs": 7,
         "command": "npx hardhat test solidity --no-compile"
+      },
+      "hardhat compile edit test/Extsload.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/Extsload.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/Extsload.t.sol && npx hardhat compile"
+      },
+      "hardhat compile edit src/types/Currency.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- src/types/Currency.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/types/Currency.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/uniswap-v4-core/scenario.json
+++ b/end-to-end/uniswap-v4-core/scenario.json
@@ -9,15 +9,17 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "compile sequence": {
+      "cold compile": {
+        "runs": 2,
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile"
+      },
+      "edit & compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files & cache": {
-            "command": "git checkout -- test/libraries/BitMath.t.sol test/PoolManager.t.sol src/types/Currency.sol && npx hardhat clean",
+          "reset files": {
+            "command": "git checkout -- test/libraries/BitMath.t.sol test/PoolManager.t.sol src/types/Currency.sol",
             "measure": false
-          },
-          "cold compile": {
-            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/libraries/BitMath.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/BitMath.t.sol && npx hardhat compile"
@@ -31,7 +33,7 @@
         }
       },
       "warm compile": {
-        "runs": 5,
+        "runs": 2,
         "command": "npx hardhat compile"
       },
       "test solidity": {

--- a/end-to-end/uniswap-v4-core/scenario.json
+++ b/end-to-end/uniswap-v4-core/scenario.json
@@ -22,12 +22,17 @@
         "runs": 7,
         "command": "npx hardhat test solidity --no-compile"
       },
-      "hardhat compile edit test/Extsload.t.sol": {
+      "edit & compile Solidity test with min deps: test/libraries/BitMath.t.sol": {
         "runs": 3,
-        "prepare": "git checkout -- test/Extsload.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/Extsload.t.sol && npx hardhat compile"
+        "prepare": "git checkout -- test/libraries/BitMath.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/BitMath.t.sol && npx hardhat compile"
       },
-      "hardhat compile edit src/types/Currency.sol": {
+      "edit & compile Solidity test with max deps: test/PoolManager.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/PoolManager.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/PoolManager.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity contract: src/types/Currency.sol": {
         "runs": 3,
         "prepare": "git checkout -- src/types/Currency.sol && npx hardhat compile",
         "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/types/Currency.sol && npx hardhat compile"

--- a/end-to-end/uniswap-v4-core/scenario.json
+++ b/end-to-end/uniswap-v4-core/scenario.json
@@ -9,10 +9,26 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
+      "compile sequence": {
         "runs": 3,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
+        "steps": {
+          "reset files & cache": {
+            "command": "git checkout -- test/libraries/BitMath.t.sol test/PoolManager.t.sol src/types/Currency.sol && npx hardhat clean",
+            "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
+          },
+          "edit & compile Solidity test with min deps: test/libraries/BitMath.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/BitMath.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity test with max deps: test/PoolManager.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/PoolManager.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity contract: src/types/Currency.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/types/Currency.sol && npx hardhat compile"
+          }
+        }
       },
       "warm compile": {
         "runs": 51,
@@ -21,21 +37,6 @@
       "test solidity": {
         "runs": 7,
         "command": "npx hardhat test solidity --no-compile"
-      },
-      "edit & compile Solidity test with min deps: test/libraries/BitMath.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/libraries/BitMath.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/BitMath.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity test with max deps: test/PoolManager.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/PoolManager.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/PoolManager.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity contract: src/types/Currency.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- src/types/Currency.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/types/Currency.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/uniswap-v4-core/scenario.json
+++ b/end-to-end/uniswap-v4-core/scenario.json
@@ -9,17 +9,15 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
-        "runs": 2,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
-      },
-      "edit & compile sequence": {
+      "compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files": {
-            "command": "git checkout -- test/libraries/BitMath.t.sol test/PoolManager.t.sol src/types/Currency.sol",
+          "reset files & cache": {
+            "command": "git checkout -- test/libraries/BitMath.t.sol test/PoolManager.t.sol src/types/Currency.sol && npx hardhat clean",
             "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/libraries/BitMath.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/BitMath.t.sol && npx hardhat compile"

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -12,17 +12,15 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
-        "runs": 2,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
-      },
-      "edit & compile sequence": {
+      "compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files": {
-            "command": "git checkout -- test/lib/CosignerLib.t.sol test/reactors/V3DutchOrderReactor.t.sol src/base/ReactorStructs.sol",
+          "reset files & cache": {
+            "command": "git checkout -- test/lib/CosignerLib.t.sol test/reactors/V3DutchOrderReactor.t.sol src/base/ReactorStructs.sol && npx hardhat clean",
             "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/lib/CosignerLib.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/lib/CosignerLib.t.sol && npx hardhat compile"

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -24,6 +24,21 @@
       "test solidity": {
         "runs": 3,
         "command": "npx hardhat test solidity --no-compile"
+      },
+      "edit & compile Solidity test with min deps: test/lib/CosignerLib.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/lib/CosignerLib.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/lib/CosignerLib.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity test with max deps: test/reactors/V3DutchOrderReactor.t.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- test/reactors/V3DutchOrderReactor.t.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/reactors/V3DutchOrderReactor.t.sol && npx hardhat compile"
+      },
+      "edit & compile Solidity contract: src/base/ReactorStructs.sol": {
+        "runs": 3,
+        "prepare": "git checkout -- src/base/ReactorStructs.sol && npx hardhat compile",
+        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/base/ReactorStructs.sol && npx hardhat compile"
       }
     }
   }

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -13,7 +13,7 @@
   "benchmark": {
     "commands": {
       "compile sequence": {
-        "runs": 3,
+        "runs": 2,
         "steps": {
           "reset files & cache": {
             "command": "git checkout -- test/lib/CosignerLib.t.sol test/reactors/V3DutchOrderReactor.t.sol src/base/ReactorStructs.sol && npx hardhat clean",
@@ -34,11 +34,11 @@
         }
       },
       "warm compile": {
-        "runs": 15,
+        "runs": 5,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 3,
+        "runs": 2,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -12,15 +12,17 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "compile sequence": {
+      "cold compile": {
+        "runs": 2,
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile"
+      },
+      "edit & compile sequence": {
         "runs": 2,
         "steps": {
-          "reset files & cache": {
-            "command": "git checkout -- test/lib/CosignerLib.t.sol test/reactors/V3DutchOrderReactor.t.sol src/base/ReactorStructs.sol && npx hardhat clean",
+          "reset files": {
+            "command": "git checkout -- test/lib/CosignerLib.t.sol test/reactors/V3DutchOrderReactor.t.sol src/base/ReactorStructs.sol",
             "measure": false
-          },
-          "cold compile": {
-            "command": "npx hardhat compile"
           },
           "edit & compile Solidity test with min deps: test/lib/CosignerLib.t.sol": {
             "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/lib/CosignerLib.t.sol && npx hardhat compile"
@@ -34,7 +36,7 @@
         }
       },
       "warm compile": {
-        "runs": 5,
+        "runs": 2,
         "command": "npx hardhat compile"
       },
       "test solidity": {

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -12,10 +12,26 @@
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {
-      "cold compile": {
+      "compile sequence": {
         "runs": 3,
-        "prepare": "npx hardhat clean",
-        "command": "npx hardhat compile"
+        "steps": {
+          "reset files & cache": {
+            "command": "git checkout -- test/lib/CosignerLib.t.sol test/reactors/V3DutchOrderReactor.t.sol src/base/ReactorStructs.sol && npx hardhat clean",
+            "measure": false
+          },
+          "cold compile": {
+            "command": "npx hardhat compile"
+          },
+          "edit & compile Solidity test with min deps: test/lib/CosignerLib.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/lib/CosignerLib.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity test with max deps: test/reactors/V3DutchOrderReactor.t.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/reactors/V3DutchOrderReactor.t.sol && npx hardhat compile"
+          },
+          "edit & compile Solidity contract: src/base/ReactorStructs.sol": {
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/base/ReactorStructs.sol && npx hardhat compile"
+          }
+        }
       },
       "warm compile": {
         "runs": 37,
@@ -24,21 +40,6 @@
       "test solidity": {
         "runs": 3,
         "command": "npx hardhat test solidity --no-compile"
-      },
-      "edit & compile Solidity test with min deps: test/lib/CosignerLib.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/lib/CosignerLib.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/lib/CosignerLib.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity test with max deps: test/reactors/V3DutchOrderReactor.t.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- test/reactors/V3DutchOrderReactor.t.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/reactors/V3DutchOrderReactor.t.sol && npx hardhat compile"
-      },
-      "edit & compile Solidity contract: src/base/ReactorStructs.sol": {
-        "runs": 3,
-        "prepare": "git checkout -- src/base/ReactorStructs.sol && npx hardhat compile",
-        "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/base/ReactorStructs.sol && npx hardhat compile"
       }
     }
   }

--- a/scripts/benchmark/helpers/stats.test.ts
+++ b/scripts/benchmark/helpers/stats.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { computeStats } from "./stats.ts";
+
+describe("computeStats", () => {
+  it("handles a single sample (stddev 0, min=max=median=mean)", () => {
+    const s = computeStats([4.2]);
+    assert.equal(s.mean, 4.2);
+    assert.equal(s.stddev, 0);
+    assert.equal(s.min, 4.2);
+    assert.equal(s.max, 4.2);
+    assert.equal(s.median, 4.2);
+    assert.deepEqual(s.times, [4.2]);
+  });
+
+  it("computes mean, min and max", () => {
+    const s = computeStats([2, 4, 6]);
+    assert.equal(s.mean, 4);
+    assert.equal(s.min, 2);
+    assert.equal(s.max, 6);
+  });
+
+  it("uses the sample standard deviation (n-1), matching hyperfine", () => {
+    // values 2,4,6: variance (n-1) = ((-2)^2+0+2^2)/2 = 4 → stddev 2
+    const s = computeStats([2, 4, 6]);
+    assert.equal(s.stddev, 2);
+  });
+
+  it("computes the median for an odd count", () => {
+    assert.equal(computeStats([5, 1, 3]).median, 3);
+  });
+
+  it("computes the median for an even count (average of middles)", () => {
+    assert.equal(computeStats([1, 2, 3, 4]).median, 2.5);
+  });
+
+  it("preserves the original order of times", () => {
+    assert.deepEqual(computeStats([3, 1, 2]).times, [3, 1, 2]);
+  });
+
+  it("throws on an empty sample set", () => {
+    assert.throws(() => computeStats([]));
+  });
+});

--- a/scripts/benchmark/helpers/stats.ts
+++ b/scripts/benchmark/helpers/stats.ts
@@ -1,0 +1,46 @@
+/**
+ * Statistical summary of a series of benchmark timings, in seconds. Shaped to
+ * match the per-result object hyperfine exports, so both the hyperfine path and
+ * the in-process steps path in regression.ts can feed the same `toEntry`.
+ */
+export interface BenchmarkStats {
+  mean: number;
+  stddev: number;
+  min: number;
+  max: number;
+  median: number;
+  times: number[];
+}
+
+/**
+ * Compute mean, sample standard deviation (n-1, matching hyperfine), min, max
+ * and median from a non-empty list of timings. `times` is returned in its
+ * original (execution) order, like hyperfine.
+ */
+export function computeStats(times: number[]): BenchmarkStats {
+  const n = times.length;
+
+  if (n === 0) {
+    throw new Error("computeStats requires at least one sample");
+  }
+
+  const mean = times.reduce((sum, t) => sum + t, 0) / n;
+
+  const stddev =
+    n > 1
+      ? Math.sqrt(times.reduce((sum, t) => sum + (t - mean) ** 2, 0) / (n - 1))
+      : 0;
+
+  const sorted = [...times].sort((a, b) => a - b);
+  const median =
+    n % 2 === 1 ? sorted[(n - 1) / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
+
+  return {
+    mean,
+    stddev,
+    min: sorted[0],
+    max: sorted[n - 1],
+    median,
+    times,
+  };
+}

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -1,5 +1,6 @@
 // cSpell:ignore cacache <-- NPM's content-addressable cache
 import { execSync } from "node:child_process";
+import { performance } from "node:perf_hooks";
 import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -1,12 +1,15 @@
 // cSpell:ignore cacache <-- NPM's content-addressable cache
+import { execSync } from "node:child_process";
 import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { runBenchmark } from "./main.ts";
 import type { BenchArgs } from "./helpers/args.ts";
+import { computeStats, type BenchmarkStats } from "./helpers/stats.ts";
 import { DEFAULT_CLONE_DIR } from "../end-to-end/helpers/args.ts";
 import { fmt, log, logError, logStep, logWarning } from "./helpers/log.ts";
+import { loadScenario } from "../end-to-end/helpers/directory.ts";
 import {
   ForceCheckout,
   ForcePublish,
@@ -14,7 +17,7 @@ import {
   init as e2eInit,
 } from "../end-to-end/subcommands/init.ts";
 import { isScenarioDefinition } from "../end-to-end/schema/scenario-schema.ts";
-import type { ScenarioDefinition } from "../end-to-end/types.ts";
+import type { ScenarioDefinition, StepsVariant } from "../end-to-end/types.ts";
 import { isVerdaccioRunning } from "../verdaccio/helpers/shell.ts";
 import {
   publish as verdaccioPublish,
@@ -30,17 +33,31 @@ DESCRIPTION
   For each scenario under end-to-end/ that is not disabled and does not opt
   out via "benchmark": { "skip": true }, runs every command declared in
   "benchmark": { "commands": { ... } } in the order they appear in
-  scenario.json. Each command entry has the shape:
+  scenario.json. Each command entry is one of two shapes:
 
+    // single command, benchmarked with hyperfine
     {
       "runs":    <positive integer>,    // hyperfine runs (required)
       "prepare": "<shell snippet>",     // optional --prepare hook
       "command": "<shell command>"      // command to benchmark (required)
     }
 
-  The command name (the map key) becomes the on-disk benchmark name:
-  "<scenarioId> / <commandName>". Scenarios missing the "commands" map (or
-  with an empty one) fail pre-flight with a summary of every offending file.
+    // step sequence, timed in-process (no hyperfine, no per-run prepare)
+    {
+      "runs":  <positive integer>,      // times to run the whole sequence
+      "steps": {                         // ordered; each step timed individually
+        "<step name>": {
+          "command": "<shell command>", // required
+          "measure": <boolean>          // optional, default true; false = run but
+        }                               //   don't emit an entry (e.g. a reset step)
+      }
+    }
+
+  Step sequences share state across steps, so a single reset/cold step per run
+  replaces the redundant per-run prepare recompiles. The command name (or, for a
+  sequence, each measured step name) becomes the on-disk benchmark name:
+  "<scenarioId> / <name>". Scenarios missing the "commands" map (or with an
+  empty one) fail pre-flight with a summary of every offending file.
 
   Writes a flat JSON array in benchmark-action/github-action-benchmark's
   customSmallerIsBetter format. Per-run times are preserved in the "extra"
@@ -93,15 +110,6 @@ interface BenchmarkEntry {
   value: number;
   range: string;
   extra: string;
-}
-
-interface HyperfineResult {
-  mean: number;
-  stddev: number;
-  min: number;
-  max: number;
-  median: number;
-  times: number[];
 }
 
 async function main(): Promise<void> {
@@ -364,9 +372,31 @@ async function runScenario(
     ForcePublish.No,
   );
 
+  // Load the initialized scenario once to resolve its working directory and
+  // env (with ${localEnv:...} tokens expanded, like exec.ts); reused by every
+  // steps phase below instead of reloading per phase.
+  const loaded = loadScenario(
+    args.e2eCloneDirectory,
+    scenario.scenarioJsonPath,
+  );
+
   const entries: BenchmarkEntry[] = [];
 
   for (const [name, cfg] of Object.entries(commands)) {
+    if ("steps" in cfg) {
+      entries.push(
+        ...runStepsPhase(
+          scenario.id,
+          loaded.workingDir,
+          loaded.definition.env,
+          name,
+          cfg,
+        ),
+      );
+
+      continue;
+    }
+
     const exportPath = path.join(scenarioTmpDir, `${slugify(name)}.json`);
 
     await runPhase(
@@ -383,6 +413,59 @@ async function runScenario(
   }
 
   return entries;
+}
+
+/**
+ * Run a step-sequence command: execute the ordered steps in-process, once per
+ * run, timing each step with the high-resolution monotonic clock. Returns one
+ * entry per measured step.
+ */
+function runStepsPhase(
+  scenarioId: string,
+  workingDir: string,
+  env: Record<string, string> | undefined,
+  seqName: string,
+  cfg: StepsVariant,
+): BenchmarkEntry[] {
+  logStep(`${fmt.pkg(seqName)} (${cfg.runs} runs)`);
+
+  const stepNames = Object.keys(cfg.steps);
+  const samples = new Map<string, number[]>();
+
+  for (const stepName of stepNames) {
+    if (cfg.steps[stepName].measure !== false) {
+      samples.set(stepName, []);
+    }
+  }
+
+  for (let run = 0; run < cfg.runs; run++) {
+    for (const stepName of stepNames) {
+      const step = cfg.steps[stepName];
+      const start = performance.now();
+
+      try {
+        execSync(step.command, {
+          cwd: workingDir,
+          stdio: "inherit",
+          env: { ...process.env, ...env },
+        });
+      } catch (error) {
+        const original = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `${scenarioId} / ${seqName}: step "${stepName}" failed on run ${run + 1}/${cfg.runs}: ${original}\n` +
+            `  Reproduce with: cd ${shellQuote(workingDir)} && ${step.command}`,
+          { cause: error },
+        );
+      }
+
+      const elapsed = (performance.now() - start) / 1000;
+      samples.get(stepName)?.push(elapsed);
+    }
+  }
+
+  return [...samples].map(([stepName, times]) =>
+    toEntry(scenarioId, stepName, computeStats(times)),
+  );
 }
 
 function slugify(name: string): string {
@@ -465,9 +548,9 @@ function buildBenchArgs(
   };
 }
 
-function readHyperfineResult(exportPath: string): HyperfineResult {
+function readHyperfineResult(exportPath: string): BenchmarkStats {
   const raw = JSON.parse(readFileSync(exportPath, "utf-8")) as {
-    results: HyperfineResult[];
+    results: BenchmarkStats[];
   };
 
   if (!Array.isArray(raw.results) || raw.results.length === 0) {
@@ -480,7 +563,7 @@ function readHyperfineResult(exportPath: string): HyperfineResult {
 function toEntry(
   scenarioId: string,
   phaseLabel: string,
-  result: HyperfineResult,
+  result: BenchmarkStats,
 ): BenchmarkEntry {
   return {
     name: `${scenarioId} / ${phaseLabel}`,

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -446,7 +446,7 @@ function runStepsPhase(
       try {
         execSync(step.command, {
           cwd: workingDir,
-          stdio: "inherit",
+          stdio: "ignore",
           env: { ...process.env, ...env },
         });
       } catch (error) {

--- a/scripts/end-to-end/schema/scenario-schema.test.ts
+++ b/scripts/end-to-end/schema/scenario-schema.test.ts
@@ -4,6 +4,7 @@ import {
   isBenchmarkConfig,
   isCommandConfig,
   isScenarioDefinition,
+  isStepConfig,
 } from "./scenario-schema.ts";
 
 const baseScenario = {
@@ -253,6 +254,18 @@ describe("isScenarioDefinition", () => {
     );
   });
 
+  it("rejects an integer-like command key (would break order)", () => {
+    assert.equal(
+      isScenarioDefinition({
+        ...baseScenario,
+        benchmark: {
+          commands: { "1": { runs: 1, command: "npx hardhat compile" } },
+        },
+      }),
+      false,
+    );
+  });
+
   it("rejects benchmark.skip values other than true", () => {
     assert.equal(
       isScenarioDefinition({ ...baseScenario, benchmark: { skip: false } }),
@@ -350,6 +363,107 @@ describe("isCommandConfig", () => {
         prepare: "",
         command: "npx hardhat compile",
       }),
+      false,
+    );
+  });
+
+  it("accepts a steps variant", () => {
+    assert.equal(
+      isCommandConfig({
+        runs: 3,
+        steps: {
+          reset: {
+            command: "git checkout -- f && npx hardhat clean",
+            measure: false,
+          },
+          "cold compile": { command: "npx hardhat compile" },
+        },
+      }),
+      true,
+    );
+  });
+
+  it("rejects when both command and steps are present", () => {
+    assert.equal(
+      isCommandConfig({
+        runs: 3,
+        command: "npx hardhat compile",
+        steps: { "cold compile": { command: "npx hardhat compile" } },
+      }),
+      false,
+    );
+  });
+
+  it("rejects when neither command nor steps is present", () => {
+    assert.equal(isCommandConfig({ runs: 3 }), false);
+  });
+
+  it("rejects an empty steps map", () => {
+    assert.equal(isCommandConfig({ runs: 3, steps: {} }), false);
+  });
+
+  it("rejects an empty step key", () => {
+    assert.equal(
+      isCommandConfig({
+        runs: 3,
+        steps: { "": { command: "npx hardhat compile" } },
+      }),
+      false,
+    );
+  });
+
+  it("rejects an integer-like step key (would break order)", () => {
+    assert.equal(
+      isCommandConfig({
+        runs: 3,
+        steps: { "1": { command: "npx hardhat compile" } },
+      }),
+      false,
+    );
+  });
+
+  it("rejects unknown keys alongside steps", () => {
+    assert.equal(
+      isCommandConfig({
+        runs: 3,
+        prepare: "x",
+        steps: { "cold compile": { command: "npx hardhat compile" } },
+      }),
+      false,
+    );
+  });
+});
+
+describe("isStepConfig", () => {
+  it("accepts a step with just a command (measure defaults true)", () => {
+    assert.equal(isStepConfig({ command: "npx hardhat compile" }), true);
+  });
+
+  it("accepts a step with measure false", () => {
+    assert.equal(
+      isStepConfig({ command: "npx hardhat clean", measure: false }),
+      true,
+    );
+  });
+
+  it("rejects a step missing command", () => {
+    assert.equal(isStepConfig({ measure: true }), false);
+  });
+
+  it("rejects an empty command", () => {
+    assert.equal(isStepConfig({ command: "" }), false);
+  });
+
+  it("rejects a non-boolean measure", () => {
+    assert.equal(
+      isStepConfig({ command: "npx hardhat compile", measure: "false" }),
+      false,
+    );
+  });
+
+  it("rejects unknown step keys", () => {
+    assert.equal(
+      isStepConfig({ command: "npx hardhat compile", runs: 3 }),
       false,
     );
   });

--- a/scripts/end-to-end/schema/scenario-schema.ts
+++ b/scripts/end-to-end/schema/scenario-schema.ts
@@ -1,4 +1,15 @@
-import type { CommandConfig, ScenarioDefinition } from "../types.ts";
+import type {
+  CommandConfig,
+  ScenarioDefinition,
+  StepConfig,
+} from "../types.ts";
+
+/** Matches integer-like keys, which V8 reorders ahead of string keys. */
+const INTEGER_LIKE_KEY = /^\d+$/;
+
+function isPositiveInteger(value: unknown): boolean {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1;
+}
 
 export function isScenarioDefinition(
   value: unknown,
@@ -68,8 +79,11 @@ function isCommandsMap(value: unknown): value is Record<string, CommandConfig> {
     return false;
   }
 
+  // Reject empty and integer-like keys so the declared command order is
+  // preserved (V8 iterates integer-like keys ahead of string keys).
   return (
-    keys.every((k) => k.length > 0) && Object.values(obj).every(isCommandConfig)
+    keys.every((k) => k.length > 0 && !INTEGER_LIKE_KEY.test(k)) &&
+    Object.values(obj).every(isCommandConfig)
   );
 }
 
@@ -79,6 +93,18 @@ export function isCommandConfig(value: unknown): value is CommandConfig {
   }
 
   const obj = value as Record<string, unknown>;
+  const hasCommand = "command" in obj;
+  const hasSteps = "steps" in obj;
+
+  // Exactly one of `command` | `steps` must be present.
+  if (hasCommand === hasSteps) {
+    return false;
+  }
+
+  return hasSteps ? isStepsVariant(obj) : isCommandVariant(obj);
+}
+
+function isCommandVariant(obj: Record<string, unknown>): boolean {
   const allowedKeys = new Set(["runs", "prepare", "command"]);
 
   for (const key of Object.keys(obj)) {
@@ -88,13 +114,64 @@ export function isCommandConfig(value: unknown): value is CommandConfig {
   }
 
   return (
-    typeof obj.runs === "number" &&
-    Number.isInteger(obj.runs) &&
-    obj.runs >= 1 &&
+    isPositiveInteger(obj.runs) &&
     typeof obj.command === "string" &&
     obj.command.length > 0 &&
     (obj.prepare === undefined ||
       (typeof obj.prepare === "string" && obj.prepare.length > 0))
+  );
+}
+
+function isStepsVariant(obj: Record<string, unknown>): boolean {
+  const allowedKeys = new Set(["runs", "steps"]);
+
+  for (const key of Object.keys(obj)) {
+    if (!allowedKeys.has(key)) {
+      return false;
+    }
+  }
+
+  return isPositiveInteger(obj.runs) && isStepsMap(obj.steps);
+}
+
+function isStepsMap(value: unknown): value is Record<string, StepConfig> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj);
+
+  if (keys.length === 0) {
+    return false;
+  }
+
+  // Reject empty and integer-like keys so the declared step order is preserved
+  // (V8 iterates integer-like keys ahead of string keys).
+  return (
+    keys.every((k) => k.length > 0 && !INTEGER_LIKE_KEY.test(k)) &&
+    Object.values(obj).every(isStepConfig)
+  );
+}
+
+export function isStepConfig(value: unknown): value is StepConfig {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const allowedKeys = new Set(["command", "measure"]);
+
+  for (const key of Object.keys(obj)) {
+    if (!allowedKeys.has(key)) {
+      return false;
+    }
+  }
+
+  return (
+    typeof obj.command === "string" &&
+    obj.command.length > 0 &&
+    (obj.measure === undefined || typeof obj.measure === "boolean")
   );
 }
 

--- a/scripts/end-to-end/schema/scenario.schema.json
+++ b/scripts/end-to-end/schema/scenario.schema.json
@@ -78,31 +78,73 @@
           "minProperties": 1,
           "propertyNames": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "^(?!\\d+$).+"
           },
           "additionalProperties": {
             "type": "object",
-            "additionalProperties": false,
-            "required": ["runs", "command"],
-            "properties": {
-              "runs": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "Number of hyperfine runs for this command"
+            "oneOf": [
+              {
+                "additionalProperties": false,
+                "required": ["runs", "command"],
+                "properties": {
+                  "runs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of hyperfine runs for this command"
+                  },
+                  "prepare": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Optional shell snippet to run before each timed run (passed to hyperfine --prepare)"
+                  },
+                  "command": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Shell command to benchmark"
+                  }
+                }
               },
-              "prepare": {
-                "type": "string",
-                "minLength": 1,
-                "description": "Optional shell snippet to run before each timed run (passed to hyperfine --prepare)"
-              },
-              "command": {
-                "type": "string",
-                "minLength": 1,
-                "description": "Shell command to benchmark"
+              {
+                "additionalProperties": false,
+                "required": ["runs", "steps"],
+                "properties": {
+                  "runs": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Number of times to run the whole step sequence"
+                  },
+                  "steps": {
+                    "type": "object",
+                    "minProperties": 1,
+                    "propertyNames": {
+                      "type": "string",
+                      "minLength": 1,
+                      "pattern": "^(?!\\d+$).+"
+                    },
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["command"],
+                      "properties": {
+                        "command": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Shell command for this step"
+                        },
+                        "measure": {
+                          "type": "boolean",
+                          "description": "Emit a benchmark entry for this step (default true)"
+                        }
+                      }
+                    },
+                    "description": "Ordered steps run as a sequence, repeated `runs` times. Each step is timed individually in-process; the key becomes the benchmark name on disk for measured steps."
+                  }
+                }
               }
-            }
+            ]
           },
-          "description": "Named commands to benchmark. Iterated in definition order; the key becomes the benchmark name on disk."
+          "description": "Named commands to benchmark. Iterated in definition order; the key becomes the benchmark name on disk. Each entry is either a single hyperfine command or an in-process step sequence."
         }
       },
       "description": "Benchmark configuration for pnpm bench and pnpm bench:regression"

--- a/scripts/end-to-end/types.ts
+++ b/scripts/end-to-end/types.ts
@@ -29,7 +29,16 @@ export interface ScenarioDefinition {
   };
 }
 
-export interface CommandConfig {
+/**
+ * A benchmark entry in a scenario's `benchmark.commands` map. Exactly one of
+ * the two variants applies, discriminated by the presence of `steps`:
+ *
+ * - {@link CommandVariant}: a single command benchmarked with hyperfine.
+ * - {@link StepsVariant}: an ordered sequence of steps, each timed in-process.
+ */
+export type CommandConfig = CommandVariant | StepsVariant;
+
+export interface CommandVariant {
   /**
    * The number of times to run this command in the regression harness.
    */
@@ -43,4 +52,31 @@ export interface CommandConfig {
    * The command to benchmark in the regression harness.
    */
   command: string;
+}
+
+export interface StepsVariant {
+  /**
+   * The number of times to run the whole step sequence in the regression
+   * harness.
+   */
+  runs: number;
+  /**
+   * The steps to run, in order, once per run. Each step is timed individually
+   * in-process (not via hyperfine), so the shared state between steps avoids
+   * the per-run reset cost of a hyperfine `prepare`. The key doubles as the
+   * benchmark name on disk for measured steps.
+   */
+  steps: Record<string, StepConfig>;
+}
+
+export interface StepConfig {
+  /**
+   * The shell command to run for this step.
+   */
+  command: string;
+  /**
+   * Whether to emit a benchmark entry for this step. Defaults to `true`; set
+   * to `false` for setup/reset steps that should run but not be measured.
+   */
+  measure?: boolean;
 }


### PR DESCRIPTION

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

⚠️ **BEWARE:** Even with the optimisation applied the CI increases from ~1hr to ~1hr25 mins (42% increase) https://github.com/NomicFoundation/hardhat/actions/runs/26901463627/job/79356102314?pr=8360

Adds three new benchmark commands to each active end-to-end scenario that measure the developer inner loop of editing a single file and recompiling:

  - edit & compile Solidity test with min dependencies: <smallest-closure test>
  - edit & compile Solidity test with max dependencies: <largest-closure test>
  - edit & compile Solidity contract: <core/widely-imported source>

Each command appends a trailing comment to invalidate the compile cache and recompiles so every run measures one file change from a previously compiled baseline.

The min/max dependency framing captures incremental recompilation at both ends of the dependency graph and applies uniformly even to repos where every test imports a shared setup (aqua, cross-chain-swap), which have no truly standalone tests.

# Faster regression benchmark: "steps" command sequences (no wasted prepare)

The original attempt (c5c6e23) resulted in excessive CI time (>3 hours). The "edit-then-compile" commands each used a `--prepare` that restores the file and recompiles **before every timed run** — so each run pays ~2 full compiles (prepare + timed). With three edit commands × `runs`, this dominated CI wall-clock time. The prepare recompiles are pure overhead: they only exist to reset state between independent hyperfine runs.

To fix this, I introduced a **`steps` sequence** command variant. A sequence runs an ordered list of commands once per `runs`, timing each step **in-process** (not hyperfine).

Because the steps share state, the natural progression replaces the per-run prepare: a single cold compile per run sets up the cache, then each edit step pays exactly one incremental recompile. State reset happens once per run in an unmeasured first step, not once per timed run.

Entry names are unchanged, so regression benchmark history (keyed on entry name) carries over.

## Config shape

Make `CommandConfig` a union, discriminated by the presence of `steps`:

```ts
export type CommandConfig = CommandVariant | StepsVariant;
export interface CommandVariant { runs: number; prepare?: string; command: string; }
export interface StepsVariant { runs: number; steps: Record<string, StepConfig>; }
export interface StepConfig { command: string; measure?: boolean; } // measure defaults true
```

## Edge cases / risks

- **History continuity** depends on step names matching today's entry names. I asked Claude to check and double-checked names manually.
- **Object key order**: sequence semantics rely on JSON insertion order, which JS preserves for all non-integer-like string keys. We guarantee this in the spec by rejecting integer-like step keys (`/^\d+$/`) in both the validator and the JSON-schema `propertyNames.pattern`, so V8's numeric-key reordering can never apply.
- **Mid-sequence failure** leaves files edited; self-healed by the next run's reset step. A full-scenario abort leaves the throwaway clone dirty — handled by the next `init`/`--force-checkout`.

## Testing

- [x] Extend `scripts/end-to-end/schema/scenario-schema.test.ts` (node:test) with valid steps-variant cases and invalid ones.
- [x] Add `scripts/benchmark/helpers/stats.test.ts` covering `computeStats` (n=1 → stddev 0; odd/even median; min/max; mean).
- [x] Running a manual `ci:perf` run to validate all is in order

## Review

I am still tweaking the number of runs per command / steps, but the code won't change any more. As such it's safe to review.

I recommend reviewing the complete diff of the code.

## No. of runs

To reduce the total run time of the benchmark regression harness, I analysis variance in the historic benchmark data to find out whether we can reduce our number of runs per benchmark.

I outlined the methodology and findings in this comment: https://github.com/NomicFoundation/hardhat/pull/8360#issuecomment-4623166025