### PR TITLE
feat: support solidity test resource config

### DIFF
--- a/.changeset/wise-otters-smile.md
+++ b/.changeset/wise-otters-smile.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Support Solidity test `memoryLimit` and fuzz/invariant `timeout` config options.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -37,6 +37,17 @@ const nonnegativeSafeIntOrBigInt = unionType(
   "Expected a nonnegative safe int or a nonnegative bigint",
 );
 
+const nonnegativeSafeIntOrSafeBigInt = unionType(
+  [
+    z.number().int().nonnegative().safe(),
+    z
+      .bigint()
+      .nonnegative()
+      .refine((value) => value <= BigInt(Number.MAX_SAFE_INTEGER)),
+  ],
+  "Expected a nonnegative safe int or a nonnegative safe bigint",
+);
+
 const solidityTestProfileUserConfigType = z.object({
   fsPermissions: z
     .object({
@@ -73,7 +84,7 @@ const solidityTestProfileUserConfigType = z.object({
       includeStorage: z.boolean().optional(),
       includePushBytes: z.boolean().optional(),
       showLogs: z.boolean().optional(),
-      timeout: nonnegativeSafeIntOrBigInt.optional(),
+      timeout: nonnegativeSafeIntOrSafeBigInt.optional(),
     })
     .optional(),
   forking: z
@@ -99,7 +110,7 @@ const solidityTestProfileUserConfigType = z.object({
       includeStorage: z.boolean().optional(),
       includePushBytes: z.boolean().optional(),
       shrinkRunLimit: z.number().optional(),
-      timeout: nonnegativeSafeIntOrBigInt.optional(),
+      timeout: nonnegativeSafeIntOrSafeBigInt.optional(),
     })
     .optional(),
   eip712Types: z

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -280,39 +280,13 @@ export async function resolveSolidityTestUserConfig(
 export function resolveFuzzConfig(
   fuzzUserConfig: SolidityTestProfileUserConfig["fuzz"] = {},
 ): SolidityTestProfileConfig["fuzz"] {
-  const resolvedConfig: SolidityTestProfileConfig["fuzz"] = {
-    seed: fuzzUserConfig.seed ?? DEFAULT_FUZZ_SEED,
+  const { seed, timeout, ...otherFuzzUserConfig } = fuzzUserConfig;
+
+  return {
+    ...otherFuzzUserConfig,
+    seed: seed ?? DEFAULT_FUZZ_SEED,
+    ...(timeout !== undefined ? { timeout: Number(timeout) } : {}),
   };
-
-  if (fuzzUserConfig.failurePersistDir !== undefined) {
-    resolvedConfig.failurePersistDir = fuzzUserConfig.failurePersistDir;
-  }
-  if (fuzzUserConfig.failurePersistFile !== undefined) {
-    resolvedConfig.failurePersistFile = fuzzUserConfig.failurePersistFile;
-  }
-  if (fuzzUserConfig.runs !== undefined) {
-    resolvedConfig.runs = fuzzUserConfig.runs;
-  }
-  if (fuzzUserConfig.maxTestRejects !== undefined) {
-    resolvedConfig.maxTestRejects = fuzzUserConfig.maxTestRejects;
-  }
-  if (fuzzUserConfig.dictionaryWeight !== undefined) {
-    resolvedConfig.dictionaryWeight = fuzzUserConfig.dictionaryWeight;
-  }
-  if (fuzzUserConfig.includeStorage !== undefined) {
-    resolvedConfig.includeStorage = fuzzUserConfig.includeStorage;
-  }
-  if (fuzzUserConfig.includePushBytes !== undefined) {
-    resolvedConfig.includePushBytes = fuzzUserConfig.includePushBytes;
-  }
-  if (fuzzUserConfig.showLogs !== undefined) {
-    resolvedConfig.showLogs = fuzzUserConfig.showLogs;
-  }
-  if (fuzzUserConfig.timeout !== undefined) {
-    resolvedConfig.timeout = Number(fuzzUserConfig.timeout);
-  }
-
-  return resolvedConfig;
 }
 
 export function resolveInvariantConfig(
@@ -322,41 +296,12 @@ export function resolveInvariantConfig(
     return undefined;
   }
 
-  const resolvedConfig: NonNullable<SolidityTestProfileConfig["invariant"]> =
-    {};
+  const { timeout, ...otherInvariantUserConfig } = invariantUserConfig;
 
-  if (invariantUserConfig.failurePersistDir !== undefined) {
-    resolvedConfig.failurePersistDir = invariantUserConfig.failurePersistDir;
-  }
-  if (invariantUserConfig.runs !== undefined) {
-    resolvedConfig.runs = invariantUserConfig.runs;
-  }
-  if (invariantUserConfig.depth !== undefined) {
-    resolvedConfig.depth = invariantUserConfig.depth;
-  }
-  if (invariantUserConfig.failOnRevert !== undefined) {
-    resolvedConfig.failOnRevert = invariantUserConfig.failOnRevert;
-  }
-  if (invariantUserConfig.callOverride !== undefined) {
-    resolvedConfig.callOverride = invariantUserConfig.callOverride;
-  }
-  if (invariantUserConfig.dictionaryWeight !== undefined) {
-    resolvedConfig.dictionaryWeight = invariantUserConfig.dictionaryWeight;
-  }
-  if (invariantUserConfig.includeStorage !== undefined) {
-    resolvedConfig.includeStorage = invariantUserConfig.includeStorage;
-  }
-  if (invariantUserConfig.includePushBytes !== undefined) {
-    resolvedConfig.includePushBytes = invariantUserConfig.includePushBytes;
-  }
-  if (invariantUserConfig.shrinkRunLimit !== undefined) {
-    resolvedConfig.shrinkRunLimit = invariantUserConfig.shrinkRunLimit;
-  }
-  if (invariantUserConfig.timeout !== undefined) {
-    resolvedConfig.timeout = Number(invariantUserConfig.timeout);
-  }
-
-  return resolvedConfig;
+  return {
+    ...otherInvariantUserConfig,
+    ...(timeout !== undefined ? { timeout: Number(timeout) } : {}),
+  };
 }
 
 export function resolveEip712TypesConfig(

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -32,6 +32,11 @@ import { DEFAULT_TEST_PROFILE } from "./test-profiles.js";
 export const DEFAULT_FUZZ_SEED =
   "0x7727ea51af0441c20da14dcd68a15dac8c9ebd589c5be8fa8c87c1d3720450bc";
 
+const nonnegativeSafeIntOrBigInt = unionType(
+  [z.number().int().nonnegative().safe(), z.bigint().nonnegative()],
+  "Expected a nonnegative safe int or a nonnegative bigint",
+);
+
 const solidityTestProfileUserConfigType = z.object({
   fsPermissions: z
     .object({
@@ -54,6 +59,7 @@ const solidityTestProfileUserConfigType = z.object({
   blockTimestamp: z.bigint().optional(),
   prevRandao: z.bigint().optional(),
   gasLimit: z.bigint().optional(),
+  memoryLimit: nonnegativeSafeIntOrBigInt.optional(),
   blockGasLimit: z.number().or(z.bigint()).or(z.literal(false)).optional(),
   transactionGasCap: z.number().or(z.bigint()).or(z.literal(false)).optional(),
   fuzz: z
@@ -67,6 +73,7 @@ const solidityTestProfileUserConfigType = z.object({
       includeStorage: z.boolean().optional(),
       includePushBytes: z.boolean().optional(),
       showLogs: z.boolean().optional(),
+      timeout: nonnegativeSafeIntOrBigInt.optional(),
     })
     .optional(),
   forking: z
@@ -92,6 +99,7 @@ const solidityTestProfileUserConfigType = z.object({
       includeStorage: z.boolean().optional(),
       includePushBytes: z.boolean().optional(),
       shrinkRunLimit: z.number().optional(),
+      timeout: nonnegativeSafeIntOrBigInt.optional(),
     })
     .optional(),
   eip712Types: z
@@ -222,12 +230,22 @@ export async function resolveSolidityTestUserConfig(
     resolveConfigurationVariable,
   );
 
+  const {
+    memoryLimit,
+    fuzz,
+    invariant,
+    eip712Types,
+    ...otherProfileUserConfig
+  } = profileUserConfig ?? {};
+
   const resolvedDefaultProfile = {
     rpcCachePath: defaultRpcCachePath,
-    ...profileUserConfig,
-    fuzz: resolveFuzzConfig(profileUserConfig?.fuzz),
+    ...otherProfileUserConfig,
+    memoryLimit: memoryLimit !== undefined ? BigInt(memoryLimit) : undefined,
+    fuzz: resolveFuzzConfig(fuzz),
+    invariant: resolveInvariantConfig(invariant),
     forking: resolvedForking,
-    eip712Types: resolveEip712TypesConfig(profileUserConfig?.eip712Types),
+    eip712Types: resolveEip712TypesConfig(eip712Types),
   };
 
   return {
@@ -251,10 +269,83 @@ export async function resolveSolidityTestUserConfig(
 export function resolveFuzzConfig(
   fuzzUserConfig: SolidityTestProfileUserConfig["fuzz"] = {},
 ): SolidityTestProfileConfig["fuzz"] {
-  return {
-    ...fuzzUserConfig,
+  const resolvedConfig: SolidityTestProfileConfig["fuzz"] = {
     seed: fuzzUserConfig.seed ?? DEFAULT_FUZZ_SEED,
   };
+
+  if (fuzzUserConfig.failurePersistDir !== undefined) {
+    resolvedConfig.failurePersistDir = fuzzUserConfig.failurePersistDir;
+  }
+  if (fuzzUserConfig.failurePersistFile !== undefined) {
+    resolvedConfig.failurePersistFile = fuzzUserConfig.failurePersistFile;
+  }
+  if (fuzzUserConfig.runs !== undefined) {
+    resolvedConfig.runs = fuzzUserConfig.runs;
+  }
+  if (fuzzUserConfig.maxTestRejects !== undefined) {
+    resolvedConfig.maxTestRejects = fuzzUserConfig.maxTestRejects;
+  }
+  if (fuzzUserConfig.dictionaryWeight !== undefined) {
+    resolvedConfig.dictionaryWeight = fuzzUserConfig.dictionaryWeight;
+  }
+  if (fuzzUserConfig.includeStorage !== undefined) {
+    resolvedConfig.includeStorage = fuzzUserConfig.includeStorage;
+  }
+  if (fuzzUserConfig.includePushBytes !== undefined) {
+    resolvedConfig.includePushBytes = fuzzUserConfig.includePushBytes;
+  }
+  if (fuzzUserConfig.showLogs !== undefined) {
+    resolvedConfig.showLogs = fuzzUserConfig.showLogs;
+  }
+  if (fuzzUserConfig.timeout !== undefined) {
+    resolvedConfig.timeout = Number(fuzzUserConfig.timeout);
+  }
+
+  return resolvedConfig;
+}
+
+export function resolveInvariantConfig(
+  invariantUserConfig: SolidityTestProfileUserConfig["invariant"],
+): SolidityTestProfileConfig["invariant"] {
+  if (invariantUserConfig === undefined) {
+    return undefined;
+  }
+
+  const resolvedConfig: NonNullable<SolidityTestProfileConfig["invariant"]> =
+    {};
+
+  if (invariantUserConfig.failurePersistDir !== undefined) {
+    resolvedConfig.failurePersistDir = invariantUserConfig.failurePersistDir;
+  }
+  if (invariantUserConfig.runs !== undefined) {
+    resolvedConfig.runs = invariantUserConfig.runs;
+  }
+  if (invariantUserConfig.depth !== undefined) {
+    resolvedConfig.depth = invariantUserConfig.depth;
+  }
+  if (invariantUserConfig.failOnRevert !== undefined) {
+    resolvedConfig.failOnRevert = invariantUserConfig.failOnRevert;
+  }
+  if (invariantUserConfig.callOverride !== undefined) {
+    resolvedConfig.callOverride = invariantUserConfig.callOverride;
+  }
+  if (invariantUserConfig.dictionaryWeight !== undefined) {
+    resolvedConfig.dictionaryWeight = invariantUserConfig.dictionaryWeight;
+  }
+  if (invariantUserConfig.includeStorage !== undefined) {
+    resolvedConfig.includeStorage = invariantUserConfig.includeStorage;
+  }
+  if (invariantUserConfig.includePushBytes !== undefined) {
+    resolvedConfig.includePushBytes = invariantUserConfig.includePushBytes;
+  }
+  if (invariantUserConfig.shrinkRunLimit !== undefined) {
+    resolvedConfig.shrinkRunLimit = invariantUserConfig.shrinkRunLimit;
+  }
+  if (invariantUserConfig.timeout !== undefined) {
+    resolvedConfig.timeout = Number(invariantUserConfig.timeout);
+  }
+
+  return resolvedConfig;
 }
 
 export function resolveEip712TypesConfig(

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts
@@ -33,6 +33,7 @@ declare module "../../../types/test.js" {
     includeStorage?: boolean;
     includePushBytes?: boolean;
     shrinkRunLimit?: number;
+    timeout?: number | bigint;
   }
 
   export interface SolidityTestFuzzUserConfig {
@@ -45,6 +46,7 @@ declare module "../../../types/test.js" {
     includeStorage?: boolean;
     includePushBytes?: boolean;
     showLogs?: boolean;
+    timeout?: number | bigint;
   }
 
   export interface SolidityTestForkingUserConfig {
@@ -66,6 +68,7 @@ declare module "../../../types/test.js" {
     blockTimestamp?: bigint;
     prevRandao?: bigint;
     gasLimit?: bigint;
+    memoryLimit?: number | bigint;
     blockGasLimit?: number | bigint | false;
     transactionGasCap?: number | bigint | false;
     fuzz?: SolidityTestFuzzUserConfig;
@@ -108,6 +111,7 @@ declare module "../../../types/test.js" {
     includeStorage?: boolean;
     includePushBytes?: boolean;
     shrinkRunLimit?: number;
+    timeout?: number;
   }
 
   export interface SolidityTestFuzzConfig {
@@ -120,6 +124,7 @@ declare module "../../../types/test.js" {
     includeStorage?: boolean;
     includePushBytes?: boolean;
     showLogs?: boolean;
+    timeout?: number;
   }
 
   export interface SolidityTestForkingConfig {
@@ -142,6 +147,7 @@ declare module "../../../types/test.js" {
     blockTimestamp?: bigint;
     prevRandao?: bigint;
     gasLimit?: bigint;
+    memoryLimit?: bigint;
     blockGasLimit?: number | bigint | false;
     transactionGasCap?: number | bigint | false;
     fuzz: SolidityTestFuzzConfig;

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
@@ -6,6 +6,7 @@ import { createHardhatRuntimeEnvironment } from "hardhat/hre";
 import {
   DEFAULT_FUZZ_SEED,
   resolveFuzzConfig,
+  resolveInvariantConfig,
 } from "../../../../src/internal/builtin-plugins/solidity-test/config.js";
 
 describe("config resolution", () => {
@@ -42,6 +43,7 @@ describe("config resolution", () => {
         maxTestRejects: 100,
         dictionaryWeight: 50,
         showLogs: true,
+        timeout: 30n,
       });
 
       assert.ok(result !== undefined, "result is undefined");
@@ -49,7 +51,22 @@ describe("config resolution", () => {
       assert.equal(result.maxTestRejects, 100);
       assert.equal(result.dictionaryWeight, 50);
       assert.equal(result.showLogs, true);
+      assert.equal(result.timeout, 30);
       assert.equal(result.seed, DEFAULT_FUZZ_SEED);
+    });
+  });
+
+  describe("resolveInvariantConfig", () => {
+    it("should return undefined when solidity test invariant config is undefined", () => {
+      const result = resolveInvariantConfig(undefined);
+
+      assert.equal(result, undefined);
+    });
+
+    it("should convert bigint timeout values to numbers", () => {
+      const result = resolveInvariantConfig({ timeout: 60n });
+
+      assert.deepEqual(result, { timeout: 60 });
     });
   });
 
@@ -59,15 +76,19 @@ describe("config resolution", () => {
         test: {
           solidity: {
             isolate: true,
+            memoryLimit: 17_179_869_184n,
             fuzz: { runs: 50 },
+            invariant: { timeout: 100n },
           },
         },
       });
 
       const defaultProfile = hre.config.test.solidity.profiles.default;
       assert.equal(defaultProfile.isolate, true);
+      assert.equal(defaultProfile.memoryLimit, 17_179_869_184n);
       assert.equal(defaultProfile.fuzz.runs, 50);
       assert.equal(defaultProfile.fuzz.seed, DEFAULT_FUZZ_SEED);
+      assert.equal(defaultProfile.invariant?.timeout, 100);
       assert.equal(defaultProfile.forking, undefined);
     });
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
@@ -68,6 +68,24 @@ describe("config resolution", () => {
 
       assert.deepEqual(result, { timeout: 60 });
     });
+
+    it("should preserve other invariant config properties", () => {
+      const result = resolveInvariantConfig({
+        runs: 500,
+        depth: 10,
+        failOnRevert: true,
+        shrinkRunLimit: 0,
+        timeout: 60n,
+      });
+
+      assert.deepEqual(result, {
+        runs: 500,
+        depth: 10,
+        failOnRevert: true,
+        shrinkRunLimit: 0,
+        timeout: 60,
+      });
+    });
   });
 
   describe("resolveSolidityTestUserConfig", () => {
@@ -90,6 +108,19 @@ describe("config resolution", () => {
       assert.equal(defaultProfile.fuzz.seed, DEFAULT_FUZZ_SEED);
       assert.equal(defaultProfile.invariant?.timeout, 100);
       assert.equal(defaultProfile.forking, undefined);
+    });
+
+    it("should normalize a number memoryLimit to a bigint", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        test: {
+          solidity: {
+            memoryLimit: 33_554_432,
+          },
+        },
+      });
+
+      const defaultProfile = hre.config.test.solidity.profiles.default;
+      assert.equal(defaultProfile.memoryLimit, 33_554_432n);
     });
 
     it("should resolve a `profiles` wrapper to the same shape as the equivalent flat config", async () => {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -126,4 +126,46 @@ describe("config validation", () => {
       },
     );
   });
+
+  it("should reject bigint fuzz timeouts that cannot be represented as safe numbers", async () => {
+    const userConfig: HardhatUserConfig = {
+      test: {
+        solidity: {
+          fuzz: { timeout: BigInt(Number.MAX_SAFE_INTEGER) + 1n },
+        },
+      },
+    };
+
+    await assertRejectsWithHardhatError(
+      createHardhatRuntimeEnvironment(userConfig),
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
+      {
+        errors:
+          "\t* Config error in config.test.solidity.fuzz.timeout: Expected a nonnegative safe int or a nonnegative safe bigint",
+      },
+    );
+  });
+
+  it("should reject bigint invariant timeouts that cannot be represented as safe numbers", async () => {
+    const userConfig: HardhatUserConfig = {
+      test: {
+        solidity: {
+          profiles: {
+            default: {
+              invariant: { timeout: BigInt(Number.MAX_SAFE_INTEGER) + 1n },
+            },
+          },
+        },
+      },
+    };
+
+    await assertRejectsWithHardhatError(
+      createHardhatRuntimeEnvironment(userConfig),
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
+      {
+        errors:
+          "\t* Config error in config.test.solidity.profiles.default.invariant.timeout: Expected a nonnegative safe int or a nonnegative safe bigint",
+      },
+    );
+  });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -168,4 +168,42 @@ describe("config validation", () => {
       },
     );
   });
+
+  it("should reject a negative memoryLimit", async () => {
+    const userConfig: HardhatUserConfig = {
+      test: {
+        solidity: {
+          memoryLimit: -1,
+        },
+      },
+    };
+
+    await assertRejectsWithHardhatError(
+      createHardhatRuntimeEnvironment(userConfig),
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
+      {
+        errors:
+          "\t* Config error in config.test.solidity.memoryLimit: Expected a nonnegative safe int or a nonnegative bigint",
+      },
+    );
+  });
+
+  it("should reject a non-integer memoryLimit", async () => {
+    const userConfig: HardhatUserConfig = {
+      test: {
+        solidity: {
+          memoryLimit: 1.5,
+        },
+      },
+    };
+
+    await assertRejectsWithHardhatError(
+      createHardhatRuntimeEnvironment(userConfig),
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
+      {
+        errors:
+          "\t* Config error in config.test.solidity.memoryLimit: Expected a nonnegative safe int or a nonnegative bigint",
+      },
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Closes #8110.

## Why

Solidity test config validation did not accept the `memoryLimit` runner option or fuzz/invariant `timeout` options described in #8110. Projects using these Foundry-compatible settings could not express them in Hardhat config.

## Changes

- Add `memoryLimit` to the Solidity test profile user/resolved config and normalize it to `bigint` for EDR.
- Add fuzz and invariant `timeout` user config support, accepting nonnegative safe numbers or safe bigints and normalizing to seconds as numbers for EDR.
- Preserve existing fuzz config resolution, including default seed behavior and existing `showLogs` support.
- Add config-resolution regression tests and a patch changeset.

## Validation

- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts`
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts`
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/type-extensions.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts`
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts`
- `pnpm prettier --check .changeset/wise-otters-smile.md`
- `cd packages/hardhat && pnpm build`

## Scope

Focused on Solidity test config resolution for existing EDR runner options. This does not add new inline-config directives or change Solidity test execution semantics beyond passing through these config values.


