### PR TITLE
feat: support contract-level solidity test inline config

### DIFF
--- a/.changeset/green-pandas-jam.md
+++ b/.changeset/green-pandas-jam.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Support contract-level inline Solidity test configuration comments, applying them to each test function in the contract while letting function-level comments override contract defaults.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/parsing.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/parsing.ts
@@ -43,6 +43,7 @@ export function extractInlineConfigFromAst(
       continue;
     }
 
+    const contractDocText = extractDocText(node.documentation);
     const members: unknown[] = Array.isArray(node.nodes) ? node.nodes : [];
     for (const member of members) {
       if (!isObject(member) || member.nodeType !== "FunctionDefinition") {
@@ -62,21 +63,31 @@ export function extractInlineConfigFromAst(
           ? member.functionSelector
           : undefined;
 
-      const docText = extractDocText(member.documentation);
-      if (docText === undefined) {
-        continue;
-      }
+      const docTexts = [
+        { scope: "contract" as const, text: contractDocText },
+        {
+          scope: "function" as const,
+          text: extractDocText(member.documentation),
+        },
+      ];
 
-      for (const line of docText.split("\n")) {
-        const parsed = parseInlineConfigLine(
-          line,
-          inputSourceName,
-          contractName,
-          fnName,
-        );
-        if (parsed !== undefined) {
-          parsed.functionSelector = fnSelector;
-          results.push(parsed);
+      for (const { scope, text } of docTexts) {
+        if (text === undefined) {
+          continue;
+        }
+
+        for (const line of text.split("\n")) {
+          const parsed = parseInlineConfigLine(
+            line,
+            inputSourceName,
+            contractName,
+            fnName,
+            scope,
+          );
+          if (parsed !== undefined) {
+            parsed.functionSelector = fnSelector;
+            results.push(parsed);
+          }
         }
       }
     }
@@ -114,6 +125,7 @@ export function parseInlineConfigLine(
   inputSourceName: string,
   contractName: string,
   functionName: string,
+  scope: RawInlineOverride["scope"] = "function",
 ): RawInlineOverride | undefined {
   // Strip leading whitespace and optional leading '*' from NatSpec text.
   // Solc's StructuredDocumentation.text has delimiters (///, /**, */) removed.
@@ -179,6 +191,7 @@ export function parseInlineConfigLine(
     inputSourceName,
     contractName,
     functionName,
+    scope,
     key: parsedKey,
     rawKey,
     rawValue,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/types.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/types.ts
@@ -3,6 +3,7 @@ export interface RawInlineOverride {
   contractName: string;
   functionName: string;
   functionSelector?: string; // from AST, hex without 0x prefix
+  scope?: "contract" | "function"; // origin of the inline config directive
   key: string; // parsed camelCase key, without profile prefix
   rawKey: string; // original key as written by the user, for error messages
   rawValue: string;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/validation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/validation.ts
@@ -26,6 +26,7 @@ export function validateInlineOverrides(overrides: RawInlineOverride[]): void {
     contractName,
     functionName,
     functionSelector,
+    scope,
     rawKey,
     rawValue,
     key,
@@ -82,7 +83,8 @@ export function validateInlineOverrides(overrides: RawInlineOverride[]): void {
       functionSelector !== undefined
         ? `${functionFqn}#${functionSelector}`
         : functionFqn;
-    const dedupeKey = `${functionId}-${key}`;
+    const overrideScope = scope ?? "function";
+    const dedupeKey = `${functionId}-${overrideScope}-${key}`;
     if (seen.has(dedupeKey)) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.SOLIDITY_TESTS.INLINE_CONFIG_DUPLICATE_KEY,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -172,6 +172,55 @@ describe("inline-config", () => {
       });
     });
 
+    it("should apply contract-level overrides to all test functions", () => {
+      const bi = makeBuildInfo(
+        "test/MyTest.sol",
+        "/** hardhat-config: fuzz.runs = 10 */",
+        {
+          MyTest: {
+            documentation: " hardhat-config: fuzz.runs = 10",
+            methodIdentifiers: {
+              "testFuzzA()": "aabbccdd",
+              "testFuzzB()": "11223344",
+            },
+            functions: [{ name: "testFuzzA" }, { name: "testFuzzB" }],
+          },
+        },
+      );
+      const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
+      const result = getTestFunctionOverrides(artifacts, [bi]);
+      assert.equal(result.length, 2);
+
+      const configs = result.map((r) => r.config);
+      assert.deepEqual(configs, [
+        { fuzz: { runs: 10 } },
+        { fuzz: { runs: 10 } },
+      ]);
+    });
+
+    it("should let function-level overrides take precedence over contract-level overrides", () => {
+      const bi = makeBuildInfo(
+        "test/MyTest.sol",
+        "/** hardhat-config: fuzz.runs = 10 */\n/// hardhat-config: fuzz.runs = 20",
+        {
+          MyTest: {
+            documentation: " hardhat-config: fuzz.runs = 10",
+            methodIdentifiers: { "testFuzz()": "aabbccdd" },
+            functions: [
+              {
+                name: "testFuzz",
+                documentation: " hardhat-config: fuzz.runs = 20",
+              },
+            ],
+          },
+        },
+      );
+      const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
+      const overrides = getTestFunctionOverrides(artifacts, [bi]);
+      assert.equal(overrides.length, 1);
+      assert.deepEqual(overrides[0].config, { fuzz: { runs: 20 } });
+    });
+
     it("should throw BUILD_INFO_NOT_FOUND when artifact references missing build info", () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/mocks.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/mocks.ts
@@ -48,6 +48,7 @@ export function makeBuildInfo(
     string,
     {
       methodIdentifiers: Record<string, string>;
+      documentation?: string | null;
       functions: Array<{
         name: string;
         documentation?: string | null;
@@ -78,6 +79,15 @@ export function makeBuildInfo(
     ([contractName, contract]) => ({
       nodeType: "ContractDefinition",
       name: contractName,
+      ...(contract.documentation !== undefined &&
+      contract.documentation !== null
+        ? {
+            documentation: {
+              nodeType: "StructuredDocumentation",
+              text: contract.documentation,
+            },
+          }
+        : {}),
       nodes: contract.functions.map((fn) => ({
         nodeType: "FunctionDefinition",
         name: fn.name,


### PR DESCRIPTION
## Summary

Closes #8144.

## Why

Solidity tests currently only apply inline config comments attached directly to each test function. Projects that put the same inline config on a test contract have to repeat it on every function.

## Changes

- Read inline config directives from `ContractDefinition` NatSpec documentation.
- Apply contract-level directives to each `test*`/`invariant*` function in that contract.
- Preserve function-level precedence when a function overrides the same key as the contract default.
- Add regression coverage for applying contract-level config to multiple functions and for function-level override precedence.
- Add a patch changeset for `hardhat`.

## Validation

- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts`
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/parsing.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/types.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/validation.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/mocks.ts`
- `pnpm prettier --check .changeset/green-pandas-jam.md`
- `cd packages/hardhat && pnpm build`

## Scope

Focused on inline Solidity test config extraction/validation. This does not add profile-specific inline config support.
