### PR TITLE
Fix sanitizeFilename handling for Windows reserved device names

### DIFF
--- a/.changeset/windows-filenames-reserve.md
+++ b/.changeset/windows-filenames-reserve.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Make `sanitizeFilename` avoid Windows reserved device names while preserving filename extensions.

--- a/packages/hardhat-utils/src/path.ts
+++ b/packages/hardhat-utils/src/path.ts
@@ -1,5 +1,8 @@
 import path from "node:path";
 
+const WINDOWS_RESERVED_FILENAME_PATTERN =
+  /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+
 /**
  * Resolves a user-provided path into an absolute path.
  *
@@ -60,8 +63,9 @@ export function shortenPath(absolutePath: string): string {
  *
  * Strips characters that are reserved on at least one of those platforms
  * (`<>:"/\|?*` and ASCII control chars), trims trailing dots and whitespace
- * (Windows silently strips them on write), and falls back to `_` if the
- * result is empty or one of the path-traversal literals `.` / `..`.
+ * (Windows silently strips them on write), avoids Windows reserved device
+ * names, and falls back to `_` if the result is empty or one of the
+ * path-traversal literals `.` / `..`.
  *
  * @param name The string to sanitize.
  * @returns A non-empty filename-safe string.
@@ -72,6 +76,18 @@ export function sanitizeFilename(name: string): string {
 
   if (result === "" || result === "." || result === "..") {
     result = "_";
+  }
+
+  if (WINDOWS_RESERVED_FILENAME_PATTERN.test(result)) {
+    const extensionIndex = result.indexOf(".");
+
+    if (extensionIndex === -1) {
+      result = `${result}_`;
+    } else {
+      result = `${result.slice(0, extensionIndex)}_${result.slice(
+        extensionIndex,
+      )}`;
+    }
   }
 
   return result;

--- a/packages/hardhat-utils/test/path.ts
+++ b/packages/hardhat-utils/test/path.ts
@@ -161,5 +161,24 @@ describe("path", () => {
         "..windowssystem32",
       );
     });
+
+    it("Should avoid Windows reserved device names", () => {
+      assert.equal(sanitizeFilename("CON"), "CON_");
+      assert.equal(sanitizeFilename("nul"), "nul_");
+      assert.equal(sanitizeFilename("COM1"), "COM1_");
+      assert.equal(sanitizeFilename("LPT9"), "LPT9_");
+      assert.equal(sanitizeFilename("CON.txt"), "CON_.txt");
+      assert.equal(sanitizeFilename("com1.log"), "com1_.log");
+    });
+
+    it(
+      "Should preserve names that only contain Windows reserved device names as substrings",
+      () => {
+        assert.equal(sanitizeFilename("CONTRACT"), "CONTRACT");
+        assert.equal(sanitizeFilename("XCOM1"), "XCOM1");
+        assert.equal(sanitizeFilename("LPT10"), "LPT10");
+        assert.equal(sanitizeFilename("NUL-device"), "NUL-device");
+      },
+    );
   });
 });


### PR DESCRIPTION

- [x] I didn't do anything of this.



<!-- Add a description of your PR here -->

This updates `sanitizeFilename` so it also avoids Windows reserved device filenames such as `CON`, `NUL`, `COM1`, and `LPT9`.

The function already strips reserved characters and trailing dots/spaces to produce cross-platform-safe filename components. Windows device names are also invalid even when they include an extension, so this change appends an underscore to the reserved base name while preserving extensions, e.g. `CON.txt` becomes `CON_.txt`.


## Changes

- Handle Windows reserved device names in `sanitizeFilename`
- Preserve filename extensions when adjusting reserved names
- Add tests for reserved names and near-matches that should remain unchanged
- Add a patch changeset for `@nomicfoundation/hardhat-utils`
