### PR TITLE
fix: retry failing Verdaccio fetch

### DIFF
--- a/scripts/end-to-end/subcommands/init.ts
+++ b/scripts/end-to-end/subcommands/init.ts
@@ -274,9 +274,8 @@ async function getLatestFromVerdaccio(
       const latest = metadata["dist-tags"]?.latest;
 
       if (latest === undefined) {
-        logWarning(
-          `Verdaccio returned no \`dist-tags.latest\` for ${packageName} ` +
-            `(GET ${url})`,
+        throw new Error(
+          `Verdaccio returned no \`dist-tags.latest\` for ${packageName} (GET ${url})`,
         );
       }
 

--- a/scripts/end-to-end/subcommands/init.ts
+++ b/scripts/end-to-end/subcommands/init.ts
@@ -247,7 +247,7 @@ function sleep(ms: number): Promise<void> {
  * submodule clone burst momentarily exhausts the runner's sockets / ephemeral
  * ports right before this fetch runs, which makes the localhost request throw
  * `fetch failed`. If the failure persists this throws, so the scenario fails
- * loudly instead of silently benchmarking out-of-date-code.
+ * loudly instead of silently benchmarking out-of-date code.
  */
 async function getLatestFromVerdaccio(
   packageName: string,

--- a/scripts/end-to-end/subcommands/init.ts
+++ b/scripts/end-to-end/subcommands/init.ts
@@ -233,10 +233,16 @@ async function updateLocalDependencies(scenario: Scenario): Promise<void> {
 async function getLatestFromVerdaccio(
   packageName: string,
 ): Promise<string | undefined> {
+  const url = `${VERDACCIO_URL}/${packageName}`;
+
   try {
-    const response = await globalThis.fetch(`${VERDACCIO_URL}/${packageName}`);
+    const response = await globalThis.fetch(url);
 
     if (!response.ok) {
+      logWarning(
+        `Could not resolve latest ${packageName} from Verdaccio: ` +
+          `GET ${url} returned ${response.status} ${response.statusText}`,
+      );
       return undefined;
     }
 
@@ -244,8 +250,23 @@ async function getLatestFromVerdaccio(
       "dist-tags"?: { latest?: string };
     };
 
-    return metadata["dist-tags"]?.latest;
-  } catch {
+    const latest = metadata["dist-tags"]?.latest;
+
+    if (latest === undefined) {
+      logWarning(
+        `Could not resolve latest ${packageName} from Verdaccio: ` +
+          `GET ${url} returned no \`dist-tags.latest\``,
+      );
+    }
+
+    return latest;
+  } catch (error) {
+    logWarning(
+      `Could not resolve latest ${packageName} from Verdaccio: ` +
+        `GET ${url} failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+    );
     return undefined;
   }
 }

--- a/scripts/end-to-end/subcommands/init.ts
+++ b/scripts/end-to-end/subcommands/init.ts
@@ -300,6 +300,7 @@ async function getLatestFromVerdaccio(
       throw new Error(
         `Could not resolve latest ${packageName} from Verdaccio after ` +
           `${VERDACCIO_FETCH_ATTEMPTS} attempts: GET ${url} failed: ${reason}`,
+        { cause: error },
       );
     }
   }

--- a/scripts/end-to-end/subcommands/init.ts
+++ b/scripts/end-to-end/subcommands/init.ts
@@ -230,45 +230,83 @@ async function updateLocalDependencies(scenario: Scenario): Promise<void> {
   );
 }
 
+const VERDACCIO_FETCH_ATTEMPTS = 4;
+const VERDACCIO_FETCH_RETRY_DELAY_MS = 1_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Resolve a package's `dist-tags.latest` from Verdaccio.
+ *
+ * Returns `undefined` only when the package genuinely isn't in the registry
+ * (404).
+ *
+ * A transient connection failure is retried. Sometimes a scenario's recursive
+ * submodule clone burst momentarily exhausts the runner's sockets / ephemeral
+ * ports right before this fetch runs, which makes the localhost request throw
+ * `fetch failed`. If the failure persists this throws, so the scenario fails
+ * loudly instead of silently benchmarking out-of-date-code.
+ */
 async function getLatestFromVerdaccio(
   packageName: string,
 ): Promise<string | undefined> {
   const url = `${VERDACCIO_URL}/${packageName}`;
 
-  try {
-    const response = await globalThis.fetch(url);
+  for (let attempt = 1; attempt <= VERDACCIO_FETCH_ATTEMPTS; attempt++) {
+    try {
+      const response = await globalThis.fetch(url);
 
-    if (!response.ok) {
-      logWarning(
-        `Could not resolve latest ${packageName} from Verdaccio: ` +
-          `GET ${url} returned ${response.status} ${response.statusText}`,
+      // A genuine "not in the registry" answer — don't retry, don't fail.
+      if (response.status === 404) {
+        return undefined;
+      }
+
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`);
+      }
+
+      const metadata = (await response.json()) as {
+        "dist-tags"?: { latest?: string };
+      };
+
+      const latest = metadata["dist-tags"]?.latest;
+
+      if (latest === undefined) {
+        logWarning(
+          `Verdaccio returned no \`dist-tags.latest\` for ${packageName} ` +
+            `(GET ${url})`,
+        );
+      }
+
+      return latest;
+    } catch (error) {
+      const reason =
+        error instanceof Error
+          ? error.cause instanceof Error
+            ? `${error.message} (${error.cause.message})`
+            : error.message
+          : String(error);
+
+      if (attempt < VERDACCIO_FETCH_ATTEMPTS) {
+        logWarning(
+          `GET ${url} failed (attempt ${attempt}/${VERDACCIO_FETCH_ATTEMPTS}): ` +
+            `${reason}; retrying in ${VERDACCIO_FETCH_RETRY_DELAY_MS}ms`,
+        );
+        await sleep(VERDACCIO_FETCH_RETRY_DELAY_MS);
+        continue;
+      }
+
+      throw new Error(
+        `Could not resolve latest ${packageName} from Verdaccio after ` +
+          `${VERDACCIO_FETCH_ATTEMPTS} attempts: GET ${url} failed: ${reason}`,
       );
-      return undefined;
     }
-
-    const metadata = (await response.json()) as {
-      "dist-tags"?: { latest?: string };
-    };
-
-    const latest = metadata["dist-tags"]?.latest;
-
-    if (latest === undefined) {
-      logWarning(
-        `Could not resolve latest ${packageName} from Verdaccio: ` +
-          `GET ${url} returned no \`dist-tags.latest\``,
-      );
-    }
-
-    return latest;
-  } catch (error) {
-    logWarning(
-      `Could not resolve latest ${packageName} from Verdaccio: ` +
-        `GET ${url} failed: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-    );
-    return undefined;
   }
+
+  // Unreachable: the loop returns or throws on the final attempt.
+  throw new Error(`Could not resolve latest ${packageName} from Verdaccio`);
 }
 
 function clone(scenarioWorkingDir: string, repo: string): void {


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Makes the e2e harness's `getLatestFromVerdaccio` resilient to transient connection failures, and adds logging so future failures are debuggable instead of silent.

## Symptoms

Regression-benchmark scenarios intermittently failed an EDR workflow because an **old** hardhat—and therefore an old `@nomicfoundation/edr`—was resolved instead of the locally-published build. The affected scenarios were inconsistent run-to-run and interleaved with passing ones, and the harness logged `No matching dependencies to update` even for scenarios that *do* declare `hardhat` as a (dev)dependency.

## Root cause

`updateLocalDependencies` resolves each local dep's target version via `getLatestFromVerdaccio`, which returned `undefined` on any failure — silently — so the scenario kept its pinned (old) version, only surfacing much later as a confusing "wrong EDR build" validation error.

After adding failure logging, I discovered that the fetch reqest `GET http://127.0.0.1:4873/<pkg>` threw `fetch failed`, firing immediately after a scenario's recursive **git submodule clone burst** (the affected scenarios are exactly the deep-submodule foundry repos). Verdaccio never restarted, so this is a transient *client-side* failure — the clone burst momentarily exhausts the runner's sockets / ephemeral ports, breaking the localhost fetch that runs right after.

## Fix

`getLatestFromVerdaccio` now:

- **Retries** transient failures (4 attempts, 1s apart) — the fetch succeeds once the clone burst settles. This is what fixes the flaky runs.
- **Fails fast**: if resolution still fails after all attempts, it throws, so the scenario fails loudly (and retryably) instead of silently installing a stale version.
- Treats a genuine **404 as `undefined`** (no retry, no throw), preserving the legitimate "package not in the registry" path so scenarios without local deps still log `No matching dependencies to update`.
- Logs failures (including `error.cause`, e.g. `other side closed`) on `!response.ok`, missing `dist-tags.latest`, and connection errors.

## Testing

- [x] Validated the resolver logic against a controllable local server: transient failure (fail ×2 then OK) returns the version after retrying; `404` returns `undefined`; a persistently-unreachable server throws after 4 attempts.
- [x] Validated that EDR's workflow ran successfully when tested against this branch