### PR TITLE
fix: keep build info for no-contract sources

### DIFF
--- a/.changeset/quiet-masks-sip.md
+++ b/.changeset/quiet-masks-sip.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix recompilation of Solidity root files that don't define contracts.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1194,6 +1194,22 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       reachableBuildInfoIds.filter((id) => id !== undefined),
     );
 
+    // Source files that compile successfully but don't define contracts only
+    // emit build-info files and an artifacts.d.ts file. There are no artifact
+    // .json files pointing back to their build-info ids, so keep the current
+    // roots' cached build-info ids reachable too.
+    for (const rootFilePath of rootFilePaths) {
+      const cacheEntry = this.#compileCache[rootFilePath];
+
+      if (cacheEntry === undefined) {
+        continue;
+      }
+
+      reachableBuildInfoIdsSet.add(
+        path.basename(cacheEntry.buildInfoPath, ".json"),
+      );
+    }
+
     // The build-info directory is expected to be flat: every build-info file
     // lives directly under it, so a non-recursive `readdir` is enough.
     const buildInfoFiles = await readdirOrEmpty(buildInfosDir);

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/no-contracts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/no-contracts.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { useTestProjectTemplate } from "../resolver/helpers.js";
+
+import { getHRE, TestProjectWrapper } from "./helpers.js";
+
+describe("Partial compilation", () => {
+  describe("Compiling a root file with no contracts", () => {
+    it("keeps its build info and does not recompile without changes", async () => {
+      await using _project = await useTestProjectTemplate({
+        name: "test",
+        version: "1.0.0",
+        files: {
+          "contracts/A.sol": `pragma solidity ^0.8.0;`,
+        },
+      });
+      const hre = await getHRE(_project);
+      const project = new TestProjectWrapper(_project, hre);
+
+      await project.compile();
+      const snapshot = await project.getSnapshot();
+
+      assert.equal(snapshot.buildInfos.length, 1);
+      assert.equal(snapshot.buildInfoOutputs.length, 1);
+      assert.deepEqual(snapshot.artifacts, {});
+      assert.ok(
+        snapshot.typeFiles["A.sol"] !== undefined,
+        "A.sol should emit a type file",
+      );
+
+      await project.compile();
+      const secondSnapshot = await project.getSnapshot();
+
+      assert.deepEqual(snapshot, secondSnapshot);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve cached build-info files for current Solidity root files that compile without emitting contract artifacts.
- Add a regression test for a root source containing only a pragma so repeated builds stay cached.

## Why
- Source files without contracts only emit build-info files and an `artifacts.d.ts` file, so artifact cleanup could delete their build-info files and force recompilation on every build.

## Changes
- Mark current roots' cached build-info ids as reachable during artifact cleanup.
- Add a partial-compilation test for no-contract root sources.
- Add a patch changeset for `hardhat`.

## Validation
- `pnpm exec node --import tsx/esm --test test/internal/builtin-plugins/solidity/build-system/partial-compilation/no-contracts.ts` from `packages/hardhat`
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts packages/hardhat/test/internal/builtin-plugins/solidity/build-system/partial-compilation/no-contracts.ts`
- `pnpm --filter hardhat build`
- `pnpm exec prettier --check .changeset/quiet-masks-sip.md`

## Scope
- Limited to build artifact cleanup and regression coverage for root Solidity files that emit no contract artifacts.

Closes #7671
