### PR TITLE
feat: support glob compiler overrides

### DIFF
--- a/.changeset/shy-overrides-glob.md
+++ b/.changeset/shy-overrides-glob.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Support glob patterns in Solidity compiler overrides.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts
@@ -11,6 +11,7 @@ import { shortenPath } from "@nomicfoundation/hardhat-utils/path";
 import { intersects, maxSatisfying, satisfies } from "semver";
 
 import { CompilationJobCreationErrorReason } from "../../../../types/solidity/build-system.js";
+import { matchesAnyGlob } from "../../../utils/glob.js";
 
 export class SolcConfigSelector {
   readonly #buildProfileName: string;
@@ -62,7 +63,7 @@ export class SolcConfigSelector {
 
     const versionRange = Array.from(new Set(allVersionPragmas)).join(" ");
 
-    const overriddenCompiler = this.#buildProfile.overrides[userSourceName];
+    const overriddenCompiler = this.#getOverriddenCompiler(userSourceName);
 
     // if there's an override, we only check that
     if (overriddenCompiler !== undefined) {
@@ -101,6 +102,26 @@ export class SolcConfigSelector {
     );
 
     return { success: true, config: matchingConfig };
+  }
+
+  #getOverriddenCompiler(
+    userSourceName: string,
+  ): SolidityCompilerConfig | undefined {
+    const exactMatch = this.#buildProfile.overrides[userSourceName];
+
+    if (exactMatch !== undefined) {
+      return exactMatch;
+    }
+
+    for (const [overridePattern, compilerConfig] of Object.entries(
+      this.#buildProfile.overrides,
+    )) {
+      if (matchesAnyGlob(userSourceName, [overridePattern])) {
+        return compilerConfig;
+      }
+    }
+
+    return undefined;
   }
 
   /**

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts
@@ -116,6 +116,100 @@ describe("SolcConfigSelector", () => {
         });
       });
 
+      it("should return the compiler if a glob override satisfies the version range", () => {
+        root = createProjectResolvedFile("contracts/Token.sol", ["^0.8.0"]);
+        dependencyGraph = new DependencyGraphImplementation();
+        dependencyGraph.addRootFile(root.inputSourceName, root);
+
+        buildProfile.overrides["contracts/**/*.sol"] = {
+          version: "0.8.1",
+          settings: {},
+        };
+
+        const selector = new SolcConfigSelector(buildProfileName, buildProfile);
+        const config =
+          selector.selectBestSolcConfigForSingleRootGraph(dependencyGraph);
+
+        assert.deepEqual(config, {
+          success: true,
+          config: buildProfile.overrides["contracts/**/*.sol"],
+        });
+      });
+
+      it("should prefer an exact override over a glob override", () => {
+        root = createProjectResolvedFile("contracts/Token.sol", ["^0.8.0"]);
+        dependencyGraph = new DependencyGraphImplementation();
+        dependencyGraph.addRootFile(root.inputSourceName, root);
+
+        buildProfile.overrides["contracts/**/*.sol"] = {
+          version: "0.8.1",
+          settings: {},
+        };
+        buildProfile.overrides[root.inputSourceName] = {
+          version: "0.8.2",
+          settings: {},
+        };
+
+        const selector = new SolcConfigSelector(buildProfileName, buildProfile);
+        const config =
+          selector.selectBestSolcConfigForSingleRootGraph(dependencyGraph);
+
+        assert.deepEqual(config, {
+          success: true,
+          config: buildProfile.overrides[root.inputSourceName],
+        });
+      });
+
+      it("should use the first matching glob override", () => {
+        root = createProjectResolvedFile("contracts/nested/Token.sol", [
+          "^0.8.0",
+        ]);
+        dependencyGraph = new DependencyGraphImplementation();
+        dependencyGraph.addRootFile(root.inputSourceName, root);
+
+        buildProfile.overrides["contracts/**/*.sol"] = {
+          version: "0.8.1",
+          settings: {},
+        };
+        buildProfile.overrides["contracts/nested/*.sol"] = {
+          version: "0.8.2",
+          settings: {},
+        };
+
+        const selector = new SolcConfigSelector(buildProfileName, buildProfile);
+        const config =
+          selector.selectBestSolcConfigForSingleRootGraph(dependencyGraph);
+
+        assert.deepEqual(config, {
+          success: true,
+          config: buildProfile.overrides["contracts/**/*.sol"],
+        });
+      });
+
+      it("should fall back to the configured compilers if no glob override matches", () => {
+        root = createProjectResolvedFile("scripts/Token.sol", ["^0.8.0"]);
+        dependencyGraph = new DependencyGraphImplementation();
+        dependencyGraph.addRootFile(root.inputSourceName, root);
+
+        buildProfile.overrides["contracts/**/*.sol"] = {
+          version: "0.8.1",
+          settings: {},
+        };
+        buildProfile.compilers.push({
+          version: "0.8.2",
+          settings: {},
+        });
+
+        const selector = new SolcConfigSelector(buildProfileName, buildProfile);
+        const config =
+          selector.selectBestSolcConfigForSingleRootGraph(dependencyGraph);
+
+        assert.deepEqual(config, {
+          success: true,
+          config: buildProfile.compilers[0],
+        });
+      });
+
       it("should return the compiler if it satisfies the version range of root and dependencies", () => {
         buildProfile.overrides[root.inputSourceName] = {
           version: "0.8.5",


### PR DESCRIPTION
## Summary
- Allows Solidity compiler override keys to use existing Hardhat glob matching.
- Keeps exact file overrides preferred over glob overrides.

## Why
Compiler overrides currently have to enumerate every file. Supporting patterns like `contracts/**/*.sol` makes nested third-party or grouped contract overrides easier to configure.

## Changes
- Resolves exact compiler overrides first, then falls back to the first matching glob override.
- Reuses the existing internal glob matcher used elsewhere in Hardhat.
- Adds regression coverage for glob matches, exact-match precedence, first-match ordering, and fallback to configured compilers.
- Adds a patch changeset.

## Validation
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts`
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts packages/hardhat/test/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts`
- `cd packages/hardhat && pnpm build`
- `pnpm prettier --check .changeset/shy-overrides-glob.md`

Note: `cd packages/hardhat && pnpm test` currently fails in the template init tests with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "hardhat" not found`; the targeted build-system test above passes.

## Scope
Focused on Solidity compiler override selection. It does not change compiler config validation or normal non-overridden compiler selection.

Closes #4686