### PR TITLE
Suppress initcode-size warning in test contracts and under coverage

### DIFF
--- a/.changeset/silent-pandas-jump.md
+++ b/.changeset/silent-pandas-jump.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Suppressed the solc initcode size warning for Solidity test contracts.
+Suppressed the solc initcode size warning for Solidity test contracts and when running under `--coverage`.

--- a/.changeset/silent-pandas-jump.md
+++ b/.changeset/silent-pandas-jump.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Suppressed the solc initcode size warning for Solidity test contracts.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -8,6 +8,7 @@ export const SPDX_WARNING = "SPDX license identifier not provided";
 export const PRAGMA_WARNING =
   "Source file does not specify required compiler version";
 const CONTRACT_SIZE_WARNING = "Contract code size is";
+const INIT_CODE_SIZE_WARNING = "Contract initcode size is";
 
 // Suppression rules are grouped by scope. Each array has its own match logic
 // in `shouldSuppressWarning` function; add new entries to the array that fits, or add
@@ -32,6 +33,7 @@ const TEST_FILE_WARNING_MESSAGES: readonly string[] = [
   SPDX_WARNING,
   PRAGMA_WARNING,
   CONTRACT_SIZE_WARNING,
+  INIT_CODE_SIZE_WARNING,
 ];
 
 // Warnings suppressed only when running with `--coverage`. An entry with no
@@ -44,6 +46,7 @@ const COVERAGE_MODE_RULES: ReadonlyArray<{
   filePath?: string;
 }> = [
   { message: CONTRACT_SIZE_WARNING },
+  { message: INIT_CODE_SIZE_WARNING },
   {
     message: NATSPEC_MEMORY_SAFE_ASSEMBLY_WARNING,
     filePath: COVERAGE_LIBRARY_FILE_NAME,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/warning-suppression.ts
@@ -15,6 +15,8 @@ describe("shouldSuppressWarning", () => {
   const NATSPEC_WARNING = NATSPEC_MEMORY_SAFE_ASSEMBLY_WARNING;
   const CONTRACT_SIZE_WARNING =
     "Contract code size is 25002 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on Mainnet.";
+  const INIT_CODE_SIZE_WARNING =
+    "Contract initcode size is 50000 bytes and exceeds 49152 bytes (a limit introduced in Shanghai). This contract may not be deployable on Mainnet.";
 
   // Mock project paths for testing
   const PROJECT_ROOT = path.join("home", "user", "project");
@@ -282,6 +284,55 @@ describe("shouldSuppressWarning", () => {
       const message = `Warning: ${SPDX_WARNING}\n  --> ${path.join("contracts", "Counter.t.sol")}:1:1:`;
       assert.equal(
         shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT, true),
+        true,
+      );
+    });
+  });
+
+  describe("Initcode-size warning", () => {
+    it("should suppress initcode-size warning on a user file when coverage=true", () => {
+      const message = `Warning: ${INIT_CODE_SIZE_WARNING}\n  --> ${path.join("contracts", "Foo.sol")}:1:1:`;
+      assert.equal(
+        shouldSuppressWarning(message, SOLIDITY_TESTS_PATH, PROJECT_ROOT, true),
+        true,
+      );
+    });
+
+    it("should NOT suppress initcode-size warning on a user file when coverage=false", () => {
+      const message = `Warning: ${INIT_CODE_SIZE_WARNING}\n  --> ${path.join("contracts", "Foo.sol")}:1:1:`;
+      assert.equal(
+        shouldSuppressWarning(
+          message,
+          SOLIDITY_TESTS_PATH,
+          PROJECT_ROOT,
+          false,
+        ),
+        false,
+      );
+    });
+
+    it("should suppress initcode-size warning on a .t.sol file when coverage=false", () => {
+      const message = `Warning: ${INIT_CODE_SIZE_WARNING}\n  --> ${path.join("contracts", "Counter.t.sol")}:1:1:`;
+      assert.equal(
+        shouldSuppressWarning(
+          message,
+          SOLIDITY_TESTS_PATH,
+          PROJECT_ROOT,
+          false,
+        ),
+        true,
+      );
+    });
+
+    it("should suppress initcode-size warning on a file in the Solidity tests dir when coverage=false", () => {
+      const message = `Warning: ${INIT_CODE_SIZE_WARNING}\n  --> ${path.join("test", "contracts", "Helper.sol")}:1:1:`;
+      assert.equal(
+        shouldSuppressWarning(
+          message,
+          SOLIDITY_TESTS_PATH,
+          PROJECT_ROOT,
+          false,
+        ),
         true,
       );
     });


### PR DESCRIPTION
`solc` emits a separate `initcode-size` warning (EIP-3860, Shanghai) in addition to the `contract-size` warning handled in #8365. This extends the same test-contract and coverage-mode suppression to it.