### PR TITLE
feat(benchmark): include mean in regression extra payload

### DIFF
--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -492,6 +492,7 @@ function toEntry(
       min: result.min,
       max: result.max,
       median: result.median,
+      mean: result.mean,
     }),
   };
 }


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Emit the arithmetic mean alongside min/max/median in the per-benchmark extra payload so github-action-benchmark commits carry `extra.mean`. This allows us to store different statistics in the `value` field depending on the benchmark.

# Testing

- Locally verified that `mean` is now part of the `extra` data:
  ```json
  [
  {
    "name": "1inch-aqua / cold compile",
    "unit": "s",
    "value": 10.415307490673333,
    "range": "± 0.3197290070590134",
    "extra": "{\"times\":[10.78446980534,10.23472971034,10.22672295634],\"min\":10.22672295634,\"max\":10.78446980534,\"median\":10.23472971034,\"mean\":10.415307490673333}"
  },
  {
    "name": "1inch-aqua / warm compile",
    "unit": "s",
    "value": 0.6894004635777777,
    "range": "± 0.02944506903664587",
    "extra": "{\"times\":[0.7059349468,0.7062245018,0.6824872558,0.6942387378,0.6367345758,0.6932189418,0.7256822518,0.7118898098,0.6481931508],\"min\":0.6367345758,\"max\":0.7256822518,\"median\":0.6942387378,\"mean\":0.6894004635777777}"
  },
  {
    "name": "1inch-aqua / test solidity",
    "unit": "s",
    "value": 0.7380209609363636,
    "range": "± 0.03705135483700279",
    "extra": "{\"times\":[0.8097780073,0.6989025553,0.7410091863,0.7760331273000001,0.7322626763,0.7253674393,0.7546233183000001,0.7215521553,0.7695373363,0.6879634633,0.7012013053],\"min\":0.6879634633,\"max\":0.8097780073,\"median\":0.7322626763,\"mean\":0.7380209609363636}"
  }
]
  ```
