### PR TITLE
Fix bindAllMethods for inherited class methods

### DIFF
--- a/.changeset/bind-inherited-methods.md
+++ b/.changeset/bind-inherited-methods.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Make `bindAllMethods` bind methods inherited from parent classes.

--- a/packages/hardhat-utils/src/lang.ts
+++ b/packages/hardhat-utils/src/lang.ts
@@ -90,9 +90,12 @@ export async function sleep(seconds: number): Promise<void> {
  * @param obj The object, which can be an instance of a class.
  */
 export function bindAllMethods<ObjectT extends object>(obj: ObjectT): void {
-  const prototype = Object.getPrototypeOf(obj);
-  const prototypeKeys =
-    prototype !== null ? Object.getOwnPropertyNames(prototype) : [];
+  const prototypeKeys: string[] = [];
+  let prototype = Object.getPrototypeOf(obj);
+  while (prototype !== null && prototype !== Object.prototype) {
+    prototypeKeys.push(...Object.getOwnPropertyNames(prototype));
+    prototype = Object.getPrototypeOf(prototype);
+  }
 
   const keys = [...prototypeKeys, ...Object.getOwnPropertyNames(obj)];
 

--- a/packages/hardhat-utils/test/lang.ts
+++ b/packages/hardhat-utils/test/lang.ts
@@ -795,6 +795,32 @@ describe("lang", () => {
       assert.equal(foo(), "bar");
     });
 
+    it("Should bind methods inherited from parent classes", () => {
+      class Foo {
+        public foo() {
+          return this.bar();
+        }
+
+        public bar() {
+          return "bar";
+        }
+      }
+
+      class FooBar extends Foo {}
+
+      const obj = new FooBar();
+
+      assert.throws(() => {
+        const foo = obj.foo;
+        foo();
+      });
+
+      bindAllMethods(obj);
+
+      const boundFoo = obj.foo;
+      assert.equal(boundFoo(), "bar");
+    });
+
     it("Should work with instances of classes with their own properties", () => {
       class FooBar {
         public foo() {


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

## Summary

This PR fixes `bindAllMethods` so that it also binds methods inherited from parent classes.

Previously, `bindAllMethods` only inspected the instance's direct prototype and own properties. As a result, methods defined on a parent class could still lose their `this` binding when extracted from a subclass instance.

This change walks the prototype chain until `Object.prototype`, preserving the existing behavior for own methods and direct class methods while covering inherited class methods too.

## Testing

```sh
pnpm --dir packages/hardhat-utils build
pnpm --dir packages/hardhat-utils exec eslint src/lang.ts test/lang.ts
pnpm --dir packages/hardhat-utils exec node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter test/lang.ts
