### PR TITLE
feat: suppress contract size warning in test contracts

### DIFF
--- a/.changeset/legal-memes-fetch.md
+++ b/.changeset/legal-memes-fetch.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Suppress the solc contract size warning for Solidity test files.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -31,6 +31,7 @@ const SPECIFIC_FILE_RULES: ReadonlyArray<{
 const TEST_FILE_WARNING_MESSAGES: readonly string[] = [
   SPDX_WARNING,
   PRAGMA_WARNING,
+  CONTRACT_SIZE_WARNING,
 ];
 
 // Warnings suppressed only when running with `--coverage`. An entry with no

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -230,8 +230,8 @@ describe("shouldSuppressWarning", () => {
     });
   });
 
-  describe("Contract-size warning (coverage-only)", () => {
-    it("should suppress contract-size warning when coverage=true", () => {
+  describe("Contract-size warning", () => {
+    it("should suppress contract-size warning on a user file when coverage=true", () => {
       const message = `Warning: ${CONTRACT_SIZE_WARNING}\n  --> ${path.join("contracts", "Foo.sol")}:1:1:`;
       assert.equal(
         shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT, true),
@@ -239,7 +239,7 @@ describe("shouldSuppressWarning", () => {
       );
     });
 
-    it("should NOT suppress contract-size warning when coverage=false", () => {
+    it("should NOT suppress contract-size warning on a user file when coverage=false", () => {
       const message = `Warning: ${CONTRACT_SIZE_WARNING}\n  --> ${path.join("contracts", "Foo.sol")}:1:1:`;
       assert.equal(
         shouldSuppressWarning(
@@ -249,6 +249,32 @@ describe("shouldSuppressWarning", () => {
           false,
         ),
         false,
+      );
+    });
+
+    it("should suppress contract-size warning on a .t.sol file when coverage=false", () => {
+      const message = `Warning: ${CONTRACT_SIZE_WARNING}\n  --> ${path.join("contracts", "Counter.t.sol")}:1:1:`;
+      assert.equal(
+        shouldSuppressWarning(
+          message,
+          SOLIDITY_TESTS_PATH,
+          PROJECT_ROOT,
+          false,
+        ),
+        true,
+      );
+    });
+
+    it("should suppress contract-size warning on a file in the Solidity tests dir when coverage=false", () => {
+      const message = `Warning: ${CONTRACT_SIZE_WARNING}\n  --> ${path.join("test", "contracts", "Helper.sol")}:1:1:`;
+      assert.equal(
+        shouldSuppressWarning(
+          message,
+          SOLIDITY_TESTS_PATH,
+          PROJECT_ROOT,
+          false,
+        ),
+        true,
       );
     });
 


### PR DESCRIPTION
Test contracts will never be deployed to mainnet. Their size is therefore not relevant.

We now suppress the contract size warning for contracts from test files (either `*.t.sol` or under the configured test folder).