### PR TITLE
feat(skill): add benchmark-run-sizing agent skill

### DIFF
--- a/.claude/skills/benchmark-run-sizing/SKILL.md
+++ b/.claude/skills/benchmark-run-sizing/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: benchmark-run-sizing
+description: >-
+  Analyzes the Hardhat regression benchmark history (the hardhat-benchmark-results
+  repo's data.js) and recommends how many times each benchmark should run. It reads
+  every commit's individual run times, computes each benchmark's per-commit
+  coefficient of variation, removes outliers, takes the 95th-percentile CV, and sizes
+  run counts for target noise levels (sigma = 3%, 1.5%, 1%, i.e. regression alert
+  limits of 10% / 5% / 3%). Use when asked to right-size benchmark run counts, justify
+  or revisit run counts, assess benchmark variance/noise, or decide whether to add or
+  remove runs after changing the regression alert threshold.
+allowed-tools: Bash(git clone *), Bash(git -C *), Bash(python3 *)
+---
+
+# Benchmark run sizing
+
+Reproduces the run-count analysis for the Hardhat regression benchmarks from their
+stored history, and emits a copy-ready markdown report.
+
+## Steps
+
+1. **Fetch the data.** Clone (or pull) the results repo and locate `hardhat3/data.js`:
+
+   ```bash
+   dir=$(mktemp -d)
+   git clone --depth 1 https://github.com/nomic-foundation-automation/hardhat-benchmark-results.git "$dir"
+   ```
+
+   (If the user gives a local path or a pasted `benches` array instead, skip the clone
+   and point the script at that file.)
+
+2. **Run the analysis script** against the data file:
+
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/scripts/analyze.py "$dir/hardhat3/data.js"
+   ```
+
+   It prints one markdown table (every benchmark, sorted by scenario then command type)
+   followed by a **Findings** section. Benchmarks with fewer than 5 commits of history
+   are marked *(provisional)* — their CV is a small-sample estimate.
+
+3. **Assemble the report.** Output the template below verbatim, inserting the script's
+   table where indicated. Then write the **Conclusion from the Findings the script
+   produced** — do not recompute numbers by hand, and do not assert anything the data
+   doesn't show. Useful angles to cover *if the data supports them*: which command
+   types are stable enough to sit at the run-count floor, where any extra runs are
+   concentrated (and on which scenarios), how the cost grows as the target tightens,
+   and — since `runs ∝ CV²` — whether reducing a noisy benchmark's CV (e.g. pinned/
+   replayed RPC, fewer fuzz iterations, or reporting median/min of runs) is cheaper than
+   adding runs. Keep it to a few bullets.
+
+## Method (what the script does)
+
+- For each benchmark, for each commit, CV = stdev(times) / mean(times) of that commit's
+  own runs (commits with < 2 runs are skipped).
+- Extreme outliers are removed per benchmark (MAD modified z-score > 3.5) to drop
+  broken runs.
+- The **95th-percentile CV** of the remaining per-commit values is the sizing input
+  (conservative: meets the noise target on all but the noisiest ~1-in-20 commits).
+- `runs = max(2, ceil(2 · (CV / target σ)²))`. Targets σ = 3% / 1.5% / 1% correspond to
+  alert limits 10% / 5% / 3% via σ ≈ limit / 3.
+- `~runtime` is the mean run time from the most recent commit.
+
+To change targets, the outlier rule, the percentile, or the floor, edit the constants
+at the top of `scripts/analyze.py`.
+
+## Report template
+
+> Replace `<<< INSERT TABLE >>>` with the script's table, and write the Conclusion from
+> the script's Findings section (see step 3).
+
+```markdown
+# Choosing benchmark run counts from observed variance
+
+## Purpose
+
+Each regression benchmark runs a command several times and records the **average**
+time. CI flags a regression when a benchmark's average rises more than a set
+**alert limit** (today 10% but we plan to incrementally reduce it to 5%). Running
+more times gives a more stable average but costs CI time. This note derives, per
+benchmark, the **minimum run count** so that normal measurement noise stays
+comfortably below the alert limit.
+
+## Notation
+
+- **run** — one execution of a benchmark command.
+- **mean** — the average time over a benchmark's runs (the number CI compares).
+- **CV** (coefficient of variation) — run-to-run standard deviation ÷ mean, as a %.
+  Measures intrinsic noisiness; independent of how many times we run.
+- **σ** (sigma) — standard deviation of the *comparison* between a new commit's mean
+  and the previous commit's mean, as a %. This is the noise the alert sees.
+- **p95** — 95th percentile: the value exceeded by only 1 in 20 commits.
+- **alert limit (L)** — the % slowdown at which CI fails the build.
+
+## Method and formulas
+
+Two standard results (take as given):
+
+1. **Standard error of the mean.** The average of *n* independent measurements, each
+   with relative spread CV, has relative spread **CV / √n**.
+2. **Error propagation of a ratio.** If two independent values each have small relative
+   spread, their ratio's relative spread is the square root of the sum of their squares.
+
+A regression check compares two independent means (new vs old), each with spread
+CV/√n. By (1) then (2):
+
+    σ = √2 · CV / √n
+
+Targeting σ ≈ L/3 (so a real L% change sits ~3 standard deviations above noise):
+
+| alert limit L | target σ |
+|---|---|
+| 10% | 3% |
+| 5%  | 1.5% |
+| 3%  | 1% |
+
+Solving for the run count:
+
+    runs = ceil( 2 · (CV / target σ)² ),  minimum 2
+
+We use the **95th-percentile CV** across commits (broken runs removed first), so the
+noise target holds on all but the noisiest commits — the ones that actually cause
+false alarms. Benchmarks marked *(provisional)* have little history, so their figure
+is a small-sample estimate that will firm up over time.
+
+## Benchmark variance and recommended runs
+
+<<< INSERT TABLE >>>
+
+## Conclusion
+
+<<< WRITE FROM THE SCRIPT'S FINDINGS — see skill step 3 >>>
+```

--- a/.claude/skills/benchmark-run-sizing/scripts/analyze.py
+++ b/.claude/skills/benchmark-run-sizing/scripts/analyze.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Analyze Hardhat regression benchmark variance and recommend run counts.
+
+Reads a github-action-benchmark `data.js` (`window.BENCHMARK_DATA = {...}`) -- or any
+file containing that object / a pasted `benches` array -- and, per benchmark:
+  * computes the per-commit coefficient of variation (CV) from each commit's run times,
+  * removes extreme outliers (MAD modified z-score > 3.5),
+  * takes the 95th-percentile CV,
+  * recommends run counts for target sigma of 3%, 1.5%, 1%.
+
+Prints one markdown table (all benchmarks) plus a data-driven Findings section.
+
+Usage: python3 analyze.py [path-to-data.js]   (default: hardhat3/data.js)
+"""
+import sys, re, json, math, statistics
+from collections import defaultdict
+
+# --- tunables -------------------------------------------------------------------
+# (label, target sigma %, corresponding alert limit %)
+TARGETS = [("sigma=3%", 3.0, 10), ("sigma=1.5%", 1.5, 5), ("sigma=1%", 1.0, 3)]
+OUTLIER_Z = 3.5          # MAD modified z-score cutoff
+PERCENTILE = 95          # CV percentile used for sizing
+MIN_RUNS = 2             # floor
+PROVISIONAL_BELOW = 5    # commits below this => provisional estimate
+# --------------------------------------------------------------------------------
+
+
+def load(path):
+    s = open(path).read()
+    s = s[s.index("{"):].rstrip().rstrip(";")     # drop "window.BENCHMARK_DATA = " / trailing ;
+    s = re.sub(r",(\s*[}\]])", r"\1", s)           # tolerate trailing commas
+    return json.loads(s)
+
+
+def percentile(xs, p):
+    xs = sorted(xs)
+    n = len(xs)
+    if n == 1:
+        return xs[0]
+    i = p / 100 * (n - 1)
+    lo = math.floor(i)
+    hi = math.ceil(i)
+    return xs[lo] + (xs[hi] - xs[lo]) * (i - lo)
+
+
+def drop_outliers(xs):
+    if len(xs) < 3:
+        return xs
+    med = statistics.median(xs)
+    mad = statistics.median([abs(x - med) for x in xs])
+    if mad == 0:
+        return xs
+    return [x for x in xs if abs(0.6745 * (x - med) / mad) <= OUTLIER_Z]
+
+
+def runs_for(cv_pct, target_pct):
+    if cv_pct <= 0:
+        return MIN_RUNS
+    return max(MIN_RUNS, math.ceil(2 * (cv_pct / target_pct) ** 2))
+
+
+def collect(data):
+    """Walk all benchmark groups, chronological order, gathering per-commit CV%."""
+    cv = defaultdict(list)
+    last_rt = {}
+    if "entries" in data:
+        iters = [e for lst in data["entries"].values() if isinstance(lst, list) for e in lst]
+    elif "benches" in data:                        # pasted single commit
+        iters = [data]
+    else:
+        iters = []
+    for entry in iters:
+        for b in entry.get("benches", []):
+            try:
+                t = json.loads(b["extra"])["times"]
+            except Exception:
+                t = []
+            if not t:
+                continue
+            mean = statistics.mean(t)
+            if mean <= 0:
+                continue
+            last_rt[b["name"]] = mean              # chronological => ends on latest
+            if len(t) >= 2:
+                cv[b["name"]].append(statistics.stdev(t) / mean * 100)
+    return cv, last_rt
+
+
+SUBORDER = [
+    "cold compile",
+    "edit & compile Solidity test with min",
+    "edit & compile Solidity test with max",
+    "edit & compile Solidity contract",
+    "warm compile",
+    "test solidity",
+]
+
+
+def sort_key(name):
+    scenario, _, sub = name.partition(" / ")
+    for i, p in enumerate(SUBORDER):
+        if sub.startswith(p):
+            return (scenario, i, sub)
+    return (scenario, len(SUBORDER), sub)
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "hardhat3/data.js"
+    cv, last_rt = collect(load(path))
+
+    rows = []
+    for name, vals in cv.items():
+        p95 = percentile(drop_outliers(vals), PERCENTILE)
+        rec = [runs_for(p95, t) for _, t, _ in TARGETS]
+        rows.append((name, last_rt.get(name, float("nan")), p95, len(vals), rec))
+    rows.sort(key=lambda r: sort_key(r[0]))
+
+    # --- table ---
+    print("### Benchmark variance and recommended runs\n")
+    print("| benchmark | ~runtime (s) | p95 CV% | runs @sigma=3% | runs @sigma=1.5% | runs @sigma=1% |")
+    print("|---|---|---|---|---|---|")
+    for name, rt, p95, nc, rec in rows:
+        prov = f" *(provisional, {nc} commit{'' if nc == 1 else 's'})*" if nc < PROVISIONAL_BELOW else ""
+        rts = "—" if rt != rt else f"{rt:.1f}"
+        print(f"| {name}{prov} | {rts} | {p95:.2f} | {rec[0]} | {rec[1]} | {rec[2]} |")
+
+    # --- findings (objective; the report's Conclusion is written from these) ---
+    print("\n### Findings\n")
+
+    def t_secs(rt, k):
+        return 0.0 if rt != rt else k * rt
+
+    for idx, (_label, _sigma, limit) in enumerate(TARGETS):
+        need = sorted(
+            ((r[0], r[4][idx]) for r in rows if r[4][idx] > MIN_RUNS),
+            key=lambda x: -x[1],
+        )
+        total = sum(t_secs(r[1], r[4][idx]) for r in rows)
+        base = sum(t_secs(r[1], MIN_RUNS) for r in rows)
+        print(
+            f"- **sigma={_sigma}% (alert limit ~{limit}%)**: "
+            f"{len(rows) - len(need)}/{len(rows)} benchmarks sit at the floor of {MIN_RUNS}; "
+            f"est. total ≈ {total / 60:.1f} min (vs {base / 60:.1f} min if all at floor)."
+        )
+        if need:
+            print("    - above floor: " + ", ".join(f"{n} → {k}" for n, k in need))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Adds a Claude Code skill that reproduces the run-count analysis for the regression benchmarks from their stored history in the https://github.com/nomic-foundation-automation/hardhat-benchmark-results repo. It reads each commit's individual run times, computes per-commit coefficient of variation, removes outliers, takes the 95th-percentile CV, and recommends run counts for target noise levels (sigma = 3% / 1.5% / 1%, i.e. alert limits 10% / 5% / 3%).

The skill ships SKILL.md (method, formulas, report template) and a bundled scripts/analyze.py that emits one markdown table for all benchmarks plus a data-driven Findings section; conclusions are derived from that output.

The skill was created based on the analysis done in https://github.com/NomicFoundation/hardhat/pull/8360

# Review

Please let me know if there is a better place to store agent skills like this for usage with Hardhat.