### PR TITLE
Add `fetch block-number` utils task

### DIFF
--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/constants/zero-address.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/constants/zero-address.ts
@@ -1,8 +1,8 @@
-import type { NewTaskActionFunction } from "../../../../../types/tasks.js";
+import type { NewUtilsTaskActionFunction } from "../../types.js";
 
 const zeroAddress = "0x0000000000000000000000000000000000000000";
 
-const zeroAddressAction: NewTaskActionFunction = async () => {
+const zeroAddressAction: NewUtilsTaskActionFunction = async () => {
   console.log(zeroAddress);
 };
 

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/convert/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/convert/index.ts
@@ -1,10 +1,13 @@
-import type { TaskDefinition } from "../../../../../types/tasks.js";
+import type { UtilsTaskDefinition } from "../../types.js";
 import type { GenerateTasksOptions } from "../index.js";
 
 import { ArgumentType } from "../../../../../types/arguments.js";
 import { emptyTask, task } from "../../../../core/config.js";
+import { buildUtilsTask } from "../utils-task.js";
 
-export function convert({ withUtils }: GenerateTasksOptions): TaskDefinition[] {
+export function convert({
+  withUtils,
+}: GenerateTasksOptions): UtilsTaskDefinition[] {
   const prefix = withUtils ? ["utils"] : [];
 
   const convertTask = emptyTask(
@@ -12,30 +15,31 @@ export function convert({ withUtils }: GenerateTasksOptions): TaskDefinition[] {
     "Convert values between common Ethereum representations",
   ).build();
 
-  const padTask = task(
-    [...prefix, "convert", "pad"],
-    "Pad a hex string to a given byte length",
-  )
-    .addPositionalArgument({
-      name: "value",
-      description: "The hex string to pad",
-    })
-    .addOption({
-      name: "length",
-      description: "The target length, in bytes",
-      type: ArgumentType.INT,
-      defaultValue: 32,
-    })
-    .addFlag({
-      name: "left",
-      description: "Pad to the left (default)",
-    })
-    .addFlag({
-      name: "right",
-      description: "Pad to the right",
-    })
-    .setAction(async () => await import("./pad.js"))
-    .build();
+  const padTask = buildUtilsTask(
+    task(
+      [...prefix, "convert", "pad"],
+      "Pad a hex string to a given byte length",
+    )
+      .addPositionalArgument({
+        name: "value",
+        description: "The hex string to pad",
+      })
+      .addOption({
+        name: "length",
+        description: "The target length, in bytes",
+        type: ArgumentType.INT,
+        defaultValue: 32,
+      })
+      .addFlag({
+        name: "left",
+        description: "Pad to the left (default)",
+      })
+      .addFlag({
+        name: "right",
+        description: "Pad to the right",
+      }),
+    async () => await import("./pad.js"),
+  );
 
   return [convertTask, padTask];
 }

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/convert/pad.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/convert/pad.ts
@@ -1,4 +1,4 @@
-import type { NewTaskActionFunction } from "../../../../../types/tasks.js";
+import type { NewUtilsTaskActionFunction } from "../../types.js";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
@@ -13,7 +13,7 @@ interface PadActionArguments {
   right: boolean;
 }
 
-const padAction: NewTaskActionFunction<PadActionArguments> = async ({
+const padAction: NewUtilsTaskActionFunction<PadActionArguments> = async ({
   value,
   length,
   left,

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/fetch/block-number.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/fetch/block-number.ts
@@ -1,0 +1,28 @@
+import type { NewUtilsTaskActionFunction } from "../../types.js";
+
+import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
+import { hexStringToBigInt } from "@nomicfoundation/hardhat-utils/hex";
+
+const fetchBlockNumberAction: NewUtilsTaskActionFunction = async (
+  _taskArguments,
+  hre,
+) => {
+  const connection = await hre.network.create();
+
+  try {
+    const blockNumber = await connection.provider.request({
+      method: "eth_blockNumber",
+    });
+
+    assertHardhatInvariant(
+      typeof blockNumber === "string",
+      "eth_blockNumber should return a string",
+    );
+
+    console.log(hexStringToBigInt(blockNumber).toString());
+  } finally {
+    await connection.close();
+  }
+};
+
+export default fetchBlockNumberAction;

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/fetch/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/fetch/index.ts
@@ -4,20 +4,20 @@ import type { GenerateTasksOptions } from "../index.js";
 import { emptyTask, task } from "../../../../core/config.js";
 import { buildUtilsTask } from "../utils-task.js";
 
-export function constants({
+export function fetch({
   withUtils,
 }: GenerateTasksOptions): UtilsTaskDefinition[] {
   const prefix = withUtils ? ["utils"] : [];
 
-  const constantsTask = emptyTask(
-    [...prefix, "constants"],
-    "Commonly used Ethereum constants",
+  const fetchTask = emptyTask(
+    [...prefix, "fetch"],
+    "Fetch on-chain data",
   ).build();
 
-  const zeroAddressTask = buildUtilsTask(
-    task([...prefix, "constants", "zeroAddress"], "Print the zero address"),
-    async () => await import("./zero-address.js"),
+  const blockNumberTask = buildUtilsTask(
+    task([...prefix, "fetch", "block-number"], "Print the latest block number"),
+    async () => await import("./block-number.js"),
   );
 
-  return [constantsTask, zeroAddressTask];
+  return [fetchTask, blockNumberTask];
 }

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/index.ts
@@ -1,9 +1,10 @@
-import type { TaskDefinition } from "../../../../types/tasks.js";
+import type { UtilsTaskDefinition } from "../types.js";
 
 import { emptyTask } from "../../../core/config.js";
 
 import { constants } from "./constants/index.js";
 import { convert } from "./convert/index.js";
+import { fetch } from "./fetch/index.js";
 
 export interface GenerateTasksOptions {
   /**
@@ -14,12 +15,15 @@ export interface GenerateTasksOptions {
   withUtils: boolean;
 }
 
-export function generateTasks(options: GenerateTasksOptions): TaskDefinition[] {
+export function generateTasks(
+  options: GenerateTasksOptions,
+): UtilsTaskDefinition[] {
   return [
     ...(options.withUtils
       ? [emptyTask("utils", "Utilities for common Ethereum tasks").build()]
       : []),
     ...constants(options),
     ...convert(options),
+    ...fetch(options),
   ];
 }

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/utils-task.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/tasks/utils-task.ts
@@ -1,0 +1,29 @@
+import type {
+  LazyActionObject,
+  NewTaskDefinitionBuilder,
+  TaskArguments,
+} from "../../../../types/tasks.js";
+import type {
+  NewUtilsTaskActionFunction,
+  NewUtilsTaskDefinition,
+} from "../types.js";
+
+/**
+ * Builds a utils task from a configured task builder and a lazily-loaded action.
+ *
+ * The standard builder's `setAction`/`build` are hardcoded to
+ * `NewTaskActionFunction`, so it can't produce a `NewUtilsTaskDefinition` on its
+ * own. This helper requires the action to be a `NewUtilsTaskActionFunction`
+ * (rejecting wider actions at the call site), which is what makes re-narrowing
+ * the built definition sound.
+ */
+export function buildUtilsTask<TaskArgumentsT extends TaskArguments>(
+  builder: NewTaskDefinitionBuilder<TaskArgumentsT>,
+  action: LazyActionObject<NewUtilsTaskActionFunction<TaskArgumentsT>>,
+): NewUtilsTaskDefinition {
+  // The narrower action is assignable to the builder's `NewTaskActionFunction`,
+  // and since `action` is statically a `NewUtilsTaskActionFunction`, re-narrowing
+  // the result is safe.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- see above
+  return builder.setAction(action).build() as NewUtilsTaskDefinition;
+}

--- a/packages/hardhat/src/internal/builtin-plugins/hhu/types.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/hhu/types.ts
@@ -1,0 +1,57 @@
+import type { HardhatRuntimeEnvironment } from "../../../types/hre.js";
+import type { NetworkManager } from "../../../types/network.js";
+import type {
+  BaseTaskDefinition,
+  EmptyTaskDefinition,
+  LazyActionObject,
+  TaskArguments,
+} from "../../../types/tasks.js";
+
+/**
+ * The subset of the HRE that utils tasks are allowed to use.
+ *
+ * It is narrowed to what the hhu binary can provide without always creating
+ * a real HRE.
+ */
+export interface UtilsHardhatRuntimeEnvironment {
+  network: Pick<NetworkManager, "create">;
+}
+
+/**
+ * The fake HRE that the hhu binary builds so it can parse and run utils without
+ * creating a real one. It's the surface utils actions use
+ * ({@link UtilsHardhatRuntimeEnvironment}) plus the `config` that
+ * `TaskManagerImplementation` needs to build the task map.
+ */
+export interface FakeHhuHardhatRuntimeEnvironment
+  extends UtilsHardhatRuntimeEnvironment {
+  config: Pick<HardhatRuntimeEnvironment["config"], "tasks" | "plugins">;
+}
+
+/**
+ * The type of a utils task's action function.
+ *
+ * It mirrors `NewTaskActionFunction`, but the HRE passed as the second argument
+ * is narrowed to `UtilsHardhatRuntimeEnvironment` so that utils tasks only
+ * depend on the small surface that both the Hardhat CLI and the hhu binary can
+ * provide.
+ */
+export type NewUtilsTaskActionFunction<
+  TaskArgumentsT extends TaskArguments = TaskArguments,
+> = (taskArguments: TaskArgumentsT, hre: UtilsHardhatRuntimeEnvironment) => any;
+
+/**
+ * The definition of a utils task.
+ *
+ * It mirrors `NewTaskDefinition`, but narrows that action to a
+ * `NewUtilsTaskActionFunction`.
+ */
+export type NewUtilsTaskDefinition = BaseTaskDefinition & {
+  action: LazyActionObject<NewUtilsTaskActionFunction>;
+};
+
+/**
+ * The subset of `TaskDefinition` that utils tasks produce: either an empty task
+ * (a namespace placeholder) or a utils task. Override tasks are not supported.
+ */
+export type UtilsTaskDefinition = EmptyTaskDefinition | NewUtilsTaskDefinition;

--- a/packages/hardhat/src/internal/cli/hhu.ts
+++ b/packages/hardhat/src/internal/cli/hhu.ts
@@ -1,6 +1,7 @@
 import type { GlobalOptionDefinitions } from "../../types/global-options.js";
 import type { HardhatRuntimeEnvironment } from "../../types/hre.js";
 import type { Task, TaskDefinition } from "../../types/tasks.js";
+import type { FakeHhuHardhatRuntimeEnvironment } from "../builtin-plugins/hhu/types.js";
 
 import {
   assertHardhatInvariant,
@@ -8,11 +9,13 @@ import {
 } from "@nomicfoundation/hardhat-errors";
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
 import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
+import { setGlobalOptionsAsEnvVariables } from "@nomicfoundation/hardhat-utils/env";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
+import { ArgumentType } from "../../types/arguments.js";
 import { isResult } from "../../utils/result.js";
 import { generateTasks } from "../builtin-plugins/hhu/tasks/index.js";
-import { globalFlag } from "../core/config.js";
+import { globalFlag, globalOption } from "../core/config.js";
 import { TaskManagerImplementation } from "../core/tasks/task-manager.js";
 import { getHardhatVersion } from "../utils/package.js";
 
@@ -60,6 +63,10 @@ export async function main(
       cliArguments,
       usedCliArguments,
     );
+
+    // We need to do this so that the global options are available when we import
+    // the HRE in utils that need it.
+    setGlobalOptionsAsEnvVariables(hhuGlobalOptions);
 
     log("Parsed hhu global options");
 
@@ -185,6 +192,18 @@ const HHU_GLOBAL_OPTIONS_DEFINITIONS: GlobalOptionDefinitions = new Map([
       }),
     },
   ],
+  [
+    "network",
+    {
+      pluginId: "builtin",
+      option: globalOption({
+        name: "network",
+        description: "The network to connect to",
+        type: ArgumentType.STRING_WITHOUT_DEFAULT,
+        defaultValue: undefined,
+      }),
+    },
+  ],
 ]);
 
 export async function parseHhuGlobalOptions(
@@ -194,6 +213,7 @@ export async function parseHhuGlobalOptions(
   help: boolean;
   showStackTraces: boolean;
   version: boolean;
+  network: string | undefined;
 }> {
   const hhuGlobalOptions = await parseGlobalOptions(
     HHU_GLOBAL_OPTIONS_DEFINITIONS,
@@ -205,6 +225,7 @@ export async function parseHhuGlobalOptions(
     help: hhuGlobalOptions.help ?? false,
     showStackTraces: hhuGlobalOptions.showStackTraces ?? isCi(),
     version: hhuGlobalOptions.version ?? false,
+    network: hhuGlobalOptions.network,
   };
 }
 
@@ -239,9 +260,16 @@ function taskDefinitionsToTasksMap(tasks: TaskDefinition[]): Map<string, Task> {
   // create one just for this. So we use a fake HRE that has the minimum
   // properties needed.
   //
+  // The exception is `network.create`: utils that need a network get the real
+  // implementation, which lazily loads Hardhat (and thus creates the project's
+  // HRE) only when such a util actually runs.
+  //
   // One downside of this approach is that we _won't_ get a compilation error
   // if `TaskManagerImplementation` tries to access a property that doesn't exist in the
   // fake HRE, but tests should catch that.
+  //
+  // The `satisfies FakeHhuHardhatRuntimeEnvironment` keeps this fake HRE in sync
+  // with the surface utils actions rely on.
   const fakeHre = makeStrictProxy<HardhatRuntimeEnvironment>(
     "hhu's proxied HRE",
     {
@@ -252,7 +280,16 @@ function taskDefinitionsToTasksMap(tasks: TaskDefinition[]): Map<string, Task> {
           plugins: [],
         },
       ),
-    },
+      network: makeStrictProxy<HardhatRuntimeEnvironment["network"]>(
+        "hhu's proxied network",
+        {
+          create: async (networkOrParams) => {
+            const hre = await import("../../index.js");
+            return await hre.network.create(networkOrParams);
+          },
+        },
+      ),
+    } satisfies FakeHhuHardhatRuntimeEnvironment,
   );
 
   const taskManager = new TaskManagerImplementation(

--- a/packages/hardhat/src/internal/cli/hhu.ts
+++ b/packages/hardhat/src/internal/cli/hhu.ts
@@ -1,6 +1,7 @@
 import type { GlobalOptionDefinitions } from "../../types/global-options.js";
 import type { HardhatRuntimeEnvironment } from "../../types/hre.js";
 import type { Task, TaskDefinition } from "../../types/tasks.js";
+import type { FakeHhuHardhatRuntimeEnvironment } from "../builtin-plugins/hhu/types.js";
 
 import {
   assertHardhatInvariant,
@@ -8,11 +9,13 @@ import {
 } from "@nomicfoundation/hardhat-errors";
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
 import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
+import { setGlobalOptionsAsEnvVariables } from "@nomicfoundation/hardhat-utils/env";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
+import { ArgumentType } from "../../types/arguments.js";
 import { isResult } from "../../utils/result.js";
 import { generateTasks } from "../builtin-plugins/hhu/tasks/index.js";
-import { globalFlag } from "../core/config.js";
+import { globalFlag, globalOption } from "../core/config.js";
 import { TaskManagerImplementation } from "../core/tasks/task-manager.js";
 import { getHardhatVersion } from "../utils/package.js";
 
@@ -60,6 +63,10 @@ export async function main(
       cliArguments,
       usedCliArguments,
     );
+
+    // We need to do this so that the global options are available when we import
+    // the HRE in utils that need it.
+    setGlobalOptionsAsEnvVariables(hhuGlobalOptions);
 
     log("Parsed hhu global options");
 
@@ -185,6 +192,18 @@ const HHU_GLOBAL_OPTIONS_DEFINITIONS: GlobalOptionDefinitions = new Map([
       }),
     },
   ],
+  [
+    "network",
+    {
+      pluginId: "builtin",
+      option: globalOption({
+        name: "network",
+        description: "The network to connect to",
+        type: ArgumentType.STRING_WITHOUT_DEFAULT,
+        defaultValue: undefined,
+      }),
+    },
+  ],
 ]);
 
 export async function parseHhuGlobalOptions(
@@ -194,6 +213,7 @@ export async function parseHhuGlobalOptions(
   help: boolean;
   showStackTraces: boolean;
   version: boolean;
+  network: string | undefined;
 }> {
   const hhuGlobalOptions = await parseGlobalOptions(
     HHU_GLOBAL_OPTIONS_DEFINITIONS,
@@ -205,6 +225,7 @@ export async function parseHhuGlobalOptions(
     help: hhuGlobalOptions.help ?? false,
     showStackTraces: hhuGlobalOptions.showStackTraces ?? isCi(),
     version: hhuGlobalOptions.version ?? false,
+    network: hhuGlobalOptions.network,
   };
 }
 
@@ -239,9 +260,16 @@ function taskDefinitionsToTasksMap(tasks: TaskDefinition[]): Map<string, Task> {
   // create one just for this. So we use a fake HRE that has the minimum
   // properties needed.
   //
+  // The exception is `network.create`: utils that need a network get the real
+  // implementation, which lazily loads Hardhat (and thus creates the project's
+  // HRE) only when such a util actually runs.
+  //
   // One downside of this approach is that we _won't_ get a compilation error
   // if `TaskManagerImplementation` tries to access a property that doesn't exist in the
   // fake HRE, but tests should catch that.
+  //
+  // The `satisfies FakeHhuHardhatRuntimeEnvironment` keeps this fake HRE in sync
+  // with the surface utils actions rely on.
   const fakeHre = makeStrictProxy<HardhatRuntimeEnvironment>(
     "hhu's proxied HRE",
     {
@@ -252,7 +280,16 @@ function taskDefinitionsToTasksMap(tasks: TaskDefinition[]): Map<string, Task> {
           plugins: [],
         },
       ),
-    },
+      network: makeStrictProxy<HardhatRuntimeEnvironment["network"]>(
+        "hhu's proxied network",
+        {
+          create: async (networkOrParams) => {
+            const hre = await import("../../index.js");
+            return await hre.network.create(networkOrParams);
+          },
+        },
+      ),
+    } satisfies FakeHhuHardhatRuntimeEnvironment,
   );
 
   const taskManager = new TaskManagerImplementation(fakeHre, new Map());

--- a/packages/hardhat/test/internal/builtin-plugins/hhu/tasks/fetch.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/hhu/tasks/fetch.ts
@@ -1,0 +1,37 @@
+import type { HardhatRuntimeEnvironment } from "../../../../../src/types/hre.js";
+
+import assert from "node:assert/strict";
+import { afterEach, before, beforeEach, describe, it } from "node:test";
+
+import { createHardhatRuntimeEnvironment } from "../../../../../src/internal/hre-initialization.js";
+
+describe("hhu utils fetch tasks", () => {
+  let hre: HardhatRuntimeEnvironment;
+
+  let logs: string[] = [];
+  const originalLog = console.log;
+
+  before(async () => {
+    hre = await createHardhatRuntimeEnvironment({}, {}, process.cwd());
+  });
+
+  beforeEach(() => {
+    logs = [];
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(" "));
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  describe("block-number", () => {
+    it("prints the latest block number of the default network", async () => {
+      await hre.tasks.getTask(["utils", "fetch", "block-number"]).run({});
+
+      assert.equal(logs.length, 1);
+      assert.match(logs[0], /^\d+$/);
+    });
+  });
+});

--- a/packages/hardhat/test/internal/cli/hhu.ts
+++ b/packages/hardhat/test/internal/cli/hhu.ts
@@ -6,10 +6,12 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
   assertRejectsWithHardhatError,
   assertThrowsHardhatError,
+  useFixtureProject,
 } from "@nomicfoundation/hardhat-test-utils";
 import { isCi } from "@nomicfoundation/hardhat-utils/ci";
 
 import { main, parseHhuGlobalOptions } from "../../../src/internal/cli/hhu.js";
+import { resetGlobalHardhatRuntimeEnvironment } from "../../../src/internal/global-hre-instance.js";
 import { createHardhatRuntimeEnvironment } from "../../../src/internal/hre-initialization.js";
 import { getHardhatVersion } from "../../../src/internal/utils/package.js";
 
@@ -52,10 +54,12 @@ AVAILABLE SUBTASKS:
 
   constants zeroAddress      Print the zero address
   convert pad                Pad a hex string to a given byte length
+  fetch block-number         Print the latest block number
 
 GLOBAL OPTIONS:
 
   --help, -h                 Show this message, or a task's help if its name is provided
+  --network                  The network to connect to
   --show-stack-traces        Show stack traces (always enabled on CI servers)
   --version                  Show the version of hhu
 
@@ -80,6 +84,7 @@ AVAILABLE SUBTASKS:
 GLOBAL OPTIONS:
 
   --help, -h                 Show this message, or a task's help if its name is provided
+  --network                  The network to connect to
   --show-stack-traces        Show stack traces (always enabled on CI servers)
   --version                  Show the version of hhu
 
@@ -100,6 +105,7 @@ Usage: hhu [GLOBAL OPTIONS] constants zeroAddress
 GLOBAL OPTIONS:
 
   --help, -h               Show this message, or a task's help if its name is provided
+  --network                The network to connect to
   --show-stack-traces      Show stack traces (always enabled on CI servers)
   --version                Show the version of hhu
 `;
@@ -143,6 +149,7 @@ GLOBAL OPTIONS:
         help: true,
         showStackTraces: true,
         version: true,
+        network: undefined,
       });
     });
 
@@ -153,6 +160,26 @@ GLOBAL OPTIONS:
         help: false,
         showStackTraces: isCi(),
         version: false,
+        network: undefined,
+      });
+    });
+
+    it("should set the network option to the given value", async () => {
+      const command = "npx hhu --network sepolia";
+      const cliArguments = command.split(" ").slice(2);
+      const usedCliArguments = new Array(cliArguments.length).fill(false);
+
+      const hhuGlobalOptions = await parseHhuGlobalOptions(
+        cliArguments,
+        usedCliArguments,
+      );
+
+      assert.deepEqual(usedCliArguments, [true, true]);
+      assert.deepEqual(hhuGlobalOptions, {
+        help: false,
+        showStackTraces: isCi(),
+        version: false,
+        network: "sepolia",
       });
     });
   });
@@ -207,6 +234,25 @@ GLOBAL OPTIONS:
       await runHhu("npx hhu convert pad --length 4 --right 0xff");
 
       assert.deepEqual(logs, ["0xff000000"]);
+    });
+
+    // This util needs a network, which exercises the fake HRE's `network.create`
+    // (it lazily loads Hardhat and creates the real HRE). That requires a real
+    // project, so we run it from a fixture project.
+    describe("`fetch block-number`", () => {
+      useFixtureProject("cli/parsing/base-project");
+
+      afterEach(() => {
+        // `network.create` creates the global HRE; reset it so it doesn't leak.
+        resetGlobalHardhatRuntimeEnvironment();
+      });
+
+      it("should print the latest block number", async () => {
+        await runHhu("npx hhu fetch block-number");
+
+        assert.equal(logs.length, 1);
+        assert.match(logs[0], /^\d+$/);
+      });
     });
   });
 });

--- a/packages/hardhat/test/internal/cli/main.ts
+++ b/packages/hardhat/test/internal/cli/main.ts
@@ -286,6 +286,7 @@ AVAILABLE SUBTASKS:
   test solidity            Run the Solidity tests
   utils constants          Commonly used Ethereum constants
   utils convert            Convert values between common Ethereum representations
+  utils fetch              Fetch on-chain data
 
 GLOBAL OPTIONS:
 


### PR DESCRIPTION
Depends on https://github.com/NomicFoundation/hardhat/pull/8388

Adds a `fetch block-number` util. This requires some significant architectural changes, which I'll try to explain.

## Using a network

We discussed with @alcuadrado the best way in which utils can specify the network, and we decided to... just use `--network`. This has the downside that you can't specify a URL in the command line itself, but that can be an orthogonal feature that we add later to Hardhat core (for example by making `--network` accept URLs, or by adding a `--network-url` option that is incompatible with `--network`).

This means that the task action needs to do `hre.network.create`, but in previous PRs we were explicitly not passing an HRE to utils tasks. Since we still don't want to create an HRE for every util (most of them won't need it), what we do is to lazily load the actual HRE when `network.create` is called in the fake HRE that `hhu` passes to tasks.

## Type-safety

This approach means that utils can only use a subset of the `HRE`; namely, they can only use `network.create` (and `config.tasks` and `config.plugins`, but those are added mainly for the `TaskManagerImplementation` to create the tasks from the task definitions). Some type trickery is done to guarantee that you get a compilation error if you try to use something else. This is easier to understand by looking at the `hhu/types.ts` file. The core idea here is that there are some `Utils`-flavored type that narrow the HRE and the actions that use it.

## The global network option in hhu

The `--network` option is added by the built-in network manager plugin, so it's not available in hhu. I simply added it as an extra global in the hhu code. Ideally this option would be exported from the network manager plugin and used from hhu, to avoid duplication. But I'm running out of time here so I didn't do it, and I don't think that option is going to be changing all the time. Still, consider it technical debt.