### PR TITLE
fix: skip tests during ignition deploy builds

### DIFF
--- a/.changeset/new-cases-create.md
+++ b/.changeset/new-cases-create.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-ignition": patch
 ---
 
-fix: skip tests during ignition deploy builds
+Avoid compiling tests during Ignition deploys.

--- a/.changeset/new-cases-create.md
+++ b/.changeset/new-cases-create.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ignition": patch
+---
+
+fix: skip tests during ignition deploy builds

--- a/packages/hardhat-ignition/src/internal/tasks/deploy.ts
+++ b/packages/hardhat-ignition/src/internal/tasks/deploy.ts
@@ -154,10 +154,9 @@ const taskDeploy: NewTaskActionFunction<TaskDeployArguments> = async (
     );
   }
 
-  const noTests = hre.config.solidity.splitTestsCompilation;
   await hre.tasks.getTask("build").run({
     quiet: true,
-    noTests,
+    noTests: true,
     defaultBuildProfile: "production",
   });
 

--- a/packages/hardhat-ignition/test/deploy/build-invocation.ts
+++ b/packages/hardhat-ignition/test/deploy/build-invocation.ts
@@ -33,7 +33,7 @@ describe("deploy - build invocation", function () {
     return { projectPath, configPath };
   }
 
-  it("should call build without noTests when splitTestsCompilation is false", async function () {
+  it("should call build with noTests when splitTestsCompilation is false", async function () {
     const { buildArgs, buildOverride } = buildArgCaptor();
     const { projectPath, configPath } = getProjectConfig();
 
@@ -56,7 +56,7 @@ describe("deploy - build invocation", function () {
     });
 
     assert.equal(buildArgs.length, 1);
-    assert.equal(buildArgs[0].noTests, false);
+    assert.equal(buildArgs[0].noTests, true);
     assert.equal(buildArgs[0].defaultBuildProfile, "production");
     assert.equal(buildArgs[0].quiet, true);
   });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts
@@ -758,6 +758,53 @@ const unifiedTestsCompilationConfig = {
 };
 
 describe("build task - unified mode cleanup", () => {
+  it("preserves existing test artifacts when building with noTests", async () => {
+    await using project = await useTestProjectTemplate(
+      unifiedCleanupProjectTemplate,
+    );
+    const hre = await project.getHRE(unifiedTestsCompilationConfig);
+
+    await hre.tasks.getTask("build").run({ force: true, quiet: true });
+
+    const artifactsPath = await hre.solidity.getArtifactsDirectory("contracts");
+    const sourceTestArtifact = path.join(
+      artifactsPath,
+      "contracts",
+      "Foo.t.sol",
+      "FooTest.json",
+    );
+    const testDirectoryArtifact = path.join(
+      artifactsPath,
+      "test",
+      "OtherFooTest.sol",
+      "OtherFooTest.json",
+    );
+
+    assert.ok(
+      await exists(sourceTestArtifact),
+      "Source-directory test artifact should exist after the initial full build",
+    );
+    assert.ok(
+      await exists(testDirectoryArtifact),
+      "Test-directory artifact should exist after the initial full build",
+    );
+
+    await hre.tasks.getTask("build").run({
+      force: true,
+      noTests: true,
+      quiet: true,
+    });
+
+    assert.ok(
+      await exists(sourceTestArtifact),
+      "Source-directory test artifact should remain after build --no-tests",
+    );
+    assert.ok(
+      await exists(testDirectoryArtifact),
+      "Test-directory artifact should remain after build --no-tests",
+    );
+  });
+
   it("includes test artifacts in duplicate-name detection", async () => {
     const duplicateNameTemplate = {
       name: "test",


### PR DESCRIPTION
## Summary
- Makes `ignition deploy` always run the build task with `noTests: true`.
- Keeps the production build profile and quiet build behavior unchanged.

## Why
- Closes #8364.
- Deployments don't need Solidity test artifacts, and compiling tests can be slow for large via-IR test suites.

## Changes
- Removes the dependency on `solidity.splitTestsCompilation` when invoking `build` from the Ignition deploy task.
- Updates the deploy build-invocation regression tests to cover both split-test settings.

## Validation
- `pnpm --dir packages/hardhat-verify build`
- `pnpm --dir packages/hardhat-ignition build`
- `pnpm --dir packages/hardhat-ignition exec mocha "test/deploy/build-invocation.ts"`
- `pnpm lint:file packages/hardhat-ignition/src/internal/tasks/deploy.ts packages/hardhat-ignition/test/deploy/build-invocation.ts`
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts`
- `pnpm lint:file packages/hardhat/test/internal/builtin-plugins/solidity/tasks/build-cleanup-artifacts.ts`

## Scope
- Focused to the Ignition deploy task's pre-deploy build invocation.

Closes #8364

