### PR TITLE
fix: add plugin migration guidance

### DIFF
--- a/.changeset/shy-plugins-teach.md
+++ b/.changeset/shy-plugins-teach.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Improve Hardhat 2 plugin API compatibility errors with the removed API name and Hardhat 3 migration guidance.

--- a/.changeset/shy-plugins-teach.md
+++ b/.changeset/shy-plugins-teach.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Improve Hardhat 2 plugin API compatibility errors with the removed API name and Hardhat 3 migration guidance.
+When a Hardhat 2 plugin calls an API that no longer exists in Hardhat 3, the error now names the specific API that was used and explains how to migrate it to Hardhat 3.

--- a/packages/hardhat/src/config.ts
+++ b/packages/hardhat/src/config.ts
@@ -7,6 +7,9 @@ import type { HardhatUserConfig } from "./types/config.js";
 
 import { throwUsingHardhat2PluginError } from "./internal/using-hardhat2-plugin-errors.js";
 
+const DEFINE_PLUGIN_MIGRATION_HINT =
+  "To migrate a plugin to Hardhat 3, export a plugin object with definePlugin from hardhat/plugins and register hook handlers in its hookHandlers field.";
+
 /**
  * Defines a Hardhat user config.
  *
@@ -42,33 +45,42 @@ export function defineConfig(config: HardhatUserConfig): HardhatUserConfig {
  * @deprecated This function is part of the Hardhat 2 plugin API.
  */
 export function extendConfig(..._args: any): any {
-  throwUsingHardhat2PluginError();
+  throwUsingHardhat2PluginError("extendConfig", DEFINE_PLUGIN_MIGRATION_HINT);
 }
 
 /**
  * @deprecated This function is part of the Hardhat 2 plugin API.
  */
 export function extendEnvironment(..._args: any): any {
-  throwUsingHardhat2PluginError();
+  throwUsingHardhat2PluginError(
+    "extendEnvironment",
+    DEFINE_PLUGIN_MIGRATION_HINT,
+  );
 }
 
 /**
  * @deprecated This function is part of the Hardhat 2 plugin API.
  */
 export function extendProvider(..._args: any): any {
-  throwUsingHardhat2PluginError();
+  throwUsingHardhat2PluginError("extendProvider", DEFINE_PLUGIN_MIGRATION_HINT);
 }
 
 /**
  * @deprecated This function is part of the Hardhat 2 plugin API.
  */
 export function scope(..._args: any): any {
-  throwUsingHardhat2PluginError();
+  throwUsingHardhat2PluginError(
+    "scope",
+    "To migrate tasks to Hardhat 3, define them with task or emptyTask from hardhat/config and include them in a plugin exported with definePlugin from hardhat/plugins.",
+  );
 }
 
 /**
  * @deprecated This function is part of the Hardhat 2 plugin API.
  */
 export function subtask(..._args: any): any {
-  throwUsingHardhat2PluginError();
+  throwUsingHardhat2PluginError(
+    "subtask",
+    "To migrate subtasks to Hardhat 3, define them as nested tasks with task or emptyTask from hardhat/config and include them in a plugin exported with definePlugin from hardhat/plugins.",
+  );
 }

