### PR TITLE
fix: honor compiler type in build info recompilation

### DIFF
--- a/.changeset/healthy-build-infos-compile.md
+++ b/.changeset/healthy-build-infos-compile.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Use the compiler type recorded in Solidity build info files when recompiling them.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -73,7 +73,6 @@ import {
 import { loadCache, saveCache } from "./cache.js";
 import { sortCompilationJobsByDescendingCost } from "./compilation-job-cost.js";
 import { CompilationJobImplementation } from "./compilation-job.js";
-import { downloadSolcCompilers, getCompiler } from "./compiler/index.js";
 import { buildDependencyGraph } from "./dependency-graph-building.js";
 import { readSourceFileFactory } from "./read-source-file.js";
 import {
@@ -1327,18 +1326,36 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     options?: CompileBuildInfoOptions,
   ): Promise<CompilerOutput> {
     const quiet = options?.quiet ?? false;
+    // We need to cast because build infos can come from Hardhat setups with
+    // plugin-defined compiler types that aren't registered in the current type
+    // definitions.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- See comment above
+    const compilerConfig = {
+      type: buildInfo.compilerType ?? "solc",
+      version: buildInfo.solcVersion,
+      settings: buildInfo.input.settings,
+    } as SolidityCompilerConfig;
 
-    // Build info recompilation is always solc-only: build info files are
-    // produced by solc and must be recompiled with the same solc version.
-    // We bypass both downloadCompilers and getCompiler hooks — this is a
-    // self-contained solc replay path, not plugin-configurable compilation.
-    await downloadSolcCompilers(new Set([buildInfo.solcVersion]), quiet);
+    await this.#hooks.runParallelHandlers("solidity", "downloadCompilers", [
+      [compilerConfig],
+      quiet,
+    ]);
 
-    const compiler = await getCompiler(buildInfo.solcVersion, {
-      preferWasm: false,
-    });
+    const compiler = await this.#hooks.runHandlerChain(
+      "solidity",
+      "getCompiler",
+      [compilerConfig],
+      async (_context, cfg) => await getSolcCompilerForConfig(cfg, false),
+    );
 
-    return await compiler.compile(buildInfo.input);
+    return await this.#hooks.runHandlerChain(
+      "solidity",
+      "invokeSolc",
+      [compiler, buildInfo.input, compilerConfig],
+      async (_context, nextCompiler, nextSolcInput) => {
+        return await nextCompiler.compile(nextSolcInput);
+      },
+    );
   }
 
   async #downloadConfiguredCompilers(quiet = false): Promise<void> {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1,6 +1,7 @@
 import type { SolidityConfig } from "../../../../../src/types/config.js";
 import type { HookContext } from "../../../../../src/types/hooks.js";
 import type {
+  Compiler,
   SolidityBuildInfo,
   SolidityBuildInfoOutput,
   SolidityBuildSystem,
@@ -571,6 +572,93 @@ describe(
           output.errors.some((e) => e.severity === "error"),
           "Output should have at least one error",
         );
+      });
+
+      it("should use the compiler type from the build info", async () => {
+        const hooks = new HookManagerImplementation(process.cwd(), []);
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We don't care about hooks in this context
+        hooks.setContext({} as HookContext);
+
+        let downloadedCompilerType: string | undefined;
+        let invokedCompilerType: string | undefined;
+
+        const customCompiler: Compiler = {
+          version: "0.8.22",
+          longVersion: "0.8.22+custom",
+          compilerPath: "custom-compiler",
+          isSolcJs: false,
+          compile: async () => ({
+            sources: {
+              "Custom.sol": {
+                id: 0,
+                ast: {},
+              },
+            },
+          }),
+        };
+
+        hooks.registerHandlers("solidity", {
+          downloadCompilers: async (_context, compilerConfigs) => {
+            downloadedCompilerType = compilerConfigs[0].type;
+          },
+          getCompiler: async (_context, compilerConfig) => {
+            assert.equal(compilerConfig.type, "custom");
+            return customCompiler;
+          },
+          invokeSolc: async (
+            _context,
+            compiler,
+            solcInput,
+            solcConfig,
+            next,
+          ) => {
+            invokedCompilerType = solcConfig.type;
+            return await next(_context, compiler, solcInput, solcConfig);
+          },
+        });
+
+        const customSolidity = new SolidityBuildSystemImplementation(hooks, {
+          solidityConfig,
+          projectRoot: process.cwd(),
+          soliditySourcesPaths: [path.join(process.cwd(), "contracts")],
+          artifactsPath: actualArtifactsPath,
+          cachePath: actualCachePath,
+          solidityTestsPath: path.join(process.cwd(), "tests"),
+          coverage: false,
+        });
+
+        const buildInfo: SolidityBuildInfo = {
+          _format: "hh3-sol-build-info-1",
+          id: "custom-build-info",
+          solcVersion: "0.8.22",
+          solcLongVersion: "0.8.22+custom",
+          compilerType: "custom",
+          userSourceNameMap: { "Custom.sol": "Custom.sol" },
+          input: {
+            language: "Solidity",
+            sources: {
+              "Custom.sol": {
+                content: "contract Custom {}",
+              },
+            },
+            settings: {
+              optimizer: { enabled: false, runs: 200 },
+              outputSelection: {
+                "*": {
+                  "*": ["abi", "evm.bytecode"],
+                },
+              },
+            },
+          },
+        };
+
+        const output = await customSolidity.compileBuildInfo(buildInfo, {
+          quiet: true,
+        });
+
+        assert.equal(downloadedCompilerType, "custom");
+        assert.equal(invokedCompilerType, "custom");
+        assert.deepEqual(Object.keys(output.sources), ["Custom.sol"]);
       });
     });
   },


### PR DESCRIPTION
## Summary
- Rebuilds Solidity build-info files through the compiler hook pipeline instead of hard-coding solc.
- Preserves the `compilerType` recorded in the build info when selecting/downloading/invoking the compiler.

## Why
Build infos produced by plugin-provided compiler types include the compiler type in their metadata, but `compileBuildInfo` replayed every build info with solc. This made the API unusable for non-solc build infos.

## Changes
- Construct a compiler config from the build info's `compilerType`, version, and input settings.
- Use the existing `downloadCompilers`, `getCompiler`, and `invokeSolc` hooks for build-info recompilation.
- Add a regression test with a custom compiler type.
- Add a patch changeset.

## Validation
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts`
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts`
- `cd packages/hardhat && pnpm lint && pnpm build`

## Scope
Focused on `SolidityBuildSystemImplementation#compileBuildInfo`; normal compilation job creation/execution is unchanged.

Closes #8081
