### PR TITLE
fix: stream parse Solidity test build outputs

### DIFF
--- a/.changeset/large-build-outputs-stream.md
+++ b/.changeset/large-build-outputs-stream.md
@@ -3,4 +3,4 @@
 "hardhat": patch
 ---
 
-Stream parse Solidity test build outputs that exceed V8's maximum string length.
+Fixed Solidity tests failing to run in projects with very large compilation outputs.

--- a/.changeset/large-build-outputs-stream.md
+++ b/.changeset/large-build-outputs-stream.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+"hardhat": patch
+---
+
+Stream parse Solidity test build outputs that exceed V8's maximum string length.

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -1507,6 +1507,15 @@ Make sure the plugin that provides the "{compilerType}" compiler is installed an
 
 Make sure the plugin that provides the compiler is installed and enabled in your Hardhat config.`,
       },
+      BUILD_INFO_OUTPUT_PARSE_ERROR: {
+        number: 919,
+        messageTemplate: `Failed to parse the compilation output for build info "{buildInfoId}".
+
+This usually means the artifact is corrupted. Recompiling your project should fix it.`,
+        websiteTitle: "Failed to parse build info output",
+        websiteDescription:
+          "Hardhat could not parse the compilation output of a build info. The artifact is likely corrupted.",
+      },
     },
     ARTIFACTS: {
       NOT_FOUND: {

--- a/packages/hardhat-utils/src/bytes.ts
+++ b/packages/hardhat-utils/src/bytes.ts
@@ -1,4 +1,6 @@
-import { buildLpsTable } from "./internal/bytes.js";
+import { Readable } from "node:stream";
+
+import { buildLpsTable, parseJsonStream } from "./internal/bytes.js";
 
 /**
  * Checks if a value is an instance of Uint8Array.
@@ -103,6 +105,17 @@ export function bytesIncludesUtf8String(
   }
 
   return false;
+}
+
+/**
+ * Parses JSON bytes as a stream. This function should be used when
+ * parsing very large JSON payloads.
+ *
+ * @param bytes The UTF-8 encoded JSON bytes.
+ * @returns The parsed JSON object.
+ */
+export async function parseJsonBytesAsStream<T>(bytes: Uint8Array): Promise<T> {
+  return await parseJsonStream<T>(Readable.from([bytes]));
 }
 
 export { bytesToBigInt, bytesToNumber, numberToBytes } from "./number.js";

--- a/packages/hardhat-utils/src/bytes.ts
+++ b/packages/hardhat-utils/src/bytes.ts
@@ -108,14 +108,29 @@ export function bytesIncludesUtf8String(
 }
 
 /**
- * Parses JSON bytes as a stream. This function should be used when
- * parsing very large JSON payloads.
+ * Parses UTF-8 encoded JSON bytes into a value.
+ *
+ * Payloads that fit in a single string are decoded and parsed with
+ * `JSON.parse`, which is much faster. Payloads too large to be held in a
+ * single string are parsed as a stream instead, which decodes and parses
+ * incrementally rather than materializing the whole payload as one string.
  *
  * @param bytes The UTF-8 encoded JSON bytes.
  * @returns The parsed JSON object.
  */
-export async function parseJsonBytesAsStream<T>(bytes: Uint8Array): Promise<T> {
-  return await parseJsonStream<T>(Readable.from([bytes]));
+export async function parseJsonBytes<T>(bytes: Uint8Array): Promise<T> {
+  let json: string;
+  try {
+    json = bytesToUtf8String(bytes);
+  } catch {
+    // `bytesToUtf8String` decodes non-fatally, so it never throws on malformed
+    // bytes; its only failure mode is a payload larger than the maximum string
+    // length the runtime can hold. Stream parsing handles those, as it never
+    // materializes the whole payload as a single string.
+    return await parseJsonStream<T>(Readable.from([bytes]));
+  }
+
+  return JSON.parse(json);
 }
 
 export { bytesToBigInt, bytesToNumber, numberToBytes } from "./number.js";

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -1,11 +1,9 @@
-import type * as StreamParserJson from "@streamparser/json-node";
 import type * as JsonStreamStringify from "json-stream-stringify";
 import type { FileHandle } from "node:fs/promises";
 
 import fsPromises from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 import { ensureError, ensureNodeErrnoExceptionError } from "./error.js";
@@ -19,14 +17,11 @@ import {
   IsDirectoryError,
   DirectoryNotEmptyError,
 } from "./errors/fs.js";
+import { parseJsonStream } from "./internal/bytes.js";
 import {
   collectAllDirectoriesMatching,
   collectAllFilesMatching,
 } from "./internal/fs.js";
-
-// We don't load @streamparser/json-node on startup because it's only
-// used for parsing very large JSON payloads.
-let streamParserJson: typeof StreamParserJson | undefined;
 
 // We don't load json-stream-stringify on startup because it's only
 // used by writeJsonFileAsStream for very large JSON objects.
@@ -406,52 +401,6 @@ export async function readJsonFile<T>(absolutePathToFile: string): Promise<T> {
     ensureError(e);
     throw new InvalidFileFormatError(absolutePathToFile, e);
   }
-}
-
-async function parseJsonStream<T>(stream: Readable): Promise<T> {
-  if (streamParserJson === undefined) {
-    streamParserJson = await import("@streamparser/json-node");
-  }
-
-  // NOTE: We set a separator to disable self-closing to be able to use the parser
-  // in the stream.pipeline context; see https://github.com/juanjoDiaz/streamparser-json/issues/47
-  const jsonParser = new streamParserJson.JSONParser({
-    separator: "",
-  });
-
-  const result: T | undefined = await pipeline(
-    stream,
-    jsonParser,
-    async (
-      elements: AsyncIterable<StreamParserJson.ParsedElementInfo.ParsedElementInfo>,
-    ): Promise<any | undefined> => {
-      let value:
-        | StreamParserJson.JsonTypes.JsonPrimitive
-        | StreamParserJson.JsonTypes.JsonStruct
-        | undefined;
-      for await (const element of elements) {
-        value = element.value;
-      }
-      return value;
-    },
-  );
-
-  if (result === undefined) {
-    throw new Error("No data");
-  }
-
-  return result;
-}
-
-/**
- * Parses JSON bytes as a stream. This function should be used when
- * parsing very large JSON payloads.
- *
- * @param bytes The UTF-8 encoded JSON bytes.
- * @returns The parsed JSON object.
- */
-export async function parseJsonBytesAsStream<T>(bytes: Uint8Array): Promise<T> {
-  return await parseJsonStream<T>(Readable.from([bytes]));
 }
 
 /**

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -25,7 +25,7 @@ import {
 } from "./internal/fs.js";
 
 // We don't load @streamparser/json-node on startup because it's only
-// used by readJsonFileAsStream for very large JSON files.
+// used for parsing very large JSON payloads.
 let streamParserJson: typeof StreamParserJson | undefined;
 
 // We don't load json-stream-stringify on startup because it's only
@@ -408,15 +408,7 @@ export async function readJsonFile<T>(absolutePathToFile: string): Promise<T> {
   }
 }
 
-/**
- * Parses JSON bytes as a stream. This avoids materializing the full input as a
- * single string, which can exceed V8's maximum string size for very large JSON
- * payloads.
- *
- * @param bytes The UTF-8 encoded JSON bytes.
- * @returns The parsed JSON object.
- */
-export async function parseJsonBytesAsStream<T>(bytes: Uint8Array): Promise<T> {
+async function parseJsonStream<T>(stream: Readable): Promise<T> {
   if (streamParserJson === undefined) {
     streamParserJson = await import("@streamparser/json-node");
   }
@@ -428,7 +420,7 @@ export async function parseJsonBytesAsStream<T>(bytes: Uint8Array): Promise<T> {
   });
 
   const result: T | undefined = await pipeline(
-    Readable.from([bytes]),
+    stream,
     jsonParser,
     async (
       elements: AsyncIterable<StreamParserJson.ParsedElementInfo.ParsedElementInfo>,
@@ -452,6 +444,17 @@ export async function parseJsonBytesAsStream<T>(bytes: Uint8Array): Promise<T> {
 }
 
 /**
+ * Parses JSON bytes as a stream. This function should be used when
+ * parsing very large JSON payloads.
+ *
+ * @param bytes The UTF-8 encoded JSON bytes.
+ * @returns The parsed JSON object.
+ */
+export async function parseJsonBytesAsStream<T>(bytes: Uint8Array): Promise<T> {
+  return await parseJsonStream<T>(Readable.from([bytes]));
+}
+
+/**
  * Reads a JSON file as a stream and parses it. The encoding used is "utf8".
  * This function should be used when parsing very large JSON files.
  *
@@ -470,40 +473,7 @@ export async function readJsonFileAsStream<T>(
   try {
     fileHandle = await fsPromises.open(absolutePathToFile, "r");
 
-    const fileReadStream = fileHandle.createReadStream();
-
-    if (streamParserJson === undefined) {
-      streamParserJson = await import("@streamparser/json-node");
-    }
-
-    // NOTE: We set a separator to disable self-closing to be able to use the parser
-    // in the stream.pipeline context; see https://github.com/juanjoDiaz/streamparser-json/issues/47
-    const jsonParser = new streamParserJson.JSONParser({
-      separator: "",
-    });
-
-    const result: T | undefined = await pipeline(
-      fileReadStream,
-      jsonParser,
-      async (
-        elements: AsyncIterable<StreamParserJson.ParsedElementInfo.ParsedElementInfo>,
-      ): Promise<any | undefined> => {
-        let value:
-          | StreamParserJson.JsonTypes.JsonPrimitive
-          | StreamParserJson.JsonTypes.JsonStruct
-          | undefined;
-        for await (const element of elements) {
-          value = element.value;
-        }
-        return value;
-      },
-    );
-
-    if (result === undefined) {
-      throw new Error("No data");
-    }
-
-    return result;
+    return await parseJsonStream<T>(fileHandle.createReadStream());
   } catch (e) {
     ensureError(e);
 

--- a/packages/hardhat-utils/src/fs.ts
+++ b/packages/hardhat-utils/src/fs.ts
@@ -5,6 +5,7 @@ import type { FileHandle } from "node:fs/promises";
 import fsPromises from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 import { ensureError, ensureNodeErrnoExceptionError } from "./error.js";
@@ -405,6 +406,49 @@ export async function readJsonFile<T>(absolutePathToFile: string): Promise<T> {
     ensureError(e);
     throw new InvalidFileFormatError(absolutePathToFile, e);
   }
+}
+
+/**
+ * Parses JSON bytes as a stream. This avoids materializing the full input as a
+ * single string, which can exceed V8's maximum string size for very large JSON
+ * payloads.
+ *
+ * @param bytes The UTF-8 encoded JSON bytes.
+ * @returns The parsed JSON object.
+ */
+export async function parseJsonBytesAsStream<T>(bytes: Uint8Array): Promise<T> {
+  if (streamParserJson === undefined) {
+    streamParserJson = await import("@streamparser/json-node");
+  }
+
+  // NOTE: We set a separator to disable self-closing to be able to use the parser
+  // in the stream.pipeline context; see https://github.com/juanjoDiaz/streamparser-json/issues/47
+  const jsonParser = new streamParserJson.JSONParser({
+    separator: "",
+  });
+
+  const result: T | undefined = await pipeline(
+    Readable.from([bytes]),
+    jsonParser,
+    async (
+      elements: AsyncIterable<StreamParserJson.ParsedElementInfo.ParsedElementInfo>,
+    ): Promise<any | undefined> => {
+      let value:
+        | StreamParserJson.JsonTypes.JsonPrimitive
+        | StreamParserJson.JsonTypes.JsonStruct
+        | undefined;
+      for await (const element of elements) {
+        value = element.value;
+      }
+      return value;
+    },
+  );
+
+  if (result === undefined) {
+    throw new Error("No data");
+  }
+
+  return result;
 }
 
 /**

--- a/packages/hardhat-utils/src/internal/bytes.ts
+++ b/packages/hardhat-utils/src/internal/bytes.ts
@@ -1,4 +1,55 @@
 // cSpell:ignore ABCAB ABCA BCAB
+import type * as StreamParserJson from "@streamparser/json-node";
+import type { Readable } from "node:stream";
+
+import { pipeline } from "node:stream/promises";
+
+// We don't load @streamparser/json-node on startup because it's only
+// used for parsing very large JSON payloads.
+let streamParserJson: typeof StreamParserJson | undefined;
+
+/**
+ * Parses a stream of UTF-8 encoded JSON bytes and returns the parsed value.
+ * This should be used when parsing very large JSON payloads.
+ *
+ * @param stream The stream of UTF-8 encoded JSON bytes.
+ * @returns The parsed JSON value.
+ */
+export async function parseJsonStream<T>(stream: Readable): Promise<T> {
+  if (streamParserJson === undefined) {
+    streamParserJson = await import("@streamparser/json-node");
+  }
+
+  // NOTE: We set a separator to disable self-closing to be able to use the parser
+  // in the stream.pipeline context; see https://github.com/juanjoDiaz/streamparser-json/issues/47
+  const jsonParser = new streamParserJson.JSONParser({
+    separator: "",
+  });
+
+  const result: T | undefined = await pipeline(
+    stream,
+    jsonParser,
+    async (
+      elements: AsyncIterable<StreamParserJson.ParsedElementInfo.ParsedElementInfo>,
+    ): Promise<any | undefined> => {
+      let value:
+        | StreamParserJson.JsonTypes.JsonPrimitive
+        | StreamParserJson.JsonTypes.JsonStruct
+        | undefined;
+      for await (const element of elements) {
+        value = element.value;
+      }
+      return value;
+    },
+  );
+
+  if (result === undefined) {
+    throw new Error("No data");
+  }
+
+  return result;
+}
+
 /**
  * Builds the LPS (Longest Prefix Suffix) table used by the Knuth-Morris-Pratt
  * string search algorithm. For each index `i` in the pattern, `lps[i]` holds

--- a/packages/hardhat-utils/test/bytes.ts
+++ b/packages/hardhat-utils/test/bytes.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { expectTypeOf } from "expect-type";
+
 import {
   isBytes,
   setLengthLeft,
@@ -8,6 +10,7 @@ import {
   utf8StringToBytes,
   bytesToUtf8String,
   bytesIncludesUtf8String,
+  parseJsonBytesAsStream,
 } from "../src/bytes.js";
 
 describe("bytes", () => {
@@ -212,6 +215,19 @@ describe("bytes", () => {
         !bytesIncludesUtf8String(haystack, "さようなら"),
         "should not find a missing multi-byte needle",
       );
+    });
+  });
+
+  describe("parseJsonBytesAsStream", () => {
+    it("Should parse JSON bytes", async () => {
+      const expectedObject = { a: 1, b: 2 };
+      const bytes = new TextEncoder().encode(JSON.stringify(expectedObject));
+
+      assert.deepEqual(await parseJsonBytesAsStream(bytes), expectedObject);
+      expectTypeOf(await parseJsonBytesAsStream(bytes)).toBeUnknown();
+      expectTypeOf(
+        await parseJsonBytesAsStream<{ a: number; b: number }>(bytes),
+      ).toMatchTypeOf<{ a: number; b: number }>();
     });
   });
 });

--- a/packages/hardhat-utils/test/bytes.ts
+++ b/packages/hardhat-utils/test/bytes.ts
@@ -10,7 +10,7 @@ import {
   utf8StringToBytes,
   bytesToUtf8String,
   bytesIncludesUtf8String,
-  parseJsonBytesAsStream,
+  parseJsonBytes,
 } from "../src/bytes.js";
 
 describe("bytes", () => {
@@ -218,16 +218,44 @@ describe("bytes", () => {
     });
   });
 
-  describe("parseJsonBytesAsStream", () => {
+  describe("parseJsonBytes", () => {
     it("Should parse JSON bytes", async () => {
       const expectedObject = { a: 1, b: 2 };
       const bytes = new TextEncoder().encode(JSON.stringify(expectedObject));
 
-      assert.deepEqual(await parseJsonBytesAsStream(bytes), expectedObject);
-      expectTypeOf(await parseJsonBytesAsStream(bytes)).toBeUnknown();
+      assert.deepEqual(await parseJsonBytes(bytes), expectedObject);
+      expectTypeOf(await parseJsonBytes(bytes)).toBeUnknown();
       expectTypeOf(
-        await parseJsonBytesAsStream<{ a: number; b: number }>(bytes),
+        await parseJsonBytes<{ a: number; b: number }>(bytes),
       ).toMatchTypeOf<{ a: number; b: number }>();
+    });
+
+    it("Should fall back to stream parsing when the payload is too large for a single string", async (t) => {
+      const expectedObject = { a: 1, b: 2 };
+      const bytes = new TextEncoder().encode(JSON.stringify(expectedObject));
+
+      // Simulate a payload too large to be decoded into a single string:
+      // `TextDecoder.decode` throws only in that case, so this exercises the
+      // stream-parsing fallback without allocating a multi-gigabyte buffer.
+      const originalDecode = TextDecoder.prototype.decode;
+      t.mock.method(
+        TextDecoder.prototype,
+        "decode",
+        function (
+          this: InstanceType<typeof TextDecoder>,
+          ...args: Parameters<typeof TextDecoder.prototype.decode>
+        ) {
+          if (args[0] === bytes) {
+            throw new RangeError(
+              "Cannot create a string longer than 0x1fffffe8 characters",
+            );
+          }
+
+          return originalDecode.call(this, args[0], args[1]);
+        },
+      );
+
+      assert.deepEqual(await parseJsonBytes(bytes), expectedObject);
     });
   });
 });

--- a/packages/hardhat-utils/test/fs.ts
+++ b/packages/hardhat-utils/test/fs.ts
@@ -34,6 +34,7 @@ import {
   readBinaryFile,
   getAccessTime,
   getFileSize,
+  parseJsonBytesAsStream,
   readJsonFileAsStream,
   writeJsonFileAsStream,
   mkdtemp,
@@ -1046,6 +1047,19 @@ describe("File system utils", () => {
       await assert.rejects(writeJsonFile(filePath, {}), {
         name: "FileSystemAccessError",
       });
+    });
+  });
+
+  describe("parseJsonBytesAsStream", () => {
+    it("Should parse JSON bytes", async () => {
+      const expectedObject = { a: 1, b: 2 };
+      const bytes = new TextEncoder().encode(JSON.stringify(expectedObject));
+
+      assert.deepEqual(await parseJsonBytesAsStream(bytes), expectedObject);
+      expectTypeOf(await parseJsonBytesAsStream(bytes)).toBeUnknown();
+      expectTypeOf(
+        await parseJsonBytesAsStream<{ a: number; b: number }>(bytes),
+      ).toMatchTypeOf<{ a: number; b: number }>();
     });
   });
 

--- a/packages/hardhat-utils/test/fs.ts
+++ b/packages/hardhat-utils/test/fs.ts
@@ -34,7 +34,6 @@ import {
   readBinaryFile,
   getAccessTime,
   getFileSize,
-  parseJsonBytesAsStream,
   readJsonFileAsStream,
   writeJsonFileAsStream,
   mkdtemp,
@@ -1047,19 +1046,6 @@ describe("File system utils", () => {
       await assert.rejects(writeJsonFile(filePath, {}), {
         name: "FileSystemAccessError",
       });
-    });
-  });
-
-  describe("parseJsonBytesAsStream", () => {
-    it("Should parse JSON bytes", async () => {
-      const expectedObject = { a: 1, b: 2 };
-      const bytes = new TextEncoder().encode(JSON.stringify(expectedObject));
-
-      assert.deepEqual(await parseJsonBytesAsStream(bytes), expectedObject);
-      expectTypeOf(await parseJsonBytesAsStream(bytes)).toBeUnknown();
-      expectTypeOf(
-        await parseJsonBytesAsStream<{ a: number; b: number }>(bytes),
-      ).toMatchTypeOf<{ a: number; b: number }>();
     });
   });
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -2,10 +2,8 @@ import type { CollectedStruct } from "./ast-walker.js";
 import type { SolidityBuildInfoOutput } from "../../../../types/solidity/solidity-artifacts.js";
 import type { BuildInfoAndOutput } from "../edr-artifacts.js";
 
-import {
-  bytesIncludesUtf8String,
-  bytesToUtf8String,
-} from "@nomicfoundation/hardhat-utils/bytes";
+import { bytesIncludesUtf8String } from "@nomicfoundation/hardhat-utils/bytes";
+import { parseJsonBytesAsStream } from "@nomicfoundation/hardhat-utils/fs";
 
 import { isPathSelected } from "../../../utils/glob.js";
 import { toUserSourceName } from "../../solidity/source-names.js";
@@ -35,11 +33,11 @@ export interface Eip712TypesConfig {
  * When `include` is empty/unset the feature is off: collection short-circuits
  * and returns an empty list without parsing any build info.
  */
-export function collectEip712CanonicalTypes(
+export async function collectEip712CanonicalTypes(
   buildInfosAndOutputs: BuildInfoAndOutput[],
   inputToUserSource: ReadonlyMap<string, string>,
   config: Eip712TypesConfig,
-): string[] {
+): Promise<string[]> {
   const { include, exclude } = config;
 
   if (include.length === 0) {
@@ -56,9 +54,8 @@ export function collectEip712CanonicalTypes(
       continue;
     }
 
-    const parsedOutput: SolidityBuildInfoOutput = JSON.parse(
-      bytesToUtf8String(output),
-    );
+    const parsedOutput =
+      await parseJsonBytesAsStream<SolidityBuildInfoOutput>(output);
 
     const sources = parsedOutput.output.sources;
     if (sources === undefined) {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -4,7 +4,7 @@ import type { BuildInfoAndOutput } from "../edr-artifacts.js";
 
 import {
   bytesIncludesUtf8String,
-  parseJsonBytesAsStream,
+  parseJsonBytes,
 } from "@nomicfoundation/hardhat-utils/bytes";
 
 import { isPathSelected } from "../../../utils/glob.js";
@@ -56,8 +56,7 @@ export async function collectEip712CanonicalTypes(
       continue;
     }
 
-    const parsedOutput =
-      await parseJsonBytesAsStream<SolidityBuildInfoOutput>(output);
+    const parsedOutput = await parseJsonBytes<SolidityBuildInfoOutput>(output);
 
     const sources = parsedOutput.output.sources;
     if (sources === undefined) {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -2,10 +2,12 @@ import type { CollectedStruct } from "./ast-walker.js";
 import type { SolidityBuildInfoOutput } from "../../../../types/solidity/solidity-artifacts.js";
 import type { BuildInfoAndOutput } from "../edr-artifacts.js";
 
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
   bytesIncludesUtf8String,
   parseJsonBytes,
 } from "@nomicfoundation/hardhat-utils/bytes";
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
 import { isPathSelected } from "../../../utils/glob.js";
 import { toUserSourceName } from "../../solidity/source-names.js";
@@ -49,14 +51,24 @@ export async function collectEip712CanonicalTypes(
   const collected: CollectedStruct[] = [];
   const selectedSources = new Set<string>();
 
-  for (const { buildInfo, output } of buildInfosAndOutputs) {
+  for (const { buildInfoId, buildInfo, output } of buildInfosAndOutputs) {
     // Byte-level fast path: a build info whose source bytes don't contain
     // `struct ` can't define any EIP-712 type, so skip JSON-parsing its output.
     if (!bytesIncludesUtf8String(buildInfo, "struct ")) {
       continue;
     }
 
-    const parsedOutput = await parseJsonBytes<SolidityBuildInfoOutput>(output);
+    let parsedOutput: SolidityBuildInfoOutput;
+    try {
+      parsedOutput = await parseJsonBytes<SolidityBuildInfoOutput>(output);
+    } catch (error) {
+      ensureError(error);
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.SOLIDITY.BUILD_INFO_OUTPUT_PARSE_ERROR,
+        { buildInfoId },
+        error,
+      );
+    }
 
     const sources = parsedOutput.output.sources;
     if (sources === undefined) {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -2,8 +2,10 @@ import type { CollectedStruct } from "./ast-walker.js";
 import type { SolidityBuildInfoOutput } from "../../../../types/solidity/solidity-artifacts.js";
 import type { BuildInfoAndOutput } from "../edr-artifacts.js";
 
-import { bytesIncludesUtf8String } from "@nomicfoundation/hardhat-utils/bytes";
-import { parseJsonBytesAsStream } from "@nomicfoundation/hardhat-utils/fs";
+import {
+  bytesIncludesUtf8String,
+  parseJsonBytesAsStream,
+} from "@nomicfoundation/hardhat-utils/bytes";
 
 import { isPathSelected } from "../../../utils/glob.js";
 import { toUserSourceName } from "../../solidity/source-names.js";

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -10,7 +10,7 @@ import {
   HardhatError,
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
-import { parseJsonBytesAsStream } from "@nomicfoundation/hardhat-utils/bytes";
+import { parseJsonBytes } from "@nomicfoundation/hardhat-utils/bytes";
 
 import { getFullyQualifiedName } from "../../../../utils/contract-names.js";
 
@@ -153,10 +153,9 @@ async function collectRawOverrides(
       continue;
     }
 
-    const buildInfoOutput =
-      await parseJsonBytesAsStream<SolidityBuildInfoOutput>(
-        buildInfoAndOutput.output,
-      );
+    const buildInfoOutput = await parseJsonBytes<SolidityBuildInfoOutput>(
+      buildInfoAndOutput.output,
+    );
 
     for (const [
       inputSourceName,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -10,7 +10,7 @@ import {
   HardhatError,
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
-import { bytesToUtf8String } from "@nomicfoundation/hardhat-utils/bytes";
+import { parseJsonBytesAsStream } from "@nomicfoundation/hardhat-utils/fs";
 
 import { getFullyQualifiedName } from "../../../../utils/contract-names.js";
 
@@ -48,11 +48,11 @@ interface CollectedOverrides {
  * in the solc AST. It only extracts them from the build info where each
  * test artifact's file was compiled as a root file.
  */
-export function getTestFunctionOverrides(
+export async function getTestFunctionOverrides(
   testSuiteArtifacts: EdrArtifactWithMetadata[],
   buildInfosAndOutputs: BuildInfoAndOutput[],
-): TestFunctionOverride[] {
-  const allRawOverrides = collectRawOverrides(
+): Promise<TestFunctionOverride[]> {
+  const allRawOverrides = await collectRawOverrides(
     testSuiteArtifacts,
     buildInfosAndOutputs,
   );
@@ -62,10 +62,10 @@ export function getTestFunctionOverrides(
   return buildTestFunctionOverrides(allRawOverrides);
 }
 
-function collectRawOverrides(
+async function collectRawOverrides(
   testSuiteArtifacts: EdrArtifactWithMetadata[],
   buildInfosAndOutputs: BuildInfoAndOutput[],
-): CollectedOverrides {
+): Promise<CollectedOverrides> {
   const overrides: RawInlineOverride[] = [];
   const methodIdentifiersByContract = new Map<string, Record<string, string>>();
 
@@ -153,9 +153,10 @@ function collectRawOverrides(
       continue;
     }
 
-    const buildInfoOutput: SolidityBuildInfoOutput = JSON.parse(
-      bytesToUtf8String(buildInfoAndOutput.output),
-    );
+    const buildInfoOutput =
+      await parseJsonBytesAsStream<SolidityBuildInfoOutput>(
+        buildInfoAndOutput.output,
+      );
 
     for (const [
       inputSourceName,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -10,7 +10,7 @@ import {
   HardhatError,
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
-import { parseJsonBytesAsStream } from "@nomicfoundation/hardhat-utils/fs";
+import { parseJsonBytesAsStream } from "@nomicfoundation/hardhat-utils/bytes";
 
 import { getFullyQualifiedName } from "../../../../utils/contract-names.js";
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -11,6 +11,7 @@ import {
   assertHardhatInvariant,
 } from "@nomicfoundation/hardhat-errors";
 import { parseJsonBytes } from "@nomicfoundation/hardhat-utils/bytes";
+import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 
 import { getFullyQualifiedName } from "../../../../utils/contract-names.js";
 
@@ -153,9 +154,19 @@ async function collectRawOverrides(
       continue;
     }
 
-    const buildInfoOutput = await parseJsonBytes<SolidityBuildInfoOutput>(
-      buildInfoAndOutput.output,
-    );
+    let buildInfoOutput: SolidityBuildInfoOutput;
+    try {
+      buildInfoOutput = await parseJsonBytes<SolidityBuildInfoOutput>(
+        buildInfoAndOutput.output,
+      );
+    } catch (error) {
+      ensureError(error);
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.SOLIDITY.BUILD_INFO_OUTPUT_PARSE_ERROR,
+        { buildInfoId },
+        error,
+      );
+    }
 
     for (const [
       inputSourceName,

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -231,12 +231,12 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
     }
   }
 
-  const testFunctionOverrides = getTestFunctionOverrides(
+  const testFunctionOverrides = await getTestFunctionOverrides(
     testSuiteArtifacts,
     allBuildInfosAndOutputs,
   );
 
-  const eip712CanonicalTypes = collectEip712CanonicalTypes(
+  const eip712CanonicalTypes = await collectEip712CanonicalTypes(
     allBuildInfosAndOutputs,
     sourceNameToUserSourceName,
     eip712Types,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 import { utf8StringToBytes } from "@nomicfoundation/hardhat-utils/bytes";
 
 import {
@@ -131,7 +131,7 @@ function contractAst(name: string, structs: unknown[]): unknown {
 }
 
 describe("eip712 - collectEip712CanonicalTypes", () => {
-  it("returns an empty list when no include is configured", () => {
+  it("returns an empty list when no include is configured", async () => {
     // The feature is opt-in: with an empty `include`, collection
     // short-circuits before any build info is parsed.
     const sources: FakeSource[] = [
@@ -145,7 +145,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     const inputToUserSource = inputToUserSourceMap(sources);
 
     assert.deepEqual(
-      collectEip712CanonicalTypes([buildInfo], inputToUserSource, {
+      await collectEip712CanonicalTypes([buildInfo], inputToUserSource, {
         include: [],
         exclude: [],
       }),
@@ -153,7 +153,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     );
     // Exclude alone is a no-op without an include to narrow.
     assert.deepEqual(
-      collectEip712CanonicalTypes([buildInfo], inputToUserSource, {
+      await collectEip712CanonicalTypes([buildInfo], inputToUserSource, {
         include: [],
         exclude: ["**"],
       }),
@@ -161,7 +161,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     );
   });
 
-  it("returns the flat canonical list for a Mail/Person fixture", () => {
+  it("returns the flat canonical list for a Mail/Person fixture", async () => {
     const sources: FakeSource[] = [
       {
         inputSourceName: "project/test/Types.sol",
@@ -181,7 +181,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-aaaaaaaa", sources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [buildInfo],
       inputToUserSourceMap(sources),
       { include: ["test/**"], exclude: [] },
@@ -193,7 +193,49 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ]);
   });
 
-  it("filters by include/exclude on the user source name", () => {
+  it("does not decode the build info output as a single string", async (t) => {
+    const sources: FakeSource[] = [
+      {
+        inputSourceName: "project/test/Types.sol",
+        userSourceName: "test/Types.sol",
+        ast: sourceUnit([
+          structAst("Person", [
+            { type: "address", name: "wallet" },
+            { type: "string", name: "name" },
+          ]),
+        ]),
+      },
+    ];
+    const buildInfo = makeBuildInfo("solc-0_8_23-large-output", sources);
+
+    const originalDecode = TextDecoder.prototype.decode;
+    t.mock.method(
+      TextDecoder.prototype,
+      "decode",
+      function (
+        this: InstanceType<typeof TextDecoder>,
+        ...args: Parameters<typeof TextDecoder.prototype.decode>
+      ) {
+        if (args[0] === buildInfo.output) {
+          throw new RangeError(
+            "Cannot create a string longer than 0x1fffffe8 characters",
+          );
+        }
+
+        return originalDecode.call(this, args[0], args[1]);
+      },
+    );
+
+    const result = await collectEip712CanonicalTypes(
+      [buildInfo],
+      inputToUserSourceMap(sources),
+      { include: ["test/**"], exclude: [] },
+    );
+
+    assert.deepEqual(result, ["Person(address wallet,string name)"]);
+  });
+
+  it("filters by include/exclude on the user source name", async () => {
     const sources: FakeSource[] = [
       {
         inputSourceName: "project/contracts/Foo.sol",
@@ -209,14 +251,14 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     const buildInfo = makeBuildInfo("solc-0_8_23-bbbbbbbb", sources);
     const inputToUserSource = inputToUserSourceMap(sources);
 
-    const onlyTests = collectEip712CanonicalTypes(
+    const onlyTests = await collectEip712CanonicalTypes(
       [buildInfo],
       inputToUserSource,
       { include: ["test/**"], exclude: [] },
     );
     assert.deepEqual(onlyTests, ["Bar(uint256 y)"]);
 
-    const excludeTests = collectEip712CanonicalTypes(
+    const excludeTests = await collectEip712CanonicalTypes(
       [buildInfo],
       inputToUserSource,
       { include: ["**"], exclude: ["test/**"] },
@@ -224,7 +266,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(excludeTests, ["Foo(uint256 x)"]);
   });
 
-  it("dedupes the same struct seen across multiple build infos", () => {
+  it("dedupes the same struct seen across multiple build infos", async () => {
     const ast = sourceUnit([
       structAst("Person", [
         { type: "address", name: "wallet" },
@@ -248,7 +290,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     const a = makeBuildInfo("solc-0_8_23-cccccccc", sourcesA);
     const b = makeBuildInfo("solc-0_8_23-dddddddd", sourcesB);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [a, b],
       inputToUserSourceMap(sourcesA, sourcesB),
       { include: ["test/**"], exclude: [] },
@@ -257,7 +299,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, ["Person(address wallet,string name)"]);
   });
 
-  it("uses the caller-provided inputToUserSource map for transitive sources", () => {
+  it("uses the caller-provided inputToUserSource map for transitive sources", async () => {
     // Mirrors `hardhat test solidity <one-test-file>`: the partial build info
     // explicitly compiles a single root, but its output also contains the
     // transitive source set. The user-facing name for those transitive
@@ -289,7 +331,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
       partialBuildSources,
     );
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [fullBuild, partialBuild],
       inputToUserSourceMap(fullBuildSources, partialBuildSources),
       { include: ["contracts/**"], exclude: [] },
@@ -298,7 +340,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, ["Person(address wallet,string name)"]);
   });
 
-  it("falls back to inputSourceName when the map omits an entry", () => {
+  it("falls back to inputSourceName when the map omits an entry", async () => {
     // Imported sources (e.g. from npm packages) that don't produce artifacts
     // won't appear in the caller-supplied `inputToUserSource` map. The
     // collector should still surface their structs, keyed by the input
@@ -313,7 +355,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
       },
     ]);
 
-    const result = collectEip712CanonicalTypes([buildInfo], new Map(), {
+    const result = await collectEip712CanonicalTypes([buildInfo], new Map(), {
       include: ["npm/**"],
       exclude: [],
     });
@@ -321,7 +363,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, ["Imported(uint256 x)"]);
   });
 
-  it("strips the project/ prefix when a project file is missing from the map", () => {
+  it("strips the project/ prefix when a project file is missing from the map", async () => {
     // A project file outside the standard root directories (e.g. a shared
     // file in `lib/` that's only ever imported and produces no artifact) is
     // absent from the caller-supplied map. Its input source name is
@@ -338,7 +380,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
       },
     ]);
 
-    const result = collectEip712CanonicalTypes([buildInfo], new Map(), {
+    const result = await collectEip712CanonicalTypes([buildInfo], new Map(), {
       include: ["lib/**"],
       exclude: [],
     });
@@ -346,7 +388,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, ["Helper(uint256 n)"]);
   });
 
-  it("throws on conflicting same-named structs within a single source file", () => {
+  it("throws on conflicting same-named structs within a single source file", async () => {
     // A top-level `struct S` and a `contract C { struct S { ... } }` with
     // a different definition share a source path but produce different
     // EIP-712 heads. Since `vm.eip712HashType` resolves by bare name, this
@@ -364,7 +406,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-11111111", sources);
 
-    assertThrowsHardhatError(
+    await assertRejectsWithHardhatError(
       () =>
         collectEip712CanonicalTypes(
           [buildInfo],
@@ -381,7 +423,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     );
   });
 
-  it("throws on conflicting same-named structs across two contracts in one file", () => {
+  it("throws on conflicting same-named structs across two contracts in one file", async () => {
     const sources: FakeSource[] = [
       {
         inputSourceName: "project/test/Types.sol",
@@ -394,7 +436,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-22222222", sources);
 
-    assertThrowsHardhatError(
+    await assertRejectsWithHardhatError(
       () =>
         collectEip712CanonicalTypes(
           [buildInfo],
@@ -411,7 +453,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     );
   });
 
-  it("dedupes identical same-named structs within a single source file", () => {
+  it("dedupes identical same-named structs within a single source file", async () => {
     // A top-level `struct S` and a `contract C { struct S { ... } }` with
     // an identical definition produce the same EIP-712 head; that's not a
     // conflict and must be silently deduped.
@@ -427,7 +469,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-33333333", sources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [buildInfo],
       inputToUserSourceMap(sources),
       { include: ["test/**"], exclude: [] },
@@ -436,7 +478,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, ["S(uint256 a)"]);
   });
 
-  it("scopes user-defined value type resolution per build info when node ids collide", () => {
+  it("scopes user-defined value type resolution per build info when node ids collide", async () => {
     // solc node ids are unique only within a single compilation. When two
     // build infos happen to assign the same numeric id to different
     // user-defined value types,
@@ -530,22 +572,26 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     const expected = ["AStruct(uint256 f)", "BStruct(bytes32 b)"];
 
     assert.deepEqual(
-      collectEip712CanonicalTypes([buildA, buildB], inputToUserSource, {
-        include: ["**"],
-        exclude: [],
-      }).sort(),
+      (
+        await collectEip712CanonicalTypes([buildA, buildB], inputToUserSource, {
+          include: ["**"],
+          exclude: [],
+        })
+      ).sort(),
       expected,
     );
     assert.deepEqual(
-      collectEip712CanonicalTypes([buildB, buildA], inputToUserSource, {
-        include: ["**"],
-        exclude: [],
-      }).sort(),
+      (
+        await collectEip712CanonicalTypes([buildB, buildA], inputToUserSource, {
+          include: ["**"],
+          exclude: [],
+        })
+      ).sort(),
       expected,
     );
   });
 
-  it("inline a dep defined in a non-included file", () => {
+  it("inline a dep defined in a non-included file", async () => {
     const sources: FakeSource[] = [
       {
         inputSourceName: "project/test/Mail.sol",
@@ -571,7 +617,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-aabbccdd", sources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [buildInfo],
       inputToUserSourceMap(sources),
       { include: ["test/**"], exclude: [] },
@@ -582,7 +628,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ]);
   });
 
-  it("inline a dep defined in a different build info", () => {
+  it("inline a dep defined in a different build info", async () => {
     const testSources: FakeSource[] = [
       {
         inputSourceName: "project/test/Mail.sol",
@@ -610,7 +656,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     const testBuild = makeBuildInfo("solc-0_8_23-11112222", testSources);
     const libBuild = makeBuildInfo("solc-0_8_23-33334444", libSources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [testBuild, libBuild],
       inputToUserSourceMap(testSources, libSources),
       { include: ["test/**"], exclude: [] },
@@ -621,7 +667,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ]);
   });
 
-  it("walks transitive deps through non-included files", () => {
+  it("walks transitive deps through non-included files", async () => {
     const sources: FakeSource[] = [
       {
         inputSourceName: "project/test/Order.sol",
@@ -656,7 +702,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-55556666", sources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [buildInfo],
       inputToUserSourceMap(sources),
       { include: ["test/**"], exclude: [] },
@@ -669,7 +715,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ]);
   });
 
-  it("does not throw on duplicate struct names confined to non-included files", () => {
+  it("does not throw on duplicate struct names confined to non-included files", async () => {
     const sources: FakeSource[] = [
       {
         inputSourceName: "project/test/Wanted.sol",
@@ -695,7 +741,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-99990000", sources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [buildInfo],
       inputToUserSourceMap(sources),
       { include: ["test/**"], exclude: [] },
@@ -704,7 +750,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, ["Wanted(uint256 x)"]);
   });
 
-  it("does not throw when an included file and a non-included, unimported file define the same struct name", () => {
+  it("does not throw when an included file and a non-included, unimported file define the same struct name", async () => {
     // `include` scopes which sources contribute structs, so a same-named
     // struct in a non-included file that nothing in the included scope imports
     // must not abort the run — the included definition wins and is emitted.
@@ -732,7 +778,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-aaaabbbb", sources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [buildInfo],
       inputToUserSourceMap(sources),
       { include: ["contracts/A.sol"], exclude: [] },
@@ -741,7 +787,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, ["Order(address user,uint256 amount)"]);
   });
 
-  it("throws HHE818 when a selected struct depends on a name two non-included files define differently", () => {
+  it("throws HHE818 when a selected struct depends on a name two non-included files define differently", async () => {
     // The conflict is real: included `Mail` depends on `Person`, which two
     // non-included files define differently, so it's reachable from the
     // selected set and genuinely ambiguous. HHE818 must steer to renaming,
@@ -778,7 +824,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-aaaacccc", sources);
 
-    assertThrowsHardhatError(
+    await assertRejectsWithHardhatError(
       () =>
         collectEip712CanonicalTypes(
           [buildInfo],
@@ -795,7 +841,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     );
   });
 
-  it("dedupes an identical struct shared by an included and a non-included file", () => {
+  it("dedupes an identical struct shared by an included and a non-included file", async () => {
     // Same `Person` in an included and a non-included file isn't a conflict:
     // dedup and selection emit it once rather than reject the duplicate name.
     const sources: FakeSource[] = [
@@ -822,7 +868,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-bbbbdddd", sources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [buildInfo],
       inputToUserSourceMap(sources),
       { include: ["contracts/A.sol"], exclude: [] },
@@ -831,7 +877,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, ["Person(address wallet,string name)"]);
   });
 
-  it("drops a selected struct when a transitive dep in a non-included file is non decodable", () => {
+  it("drops a selected struct when a transitive dep in a non-included file is non decodable", async () => {
     const sources: FakeSource[] = [
       {
         inputSourceName: "project/test/Order.sol",
@@ -871,7 +917,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-aaaa9999", sources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [buildInfo],
       inputToUserSourceMap(sources),
       { include: ["test/**"], exclude: [] },
@@ -880,7 +926,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, []);
   });
 
-  it("skips build infos whose output has no sources", () => {
+  it("skips build infos whose output has no sources", async () => {
     // Defensive: a build info output without a `sources` key must be silently
     // skipped, and structs from sibling build infos must still be collected.
     // The empty build info still includes `struct ` in its bytes so it gets
@@ -917,7 +963,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const goodBuildInfo = makeBuildInfo("solc-0_8_23-99999999", goodSources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [
         {
           buildInfoId: emptyBuildInfoId,
@@ -933,7 +979,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, ["Person(address wallet,string name)"]);
   });
 
-  it("skips build infos whose bytes don't contain `struct `", () => {
+  it("skips build infos whose bytes don't contain `struct `", async () => {
     // Byte-level fast path: a build info that can't define EIP-712 types
     // must be skipped without parsing its output. We exercise it by handing
     // in a build info whose `output` bytes would crash JSON.parse — if the
@@ -965,7 +1011,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const goodBuildInfo = makeBuildInfo("solc-0_8_23-66666666", goodSources);
 
-    const result = collectEip712CanonicalTypes(
+    const result = await collectEip712CanonicalTypes(
       [
         {
           buildInfoId: skippableBuildInfoId,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -238,6 +238,32 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     assert.deepEqual(result, ["Person(address wallet,string name)"]);
   });
 
+  it("throws a HardhatError when the build info output cannot be parsed", async () => {
+    const sources: FakeSource[] = [
+      {
+        inputSourceName: "project/test/Types.sol",
+        userSourceName: "test/Types.sol",
+        ast: sourceUnit([
+          structAst("Person", [{ type: "address", name: "x" }]),
+        ]),
+      },
+    ];
+    const buildInfo = makeBuildInfo("solc-0_8_23-cccccccc", sources);
+    const corrupted = {
+      ...buildInfo,
+      output: utf8StringToBytes("{ not valid json"),
+    };
+
+    await assertRejectsWithHardhatError(
+      collectEip712CanonicalTypes([corrupted], inputToUserSourceMap(sources), {
+        include: ["test/**"],
+        exclude: [],
+      }),
+      HardhatError.ERRORS.CORE.SOLIDITY.BUILD_INFO_OUTPUT_PARSE_ERROR,
+      { buildInfoId: buildInfo.buildInfoId },
+    );
+  });
+
   it("filters by include/exclude on the user source name", async () => {
     const sources: FakeSource[] = [
       {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts
@@ -193,7 +193,7 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ]);
   });
 
-  it("does not decode the build info output as a single string", async (t) => {
+  it("falls back to stream parsing when the build info output is too large for a single string", async (t) => {
     const sources: FakeSource[] = [
       {
         inputSourceName: "project/test/Types.sol",
@@ -208,6 +208,9 @@ describe("eip712 - collectEip712CanonicalTypes", () => {
     ];
     const buildInfo = makeBuildInfo("solc-0_8_23-large-output", sources);
 
+    // Simulate an output too large to be decoded into a single string:
+    // `TextDecoder.decode` throws only in that case, so this exercises the
+    // stream-parsing fallback without allocating a multi-gigabyte buffer.
     const originalDecode = TextDecoder.prototype.decode;
     t.mock.method(
       TextDecoder.prototype,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -147,7 +147,7 @@ describe("inline-config", () => {
       assert.deepEqual(overrides[0].config, { fuzz: { runs: 50 } });
     });
 
-    it("should not decode the build info output as a single string", async (t) => {
+    it("should fall back to stream parsing when the build info output is too large for a single string", async (t) => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 50",
@@ -164,6 +164,9 @@ describe("inline-config", () => {
         },
       );
 
+      // Simulate an output too large to be decoded into a single string:
+      // `TextDecoder.decode` throws only in that case, so this exercises the
+      // stream-parsing fallback without allocating a multi-gigabyte buffer.
       const originalDecode = TextDecoder.prototype.decode;
       t.mock.method(
         TextDecoder.prototype,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
+import { utf8StringToBytes } from "@nomicfoundation/hardhat-utils/bytes";
 
 import {
   getFunctionFqn,
@@ -190,6 +191,37 @@ describe("inline-config", () => {
 
       assert.equal(overrides.length, 1);
       assert.deepEqual(overrides[0].config, { fuzz: { runs: 50 } });
+    });
+
+    it("should throw a HardhatError when the build info output cannot be parsed", async () => {
+      const bi = makeBuildInfo(
+        "test/MyTest.sol",
+        "/// hardhat-config: fuzz.runs = 50",
+        {
+          MyTest: {
+            methodIdentifiers: { "testFuzz()": "aabbccdd" },
+            functions: [
+              {
+                name: "testFuzz",
+                documentation: " hardhat-config: fuzz.runs = 50",
+              },
+            ],
+          },
+        },
+      );
+
+      const corrupted = {
+        ...bi,
+        output: utf8StringToBytes("{ not valid json"),
+      };
+
+      const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
+
+      await assertRejectsWithHardhatError(
+        getTestFunctionOverrides(artifacts, [corrupted]),
+        HardhatError.ERRORS.CORE.SOLIDITY.BUILD_INFO_OUTPUT_PARSE_ERROR,
+        { buildInfoId: bi.buildInfoId },
+      );
     });
 
     it("should merge overrides from mixed hardhat-config: and forge-config: prefixes", async () => {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
 import {
   getFunctionFqn,
@@ -14,7 +14,7 @@ import { makeBuildInfo, makeTestSuiteArtifact } from "./mocks.js";
 
 describe("inline-config", () => {
   describe("getTestFunctionOverrides", () => {
-    it("should return empty array when no build infos contain inline config", () => {
+    it("should return empty array when no build infos contain inline config", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "// just a comment\ncontract MyTest {}",
@@ -26,10 +26,10 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      assert.deepEqual(getTestFunctionOverrides(artifacts, [bi]), []);
+      assert.deepEqual(await getTestFunctionOverrides(artifacts, [bi]), []);
     });
 
-    it("should deduplicate when same source appears in multiple build infos", () => {
+    it("should deduplicate when same source appears in multiple build infos", async () => {
       const bi1 = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10",
@@ -61,11 +61,11 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      const overrides = getTestFunctionOverrides(artifacts, [bi1, bi2]);
+      const overrides = await getTestFunctionOverrides(artifacts, [bi1, bi2]);
       assert.equal(overrides.length, 1);
     });
 
-    it("should produce correct ArtifactId with solcVersion", () => {
+    it("should produce correct ArtifactId with solcVersion", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10",
@@ -85,7 +85,7 @@ describe("inline-config", () => {
       const artifacts = [
         makeTestSuiteArtifact("test/MyTest.sol", "MyTest", "0.8.20"),
       ];
-      const overrides = getTestFunctionOverrides(artifacts, [bi]);
+      const overrides = await getTestFunctionOverrides(artifacts, [bi]);
       assert.deepEqual(overrides[0].identifier.contractArtifact, {
         name: "MyTest",
         source: "test/MyTest.sol",
@@ -93,7 +93,7 @@ describe("inline-config", () => {
       });
     });
 
-    it("should throw UNRESOLVED_SELECTOR when function has no ABI entry", () => {
+    it("should throw UNRESOLVED_SELECTOR when function has no ABI entry", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10",
@@ -110,7 +110,7 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      assertThrowsHardhatError(
+      await assertRejectsWithHardhatError(
         () => getTestFunctionOverrides(artifacts, [bi]),
         HardhatError.ERRORS.CORE.SOLIDITY_TESTS
           .INLINE_CONFIG_UNRESOLVED_SELECTOR,
@@ -124,7 +124,7 @@ describe("inline-config", () => {
       );
     });
 
-    it("should process a basic end-to-end case", () => {
+    it("should process a basic end-to-end case", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 50",
@@ -141,13 +141,55 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      const overrides = getTestFunctionOverrides(artifacts, [bi]);
+      const overrides = await getTestFunctionOverrides(artifacts, [bi]);
       assert.equal(overrides.length, 1);
       assert.equal(overrides[0].identifier.functionSelector, "0xaabbccdd");
       assert.deepEqual(overrides[0].config, { fuzz: { runs: 50 } });
     });
 
-    it("should merge overrides from mixed hardhat-config: and forge-config: prefixes", () => {
+    it("should not decode the build info output as a single string", async (t) => {
+      const bi = makeBuildInfo(
+        "test/MyTest.sol",
+        "/// hardhat-config: fuzz.runs = 50",
+        {
+          MyTest: {
+            methodIdentifiers: { "testFuzz()": "aabbccdd" },
+            functions: [
+              {
+                name: "testFuzz",
+                documentation: " hardhat-config: fuzz.runs = 50",
+              },
+            ],
+          },
+        },
+      );
+
+      const originalDecode = TextDecoder.prototype.decode;
+      t.mock.method(
+        TextDecoder.prototype,
+        "decode",
+        function (
+          this: InstanceType<typeof TextDecoder>,
+          ...args: Parameters<typeof TextDecoder.prototype.decode>
+        ) {
+          if (args[0] === bi.output) {
+            throw new RangeError(
+              "Cannot create a string longer than 0x1fffffe8 characters",
+            );
+          }
+
+          return originalDecode.call(this, args[0], args[1]);
+        },
+      );
+
+      const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
+      const overrides = await getTestFunctionOverrides(artifacts, [bi]);
+
+      assert.equal(overrides.length, 1);
+      assert.deepEqual(overrides[0].config, { fuzz: { runs: 50 } });
+    });
+
+    it("should merge overrides from mixed hardhat-config: and forge-config: prefixes", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10\n/// forge-config: fuzz.max-test-rejects = 500",
@@ -165,14 +207,14 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      const overrides = getTestFunctionOverrides(artifacts, [bi]);
+      const overrides = await getTestFunctionOverrides(artifacts, [bi]);
       assert.equal(overrides.length, 1);
       assert.deepEqual(overrides[0].config, {
         fuzz: { runs: 10, maxTestRejects: 500 },
       });
     });
 
-    it("should throw BUILD_INFO_NOT_FOUND when artifact references missing build info", () => {
+    it("should throw BUILD_INFO_NOT_FOUND when artifact references missing build info", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10",
@@ -192,7 +234,7 @@ describe("inline-config", () => {
       );
 
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      assertThrowsHardhatError(
+      await assertRejectsWithHardhatError(
         () => getTestFunctionOverrides(artifacts, [bi]),
         HardhatError.ERRORS.CORE.SOLIDITY_TESTS
           .BUILD_INFO_NOT_FOUND_FOR_CONTRACT,
@@ -202,7 +244,7 @@ describe("inline-config", () => {
       );
     });
 
-    it("should produce separate overrides for overloaded functions", () => {
+    it("should produce separate overrides for overloaded functions", async () => {
       const bi = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10\n/// hardhat-config: fuzz.runs = 20",
@@ -228,7 +270,7 @@ describe("inline-config", () => {
         },
       );
       const artifacts = [makeTestSuiteArtifact("test/MyTest.sol", "MyTest")];
-      const result = getTestFunctionOverrides(artifacts, [bi]);
+      const result = await getTestFunctionOverrides(artifacts, [bi]);
       assert.equal(result.length, 2);
 
       const selectors = result.map((r) => r.identifier.functionSelector).sort();
@@ -241,7 +283,7 @@ describe("inline-config", () => {
       assert.deepEqual(bySelector.get("0x11223344"), { fuzz: { runs: 20 } });
     });
 
-    it("should not duplicate overrides when same source is a root in multiple build infos", () => {
+    it("should not duplicate overrides when same source is a root in multiple build infos", async () => {
       const bi1 = makeBuildInfo(
         "test/MyTest.sol",
         "/// hardhat-config: fuzz.runs = 10",
@@ -280,12 +322,12 @@ describe("inline-config", () => {
       const artifacts = [
         makeTestSuiteArtifact("test/MyTest.sol", "MyTest", "0.8.23", "bi-1"),
       ];
-      const overrides = getTestFunctionOverrides(artifacts, [bi1, bi2]);
+      const overrides = await getTestFunctionOverrides(artifacts, [bi1, bi2]);
       assert.equal(overrides.length, 1);
       assert.deepEqual(overrides[0].config, { fuzz: { runs: 10 } });
     });
 
-    it("should handle multiple contracts in a single source file", () => {
+    it("should handle multiple contracts in a single source file", async () => {
       const bi = makeBuildInfo(
         "test/Multi.sol",
         "/// hardhat-config: fuzz.runs = 10\n/// hardhat-config: fuzz.runs = 20",
@@ -314,7 +356,7 @@ describe("inline-config", () => {
         makeTestSuiteArtifact("test/Multi.sol", "ContractA"),
         makeTestSuiteArtifact("test/Multi.sol", "ContractB"),
       ];
-      const result = getTestFunctionOverrides(artifacts, [bi]);
+      const result = await getTestFunctionOverrides(artifacts, [bi]);
       assert.equal(result.length, 2);
 
       const bySelector = new Map(


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

Closes #8341

## Description

The Solidity test runner decoded selected build-info output bytes into one full string before parsing JSON. Very large outputs can exceed V8's maximum string size before JSON parsing starts.

This changes inline config and EIP-712 collection to parse build-info outputs through a streaming JSON parser from `hardhat-utils`, and awaits those collectors from the Solidity test task action. The existing byte-level skip checks remain in place.

Breaking change: No.

## Tests

- `pnpm lint:file packages/hardhat-utils/src/fs.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/inline-config/index.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/index.ts packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts`
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config/index.ts packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/index.ts`
- `pnpm test:file packages/hardhat-utils/test/fs.ts`