### PR TITLE
chore: exclude hardhat-ignition tests from build

### DIFF
--- a/packages/hardhat-ignition/test/.eslintrc.js
+++ b/packages/hardhat-ignition/test/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: [`${__dirname}/../.eslintrc.js`],
   parserOptions: {
-    project: `${__dirname}/../tsconfig.json`,
+    project: `${__dirname}/../tsconfig.test.json`,
     sourceType: "module",
   },
   rules: {

--- a/packages/hardhat-ignition/tsconfig.json
+++ b/packages/hardhat-ignition/tsconfig.json
@@ -12,5 +12,6 @@
     { "path": "../hardhat-network-helpers" },
     { "path": "../hardhat-verify" },
     { "path": "../hardhat-ignition-ui/tsconfig.node.json" }
-  ]
+  ],
+  "exclude": ["./test/", "./dist", "./node_modules"]
 }

--- a/packages/hardhat-ignition/tsconfig.test.json
+++ b/packages/hardhat-ignition/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
This is a fix for the Hardhat 2 pnpm lock file CI check.

We avoid a dependency clash with `ox` by excluding the tests. This is working around quirks in changed module resolution that brought in a `ts` file inside `ox` unexpectedly, removing the tests from the build output avoids the issue.

The tests do not depend on the output into the `dist` folder, as they transpile at runtime.