### PR TITLE
bench: reduce aave-v4 fuzz workload

### DIFF
--- a/end-to-end/aave-v4/preinstall.sh
+++ b/end-to-end/aave-v4/preinstall.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Reduce the Solidity-test fuzz workload for benchmarking.
+#
+# The "aave-v4 / test solidity" regression benchmark is the single most
+# expensive entry: ~82 s/run, and its run-to-run time is dominated by
+# wall-clock jitter on a large, *deterministic* fuzz workload (the fuzz seed
+# is pinned, so inputs do not change between runs). That jitter gives it a
+# ~10% coefficient of variation, which — at 82 s/run — makes a tight (5%/3%)
+# regression alert limit cost over an hour of CI for this benchmark alone.
+#
+# Cutting the per-test fuzz iteration count slashes the per-run time (and
+# therefore the cost of the many runs a tight limit needs) without changing
+# what is exercised, since the seed stays pinned. This is a benchmark-only
+# workload reduction.
+#
+# Tune FUZZ_RUNS to trade benchmark cost against the fuzz volume exercised.
+FUZZ_RUNS=100
+
+# Use node for the file transforms to avoid BSD/GNU sed portability issues
+# (matches the convention used by the other scenarios' preinstall scripts).
+node -e "
+const fs = require('fs');
+const fuzzRuns = ${FUZZ_RUNS};
+
+// 1) hardhat.config.ts — test.solidity.fuzz.runs. Scope the replacement to the
+//    fuzz block so we never touch the (much larger) optimizer 'runs' values.
+const hhPath = 'hardhat.config.ts';
+const hhConfig = fs.readFileSync(hhPath, 'utf8');
+const hhRe = /(\bfuzz:\s*\{[^}]*?\bruns:\s*)1000\b/;
+if (!hhRe.test(hhConfig)) {
+  console.error(
+    'aave-v4 preinstall: expected fuzz \`runs: 1000\` not found in ' + hhPath +
+      ' — the pinned commit may have changed. Refusing to run the benchmark ' +
+      'against an unexpected fuzz workload.',
+  );
+  process.exit(1);
+}
+fs.writeFileSync(hhPath, hhConfig.replace(hhRe, \`\$1\${fuzzRuns}\`));
+
+// 2) foundry.toml — [profile.default.fuzz] runs. The word boundary after 1000
+//    keeps this off 'runs = 10000'/'runs = 5000' and the 'optimizer_runs' values.
+const fdPath = 'foundry.toml';
+const fdConfig = fs.readFileSync(fdPath, 'utf8');
+const fdRe = /\bruns = 1000\b/;
+if (!fdRe.test(fdConfig)) {
+  console.error(
+    'aave-v4 preinstall: expected \`runs = 1000\` not found in ' + fdPath +
+      ' — the pinned commit may have changed. Refusing to run the benchmark ' +
+      'against an unexpected fuzz workload.',
+  );
+  process.exit(1);
+}
+fs.writeFileSync(fdPath, fdConfig.replace(fdRe, \`runs = \${fuzzRuns}\`));
+
+console.log(
+  \`aave-v4 preinstall: reduced fuzz runs 1000 -> \${fuzzRuns} in \` +
+    'hardhat.config.ts and foundry.toml for benchmarking',
+);
+"

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -36,7 +36,7 @@
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 5,
+        "runs": 17,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -6,6 +6,7 @@
   "commit": "f729aeff7cc61d576e8f89e818e05265ec9f65e9",
   "packageManager": "yarn",
   "submodules": true,
+  "preinstall": "./preinstall.sh",
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {
     "commands": {

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -36,7 +36,7 @@
         "command": "npx hardhat compile"
       },
       "test solidity": {
-        "runs": 17,
+        "runs": 24,
         "command": "npx hardhat test solidity --no-compile"
       }
     }

--- a/end-to-end/uniswap-x/preinstall-foundry.sh
+++ b/end-to-end/uniswap-x/preinstall-foundry.sh
@@ -3,15 +3,36 @@
 # Build calibur in isolation so CaliburEntry's artifact is produced on disk.
 (cd lib/calibur && forge build)
 
-# Restore the original explicit artifact path for vm.getCode. The upstream
-# fork shortened it to "CaliburEntry.sol" for Hardhat compat, but that form
-# requires CaliburEntry to be in forge test's compile graph — impossible
-# without patching the submodule because of the pragma/via_ir conflicts above.
-# The existing `fs_permissions` entry for `./lib/calibur/out/` already grants
-# read access to the pre-built artifact.
-sed -i 's|vm.getCode("CaliburEntry.sol")|vm.getCode("lib/calibur/out/CaliburEntry.sol/CaliburEntry.json")|' \
-  test/native-input/DelegationHandler.sol
+# Use node for file transforms to avoid BSD/GNU sed portability issues
+# (matches the convention used by the other scenarios' preinstall scripts).
+node -e '
+const fs = require("fs");
 
-# Drop the default profile's `no_match_path = "*/integration/*"` so `forge test`
-# runs the integration suite — matches EDR's default of running everything.
-sed -i '/^no_match_path *= *"\*\/integration\/\*"$/d' foundry.toml
+// Restore the original explicit artifact path for vm.getCode. The upstream
+// fork shortened it to "CaliburEntry.sol" for Hardhat compat, but that form
+// requires CaliburEntry to be in forge test compile graph, which is impossible
+// without patching the submodule because of the pragma/via_ir conflicts above.
+// The existing fs_permissions entry for ./lib/calibur/out/ already grants read
+// access to the pre-built artifact.
+const handlerPath = "test/native-input/DelegationHandler.sol";
+const handler = fs.readFileSync(handlerPath, "utf8");
+fs.writeFileSync(
+  handlerPath,
+  handler.replaceAll(
+    "vm.getCode(\"CaliburEntry.sol\")",
+    "vm.getCode(\"lib/calibur/out/CaliburEntry.sol/CaliburEntry.json\")",
+  ),
+);
+
+// Drop the default profile no_match_path = "*/integration/*" so forge test
+// runs the integration suite, matching EDR default of running everything.
+const tomlPath = "foundry.toml";
+const toml = fs.readFileSync(tomlPath, "utf8");
+fs.writeFileSync(
+  tomlPath,
+  toml
+    .split("\n")
+    .filter((line) => !/^no_match_path *= *"\*\/integration\/\*"$/.test(line))
+    .join("\n"),
+);
+'


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

**⚠️ Beware: Due to the change in benchmark content, this will invalidate historic benchmark runs. This means that we'll have to 1) re-run the Foundry baseline for the `forge test` command; and 2) delete the historic runs for `npx hardhat test`**

Adds end-to-end/aave-v4/preinstall.sh to lower the Solidity-test fuzz.runs (1000 -> 100) on the cloned project, wired via scenario.json. Benchmark-only workload reduction; produces a one-time step in the stored series (the series continues, keyed on the unchanged benchmark name).

Keeps the Hardhat and Foundry configs consistent. The foundry.toml edit uses a word-boundary match so it never touches runs=10000/5000 or optimizer_runs.

aave-v4 benchmark runtime decreased from ~82 s to ~11.8 s/run. This allowed us to increase the number of runs to 24, resulting in less variance and thus more stable commit-to-commit benchmark limit checks.

**Bonus:** Also converted two `sed -i` edits in uniswap-x/preinstall-foundry.sh to node as well, matching the ens-contracts convention that deliberately avoids sed for BSD/GNU portability (local devs may run the e2e/benchmark scenarios on macOS). The node transforms were verified to reproduce the sed edits exactly.

# Motivation

The aave-v4 / test solidity regression benchmark is the dominant CI cost: at ~82 s/run and ~10% CV, a tight (5%/3%) alert limit needs too many runs. Its variance is wall-clock jitter on a large, deterministic fuzz workload (the fuzz seed is pinned, so inputs do not change between runs), so cutting the per-test fuzz iteration count slashes per-run time without changing what is exercised, making the required runs affordable.

# Statistical Analysis

I used the same statistical analysis as explained in https://github.com/NomicFoundation/hardhat/pull/8360#issuecomment-4623166025

## Measured input

Two post-fuzz-reduction CI runs (self-hosted runner), `aave-v4 / test solidity`:

| run        | n   | mean runtime | CV        |
| ---------- | --- | ------------ | --------- |
| first      | 3   | 11.8 s       | 4.31%     |
| **second** | 17  | 11.8 s       | **5.17%** |

The **n = 17 run is the trustworthy estimate** (the n = 3 figure had too small a sample set). Runtime is stable at **~11.8 s/run**, down from ~82 s before the fuzz-iteration cut. For reference, the pre-change p95 was 9.74% on the heavier workload, and historical aave per-commit CV ranged 1.2–12.8%. Taking **CV ≈ 5.17%** as the working figure:

## Why 24 runs?

At the measured CV = 5.17%, the required run counts are:

| alert limit | target σ | runs required | N = 24                            |
| ----------- | -------- | ------------- | --------------------------------- |
| 10% (today) | 3.0%     | 6             | ✅ ample (4× margin)              |
| **5%**      | **1.5%** | **24**        | ✅ **meets** — σ@24 = 1.49% (~5%) |
| 3%          | 1.0%     | 54            | ❌ would need 54                  |

So **24 is the 5%-limit count** for this benchmark. At 24 runs the comparison noise is **σ = √2·5.17/√24 = 1.49%**, just inside the 1.5% target, keeping a real regression ~3σ clear of noise up to a **~5.0% limit**. It also covers today's 10% limit with large margin, and stops short of the 54 a future 3% limit would need.

**Cost:** 24 × 11.8 s ≈ **4.7 min**. (For comparison, a 5% limit on the pre-fix 82 s workload needed ~85 runs ≈ 116 min — the fuzz reduction is what makes 24 runs cheap.)