### PR TITLE
build: upgrade to EDR v0.12.0

### DIFF
--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -93,7 +93,7 @@
     "typescript": "~6.0.3"
   },
   "dependencies": {
-    "@nomicfoundation/edr": "0.12.0-next.34",
+    "@nomicfoundation/edr": "0.12.0",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.14",
     "@nomicfoundation/hardhat-utils": "workspace:^4.1.3",
     "@nomicfoundation/hardhat-vendored": "workspace:^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
   packages/hardhat:
     dependencies:
       '@nomicfoundation/edr':
-        specifier: 0.12.0-next.34
-        version: 0.12.0-next.34
+        specifier: 0.12.0
+        version: 0.12.0
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.14
         version: link:../hardhat-errors
@@ -2933,36 +2933,36 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.34':
-    resolution: {integrity: sha512-Rq7DYVNcgWaanNP4QC2akcP88cyIF8LoeQfoTz7F6ktHVH34DJ92YM7pP6wCUef5QWY5IzWpq/dRkT93AnF4ww==}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0':
+    resolution: {integrity: sha512-z/8jU2dgZjhY2iLtJ1DGi3t/N2xbmjgok9K3R0f7+UZxSSJ5LbXCFn5So33fVh47RzGzOqEB+Yk4SdyUq2odqw==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.34':
-    resolution: {integrity: sha512-2233FIcdxx/6TgLZYzlR1ZabTIGxp7kZOA1HQTa0rOeEttWzvuhnGOluiqXvLTexI4pxmAbDo1ZVzICXxOt5AA==}
+  '@nomicfoundation/edr-darwin-x64@0.12.0':
+    resolution: {integrity: sha512-F9RrA60mEtxfKFiGB7QsydoUwzz4ckoustVMFegcIKmjRxRVb1qrRYiAc9oQiKMdJWIZKDYsOpHABJ9Um4U/+g==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.34':
-    resolution: {integrity: sha512-IF64IYr+RKH1l2XPdswaZsXtfOXNk84VjxZjhjtU16Q4OyZUQ1PIiVPO5PThFvw6IOqY63kGIkKee8iGES8dXQ==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0':
+    resolution: {integrity: sha512-EtGRZbh1d4BF/1SIG5rVrKQ9R0nuNvPgCYiU5fCmY3bojAFOUf4m7I2ezIhim1vb1QBlXmFaoFNPZFIdMltBGA==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.34':
-    resolution: {integrity: sha512-xdT1GMiUkZHlgRv+LjsJ8DhpJQzDa3M9kbEWUh+9zghCkAgpJyfjNl7nbqLmCj6Bnt3zS3MZw1lOR7xTRpi6LA==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0':
+    resolution: {integrity: sha512-5gWtmKuVfftcO1OUbF/3KTPVSR6klC7RI9Z96G5lDO325jQhYqOG+hkvDPKtM+nbYf+A0veOndghqbUgAX+E4A==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.34':
-    resolution: {integrity: sha512-0M2Vfa9/lFSxBvJB8BrA50aB5I9aGbUTTRoYc90QYjNQOEce2O9K5kxxRcqwNLbIgjPh1AZEeoVefDDaaTsQ0Q==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0':
+    resolution: {integrity: sha512-0Ty0fov3/NFL0dIshNTGCi06sjVzsgB7k+n9LAoj+57OsqP9X4e3P5XwjlTSNuyYshv8JdYMHqY+1ZIZ8SHsyQ==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.34':
-    resolution: {integrity: sha512-i2K3kPQVqD/GD/HubzYtsap4o6FaWg4HsOgfqy+QiPBBXNC+ImovdfnhtlRra/wRt11xe4MUVllmSlZGunlDLA==}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0':
+    resolution: {integrity: sha512-e5du3t17vdB3tAY0kl3Ip1cu8CcwiaeJeUC4mMPmL91HDM//AQehqpyIP8upam4AeIl1H6FA3xIUIDA6VOZSxg==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.34':
-    resolution: {integrity: sha512-NuLmTD29yWLj3FehUObynlHK2d3w1rq0MF8hu5nYqzTYbs7MSdpsJVK+68bm361HsRqXsYaIasVuK/Nz1PnZ0w==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0':
+    resolution: {integrity: sha512-wD8YxhFdlY2IXb7uVrSF7VHartFKXEYeiE6ISJOV10Y7YOUE1IzfwB0QOdKtLUepwB+HXis+KRy4h22dWEbT0A==}
     engines: {node: '>= 20'}
 
-  '@nomicfoundation/edr@0.12.0-next.34':
-    resolution: {integrity: sha512-tySWgpY9BqFTeU4+29vXMKyeB1MD3CVcI2yk3Ft2H7kYWz9HMed27t8Cu/fL2hRsrtyPTAM1vfV0OIfKlnp4NQ==}
+  '@nomicfoundation/edr@0.12.0':
+    resolution: {integrity: sha512-dVfrB70L//W05s+s+/c6n52Fct+kVKoXYT+/CKL9ZsNdq/yLr5LaPNsvpVkQHP1JdAiOrubUzA/MwZIk4gRxAQ==}
     engines: {node: '>= 20'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -8501,29 +8501,29 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.0-next.34': {}
+  '@nomicfoundation/edr-darwin-arm64@0.12.0': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.0-next.34': {}
+  '@nomicfoundation/edr-darwin-x64@0.12.0': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.34': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.12.0': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.34': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.12.0': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.34': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.12.0': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.0-next.34': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.12.0': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.34': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.12.0': {}
 
-  '@nomicfoundation/edr@0.12.0-next.34':
+  '@nomicfoundation/edr@0.12.0':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.12.0-next.34
-      '@nomicfoundation/edr-darwin-x64': 0.12.0-next.34
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0-next.34
-      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0-next.34
-      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.34
-      '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.34
-      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.34
+      '@nomicfoundation/edr-darwin-arm64': 0.12.0
+      '@nomicfoundation/edr-darwin-x64': 0.12.0
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.0
+      '@nomicfoundation/edr-linux-arm64-musl': 0.12.0
+      '@nomicfoundation/edr-linux-x64-gnu': 0.12.0
+      '@nomicfoundation/edr-linux-x64-musl': 0.12.0
+      '@nomicfoundation/edr-win32-x64-msvc': 0.12.0
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

EDR switched from pre-releases (using `.next`) to normal releases. This bumps to the next "release" version of EDR.

Other than the change in version number, EDR only contains upgrades of its internal dependencies.

# Testing

- [ ] Running a `ci:perf` regression benchmark run just in case
