### PR TITLE
Add BattleChain mainnet (626) and testnet (627) chain descriptors

### DIFF
--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/chain-descriptors.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/chain-descriptors.ts
@@ -327,6 +327,36 @@ export const DEFAULT_CHAIN_DESCRIPTORS: ChainDescriptorsConfig = new Map([
       },
     },
   ],
+  // battlechain mainnet
+  [
+    626n,
+    {
+      name: "BattleChain Mainnet",
+      chainType: GENERIC_CHAIN_TYPE,
+      blockExplorers: {
+        blockscout: {
+          name: "BattleChain Explorer",
+          url: "https://explorer.battlechain.com",
+          apiUrl: "https://block-explorer-api.battlechain.com/api",
+        },
+      },
+    },
+  ],
+  // battlechain testnet
+  [
+    627n,
+    {
+      name: "BattleChain Testnet",
+      chainType: GENERIC_CHAIN_TYPE,
+      blockExplorers: {
+        blockscout: {
+          name: "BattleChain Explorer",
+          url: "https://explorer.testnet.battlechain.com",
+          apiUrl: "https://block-explorer-api.testnet.battlechain.com/api",
+        },
+      },
+    },
+  ],
   // binance smart chain mainnet
   [
     56n,


### PR DESCRIPTION
Adds chain descriptors for BattleChain mainnet (626) and testnet (627).

BattleChain is a ZKsync-based Ethereum L2. Its block explorer runs matter-labs/block-explorer, which exposes an Etherscan-compatible verification API (`?module=&action=` request format). That API is wired through the `blockscout` descriptor slot, whose request format matches.