### PR TITLE
Handle Windows superscript COM/LPT device names in sanitizeFilename

### DIFF
--- a/.changeset/windows-superscript-device-names.md
+++ b/.changeset/windows-superscript-device-names.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Make `sanitizeFilename` avoid Windows reserved COM and LPT device names that use superscript digits.

--- a/packages/hardhat-utils/src/path.ts
+++ b/packages/hardhat-utils/src/path.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 
 const WINDOWS_RESERVED_FILENAME_PATTERN =
-  /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+  /^(con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(\..*)?$/i;
 
 /**
  * Resolves a user-provided path into an absolute path.

--- a/packages/hardhat-utils/test/path.ts
+++ b/packages/hardhat-utils/test/path.ts
@@ -171,6 +171,15 @@ describe("path", () => {
       assert.equal(sanitizeFilename("com1.log"), "com1_.log");
     });
 
+    it("Should avoid Windows reserved device names with superscript digits", () => {
+      assert.equal(sanitizeFilename("COM¹"), "COM¹_");
+      assert.equal(sanitizeFilename("COM²"), "COM²_");
+      assert.equal(sanitizeFilename("COM³.log"), "COM³_.log");
+      assert.equal(sanitizeFilename("LPT¹"), "LPT¹_");
+      assert.equal(sanitizeFilename("LPT²"), "LPT²_");
+      assert.equal(sanitizeFilename("LPT³.txt"), "LPT³_.txt");
+    });
+
     it("Should preserve names that only contain Windows reserved device names as substrings", () => {
       assert.equal(sanitizeFilename("CONTRACT"), "CONTRACT");
       assert.equal(sanitizeFilename("XCOM1"), "XCOM1");


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->



## Summary

- Update `sanitizeFilename` to treat `COM¹`-`COM³` and `LPT¹`-`LPT³` as Windows reserved device names.
- Preserve extensions when adjusting those names, matching the existing behavior for `COM1`/`LPT1`.
- Add regression tests for superscript-digit COM/LPT device names.
- Add a patch changeset for `@nomicfoundation/hardhat-utils`.

## Motivation

Windows treats the superscript digits `¹`, `²`, and `³` as valid digits in `COM#` and `LPT#` device names, so names like `COM¹` and `LPT³.txt` are reserved in every directory.

This makes `sanitizeFilename` consistent with the Windows filename rules and with the existing reserved-device-name handling added in #8402.

Reference: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file

## Tests

- `pnpm --filter @nomicfoundation/hardhat-utils build`
- `pnpm lint:file packages/hardhat-utils/src/path.ts packages/hardhat-utils/test/path.ts`
- `pnpm prettier --check .changeset/windows-superscript-device-names.md`
- `pnpm spellcheck:file .changeset/windows-superscript-device-names.md packages/hardhat-utils/test/path.ts packages/hardhat-utils/src/path.ts`
- From `packages/hardhat-utils`: `node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter --test-name-pattern sanitizeFilename test/path.ts`