### PR TITLE
feat/coverage skip files

### DIFF
--- a/.changeset/coverage-skip-files.md
+++ b/.changeset/coverage-skip-files.md
@@ -1,0 +1,6 @@
+---
+"hardhat": minor
+# docs: https://github.com/NomicFoundation/hardhat-website/pull/275
+---
+
+Added support for `coverage.skipFiles`, a list of globs of Solidity files to exclude from coverage instrumentation and reporting during a `--coverage` run.

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/config.ts
@@ -1,0 +1,28 @@
+import type { HardhatUserConfig } from "../../../config.js";
+import type { CoverageConfig } from "../../../types/config.js";
+import type { HardhatUserConfigValidationError } from "../../../types/hooks.js";
+
+import { validateUserConfigZodType } from "@nomicfoundation/hardhat-zod-utils";
+import { z } from "zod";
+
+const userConfigType = z.object({
+  coverage: z
+    .object({
+      skipFiles: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+
+export function validateCoverageUserConfig(
+  userConfig: unknown,
+): HardhatUserConfigValidationError[] {
+  return validateUserConfigZodType(userConfig, userConfigType);
+}
+
+export function resolveCoverageConfig(
+  userConfig: HardhatUserConfig,
+): CoverageConfig {
+  return {
+    skipFiles: userConfig.coverage?.skipFiles ?? [],
+  };
+}

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/config.ts
@@ -1,0 +1,30 @@
+import type { ConfigHooks } from "../../../../types/hooks.js";
+
+import {
+  resolveCoverageConfig,
+  validateCoverageUserConfig,
+} from "../config.js";
+
+export default async (): Promise<Partial<ConfigHooks>> => {
+  const handlers: Partial<ConfigHooks> = {
+    validateUserConfig: async (userConfig) =>
+      validateCoverageUserConfig(userConfig),
+    resolveUserConfig: async (
+      userConfig,
+      resolveConfigurationVariable,
+      next,
+    ) => {
+      const resolvedConfig = await next(
+        userConfig,
+        resolveConfigurationVariable,
+      );
+
+      return {
+        ...resolvedConfig,
+        coverage: resolveCoverageConfig(userConfig),
+      };
+    },
+  };
+
+  return handlers;
+};

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/solidity.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/hook-handlers/solidity.ts
@@ -8,6 +8,8 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
+import { matchesAnyGlob } from "../../../utils/glob.js";
+import { toUserSourceName } from "../../solidity/source-names.js";
 import { getCoverageManager } from "../helpers/accessors.js";
 import { instrumentSolidityFileForCompilationJob } from "../instrumentation.js";
 
@@ -22,12 +24,23 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
     solcVersion,
     next,
   ) => {
+    // This hook runs on every project file of every build. Coverage is the
+    // only reason to preprocess them, so when it is off we pass the file
+    // through untouched and keep the common path free of the work below.
+    if (!context.globalOptions.coverage) {
+      return await next(context, sourceName, fsPath, fileContent, solcVersion);
+    }
+
     // NOTE: We do not want to instrument the test project files as we don't
     // want to report coverage for them.
-
     const isTestSource = (await context.solidity.getScope(fsPath)) === "tests";
 
-    if (context.globalOptions.coverage && !isTestSource) {
+    const isSkipped = matchesAnyGlob(
+      toUserSourceName(sourceName),
+      context.config.coverage.skipFiles,
+    );
+
+    if (!isTestSource && !isSkipped) {
       try {
         const { source, metadata } = instrumentSolidityFileForCompilationJob({
           compilationJobSolcVersion: solcVersion,

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/index.ts
@@ -16,6 +16,7 @@ const hardhatPlugin: HardhatPlugin = definePlugin({
   ],
   hookHandlers: {
     clean: () => import("./hook-handlers/clean.js"),
+    config: () => import("./hook-handlers/config.js"),
     hre: () => import("./hook-handlers/hre.js"),
     solidity: () => import("./hook-handlers/solidity.js"),
     test: () => import("./hook-handlers/test.js"),

--- a/packages/hardhat/src/internal/builtin-plugins/coverage/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/coverage/type-extensions.ts
@@ -3,3 +3,27 @@ declare module "../../../types/global-options.js" {
     coverage: boolean;
   }
 }
+
+declare module "../../../types/config.js" {
+  export interface CoverageUserConfig {
+    /**
+     * Globs of Solidity source files to exclude from coverage instrumentation.
+     * A project file whose project-relative source name matches any of these
+     * globs is not instrumented during a `--coverage` run, and so does not
+     * appear in coverage reports.
+     */
+    skipFiles?: string[];
+  }
+
+  export interface HardhatUserConfig {
+    coverage?: CoverageUserConfig;
+  }
+
+  export interface CoverageConfig {
+    skipFiles: string[];
+  }
+
+  export interface HardhatConfig {
+    coverage: CoverageConfig;
+  }
+}

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -7,6 +7,7 @@ import {
   bytesToUtf8String,
 } from "@nomicfoundation/hardhat-utils/bytes";
 
+import { isPathSelected } from "../../../utils/glob.js";
 import { HARDHAT_PROJECT_INPUT_SOURCE_NAME_ROOT } from "../../solidity/constants.js";
 
 import {
@@ -14,7 +15,6 @@ import {
   extractStructsFromAst,
 } from "./ast-walker.js";
 import { canonicalizeStructs } from "./canonicalize.js";
-import { isPathSelected } from "./glob.js";
 
 export interface Eip712TypesConfig {
   include: string[];

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -8,7 +8,7 @@ import {
 } from "@nomicfoundation/hardhat-utils/bytes";
 
 import { isPathSelected } from "../../../utils/glob.js";
-import { HARDHAT_PROJECT_INPUT_SOURCE_NAME_ROOT } from "../../solidity/constants.js";
+import { toUserSourceName } from "../../solidity/source-names.js";
 
 import {
   buildUserDefinedValueTypeIndex,
@@ -20,11 +20,6 @@ export interface Eip712TypesConfig {
   include: string[];
   exclude: string[];
 }
-
-// When a transitive project file doesn't produce an artifact — and so is
-// missing from `inputToUserSource` — stripping this prefix recovers the
-// user-facing path that the user's include/exclude globs are written against.
-const PROJECT_INPUT_SOURCE_NAME_PREFIX = `${HARDHAT_PROJECT_INPUT_SOURCE_NAME_ROOT}/`;
 
 /**
  * Walks every compiled source's AST, extracts every struct definition, and
@@ -89,15 +84,12 @@ export function collectEip712CanonicalTypes(
     );
 
     for (const [inputSourceName, source] of Object.entries(sources)) {
-      let userSourceName = inputToUserSource.get(inputSourceName);
-
-      if (userSourceName === undefined) {
-        userSourceName = inputSourceName.startsWith(
-          PROJECT_INPUT_SOURCE_NAME_PREFIX,
-        )
-          ? inputSourceName.slice(PROJECT_INPUT_SOURCE_NAME_PREFIX.length)
-          : inputSourceName;
-      }
+      // A transitive project file that doesn't produce an artifact is missing
+      // from `inputToUserSource`; recovering the user source name from the
+      // input source name covers that case.
+      const userSourceName =
+        inputToUserSource.get(inputSourceName) ??
+        toUserSourceName(inputSourceName);
 
       // Collect every source so non-selected files can serve as dep targets;
       // selection is enforced at emit time via `selectedNames`.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/source-names.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/source-names.ts
@@ -1,0 +1,19 @@
+import { HARDHAT_PROJECT_INPUT_SOURCE_NAME_ROOT } from "./constants.js";
+
+const PROJECT_INPUT_SOURCE_NAME_PREFIX = `${HARDHAT_PROJECT_INPUT_SOURCE_NAME_ROOT}/`;
+
+/**
+ * Recovers the user-facing source name from a solc input source name by
+ * stripping the Hardhat project prefix.
+ *
+ * Project files have an input source name like `project/contracts/Foo.sol`,
+ * whereas the user writes paths — and config globs — against the
+ * project-relative `contracts/Foo.sol`. npm package input source names
+ * (`npm/<pkg>@<version>/...`) don't carry the project prefix and are returned
+ * unchanged.
+ */
+export function toUserSourceName(inputSourceName: string): string {
+  return inputSourceName.startsWith(PROJECT_INPUT_SOURCE_NAME_PREFIX)
+    ? inputSourceName.slice(PROJECT_INPUT_SOURCE_NAME_PREFIX.length)
+    : inputSourceName;
+}

--- a/packages/hardhat/src/internal/utils/glob.ts
+++ b/packages/hardhat/src/internal/utils/glob.ts
@@ -15,11 +15,11 @@ export function isPathSelected(
     return false;
   }
 
-  if (!matchesAny(path, include)) {
+  if (!matchesAnyGlob(path, include)) {
     return false;
   }
 
-  if (exclude.length > 0 && matchesAny(path, exclude)) {
+  if (exclude.length > 0 && matchesAnyGlob(path, exclude)) {
     return false;
   }
 
@@ -29,7 +29,7 @@ export function isPathSelected(
 /**
  * Returns true if `value` matches at least one of the given glob patterns.
  */
-function matchesAny(value: string, patterns: string[]): boolean {
+export function matchesAnyGlob(value: string, patterns: string[]): boolean {
   for (const pattern of patterns) {
     if (getCompiledGlob(pattern).test(value)) {
       return true;

--- a/packages/hardhat/test/internal/builtin-plugins/coverage/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/coverage/config.ts
@@ -1,0 +1,46 @@
+import type { HardhatUserConfig } from "../../../../src/types/config.js";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
+
+import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+
+describe("coverage config", () => {
+  it("should default `skipFiles` to an empty array when not set", async () => {
+    const hre = await createHardhatRuntimeEnvironment({});
+
+    assert.deepEqual(hre.config.coverage.skipFiles, []);
+  });
+
+  it("should resolve user-provided `skipFiles`", async () => {
+    const hre = await createHardhatRuntimeEnvironment({
+      coverage: {
+        skipFiles: ["**/mocks/**"],
+      },
+    });
+
+    assert.deepEqual(hre.config.coverage.skipFiles, ["**/mocks/**"]);
+  });
+
+  it("should throw when `skipFiles` is not an array of strings", async () => {
+    const userConfig: HardhatUserConfig = {
+      coverage: {
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          -- intentionally violating the types for the test */
+        skipFiles: "not an array" as any,
+      },
+    };
+
+    await assertRejectsWithHardhatError(
+      createHardhatRuntimeEnvironment(userConfig),
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
+      {
+        errors:
+          "\t* Config error in config.coverage.skipFiles: Expected array, received string",
+      },
+    );
+  });
+});

--- a/packages/hardhat/test/internal/builtin-plugins/coverage/hook-handlers/solidity.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/coverage/hook-handlers/solidity.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { createHardhatRuntimeEnvironment } from "../../../../../src/hre.js";
+import { CoverageManagerImplementation } from "../../../../../src/internal/builtin-plugins/coverage/coverage-manager.js";
+import { getCoverageManager } from "../../../../../src/internal/builtin-plugins/coverage/helpers/accessors.js";
+
+describe("coverage/hook-handlers/solidity — skipFiles", () => {
+  const SOURCE = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract C {
+  function f(uint256 n) public pure returns (uint256) {
+    if (n == 0) {
+      return 0;
+    }
+    return n;
+  }
+}
+`;
+
+  const SOLC_VERSION = "0.8.28";
+
+  async function preprocess(
+    hre: Awaited<ReturnType<typeof createHardhatRuntimeEnvironment>>,
+    sourceName: string,
+    fsPath: string,
+  ): Promise<string> {
+    return await hre.hooks.runHandlerChain(
+      "solidity",
+      "preprocessProjectFileBeforeBuilding",
+      [sourceName, fsPath, SOURCE, SOLC_VERSION],
+      async (_context, _sourceName, _fsPath, fileContent) => fileContent,
+    );
+  }
+
+  it("does not instrument a file whose source name matches a skipFiles glob", async () => {
+    const hre = await createHardhatRuntimeEnvironment(
+      { coverage: { skipFiles: ["**/mocks/**"] } },
+      { coverage: true },
+    );
+    const coverageManager = getCoverageManagerImpl(hre);
+
+    const fsPath = path.join(
+      hre.config.paths.root,
+      "contracts",
+      "mocks",
+      "Mock.sol",
+    );
+
+    const result = await preprocess(
+      hre,
+      "project/contracts/mocks/Mock.sol",
+      fsPath,
+    );
+
+    // Skipped files are passed through unchanged and produce no metadata.
+    assert.equal(result, SOURCE);
+    assert.equal(
+      coverageManager.filesMetadata.has(
+        path.join("contracts", "mocks", "Mock.sol"),
+      ),
+      false,
+    );
+  });
+
+  it("instruments a file whose source name does not match any skipFiles glob", async () => {
+    const hre = await createHardhatRuntimeEnvironment(
+      { coverage: { skipFiles: ["**/mocks/**"] } },
+      { coverage: true },
+    );
+    const coverageManager = getCoverageManagerImpl(hre);
+
+    const fsPath = path.join(hre.config.paths.root, "contracts", "Token.sol");
+
+    const result = await preprocess(hre, "project/contracts/Token.sol", fsPath);
+
+    // Non-skipped files are instrumented and produce metadata.
+    assert.notEqual(result, SOURCE);
+    assert.equal(
+      coverageManager.filesMetadata.has(path.join("contracts", "Token.sol")),
+      true,
+    );
+  });
+});
+
+function getCoverageManagerImpl(
+  hre: Awaited<ReturnType<typeof createHardhatRuntimeEnvironment>>,
+): CoverageManagerImplementation {
+  const coverageManager = getCoverageManager(hre);
+
+  assert.ok(
+    coverageManager instanceof CoverageManagerImplementation,
+    "expected a CoverageManagerImplementation",
+  );
+
+  return coverageManager;
+}

--- a/packages/hardhat/test/internal/utils/glob.ts
+++ b/packages/hardhat/test/internal/utils/glob.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { isPathSelected } from "../../../../../src/internal/builtin-plugins/solidity-test/eip712/glob.js";
+import {
+  isPathSelected,
+  matchesAnyGlob,
+} from "../../../src/internal/utils/glob.js";
 
-describe("eip712 - glob", () => {
+describe("glob", () => {
   describe("isPathSelected", () => {
     it("matches nothing when include is empty", () => {
       assert.equal(isPathSelected("a/b.sol", [], []), false);
@@ -338,6 +341,28 @@ describe("eip712 - glob", () => {
         assert.equal(isPathSelected("a", ["[!]"], []), true);
         assert.equal(isPathSelected("ab", ["[!]"], []), false);
       });
+    });
+  });
+
+  describe("matchesAnyGlob", () => {
+    it("returns false when there are no patterns", () => {
+      assert.equal(matchesAnyGlob("a/b.sol", []), false);
+    });
+
+    it("returns true when any pattern matches", () => {
+      assert.equal(
+        matchesAnyGlob("contracts/mocks/Foo.sol", ["**/mocks/**"]),
+        true,
+      );
+      assert.equal(matchesAnyGlob("contracts/Foo.sol", ["**/mocks/**"]), false);
+    });
+
+    it("matches against any of several patterns", () => {
+      const patterns = ["**/mocks/**", "**/Migrations.sol"];
+
+      assert.equal(matchesAnyGlob("contracts/mocks/Foo.sol", patterns), true);
+      assert.equal(matchesAnyGlob("contracts/Migrations.sol", patterns), true);
+      assert.equal(matchesAnyGlob("contracts/Token.sol", patterns), false);
     });
   });
 });


### PR DESCRIPTION
Coverage now supports a `skipFiles` option for excluding Solidity files from instrumentation and reporting, for instance Mock contracts or other test helpers.

`skipFiles` is a list of globs. During a `--coverage` run, any project Solidity file whose project-relative source name matches one of the globs is not instrumented, and so does not appear in the coverage report:

```ts
// hardhat.config.ts
export default {
  coverage: {
    skipFiles: ["**/mocks/**", "contracts/Migrations.sol"],
  },
};
```

Because a skipped file is passed through to solc unchanged, it produces no coverage metadata.

Resolves https://github.com/NomicFoundation/hardhat/issues/8359.

## Technical decisions

### What do we `glob` over?

The config option `skipFiles` works in terms of globs over the derived source name **not** the file path directly.

This matches the convention used for Solidity Test's `eip712` `include`/`exclude` globs match. Instrumentation only runs over project files (never npm dependencies), so the source name and the project-relative path coincide.

The existing glob engine from `eip712` has been reused. It lived under the `solidity-test` plugin's `eip712` folder but has been moved to `internal/utils/glob.ts`.

### Base folder paths

Note that the glob engine expects globs, a folder directory of `contracts/mocks/` will not itself match. It would have to be `contracts/mocks/**`. This is an existing constraint in the `eip712` matching.

## Documentation

A new configuration section has been added in: https://github.com/NomicFoundation/hardhat-website/pull/275

Preview: https://hardhat-website-git-feat-coverage-skip-files-nomic-foundation.vercel.app/docs/reference/configuration#coverage-configuration

## Review

> [!NOTE] 
> Review a commit at a time for easier review

## Manual testing

Against `packages/example-project`, add a `skipFiles` glob to the config and confirm the matched files drop out of the coverage report:

```shell
cd packages/example-project

# In hardhat.config.ts, add to the config object:
#   coverage: { skipFiles: ["contracts/Calculator.sol", "**/CallTypes.sol"] },

npx hardhat test nodejs --coverage
```

`contracts/Calculator.sol` and `contracts/CallTypes.sol` should be absent from the printed coverage table (and the totals recomputed), while the other contracts remain. Removing the `skipFiles` entry brings them back.

