### PR TITLE
Add utils binary and built-in tasks

### DIFF
--- a/.changeset/beige-teams-win.md
+++ b/.changeset/beige-teams-win.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Add hhu binary and builtin-plugin

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -13,7 +13,8 @@
   "type": "module",
   "types": "dist/src/index.d.ts",
   "bin": {
-    "hardhat": "./dist/src/cli.js"
+    "hardhat": "./dist/src/cli.js",
+    "hhu": "./dist/src/hhu.js"
   },
   "exports": {
     ".": "./dist/src/index.js",

--- a/packages/hardhat/src/hhu.ts
+++ b/packages/hardhat/src/hhu.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { exitIfNodeVersionNotSupported } from "./internal/cli/node-version.js";
+
+// We enable the sourcemaps before loading main, so that everything except this
+// small file is loaded with sourcemaps enabled.
+process.setSourceMapsEnabled(true);
+
+// We check the Node.js version before loading main, so that if there is some
+// unsupported js syntax or Node API elsewhere, we get to exit with a clear
+// error before crashing.
+exitIfNodeVersionNotSupported();
+
+// eslint-disable-next-line no-restricted-syntax -- Allow top-level await here
+const { main } = await import("./internal/cli/hhu.js");
+
+// eslint-disable-next-line no-restricted-syntax -- We do want TLA here
+await main(process.argv.slice(2));

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/index.ts
@@ -1,0 +1,13 @@
+import type { HardhatPlugin } from "../../../types/plugins.js";
+
+import { definePlugin } from "../../../plugins.js";
+
+import { generateTasks } from "./tasks/index.js";
+
+const hardhatPlugin: HardhatPlugin = definePlugin({
+  id: "builtin:hhu",
+  tasks: generateTasks({ withUtils: true }),
+  npmPackage: "hardhat",
+});
+
+export default hardhatPlugin;

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/constants.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/constants.ts
@@ -1,0 +1,28 @@
+import type { GenerateTasksOptions } from "./index.js";
+import type { TaskDefinition } from "../../../../types/index.js";
+
+import { emptyTask, task } from "../../../core/config.js";
+
+const zeroAddress = "0x0000000000000000000000000000000000000000";
+
+export function constants({
+  withUtils,
+}: GenerateTasksOptions): TaskDefinition[] {
+  const prefix = withUtils ? ["utils"] : [];
+
+  const constantsTask = emptyTask(
+    [...prefix, "constants"],
+    "Commonly used Ethereum constants",
+  ).build();
+
+  const zeroAddressTask = task(
+    [...prefix, "constants", "zeroAddress"],
+    "Print the zero address",
+  )
+    .setAction(async () => ({
+      default: () => console.log(zeroAddress),
+    }))
+    .build();
+
+  return [constantsTask, zeroAddressTask];
+}

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/constants/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/constants/index.ts
@@ -1,9 +1,7 @@
-import type { GenerateTasksOptions } from "./index.js";
-import type { TaskDefinition } from "../../../../types/index.js";
+import type { TaskDefinition } from "../../../../../types/index.js";
+import type { GenerateTasksOptions } from "../index.js";
 
-import { emptyTask, task } from "../../../core/config.js";
-
-const zeroAddress = "0x0000000000000000000000000000000000000000";
+import { emptyTask, task } from "../../../../core/config.js";
 
 export function constants({
   withUtils,
@@ -19,9 +17,7 @@ export function constants({
     [...prefix, "constants", "zeroAddress"],
     "Print the zero address",
   )
-    .setAction(async () => ({
-      default: () => console.log(zeroAddress),
-    }))
+    .setAction(async () => await import("./zero-address.js"))
     .build();
 
   return [constantsTask, zeroAddressTask];

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/constants/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/constants/index.ts
@@ -1,4 +1,4 @@
-import type { TaskDefinition } from "../../../../../types/index.js";
+import type { TaskDefinition } from "../../../../../types/tasks.js";
 import type { GenerateTasksOptions } from "../index.js";
 
 import { emptyTask, task } from "../../../../core/config.js";

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/constants/zero-address.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/constants/zero-address.ts
@@ -1,0 +1,9 @@
+import type { NewTaskActionFunction } from "../../../../../types/tasks.js";
+
+const zeroAddress = "0x0000000000000000000000000000000000000000";
+
+const zeroAddressAction: NewTaskActionFunction = async () => {
+  console.log(zeroAddress);
+};
+
+export default zeroAddressAction;

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/index.ts
@@ -1,6 +1,6 @@
-import type { TaskDefinition } from "../../../../types/index.js";
+import type { TaskDefinition } from "../../../../types/tasks.js";
 
-import { emptyTask } from "../../../../config.js";
+import { emptyTask } from "../../../core/config.js";
 
 import { constants } from "./constants/index.js";
 

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/index.ts
@@ -1,0 +1,23 @@
+import type { TaskDefinition } from "../../../../types/index.js";
+
+import { emptyTask } from "../../../../config.js";
+
+import { constants } from "./constants.js";
+
+export interface GenerateTasksOptions {
+  /**
+   * Whether to nest every task under a top-level `utils` task. Used by the
+   * Hardhat CLI (`hardhat utils constants ...`) but not by the standalone hhu
+   * binary (`hhu constants ...`).
+   */
+  withUtils: boolean;
+}
+
+export function generateTasks(options: GenerateTasksOptions): TaskDefinition[] {
+  return [
+    ...(options.withUtils
+      ? [emptyTask("utils", "Utilities for common Ethereum tasks").build()]
+      : []),
+    ...constants(options),
+  ];
+}

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/index.ts
@@ -2,7 +2,7 @@ import type { TaskDefinition } from "../../../../types/index.js";
 
 import { emptyTask } from "../../../../config.js";
 
-import { constants } from "./constants.js";
+import { constants } from "./constants/index.js";
 
 export interface GenerateTasksOptions {
   /**

--- a/packages/hardhat/src/internal/builtin-plugins/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/index.ts
@@ -6,6 +6,7 @@ import console from "./console/index.js";
 import coverage from "./coverage/index.js";
 import flatten from "./flatten/index.js";
 import gasAnalytics from "./gas-analytics/index.js";
+import hhu from "./hhu/index.js";
 import networkManager from "./network-manager/index.js";
 import node from "./node/index.js";
 import run from "./run/index.js";
@@ -22,6 +23,7 @@ export type * from "./console/index.js";
 export type * from "./coverage/index.js";
 export type * from "./flatten/index.js";
 export type * from "./gas-analytics/index.js";
+export type * from "./hhu/index.js";
 export type * from "./network-manager/index.js";
 export type * from "./node/index.js";
 export type * from "./run/index.js";
@@ -46,4 +48,5 @@ export const builtinPlugins: HardhatPlugin[] = [
   node,
   flatten,
   telemetry,
+  hhu,
 ];

--- a/packages/hardhat/src/internal/cli/help/get-global-help-string.ts
+++ b/packages/hardhat/src/internal/cli/help/get-global-help-string.ts
@@ -14,6 +14,7 @@ import {
 export async function getGlobalHelpString(
   rootTasks: Map<string, Task>,
   globalOptionDefinitions: GlobalOptionDefinitions,
+  { command = "hardhat" }: { command?: "hardhat" | "hhu" } = {},
 ): Promise<string> {
   const version = await getHardhatVersion();
 
@@ -27,7 +28,7 @@ export async function getGlobalHelpString(
 
   let output = `Hardhat version ${version}
 
-Usage: hardhat [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUMENTS]
+Usage: ${command} [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUMENTS]
 `;
 
   if (tasks.length > 0) {
@@ -40,7 +41,7 @@ Usage: hardhat [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUM
 
   output += getSection("GLOBAL OPTIONS", globalOptions, namePadding);
 
-  output += `\nTo get help for a specific task run: npx hardhat <TASK> [SUBTASK] --help`;
+  output += `\nTo get help for a specific task run: npx ${command} <TASK> [SUBTASK] --help`;
 
   return output;
 }

--- a/packages/hardhat/src/internal/cli/help/get-help-string.ts
+++ b/packages/hardhat/src/internal/cli/help/get-help-string.ts
@@ -16,6 +16,7 @@ import {
 export async function getHelpString(
   task: Task,
   globalOptionDefinitions: GlobalOptionDefinitions,
+  { command = "hardhat" }: { command?: "hardhat" | "hhu" } = {},
 ): Promise<string> {
   const { options, positionalArguments } = parseOptions(task);
 
@@ -34,20 +35,20 @@ export async function getHelpString(
   let output = `${styleText("bold", task.description)}`;
 
   if (task.isEmpty) {
-    output += `\n\nUsage: hardhat [GLOBAL OPTIONS] ${task.id.join(" ")} <SUBTASK> [SUBTASK OPTIONS] [--] [SUBTASK POSITIONAL ARGUMENTS]\n`;
+    output += `\n\nUsage: ${command} [GLOBAL OPTIONS] ${task.id.join(" ")} <SUBTASK> [SUBTASK OPTIONS] [--] [SUBTASK POSITIONAL ARGUMENTS]\n`;
 
     if (subtasks.length > 0) {
       output += getSection("AVAILABLE SUBTASKS", subtasks, namePadding);
 
       output += getSection("GLOBAL OPTIONS", globalOptions, namePadding);
 
-      output += `\nTo get help for a specific task run: npx hardhat ${task.id.join(" ")} <SUBTASK> --help`;
+      output += `\nTo get help for a specific task run: npx ${command} ${task.id.join(" ")} <SUBTASK> --help`;
     }
 
     return output;
   }
 
-  const usage = getUsageString(task, options, positionalArguments);
+  const usage = getUsageString(task, options, positionalArguments, { command });
 
   output += `\n\n${usage}\n`;
 

--- a/packages/hardhat/src/internal/cli/help/utils.ts
+++ b/packages/hardhat/src/internal/cli/help/utils.ts
@@ -172,8 +172,9 @@ export function getUsageString(
   task: Task,
   options: ReturnType<typeof parseOptions>["options"],
   positionalArguments: ReturnType<typeof parseOptions>["positionalArguments"],
+  { command = "hardhat" }: { command?: "hardhat" | "hhu" } = {},
 ): string {
-  let output = `Usage: hardhat [GLOBAL OPTIONS] ${task.id.join(" ")}`;
+  let output = `Usage: ${command} [GLOBAL OPTIONS] ${task.id.join(" ")}`;
 
   if (options.length > 0) {
     output += ` ${options

--- a/packages/hardhat/src/internal/cli/hhu.ts
+++ b/packages/hardhat/src/internal/cli/hhu.ts
@@ -255,7 +255,10 @@ function taskDefinitionsToTasksMap(tasks: TaskDefinition[]): Map<string, Task> {
     },
   );
 
-  const taskManager = new TaskManagerImplementation(fakeHre, new Map());
+  const taskManager = new TaskManagerImplementation(
+    fakeHre,
+    new Map(HHU_GLOBAL_OPTIONS_DEFINITIONS),
+  );
 
   return taskManager.rootTasks;
 }

--- a/packages/hardhat/src/internal/cli/hhu.ts
+++ b/packages/hardhat/src/internal/cli/hhu.ts
@@ -9,6 +9,7 @@ import {
   assertHardhatInvariant,
   HardhatError,
 } from "@nomicfoundation/hardhat-errors";
+import { isCi } from "@nomicfoundation/hardhat-utils/ci";
 import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
@@ -205,7 +206,7 @@ export async function parseHhuGlobalOptions(
 
   return {
     help: hhuGlobalOptions.help ?? false,
-    showStackTraces: hhuGlobalOptions.showStackTraces ?? false,
+    showStackTraces: hhuGlobalOptions.showStackTraces ?? isCi(),
     version: hhuGlobalOptions.version ?? false,
   };
 }

--- a/packages/hardhat/src/internal/cli/hhu.ts
+++ b/packages/hardhat/src/internal/cli/hhu.ts
@@ -1,9 +1,6 @@
 import type { GlobalOptionDefinitions } from "../../types/global-options.js";
-import type {
-  HardhatRuntimeEnvironment,
-  Task,
-  TaskDefinition,
-} from "../../types/index.js";
+import type { HardhatRuntimeEnvironment } from "../../types/hre.js";
+import type { Task, TaskDefinition } from "../../types/tasks.js";
 
 import {
   assertHardhatInvariant,
@@ -13,9 +10,9 @@ import { isCi } from "@nomicfoundation/hardhat-utils/ci";
 import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
-import { globalFlag } from "../../config.js";
 import { isResult } from "../../utils/result.js";
 import { generateTasks } from "../builtin-plugins/hhu/tasks/index.js";
+import { globalFlag } from "../core/config.js";
 import { TaskManagerImplementation } from "../core/tasks/task-manager.js";
 import { getHardhatVersion } from "../utils/package.js";
 

--- a/packages/hardhat/src/internal/cli/hhu.ts
+++ b/packages/hardhat/src/internal/cli/hhu.ts
@@ -1,0 +1,263 @@
+import type { GlobalOptionDefinitions } from "../../types/global-options.js";
+import type {
+  HardhatRuntimeEnvironment,
+  Task,
+  TaskDefinition,
+} from "../../types/index.js";
+
+import {
+  assertHardhatInvariant,
+  HardhatError,
+} from "@nomicfoundation/hardhat-errors";
+import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
+
+import { globalFlag } from "../../config.js";
+import { isResult } from "../../utils/result.js";
+import { generateTasks } from "../builtin-plugins/hhu/tasks/index.js";
+import { TaskManagerImplementation } from "../core/tasks/task-manager.js";
+import { getHardhatVersion } from "../utils/package.js";
+
+import { printErrorMessages } from "./error-handler.js";
+import { getGlobalHelpString } from "./help/get-global-help-string.js";
+import { getHelpString } from "./help/get-help-string.js";
+import {
+  parseGlobalOptions,
+  parseRawArguments,
+  parseTask,
+  parseTaskArguments,
+} from "./parser.js";
+import { sendTaskAnalytics } from "./telemetry/analytics/analytics.js";
+import { setupGlobalUnhandledErrorHandlers } from "./telemetry/error-reporter/global-error-handlers.js";
+import { sendErrorTelemetry } from "./telemetry/error-reporter/reporter.js";
+
+interface MainOptions {
+  print?: (message: string) => void;
+  rethrowErrors?: true;
+}
+
+export async function main(
+  rawArguments: string[],
+  options: MainOptions = {},
+): Promise<void> {
+  // We set up the global unhandled errors before running any functionality
+  setupGlobalUnhandledErrorHandlers();
+
+  const print = options.print ?? console.log;
+
+  const log = createDebug("hardhat:core:hhu:main");
+
+  let hhuGlobalOptions;
+
+  log("hhu started");
+
+  try {
+    const cliArguments = parseRawArguments(rawArguments);
+
+    const usedCliArguments: boolean[] = new Array(cliArguments.length).fill(
+      false,
+    );
+
+    hhuGlobalOptions = await parseHhuGlobalOptions(
+      cliArguments,
+      usedCliArguments,
+    );
+
+    log("Parsed hhu global options");
+
+    if (hhuGlobalOptions.version) {
+      return await printHhuVersionMessage(print);
+    }
+
+    const globalOptionDefinitions: GlobalOptionDefinitions = new Map(
+      HHU_GLOBAL_OPTIONS_DEFINITIONS,
+    );
+
+    const rootTasks = taskDefinitionsToTasksMap(
+      generateTasks({ withUtils: false }),
+    );
+
+    const taskOrId = parseTask(cliArguments, usedCliArguments, rootTasks);
+
+    if (Array.isArray(taskOrId)) {
+      if (taskOrId.length === 0) {
+        const globalHelp = await getGlobalHelpString(
+          rootTasks,
+          globalOptionDefinitions,
+          { command: "hhu" },
+        );
+
+        print(globalHelp);
+        return;
+      }
+
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.TASK_DEFINITIONS.TASK_NOT_FOUND,
+        { task: taskOrId.join(" ") },
+      );
+    }
+
+    const task = taskOrId;
+
+    if (task.isEmpty && usedCliArguments.includes(false)) {
+      const invalidSubtask = cliArguments[usedCliArguments.indexOf(false)];
+
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_SUBTASK,
+        {
+          task: task.id.join(" "),
+          invalidSubtask,
+        },
+      );
+    }
+
+    if (hhuGlobalOptions.help || task.isEmpty) {
+      const taskHelp = await getHelpString(task, globalOptionDefinitions, {
+        command: "hhu",
+      });
+
+      print(taskHelp);
+      return;
+    }
+
+    const taskArguments = parseTaskArguments(
+      cliArguments,
+      usedCliArguments,
+      task,
+    );
+
+    log(`Running task "${task.id.join(" ")}"`);
+
+    const [taskResult] = await Promise.all([
+      task.run(taskArguments),
+      sendTaskAnalytics(task.id),
+    ]);
+
+    if (isResult(taskResult) && !taskResult.success) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    ensureError(error);
+    await printErrorMessages(error, hhuGlobalOptions?.showStackTraces);
+
+    try {
+      await sendErrorTelemetry(error);
+    } catch (e) {
+      log("Couldn't report error to sentry: %O", e);
+    }
+
+    if (options.rethrowErrors) {
+      throw error;
+    }
+
+    process.exitCode = 1;
+  }
+}
+
+const HHU_GLOBAL_OPTIONS_DEFINITIONS: GlobalOptionDefinitions = new Map([
+  [
+    "help",
+    {
+      pluginId: "builtin",
+      option: globalFlag({
+        name: "help",
+        shortName: "h",
+        description:
+          "Show this message, or a task's help if its name is provided.",
+      }),
+    },
+  ],
+  [
+    "showStackTraces",
+    {
+      pluginId: "builtin",
+      option: globalFlag({
+        name: "showStackTraces",
+        description: "Show stack traces (always enabled on CI servers).",
+      }),
+    },
+  ],
+  [
+    "version",
+    {
+      pluginId: "builtin",
+      option: globalFlag({
+        name: "version",
+        description: "Show the version of hhu.",
+      }),
+    },
+  ],
+]);
+
+export async function parseHhuGlobalOptions(
+  cliArguments: string[],
+  usedCliArguments: boolean[],
+): Promise<{
+  help: boolean;
+  showStackTraces: boolean;
+  version: boolean;
+}> {
+  const hhuGlobalOptions = await parseGlobalOptions(
+    HHU_GLOBAL_OPTIONS_DEFINITIONS,
+    cliArguments,
+    usedCliArguments,
+  );
+
+  return {
+    help: hhuGlobalOptions.help ?? false,
+    showStackTraces: hhuGlobalOptions.showStackTraces ?? false,
+    version: hhuGlobalOptions.version ?? false,
+  };
+}
+
+export async function printHhuVersionMessage(
+  print: (message: string) => void = console.log,
+): Promise<void> {
+  print(await getHardhatVersion());
+}
+
+function makeStrictProxy<T extends object>(
+  name: string,
+  object: Partial<T>,
+): T {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- unaccessible properties will throw an assertion error
+  return new Proxy(object as T, {
+    get(target, property) {
+      assertHardhatInvariant(
+        property in object,
+        `Unexpected access of property "${String(property)}" in ${name}.`,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- we know this is safe because of the assertion above
+      return target[property as keyof T];
+    },
+  });
+}
+
+function taskDefinitionsToTasksMap(tasks: TaskDefinition[]): Map<string, Task> {
+  // To be able to parse the hhu arguments, we need to create a tasks map from
+  // the task definitions. The easiest way to do that is by using
+  // `TaskManagerImplementation`, but this needs an HRE and we don't want to
+  // create one just for this. So we use a fake HRE that has the minimum
+  // properties needed.
+  //
+  // One downside of this approach is that we _won't_ get a compilation error
+  // if `TaskManagerImplementation` tries to access a property that doesn't exist in the
+  // fake HRE, but tests should catch that.
+  const fakeHre = makeStrictProxy<HardhatRuntimeEnvironment>(
+    "hhu's proxied HRE",
+    {
+      config: makeStrictProxy<HardhatRuntimeEnvironment["config"]>(
+        "hhu's proxied config",
+        {
+          tasks,
+          plugins: [],
+        },
+      ),
+    },
+  );
+
+  const taskManager = new TaskManagerImplementation(fakeHre, new Map());
+
+  return taskManager.rootTasks;
+}

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -233,7 +233,11 @@ export async function main(
     // This must be the first time we set it, otherwise we let it crash
     setGlobalHardhatRuntimeEnvironment(hre);
 
-    const taskOrId = parseTask(cliArguments, usedCliArguments, hre);
+    const taskOrId = parseTask(
+      cliArguments,
+      usedCliArguments,
+      hre.tasks.rootTasks,
+    );
 
     if (Array.isArray(taskOrId)) {
       if (taskOrId.length === 0) {

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -1,17 +1,8 @@
-import type {
-  GlobalOptionDefinitions,
-  GlobalOptions,
-} from "../../types/global-options.js";
-import type { HardhatRuntimeEnvironment } from "../../types/hre.js";
-import type { Task, TaskArguments } from "../../types/tasks.js";
 import type { DebugLogger } from "@nomicfoundation/hardhat-utils/debug";
 
 import { fileURLToPath } from "node:url";
 
-import {
-  HardhatError,
-  assertHardhatInvariant,
-} from "@nomicfoundation/hardhat-errors";
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
 import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
@@ -21,14 +12,8 @@ import {
   findDependencyPackageJson,
   readClosestPackageJson,
 } from "@nomicfoundation/hardhat-utils/package";
-import { kebabToCamelCase } from "@nomicfoundation/hardhat-utils/string";
 import { register } from "tsx/esm/api";
 
-import {
-  ArgumentType,
-  type OptionDefinition,
-  type PositionalArgumentDefinition,
-} from "../../types/arguments.js";
 import { isResult } from "../../utils/result.js";
 import { BUILTIN_GLOBAL_OPTIONS_DEFINITIONS } from "../builtin-global-options.js";
 import { builtinPlugins } from "../builtin-plugins/index.js";
@@ -36,18 +21,23 @@ import {
   importUserConfig,
   resolveHardhatConfigPath,
 } from "../config-loading.js";
-import { parseArgumentValue } from "../core/arguments.js";
 import { buildGlobalOptionDefinitions } from "../core/global-options.js";
 import { resolveProjectRoot } from "../core/hre.js";
 import { resolvePluginList } from "../core/plugins/resolve-plugin-list.js";
 import { warnAboutUnusedLoadedPlugins } from "../core/plugins/unused-plugins-warning.js";
-import { isArgumentRequired } from "../core/tasks/utils.js";
 import { setGlobalHardhatRuntimeEnvironment } from "../global-hre-instance.js";
 import { createHardhatRuntimeEnvironment } from "../hre-initialization.js";
 
 import { printErrorMessages } from "./error-handler.js";
 import { getGlobalHelpString } from "./help/get-global-help-string.js";
 import { getHelpString } from "./help/get-help-string.js";
+import {
+  parseBuiltinGlobalOptions,
+  parseGlobalOptions,
+  parseRawArguments,
+  parseTask,
+  parseTaskArguments,
+} from "./parser.js";
 import { sendTaskAnalytics } from "./telemetry/analytics/analytics.js";
 import { setupGlobalUnhandledErrorHandlers } from "./telemetry/error-reporter/global-error-handlers.js";
 import {
@@ -341,480 +331,6 @@ export async function main(
   }
 }
 
-export async function parseBuiltinGlobalOptions(
-  cliArguments: string[],
-  usedCliArguments: boolean[],
-): Promise<{
-  init: boolean;
-  configPath: string | undefined;
-  showStackTraces: boolean;
-  help: boolean;
-  version: boolean;
-}> {
-  let configPath: string | undefined;
-  let showStackTraces: boolean = isCi();
-  let help: boolean = false;
-  let version: boolean = false;
-  let init: boolean = false;
-
-  // TODO: Use parseGlobalOptions(BUILTIN_GLOBAL_OPTIONS_DEFINITIONS, ...) instead
-  for (let i = 0; i < cliArguments.length; i++) {
-    const arg = cliArguments[i];
-
-    if (arg === "--init") {
-      usedCliArguments[i] = true;
-      init = true;
-      continue;
-    }
-
-    if (arg === "--config") {
-      usedCliArguments[i] = true;
-
-      if (configPath !== undefined) {
-        throw new HardhatError(
-          HardhatError.ERRORS.CORE.ARGUMENTS.DUPLICATED_NAME,
-          {
-            name: "--config",
-          },
-        );
-      }
-
-      if (
-        usedCliArguments[i + 1] === undefined ||
-        usedCliArguments[i + 1] === true
-      ) {
-        throw new HardhatError(
-          HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_CONFIG_FILE,
-        );
-      }
-
-      configPath = cliArguments[i + 1];
-      i++;
-
-      usedCliArguments[i] = true;
-      continue;
-    }
-
-    if (arg === "--show-stack-traces") {
-      usedCliArguments[i] = true;
-      showStackTraces = true;
-      continue;
-    }
-
-    if (arg === "--help" || arg === "-h") {
-      usedCliArguments[i] = true;
-      help = true;
-      continue;
-    }
-
-    if (arg === "--version") {
-      usedCliArguments[i] = true;
-      version = true;
-      continue;
-    }
-  }
-
-  if (init && configPath !== undefined) {
-    throw new HardhatError(
-      HardhatError.ERRORS.CORE.ARGUMENTS.CANNOT_COMBINE_INIT_AND_CONFIG_PATH,
-    );
-  }
-
-  return { init, configPath, showStackTraces, help, version };
-}
-
-export async function parseGlobalOptions(
-  globalOptionDefinitions: GlobalOptionDefinitions,
-  cliArguments: string[],
-  usedCliArguments: boolean[],
-): Promise<Partial<GlobalOptions>> {
-  const globalOptions: Partial<GlobalOptions> = {};
-
-  const optionDefinitions = new Map(
-    [...globalOptionDefinitions].map(([key, value]) => [key, value.option]),
-  );
-
-  parseOptions(
-    cliArguments,
-    usedCliArguments,
-    optionDefinitions,
-    globalOptions,
-    true,
-  );
-
-  return globalOptions;
-}
-
-/**
- * Parses the task from the cli args.
- *
- * @returns The task, or an array with the unrecognized task id.
- * If no task id is provided, an empty array is returned.
- */
-export function parseTask(
-  cliArguments: string[],
-  usedCliArguments: boolean[],
-  hre: HardhatRuntimeEnvironment,
-): Task | string[] {
-  const taskOrId = getTaskFromCliArguments(cliArguments, usedCliArguments, hre);
-
-  return taskOrId;
-}
-
-function getTaskFromCliArguments(
-  cliArguments: string[],
-  usedCliArguments: boolean[],
-  hre: HardhatRuntimeEnvironment,
-): string[] | Task {
-  const taskId = [];
-  let task: Task | undefined;
-
-  for (let i = 0; i < cliArguments.length; i++) {
-    if (usedCliArguments[i]) {
-      continue;
-    }
-
-    const arg = cliArguments[i];
-
-    if (arg.startsWith("-")) {
-      /* A standalone '--' is ok because it is used to separate CLI tool arguments
-       * from task arguments, ensuring the tool passes subsequent options directly
-       * to the task. Everything after "--" should be considered as a positional
-       * argument. */
-      if (arg === "--" || task !== undefined) {
-        break;
-      }
-
-      /* At this point in the code, the global options have already been parsed, so
-       * the remaining options starting with '--' are task options. Hence, if no task
-       * is defined, it means that the option is not assigned to any task, and it's
-       * an error. */
-      throw new HardhatError(
-        HardhatError.ERRORS.CORE.ARGUMENTS.UNRECOGNIZED_OPTION,
-        {
-          option: arg,
-        },
-      );
-    }
-
-    if (task === undefined) {
-      try {
-        task = hre.tasks.getTask(arg);
-      } catch (_error) {
-        return [arg]; // No task found
-      }
-    } else {
-      const subtask = task.subtasks.get(arg);
-
-      if (subtask === undefined) {
-        break;
-      }
-
-      task = subtask;
-    }
-
-    usedCliArguments[i] = true;
-    taskId.push(arg);
-  }
-
-  if (task === undefined) {
-    return taskId;
-  }
-
-  return task;
-}
-
-export function parseTaskArguments(
-  cliArguments: string[],
-  usedCliArguments: boolean[],
-  task: Task,
-): TaskArguments {
-  const taskArguments: TaskArguments = {};
-
-  // Parse options
-  parseOptions(cliArguments, usedCliArguments, task.options, taskArguments);
-
-  parsePositionalAndVariadicArguments(
-    cliArguments,
-    usedCliArguments,
-    task,
-    taskArguments,
-  );
-
-  const unusedIndex = usedCliArguments.indexOf(false);
-
-  if (unusedIndex !== -1) {
-    throw new HardhatError(HardhatError.ERRORS.CORE.ARGUMENTS.UNUSED_ARGUMENT, {
-      value: cliArguments[unusedIndex],
-    });
-  }
-
-  return taskArguments;
-}
-
-/**
- * Parses the raw arguments from the command line, returning an array of
- * arguments. If an argument starts with "--" and contains "=" (i.e. "--option=123")
- * it is split into two separate arguments: the option name and the option value.
- */
-export function parseRawArguments(rawArguments: string[]): string[] {
-  return rawArguments.flatMap((arg) => {
-    if (arg.startsWith("--") && arg.includes("=")) {
-      const index = arg.indexOf("=");
-      const optionName = arg.substring(0, index);
-      const optionValue = arg.substring(index + 1);
-
-      return [optionName, optionValue];
-    }
-
-    return arg;
-  });
-}
-
-function parseOptions(
-  cliArguments: string[],
-  usedCliArguments: boolean[],
-  optionDefinitions: Map<string, OptionDefinition>,
-  providedArguments: TaskArguments,
-  ignoreUnknownOption = false,
-) {
-  const optionDefinitionsByShortName = new Map<string, OptionDefinition>();
-  for (const optionDefinition of optionDefinitions.values()) {
-    if (optionDefinition.shortName !== undefined) {
-      optionDefinitionsByShortName.set(
-        optionDefinition.shortName,
-        optionDefinition,
-      );
-    }
-  }
-
-  for (let i = 0; i < cliArguments.length; i++) {
-    if (usedCliArguments[i]) {
-      continue;
-    }
-
-    if (cliArguments[i] === "--") {
-      /* A standalone '--' is ok because it is used to separate CLI tool arguments
-       * from task arguments, ensuring the tool passes subsequent options directly
-       * to the task. Everything after "--" should be considered as a positional
-       * argument. */
-      break;
-    }
-
-    const arg = cliArguments[i];
-
-    let optionDefinition: OptionDefinition | undefined;
-
-    const providedByName = arg.startsWith("--");
-    const providedByShortName = !providedByName && arg.startsWith("-");
-
-    if (providedByName) {
-      const name = kebabToCamelCase(arg.substring(2));
-      optionDefinition = optionDefinitions.get(name);
-    } else if (providedByShortName) {
-      const shortName = arg[1];
-
-      // Check if the short name is valid
-      if (Array.from(arg.substring(1)).some((c) => c !== shortName)) {
-        throw new HardhatError(
-          HardhatError.ERRORS.CORE.ARGUMENTS.CANNOT_GROUP_OPTIONS,
-          {
-            option: arg,
-          },
-        );
-      }
-
-      optionDefinition = optionDefinitionsByShortName.get(shortName);
-    } else {
-      continue;
-    }
-
-    if (optionDefinition === undefined) {
-      if (ignoreUnknownOption === true) {
-        continue;
-      }
-
-      // Only throw an error when the argument is not a global option, because
-      // it might be a option related to a task
-      throw new HardhatError(
-        HardhatError.ERRORS.CORE.ARGUMENTS.UNRECOGNIZED_OPTION,
-        {
-          option: arg,
-        },
-      );
-    }
-
-    if (optionDefinition.hidden === true) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CORE.ARGUMENTS.NO_HIDDEN_OPTION_CLI,
-        {
-          option: arg,
-        },
-      );
-    }
-
-    const optionName = optionDefinition.name;
-
-    // Check if the short name is valid again now that we know its type
-    // E.g. --flag --flag
-    const optionAlreadyProvided = providedArguments[optionName] !== undefined;
-    // E.g. -ff
-    const shortOptionGroupedAndRepeated = providedByShortName && arg.length > 2;
-    const isLevelOption = optionDefinition.type === ArgumentType.LEVEL;
-    if (
-      optionAlreadyProvided ||
-      (shortOptionGroupedAndRepeated && !isLevelOption)
-    ) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CORE.ARGUMENTS.CANNOT_REPEAT_OPTIONS,
-        {
-          option: arg,
-          type: optionDefinition.type,
-        },
-      );
-    }
-
-    usedCliArguments[i] = true;
-
-    if (optionDefinition.type === ArgumentType.FLAG) {
-      providedArguments[optionName] = true;
-      continue;
-    } else if (
-      optionDefinition.type === ArgumentType.LEVEL &&
-      providedByShortName
-    ) {
-      providedArguments[optionName] = arg.length - 1;
-      continue;
-    } else if (
-      usedCliArguments[i + 1] !== undefined &&
-      usedCliArguments[i + 1] === false
-    ) {
-      i++;
-
-      providedArguments[optionName] = parseArgumentValue(
-        cliArguments[i],
-        optionDefinition.type,
-        optionName,
-      );
-
-      usedCliArguments[i] = true;
-
-      continue;
-    }
-
-    throw new HardhatError(
-      HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
-      {
-        argument: arg,
-      },
-    );
-  }
-}
-
-function parsePositionalAndVariadicArguments(
-  cliArguments: string[],
-  usedCliArguments: boolean[],
-  task: Task,
-  providedArguments: TaskArguments,
-) {
-  let argIndex = 0;
-
-  for (let i = 0; i < cliArguments.length; i++) {
-    if (usedCliArguments[i] === true) {
-      continue;
-    }
-
-    if (cliArguments[i] === "--") {
-      /* A standalone '--' is ok because it is used to separate CLI tool arguments
-       * from task arguments, ensuring the tool passes subsequent options directly
-       * to the task. Everything after "--" should be considered as a positional
-       * argument. */
-      usedCliArguments[i] = true;
-      continue;
-    }
-
-    const argumentDefinition = task.positionalArguments[argIndex];
-
-    if (argumentDefinition === undefined) {
-      break;
-    }
-
-    usedCliArguments[i] = true;
-
-    const formattedValue = parseArgumentValue(
-      cliArguments[i],
-      argumentDefinition.type,
-      argumentDefinition.name,
-    );
-
-    if (argumentDefinition.isVariadic === false) {
-      providedArguments[argumentDefinition.name] = formattedValue;
-      argIndex++;
-      continue;
-    }
-
-    // Handle variadic arguments. No longer increment "argIndex" because there can
-    // only be one variadic argument, and it will consume all remaining arguments.
-    providedArguments[argumentDefinition.name] =
-      providedArguments[argumentDefinition.name] ?? [];
-    const variadicTaskArg = providedArguments[argumentDefinition.name];
-    assertHardhatInvariant(
-      Array.isArray(variadicTaskArg),
-      "Variadic argument values should be an array",
-    );
-    variadicTaskArg.push(formattedValue);
-  }
-
-  // Check if all the required arguments have been used
-  validateRequiredArguments(task.positionalArguments, providedArguments);
-}
-
-function validateRequiredArguments(
-  argumentDefinitions: PositionalArgumentDefinition[],
-  taskArguments: TaskArguments,
-) {
-  const missingRequiredArgument = argumentDefinitions.find(
-    ({ defaultValue, name, type }) =>
-      isArgumentRequired(type, defaultValue) &&
-      taskArguments[name] === undefined,
-  );
-
-  if (missingRequiredArgument === undefined) {
-    return;
-  }
-
-  throw new HardhatError(
-    HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
-    { argument: missingRequiredArgument.name },
-  );
-}
-
-/**
- * Prints an error message if the user is running Hardhat on CJS mode, returning
- * `true` if the message was printed.
- */
-async function printEsmErrorMessageIfNecessary(
-  projectRoot: string,
-  print: (message: string) => void,
-): Promise<boolean> {
-  const packageJson = await readClosestPackageJson(projectRoot);
-
-  if (packageJson.type !== "module") {
-    print(`Hardhat only supports ESM projects.
-
-Please make sure you have \`"type": "module"\` in your package.json.
-
-You can set it automatically by running:
-
-npm pkg set type="module"
-`);
-
-    return true;
-  }
-
-  return false;
-}
-
 /**
  * Returns true if Hardhat is installed locally or linked from its repository,
  * by looking for it using the node module resolution logic.
@@ -825,7 +341,7 @@ npm pkg set type="module"
 async function isHardhatInstalledLocallyOrLinked(
   configPath: string,
   log: DebugLogger,
-) {
+): Promise<boolean> {
   try {
     // Based on Node.js resolution algorithm find the real path
     // of the project's version of Hardhat
@@ -855,4 +371,30 @@ async function isHardhatInstalledLocallyOrLinked(
     log("Error during installed locally/linked test", error);
     return false;
   }
+}
+
+/**
+ * Prints an error message if the user is running Hardhat on CJS mode, returning
+ * `true` if the message was printed.
+ */
+async function printEsmErrorMessageIfNecessary(
+  projectRoot: string,
+  print: (message: string) => void,
+): Promise<boolean> {
+  const packageJson = await readClosestPackageJson(projectRoot);
+
+  if (packageJson.type !== "module") {
+    print(`Hardhat only supports ESM projects.
+
+Please make sure you have \`"type": "module"\` in your package.json.
+
+You can set it automatically by running:
+
+npm pkg set type="module"
+`);
+
+    return true;
+  }
+
+  return false;
 }

--- a/packages/hardhat/src/internal/cli/parser.ts
+++ b/packages/hardhat/src/internal/cli/parser.ts
@@ -1,0 +1,469 @@
+import type {
+  GlobalOptionDefinitions,
+  GlobalOptions,
+} from "../../types/global-options.js";
+import type { HardhatRuntimeEnvironment } from "../../types/hre.js";
+import type { Task, TaskArguments } from "../../types/tasks.js";
+
+import {
+  HardhatError,
+  assertHardhatInvariant,
+} from "@nomicfoundation/hardhat-errors";
+import { isCi } from "@nomicfoundation/hardhat-utils/ci";
+import { kebabToCamelCase } from "@nomicfoundation/hardhat-utils/string";
+
+import {
+  ArgumentType,
+  type OptionDefinition,
+  type PositionalArgumentDefinition,
+} from "../../types/arguments.js";
+import { parseArgumentValue } from "../core/arguments.js";
+import { isArgumentRequired } from "../core/tasks/utils.js";
+
+export async function parseBuiltinGlobalOptions(
+  cliArguments: string[],
+  usedCliArguments: boolean[],
+): Promise<{
+  init: boolean;
+  configPath: string | undefined;
+  showStackTraces: boolean;
+  help: boolean;
+  version: boolean;
+}> {
+  let configPath: string | undefined;
+  let showStackTraces: boolean = isCi();
+  let help: boolean = false;
+  let version: boolean = false;
+  let init: boolean = false;
+
+  // TODO: Use parseGlobalOptions(BUILTIN_GLOBAL_OPTIONS_DEFINITIONS, ...) instead
+  for (let i = 0; i < cliArguments.length; i++) {
+    const arg = cliArguments[i];
+
+    if (arg === "--init") {
+      usedCliArguments[i] = true;
+      init = true;
+      continue;
+    }
+
+    if (arg === "--config") {
+      usedCliArguments[i] = true;
+
+      if (configPath !== undefined) {
+        throw new HardhatError(
+          HardhatError.ERRORS.CORE.ARGUMENTS.DUPLICATED_NAME,
+          {
+            name: "--config",
+          },
+        );
+      }
+
+      if (
+        usedCliArguments[i + 1] === undefined ||
+        usedCliArguments[i + 1] === true
+      ) {
+        throw new HardhatError(
+          HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_CONFIG_FILE,
+        );
+      }
+
+      configPath = cliArguments[i + 1];
+      i++;
+
+      usedCliArguments[i] = true;
+      continue;
+    }
+
+    if (arg === "--show-stack-traces") {
+      usedCliArguments[i] = true;
+      showStackTraces = true;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      usedCliArguments[i] = true;
+      help = true;
+      continue;
+    }
+
+    if (arg === "--version") {
+      usedCliArguments[i] = true;
+      version = true;
+      continue;
+    }
+  }
+
+  if (init && configPath !== undefined) {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.ARGUMENTS.CANNOT_COMBINE_INIT_AND_CONFIG_PATH,
+    );
+  }
+
+  return { init, configPath, showStackTraces, help, version };
+}
+
+export async function parseGlobalOptions(
+  globalOptionDefinitions: GlobalOptionDefinitions,
+  cliArguments: string[],
+  usedCliArguments: boolean[],
+): Promise<Partial<GlobalOptions>> {
+  const globalOptions: Partial<GlobalOptions> = {};
+
+  const optionDefinitions = new Map(
+    [...globalOptionDefinitions].map(([key, value]) => [key, value.option]),
+  );
+
+  parseOptions(
+    cliArguments,
+    usedCliArguments,
+    optionDefinitions,
+    globalOptions,
+    true,
+  );
+
+  return globalOptions;
+}
+
+/**
+ * Parses the task from the cli args.
+ *
+ * @returns The task, or an array with the unrecognized task id.
+ * If no task id is provided, an empty array is returned.
+ */
+export function parseTask(
+  cliArguments: string[],
+  usedCliArguments: boolean[],
+  hre: HardhatRuntimeEnvironment,
+): Task | string[] {
+  const taskOrId = getTaskFromCliArguments(cliArguments, usedCliArguments, hre);
+
+  return taskOrId;
+}
+
+function getTaskFromCliArguments(
+  cliArguments: string[],
+  usedCliArguments: boolean[],
+  hre: HardhatRuntimeEnvironment,
+): string[] | Task {
+  const taskId = [];
+  let task: Task | undefined;
+
+  for (let i = 0; i < cliArguments.length; i++) {
+    if (usedCliArguments[i]) {
+      continue;
+    }
+
+    const arg = cliArguments[i];
+
+    if (arg.startsWith("-")) {
+      /* A standalone '--' is ok because it is used to separate CLI tool arguments
+       * from task arguments, ensuring the tool passes subsequent options directly
+       * to the task. Everything after "--" should be considered as a positional
+       * argument. */
+      if (arg === "--" || task !== undefined) {
+        break;
+      }
+
+      /* At this point in the code, the global options have already been parsed, so
+       * the remaining options starting with '--' are task options. Hence, if no task
+       * is defined, it means that the option is not assigned to any task, and it's
+       * an error. */
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.ARGUMENTS.UNRECOGNIZED_OPTION,
+        {
+          option: arg,
+        },
+      );
+    }
+
+    if (task === undefined) {
+      try {
+        task = hre.tasks.getTask(arg);
+      } catch (_error) {
+        return [arg]; // No task found
+      }
+    } else {
+      const subtask = task.subtasks.get(arg);
+
+      if (subtask === undefined) {
+        break;
+      }
+
+      task = subtask;
+    }
+
+    usedCliArguments[i] = true;
+    taskId.push(arg);
+  }
+
+  if (task === undefined) {
+    return taskId;
+  }
+
+  return task;
+}
+
+export function parseTaskArguments(
+  cliArguments: string[],
+  usedCliArguments: boolean[],
+  task: Task,
+): TaskArguments {
+  const taskArguments: TaskArguments = {};
+
+  // Parse options
+  parseOptions(cliArguments, usedCliArguments, task.options, taskArguments);
+
+  parsePositionalAndVariadicArguments(
+    cliArguments,
+    usedCliArguments,
+    task,
+    taskArguments,
+  );
+
+  const unusedIndex = usedCliArguments.indexOf(false);
+
+  if (unusedIndex !== -1) {
+    throw new HardhatError(HardhatError.ERRORS.CORE.ARGUMENTS.UNUSED_ARGUMENT, {
+      value: cliArguments[unusedIndex],
+    });
+  }
+
+  return taskArguments;
+}
+
+/**
+ * Parses the raw arguments from the command line, returning an array of
+ * arguments. If an argument starts with "--" and contains "=" (i.e. "--option=123")
+ * it is split into two separate arguments: the option name and the option value.
+ */
+export function parseRawArguments(rawArguments: string[]): string[] {
+  return rawArguments.flatMap((arg) => {
+    if (arg.startsWith("--") && arg.includes("=")) {
+      const index = arg.indexOf("=");
+      const optionName = arg.substring(0, index);
+      const optionValue = arg.substring(index + 1);
+
+      return [optionName, optionValue];
+    }
+
+    return arg;
+  });
+}
+
+function parseOptions(
+  cliArguments: string[],
+  usedCliArguments: boolean[],
+  optionDefinitions: Map<string, OptionDefinition>,
+  providedArguments: TaskArguments,
+  ignoreUnknownOption = false,
+) {
+  const optionDefinitionsByShortName = new Map<string, OptionDefinition>();
+  for (const optionDefinition of optionDefinitions.values()) {
+    if (optionDefinition.shortName !== undefined) {
+      optionDefinitionsByShortName.set(
+        optionDefinition.shortName,
+        optionDefinition,
+      );
+    }
+  }
+
+  for (let i = 0; i < cliArguments.length; i++) {
+    if (usedCliArguments[i]) {
+      continue;
+    }
+
+    if (cliArguments[i] === "--") {
+      /* A standalone '--' is ok because it is used to separate CLI tool arguments
+       * from task arguments, ensuring the tool passes subsequent options directly
+       * to the task. Everything after "--" should be considered as a positional
+       * argument. */
+      break;
+    }
+
+    const arg = cliArguments[i];
+
+    let optionDefinition: OptionDefinition | undefined;
+
+    const providedByName = arg.startsWith("--");
+    const providedByShortName = !providedByName && arg.startsWith("-");
+
+    if (providedByName) {
+      const name = kebabToCamelCase(arg.substring(2));
+      optionDefinition = optionDefinitions.get(name);
+    } else if (providedByShortName) {
+      const shortName = arg[1];
+
+      // Check if the short name is valid
+      if (Array.from(arg.substring(1)).some((c) => c !== shortName)) {
+        throw new HardhatError(
+          HardhatError.ERRORS.CORE.ARGUMENTS.CANNOT_GROUP_OPTIONS,
+          {
+            option: arg,
+          },
+        );
+      }
+
+      optionDefinition = optionDefinitionsByShortName.get(shortName);
+    } else {
+      continue;
+    }
+
+    if (optionDefinition === undefined) {
+      if (ignoreUnknownOption === true) {
+        continue;
+      }
+
+      // Only throw an error when the argument is not a global option, because
+      // it might be a option related to a task
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.ARGUMENTS.UNRECOGNIZED_OPTION,
+        {
+          option: arg,
+        },
+      );
+    }
+
+    if (optionDefinition.hidden === true) {
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.ARGUMENTS.NO_HIDDEN_OPTION_CLI,
+        {
+          option: arg,
+        },
+      );
+    }
+
+    const optionName = optionDefinition.name;
+
+    // Check if the short name is valid again now that we know its type
+    // E.g. --flag --flag
+    const optionAlreadyProvided = providedArguments[optionName] !== undefined;
+    // E.g. -ff
+    const shortOptionGroupedAndRepeated = providedByShortName && arg.length > 2;
+    const isLevelOption = optionDefinition.type === ArgumentType.LEVEL;
+    if (
+      optionAlreadyProvided ||
+      (shortOptionGroupedAndRepeated && !isLevelOption)
+    ) {
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.ARGUMENTS.CANNOT_REPEAT_OPTIONS,
+        {
+          option: arg,
+          type: optionDefinition.type,
+        },
+      );
+    }
+
+    usedCliArguments[i] = true;
+
+    if (optionDefinition.type === ArgumentType.FLAG) {
+      providedArguments[optionName] = true;
+      continue;
+    } else if (
+      optionDefinition.type === ArgumentType.LEVEL &&
+      providedByShortName
+    ) {
+      providedArguments[optionName] = arg.length - 1;
+      continue;
+    } else if (
+      usedCliArguments[i + 1] !== undefined &&
+      usedCliArguments[i + 1] === false
+    ) {
+      i++;
+
+      providedArguments[optionName] = parseArgumentValue(
+        cliArguments[i],
+        optionDefinition.type,
+        optionName,
+      );
+
+      usedCliArguments[i] = true;
+
+      continue;
+    }
+
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+      {
+        argument: arg,
+      },
+    );
+  }
+}
+
+function parsePositionalAndVariadicArguments(
+  cliArguments: string[],
+  usedCliArguments: boolean[],
+  task: Task,
+  providedArguments: TaskArguments,
+) {
+  let argIndex = 0;
+
+  for (let i = 0; i < cliArguments.length; i++) {
+    if (usedCliArguments[i] === true) {
+      continue;
+    }
+
+    if (cliArguments[i] === "--") {
+      /* A standalone '--' is ok because it is used to separate CLI tool arguments
+       * from task arguments, ensuring the tool passes subsequent options directly
+       * to the task. Everything after "--" should be considered as a positional
+       * argument. */
+      usedCliArguments[i] = true;
+      continue;
+    }
+
+    const argumentDefinition = task.positionalArguments[argIndex];
+
+    if (argumentDefinition === undefined) {
+      break;
+    }
+
+    usedCliArguments[i] = true;
+
+    const formattedValue = parseArgumentValue(
+      cliArguments[i],
+      argumentDefinition.type,
+      argumentDefinition.name,
+    );
+
+    if (argumentDefinition.isVariadic === false) {
+      providedArguments[argumentDefinition.name] = formattedValue;
+      argIndex++;
+      continue;
+    }
+
+    // Handle variadic arguments. No longer increment "argIndex" because there can
+    // only be one variadic argument, and it will consume all remaining arguments.
+    providedArguments[argumentDefinition.name] =
+      providedArguments[argumentDefinition.name] ?? [];
+    const variadicTaskArg = providedArguments[argumentDefinition.name];
+    assertHardhatInvariant(
+      Array.isArray(variadicTaskArg),
+      "Variadic argument values should be an array",
+    );
+    variadicTaskArg.push(formattedValue);
+  }
+
+  // Check if all the required arguments have been used
+  validateRequiredArguments(task.positionalArguments, providedArguments);
+}
+
+function validateRequiredArguments(
+  argumentDefinitions: PositionalArgumentDefinition[],
+  taskArguments: TaskArguments,
+) {
+  const missingRequiredArgument = argumentDefinitions.find(
+    ({ defaultValue, name, type }) =>
+      isArgumentRequired(type, defaultValue) &&
+      taskArguments[name] === undefined,
+  );
+
+  if (missingRequiredArgument === undefined) {
+    return;
+  }
+
+  throw new HardhatError(
+    HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+    { argument: missingRequiredArgument.name },
+  );
+}

