### PR TITLE
fix(network-manager): validate "initialDate" as a parseable date string

### DIFF
--- a/.changeset/wide-ants-blow.md
+++ b/.changeset/wide-ants-blow.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Validate `initialDate` is a parseable date string at config-load time, avoids BigInt(NaN) crash.
+Improved validation for `initialDate` network configuration. Invalid `Date` objects and unparseable date `string`s are now rejected during config loading rather than causing a runtime error later.

--- a/.changeset/wide-ants-blow.md
+++ b/.changeset/wide-ants-blow.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Validate `initialDate` is a parseable date string at config-load time, avoids BigInt(NaN) crash.

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -322,12 +322,13 @@ const edrNetworkUserConfigSchema = z.object({
   hardfork: z.optional(z.string()),
   initialBaseFeePerGas: z.optional(gasUnitUserConfigSchema),
   initialDate: z.optional(
-    unionType([z.string(), z.instanceof(Date)], "Expected a string or a Date")
-      .refine(
-        (val) =>
-          typeof val !== "string" || !Number.isNaN(Date.parse(val)),
-        { message: "initialDate must be a parseable date string" },
-      ),
+    unionType(
+      [z.string(), z.instanceof(Date)],
+      "Expected a string or a Date",
+    ).refine(
+      (val) => typeof val !== "string" || !Number.isNaN(Date.parse(val)),
+      { message: "initialDate must be a parseable date string" },
+    ),
   ),
   loggingEnabled: z.optional(z.boolean()),
   minGasPrice: z.optional(gasUnitUserConfigSchema),

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -326,8 +326,13 @@ const edrNetworkUserConfigSchema = z.object({
       [z.string(), z.instanceof(Date)],
       "Expected a string or a Date",
     ).refine(
-      (val) => typeof val !== "string" || !Number.isNaN(Date.parse(val)),
-      { message: "initialDate must be a parseable date string" },
+      (val) => {
+        const ts = typeof val === "string" ? Date.parse(val) : val.getTime();
+        return !Number.isNaN(ts);
+      },
+      {
+        message: "initialDate must be a parseable date string or a valid Date",
+      },
     ),
   ),
   loggingEnabled: z.optional(z.boolean()),

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -327,8 +327,10 @@ const edrNetworkUserConfigSchema = z.object({
       "Expected a string or a Date",
     ).refine(
       (val) => {
-        const ts = typeof val === "string" ? Date.parse(val) : val.getTime();
-        return !Number.isNaN(ts);
+        if (typeof val === "string") return !Number.isNaN(Date.parse(val));
+        if (val instanceof Date) return !Number.isNaN(val.getTime());
+        // already union of string/Date, all types are exhausted
+        return true;
       },
       {
         message: "initialDate must be a parseable date string or a valid Date",

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -322,7 +322,12 @@ const edrNetworkUserConfigSchema = z.object({
   hardfork: z.optional(z.string()),
   initialBaseFeePerGas: z.optional(gasUnitUserConfigSchema),
   initialDate: z.optional(
-    unionType([z.string(), z.instanceof(Date)], "Expected a string or a Date"),
+    unionType([z.string(), z.instanceof(Date)], "Expected a string or a Date")
+      .refine(
+        (val) =>
+          typeof val !== "string" || !Number.isNaN(Date.parse(val)),
+        { message: "initialDate must be a parseable date string" },
+      ),
   ),
   loggingEnabled: z.optional(z.boolean()),
   minGasPrice: z.optional(gasUnitUserConfigSchema),

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -623,6 +623,20 @@ describe("network-manager/hook-handlers/config", () => {
       assert.equal(validationErrors.length, 0);
     });
 
+    it("should accept a parseable initialDate string", async () => {
+      const config: HardhatUserConfig = {
+        networks: {
+          test: {
+            type: "edr-simulated",
+            initialDate: "2024-01-01T00:00:00.000Z",
+          },
+        },
+      };
+
+      const validationErrors = await validateNetworkUserConfig(config);
+      assert.equal(validationErrors.length, 0);
+    });
+
     it("should throw if the initialDate is not a parseable date string", async () => {
       const config: HardhatUserConfig = {
         networks: {

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -651,7 +651,28 @@ describe("network-manager/hook-handlers/config", () => {
       assertValidationErrors(validationErrors, [
         {
           path: ["networks", "test", "initialDate"],
-          message: "initialDate must be a parseable date string",
+          message:
+            "initialDate must be a parseable date string or a valid Date",
+        },
+      ]);
+    });
+
+    it("should throw if the initialDate is an invalid Date instance", async () => {
+      const config: HardhatUserConfig = {
+        networks: {
+          test: {
+            type: "edr-simulated",
+            initialDate: new Date("invalid"),
+          },
+        },
+      };
+
+      const validationErrors = await validateNetworkUserConfig(config);
+      assertValidationErrors(validationErrors, [
+        {
+          path: ["networks", "test", "initialDate"],
+          message:
+            "initialDate must be a parseable date string or a valid Date",
         },
       ]);
     });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -623,6 +623,25 @@ describe("network-manager/hook-handlers/config", () => {
       assert.equal(validationErrors.length, 0);
     });
 
+    it("should throw if the initialDate is not a parseable date string", async () => {
+      const config: HardhatUserConfig = {
+        networks: {
+          test: {
+            type: "edr-simulated",
+            initialDate: "today",
+          },
+        },
+      };
+
+      const validationErrors = await validateNetworkUserConfig(config);
+      assertValidationErrors(validationErrors, [
+        {
+          path: ["networks", "test", "initialDate"],
+          message: "initialDate must be a parseable date string",
+        },
+      ]);
+    });
+
     describe("http network specific fields", () => {
       it("should throw if the url is missing", async () => {
         const config = {


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary

The `initialDate` schema for EDR networks accepts any string.
An unparseable value (e.g. `"yesterday"`) survives config validation, flows through `timeStringToBigInt` and lands in `BigInt(NaN)` inside the EDR provider, throwing `TypeError: Cannot convert NaN to a BigInt`.

## Fix

Added a `.refine()` to the existing union schema that calls `Date.parse(value)` and rejects values that produce `NaN`.
Date instances are accepted as before, parseable strings pass, **unparseable strings now fail at config-load time** instead of execution time.

## Tests

`packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts`:

- A parseable ISO date string passes validation.
- `"today"` fails with the new refine message rather than reaching `BigInt(NaN)`

## Changeset

`patch` on `hardhat`