### PR TITLE
fix: throw descriptive hardhat errors on 4 generic error sites

### DIFF
--- a/.changeset/mean-toads-eat.md
+++ b/.changeset/mean-toads-eat.md
@@ -1,5 +1,7 @@
 ---
+"hardhat": patch
 "@nomicfoundation/hardhat-verify": patch
+"@nomicfoundation/hardhat-errors": patch
 ---
 
-Replace three user-reachable `assertHardhatInvariant` calls in `artifacts.ts` with descriptive `HardhatError`s so users see actionable messages instead of HH900.
+Surface descriptive `HardhatError`s at four solidity-build and hardhat-verify error sites that previously threw generic errors.

--- a/.changeset/mean-toads-eat.md
+++ b/.changeset/mean-toads-eat.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Replace three user-reachable `assertHardhatInvariant` calls in `artifacts.ts` with descriptive `HardhatError`s so users see actionable messages instead of HH900.

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -1479,6 +1479,14 @@ Try re-running without these files, or without the flag.`,
 
 For example, you may be trying to build a test file with \`--no-tests\`, which isn't a valid operation.`,
       },
+      COMPILER_SUBPROCESS_CRASH: {
+        number: 918,
+        messageTemplate: `The solc subprocess exited with code {code}.`,
+        websiteTitle: "Solc subprocess crashed",
+        websiteDescription: `The solc subprocess exited with a non-zero status code while compiling your contracts.
+
+This usually indicates that solc itself crashed. If this error persists, run \`npx hardhat clean --global\` and try again.`,
+      },
     },
     ARTIFACTS: {
       NOT_FOUND: {

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -3046,6 +3046,36 @@ Please verify the address and network, and try again later if necessary.`,
 
 To resolve this, set a valid non-empty API key in your Hardhat config, then try again.`,
       },
+      COMPILATION_JOBS_CREATION_FAILED: {
+        number: 80030,
+        messageTemplate: `Could not build a compilation job for "{sourceName}" under build profile "{buildProfile}": {formattedReason}`,
+        websiteTitle: "Compilation jobs creation failed",
+        websiteDescription: `The Solidity build system was unable to create a compilation job for the contract being verified.
+
+Common causes:
+
+- The selected build profile does not include this source.
+- The contract's pragma is incompatible with the configured Solidity compiler versions.
+- A dependency's pragma is incompatible with the configured Solidity compiler versions.
+
+Check the reported reason and adjust your Hardhat configuration or the contract's source, then try again.`,
+      },
+      COMPILATION_JOB_NOT_FOUND_FOR_CONTRACT: {
+        number: 80031,
+        messageTemplate: `No compilation job was found for "{sourceName}" under build profile "{buildProfile}".`,
+        websiteTitle: "Compilation job not found",
+        websiteDescription: `The Solidity build system did not return a compilation job for the contract being verified.
+
+This usually means the contract is not part of the selected build profile. Make sure the contract is included in your Hardhat configuration and that you are using the correct \`--build-profile\`.`,
+      },
+      COMPILER_INPUT_NOT_FOUND_FOR_CONTRACT: {
+        number: 80032,
+        messageTemplate: `Could not get the compiler input for "{sourceName}" under build profile "{buildProfile}".`,
+        websiteTitle: "Compiler input not found",
+        websiteDescription: `The Solidity build system returned a compilation job that did not contain a compiler input for the contract being verified.
+
+Make sure the contract is included in the selected build profile and that you are using the correct \`--build-profile\`, then try again.`,
+      },
     },
     VALIDATION: {
       INVALID_ADDRESS: {

--- a/packages/hardhat-verify/src/internal/artifacts.ts
+++ b/packages/hardhat-verify/src/internal/artifacts.ts
@@ -7,7 +7,7 @@ import type {
 
 import path from "node:path";
 
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { readJsonFile } from "@nomicfoundation/hardhat-utils/fs";
 
 export interface BuildInfoAndOutput {
@@ -90,26 +90,42 @@ export async function getCompilerInput(
     },
   );
 
-  assertHardhatInvariant(
-    getCompilationJobsResult.success,
-    "getCompilationJobs should not error",
-  );
+  if (!getCompilationJobsResult.success) {
+    throw new HardhatError(
+      HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.COMPILATION_JOBS_CREATION_FAILED,
+      {
+        sourceName,
+        buildProfile: buildProfileName,
+        formattedReason: getCompilationJobsResult.formattedReason,
+      },
+    );
+  }
 
   const compilationJob = getCompilationJobsResult.compilationJobsPerFile;
 
-  // TODO: should this be an error instead?
-  assertHardhatInvariant(
-    compilationJob instanceof Map && compilationJob.size === 1,
-    "The compilation job for the contract source was not found.",
-  );
+  if (!(compilationJob instanceof Map) || compilationJob.size !== 1) {
+    throw new HardhatError(
+      HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL
+        .COMPILATION_JOB_NOT_FOUND_FOR_CONTRACT,
+      {
+        sourceName,
+        buildProfile: buildProfileName,
+      },
+    );
+  }
 
   const compilerInput = await compilationJob.get(rootFilePath)?.getSolcInput();
 
-  // TODO: should this be an error instead?
-  assertHardhatInvariant(
-    compilerInput !== undefined,
-    "The compiler input for the contract source was not found.",
-  );
+  if (compilerInput === undefined) {
+    throw new HardhatError(
+      HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL
+        .COMPILER_INPUT_NOT_FOUND_FOR_CONTRACT,
+      {
+        sourceName,
+        buildProfile: buildProfileName,
+      },
+    );
+  }
 
   return compilerInput;
 }

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/compiler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/compiler.ts
@@ -43,7 +43,7 @@ const BASE_PATH_MIN_VERSION: SemverVersion = [0, 6, 9];
  * @param args The arguments to pass to the compilation command
  * @param input The solc input to pass to the compilation command on stdin
  * @returns The compilation output
- * @throws Error if the compilation process exits with a non-zero exit code.
+ * @throws HardhatError if the compilation process exits with a non-zero exit code.
  * @throws HardhatInvariantError if the any of the io streams are null.
  */
 export async function spawnCompile(
@@ -88,7 +88,12 @@ export async function spawnCompile(
         await stdoutFileHandle.close();
 
         if (code !== 0) {
-          return reject(new Error(`Subprocess exited with code ${code}`));
+          return reject(
+            new HardhatError(
+              HardhatError.ERRORS.CORE.SOLIDITY.COMPILER_SUBPROCESS_CRASH,
+              { code: code ?? "null" },
+            ),
+          );
         }
 
         resolve(await readJsonFileAsStream(stdoutPath));


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary

https://github.com/NomicFoundation/hardhat/blob/c62b6548bdb72b64000bb4402f3109a8cfe3cbb5/packages/hardhat-verify/src/internal/artifacts.ts#L100 
> Above Todo is addressed in this PR. 

Four sites in `hardhat-verify` and the solidity build system threw raw `Error` or `assertHardhatInvariant`. Users got generic errors with no error code, no docs link.
This PR replaces all four with descriptive `HardhatError`s.

## Fix

In the solidity build system:

- `compiler.ts`: solc subprocess non-zero exit -> `CORE.SOLIDITY.COMPILER_SUBPROCESS_CRASH` (918)

In `hardhat-verify` (all in `artifacts.ts`/`getCompilerInput`):

- compilation jobs creation failed -> `HARDHAT_VERIFY.GENERAL.COMPILATION_JOBS_CREATION_FAILED` (80030)
- no compilation job for contract -> `COMPILATION_JOB_NOT_FOUND_FOR_CONTRACT` (80031)
- compiler input missing for contract -> `COMPILER_INPUT_NOT_FOUND_FOR_CONTRACT` (80032)

> These three could be collapsed into a single `COMPILATION_JOB_CREATION_FAILED` error on compilation job creation, wanted to keep it open for feedback. lmk!

## Tests

`spawn-compile.ts`: spawn a fake compiler that `process.exit(7)`s; assert rejection with `COMPILER_SUBPROCESS_CRASH`. `artifacts.ts`: stub the build system per condition, drive `getCompilerInput`, assert each new code via `assertRejectsWithHardhatError`.

## Changeset

`patch` on `hardhat`, `hardhat-verify`, `hardhat-errors`.
