### PR TITLE
fix(hardhat-verify): read contract info from the artifact instead of from the buildInfo

### DIFF
--- a/.changeset/rude-wolves-try.md
+++ b/.changeset/rude-wolves-try.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Read contract info from the `artifact` in the candidate loop, not `buildInfo`.

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -1,6 +1,6 @@
 import type { BuildInfoAndOutput } from "./artifacts.js";
 import type { Bytecode } from "./bytecode.js";
-import type { ArtifactManager } from "hardhat/types/artifacts";
+import type { Artifact, ArtifactManager } from "hardhat/types/artifacts";
 import type {
   CompilerInput,
   CompilerOutputContract,
@@ -110,10 +110,18 @@ export class ContractInformationResolver {
       );
     }
 
-    const isSolcVersionCompatible = this.#compatibleSolcVersions.includes(
-      buildInfoAndOutput.buildInfo.solcVersion,
-    );
-    if (!isSolcVersionCompatible) {
+    const artifact = await this.#artifacts.readArtifact(contract);
+    const solcVersion = await this.#resolveSolcVersion(artifact);
+    if (solcVersion === undefined) {
+      throw new HardhatError(
+        HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.BUILD_INFO_NOT_FOUND,
+        {
+          contract,
+        },
+      );
+    }
+
+    if (!this.#compatibleSolcVersions.includes(solcVersion)) {
       const formattedSolcVersion = formatInferredSolcVersion(
         deployedBytecode.solcVersion,
       );
@@ -125,7 +133,7 @@ export class ContractInformationResolver {
         HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.BUILD_INFO_SOLC_VERSION_MISMATCH,
         {
           contract,
-          buildInfoSolcVersion: buildInfoAndOutput.buildInfo.solcVersion,
+          buildInfoSolcVersion: solcVersion,
           networkName: this.#networkName,
           versionDetails,
         },
@@ -134,6 +142,7 @@ export class ContractInformationResolver {
 
     const contractInformation = this.#matchAndBuild(
       contract,
+      artifact,
       buildInfoAndOutput,
       deployedBytecode,
     );
@@ -174,15 +183,19 @@ export class ContractInformationResolver {
         continue;
       }
 
-      const isSolcVersionCompatible = this.#compatibleSolcVersions.includes(
-        buildInfoAndOutput.buildInfo.solcVersion,
-      );
-      if (!isSolcVersionCompatible) {
+      const artifact = await this.#artifacts.readArtifact(contract);
+      const solcVersion = await this.#resolveSolcVersion(artifact);
+      if (solcVersion === undefined) {
+        continue;
+      }
+
+      if (!this.#compatibleSolcVersions.includes(solcVersion)) {
         continue;
       }
 
       const contractInformation = this.#matchAndBuild(
         contract,
+        artifact,
         buildInfoAndOutput,
         deployedBytecode,
       );
@@ -210,11 +223,20 @@ export class ContractInformationResolver {
     return matches[0];
   }
 
+  async #resolveSolcVersion(artifact: Artifact): Promise<string | undefined> {
+    const parsed = /^solc-(\d+)_(\d+)_(\d+)-/
+      .exec(artifact.buildInfoId)
+      ?.slice(1, 4)
+      .join(".");
+    return parsed;
+  }
+
   /**
    * Compares on-chain bytecode against the compiled deployedBytecode in the
    * build output, and assembles a ContractInformation object if they match.
    *
    * @param contract The fully qualified contract name (e.g. "src/A.sol:MyA").
+   * @param artifact The Hardhat artifact for the contract.
    * @param buildInfoAndOutput An object containing the compiler’s BuildInfo
    * and its Output.
    * @param deployedBytecode The on-chain bytecode wrapped in a Bytecode instance.
@@ -225,11 +247,13 @@ export class ContractInformationResolver {
    */
   #matchAndBuild(
     contract: string,
+    artifact: Artifact,
     { buildInfo, buildInfoOutput }: BuildInfoAndOutput,
     deployedBytecode: Bytecode,
   ): ContractInformation | null {
     const { sourceName, contractName } = parseFullyQualifiedName(contract);
-    const inputSourceName = buildInfo.userSourceNameMap[sourceName];
+    const inputSourceName =
+      artifact.inputSourceName ?? buildInfo.userSourceNameMap[sourceName];
 
     const compilerOutputContract =
       buildInfoOutput.output.contracts?.[inputSourceName]?.[contractName];

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -110,7 +110,6 @@ export class ContractInformationResolver {
       );
     }
 