--- a/packages/hardhat/src/internal/cli/parser.ts
+++ b/packages/hardhat/src/internal/cli/parser.ts
@@ -2,7 +2,6 @@ import type {
   GlobalOptionDefinitions,
   GlobalOptions,
 } from "../../types/global-options.js";
-import type { HardhatRuntimeEnvironment } from "../../types/hre.js";
 import type { Task, TaskArguments } from "../../types/tasks.js";
 
 import {
@@ -133,9 +132,13 @@ export async function parseGlobalOptions(
 export function parseTask(
   cliArguments: string[],
   usedCliArguments: boolean[],
-  hre: HardhatRuntimeEnvironment,
+  tasksMap: Map<string, Task>,
 ): Task | string[] {
-  const taskOrId = getTaskFromCliArguments(cliArguments, usedCliArguments, hre);
+  const taskOrId = getTaskFromCliArguments(
+    cliArguments,
+    usedCliArguments,
+    tasksMap,
+  );
 
   return taskOrId;
 }
@@ -143,7 +146,7 @@ export function parseTask(
 function getTaskFromCliArguments(
   cliArguments: string[],
   usedCliArguments: boolean[],
-  hre: HardhatRuntimeEnvironment,
+  tasksMap: Map<string, Task>,
 ): string[] | Task {
   const taskId = [];
   let task: Task | undefined;
@@ -177,9 +180,9 @@ function getTaskFromCliArguments(
     }
 
     if (task === undefined) {
-      try {
-        task = hre.tasks.getTask(arg);
-      } catch (_error) {
+      task = tasksMap.get(arg);
+
+      if (task === undefined) {
         return [arg]; // No task found
       }
     } else {

--- a/packages/hardhat/test/internal/builtin-plugins/hhu/tasks/constants.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/hhu/tasks/constants.ts
@@ -1,0 +1,38 @@
+import type { HardhatRuntimeEnvironment } from "../../../../../src/types/hre.js";
+
+import assert from "node:assert/strict";
+import { afterEach, before, beforeEach, describe, it } from "node:test";
+
+import { createHardhatRuntimeEnvironment } from "../../../../../src/internal/hre-initialization.js";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+describe("hhu utils constants tasks", () => {
+  let hre: HardhatRuntimeEnvironment;
+
+  let logs: string[] = [];
+  const originalLog = console.log;
+
+  before(async () => {
+    hre = await createHardhatRuntimeEnvironment({}, {}, process.cwd());
+  });
+
+  beforeEach(() => {
+    logs = [];
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(" "));
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  describe("zeroAddress", () => {
+    it("prints the zero address", async () => {
+      await hre.tasks.getTask(["utils", "constants", "zeroAddress"]).run({});
+
+      assert.deepEqual(logs, [ZERO_ADDRESS]);
+    });
+  });
+});

--- a/packages/hardhat/test/internal/cli/hhu.ts
+++ b/packages/hardhat/test/internal/cli/hhu.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { styleText } from "node:util";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import {
+  assertRejectsWithHardhatError,
+  assertThrowsHardhatError,
+} from "@nomicfoundation/hardhat-test-utils";
+import { isCi } from "@nomicfoundation/hardhat-utils/ci";
+
+import { main, parseHhuGlobalOptions } from "../../../src/internal/cli/hhu.js";
+import { createHardhatRuntimeEnvironment } from "../../../src/internal/hre-initialization.js";
+import { getHardhatVersion } from "../../../src/internal/utils/package.js";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+async function runHhu(command: string): Promise<string[]> {
+  const lines: string[] = [];
+
+  const cliArguments = command.split(" ").slice(2);
+
+  await main(cliArguments, {
+    print: (message) => {
+      lines.push(message);
+    },
+    rethrowErrors: true,
+  });
+
+  return lines;
+}
+
+describe("hhu", () => {
+  describe("main", () => {
+    describe("--version", () => {
+      it("should print the version and instantly return", async () => {
+        const lines = await runHhu("npx hhu --version");
+
+        assert.deepEqual(lines, [await getHardhatVersion()]);
+      });
+    });
+
+    describe("global help", () => {
+      it("should print the hhu global help with un-prefixed tasks", async () => {
+        const help = (await runHhu("npx hhu")).join("");
+
+        const expected = `Hardhat version ${await getHardhatVersion()}
+
+Usage: hhu [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUMENTS]
+
+AVAILABLE SUBTASKS:
+
+  constants zeroAddress      Print the zero address
+
+GLOBAL OPTIONS:
+
+  --help, -h                 Show this message, or a task's help if its name is provided
+  --show-stack-traces        Show stack traces (always enabled on CI servers)
+  --version                  Show the version of hhu
+
+To get help for a specific task run: npx hhu <TASK> [SUBTASK] --help`;
+
+        assert.equal(help, expected);
+      });
+    });
+
+    describe("task help", () => {
+      it("should print the help for an empty task (namespace)", async () => {
+        const help = (await runHhu("npx hhu constants --help")).join("");
+
+        const expected = `${styleText("bold", "Commonly used Ethereum constants")}
+
+Usage: hhu [GLOBAL OPTIONS] constants <SUBTASK> [SUBTASK OPTIONS] [--] [SUBTASK POSITIONAL ARGUMENTS]
+
+AVAILABLE SUBTASKS:
+
+  constants zeroAddress      Print the zero address
+
+GLOBAL OPTIONS:
+
+  --help, -h                 Show this message, or a task's help if its name is provided
+  --show-stack-traces        Show stack traces (always enabled on CI servers)
+  --version                  Show the version of hhu
+
+To get help for a specific task run: npx hhu constants <SUBTASK> --help`;
+
+        assert.equal(help, expected);
+      });
+
+      it("should print the help for a task with an action", async () => {
+        const help = (
+          await runHhu("npx hhu constants zeroAddress --help")
+        ).join("");
+
+        const expected = `${styleText("bold", "Print the zero address")}
+
+Usage: hhu [GLOBAL OPTIONS] constants zeroAddress
+
+GLOBAL OPTIONS:
+
+  --help, -h               Show this message, or a task's help if its name is provided
+  --show-stack-traces      Show stack traces (always enabled on CI servers)
+  --version                Show the version of hhu
+`;
+
+        assert.equal(help, expected);
+      });
+    });
+
+    describe("errors", () => {
+      it("should throw when the task does not exist", async () => {
+        await assertRejectsWithHardhatError(
+          () => runHhu("npx hhu nonExistentTask"),
+          HardhatError.ERRORS.CORE.TASK_DEFINITIONS.TASK_NOT_FOUND,
+          { task: "nonExistentTask" },
+        );
+      });
+
+      it("should throw when the subtask does not exist", async () => {
+        await assertRejectsWithHardhatError(
+          () => runHhu("npx hhu constants nonExistentSubtask"),
+          HardhatError.ERRORS.CORE.TASK_DEFINITIONS.UNRECOGNIZED_SUBTASK,
+          { task: "constants", invalidSubtask: "nonExistentSubtask" },
+        );
+      });
+    });
+  });
+
+  describe("parseHhuGlobalOptions", () => {
+    it("should set hhu's global options", async () => {
+      const command = "npx hhu --help --version --show-stack-traces";
+      const cliArguments = command.split(" ").slice(2);
+      const usedCliArguments = new Array(cliArguments.length).fill(false);
+
+      const hhuGlobalOptions = await parseHhuGlobalOptions(
+        cliArguments,
+        usedCliArguments,
+      );
+
+      assert.deepEqual(usedCliArguments, [true, true, true]);
+      assert.deepEqual(hhuGlobalOptions, {
+        help: true,
+        showStackTraces: true,
+        version: true,
+      });
+    });
+
+    it("should not set any of hhu's global options", async () => {
+      const hhuGlobalOptions = await parseHhuGlobalOptions([], []);
+
+      assert.deepEqual(hhuGlobalOptions, {
+        help: false,
+        showStackTraces: isCi(),
+        version: false,
+      });
+    });
+  });
+
+  describe("utils prefix", () => {
+    it("should not be used by hhu, while Hardhat does not expose the un-prefixed tasks", async () => {
+      // hhu must NOT understand the Hardhat-style `utils` prefix.
+      await assertRejectsWithHardhatError(
+        () => runHhu("npx hhu utils constants zeroAddress"),
+        HardhatError.ERRORS.CORE.TASK_DEFINITIONS.TASK_NOT_FOUND,
+        { task: "utils" },
+      );
+
+      // Hardhat must NOT understand the hhu-style un-prefixed task.
+      const hre = await createHardhatRuntimeEnvironment({}, {}, process.cwd());
+      assertThrowsHardhatError(
+        () => hre.tasks.getTask(["constants", "zeroAddress"]),
+        HardhatError.ERRORS.CORE.TASK_DEFINITIONS.TASK_NOT_FOUND,
+        { task: "constants" },
+      );
+    });
+  });
+
+  describe("smoke tests", () => {
+    let logs: string[] = [];
+    const originalLog = console.log;
+
+    beforeEach(() => {
+      logs = [];
+      console.log = (...args: unknown[]) => {
+        logs.push(args.join(" "));
+      };
+    });
+
+    afterEach(() => {
+      console.log = originalLog;
+    });
+
+    it("`constants zeroAddress` should print the zero address", async () => {
+      await runHhu("npx hhu constants zeroAddress");
+
+      assert.deepEqual(logs, [ZERO_ADDRESS]);
+    });
+  });
+});

--- a/packages/hardhat/test/internal/cli/main.ts
+++ b/packages/hardhat/test/internal/cli/main.ts
@@ -24,14 +24,14 @@ import {
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
 
 import { getTemplates } from "../../../src/internal/cli/init/template.js";
+import { main } from "../../../src/internal/cli/main.js";
 import {
-  main,
   parseGlobalOptions,
   parseBuiltinGlobalOptions,
   parseTask,
   parseTaskArguments,
   parseRawArguments,
-} from "../../../src/internal/cli/main.js";
+} from "../../../src/internal/cli/parser.js";
 import {
   globalOption,
   globalFlag,

--- a/packages/hardhat/test/internal/cli/main.ts
+++ b/packages/hardhat/test/internal/cli/main.ts
@@ -284,6 +284,7 @@ AVAILABLE TASKS:
 AVAILABLE SUBTASKS:
 
   test solidity            Run the Solidity tests
+  utils constants          Commonly used Ethereum constants
 
 GLOBAL OPTIONS:
 

--- a/packages/hardhat/test/internal/cli/main.ts
+++ b/packages/hardhat/test/internal/cli/main.ts
@@ -877,7 +877,11 @@ GLOBAL OPTIONS:
           taskArguments: TaskArguments;
         }
       | string[] {
-      const parsedTask = parseTask(cliArguments, usedCliArguments, hreLocal);
+      const parsedTask = parseTask(
+        cliArguments,
+        usedCliArguments,
+        hreLocal.tasks.rootTasks,
+      );
       if (Array.isArray(parsedTask)) {
         return parsedTask;
       }


### PR DESCRIPTION
This PR adds the scaffolding needed to start building Hardhat's low-level utils. Each util can be invoked in two ways:

- As a built-in Hardhat task: `hardhat utils constants zeroAddress`
- Through a new standalone binary (name TBD): `hhu constants zeroAddress`

Note the `hhu` invocation drops the `utils` prefix; other than that, both expose the same tasks and flags.

There's only one util so far, `constants zeroAddress`, which I used as the forcing function to get the plugin and the binary working end to end.

I split the PR into commits that should be easy to review on their own. The first one can be skipped since it just moves some parsing functionality from `cli/main.ts` to a separate module so that `cli/hhu.ts` can use them.

## Implementation notes

- **The `hhu` built-in plugin** defines the utils as tasks. This is the source of truth for the utils. There is some trickery here to have the `utils` prefix for the built-in tasks but to omit it when the tasks are loaded from `hhu`.
- **The `hhu` binary doesn't create an HRE** for performance reasons. A fake HRE is then passed to `TaskManagerImplementation` to build the tasks from the definitions improted from the built-in plugin.