### PR TITLE
Migrate to pnpm 11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
   "image": "mcr.microsoft.com/devcontainers/base:trixie",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "24"
+      "version": "24",
+      "pnpmVersion": "11.6.0"
     }
   },
   "onCreateCommand": "scripts/setup.sh",

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -5,7 +5,7 @@ inputs:
   pnpm-version:
     description: Version of pnpm to install
     required: false
-    default: "10.28.2"
+    default: "11.6.0"
   node-version:
     description: Version of node to install
     required: false

--- a/.github/workflows/check-v3-with-latest-dependencies.yml
+++ b/.github/workflows/check-v3-with-latest-dependencies.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Run build
         # Ensure all projects are built before parallel test execution
         run: pnpm build
+      # pnpm 11 skips creating bin symlinks whose target isn't built at install
+      # time; relink workspace bins (e.g. hardhat) now that the build output
+      # exists. See pnpm/pnpm#10524.
+      - name: Recreate workspace bin links
+        run: pnpm rebuild -r
       - name: Run tests
         run: pnpm test || (echo "===== Retry =====" && pnpm test)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,13 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build
         run: pnpm run --if-present build
+      # The hardhat package's template tests spawn `pnpm hardhat` inside template
+      # projects that depend on other workspace packages (e.g. the toolboxes),
+      # which `pnpm run build` (the package under test) doesn't build. Build the
+      # whole workspace so those dependencies are available to the templates.
+      - name: Build all workspace packages
+        if: matrix.package == 'hardhat'
+        run: pnpm -r build
       # pnpm 11 skips creating bin symlinks whose target doesn't exist yet, so
       # workspace CLIs (e.g. hardhat) built after install have no bin until we
       # relink them once the build output exists. See pnpm/pnpm#10524.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,11 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build
         run: pnpm run --if-present build
+      # pnpm 11 skips creating bin symlinks whose target doesn't exist yet, so
+      # workspace CLIs (e.g. hardhat) built after install have no bin until we
+      # relink them once the build output exists. See pnpm/pnpm#10524.
+      - name: Recreate workspace bin links
+        run: pnpm rebuild -r
       - name: Run tests
         env:
           __DO_NOT_USE_IS_HARDHAT_CI: true
@@ -374,6 +379,11 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build
         run: pnpm run --if-present build
+      # pnpm 11 skips creating bin symlinks whose target doesn't exist yet, so
+      # workspace CLIs (e.g. hardhat) built after install have no bin until we
+      # relink them once the build output exists. See pnpm/pnpm#10524.
+      - name: Recreate workspace bin links
+        run: pnpm rebuild -r
       - name: Run tests
         env:
           __DO_NOT_USE_IS_HARDHAT_CI: true
@@ -424,6 +434,11 @@ jobs:
           pnpm ls
       - name: Build
         run: pnpm run --if-present build
+      # pnpm 11 skips creating bin symlinks whose target doesn't exist yet, so
+      # workspace CLIs (e.g. hardhat) built after install have no bin until we
+      # relink them once the build output exists. See pnpm/pnpm#10524.
+      - name: Recreate workspace bin links
+        run: pnpm rebuild -r
       - name: Run tests
         env:
           __DO_NOT_USE_IS_HARDHAT_CI: true

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # pnpm 11 skips creating bin symlinks whose target isn't built at install
+      # time; relink workspace bins (e.g. hardhat) now that the build output
+      # exists. See pnpm/pnpm#10524.
+      - name: Recreate workspace bin links
+        run: pnpm rebuild -r
+
       - name: Run tests
         run: pnpm test
 
@@ -96,6 +102,12 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      # pnpm 11 skips creating bin symlinks whose target isn't built at install
+      # time; relink workspace bins (e.g. hardhat) now that the build output
+      # exists. See pnpm/pnpm#10524.
+      - name: Recreate workspace bin links
+        run: pnpm rebuild -r
 
       - name: Run regression benchmark
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-hoist-pattern[]=!@types/*
-minimum-release-age=10080
-minimum-release-age-exclude[]="hardhat"
-minimum-release-age-exclude[]="@nomicfoundation/*"

--- a/cspell.dictionary.txt
+++ b/cspell.dictionary.txt
@@ -84,6 +84,7 @@ napi
 niño
 NFKC
 Nomic
+nomicfoundation
 nomiclabs
 normalise
 NOTOK

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "SEE LICENSE IN EACH PACKAGE'S LICENSE FILE",
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@10.28.2",
+  "packageManager": "pnpm@11.6.0",
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.16.0",
@@ -40,16 +40,5 @@
     "e2e": "node ./scripts/end-to-end/main.ts",
     "bench": "node ./scripts/benchmark/main.ts",
     "bench:regression": "node ./scripts/benchmark/regression.ts"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "node-hid"
-    ],
-    "ignoredBuiltDependencies": [
-      "esbuild",
-      "keccak",
-      "unrs-resolver",
-      "usb"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,18 @@
 packages:
   - "packages/*"
   - "packages/hardhat/templates/hardhat-3/*"
+
+allowBuilds:
+  node-hid: true
+  esbuild: false
+  keccak: false
+  unrs-resolver: false
+  usb: false
+
+hoistPattern:
+  - "!@types/*"
+
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - hardhat
+  - "@nomicfoundation/*"


### PR DESCRIPTION
Bumps pnpm from 10.28.2 to 11.6.0.

* pnpm 11 no longer reads pnpm settings from the `pnpm` field in `package.json`, and `.npmrc` is now only used for registry/auth settings. Because of that, our pnpm config had to move to `pnpm-workspace.yaml`.
* The main change is the build-script config: `onlyBuiltDependencies` / `ignoredBuiltDependencies` are gone, replaced by a single `allowBuilds` map. `node-hid` is set to `true` because it still needs to build, and the previously ignored packages (`esbuild`, `keccak`, `unrs-resolver`, `usb`) are set to `false`, matching the previous behavior under the new default-on `strictDepBuilds`.
* The hoist pattern and `minimum-release-age` settings moved over too, and `.npmrc` was deleted since it only contained settings that now belong in `pnpm-workspace.yaml`.
* The pnpm version is now pinned in three places, all kept in sync: the `packageManager` field, the `pnpm-version` default in the `setup-env` CI action, and the devcontainer. The devcontainer now uses the node feature’s `pnpmVersion` option, avoiding a dependency on corepack, which is no longer included with Node 25+.
* pnpm 11 no longer creates a bin symlink when its target doesn't exist yet (and won't add it on a later install). Since the `hardhat` CLI isn't built at install time, the `hardhat` bin goes missing and tests that call `pnpm hardhat` fail. A `pnpm rebuild -r` step now runs after the build to recreate the bin links, in every CI job that builds and then runs tests.
* The `[hardhat]` test job only built the `hardhat` package, but its template tests run `hardhat compile` in projects that depend on other workspace packages (the toolboxes). Those now get built by a `pnpm -r build` step before the tests run, scoped to the `hardhat` job.

Closes #8245.
