### PR TITLE
fix: honor compiler type in build info recompilation

### DIFF
--- a/.changeset/healthy-build-infos-compile.md
+++ b/.changeset/healthy-build-infos-compile.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Fix `SolidityBuildSystem#compileBuildInfo` so build infos produced by non-solc compiler types are replayed through the Solidity compiler hooks, throwing a clear error when no plugin handles the build info's compiler type.
+Fix `SolidityBuildSystem#compileBuildInfo` so build infos produced by non-solc compiler types are replayed through the Solidity compiler hooks.

--- a/.changeset/healthy-build-infos-compile.md
+++ b/.changeset/healthy-build-infos-compile.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Fix `SolidityBuildSystem#compileBuildInfo` so build infos produced by non-solc compiler types are replayed through the Solidity compiler hooks.
+Fix `SolidityBuildSystem#compileBuildInfo` so build infos produced by non-solc compiler types are replayed through the Solidity compiler hooks, throwing a clear error when no plugin handles the build info's compiler type.

--- a/.changeset/healthy-build-infos-compile.md
+++ b/.changeset/healthy-build-infos-compile.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fix `SolidityBuildSystem#compileBuildInfo` so build infos produced by non-solc compiler types are replayed through the Solidity compiler hooks.

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -1497,6 +1497,16 @@ Try re-running without these files, or without the flag.`,
 
 For example, you may be trying to build a test file with \`--no-tests\`, which isn't a valid operation.`,
       },
+      BUILD_INFO_COMPILER_TYPE_NOT_HANDLED: {
+        number: 918,
+        messageTemplate: `The build info you are trying to compile was produced by the "{compilerType}" compiler (version {version}), but no plugin registered a handler for that compiler type.
+
+Make sure the plugin that provides the "{compilerType}" compiler is installed and enabled in your Hardhat config.`,
+        websiteTitle: "No compiler registered for build info compiler type",
+        websiteDescription: `The build info you are trying to compile was produced by a non-\`solc\` compiler type, but no installed plugin registered a handler for that compiler type.
+
+Make sure the plugin that provides the compiler is installed and enabled in your Hardhat config.`,
+      },
     },
     ARTIFACTS: {
       NOT_FOUND: {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1355,7 +1355,15 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       "solidity",
       "getCompiler",
       [partialCompilerConfig],
-      async (_context, cfg) => await getSolcCompilerForConfig(cfg, false),
+      async () => {
+        throw new HardhatError(
+          HardhatError.ERRORS.CORE.SOLIDITY.BUILD_INFO_COMPILER_TYPE_NOT_HANDLED,
+          {
+            compilerType,
+            version: buildInfo.solcVersion,
+          },
+        );
+      },
     );
 
     return await compiler.compile(buildInfo.input);

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1343,29 +1343,37 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
       return await solcCompiler.compile(buildInfo.input);
     }
 
-    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
-      Build infos may come from setups whose compiler type is unknown to the
-      current Hardhat type definitions, but plugins can still handle them via
-      the compiler hooks. */
-    const compilerConfig = {
-      type: compilerType,
-      version: buildInfo.solcVersion,
-      settings: buildInfo.input.settings,
-    } as SolidityCompilerConfig;
+    const partialCompilerConfig =
+      this.#getPartialSolidityCompilerConfigFromBuildInfo(buildInfo);
 
     await this.#hooks.runParallelHandlers("solidity", "downloadCompilers", [
-      [compilerConfig],
+      [partialCompilerConfig],
       quiet,
     ]);
 
     const compiler = await this.#hooks.runHandlerChain(
       "solidity",
       "getCompiler",
-      [compilerConfig],
+      [partialCompilerConfig],
       async (_context, cfg) => await getSolcCompilerForConfig(cfg, false),
     );
 
     return await compiler.compile(buildInfo.input);
