### PR TITLE
fix: do not download compiler if path defined

### DIFF
--- a/.changeset/local-compiler-path-skips-download.md
+++ b/.changeset/local-compiler-path-skips-download.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed the `build` task attempting to download a compiler even though a `path` to a local compiler is configured.

--- a/cspell.dictionary.txt
+++ b/cspell.dictionary.txt
@@ -124,6 +124,7 @@ ufixed
 Uints
 Uncontended
 uncompiled
+undownloadable
 unidici
 unmined
 unpad

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -96,6 +96,17 @@ export function isSolcSolidityCompilerConfig(
   return config.type === undefined || config.type === "solc";
 }
 
+/**
+ * Returns true if the given compiler config defines a custom path to a solc
+ * compiler (native binary or WASM bundle). Such a compiler is user-provided and
+ * does not need to be downloaded.
+ */
+export function isSolcSolidityCompilerLocalBinary(
+  config: SolidityCompilerConfig,
+): boolean {
+  return isSolcSolidityCompilerConfig(config) && config.path !== undefined;
+}
+
 interface CompilationResult {
   compilationJob: CompilationJob;
   compilerOutput: CompilerOutput;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/config.ts
@@ -613,6 +613,7 @@ function copyFromDefault(
     return {
       version: defaultSolidityConfig.version,
       type: defaultSolidityConfig.type,
+      path: defaultSolidityConfig.path,
     };
   }
 
@@ -620,12 +621,17 @@ function copyFromDefault(
     compilers: defaultSolidityConfig.compilers.map((c) => ({
       version: c.version,
       type: c.type,
+      path: c.path,
     })),
     overrides: Object.fromEntries(
       Object.entries(defaultSolidityConfig.overrides ?? {}).map(
         ([userSourceName, override]) => [
           userSourceName,
-          { version: override.version, type: override.type },
+          {
+            version: override.version,
+            type: override.type,
+            path: override.path,
+          },
         ],
       ),
     ),

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/solidity-hooks.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/solidity-hooks.ts
@@ -1,7 +1,10 @@
 import type { SolidityCompilerConfig } from "../../../types/config.js";
 import type { Compiler } from "../../../types/solidity.js";
 
-import { isSolcSolidityCompilerConfig } from "./build-system/build-system.js";
+import {
+  isSolcSolidityCompilerConfig,
+  isSolcSolidityCompilerLocalBinary,
+} from "./build-system/build-system.js";
 import {
   downloadSolcCompilers,
   getCompiler,
@@ -16,7 +19,10 @@ export async function downloadSolcCompilersHandler(
   quiet: boolean,
 ): Promise<void> {
   const solcVersions = new Set(
-    compilerConfigs.filter(isSolcSolidityCompilerConfig).map((c) => c.version),
+    compilerConfigs
+      .filter(isSolcSolidityCompilerConfig)
+      .filter((c) => !isSolcSolidityCompilerLocalBinary(c))
+      .map((c) => c.version),
   );
 
   if (solcVersions.size > 0) {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/config.ts
@@ -1309,6 +1309,59 @@ describe("solidity plugin config resolution", () => {
     });
   });
 
+  describe("per-compiler path resolution", () => {
+    // A custom `path` points at a user-provided local solc binary. The
+    // auto-generated `production` profile is cloned from `default`, and it must
+    // preserve `path` — otherwise the build attempts to download that compiler,
+    // which is exactly the bug from
+    // https://github.com/NomicFoundation/hardhat/issues/8366.
+    it("should preserve path in both default and production profiles for a single-version config", async () => {
+      const resolvedConfig = await resolveSolidityUserConfig(
+        { solidity: { version: "0.8.28", path: "/path/to/solc" } },
+        otherResolvedConfig,
+      );
+
+      assert.equal(
+        resolvedConfig.solidity.profiles.default.compilers[0].path,
+        "/path/to/solc",
+      );
+      assert.equal(
+        resolvedConfig.solidity.profiles.production.compilers[0].path,
+        "/path/to/solc",
+      );
+    });
+
+    it("should preserve path in overrides for both default and production profiles", async () => {
+      const resolvedConfig = await resolveSolidityUserConfig(
+        {
+          solidity: {
+            compilers: [{ version: "0.8.28" }],
+            overrides: {
+              "contracts/Special.sol": {
+                version: "0.8.31",
+                path: "/path/to/solc-0.8.31",
+              },
+            },
+          },
+        },
+        otherResolvedConfig,
+      );
+
+      assert.equal(
+        resolvedConfig.solidity.profiles.default.overrides[
+          "contracts/Special.sol"
+        ].path,
+        "/path/to/solc-0.8.31",
+      );
+      assert.equal(
+        resolvedConfig.solidity.profiles.production.overrides[
+          "contracts/Special.sol"
+        ].path,
+        "/path/to/solc-0.8.31",
+      );
+    });
+  });
+
   describe(
     "ARM64 Linux per-compiler preferWasm defaults",
     {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/hooks.ts
@@ -33,6 +33,7 @@ import { beforeEach, describe, it } from "node:test";
 import { useFixtureProject } from "@nomicfoundation/hardhat-test-utils";
 
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
+import { downloadSolcCompilersHandler } from "../../../../src/internal/builtin-plugins/solidity/solidity-hooks.js";
 import { FileBuildResultType } from "../../../../src/types/solidity.js";
 
 /**
@@ -520,6 +521,47 @@ describe("solidity - hooks", () => {
         quiet: true,
       });
     });
+
+    // A compiler config with a `path` is user-provided and resolved directly
+    // from disk during compilation, so it must not be downloaded. The version
+    // here is a full long-version string that does not exist in the binaries
+    // list — without the path-skip it would be downloaded and throw
+    // DOWNLOAD_FAILED. The handler must resolve without throwing or hitting
+    // the network. See https://github.com/NomicFoundation/hardhat/issues/8366.
+    it("should skip download for solc configs with a custom path", async () => {
+      await downloadSolcCompilersHandler(
+        [
+          {
+            version: "0.8.30+commit.73712a01.Linux.g++",
+            path: "/some/local/path/to/solc",
+            settings: {},
+          },
+        ],
+        true,
+      );
+    });
+
+    it(
+      "should download path-less versions while skipping path-backed ones",
+      {
+        skip: process.env.HARDHAT_DISABLE_SLOW_TESTS === "true",
+      },
+      async () => {
+        // Mixed configs: the path-backed config (undownloadable version) is
+        // skipped, while the normal solc config still resolves from the cache.
+        await downloadSolcCompilersHandler(
+          [
+            {
+              version: "0.8.30+commit.73712a01.Linux.g++",
+              path: "/some/local/path/to/solc",
+              settings: {},
+            },
+            { version: "0.8.23", settings: {} },
+          ],
+          true,
+        );
+      },
+    );
   });
 
   describe("getCompiler", () => {


### PR DESCRIPTION
The `downloadSolcCompilerHandler` now filters out configs that have a `path` set, that is a local binary should be used rather than downloaded.

This avoids an attempted download over the network for compilers that exist locally. Previously a user could define a local binary to avoid network issues, but would still be unable to build because an attempt to download would still happen.

Resolves #8366.
