### PR TITLE
fix(hardhat-verify): reject 'verify' invocations against local dev networks

### DIFF
--- a/.changeset/early-yaks-hold.md
+++ b/.changeset/early-yaks-hold.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-verify": patch
 ---
 
-Reject `verify` invocations against local dev networks (chain ID 31337 or 1337), surfacing `NETWORK_NOT_SUPPORTED` error instead of letting the downstream explorer client fail cryptically.
+Running `verify` against local development networks (chain IDs 31337 and 1337) now fails with a clear `NETWORK_NOT_SUPPORTED` error.

--- a/.changeset/early-yaks-hold.md
+++ b/.changeset/early-yaks-hold.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-verify": patch
 ---
 
-Reject `verify` invocations against local dev networks (chain id 31337 or 1337),surfacing `NETWORK_NOT_SUPPORTED` error instead of letting the downstream explorer client fail cryptically.
+Reject `verify` invocations against local dev networks (chain ID 31337 or 1337), surfacing `NETWORK_NOT_SUPPORTED` error instead of letting the downstream explorer client fail cryptically.

--- a/.changeset/early-yaks-hold.md
+++ b/.changeset/early-yaks-hold.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+"@nomicfoundation/hardhat-errors": patch
+---
+
+Reject `verify` invocations against local HH dev network.

--- a/.changeset/early-yaks-hold.md
+++ b/.changeset/early-yaks-hold.md
@@ -1,6 +1,5 @@
 ---
 "@nomicfoundation/hardhat-verify": patch
-"@nomicfoundation/hardhat-errors": patch
 ---
 
-Reject `verify` invocations against local dev networks (chainId 31337 or 1337).
+Reject `verify` invocations against local dev networks (chain id 31337 or 1337),surfacing `NETWORK_NOT_SUPPORTED` error instead of letting the downstream explorer client fail cryptically.

--- a/.changeset/early-yaks-hold.md
+++ b/.changeset/early-yaks-hold.md
@@ -3,4 +3,4 @@
 "@nomicfoundation/hardhat-errors": patch
 ---
 
-Reject `verify` invocations against local HH dev network.
+Reject `verify` invocations against local dev networks (chainId 31337 or 1337).

--- a/packages/hardhat-verify/src/internal/chains.ts
+++ b/packages/hardhat-verify/src/internal/chains.ts
@@ -17,7 +17,10 @@ export async function getChainId(provider: EthereumProvider): Promise<number> {
 }
 
 const DEV_NETWORK_CHAIN_IDS: readonly number[] = [31337, 1337];
