### PR TITLE
fix(hardhat-solx): apply solx defaults (optimizer -O1, viaIR) at config resolution

### DIFF
--- a/packages/hardhat-solx/README.md
+++ b/packages/hardhat-solx/README.md
@@ -95,6 +95,46 @@ export default defineConfig({
 });
 ```
 
+### Optimization level
+
+solx optimizes via LLVM; set the level per profile with `settings.optimizer.mode` — one of `"1"`, `"2"`, `"3"` (best performance), `"s"` (optimize for size), or `"z"` (aggressively minimize size). The plugin defaults to `"1"` (solx's own default if left unset is `"3"`).
+
+solx has two independent optimizer knobs, and both affect the output:
+
+- `optimizer.mode` (above) is the LLVM backend level. There is **no "off"** — the minimum is `"1"`, so LLVM always optimizes.
+- `optimizer.enabled` is the Yul optimizer (standard solc semantics), `false` by default. Enabling it optimizes _on top of_ LLVM; it does not turn LLVM off.
+
+For example, optimizing for size instead of performance:
+
+```typescript
+import { defineConfig } from "hardhat/config";
+import hardhatSolx from "@nomicfoundation/hardhat-solx";
+
+export default defineConfig({
+  plugins: [hardhatSolx],
+  solidity: {
+    profiles: {
+      default: { version: "0.8.34" },
+      solx: {
+        type: "solx",
+        version: "0.8.34",
+        settings: { optimizer: { mode: "z" } }, // optimize for size
+      },
+    },
+  },
+});
+```
+
+Or run the Yul optimizer as well, on top of LLVM `-O3` (both knobs on) — just the `solx` profile:
+
+```typescript
+solx: {
+  type: "solx",
+  version: "0.8.34",
+  settings: { optimizer: { enabled: true, mode: "3" } },
+},
+```
+
 ### Supported Solidity versions
 
 solx maps each Solidity version to a specific solx binary version internally. Currently supported: `0.8.34` (solx 0.1.4). Earlier solx releases did not emit the DWARF debug info that EDR relies on for Solidity stack traces, so they are not supported by this plugin.

--- a/packages/hardhat-solx/src/internal/constants.ts
+++ b/packages/hardhat-solx/src/internal/constants.ts
@@ -15,10 +15,12 @@ export const SUPPORTED_SOLX_EVM_VERSIONS: readonly string[] = [
   "osaka",
 ] as const;
 
-export const DEFAULT_SOLX_SETTINGS: Record<string, unknown> = {
-  viaIR: false,
-  LLVMOptimization: "1",
-};
+/**
+ * Default LLVM optimization level, passed to solx via `settings.optimizer.mode`
+ * ("1"/"2"/"3"/"s"/"z"; users override per profile). Deliberately -O1 to
+ * optimize for compile speed (solx's own default if unset is -O3).
+ */
+export const DEFAULT_SOLX_OPTIMIZER_MODE = "1";
 
 /** Maps Solidity versions to the solx version that embeds them. */
 export const SOLIDITY_TO_SOLX_VERSION_MAP: Record<string, string> = {

--- a/packages/hardhat-solx/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-solx/src/internal/hook-handlers/config.ts
@@ -245,9 +245,8 @@ async function augmentIfSolx<
     ...entry,
     settings: {
       ...settings,
-      // Default here (not in SolxCompiler.compile) so it reaches the resolved
-      // solcInput, hence the build-id hash. Nullish-coalesce so an explicit
-      // `mode: undefined` doesn't clobber the default back to solx's -O3.
+      // Defaults added here instead of in SolxCompiler.compile so this reaches
+      // the solcInput and hence the build-id hash.
       viaIR: settings.viaIR ?? false,
       optimizer: {
         ...optimizer,

--- a/packages/hardhat-solx/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-solx/src/internal/hook-handlers/config.ts
@@ -19,6 +19,7 @@ import {
 import { z } from "zod";
 
 import {
+  DEFAULT_SOLX_OPTIMIZER_MODE,
   SOLIDITY_TO_SOLX_VERSION_MAP,
   SOLX_COMPILER_TYPE,
   SUPPORTED_SOLX_EVM_VERSIONS,
@@ -237,10 +238,21 @@ async function augmentIfSolx<
     return entry;
   }
   const settings = isObject(entry.settings) ? entry.settings : {};
+  const optimizer: Record<string, unknown> = isObject(settings.optimizer)
+    ? settings.optimizer
+    : {};
   return {
     ...entry,
     settings: {
       ...settings,
+      // Default here (not in SolxCompiler.compile) so it reaches the resolved
+      // solcInput, hence the build-id hash. Nullish-coalesce so an explicit
+      // `mode: undefined` doesn't clobber the default back to solx's -O3.
+      viaIR: settings.viaIR ?? false,
+      optimizer: {
+        ...optimizer,
+        mode: optimizer.mode ?? DEFAULT_SOLX_OPTIMIZER_MODE,
+      },
       outputSelection: await addSolxDebugInfoSelectors(
         entry.settings?.outputSelection,
       ),

--- a/packages/hardhat-solx/src/internal/hook-handlers/solidity.ts
+++ b/packages/hardhat-solx/src/internal/hook-handlers/solidity.ts
@@ -11,7 +11,6 @@ import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
 import { exists } from "@nomicfoundation/hardhat-utils/fs";
 
 import {
-  DEFAULT_SOLX_SETTINGS,
   SOLIDITY_TO_SOLX_VERSION_MAP,
   SOLX_COMPILER_TYPE,
 } from "../constants.js";
@@ -105,11 +104,7 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
         `Creating SolxCompiler with custom path for Solidity ${compilerConfig.version} (solx ${customSolxVersion}) at ${compilerConfig.path}`,
       );
 
-      return new SolxCompiler(
-        customSolxVersion,
-        compilerConfig.path,
-        DEFAULT_SOLX_SETTINGS,
-      );
+      return new SolxCompiler(customSolxVersion, compilerConfig.path);
     }
 
     const solxVersion = SOLIDITY_TO_SOLX_VERSION_MAP[compilerConfig.version];
@@ -129,6 +124,6 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
       `Creating SolxCompiler for Solidity ${compilerConfig.version} (solx ${solxVersion}) at ${binaryPath}`,
     );
 
-    return new SolxCompiler(solxVersion, binaryPath, DEFAULT_SOLX_SETTINGS);
+    return new SolxCompiler(solxVersion, binaryPath);
   },
 });

--- a/packages/hardhat-solx/src/internal/solx-compiler.ts
+++ b/packages/hardhat-solx/src/internal/solx-compiler.ts
@@ -19,36 +19,23 @@ export class SolxCompiler implements Compiler {
   public readonly compilerPath: string;
   public readonly isSolcJs: boolean = false;
 
-  readonly #extraSettings: Record<string, unknown>;
   readonly #spawnCompile: typeof defaultSpawnCompile;
 
   constructor(
     solxVersion: string,
     compilerPath: string,
-    extraSettings: Record<string, unknown> = {},
     spawnCompile: typeof defaultSpawnCompile = defaultSpawnCompile,
   ) {
     this.version = solxVersion;
     this.longVersion = `${solxVersion}+solx`;
     this.compilerPath = compilerPath;
-    this.#extraSettings = extraSettings;
     this.#spawnCompile = spawnCompile;
   }
 
   public async compile(input: CompilerInput): Promise<CompilerOutput> {
     const args = ["--standard-json", "--no-import-callback"];
 
-    // Merge default solx settings with user settings. User settings take
-    // precedence, allowing overrides of viaIR, LLVMOptimization, etc.
-    const modifiedInput: CompilerInput = {
-      ...input,
-      settings: {
-        ...this.#extraSettings,
-        ...input.settings,
-      },
-    };
-
-    return await this.#spawnCompile(this.compilerPath, args, modifiedInput);
+    return await this.#spawnCompile(this.compilerPath, args, input);
   }
 }
 

--- a/packages/hardhat-solx/test/config.ts
+++ b/packages/hardhat-solx/test/config.ts
@@ -231,6 +231,157 @@ describe("hardhat-solx plugin config resolution", () => {
       );
     }
   });
+
+  it("defaults the optimizer mode on solx-typed compilers in resolved config", async () => {
+    const resolvedConfig = await resolveUserConfig(
+      {},
+      undefined as any,
+      makeNext({
+        solx: {
+          isolated: false,
+          preferWasm: false,
+          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+          overrides: {},
+        },
+      }),
+    );
+
+    const solxCompiler = resolvedConfig.solidity.profiles.solx.compilers[0];
+    assert.equal(solxCompiler.settings.optimizer.mode, "1");
+  });
+
+  it("lets a user-set optimizer mode win over the solx default", async () => {
+    const resolvedConfig = await resolveUserConfig(
+      {},
+      undefined as any,
+      makeNext({
+        solx: {
+          isolated: false,
+          preferWasm: false,
+          compilers: [
+            {
+              version: "0.8.34",
+              type: "solx",
+              settings: { optimizer: { enabled: true, mode: "z" } },
+            },
+          ],
+          overrides: {},
+        },
+      }),
+    );
+
+    const solxCompiler = resolvedConfig.solidity.profiles.solx.compilers[0];
+    assert.deepEqual(solxCompiler.settings.optimizer, {
+      enabled: true,
+      mode: "z",
+    });
+  });
+
+  it("fills the optimizer mode without clobbering other user optimizer fields", async () => {
+    const resolvedConfig = await resolveUserConfig(
+      {},
+      undefined as any,
+      makeNext({
+        solx: {
+          isolated: false,
+          preferWasm: false,
+          compilers: [
+            {
+              version: "0.8.34",
+              type: "solx",
+              settings: { optimizer: { enabled: true } },
+            },
+          ],
+          overrides: {},
+        },
+      }),
+    );
+
+    const solxCompiler = resolvedConfig.solidity.profiles.solx.compilers[0];
+    assert.deepEqual(solxCompiler.settings.optimizer, {
+      enabled: true,
+      mode: "1",
+    });
+  });
+
+  it("does not let an undefined user optimizer mode clobber the default", async () => {
+    const resolvedConfig = await resolveUserConfig(
+      {},
+      undefined as any,
+      makeNext({
+        solx: {
+          isolated: false,
+          preferWasm: false,
+          compilers: [
+            {
+              version: "0.8.34",
+              type: "solx",
+              settings: { optimizer: { enabled: true, mode: undefined } },
+            },
+          ],
+          overrides: {},
+        },
+      }),
+    );
+
+    const solxCompiler = resolvedConfig.solidity.profiles.solx.compilers[0];
+    assert.equal(solxCompiler.settings.optimizer.mode, "1");
+  });
+
+  it("defaults viaIR to false on solx-typed compilers, letting a user value win", async () => {
+    const resolvedConfig = await resolveUserConfig(
+      {},
+      undefined as any,
+      makeNext({
+        solx: {
+          isolated: false,
+          preferWasm: false,
+          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+          overrides: {
+            "contracts/ViaIR.sol": {
+              version: "0.8.34",
+              type: "solx",
+              settings: { viaIR: true },
+            },
+          },
+        },
+      }),
+    );
+
+    const solxCompiler = resolvedConfig.solidity.profiles.solx.compilers[0];
+    assert.equal(solxCompiler.settings.viaIR, false);
+    const override =
+      resolvedConfig.solidity.profiles.solx.overrides["contracts/ViaIR.sol"];
+    assert.equal(override.settings.viaIR, true);
+    assert.equal(override.settings.optimizer.mode, "1");
+  });
+
+  it("preserves user-set settings (e.g. evmVersion) while adding solx defaults", async () => {
+    const resolvedConfig = await resolveUserConfig(
+      {},
+      undefined as any,
+      makeNext({
+        solx: {
+          isolated: false,
+          preferWasm: false,
+          compilers: [
+            {
+              version: "0.8.34",
+              type: "solx",
+              settings: { evmVersion: "prague" },
+            },
+          ],
+          overrides: {},
+        },
+      }),
+    );
+
+    const solxCompiler = resolvedConfig.solidity.profiles.solx.compilers[0];
+    // An arbitrary user solc setting survives config resolution untouched...
+    assert.equal(solxCompiler.settings.evmVersion, "prague");
+    // ...alongside a default the plugin fills in (the mode default has its own test).
+    assert.equal(solxCompiler.settings.viaIR, false);
+  });
 });
 
 describe("hardhat-solx EVM version validation", () => {

--- a/packages/hardhat-solx/test/optimizer-mode.ts
+++ b/packages/hardhat-solx/test/optimizer-mode.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions -- test reads
+the solx-specific `optimizer.mode`, which isn't on hardhat's CompilerInput type */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { useEphemeralFixtureProject } from "@nomicfoundation/hardhat-test-utils";
+import {
+  createHardhatRuntimeEnvironment,
+  importUserConfig,
+  resolveHardhatConfigPath,
+} from "hardhat/hre";
+
+// Proves the plugin's default optimizer.mode reaches the resolved solcInput
+// (which hardhat persists as build-info) through the real pipeline — asserting
+// the compiler *input*, not compiled output, and without spawning solx.
+describe("hardhat-solx optimizer mode reaches the solc input", () => {
+  useEphemeralFixtureProject("simple");
+
+  it("defaults optimizer.mode to -O1 in the solx profile's solcInput", async () => {
+    const configPath = await resolveHardhatConfigPath();
+    const userConfig = await importUserConfig(configPath);
+    const hre = await createHardhatRuntimeEnvironment(userConfig);
+
+    const rootFilePaths = await hre.solidity.getRootFilePaths({
+      scope: "contracts",
+    });
+
+    const jobsResult = await hre.solidity.getCompilationJobs(rootFilePaths, {
+      force: true,
+      quiet: true,
+      buildProfile: "solx",
+    });
+    assert.ok(
+      jobsResult.success,
+      "getCompilationJobs should succeed for the solx profile",
+    );
+
+    const job = [...jobsResult.compilationJobsPerFile.values()][0];
+    const solcInput = await job.getSolcInput();
+
+    const optimizer = solcInput.settings.optimizer as
+      | { mode?: string }
+      | undefined;
+    assert.equal(
+      optimizer?.mode,
+      "1",
+      "the plugin's default -O1 should reach the resolved solcInput (and thus build-info)",
+    );
+    assert.equal(
+      (solcInput.settings as { viaIR?: boolean }).viaIR,
+      false,
+      "the plugin's default viaIR:false should also reach the resolved solcInput",
+    );
+  });
+});

--- a/packages/hardhat-solx/test/solx-compiler.ts
+++ b/packages/hardhat-solx/test/solx-compiler.ts
@@ -40,11 +40,10 @@ describe("SolxCompiler", () => {
     assert.equal(compiler.isSolcJs, false);
   });
 
-  it("calls spawnCompile with correct binary path and args", async () => {
+  it("forwards binary path, args, and the input unchanged to spawnCompile", async () => {
     const compiler = new SolxCompiler(
       "0.1.4",
       "/path/to/solx",
-      {},
       fakeSpawnCompile,
     );
     const input: CompilerInput = {
@@ -59,66 +58,16 @@ describe("SolxCompiler", () => {
     const call = spawnCompileCalls[0];
     assert.equal(call.command, "/path/to/solx");
     assert.deepEqual(call.args, ["--standard-json", "--no-import-callback"]);
-  });
-
-  it("merges extraSettings into input.settings", async () => {
-    const compiler = new SolxCompiler(
-      "0.1.4",
-      "/path/to/solx",
-      { LLVMOptimization: "1" },
-      fakeSpawnCompile,
-    );
-    const input: CompilerInput = {
-      language: "Solidity",
-      sources: { "A.sol": { content: "pragma solidity ^0.8.0;" } },
-      settings: {
-        optimizer: { enabled: true },
-        outputSelection: { "*": { "*": ["abi"] } },
-      },
-    };
-
-    await compiler.compile(input);
-
-    assert.equal(spawnCompileCalls.length, 1);
-    // The outputSelection passes through unchanged: the plugin's
-    // `resolveUserConfig` hook is what adds the solx-specific debugInfo
-    // selectors, so by the time `SolxCompiler.compile` runs they're
-    // already present on whatever the build system constructed.
-    assert.deepEqual(spawnCompileCalls[0].input.settings, {
-      optimizer: { enabled: true },
-      outputSelection: { "*": { "*": ["abi"] } },
-      LLVMOptimization: "1",
-    });
-  });
-
-  it("does not modify the original input object", async () => {
-    const compiler = new SolxCompiler(
-      "0.1.4",
-      "/path/to/solx",
-      { LLVMOptimization: "1" },
-      fakeSpawnCompile,
-    );
-    const input: CompilerInput = {
-      language: "Solidity",
-      sources: { "A.sol": { content: "pragma solidity ^0.8.0;" } },
-      settings: { optimizer: { enabled: true }, outputSelection: {} },
-    };
-
-    const originalSettings = { ...input.settings };
-    await compiler.compile(input);
-
-    assert.deepEqual(
-      input.settings,
-      originalSettings,
-      "Original input settings should not be modified",
-    );
+    // compile() transforms nothing — solx's defaults (optimizer mode, viaIR,
+    // debugInfo) are applied at config resolution, so the input reaches solx
+    // exactly as the build system constructed it.
+    assert.equal(call.input, input);
   });
 
   it("returns the output from spawnCompile", async () => {
     const compiler = new SolxCompiler(
       "0.1.4",
       "/path/to/solx",
-      {},
       fakeSpawnCompile,
     );
     const input: CompilerInput = {


### PR DESCRIPTION
As part of testing https://github.com/NomicFoundation/hardhat/pull/8415, I noticed the optimisation settings weren't being piped through to solx. I also took the opportunity to use the same config unification approach for optimiser as the `outputSelection`.  At that point the `extraSettings` weren't really needed any more.

# Summary

`hardhat-solx` defaulted solx settings in **two** places, neither of which reached the resolved
`solcInput`:
- **optimizer** — via a dead `LLVMOptimization: "1"` key that solx doesn't recognize (it reads
  `settings.optimizer.mode` and silently used its own `-O3`); and
- **viaIR** — via a compile-time `extraSettings` merge inside `SolxCompiler.compile`.

Because both bypassed the resolved `solcInput`, neither reached the **build-info** or the
**build-id hash** — a latent cache-staleness bug (a change to a default wouldn't invalidate caches).

This unifies defaulting at **config resolution** (`augmentIfSolx`, next to the existing DWARF
`debugInfo` selector injection), so all solx defaults land in the `solcInput`:
- `optimizer.mode` defaults to `"1"` — restoring the plugin's original `-O1` intent, now actually
  wired through.
- `viaIR` defaults to `false` (matching solx's own default — verified in solx's solc fork).

A user-set `optimizer.mode` / `viaIR` still wins. The now-empty `DEFAULT_SOLX_SETTINGS` + the
`extraSettings` plumbing are retired; `SolxCompiler.compile` forwards the input unchanged.

## Why `-O1`

`-O1` is the product-chosen default: **compile time is the priority**, and `-O1`/`-O3` compile at
~equal cost on the OZ corpus (DWARF dominates solx's compile cost). Users who want solx's `-O3` set
`optimizer.mode: "3"`.

## Behavior change

- Effective default optimization level goes `-O3` (what solx silently used via the dead key) → `-O1`.
- On upgrade, the build-id now folds in `optimizer.mode` and `viaIR` (previously absent), so existing
  solx projects recompile **once**. Expected and harmless.

## Tests

- **Config resolution** (`test/config.ts`): optimizer default is `"1"`; a user mode (`"z"`) wins; the
  default fills `mode` **without clobbering** other optimizer fields (`{enabled:true}` → `{enabled:true,
  mode:"1"}`) and isn't defeated by an explicit `mode: undefined`; `viaIR` defaults `false` with a user
  `true` winning; and an arbitrary user solc setting (`evmVersion`) passes through `augmentIfSolx`
  untouched alongside the injected defaults.
- **Pipeline** (`test/optimizer-mode.ts`): the default reaches the resolved `solcInput` through the
  real HRE build (`getSolcInput`) — asserting the compiler *input* (which becomes build-info), no
  solx spawn.
- `SolxCompiler` test re-anchored: `compile` forwards the input unchanged (defaults come from config
  resolution).

## Evidence that `optimizer.mode` reaches solx

Beyond the tests, compiling one contract straight through the solx `0.1.4` binary
(`solx --standard-json`, varying only `settings.optimizer.mode`) shows the level both **reaches** solx
and **changes** its output — deployed bytecode differs per mode, and solx rejects an unknown mode (so it
clearly parses the field):

| `optimizer.mode` | deployed bytecode | sha256 (first 16) |
|---|---|---|
| `"1"` (plugin default) | 268 B | `65214d6cc4006ab9` |
| `"2"` | 219 B | `507ebdcc083be8e0` |
| `"3"` | 219 B | `8ce53a7601dbf027` |
| `"s"` | 219 B | `be089b4853daeb4a` |
| `"z"` | 213 B | `311cc445b33304bc` |
| `"0"` | — | error: `unexpected optimization option '0': only values 1, 2, 3, s, z are supported` |

`"2"`/`"3"`/`"s"` land at the same size here but produce **distinct** bytecode (different hashes); `"1"` is
the largest and `"z"` the smallest — consistent with `-O1` being the lighter default.

## Notes

- Drops `"0"` from the documented/commented mode list (solx 0.1.4 rejects it), and notes solx has no
  "off" level — the minimum is `"1"`, controlled by `mode`.
- **No changeset**: `@nomicfoundation/hardhat-solx` is `private` and in `.changeset/config.json`'s
  `ignore` list.
- No DWARF changes — the plugin still force-emits DWARF as on `main`.

