### PR TITLE
test: reduce benchmark run counts

### DIFF
--- a/end-to-end/1inch-aqua/scenario.json
+++ b/end-to-end/1inch-aqua/scenario.json
@@ -10,16 +10,16 @@
   "benchmark": {
     "commands": {
       "cold compile": {
-        "runs": 5,
+        "runs": 3,
         "prepare": "npx hardhat clean",
         "command": "npx hardhat compile"
       },
       "warm compile": {
-        "runs": 55,
+        "runs": 9,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 83,
+        "runs": 11,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/1inch-cross-chain-swap/scenario.json
+++ b/end-to-end/1inch-cross-chain-swap/scenario.json
@@ -18,7 +18,7 @@
         "command": "npx hardhat compile"
       },
       "warm compile": {
-        "runs": 97,
+        "runs": 11,
         "command": "npx hardhat compile"
       },
       "test solidity": {

--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -15,11 +15,11 @@
         "command": "npx hardhat compile"
       },
       "warm compile": {
-        "runs": 45,
+        "runs": 5,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 29,
+        "runs": 15,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -15,7 +15,7 @@
         "command": "npx hardhat compile"
       },
       "warm compile": {
-        "runs": 39,
+        "runs": 17,
         "command": "npx hardhat compile"
       },
       "test solidity": {

--- a/end-to-end/ens-verifiable-factory/scenario.json
+++ b/end-to-end/ens-verifiable-factory/scenario.json
@@ -10,16 +10,16 @@
   "benchmark": {
     "commands": {
       "cold compile": {
-        "runs": 13,
+        "runs": 3,
         "prepare": "npx hardhat clean",
         "command": "npx hardhat compile"
       },
       "warm compile": {
-        "runs": 77,
+        "runs": 7,
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 69,
+        "runs": 3,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/lidofinance-dual-governance/scenario.json
+++ b/end-to-end/lidofinance-dual-governance/scenario.json
@@ -18,7 +18,7 @@
         "command": "npx hardhat compile"
       },
       "warm compile": {
-        "runs": 83,
+        "runs": 9,
         "command": "npx hardhat compile"
       },
       "test solidity": {

--- a/end-to-end/uniswap-v4-core/scenario.json
+++ b/end-to-end/uniswap-v4-core/scenario.json
@@ -15,7 +15,7 @@
         "command": "npx hardhat compile"
       },
       "warm compile": {
-        "runs": 51,
+        "runs": 15,
         "command": "npx hardhat compile"
       },
       "test solidity": {

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -18,7 +18,7 @@
         "command": "npx hardhat compile"
       },
       "warm compile": {
-        "runs": 37,
+        "runs": 15,
         "command": "npx hardhat compile"
       },
       "test solidity": {


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Lowers the per-command run counts in the e2e benchmark scenarios to the smallest values that keep the reported average within 0.5% of the full-sample mean, with a floor of 3 runs and rounded up to the nearest odd number so each command retains a true median.

Reduces total runs per commit across the eight benchmarked scenarios from 726 to 166 (~77% fewer) with negligible impact on reported averages.

The analysis was run over the benchmark history **from commit `300d180` to the latest available result** (19 commits, 2026-05-21 → 2026-05-29). Only the eight scenarios that have benchmark results in that window are covered; scenarios without benchmark data or without a `benchmark.commands` block were left untouched.

This change was inspired by the increased benchmark run times due to #8360.

## 1. Runs: current vs. Min@0.5% vs. new

| Scenario | Command | Current | Min@0.5% | New |
|---|---|---:|---:|---:|
| 1inch-aqua | cold compile | 5 | 1 | 3 |
| 1inch-aqua | warm compile | 55 | 9 | 9 |
| 1inch-aqua | test solidity | 83 | 11 | 11 |
| 1inch-cross-chain-swap | cold compile | 3 | 3 | 3 |
| 1inch-cross-chain-swap | warm compile | 97 | 10 | 11 |
| 1inch-cross-chain-swap | test solidity | 9 | 9 | 9 |
| 1inch-swap-vm | cold compile | 3 | 1 | 3 |
| 1inch-swap-vm | warm compile | 45 | 4 | 5 |
| 1inch-swap-vm | test solidity | 29 | 14 | 15 |
| aave-v4 | cold compile | 3 | 3 | 3 |
| aave-v4 | warm compile | 39 | 16 | 17 |
| aave-v4 | test solidity | 3 | 3 | 3 |
| ens-verifiable-factory | cold compile | 13 | 3 | 3 |
| ens-verifiable-factory | warm compile | 77 | 6 | 7 |
| ens-verifiable-factory | test solidity | 69 | 3 | 3 |
| lidofinance-dual-governance | cold compile | 3 | 3 | 3 |
| lidofinance-dual-governance | warm compile | 83 | 8 | 9 |
| lidofinance-dual-governance | test solidity | 3 | 3 | 3 |
| uniswap-v4-core | cold compile | 3 | 1 | 3 |
| uniswap-v4-core | warm compile | 51 | 14 | 15 |
| uniswap-v4-core | test solidity | 7 | 7 | 7 |
| uniswap-x | cold compile | 3 | 3 | 3 |
| uniswap-x | warm compile | 37 | 15 | 15 |
| uniswap-x | test solidity | 3 | 1 | 3 |
| **Total runs / commit** | | **726** | **151** | **166** |

## 2. Formula: the Min@0.5% number

For a single command in a single commit, let `times = [t₁, t₂, …, t_N]` be the recorded per-run durations (the `extra.times` array in the benchmark data) and let the full-sample mean be:

```
fullMean = mean(t₁ … t_N)
```

`Min@0.5%` for that commit is the smallest prefix length `k` such that **every** cumulative mean from `k` onward stays within 0.5% of `fullMean`:

```
Min@0.5%(commit) = min {k : for all j in [k, N], | mean(t₁ … t_j) − fullMean | / fullMean ≤ 0.005 }
```

The "and stays" condition (checking all `j ≥ k`, not just `j = k`) avoids picking a `k` where the running mean only crosses the threshold by coincidence before drifting out again.

The value reported per command in the table is the **worst case across all 19 commits** in the window, so the chosen run count is robust over the whole period:

```
Min@0.5%(command) = max over commits of Min@0.5%(commit)
```

## 3. Formula: the new run count

Two adjustments are applied to `Min@0.5%` to keep each measurement statistically sensible:

```
New = max(Min@0.5%, 3)                       // floor of 3 runs
New = (Min@0.5% is even) ? New + 1 : New     // round up to an odd count
```

- **Floor of 3** — guarantees a min/median/max and lets hyperfine flag an  anomalous run; a 1- or 2-run sample has no such safety net.
- **Odd count** — an odd number of runs yields a true median (the middle value) rather than an average of the two central values. The `+1` is applied when the raw `Min@0.5%` is even.

## 4. Runtime: current vs. expected new

Estimated from the measured mean per-run time of each command (latest commit in the window) multiplied by the run count. This is **command-execution time only**.

### Per command

| Command | Current | New |
|---|---:|---:|
| cold compile | 49.9 min | 48.9 min |
| warm compile | 6.0 min | 1.2 min |
| test solidity | 10.3 min | 8.4 min |
| **Full suite** | **66.3 min** | **58.5 min** |

### Per scenario (minutes)

| Scenario | Current | New | Saved |
|---|---:|---:|---:|
| 1inch-aqua | 2.0 | 0.6 | 1.4 |
| 1inch-cross-chain-swap | 13.5 | 12.6 | 0.8 |
| 1inch-swap-vm | 14.1 | 12.9 | 1.2 |
| aave-v4 | 14.3 | 13.9 | 0.4 |
| ens-verifiable-factory | 2.7 | 0.3 | 2.3 |
| lidofinance-dual-governance | 3.7 | 2.9 | 0.8 |
| uniswap-v4-core | 11.7 | 11.0 | 0.6 |
| uniswap-x | 4.3 | 4.1 | 0.3 |
| **Total** | **66.3** | **58.5** | **7.8** |

## 5. Cost savings and caveats

The change reduces run count per commit from **726 to 166 (≈77% fewer runs)**,
but estimated compute time only drops from **66.3 min to 58.5 min — a saving of
~7.8 min (≈11.8%)**.

The gap between "77% fewer runs" and "~12% less time" shows that cold compile dominates the clock. It accounts for ~75% of compute time (~50 min) yet already runs at or near the 3-run floor, so it can barely be reduced. The large run-count cuts land almost entirely on the cheap warm-compile phase (6.0 → 1.2 min), which is a big proportional cut but a small absolute one.

Caveats on the runtime numbers:

- **Compute time only.** The estimates exclude per-scenario fixed overhead — cloning repos, `pnpm`/`yarn install`, and cache warm-up between phases — which the suite also incurs. Real wall-clock savings will therefore be a *smaller* percentage than the ~11.8% shown.
- **Per-run times are taken from the latest commit** in the window. Run durations vary slightly between commits and CI runners, so treat the minute figures as estimates, not guarantees.
- **Calibrated on a low-variance window.** The `Min@0.5%` values come from the history since `300d180`. A noisier future period could justify slightly higher counts; the odd-count rounding provides some margin.

# Testing
I ran a run on the dedicated benchmark runner. No outliers were reported: https://github.com/NomicFoundation/hardhat/actions/runs/26842106786/attempts/1#summary-79153035280