-export function rejectLocalNetworks(networkName: string, chainId: number): void {
+export function rejectLocalNetworks(
+  networkName: string,
+  chainId: number,
+): void {
   if (DEV_NETWORK_CHAIN_IDS.includes(chainId)) {
     throw new HardhatError(
       HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.NETWORK_NOT_SUPPORTED,

--- a/packages/hardhat-verify/src/internal/chains.ts
+++ b/packages/hardhat-verify/src/internal/chains.ts
@@ -17,11 +17,11 @@ export async function getChainId(provider: EthereumProvider): Promise<number> {
 }
 
 const DEV_NETWORK_CHAIN_IDS: readonly number[] = [31337, 1337];
-export function rejectLocalNetworks(chainId: number): void {
+export function rejectLocalNetworks(networkName: string, chainId: number): void {
   if (DEV_NETWORK_CHAIN_IDS.includes(chainId)) {
     throw new HardhatError(
-      HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.UNSUPPORTED_DEV_NETWORK,
-      { chainId },
+      HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.NETWORK_NOT_SUPPORTED,
+      { networkName, chainId },
     );
   }
 }

--- a/packages/hardhat-verify/src/internal/chains.ts
+++ b/packages/hardhat-verify/src/internal/chains.ts
@@ -1,5 +1,7 @@
 import type { EthereumProvider } from "hardhat/types/providers";
 
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+
 const chainIdCache = new WeakMap<EthereumProvider, number>();
 
 export async function getChainId(provider: EthereumProvider): Promise<number> {
@@ -12,4 +14,13 @@ export async function getChainId(provider: EthereumProvider): Promise<number> {
   chainIdCache.set(provider, chainId);
 
   return chainId;
+}
+
+export function rejectLocalNetworks(chainId: number): void {
+  if (chainId===31337) {
+    throw new HardhatError(
+      HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.UNSUPPORTED_DEV_NETWORK,
+      { chainId },
+    );
+  }
 }

--- a/packages/hardhat-verify/src/internal/chains.ts
+++ b/packages/hardhat-verify/src/internal/chains.ts
@@ -16,8 +16,9 @@ export async function getChainId(provider: EthereumProvider): Promise<number> {
   return chainId;
 }
 
+const DEV_NETWORK_CHAIN_IDS: readonly number[] = [31337, 1337];
 export function rejectLocalNetworks(chainId: number): void {
-  if (chainId===31337) {
+  if (DEV_NETWORK_CHAIN_IDS.includes(chainId)) {
     throw new HardhatError(
       HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.UNSUPPORTED_DEV_NETWORK,
       { chainId },

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -16,7 +16,7 @@ import { isFullyQualifiedName } from "hardhat/utils/contract-names";
 
 import { getCompilerInput } from "./artifacts.js";
 import { Bytecode } from "./bytecode.js";
-import { getChainId } from "./chains.js";
+import { rejectLocalNetworks, getChainId } from "./chains.js";
 import { encodeConstructorArgs } from "./constructor-args.js";
 import { ContractInformationResolver } from "./contract.js";
 import { ETHERSCAN_PROVIDER_NAME } from "./etherscan.js";
@@ -114,6 +114,8 @@ export async function verifyContract(
   const connection = await network.create();
   const { networkName } = connection;
   const resolvedProvider = provider ?? connection.provider;
+
+  rejectLocalNetworks(await getChainId(resolvedProvider));
 
   const instance = await createVerificationProviderInstance({
     provider: resolvedProvider,

--- a/packages/hardhat-verify/src/internal/verification.ts
+++ b/packages/hardhat-verify/src/internal/verification.ts
@@ -115,7 +115,7 @@ export async function verifyContract(
   const { networkName } = connection;
   const resolvedProvider = provider ?? connection.provider;
 
-  rejectLocalNetworks(await getChainId(resolvedProvider));
+  rejectLocalNetworks(networkName, await getChainId(resolvedProvider));
 
   const instance = await createVerificationProviderInstance({
     provider: resolvedProvider,

--- a/packages/hardhat-verify/test/chains.ts
+++ b/packages/hardhat-verify/test/chains.ts
@@ -19,11 +19,11 @@ describe("chains", () => {
     });
 
     it("should not throw for a public chain id (1)", () => {
-      assert.doesNotThrow(() => rejectLocalNetworks(1));
+      rejectLocalNetworks(1);
     });
 
     it("should not throw for Sepolia (11155111)", () => {
-      assert.doesNotThrow(() => rejectLocalNetworks(11155111));
+      rejectLocalNetworks(11155111);
     });
   });
 

--- a/packages/hardhat-verify/test/chains.ts
+++ b/packages/hardhat-verify/test/chains.ts
@@ -9,21 +9,21 @@ import { rejectLocalNetworks, getChainId } from "../src/internal/chains.js";
 import { MockEthereumProvider } from "./utils.js";
 
 describe("chains", () => {
-  describe("assertVerifiableNetwork", () => {
+  describe("rejectLocalNetworks", () => {
     it("should throw for Hardhat Network chain id (31337)", () => {
       assertThrowsHardhatError(
-        () => rejectLocalNetworks(31337),
-        HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.UNSUPPORTED_DEV_NETWORK,
-        { chainId: 31337 },
+        () => rejectLocalNetworks("hardhat", 31337),
+        HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.NETWORK_NOT_SUPPORTED,
+        { networkName: "hardhat", chainId: 31337 },
       );
     });
 
     it("should not throw for a public chain id (1)", () => {
-      rejectLocalNetworks(1);
+      rejectLocalNetworks("mainnet", 1);
     });
 
     it("should not throw for Sepolia (11155111)", () => {
-      rejectLocalNetworks(11155111);
+      rejectLocalNetworks("sepolia", 11155111);
     });
   });
 

--- a/packages/hardhat-verify/test/chains.ts
+++ b/packages/hardhat-verify/test/chains.ts
@@ -18,6 +18,14 @@ describe("chains", () => {
       );
     });
 
+    it("should throw for Ganache Network chain id (1337)", () => {
+      assertThrowsHardhatError(
+        () => rejectLocalNetworks("localhost", 1337),
+        HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.NETWORK_NOT_SUPPORTED,
+        { networkName: "localhost", chainId: 1337 },
+      );
+    });
+
     it("should not throw for a public chain id (1)", () => {
       rejectLocalNetworks("mainnet", 1);
     });

--- a/packages/hardhat-verify/test/chains.ts
+++ b/packages/hardhat-verify/test/chains.ts
@@ -1,11 +1,32 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { getChainId } from "../src/internal/chains.js";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
+
+import { rejectLocalNetworks, getChainId } from "../src/internal/chains.js";
 
 import { MockEthereumProvider } from "./utils.js";
 
 describe("chains", () => {
+  describe("assertVerifiableNetwork", () => {
+    it("should throw for Hardhat Network chain id (31337)", () => {
+      assertThrowsHardhatError(
+        () => rejectLocalNetworks(31337),
+        HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.UNSUPPORTED_DEV_NETWORK,
+        { chainId: 31337 },
+      );
+    });
+
+    it("should not throw for a public chain id (1)", () => {
+      assert.doesNotThrow(() => rejectLocalNetworks(1));
+    });
+
+    it("should not throw for Sepolia (11155111)", () => {
+      assert.doesNotThrow(() => rejectLocalNetworks(11155111));
+    });
+  });
+
   describe("getChainId", () => {
     it("should return the chainId", async () => {
       const provider = new MockEthereumProvider({ eth_chainId: "0x1" });


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary
> Addresses #7042 item 2: `Throw a specific error when the network is a development network.`

`hardhat verify` runs against any network the user passes, including the local Hardhat Network (31337) or legacy Ganache (1337). The request fails downstream inside the Etherscan client with an unrelated error.

## Fix

Added `rejectLocalNetworks(networkName, chainId)` in `packages/hardhat-verify/src/internal/chains.ts`. For known development chain ids, it throws the existing `HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.NETWORK_NOT_SUPPORTED` (80000).

## Tests

`packages/hardhat-verify/test/chains.ts`:
- should throw for Hardhat/Ganache Network chain id
- should **not** throw for Sepolia/Mainnet

## Changeset

`patch` on `hardhat-verify`