### PR TITLE
Add `convert pad` util

### DIFF
--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -915,6 +915,24 @@ Please double check your arguments.`,
 
 Use "--init --template <name>" to initialize a project with a specific template, or "--init --templates" to list the available templates.`,
       },
+      MUTUALLY_EXCLUSIVE_OPTIONS: {
+        number: 514,
+        messageTemplate:
+          'The options "--{optionA}" and "--{optionB}" cannot be used together',
+        websiteTitle: "Mutually exclusive options",
+        websiteDescription: `You are trying to use two options that cannot be used together.
+
+Please double check your arguments.`,
+      },
+      INVALID_VALUE: {
+        number: 515,
+        messageTemplate:
+          'Invalid value "{value}" for argument "{name}": {reason}',
+        websiteTitle: "Invalid argument value",
+        websiteDescription: `One of the arguments you provided has an invalid value.
+
+Please double check your arguments.`,
+      },
     },
     BUILTIN_TASKS: {
       RUN_FILE_NOT_FOUND: {

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/convert/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/convert/index.ts
@@ -1,0 +1,41 @@
+import type { TaskDefinition } from "../../../../../types/tasks.js";
+import type { GenerateTasksOptions } from "../index.js";
+
+import { ArgumentType } from "../../../../../types/arguments.js";
+import { emptyTask, task } from "../../../../core/config.js";
+
+export function convert({ withUtils }: GenerateTasksOptions): TaskDefinition[] {
+  const prefix = withUtils ? ["utils"] : [];
+
+  const convertTask = emptyTask(
+    [...prefix, "convert"],
+    "Convert values between common Ethereum representations",
+  ).build();
+
+  const padTask = task(
+    [...prefix, "convert", "pad"],
+    "Pad a hex string to a given byte length",
+  )
+    .addPositionalArgument({
+      name: "value",
+      description: "The hex string to pad",
+    })
+    .addOption({
+      name: "length",
+      description: "The target length, in bytes",
+      type: ArgumentType.INT,
+      defaultValue: 32,
+    })
+    .addFlag({
+      name: "left",
+      description: "Pad to the left (default)",
+    })
+    .addFlag({
+      name: "right",
+      description: "Pad to the right",
+    })
+    .setAction(async () => await import("./pad.js"))
+    .build();
+
+  return [convertTask, padTask];
+}

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/convert/pad.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/convert/pad.ts
@@ -26,6 +26,14 @@ const padAction: NewTaskActionFunction<PadActionArguments> = async ({
     );
   }
 
+  if (length < 0) {
+    throw new HardhatError(HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE, {
+      value: length,
+      name: "length",
+      reason: "it must be a non-negative integer",
+    });
+  }
+
   if (!isHexString(value)) {
     throw new HardhatError(
       HardhatError.ERRORS.CORE.GENERAL.INVALID_HEX_STRING,

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/convert/pad.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/convert/pad.ts
@@ -1,0 +1,53 @@
+import type { NewTaskActionFunction } from "../../../../../types/tasks.js";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import {
+  getUnprefixedHexString,
+  isHexString,
+} from "@nomicfoundation/hardhat-utils/hex";
+
+interface PadActionArguments {
+  value: string;
+  length: number;
+  left: boolean;
+  right: boolean;
+}
+
+const padAction: NewTaskActionFunction<PadActionArguments> = async ({
+  value,
+  length,
+  left,
+  right,
+}) => {
+  if (left && right) {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.ARGUMENTS.MUTUALLY_EXCLUSIVE_OPTIONS,
+      { optionA: "left", optionB: "right" },
+    );
+  }
+
+  if (!isHexString(value)) {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_HEX_STRING,
+      { value },
+    );
+  }
+
+  const unprefixedHexString = getUnprefixedHexString(value);
+
+  if (unprefixedHexString.length > length * 2) {
+    throw new HardhatError(HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE, {
+      value,
+      name: "value",
+      reason: `it's longer than the target length of ${length} bytes`,
+    });
+  }
+
+  const paddedHexString = right
+    ? unprefixedHexString.padEnd(length * 2, "0")
+    : unprefixedHexString.padStart(length * 2, "0");
+
+  console.log(`0x${paddedHexString}`);
+};
+
+export default padAction;

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/index.ts
@@ -3,6 +3,7 @@ import type { TaskDefinition } from "../../../../types/tasks.js";
 import { emptyTask } from "../../../core/config.js";
 
 import { constants } from "./constants/index.js";
+import { convert } from "./convert/index.js";
 
 export interface GenerateTasksOptions {
   /**
@@ -19,5 +20,6 @@ export function generateTasks(options: GenerateTasksOptions): TaskDefinition[] {
       ? [emptyTask("utils", "Utilities for common Ethereum tasks").build()]
       : []),
     ...constants(options),
+    ...convert(options),
   ];
 }

--- a/packages/hardhat/test/internal/builtin-plugins/hhu/tasks/convert.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/hhu/tasks/convert.ts
@@ -1,0 +1,91 @@
+import type { HardhatRuntimeEnvironment } from "../../../../../src/types/hre.js";
+
+import assert from "node:assert/strict";
+import { afterEach, before, beforeEach, describe, it } from "node:test";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
+
+import { createHardhatRuntimeEnvironment } from "../../../../../src/internal/hre-initialization.js";
+
+describe("hhu utils convert tasks", () => {
+  let hre: HardhatRuntimeEnvironment;
+
+  let logs: string[] = [];
+  const originalLog = console.log;
+
+  before(async () => {
+    hre = await createHardhatRuntimeEnvironment({}, {}, process.cwd());
+  });
+
+  beforeEach(() => {
+    logs = [];
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(" "));
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  describe("pad", () => {
+    async function runPad(taskArguments: Record<string, unknown>) {
+      await hre.tasks.getTask(["utils", "convert", "pad"]).run(taskArguments);
+    }
+
+    it("pads to the left to 32 bytes by default", async () => {
+      await runPad({ value: "ff" });
+
+      assert.deepEqual(logs, [
+        "0x00000000000000000000000000000000000000000000000000000000000000ff",
+      ]);
+    });
+
+    it("accepts values with the 0x prefix", async () => {
+      await runPad({ value: "0xff", length: 8 });
+
+      assert.deepEqual(logs, ["0x00000000000000ff"]);
+    });
+
+    it("pads to the left when the left flag is used", async () => {
+      await runPad({ value: "ff", length: 8, left: true });
+
+      assert.deepEqual(logs, ["0x00000000000000ff"]);
+    });
+
+    it("pads to the right when the right flag is used", async () => {
+      await runPad({ value: "0xff", length: 4, right: true });
+
+      assert.deepEqual(logs, ["0xff000000"]);
+    });
+
+    it("throws when both the left and right flags are used", async () => {
+      await assertRejectsWithHardhatError(
+        runPad({ value: "ff", left: true, right: true }),
+        HardhatError.ERRORS.CORE.ARGUMENTS.MUTUALLY_EXCLUSIVE_OPTIONS,
+        { optionA: "left", optionB: "right" },
+      );
+    });
+
+    it("throws when the value is not a valid hex string", async () => {
+      await assertRejectsWithHardhatError(
+        runPad({ value: "0xnothex" }),
+        HardhatError.ERRORS.CORE.GENERAL.INVALID_HEX_STRING,
+        { value: "0xnothex" },
+      );
+    });
+
+    it("throws when the value is longer than the target length", async () => {
+      await assertRejectsWithHardhatError(
+        runPad({ value: "0xffffff", length: 2 }),
+        HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE,
+        {
+          value: "0xffffff",
+          name: "value",
+          reason: "it's longer than the target length of 2 bytes",
+        },
+      );
+    });
+  });
+});

--- a/packages/hardhat/test/internal/builtin-plugins/hhu/tasks/convert.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/hhu/tasks/convert.ts
@@ -1,3 +1,4 @@
+// cSpell:ignore 0xnothex
 import type { HardhatRuntimeEnvironment } from "../../../../../src/types/hre.js";
 
 import assert from "node:assert/strict";

--- a/packages/hardhat/test/internal/builtin-plugins/hhu/tasks/convert.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/hhu/tasks/convert.ts
@@ -88,5 +88,23 @@ describe("hhu utils convert tasks", () => {
         },
       );
     });
+
+    it("throws when the length is negative", async () => {
+      await assertRejectsWithHardhatError(
+        runPad({ value: "ff", length: -1 }),
+        HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE,
+        {
+          value: -1,
+          name: "length",
+          reason: "it must be a non-negative integer",
+        },
+      );
+    });
+
+    it("accepts a length of 0 for an empty value", async () => {
+      await runPad({ value: "0x", length: 0 });
+
+      assert.deepEqual(logs, ["0x"]);
+    });
   });
 });

--- a/packages/hardhat/test/internal/cli/hhu.ts
+++ b/packages/hardhat/test/internal/cli/hhu.ts
@@ -51,6 +51,7 @@ Usage: hhu [GLOBAL OPTIONS] <TASK> [SUBTASK] [TASK OPTIONS] [--] [TASK ARGUMENTS
 AVAILABLE SUBTASKS:
 
   constants zeroAddress      Print the zero address
+  convert pad                Pad a hex string to a given byte length
 
 GLOBAL OPTIONS:
 
@@ -194,6 +195,18 @@ GLOBAL OPTIONS:
       await runHhu("npx hhu constants zeroAddress");
 
       assert.deepEqual(logs, [ZERO_ADDRESS]);
+    });
+
+    it("`convert pad` should pad to the left by default", async () => {
+      await runHhu("npx hhu convert pad --length 8 ff");
+
+      assert.deepEqual(logs, ["0x00000000000000ff"]);
+    });
+
+    it("`convert pad --right` should pad to the right", async () => {
+      await runHhu("npx hhu convert pad --length 4 --right 0xff");
+
+      assert.deepEqual(logs, ["0xff000000"]);
     });
   });
 });

--- a/packages/hardhat/test/internal/cli/main.ts
+++ b/packages/hardhat/test/internal/cli/main.ts
@@ -285,6 +285,7 @@ AVAILABLE SUBTASKS:
 
   test solidity            Run the Solidity tests
   utils constants          Commonly used Ethereum constants
+  utils convert            Convert values between common Ethereum representations
 
 GLOBAL OPTIONS:
 


### PR DESCRIPTION
Depends on https://github.com/NomicFoundation/hardhat/pull/8386

Adds the `convert pad` util, to validate that arguments and options work correctly.