+  }
+
+  #getPartialSolidityCompilerConfigFromBuildInfo(
+    buildInfo: SolidityBuildInfo,
+  ): SolidityCompilerConfig {
+    return {
+      /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+      Build infos may come from setups whose compiler type is unknown to the
+      current Hardhat type definitions, but plugins can still handle them via
+      the compiler hooks. */
+      type: (buildInfo.compilerType ??
+        "solc") as SolidityCompilerConfig["type"],
+      version: buildInfo.solcVersion,
+      settings: buildInfo.input.settings,
+    };
   }
 
   async #downloadConfiguredCompilers(quiet = false): Promise<void> {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1327,16 +1327,43 @@ export class SolidityBuildSystemImplementation implements SolidityBuildSystem {
     options?: CompileBuildInfoOptions,
   ): Promise<CompilerOutput> {
     const quiet = options?.quiet ?? false;
+    const compilerType = buildInfo.compilerType ?? "solc";
 
-    // Build info recompilation is always solc-only: build info files are
-    // produced by solc and must be recompiled with the same solc version.
-    // We bypass both downloadCompilers and getCompiler hooks — this is a
-    // self-contained solc replay path, not plugin-configurable compilation.
-    await downloadSolcCompilers(new Set([buildInfo.solcVersion]), quiet);
+    if (compilerType === "solc") {
+      // Build info recompilation for solc is self-contained: solc build info
+      // files must be replayed with the same solc version. We bypass both
+      // downloadCompilers and getCompiler hooks to preserve the historical solc
+      // path and avoid making it depend on the current project config.
+      await downloadSolcCompilers(new Set([buildInfo.solcVersion]), quiet);
 
-    const compiler = await getCompiler(buildInfo.solcVersion, {
-      preferWasm: false,
-    });
+      const solcCompiler = await getCompiler(buildInfo.solcVersion, {
+        preferWasm: false,
+      });
+
+      return await solcCompiler.compile(buildInfo.input);
+    }
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+      Build infos may come from setups whose compiler type is unknown to the
+      current Hardhat type definitions, but plugins can still handle them via
+      the compiler hooks. */
+    const compilerConfig = {
+      type: compilerType,
+      version: buildInfo.solcVersion,
+      settings: buildInfo.input.settings,
+    } as SolidityCompilerConfig;
+
+    await this.#hooks.runParallelHandlers("solidity", "downloadCompilers", [
+      [compilerConfig],
+      quiet,
+    ]);
+
+    const compiler = await this.#hooks.runHandlerChain(
+      "solidity",
+      "getCompiler",
+      [compilerConfig],
+      async (_context, cfg) => await getSolcCompilerForConfig(cfg, false),
+    );
 
     return await compiler.compile(buildInfo.input);
   }

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -1,6 +1,11 @@
-import type { SolidityConfig } from "../../../../../src/types/config.js";
+import type {
+  SolidityCompilerConfig,
+  SolidityConfig,
+} from "../../../../../src/types/config.js";
 import type { HookContext } from "../../../../../src/types/hooks.js";
 import type {
+  Compiler,
+  CompilerOutput,
   SolidityBuildInfo,
   SolidityBuildInfoOutput,
   SolidityBuildSystem,
@@ -571,6 +576,90 @@ describe(
           output.errors.some((e) => e.severity === "error"),
           "Output should have at least one error",
         );
+      });
+
+      it("should use compiler hooks for build infos with a non-solc compiler type", async () => {
+        const fakeOutput: CompilerOutput = {
+          contracts: {},
+          sources: {},
+        };
+        const customCompiler: Compiler = {
+          version: "0.8.22",
+          longVersion: "0.8.22+custom",
+          compilerPath: "/mock/custom-compiler",
+          isSolcJs: false,
+          compile: async () => fakeOutput,
+        };
+
+        let downloadConfigs: SolidityCompilerConfig[] | undefined;
+        let getCompilerConfig: SolidityCompilerConfig | undefined;
+        let compileInput: SolidityBuildInfo["input"] | undefined;
+
+        const hooks = new HookManagerImplementation(process.cwd(), []);
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We don't care about hooks in this context
+        hooks.setContext({} as HookContext);
+        hooks.registerHandlers("solidity", await createSolidityHookHandlers());
+        hooks.registerHandlers("solidity", {
+          downloadCompilers: async (_context, compilerConfigs) => {
+            downloadConfigs = compilerConfigs;
+          },
+          getCompiler: async (_context, compilerConfig) => {
+            getCompilerConfig = compilerConfig;
+            return {
+              ...customCompiler,
+              compile: async (input) => {
+                compileInput = input;
+                return await customCompiler.compile(input);
+              },
+            };
+          },
+        });
+
+        const buildSystem = new SolidityBuildSystemImplementation(hooks, {
+          solidityConfig,
+          projectRoot: process.cwd(),
+          soliditySourcesPaths: [path.join(process.cwd(), "contracts")],
+          artifactsPath: actualArtifactsPath,
+          cachePath: actualCachePath,
+          solidityTestsPath: path.join(process.cwd(), "tests"),
+          coverage: false,
+        });
+
+        const buildInfo: SolidityBuildInfo = {
+          _format: "hh3-sol-build-info-1",
+          id: "solc-0_8_22-custom-test",
+          solcVersion: "0.8.22",
+          solcLongVersion: "0.8.22+custom",
+          compilerType: "custom",
+          userSourceNameMap: { "contracts/A.sol": "contracts/A.sol" },
+          input: {
+            language: "Solidity",
+            sources: {
+              "contracts/A.sol": { content: "contract A {}" },
+            },
+            settings: {
+              optimizer: { enabled: false, runs: 200 },
+              outputSelection: { "*": { "*": ["abi"] } },
+            },
+          },
+        };
+
+        const output = await buildSystem.compileBuildInfo(buildInfo, {
+          quiet: true,
+        });
+
+        const expectedDownloadConfigs: unknown = [
+          {
+            type: "custom",
+            version: "0.8.22",
+            settings: buildInfo.input.settings,
+          },
+        ];
+
+        assert.equal(output, fakeOutput);
+        assert.deepEqual(downloadConfigs, expectedDownloadConfigs);
+        assert.deepEqual(getCompilerConfig, downloadConfigs?.[0]);
+        assert.equal(compileInput, buildInfo.input);
       });
     });
   },

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts
@@ -661,6 +661,54 @@ describe(
         assert.deepEqual(getCompilerConfig, downloadConfigs?.[0]);
         assert.equal(compileInput, buildInfo.input);
       });
