### PR TITLE
feat: re-enable transaction gas cap for solidity test

### DIFF
--- a/.changeset/cruel-oranges-cheer.md
+++ b/.changeset/cruel-oranges-cheer.md
@@ -1,0 +1,6 @@
+---
+"hardhat": patch
+#docs: https://github.com/NomicFoundation/hardhat-website/pull/279
+---
+
+Support setting the transaction gas cap in Solidity Tests

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -55,10 +55,7 @@ const solidityTestProfileUserConfigType = z.object({
   prevRandao: z.bigint().optional(),
   gasLimit: z.bigint().optional(),
   blockGasLimit: z.number().or(z.bigint()).or(z.literal(false)).optional(),
-  // TODO: widen back to .number().or(z.bigint()).or(z.literal(false))
-  // once Solidity test runner no longer breaks setUp() when
-  // disableTransactionGasCap is false. See PR #8301.
-  transactionGasCap: z.literal(false).optional(),
+  transactionGasCap: z.number().or(z.bigint()).or(z.literal(false)).optional(),
   fuzz: z
     .object({
       failurePersistDir: z.string().optional(),

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -321,12 +321,7 @@ describe("solidity-test/task-action", function () {
         );
       });
 
-      // TODO: currently fails because any active transactionGasCap
-      // breaks Solidity test setUp with a generic "EVM error", regardless of
-      // whether the cap would actually be exceeded.
-      // Similarly the exact error should be asserted rather than just
-      // success and failure.
-      it.skip("should pass when transactionGasCap is high enough to allow execution", async () => {
+      it("should pass when transactionGasCap is high enough to allow execution", async () => {
         hre = await createHardhatRuntimeEnvironment(hardhatConfigGasCapHigh);
 
         const result = await hre.tasks
@@ -340,7 +335,7 @@ describe("solidity-test/task-action", function () {
         );
       });
 
-      it.skip("should fail when transactionGasCap is set below required gas", async () => {
+      it("should fail when transactionGasCap is set below required gas", async () => {
         hre = await createHardhatRuntimeEnvironment(hardhatConfigGasCapLow);
 
         const result = await hre.tasks
@@ -348,10 +343,21 @@ describe("solidity-test/task-action", function () {
           .run({ noCompile: true });
 
         assert.equal(result.success, false);
-        assert.ok(
-          Array.isArray(result.error.suiteResults),
-          "suiteResults should be an array",
+
+        const suite = result.error.suiteResults.find(
+          (s: SuiteResult) => s.id.name === "TransactionGasCapTest",
         );
+        assert.ok(
+          suite !== undefined,
+          "expected a TransactionGasCapTest suite",
+        );
+
+        const testResult = suite.testResults.find(
+          (t: TestResult) => t.name === "testGasBand()",
+        );
+        assert.ok(testResult !== undefined, "expected a testGasBand() result");
+        assert.equal(testResult.status, "Failure");
+        assert.equal(testResult.reason, "EvmError: OutOfGas");
       });
     });
 


### PR DESCRIPTION
The transaction gas cap for Solidity Test was initially disabled by forcing the value to always be false. The underlying bug in EDR has now been fixed, so the validation has now been expanded back to allow setting a bigint for the transaction gas cap.

This brings Solidity Test into line with the capabilities of JS/TS tests and scripts.

Resolves #8337.

## Docs

https://github.com/NomicFoundation/hardhat-website/pull/279
