### PR TITLE
ci: fix stale dependency resolution in regression benchmark

### DIFF
--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -97,6 +97,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y hyperfine
 
+      - name: Configure E2E clone directory
+        # Clone scenarios into the runner's temp dir instead of the default
+        # /tmp/end-to-end, which persists across runs on the self-hosted
+        # runner. The "Clean up temp dir" step below removes it after the run.
+        run: echo "E2E_CLONE_DIR=$RUNNER_TEMP/hardhat-e2e-clones" >> "$GITHUB_ENV"
+
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline
 
@@ -108,6 +114,22 @@ jobs:
       # exists. See pnpm/pnpm#10524.
       - name: Recreate workspace bin links
         run: pnpm rebuild -r
+
+      - name: Clear stale pnpm metadata cache
+        # The self-hosted runner reuses ~/.cache/pnpm across runs. The benchmark
+        # republishes deterministic versions (e.g. hardhat@3.9.1) whose content
+        # can change between runs (new @nomicfoundation/edr pin), so a prior
+        # run's cached registry metadata makes pnpm-based scenario installs
+        # resolve a stale hardhat with outdated dependencies.
+        #
+        # pnpm 11 ignores `npm_config_cache_dir`, so the metadata cache can't be
+        # relocated.
+        #
+        # The content-addressable store is separate and kept on purpose: it's
+        # keyed by integrity hash, so with fresh metadata pnpm derives the correct
+        # hash and any stale entry is simply never matched. Keeping it is safe and
+        # preserves install speed.
+        run: rm -rf "$HOME/.cache/pnpm"
 
       - name: Run regression benchmark
         env:
@@ -142,3 +164,9 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+
+      - name: Clean up temp dir
+        # Self-hosted runners don't automatically wipe RUNNER_TEMP between jobs,
+        # so we do this manually to avoid polluting future runs.
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/hardhat-e2e-clones"

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -101,7 +101,7 @@ jobs:
         # Clone scenarios into the runner's temp dir instead of the default
         # /tmp/end-to-end, which persists across runs on the self-hosted
         # runner. The "Clean up temp dir" step below removes it after the run.
-        run: echo "E2E_CLONE_DIR=$RUNNER_TEMP/hardhat-e2e-clones" >> "$GITHUB_ENV"
+        run: echo "E2E_CLONE_DIR=${RUNNER_TEMP:?}/hardhat-e2e-clones" >> "$GITHUB_ENV"
 
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline
@@ -129,7 +129,7 @@ jobs:
         # keyed by integrity hash, so with fresh metadata pnpm derives the correct
         # hash and any stale entry is simply never matched. Keeping it is safe and
         # preserves install speed.
-        run: rm -rf "$HOME/.cache/pnpm"
+        run: rm -rf "${HOME:?}/.cache/pnpm"
 
       - name: Run regression benchmark
         env:

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -166,7 +166,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
 
       - name: Clean up temp dir
-        # Self-hosted runners don't automatically wipe RUNNER_TEMP between jobs,
-        # so we do this manually to avoid polluting future runs.
+        # Self-hosted runners don't automatically wipe the E2E_CLONE_DIR written
+        # to RUNNER_TEMP between jobs, so we do this manually to avoid polluting
+        # future runs.
         if: always()
-        run: rm -rf "$RUNNER_TEMP/hardhat-e2e-clones"
+        run: rm -rf "$E2E_CLONE_DIR"


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Backports two stale-state fixes from EDR's `hh3-regression-benchmark` workflow (NomicFoundation/edr#1508, NomicFoundation/edr#1512) to the self-hosted benchmark runner:

- **Clear pnpm's metadata cache (`~/.cache/pnpm`) before the benchmark.** The benchmark republishes deterministic versions to Verdaccio whose content can change between runs (e.g. a new `@nomicfoundation/edr` pin), so cached registry metadata from a prior run makes pnpm-based scenario installs resolve stale dependencies. The content-addressable store is kept: it's keyed by integrity hash, so fresh metadata never matches a stale entry.
- **Clone E2E scenarios into `$RUNNER_TEMP` instead of the persistent `/tmp/end-to-end` default**, and remove them in an `always()` cleanup step.

Expected to resolve the staleness that the diagnostic from #8424 surfaced in https://github.com/NomicFoundation/hardhat/actions/runs/28920792273/job/85797374165#step:11:1

