### PR TITLE
fix(e2e): make the regression benchmark work with pnpm 11

### DIFF
--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -3,8 +3,12 @@
   "description": "1inch SwapVM contract fork to Hardhat 3.",
   "tags": ["external-repo"],
   "repo": "anaPerezGhiglia/1inch-swap-vm",
-  "commit": "eacd08361caf75431d2b4409136cf4eb10fa63a3",
+  "commit": "7102f412db16aaf10dafa8dd40c4b85f99f0bb4e",
   "packageManager": "pnpm",
+  "env": {
+    "pnpm_config_block_exotic_subdeps": "false",
+    "pnpm_config_dangerously_allow_all_builds": "true"
+  },
   "submodules": false,
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {

--- a/end-to-end/ens-verifiable-factory/scenario.json
+++ b/end-to-end/ens-verifiable-factory/scenario.json
@@ -5,6 +5,9 @@
   "repo": "anaPerezGhiglia/ensdomains-verifiable-factory",
   "commit": "cd6622442c298ae89c4d92bcbc93a0faca4fbfae",
   "packageManager": "pnpm",
+  "env": {
+    "pnpm_config_dangerously_allow_all_builds": "true"
+  },
   "submodules": true,
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {

--- a/end-to-end/uniswap-v4-core/scenario.json
+++ b/end-to-end/uniswap-v4-core/scenario.json
@@ -5,6 +5,9 @@
   "repo": "anaPerezGhiglia/uniswap-v4-core",
   "commit": "ab2b22eef19e0abe29d67420dde81b5d54455ae5",
   "packageManager": "pnpm",
+  "env": {
+    "pnpm_config_dangerously_allow_all_builds": "true"
+  },
   "submodules": true,
   "defaultCommand": "npx hardhat test solidity",
   "benchmark": {

--- a/scripts/end-to-end/helpers/install.test.ts
+++ b/scripts/end-to-end/helpers/install.test.ts
@@ -1,81 +1,64 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { getInstallArgs } from "./install.ts";
+import { getInstallArgs, getUpdateArgs } from "./install.ts";
 
 const REGISTRY = "http://127.0.0.1:4873";
 
 describe("getInstallArgs", () => {
-  describe("yarn", () => {
-    it("omits --registry (env var carries it) when lockfile updates are not allowed", () => {
-      assert.deepEqual(getInstallArgs("yarn", false, REGISTRY), ["install"]);
-    });
-
-    it("appends --no-immutable when lockfile updates are allowed", () => {
-      assert.deepEqual(getInstallArgs("yarn", true, REGISTRY), [
-        "install",
-        "--no-immutable",
-      ]);
-    });
+  it("omits --registry for yarn (it rejects the CLI flag)", () => {
+    assert.deepEqual(getInstallArgs("yarn", REGISTRY), ["install"]);
   });
 
-  describe("npm", () => {
-    it("passes --registry when lockfile updates are not allowed", () => {
-      assert.deepEqual(getInstallArgs("npm", false, REGISTRY), [
-        "install",
-        `--registry=${REGISTRY}`,
-      ]);
-    });
-
-    it("does not append a lockfile flag (npm install never freezes)", () => {
-      assert.deepEqual(getInstallArgs("npm", true, REGISTRY), [
-        "install",
-        `--registry=${REGISTRY}`,
-      ]);
-    });
+  it("passes --registry for npm", () => {
+    assert.deepEqual(getInstallArgs("npm", REGISTRY), [
+      "install",
+      `--registry=${REGISTRY}`,
+    ]);
   });
 
-  describe("pnpm", () => {
-    it("appends --trust-lockfile for a Verdaccio registry when lockfile updates are not allowed", () => {
-      assert.deepEqual(getInstallArgs("pnpm", false, REGISTRY), [
-        "install",
-        `--registry=${REGISTRY}`,
-        "--trust-lockfile",
-      ]);
-    });
-
-    it("appends --no-frozen-lockfile and --trust-lockfile when lockfile updates are allowed", () => {
-      assert.deepEqual(getInstallArgs("pnpm", true, REGISTRY), [
-        "install",
-        `--registry=${REGISTRY}`,
-        "--no-frozen-lockfile",
-        "--trust-lockfile",
-      ]);
-    });
-
-    it("omits --trust-lockfile when the registry is not Verdaccio", () => {
-      const npmRegistry = "https://registry.npmjs.org";
-      assert.deepEqual(getInstallArgs("pnpm", true, npmRegistry), [
-        "install",
-        `--registry=${npmRegistry}`,
-        "--no-frozen-lockfile",
-      ]);
-    });
+  it("passes --registry for pnpm", () => {
+    assert.deepEqual(getInstallArgs("pnpm", REGISTRY), [
+      "install",
+      `--registry=${REGISTRY}`,
+    ]);
   });
 
-  describe("bun", () => {
-    it("passes --registry when lockfile updates are not allowed", () => {
-      assert.deepEqual(getInstallArgs("bun", false, REGISTRY), [
-        "install",
-        `--registry=${REGISTRY}`,
-      ]);
-    });
+  it("passes --registry for bun", () => {
+    assert.deepEqual(getInstallArgs("bun", REGISTRY), [
+      "install",
+      `--registry=${REGISTRY}`,
+    ]);
+  });
+});
 
-    it("appends --no-frozen-lockfile when lockfile updates are allowed", () => {
-      assert.deepEqual(getInstallArgs("bun", true, REGISTRY), [
-        "install",
-        `--registry=${REGISTRY}`,
-        "--no-frozen-lockfile",
-      ]);
-    });
+describe("getUpdateArgs", () => {
+  const specs = ["hardhat@3.9.1", "@nomicfoundation/hardhat-ethers@4.0.14"];
+
+  it("uses `pnpm update <specs>`", () => {
+    assert.deepEqual(getUpdateArgs("pnpm", specs, REGISTRY), [
+      "update",
+      ...specs,
+      `--registry=${REGISTRY}`,
+    ]);
+  });
+
+  it("uses `npm install <specs>`", () => {
+    assert.deepEqual(getUpdateArgs("npm", specs, REGISTRY), [
+      "install",
+      ...specs,
+      `--registry=${REGISTRY}`,
+    ]);
+  });
+
+  it("uses `bun add <specs>`", () => {
+    assert.deepEqual(getUpdateArgs("bun", specs, REGISTRY), [
+      "add",
+      ...specs,
+      `--registry=${REGISTRY}`,
+    ]);
+  });
+
+  it("uses `yarn add <specs>` (registry comes from config, not a flag)", () => {
+    assert.deepEqual(getUpdateArgs("yarn", specs, REGISTRY), ["add", ...specs]);
   });
 });

--- a/scripts/end-to-end/helpers/install.test.ts
+++ b/scripts/end-to-end/helpers/install.test.ts
@@ -35,17 +35,28 @@ describe("getInstallArgs", () => {
   });
 
   describe("pnpm", () => {
-    it("passes --registry when lockfile updates are not allowed", () => {
+    it("appends --trust-lockfile for a Verdaccio registry when lockfile updates are not allowed", () => {
       assert.deepEqual(getInstallArgs("pnpm", false, REGISTRY), [
         "install",
         `--registry=${REGISTRY}`,
+        "--trust-lockfile",
       ]);
     });
 
-    it("appends --no-frozen-lockfile when lockfile updates are allowed", () => {
+    it("appends --no-frozen-lockfile and --trust-lockfile when lockfile updates are allowed", () => {
       assert.deepEqual(getInstallArgs("pnpm", true, REGISTRY), [
         "install",
         `--registry=${REGISTRY}`,
+        "--no-frozen-lockfile",
+        "--trust-lockfile",
+      ]);
+    });
+
+    it("omits --trust-lockfile when the registry is not Verdaccio", () => {
+      const npmRegistry = "https://registry.npmjs.org";
+      assert.deepEqual(getInstallArgs("pnpm", true, npmRegistry), [
+        "install",
+        `--registry=${npmRegistry}`,
         "--no-frozen-lockfile",
       ]);
     });

--- a/scripts/end-to-end/helpers/install.ts
+++ b/scripts/end-to-end/helpers/install.ts
@@ -84,6 +84,18 @@ export function getInstallArgs(
     }
   }
 
+  // pnpm 11 verifies every lockfile entry's tarball URL against the active
+  // registry's metadata (ERR_PNPM_TARBALL_URL_MISMATCH). Scenario lockfiles can
+  // pin an absolute `registry.npmjs.org` tarball, but installing through
+  // Verdaccio serves the same package from 127.0.0.1, so the check fails. The
+  // scenario lockfile is a trusted benchmark fixture, so skip that re-
+  // verification rather than regenerate the lockfile. Scoped to pnpm (the only
+  // package manager with this flag) and to Verdaccio-backed installs (the only
+  // place the tarball host is rewritten).
+  if (packageManager === "pnpm" && registryUrl === VERDACCIO_URL) {
+    args.push("--trust-lockfile");
+  }
+
   return args;
 }
 

--- a/scripts/end-to-end/helpers/install.ts
+++ b/scripts/end-to-end/helpers/install.ts
@@ -15,7 +15,47 @@ import type { ScenarioDefinition } from "../types.ts";
 export function installDependencies(
   workDir: string,
   packageManager: ScenarioDefinition["packageManager"],
-  allowLockfileUpdates: boolean,
+  env?: Record<string, string>,
+): void {
+  logStep("Installing dependencies");
+
+  runPackageManager(
+    workDir,
+    packageManager,
+    getInstallArgs(packageManager, VERDACCIO_URL),
+    env,
+  );
+}
+
+/**
+ * Update the scenario's local (`hardhat` / `@nomicfoundation/*`) dependencies to
+ * the given `name@version` specs using the scenario's package manager.
+ */
+export function updateDependencies(
+  workDir: string,
+  packageManager: ScenarioDefinition["packageManager"],
+  specs: string[],
+  env?: Record<string, string>,
+): void {
+  logStep("Updating local dependencies");
+
+  runPackageManager(
+    workDir,
+    packageManager,
+    getUpdateArgs(packageManager, specs, VERDACCIO_URL),
+    env,
+  );
+}
+
+/**
+ * Point the scenario's package manager at Verdaccio and run it with `args`.
+ * Shared by install and targeted-update so both get the same registry config,
+ * corepack bootstrap (yarn), and environment.
+ */
+function runPackageManager(
+  workDir: string,
+  packageManager: ScenarioDefinition["packageManager"],
+  args: string[],
   env?: Record<string, string>,
 ): void {
   writeRegistryConfig(workDir, packageManager);
@@ -29,27 +69,38 @@ export function installDependencies(
     });
   }
 
-  logStep("Installing dependencies");
-
-  const installArgs = getInstallArgs(
-    packageManager,
-    allowLockfileUpdates,
-    VERDACCIO_URL,
-  );
-
-  execFileSync(which(packageManager), installArgs, {
+  execFileSync(which(packageManager), args, {
     cwd: workDir,
     stdio: "inherit",
     env: {
       ...process.env,
       ...env,
       COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
-      npm_config_minimum_release_age: "0",
-      // Yarn Classic doesn't honor project .yarnrc for `registry` on the
-      // GitHub Actions runner, so force the registry via env var. This is
-      // the highest-priority npm config source, so it overrides any
-      // user/global .npmrc that might be present.
-      npm_config_registry: VERDACCIO_URL,
+      ...(packageManager === "pnpm"
+        ? {
+            // The local packages (hardhat, @nomicfoundation/*) are published to
+            // Verdaccio minutes before this runs; pnpm 11 defaults minimumReleaseAge
+            // to one day and would block them.
+            pnpm_config_minimum_release_age: "0",
+            // pnpm 11 re-verifies every lockfile entry's tarball URL against the
+            // active registry (ERR_PNPM_TARBALL_URL_MISMATCH). Scenario lockfiles
+            // pin absolute registry.npmjs.org tarballs, but installing through
+            // Verdaccio serves them from 127.0.0.1, so the check fails on entries
+            // a targeted update doesn't touch. The scenario lockfile is a trusted
+            // benchmark fixture, so trust it. Set as config (not a flag) so it
+            // applies to both `pnpm install` and `pnpm update`.
+            pnpm_config_trust_lockfile: "true",
+          }
+        : {
+            // The local packages (hardhat, @nomicfoundation/*) are published to
+            // Verdaccio minutes before this runs; so disable any release-age gate.
+            npm_config_minimum_release_age: "0",
+            // Yarn Classic doesn't honor project .yarnrc for `registry` on the
+            // GitHub Actions runner, so force the registry via env var. This is
+            // the highest-priority npm config source, so it overrides any
+            // user/global .npmrc that might be present.
+            npm_config_registry: VERDACCIO_URL,
+          }),
     },
   });
 }
@@ -57,46 +108,40 @@ export function installDependencies(
 /**
  * Build the package-manager-specific `install` args for a Verdaccio-backed
  * install.
- *
- * `--use-local` patches the scenario's package.json, drifting the lockfile.
- * Since CI defaults to frozen-lockfile mode for pnpm and Yarn Berry, we allow
- * lockfile updates.
  */
 export function getInstallArgs(
   packageManager: ScenarioDefinition["packageManager"],
-  allowLockfileUpdates: boolean,
   registryUrl: string,
 ): string[] {
   // bun doesn't reliably read cwd `bunfig.toml`, so it needs the `--registry` CLI flag.
   // npm & pnpm don't strictly need `--registry` but we pass it for redundancy.
   // yarn is excluded because it rejects `--registry` as a CLI flag.
-  const args =
-    packageManager === "yarn"
-      ? ["install"]
-      : ["install", `--registry=${registryUrl}`];
+  return packageManager === "yarn"
+    ? ["install"]
+    : ["install", `--registry=${registryUrl}`];
+}
 
-  if (allowLockfileUpdates) {
-    // npm install never freezes (only `npm ci` does), so it doesn't need any flag.
-    if (packageManager === "pnpm" || packageManager === "bun") {
-      args.push("--no-frozen-lockfile");
-    } else if (packageManager === "yarn") {
-      args.push("--no-immutable");
-    }
+/**
+ * Build the package-manager-specific args to update `specs` (e.g.
+ * `["hardhat@3.9.1"]`) against a Verdaccio-backed registry.
+ */
+export function getUpdateArgs(
+  packageManager: ScenarioDefinition["packageManager"],
+  specs: string[],
+  registryUrl: string,
+): string[] {
+  switch (packageManager) {
+    case "pnpm":
+      return ["update", ...specs, `--registry=${registryUrl}`];
+    case "npm":
+      return ["install", ...specs, `--registry=${registryUrl}`];
+    case "bun":
+      return ["add", ...specs, `--registry=${registryUrl}`];
+    case "yarn":
+      // `yarn add` updates an existing dependency in both Classic and Berry;
+      // the registry comes from .yarnrc.yml / npm_config_registry.
+      return ["add", ...specs];
   }
-
-  // pnpm 11 verifies every lockfile entry's tarball URL against the active
-  // registry's metadata (ERR_PNPM_TARBALL_URL_MISMATCH). Scenario lockfiles can
-  // pin an absolute `registry.npmjs.org` tarball, but installing through
-  // Verdaccio serves the same package from 127.0.0.1, so the check fails. The
-  // scenario lockfile is a trusted benchmark fixture, so skip that re-
-  // verification rather than regenerate the lockfile. Scoped to pnpm (the only
-  // package manager with this flag) and to Verdaccio-backed installs (the only
-  // place the tarball host is rewritten).
-  if (packageManager === "pnpm" && registryUrl === VERDACCIO_URL) {
-    args.push("--trust-lockfile");
-  }
-
-  return args;
 }
 
 function writeRegistryConfig(

--- a/scripts/end-to-end/subcommands/init.ts
+++ b/scripts/end-to-end/subcommands/init.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { installDependencies } from "../helpers/install.ts";
+import { installDependencies, updateDependencies } from "../helpers/install.ts";
 import { git, which, ROOT_DIR } from "../helpers/shell.ts";
 import { fmt, log, logStep, logWarning } from "../helpers/log.ts";
 import {
@@ -107,10 +107,10 @@ export async function init(
     setupScenario(scenario, forceCheckout);
 
     if (useLocal === UseLocal.Yes) {
-      await upgradeLocalDependencies(scenario);
+      await updateLocalDependencies(scenario);
     }
 
-    installScenarioDeps(scenario, useLocal === UseLocal.Yes);
+    installScenarioDeps(scenario);
   } finally {
     if (startedVerdaccio) {
       verdaccioStop();
@@ -162,10 +162,7 @@ function setupScenario(scenario: Scenario, forceCheckout: ForceCheckout): void {
  * Install dependencies using the scenario's package manager or custom
  * install script.
  */
-function installScenarioDeps(
-  scenario: Scenario,
-  allowLockfileUpdates: boolean,
-): void {
+function installScenarioDeps(scenario: Scenario): void {
   const { scenarioDir, workingDir, definition } = scenario;
 
   if (definition.install !== undefined) {
@@ -176,28 +173,24 @@ function installScenarioDeps(
       definition.env,
     );
   } else {
-    installDependencies(
-      workingDir,
-      definition.packageManager,
-      allowLockfileUpdates,
-      definition.env,
-    );
+    installDependencies(workingDir, definition.packageManager, definition.env);
   }
 }
 
 /**
- * Patch the scenario's package.json to pin hardhat / @nomicfoundation/*
- * dependencies to the latest versions available in Verdaccio. Verdaccio
- * merges locally published packages with npm (via proxy), so this returns
- * bumped local versions where available and npm versions for everything else.
+ * Update the scenario's hardhat / @nomicfoundation/* dependencies to the latest
+ * versions available in Verdaccio using the scenario's package manager. A
+ * targeted update writes package.json and the lockfile together and installs,
+ * without re-resolving the rest of the tree — so it can't split a shared
+ * transitive dependency across versions.
  */
-async function upgradeLocalDependencies(scenario: Scenario): Promise<void> {
-  logStep("Upgrading dependencies to latest Verdaccio versions");
+async function updateLocalDependencies(scenario: Scenario): Promise<void> {
+  logStep("Updating local dependencies to latest Verdaccio versions");
 
   const pkgJsonPath = resolve(scenario.workingDir, "package.json");
   const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
 
-  let updated = false;
+  const specs: string[] = [];
 
   for (const depField of ["dependencies", "devDependencies"] as const) {
     const deps = pkgJson[depField] as Record<string, string> | undefined;
@@ -214,18 +207,27 @@ async function upgradeLocalDependencies(scenario: Scenario): Promise<void> {
       const version = await getLatestFromVerdaccio(name);
 
       if (version !== undefined) {
-        deps[name] = version;
-        updated = true;
+        specs.push(`${name}@${version}`);
         log(`  ${fmt.pkg(name)} → ${fmt.version(version)}`);
       }
     }
   }
 
-  if (updated) {
-    writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + "\n");
-  } else {
+  if (specs.length === 0) {
+    // Nothing to bump; the unconditional installScenarioDeps below realizes
+    // node_modules.
     log("No matching dependencies to update");
+    return;
   }
+
+  const { workingDir, definition } = scenario;
+
+  updateDependencies(
+    workingDir,
+    definition.packageManager,
+    specs,
+    definition.env,
+  );
 }
 
 async function getLatestFromVerdaccio(


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

The pnpm 11 migration in #8395 broke the E2E regression benchmark in two ways, both surfacing only when scenarios install through Verdaccio:

1. **Tree-wide re-resolution.** Init pinned each scenario's `hardhat` by hand-editing `package.json` and reinstalling with `--no-frozen-lockfile`, which re-resolved the entire tree and split shared transitives (e.g. `@openzeppelin/contracts` into 5.4.0 + 5.1.0), failing compile.
2. **New supply-chain gates** (`minimumReleaseAge`, tarball-URL verification, exotic-subdep + build-script blocking) rejected the trusted benchmark fixtures.

## Changes

- **Targeted dependency update** (`install.ts`, `init.ts`): replaced the `package.json` hand-edit + full reinstall with a package-manager-native targeted update — `pnpm update` / `npm install` / `bun|yarn add` — that bumps only `hardhat`/`@nomicfoundation/*` and writes `package.json` and the lockfile together, with no tree-wide re-resolution. Added a shared `runPackageManager` and `getUpdateArgs`; `getInstallArgs` no longer toggles frozen-lockfile flags.
- **Minimal harness-wide pnpm env** (`install.ts`): `pnpm_config_minimum_release_age=0` (just-published local packages) and `pnpm_config_trust_lockfile=true` (committed lockfiles pin `registry.npmjs.org` tarballs while Verdaccio serves `127.0.0.1`). The npm family keeps `npm_config_minimum_release_age` + `npm_config_registry`.
- **Per-scenario overrides, not global** (`end-to-end/*/scenario.json`): scenarios opt into `pnpm_config_dangerously_allow_all_builds` (native build scripts) and `pnpm_config_block_exotic_subdeps=false` (git-resolved subdeps) only where needed.
- **Tests** (`install.test.ts`): rewritten to cover `getInstallArgs` + the new `getUpdateArgs`.

## Verification

- [x] Successfully completed a benchmark run on the CI runner
  - [CI run](https://github.com/NomicFoundation/hardhat/actions/runs/27957794031/job/82734360253?pr=8401) failed due to a regression but was other issues were resolved
- [x] New tests of the package manager-specific update commands\