-
     const artifact = await this.#artifacts.readArtifact(contract);
     const solcVersion = await this.#resolveSolcVersion(artifact, contract);
     if (solcVersion === undefined) {
@@ -224,13 +223,20 @@ export class ContractInformationResolver {
     return matches[0];
   }
 
+  #parseSolcVersion(buildInfoId: string): string | undefined {
+    const match = /^solc-(\d+)_(\d+)_(\d+)-/.exec(buildInfoId);
+    return `${match[1]}.${match[2]}.${match[3]}`;
+  }
+
   async #resolveSolcVersion(
     artifact: Artifact,
     contract: string,
   ): Promise<string | undefined> {
     if (artifact.buildInfoId !== undefined) {
-      const parsed = /^solc-(\d+)_(\d+)_(\d+)-/.exec(artifact.buildInfoId)?.slice(1, 4).join(".");
+      const parsed = this.#parseSolcVersion(artifact.buildInfoId);
+      if (parsed !== undefined) {
         return parsed;
+      }
     }
 
     // Fallback: the artifact lacks a parseable buildInfoId,

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -110,8 +110,9 @@ export class ContractInformationResolver {
       );
     }
 
+
     const artifact = await this.#artifacts.readArtifact(contract);
-    const solcVersion = await this.#resolveSolcVersion(artifact);
+    const solcVersion = await this.#resolveSolcVersion(artifact, contract);
     if (solcVersion === undefined) {
       throw new HardhatError(
         HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.BUILD_INFO_NOT_FOUND,
@@ -184,7 +185,7 @@ export class ContractInformationResolver {
       }
 
       const artifact = await this.#artifacts.readArtifact(contract);
-      const solcVersion = await this.#resolveSolcVersion(artifact);
+      const solcVersion = await this.#resolveSolcVersion(artifact, contract);
       if (solcVersion === undefined) {
         continue;
       }
@@ -223,12 +224,22 @@ export class ContractInformationResolver {
     return matches[0];
   }
 
-  async #resolveSolcVersion(artifact: Artifact): Promise<string | undefined> {
-    const parsed = /^solc-(\d+)_(\d+)_(\d+)-/
-      .exec(artifact.buildInfoId)
-      ?.slice(1, 4)
-      .join(".");
-    return parsed;
+  async #resolveSolcVersion(
+    artifact: Artifact,
+    contract: string,
+  ): Promise<string | undefined> {
+    if (artifact.buildInfoId !== undefined) {
+      const parsed = /^solc-(\d+)_(\d+)_(\d+)-/.exec(artifact.buildInfoId)?.slice(1, 4).join(".");
+        return parsed;
+    }
+
+    // Fallback: the artifact lacks a parseable buildInfoId,
+    // read the buildInfo from disk for this single candidate.
+    const buildInfoAndOutput = await getBuildInfoAndOutput(
+      this.#artifacts,
+      contract,
+    );
+    return buildInfoAndOutput?.buildInfo.solcVersion;
   }
 
   /**

--- a/packages/hardhat-verify/src/internal/contract.ts
+++ b/packages/hardhat-verify/src/internal/contract.ts
@@ -223,8 +223,23 @@ export class ContractInformationResolver {
     return matches[0];
   }
 
-  #parseSolcVersion(buildInfoId: string): string | undefined {
+  /**
+   * Parses the solc version out of a Hardhat build info id.
+   *
+   * The id format is documented at
+   * `packages/hardhat/src/types/solidity/solidity-artifacts.ts`:
+   *   `solc-<major>_<minor>_<patch>-<job-hash>` or
+   *   `solc-<major>_<minor>_<patch>-<compiler-type>-<job-hash>`.
+   *
+   * Returns the dotted version string (e.g. `"0.8.28"`), or `undefined`.
+   */
+  #parseSolcVersion(
+    buildInfoId: string,
+  ): string | undefined {
     const match = /^solc-(\d+)_(\d+)_(\d+)-/.exec(buildInfoId);
+    if (match === null) {
+      return undefined;
+    }
     return `${match[1]}.${match[2]}.${match[3]}`;
   }
 


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.

---

## Summary
> Addresses #7042 item 1: `Read contract information from the artifact instead of from the buildInfo.`

`ContractInformationResolver` reads the full `buildInfo` for every artifact candidate when inferring a deployed contract by bytecode lookup. buildInfo carries the full `CompilerInput` plus `CompilerOutput`; the resolver only needs the artifact's `solcVersion` to filter incompatible candidates.

## Fix

Filter candidates with the lightweight `artifact` first; only read the heavy `buildInfo` for the single one that remains: ** from N buildInfo reads to 1 per resolver call.**

## Tests

- No tests were present for `packages/hardhat-verify/test/contract.ts`. So, **I will be pushing all related tests in a follow-up PR merging to this branch.** 

## Changeset

`patch` on `hardhat-verify`
