### PR TITLE
fix: link console libraries in solidity tests

### DIFF
--- a/.changeset/tiny-console-libraries.md
+++ b/.changeset/tiny-console-libraries.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix Solidity tests that take the address of imported console libraries.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts
@@ -20,6 +20,9 @@ export interface EdrArtifactWithMetadata {
 export const BUILD_INFO_FORMAT: RegExp =
   /^solc-(?<major>\d+)_(?<minor>\d+)_(?<patch>\d+)(?:-(?<compilerType>[a-zA-Z][a-zA-Z0-9]*))?-[0-9a-fA-F]*$/;
 
+const HARDHAT_CONSOLE_LIBRARY_ADDRESS =
+  "0x000000000000000000636f6e736f6c652e6c6f67";
+
 /**
  * This function returns all the build infos and associated outputs.
  *
@@ -119,7 +122,7 @@ export async function buildEdrArtifactsWithMetadata(
 
   const solcVersions = new Map(solcVersionsArray);
 
-  return artifacts.map((artifact) => {
+  const edrArtifacts = artifacts.map((artifact) => {
     assertHardhatInvariant(
       artifact.buildInfoId !== undefined,
       `buildInfoId should not be undefined for artifact: ${displayArtifactForError(artifact)}`,
@@ -159,6 +162,65 @@ export async function buildEdrArtifactsWithMetadata(
       buildInfoId: artifact.buildInfoId,
     };
   });
+
+  const edrArtifactIds = new Set(
+    edrArtifacts.map(({ edrArtifact }) => formatEdrArtifactId(edrArtifact.id)),
+  );
+
+  for (const artifact of artifacts) {
+    assertHardhatInvariant(
+      artifact.buildInfoId !== undefined,
+      `buildInfoId should not be undefined for artifact: ${displayArtifactForError(artifact)}`,
+    );
+
+    const solcVersion = solcVersions.get(artifact.buildInfoId);
+
+    assertHardhatInvariant(
+      solcVersion !== undefined,
+      `solcVersion should not be undefined for artifact: ${displayArtifactForError(artifact)}`,
+    );
+
+    for (const [source, libraries] of Object.entries(artifact.linkReferences)) {
+      for (const name of Object.keys(libraries)) {
+        if (!isConsoleLibrary(source, name)) {
+          continue;
+        }
+
+        const id = { name, solcVersion, source };
+        const formattedId = formatEdrArtifactId(id);
+
+        if (edrArtifactIds.has(formattedId)) {
+          continue;
+        }
+
+        edrArtifactIds.add(formattedId);
+        edrArtifacts.push({
+          edrArtifact: {
+            id,
+            contract: {
+              abi: "[]",
+              bytecode: HARDHAT_CONSOLE_LIBRARY_ADDRESS,
+              linkReferences: {},
+              deployedBytecode: "0x",
+              deployedLinkReferences: {},
+            },
+          },
+          userSourceName: source,
+          buildInfoId: artifact.buildInfoId,
+        });
+      }
+    }
+  }
+
+  return edrArtifacts;
+}
+
+function isConsoleLibrary(source: string, name: string): boolean {
+  return name === "console" && source.endsWith("/console.sol");
+}
+
+function formatEdrArtifactId(id: EdrArtifact["id"]): string {
+  return `${id.source}:${id.name}:${id.solcVersion}`;
 }
 
 function displayArtifactForError(artifact: Artifact): string {

--- a/packages/hardhat/test/fixture-projects/solidity-test/lib/forge-std/src/console.sol
+++ b/packages/hardhat/test/fixture-projects/solidity-test/lib/forge-std/src/console.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library console {}

--- a/packages/hardhat/test/fixture-projects/solidity-test/test/contracts/console-address/ConsoleAddress.t.sol
+++ b/packages/hardhat/test/fixture-projects/solidity-test/test/contracts/console-address/ConsoleAddress.t.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../../lib/forge-std/src/console.sol";
+
+contract ConsoleAddressTest {
+  function testConsoleAddressCanBeLinked() public pure {
+    address consoleAddress = address(console);
+
+    require(consoleAddress != address(0), "console should be linked");
+  }
+}

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/edr-artifacts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/edr-artifacts.ts
@@ -1,7 +1,15 @@
+import type {
+  Artifact,
+  ArtifactManager,
+} from "../../../../src/types/artifacts.js";
+
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { BUILD_INFO_FORMAT } from "../../../../src/internal/builtin-plugins/solidity-test/edr-artifacts.js";
+import {
+  BUILD_INFO_FORMAT,
+  buildEdrArtifactsWithMetadata,
+} from "../../../../src/internal/builtin-plugins/solidity-test/edr-artifacts.js";
 
 describe("BUILD_INFO_FORMAT", () => {
   it("matches a standard build ID", () => {
@@ -45,3 +53,150 @@ describe("BUILD_INFO_FORMAT", () => {
     assert.equal(match, null);
   });
 });
+
+describe("buildEdrArtifactsWithMetadata", () => {
+  it("adds a placeholder for missing console library artifacts", async () => {
+    const testArtifact = createArtifact({
+      contractName: "ConsoleAddrTest",
+      sourceName: "test/ConsoleAddr.t.sol",
+      inputSourceName: "project/test/ConsoleAddr.t.sol",
+      linkReferences: {
+        "project/lib/forge-std/src/console.sol": {
+          console: [{ start: 25, length: 20 }],
+        },
+      },
+    });
+
+    const artifactManager = new StaticArtifactManager([testArtifact]);
+    const edrArtifacts = await buildEdrArtifactsWithMetadata(artifactManager);
+
+    assert.deepEqual(
+      edrArtifacts.map(({ edrArtifact }) => edrArtifact.id),
+      [
+        {
+          name: "ConsoleAddrTest",
+          source: "project/test/ConsoleAddr.t.sol",
+          solcVersion: "0.8.25",
+        },
+        {
+          name: "console",
+          source: "project/lib/forge-std/src/console.sol",
+          solcVersion: "0.8.25",
+        },
+      ],
+    );
+    assert.equal(
+      edrArtifacts[1].edrArtifact.contract.bytecode,
+      "0x000000000000000000636f6e736f6c652e6c6f67",
+    );
+  });
+
+  it("doesn't add duplicate console library artifacts", async () => {
+    const consoleArtifact = createArtifact({
+      contractName: "console",
+      sourceName: "lib/forge-std/src/console.sol",
+      inputSourceName: "project/lib/forge-std/src/console.sol",
+    });
+    const testArtifact = createArtifact({
+      contractName: "ConsoleAddrTest",
+      sourceName: "test/ConsoleAddr.t.sol",
+      inputSourceName: "project/test/ConsoleAddr.t.sol",
+      linkReferences: {
+        "project/lib/forge-std/src/console.sol": {
+          console: [{ start: 25, length: 20 }],
+        },
+      },
+    });
+
+    const artifactManager = new StaticArtifactManager([
+      consoleArtifact,
+      testArtifact,
+    ]);
+    const edrArtifacts = await buildEdrArtifactsWithMetadata(artifactManager);
+
+    assert.equal(
+      edrArtifacts.filter(
+        ({ edrArtifact }) => edrArtifact.id.name === "console",
+      ).length,
+      1,
+    );
+  });
+});
+
+function createArtifact(overrides: Partial<Artifact>): Artifact {
+  return {
+    _format: "hh3-artifact-1",
+    contractName: "Counter",
+    sourceName: "contracts/Counter.sol",
+    abi: [],
+    bytecode: "0x00",
+    linkReferences: {},
+    deployedBytecode: "0x00",
+    deployedLinkReferences: {},
+    buildInfoId: "solc-0_8_25-abcdef",
+    inputSourceName: "project/contracts/Counter.sol",
+    ...overrides,
+  };
+}
+
+class StaticArtifactManager implements ArtifactManager {
+  readonly #artifactsByFullyQualifiedName: Map<string, Artifact>;
+
+  constructor(artifacts: Artifact[]) {
+    this.#artifactsByFullyQualifiedName = new Map(
+      artifacts.map((artifact) => [
+        `${artifact.sourceName}:${artifact.contractName}`,
+        artifact,
+      ]),
+    );
+  }
+
+  public async getAllFullyQualifiedNames(): Promise<ReadonlySet<string>> {
+    return new Set(this.#artifactsByFullyQualifiedName.keys());
+  }
+
+  public async readArtifact(
+    contractNameOrFullyQualifiedName: string,
+  ): Promise<any> {
+    const artifact = this.#artifactsByFullyQualifiedName.get(
+      contractNameOrFullyQualifiedName,
+    );
+    assert.ok(
+      artifact !== undefined,
+      `Missing mock artifact ${contractNameOrFullyQualifiedName}`,
+    );
+    return artifact;
+  }
+
+  public async getArtifactPath(): Promise<string> {
+    assert.fail("Not implemented in StaticArtifactManager");
+  }
+
+  public async artifactExists(): Promise<boolean> {
+    assert.fail("Not implemented in StaticArtifactManager");
+  }
+
+  public async getAllArtifactPaths(): Promise<ReadonlySet<string>> {
+    assert.fail("Not implemented in StaticArtifactManager");
+  }
+
+  public async getBuildInfoId(): Promise<string | undefined> {
+    assert.fail("Not implemented in StaticArtifactManager");
+  }
+
+  public async getAllBuildInfoIds(): Promise<ReadonlySet<string>> {
+    assert.fail("Not implemented in StaticArtifactManager");
+  }
+
+  public async getBuildInfoPath(): Promise<string | undefined> {
+    assert.fail("Not implemented in StaticArtifactManager");
+  }
+
+  public async getBuildInfoOutputPath(): Promise<string | undefined> {
+    assert.fail("Not implemented in StaticArtifactManager");
+  }
+
+  public async clearCache(): Promise<void> {
+    assert.fail("Not implemented in StaticArtifactManager");
+  }
+}

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -61,6 +61,11 @@ const hardhatConfigAbstractAndInterfaceTests = {
   paths: { tests: { solidity: "test/contracts/abstract-and-interface" } },
 };
 
+const hardhatConfigConsoleAddressTests = {
+  ...hardhatConfig,
+  paths: { tests: { solidity: "test/contracts/console-address" } },
+};
+
 const TX_GAS_CAP_TEST_PATH = {
   tests: { solidity: "test/contracts/transaction-gas-cap" },
 };
@@ -690,6 +695,16 @@ describe("solidity-test/task-action", function () {
 
     // The test should not throw, which means the precompile exists
     // and works as expected
+  });
+
+  it("should link imported console libraries when their address is taken", async () => {
+    hre = await createHardhatRuntimeEnvironment(
+      hardhatConfigConsoleAddressTests,
+    );
+
+    await hre.tasks.getTask(["test", "solidity"]).run({
+      noCompile: false,
+    });
   });
 
   describe("abstract contracts and interfaces", () => {


### PR DESCRIPTION
## Summary
- Adds a Solidity Test EDR artifact placeholder for imported `console` libraries when a test takes `address(console)` but no library artifact was emitted.
- Uses Hardhat's console address as the link target and avoids duplicating an existing console artifact.
- Adds unit and task-action regression coverage plus a changeset.

## Why
Solidity tests that take the address of an imported console library can produce a link reference to `console.sol:console`, while the test artifact set only includes root artifacts. That made the EDR runner fail before executing the test.

## Changes
- Detect missing `*/console.sol:console` link references in `buildEdrArtifactsWithMetadata`.
- Add a synthetic console artifact with the stable console address when the linked artifact is absent.
- Add a fixture Solidity test that takes `address(console)`.

## Validation
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/edr-artifacts.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts`
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/edr-artifacts.ts`
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts`
- `pnpm prettier --check .changeset/tiny-console-libraries.md`

## Scope
Focused Solidity Test linking fix for imported console libraries.

Closes #8404
