### PR TITLE
Fix flaky EDR context initialization race

### DIFF
--- a/.changeset/brave-otters-rescue.md
+++ b/.changeset/brave-otters-rescue.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed an intermittent "Provider for provided chain type does not exist" error that could occur when multiple network connections were created concurrently.

--- a/packages/hardhat/src/internal/edr/context.ts
+++ b/packages/hardhat/src/internal/edr/context.ts
@@ -10,32 +10,48 @@ import {
   opSolidityTestRunnerFactory,
 } from "@nomicfoundation/edr";
 
-let _globalEdrContext: EdrContext | undefined;
+// We cache the initialization *promise* (assigned synchronously, before any
+// await) rather than the resolved context. This way concurrent callers share a
+// single in-flight initialization and always receive a fully-registered
+// context, instead of racing on a half-initialized one.
+let _globalEdrContext: Promise<EdrContext> | undefined;
 
 export async function getGlobalEdrContext(): Promise<EdrContext> {
   if (_globalEdrContext === undefined) {
-    _globalEdrContext = new EdrContext();
-    await _globalEdrContext.registerProviderFactory(
-      GENERIC_CHAIN_TYPE,
-      genericChainProviderFactory(),
-    );
-    await _globalEdrContext.registerProviderFactory(
-      L1_CHAIN_TYPE,
-      l1ProviderFactory(),
-    );
-    await _globalEdrContext.registerProviderFactory(
-      OP_CHAIN_TYPE,
-      opProviderFactory(),
-    );
-    await _globalEdrContext.registerSolidityTestRunnerFactory(
-      L1_CHAIN_TYPE,
-      l1SolidityTestRunnerFactory(),
-    );
-    await _globalEdrContext.registerSolidityTestRunnerFactory(
-      OP_CHAIN_TYPE,
-      opSolidityTestRunnerFactory(),
-    );
+    const context = createGlobalEdrContext();
+    _globalEdrContext = context;
+
+    // If initialization fails, clear the cached promise so a later call can
+    // retry instead of permanently returning a rejected promise. The identity
+    // guard prevents a stale rejection from wiping a newer promise created by
+    // a retry.
+    context.catch(() => {
+      if (_globalEdrContext === context) {
+        _globalEdrContext = undefined;
+      }
+    });
   }
 
-  return _globalEdrContext;
+  return await _globalEdrContext;
+}
+
+async function createGlobalEdrContext(): Promise<EdrContext> {
+  const context = new EdrContext();
+
+  await context.registerProviderFactory(
+    GENERIC_CHAIN_TYPE,
+    genericChainProviderFactory(),
+  );
+  await context.registerProviderFactory(L1_CHAIN_TYPE, l1ProviderFactory());
+  await context.registerProviderFactory(OP_CHAIN_TYPE, opProviderFactory());
+  await context.registerSolidityTestRunnerFactory(
+    L1_CHAIN_TYPE,
+    l1SolidityTestRunnerFactory(),
+  );
+  await context.registerSolidityTestRunnerFactory(
+    OP_CHAIN_TYPE,
+    opSolidityTestRunnerFactory(),
+  );
+
+  return context;
 }

--- a/packages/hardhat/test/internal/edr/context.ts
+++ b/packages/hardhat/test/internal/edr/context.ts
@@ -1,0 +1,80 @@
+import type * as EdrContextModule from "../../../src/internal/edr/context.js";
+import type { EdrNetworkConfig } from "../../../src/types/config.js";
+import type { RequireField } from "../../../src/types/utils.js";
+
+import { describe, it } from "node:test";
+
+import { ContractDecoder, L1_CHAIN_TYPE } from "@nomicfoundation/edr";
+
+import { getProviderConfig } from "../../../src/internal/builtin-plugins/network-manager/edr/edr-provider.js";
+
+const networkConfigStub: RequireField<EdrNetworkConfig, "chainType"> = {
+  type: "edr-simulated",
+  chainType: "l1",
+  accounts: [],
+  allowBlocksWithSameTimestamp: true,
+  allowUnlimitedContractSize: true,
+  blockGasLimit: 60_000_000n,
+  chainId: 31337,
+  coinbase: Buffer.from("0000000000000000000000000000000000000000", "hex"),
+  gas: "auto",
+  gasMultiplier: 1,
+  gasPrice: "auto",
+  hardfork: "osaka",
+  initialDate: new Date(),
+  loggingEnabled: false,
+  minGasPrice: 0n,
+  mining: { auto: true, interval: 0, mempool: { order: "fifo" } },
+  networkId: 31337,
+  throwOnCallFailures: true,
+  throwOnTransactionFailures: true,
+  forking: undefined,
+};
+
+const noopLoggerConfig = {
+  enable: false,
+  decodeConsoleLogInputsCallback: () => [],
+  printLineCallback: () => {},
+};
+
+const noopSubscriptionConfig = {
+  subscriptionCallback: () => {},
+};
+
+describe("getGlobalEdrContext", () => {
+  it("registers all factories before any concurrent caller can use the context", async () => {
+    // Import a fresh copy of the module so the test exercises lazy
+    // initialization from scratch, independent of any other test in the
+    // shared `isolation: "none"` process. The `?v=` query gives the tsx/esm
+    // loader a distinct module instance with its own `_globalEdrContext`.
+    const url =
+      new URL("../../../src/internal/edr/context.js", import.meta.url).href +
+      "?v=race";
+    const freshContext: typeof EdrContextModule = await import(url);
+    const { getGlobalEdrContext } = freshContext;
+
+    const providerConfig = await getProviderConfig(
+      networkConfigStub,
+      undefined,
+      undefined,
+      new Map(),
+    );
+
+    const makeProvider = async () => {
+      const context = await getGlobalEdrContext();
+      return await context.createProvider(
+        L1_CHAIN_TYPE,
+        providerConfig,
+        noopLoggerConfig,
+        noopSubscriptionConfig,
+        new ContractDecoder(),
+      );
+    };
+
+    // Both concurrent callers must receive a fully-registered context. If
+    // initialization ever regresses to handing out a half-initialized
+    // (zero-factory) context, the second caller's createProvider would reject
+    // with "Provider for provided chain type does not exist".
+    await Promise.all([makeProvider(), makeProvider()]);
+  });
+});


### PR DESCRIPTION
Fixes an intermittent "Provider for provided chain type does not exist" error caused by a race condition in `getGlobalEdrContext`, where a concurrent caller could receive an EDR context before its provider factories finished registering. The context now caches the initialization promise so all callers share one fully-registered context, and clears the cache on failure to allow retries.