### PR TITLE
feat: support solidity test profiles

### DIFF
--- a/.changeset/brown-dingos-serve.md
+++ b/.changeset/brown-dingos-serve.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Support named profiles in Solidity test config and inline config overrides.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -13,7 +13,6 @@ import type {
 
 import path from "node:path";
 
-import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 import { resolveFromRoot } from "@nomicfoundation/hardhat-utils/path";
 import {
@@ -116,12 +115,6 @@ const solidityTestProfilesUserConfigType = z.object({
     .refine(
       (profiles) => DEFAULT_TEST_PROFILE in profiles,
       "A `default` profile is required when using `profiles`",
-    )
-    .refine(
-      (profiles) =>
-        !(DEFAULT_TEST_PROFILE in profiles) ||
-        Object.keys(profiles).every((name) => name === DEFAULT_TEST_PROFILE),
-      "Only the `default` profile is supported. Other profile names will be supported in a future release.",
     ),
 });
 
@@ -206,29 +199,27 @@ export async function resolveSolidityTestUserConfig(
   const defaultRpcCachePath = path.join(resolvedConfig.paths.cache, "edr");
 
   const solidityUserConfig = userConfig.test?.solidity;
-  let profileUserConfig: SolidityTestProfileUserConfig | undefined;
+  let profileUserConfigs: Record<string, SolidityTestProfileUserConfig>;
   if (solidityUserConfig !== undefined && "profiles" in solidityUserConfig) {
-    profileUserConfig = solidityUserConfig.profiles[DEFAULT_TEST_PROFILE];
-    assertHardhatInvariant(
-      profileUserConfig !== undefined,
-      "default profile must be present when the profiles wrapper user config is supplied",
-    );
+    profileUserConfigs = solidityUserConfig.profiles;
   } else {
-    profileUserConfig = solidityUserConfig;
+    profileUserConfigs = {
+      [DEFAULT_TEST_PROFILE]: solidityUserConfig ?? {},
+    };
   }
 
-  const resolvedForking = resolveSolidityTestForkingConfig(
-    profileUserConfig?.forking,
-    resolveConfigurationVariable,
+  const resolvedProfiles = Object.fromEntries(
+    Object.entries(profileUserConfigs).map(
+      ([profileName, profileUserConfig]) => [
+        profileName,
+        resolveSolidityTestProfileUserConfig(
+          profileUserConfig,
+          defaultRpcCachePath,
+          resolveConfigurationVariable,
+        ),
+      ],
+    ),
   );
-
-  const resolvedDefaultProfile = {
-    rpcCachePath: defaultRpcCachePath,
-    ...profileUserConfig,
-    fuzz: resolveFuzzConfig(profileUserConfig?.fuzz),
-    forking: resolvedForking,
-    eip712Types: resolveEip712TypesConfig(profileUserConfig?.eip712Types),
-  };
 
   return {
     ...resolvedConfig,
@@ -242,9 +233,28 @@ export async function resolveSolidityTestUserConfig(
     test: {
       ...resolvedConfig.test,
       solidity: {
-        profiles: { [DEFAULT_TEST_PROFILE]: resolvedDefaultProfile },
+        profiles: resolvedProfiles,
       },
     },
+  };
+}
+
+function resolveSolidityTestProfileUserConfig(
+  profileUserConfig: SolidityTestProfileUserConfig,
+  defaultRpcCachePath: string,
+  resolveConfigurationVariable: ConfigurationVariableResolver,
+): SolidityTestProfileConfig {
+  const resolvedForking = resolveSolidityTestForkingConfig(
+    profileUserConfig.forking,
+    resolveConfigurationVariable,
+  );
+
+  return {
+    rpcCachePath: defaultRpcCachePath,
+    ...profileUserConfig,
+    fuzz: resolveFuzzConfig(profileUserConfig.fuzz),
+    forking: resolvedForking,
+    eip712Types: resolveEip712TypesConfig(profileUserConfig.eip712Types),
   };
 }
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -13,6 +13,7 @@ import {
 import { bytesToUtf8String } from "@nomicfoundation/hardhat-utils/bytes";
 
 import { getFullyQualifiedName } from "../../../../utils/contract-names.js";
+import { DEFAULT_TEST_PROFILE } from "../test-profiles.js";
 
 import {
   buildInfoContainsInlineConfig,
@@ -51,6 +52,7 @@ interface CollectedOverrides {
 export function getTestFunctionOverrides(
   testSuiteArtifacts: EdrArtifactWithMetadata[],
   buildInfosAndOutputs: BuildInfoAndOutput[],
+  selectedProfile: string = DEFAULT_TEST_PROFILE,
 ): TestFunctionOverride[] {
   const allRawOverrides = collectRawOverrides(
     testSuiteArtifacts,
@@ -59,7 +61,7 @@ export function getTestFunctionOverrides(
 
   validateInlineOverrides(allRawOverrides.overrides);
 
-  return buildTestFunctionOverrides(allRawOverrides);
+  return buildTestFunctionOverrides(allRawOverrides, selectedProfile);
 }
 
 function collectRawOverrides(
@@ -191,6 +193,7 @@ function collectRawOverrides(
 
 function buildTestFunctionOverrides(
   collected: CollectedOverrides,
+  selectedProfile: string,
 ): TestFunctionOverride[] {
   const { overrides, artifactIdsByFqn, methodIdentifiersByContract } =
     collected;
@@ -200,6 +203,10 @@ function buildTestFunctionOverrides(
   // overloaded functions. Otherwise fall back to function name only.
   const overridesByFunction = new Map<string, RawInlineOverride[]>();
   for (const override of overrides) {
+    if (override.profile !== selectedProfile) {
+      continue;
+    }
+
     const functionFqn = getFunctionFqn(
       override.inputSourceName,
       override.contractName,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/parsing.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/parsing.ts
@@ -7,6 +7,8 @@ import {
   snakeToCamelCase,
 } from "@nomicfoundation/hardhat-utils/string";
 
+import { DEFAULT_TEST_PROFILE } from "../test-profiles.js";
+
 import {
   HARDHAT_CONFIG_PREFIX,
   FORGE_CONFIG_PREFIX,
@@ -150,6 +152,7 @@ export function parseInlineConfigLine(
   const rawKey = keyValueSegment.slice(0, eqIndex).trim();
   let parsedKey = rawKey;
   const rawValue = keyValueSegment.slice(eqIndex + 1).trim();
+  let profile = DEFAULT_TEST_PROFILE;
 
   // Detect profile prefix: if the first dot-segment is NOT a known top-level
   // category, treat it as a profile name.
@@ -157,18 +160,7 @@ export function parseInlineConfigLine(
   if (firstDot !== -1) {
     const firstSegment = rawKey.slice(0, firstDot);
     if (!TOP_LEVEL_KEYS.includes(firstSegment)) {
-      // It's a profile. Validate it.
-      const profile = firstSegment;
-      if (profile !== "default") {
-        throw new HardhatError(
-          HardhatError.ERRORS.CORE.SOLIDITY_TESTS.INLINE_CONFIG_UNSUPPORTED_PROFILE,
-          {
-            profile,
-            functionFqn,
-          },
-        );
-      }
-      // Strip the "default." prefix
+      profile = firstSegment;
       parsedKey = rawKey.slice(firstDot + 1);
     }
   }
@@ -176,6 +168,7 @@ export function parseInlineConfigLine(
   parsedKey = snakeToCamelCase(kebabToCamelCase(parsedKey));
 
   return {
+    profile,
     inputSourceName,
     contractName,
     functionName,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/types.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/types.ts
@@ -1,4 +1,5 @@
 export interface RawInlineOverride {
+  profile: string;
   inputSourceName: string;
   contractName: string;
   functionName: string;

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/validation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/validation.ts
@@ -26,6 +26,7 @@ export function validateInlineOverrides(overrides: RawInlineOverride[]): void {
     contractName,
     functionName,
     functionSelector,
+    profile,
     rawKey,
     rawValue,
     key,
@@ -82,7 +83,7 @@ export function validateInlineOverrides(overrides: RawInlineOverride[]): void {
       functionSelector !== undefined
         ? `${functionFqn}#${functionSelector}`
         : functionFqn;
-    const dedupeKey = `${functionId}-${key}`;
+    const dedupeKey = `${functionId}-${profile}-${key}`;
     if (seen.has(dedupeKey)) {
       throw new HardhatError(
         HardhatError.ERRORS.CORE.SOLIDITY_TESTS.INLINE_CONFIG_DUPLICATE_KEY,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -202,8 +202,13 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   let includesFailures = false;
   let includesErrors = false;
 
+  const selectedTestProfile =
+    hre.config.test.solidity.profiles[hre.globalOptions.buildProfile] !==
+    undefined
+      ? hre.globalOptions.buildProfile
+      : DEFAULT_TEST_PROFILE;
   const { eip712Types, ...solidityTestConfig } =
-    hre.config.test.solidity.profiles[DEFAULT_TEST_PROFILE];
+    hre.config.test.solidity.profiles[selectedTestProfile];
 
   let observabilityConfig: ObservabilityConfig | undefined;
   if (hre.globalOptions.coverage) {
@@ -234,6 +239,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   const testFunctionOverrides = getTestFunctionOverrides(
     testSuiteArtifacts,
     allBuildInfosAndOutputs,
+    selectedTestProfile,
   );
 
   const eip712CanonicalTypes = collectEip712CanonicalTypes(

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
@@ -99,5 +99,36 @@ describe("config resolution", () => {
         flatHre.config.test.solidity,
       );
     });
+
+    it("should resolve named profiles", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        test: {
+          solidity: {
+            profiles: {
+              default: {
+                fuzz: { runs: 50 },
+              },
+              ci: {
+                isolate: true,
+                fuzz: { runs: 1_000, seed: "0x123" },
+              },
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(Object.keys(hre.config.test.solidity.profiles), [
+        "default",
+        "ci",
+      ]);
+      assert.equal(hre.config.test.solidity.profiles.default.fuzz.runs, 50);
+      assert.equal(
+        hre.config.test.solidity.profiles.default.fuzz.seed,
+        DEFAULT_FUZZ_SEED,
+      );
+      assert.equal(hre.config.test.solidity.profiles.ci.isolate, true);
+      assert.equal(hre.config.test.solidity.profiles.ci.fuzz.runs, 1_000);
+      assert.equal(hre.config.test.solidity.profiles.ci.fuzz.seed, "0x123");
+    });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -147,6 +147,32 @@ describe("inline-config", () => {
       assert.deepEqual(overrides[0].config, { fuzz: { runs: 50 } });
     });
 
+    it("should apply only inline overrides for the selected profile", () => {
+      const bi = makeBuildInfo(
+        "test/MyTest.sol",
+        "/// hardhat-config: fuzz.runs = 50\n/// hardhat-config: ci.fuzz.runs = 1000",
+        {
+          MyTest: {
+            methodIdentifiers: { "testFuzz()": "aabbccdd" },
+            functions: [
+              {
+                name: "testFuzz",
+                documentation:
+                  " hardhat-config: fuzz.runs = 50\n hardhat-config: ci.fuzz.runs = 1000",
+              },
+            ],
+          },
+        },
+      );
+      const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
+
+      const defaultOverrides = getTestFunctionOverrides(artifacts, [bi]);
+      const ciOverrides = getTestFunctionOverrides(artifacts, [bi], "ci");
+
+      assert.deepEqual(defaultOverrides[0].config, { fuzz: { runs: 50 } });
+      assert.deepEqual(ciOverrides[0].config, { fuzz: { runs: 1000 } });
+    });
+
     it("should merge overrides from mixed hardhat-config: and forge-config: prefixes", () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/mocks.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/mocks.ts
@@ -7,6 +7,7 @@ export function makeRawOverride(
   partial: Partial<RawInlineOverride> & { key: string; rawValue: string },
 ): RawInlineOverride {
   return {
+    profile: partial.profile ?? "default",
     inputSourceName: partial.inputSourceName ?? "test/MyTest.sol",
     contractName: partial.contractName ?? "MyTest",
     functionName: partial.functionName ?? "testFoo",


### PR DESCRIPTION
## Summary

Closes #8145.

## Why

Solidity test config accepted a `profiles` wrapper but rejected every profile except `default`, and inline config rejected non-default profile prefixes. That prevented projects from using profile-specific Solidity test settings for local vs CI-style runs.

## Changes

- Resolve all configured Solidity test profiles instead of collapsing to `default`.
- Select the Solidity test profile matching `--build-profile`, falling back to `default` when no matching test profile exists.
- Parse profile-prefixed inline config keys such as `ci.fuzz.runs` and apply only the overrides for the selected profile.
- Keep duplicate inline-key detection scoped per profile.
- Add regression coverage for named config profiles and selected-profile inline overrides.
- Add a patch changeset for `hardhat`.

## Validation

- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts`
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/parsing.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/validation.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/types.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/mocks.ts --fix`
- `pnpm prettier --check .changeset/brown-dingos-serve.md`
- `cd packages/hardhat && pnpm build`

## Scope

Focused on Solidity test profile resolution and inline override selection. This does not add a separate test-profile CLI flag; it follows the existing build profile selection used by Solidity builds.