+
+      it("should throw when no plugin handles a non-solc compiler type", async () => {
+        const hooks = new HookManagerImplementation(process.cwd(), []);
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- We don't care about hooks in this context
+        hooks.setContext({} as HookContext);
+        // Only the default solc handlers are registered, so no plugin can
+        // provide a compiler for the "custom" type.
+        hooks.registerHandlers("solidity", await createSolidityHookHandlers());
+
+        const buildSystem = new SolidityBuildSystemImplementation(hooks, {
+          solidityConfig,
+          projectRoot: process.cwd(),
+          soliditySourcesPaths: [path.join(process.cwd(), "contracts")],
+          artifactsPath: actualArtifactsPath,
+          cachePath: actualCachePath,
+          solidityTestsPath: path.join(process.cwd(), "tests"),
+          coverage: false,
+        });
+
+        const buildInfo: SolidityBuildInfo = {
+          _format: "hh3-sol-build-info-1",
+          id: "solc-0_8_22-custom-test",
+          solcVersion: "0.8.22",
+          solcLongVersion: "0.8.22+custom",
+          compilerType: "custom",
+          userSourceNameMap: { "contracts/A.sol": "contracts/A.sol" },
+          input: {
+            language: "Solidity",
+            sources: {
+              "contracts/A.sol": { content: "contract A {}" },
+            },
+            settings: {
+              optimizer: { enabled: false, runs: 200 },
+              outputSelection: { "*": { "*": ["abi"] } },
+            },
+          },
+        };
+
+        await assertRejectsWithHardhatError(
+          buildSystem.compileBuildInfo(buildInfo, { quiet: true }),
+          HardhatError.ERRORS.CORE.SOLIDITY
+            .BUILD_INFO_COMPILER_TYPE_NOT_HANDLED,
+          {
+            compilerType: "custom",
+            version: "0.8.22",
+          },
+        );
+      });
     });
   },
 );


### PR DESCRIPTION
## Summary
- Replays non-solc Solidity build infos through the Solidity compiler hooks instead of always using the built-in solc path.
- Keeps existing solc build-info recompilation behavior unchanged.

## Why
`SolidityBuildSystem#compileBuildInfo` can receive build infos produced by plugin-provided compiler types. Those build infos carry `compilerType`, but the replay path ignored it and always invoked solc.

## Changes
- Detects non-solc `compilerType` values and constructs a matching compiler config from the build info.
- Runs `downloadCompilers` and `getCompiler` hooks for non-solc build-info replay.
- Adds a regression test that uses a custom compiler hook.
- Adds a patch changeset for `hardhat`.

## Validation
- `pnpm lint:file packages/hardhat/src/internal/builtin-plugins/solidity/build-system/build-system.ts packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts`
- `pnpm test:file packages/hardhat/test/internal/builtin-plugins/solidity/build-system/build-system.ts`
- `pnpm --filter hardhat build`
- `pnpm prettier --check .changeset/healthy-build-infos-compile.md`

## Scope
Focused fix for build-info recompilation; no changes to normal project compilation.

Closes #8081