--- a/packages/hardhat/src/internal/using-hardhat2-plugin-errors.ts
+++ b/packages/hardhat/src/internal/using-hardhat2-plugin-errors.ts
@@ -6,7 +6,7 @@ import { shortenPath } from "@nomicfoundation/hardhat-utils/path";
 
 export class UsingHardhat2PluginError extends CustomError {
   public readonly callerRelativePath: string | undefined;
-  constructor(apiName?: string, migrationHint?: string) {
+  constructor(apiName: string, migrationHint?: string) {
     const callerPath = getCallerRelativePath();
 
     let message: string;
@@ -18,9 +18,7 @@ This file is part of a Hardhat 2 plugin calling an API that was removed in Hardh
       message = `You are trying to use a Hardhat 2 plugin in a Hardhat 3 project.`;
     }
 
-    if (apiName !== undefined) {
-      message += `\n\nThe removed API is: ${styleText("bold", apiName)}.`;
-    }
+    message += `\n\nThe removed API is: ${styleText("bold", apiName)}.`;
 
     if (migrationHint !== undefined) {
       message += `\n\n${migrationHint}`;
@@ -107,7 +105,7 @@ export function getCallerRelativePath(depth: number = 5): string | undefined {
 }
 
 export function throwUsingHardhat2PluginError(
-  apiName?: string,
+  apiName: string,
   migrationHint?: string,
 ): never {
   /* eslint-disable-next-line no-restricted-syntax -- Intentionally throwing a

--- a/packages/hardhat/src/internal/using-hardhat2-plugin-errors.ts
+++ b/packages/hardhat/src/internal/using-hardhat2-plugin-errors.ts
@@ -6,7 +6,7 @@ import { shortenPath } from "@nomicfoundation/hardhat-utils/path";
 
 export class UsingHardhat2PluginError extends CustomError {
   public readonly callerRelativePath: string | undefined;
-  constructor() {
+  constructor(apiName?: string, migrationHint?: string) {
     const callerPath = getCallerRelativePath();
 
     let message: string;
@@ -16,6 +16,14 @@ export class UsingHardhat2PluginError extends CustomError {
 This file is part of a Hardhat 2 plugin calling an API that was removed in Hardhat 3: ${styleText("bold", callerPath)}`;
     } else {
       message = `You are trying to use a Hardhat 2 plugin in a Hardhat 3 project.`;
+    }
+
+    if (apiName !== undefined) {
+      message += `\n\nThe removed API is: ${styleText("bold", apiName)}.`;
+    }
+
+    if (migrationHint !== undefined) {
+      message += `\n\n${migrationHint}`;
     }
 
     super(message);
@@ -98,8 +106,11 @@ export function getCallerRelativePath(depth: number = 5): string | undefined {
   }
 }
 
-export function throwUsingHardhat2PluginError(): never {
+export function throwUsingHardhat2PluginError(
+  apiName?: string,
+  migrationHint?: string,
+): never {
   /* eslint-disable-next-line no-restricted-syntax -- Intentionally throwing a
     custom error here so that we always print the stack trace */
-  throw new UsingHardhat2PluginError();
+  throw new UsingHardhat2PluginError(apiName, migrationHint);
 }

--- a/packages/hardhat/src/plugins.ts
+++ b/packages/hardhat/src/plugins.ts
@@ -5,6 +5,9 @@ import type { HardhatPlugin } from "./types/plugins.js";
 import { registerLoadedPlugin } from "./internal/core/plugins/loaded-plugins-registry.js";
 import { throwUsingHardhat2PluginError } from "./internal/using-hardhat2-plugin-errors.js";
 
+const LAZY_LOADING_MIGRATION_HINT =
+  "To migrate a plugin to Hardhat 3, export a plugin object with definePlugin from hardhat/plugins and register lazy-loaded logic through dependencies, hook handlers, and task actions.";
+
 /**
  * Defines a Hardhat plugin.
  *
@@ -25,18 +28,12 @@ export function definePlugin(plugin: HardhatPlugin): HardhatPlugin {
  * @deprecated This function is part of the Hardhat 2 plugin API.
  */
 export function lazyFunction(..._args: any): any {
-  throwUsingHardhat2PluginError(
-    "lazyFunction",
-    "To migrate a plugin to Hardhat 3, export a plugin object with definePlugin from hardhat/plugins and register lazy-loaded logic through dependencies, hook handlers, and task actions.",
-  );
+  throwUsingHardhat2PluginError("lazyFunction", LAZY_LOADING_MIGRATION_HINT);
 }
 
 /**
  * @deprecated This function is part of the Hardhat 2 plugin API.
  */
 export function lazyObject(..._args: any): any {
-  throwUsingHardhat2PluginError(
-    "lazyObject",
-    "To migrate a plugin to Hardhat 3, export a plugin object with definePlugin from hardhat/plugins and register lazy-loaded logic through dependencies, hook handlers, and task actions.",
-  );
+  throwUsingHardhat2PluginError("lazyObject", LAZY_LOADING_MIGRATION_HINT);
 }

--- a/packages/hardhat/src/plugins.ts
+++ b/packages/hardhat/src/plugins.ts
@@ -25,12 +25,18 @@ export function definePlugin(plugin: HardhatPlugin): HardhatPlugin {
  * @deprecated This function is part of the Hardhat 2 plugin API.
  */
 export function lazyFunction(..._args: any): any {
-  throwUsingHardhat2PluginError();
+  throwUsingHardhat2PluginError(
+    "lazyFunction",
+    "To migrate a plugin to Hardhat 3, export a plugin object with definePlugin from hardhat/plugins and register lazy-loaded logic through dependencies, hook handlers, and task actions.",
+  );
 }
 
 /**
  * @deprecated This function is part of the Hardhat 2 plugin API.
  */
 export function lazyObject(..._args: any): any {
-  throwUsingHardhat2PluginError();
+  throwUsingHardhat2PluginError(
+    "lazyObject",
+    "To migrate a plugin to Hardhat 3, export a plugin object with definePlugin from hardhat/plugins and register lazy-loaded logic through dependencies, hook handlers, and task actions.",
+  );
 }

--- a/packages/hardhat/test/config.ts
+++ b/packages/hardhat/test/config.ts
@@ -13,94 +13,85 @@ import {
 } from "../src/config.js";
 import { UsingHardhat2PluginError } from "../src/internal/using-hardhat2-plugin-errors.js";
 
+function assertHardhat2PluginError(
+  error: unknown,
+  removedApi: string,
+  migrationHint: RegExp,
+): true {
+  assert.ok(
+    error instanceof UsingHardhat2PluginError,
+    "Should be a UsingHardhat2PluginError",
+  );
+  assert.ok(
+    error.callerRelativePath?.includes(path.join("test", "config.ts")) === true,
+    "Should have the caller path",
+  );
+  assert.match(
+    error.message,
+    new RegExp(`The removed API is: .*${removedApi}`),
+  );
+  assert.match(error.message, migrationHint);
+  return true;
+}
+
 describe("Hardhat 2 plugin compatibility", () => {
   it("should throw when calling extendConfig", () => {
     assertThrows(
       () => extendConfig(),
-      (error) => {
-        assert.ok(
-          error instanceof UsingHardhat2PluginError,
-          "Should be a UsingHardhat2PluginError",
-        );
-        assert.ok(
-          error.callerRelativePath?.includes(path.join("test", "config.ts")) ===
-            true,
-          "Should have the caller path",
-        );
-        return true;
-      },
+      (error) =>
+        assertHardhat2PluginError(
+          error,
+          "extendConfig",
+          /definePlugin from hardhat\/plugins/,
+        ),
     );
   });
 
   it("should throw when calling extendEnvironment", () => {
     assertThrows(
       () => extendEnvironment(),
-      (error) => {
-        assert.ok(
-          error instanceof UsingHardhat2PluginError,
-          "Should be a UsingHardhat2PluginError",
-        );
-        assert.ok(
-          error.callerRelativePath?.includes(path.join("test", "config.ts")) ===
-            true,
-          "Should have the caller path",
-        );
-        return true;
-      },
+      (error) =>
+        assertHardhat2PluginError(
+          error,
+          "extendEnvironment",
+          /definePlugin from hardhat\/plugins/,
+        ),
     );
   });
 
   it("should throw when calling extendProvider", () => {
     assertThrows(
       () => extendProvider(),
-      (error) => {
-        assert.ok(
-          error instanceof UsingHardhat2PluginError,
-          "Should be a UsingHardhat2PluginError",
-        );
-        assert.ok(
-          error.callerRelativePath?.includes(path.join("test", "config.ts")) ===
-            true,
-          "Should have the caller path",
-        );
-        return true;
-      },
+      (error) =>
+        assertHardhat2PluginError(
+          error,
+          "extendProvider",
+          /definePlugin from hardhat\/plugins/,
+        ),
     );
   });
 
   it("should throw when calling scope", () => {
     assertThrows(
       () => scope(),
-      (error) => {
-        assert.ok(
-          error instanceof UsingHardhat2PluginError,
-          "Should be a UsingHardhat2PluginError",
-        );
-        assert.ok(
-          error.callerRelativePath?.includes(path.join("test", "config.ts")) ===
-            true,
-          "Should have the caller path",
-        );
-        return true;
-      },
+      (error) =>
+        assertHardhat2PluginError(
+          error,
+          "scope",
+          /task or emptyTask from hardhat\/config/,
+        ),
     );
   });
 
   it("should throw when calling subtask", () => {
     assertThrows(
       () => subtask(),
-      (error) => {
-        assert.ok(
-          error instanceof UsingHardhat2PluginError,
-          "Should be a UsingHardhat2PluginError",
-        );
-        assert.ok(
-          error.callerRelativePath?.includes(path.join("test", "config.ts")) ===
-            true,
-          "Should have the caller path",
-        );
-        return true;
-      },
+      (error) =>
+        assertHardhat2PluginError(
+          error,
+          "subtask",
+          /nested tasks with task or emptyTask/,
+        ),
     );
   });
 });

--- a/packages/hardhat/test/internal/cli/error-handler.ts
+++ b/packages/hardhat/test/internal/cli/error-handler.ts
@@ -272,7 +272,7 @@ describe("error-handler", () => {
       // the HH2_TO_HH3_MIGRATION branch, so the output should match it.
       it("is treated as a Hardhat 2 to Hardhat 3 migration error", async () => {
         const lines: Array<string | Error> = [];
-        const error = new UsingHardhat2PluginError();
+        const error = new UsingHardhat2PluginError("extendConfig");
 
         await printErrorMessages(error, false, (msg: string | Error) => {
           lines.push(msg);

--- a/packages/hardhat/test/plugins.ts
+++ b/packages/hardhat/test/plugins.ts
@@ -7,42 +7,36 @@ import { assertThrows } from "@nomicfoundation/hardhat-test-utils";
 import { UsingHardhat2PluginError } from "../src/internal/using-hardhat2-plugin-errors.js";
 import { lazyFunction, lazyObject } from "../src/plugins.js";
 
+function assertHardhat2PluginError(error: unknown, removedApi: string): true {
+  assert.ok(
+    error instanceof UsingHardhat2PluginError,
+    "Should be a UsingHardhat2PluginError",
+  );
+  assert.ok(
+    error.callerRelativePath?.includes(path.join("test", "plugins.ts")) ===
+      true,
+    "Should have the caller path",
+  );
+  assert.match(
+    error.message,
+    new RegExp(`The removed API is: .*${removedApi}`),
+  );
+  assert.match(error.message, /definePlugin from hardhat\/plugins/);
+  return true;
+}
+
 describe("Hardhat 2 plugin compatibility", () => {
   it("should throw when calling lazyFunction", () => {
     assertThrows(
       () => lazyFunction(),
-      (error) => {
-        assert.ok(
-          error instanceof UsingHardhat2PluginError,
-          "Should be a UsingHardhat2PluginError",
-        );
-        assert.ok(
-          error.callerRelativePath?.includes(
-            path.join("test", "plugins.ts"),
-          ) === true,
-          "Should have the caller path",
-        );
-        return true;
-      },
+      (error) => assertHardhat2PluginError(error, "lazyFunction"),
     );
   });
 
   it("should throw when calling lazyObject", () => {
     assertThrows(
       () => lazyObject(),
-      (error) => {
-        assert.ok(
-          error instanceof UsingHardhat2PluginError,
-          "Should be a UsingHardhat2PluginError",
-        );
-        assert.ok(
-          error.callerRelativePath?.includes(
-            path.join("test", "plugins.ts"),
-          ) === true,
-          "Should have the caller path",
-        );
-        return true;
-      },
+      (error) => assertHardhat2PluginError(error, "lazyObject"),
     );
   });
 });


### PR DESCRIPTION
## Summary

Improve the Hardhat 2 plugin API compatibility errors so external plugin authors see:

- the specific removed API that was called
- a short Hardhat 3 migration hint for `definePlugin`, hook handlers, lazy-loaded logic, and migrated task definitions

## Why

External plugins migrating from Hardhat 2 currently get a generic Hardhat 2 plugin API error plus the caller path. Naming the removed API and pointing to the Hardhat 3 plugin shape makes the next migration step clearer.

Refs #8342

## Changes

- Add optional removed-API and migration-hint details to `UsingHardhat2PluginError`.
- Pass specific guidance from removed Hardhat 2 APIs exported by `hardhat/config` and `hardhat/plugins`.
- Extend compatibility tests to assert the API-specific guidance is included.
- Add a patch changeset for `hardhat`.

## Validation

- `pnpm test:file packages/hardhat/test/config.ts packages/hardhat/test/plugins.ts packages/hardhat/test/internal/hardhat2-plugin-errors.ts`
- `pnpm lint:file packages/hardhat/src/internal/using-hardhat2-plugin-errors.ts packages/hardhat/src/config.ts packages/hardhat/src/plugins.ts packages/hardhat/test/config.ts packages/hardhat/test/plugins.ts`
- `pnpm exec prettier --check .changeset/shy-plugins-teach.md`

## Scope

Focused on migration diagnostics for existing removed Hardhat 2 plugin API stubs; it does not introduce new plugin APIs or change runtime plugin loading behavior.
