### PR TITLE
Add detectAgentEnvironment util to hardhat-utils

### DIFF
--- a/.changeset/detect-agent-environment.md
+++ b/.changeset/detect-agent-environment.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Add `detectAgentEnvironment` and `isInteractive` utils

--- a/packages/hardhat-utils/package.json
+++ b/packages/hardhat-utils/package.json
@@ -21,6 +21,7 @@
     "./date": "./dist/src/date.js",
     "./debug": "./dist/src/debug.js",
     "./env": "./dist/src/env.js",
+    "./environment": "./dist/src/environment.js",
     "./error": "./dist/src/error.js",
     "./eth": "./dist/src/eth.js",
     "./fast-semver": "./dist/src/fast-semver.js",

--- a/packages/hardhat-utils/src/environment.ts
+++ b/packages/hardhat-utils/src/environment.ts
@@ -1,0 +1,76 @@
+/**
+ * The result of detecting whether the current process is running inside an
+ * AI coding agent environment.
+ */
+export interface AgentEnvironment {
+  /**
+   * True if at least one agent environment was detected.
+   */
+  isAgent: boolean;
+
+  /**
+   * The identifiers of every detected agent, deduplicated.
+   *
+   * More than one agent can be reported at the same time, as agent sessions
+   * can be nested.
+   */
+  agents: string[];
+}
+
+/**
+ * Detects whether the current process is running inside an AI coding agent
+ * environment, based on the environment variables that those tools set in
+ * the shells they spawn.
+ *
+ * Currently supported: Claude Code and Codex. Other agents that advertise
+ * themselves via the generic `AI_AGENT` variable are reported as "unknown".
+ *
+ * @returns The detected agent environment.
+ */
+export function detectAgentEnvironment(): AgentEnvironment {
+  const env = process.env;
+
+  const detectedAgents: string[] = [];
+
+  // Claude Code sets these in every shell command it runs
+  if (
+    env.CLAUDECODE !== undefined ||
+    env.CLAUDE_CODE_ENTRYPOINT !== undefined
+  ) {
+    detectedAgents.push("claude-code");
+  }
+
+  // Codex sets these in the shells it spawns
+  if (
+    env.CODEX_THREAD_ID !== undefined ||
+    env.CODEX_CI !== undefined ||
+    env.CODEX_SANDBOX_NETWORK_DISABLED !== undefined
+  ) {
+    detectedAgents.push("codex");
+  }
+
+  // Generic marker set by some agents alongside their own variables (e.g.
+  // Claude Code sets `AI_AGENT=claude-code_<version>_agent`). It is only
+  // reported when no known agent matched, to avoid double counting
+  if (detectedAgents.length === 0 && env.AI_AGENT !== undefined) {
+    detectedAgents.push("unknown");
+  }
+
+  return {
+    isAgent: detectedAgents.length > 0,
+    agents: detectedAgents,
+  };
+}
+
+/**
+ * Checks whether the current process is running interactively, meaning both
+ * stdin and stdout are TTYs.
+ *
+ * This is orthogonal to agent detection, but can be a useful hint of whether
+ * the process is running in an automated environment.
+ *
+ * @returns True if the current process is running interactively.
+ */
+export function isInteractive(): boolean {
+  return process.stdin.isTTY === true && process.stdout.isTTY === true;
+}

--- a/packages/hardhat-utils/test/environment.ts
+++ b/packages/hardhat-utils/test/environment.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { after, beforeEach, describe, it } from "node:test";
+
+import { detectAgentEnvironment, isInteractive } from "../src/environment.js";
+
+// Get the original ENV variables and TTY states so they can be restored at
+// the end of the tests
+const ORIGINAL_ENV_VARS = process.env;
+const ORIGINAL_STDIN_IS_TTY = process.stdin.isTTY;
+const ORIGINAL_STDOUT_IS_TTY = process.stdout.isTTY;
+
+describe("environment", () => {
+  describe("detectAgentEnvironment", () => {
+    beforeEach(() => {
+      process.env = {};
+    });
+
+    after(() => {
+      // Restore original ENV variables
+      process.env = ORIGINAL_ENV_VARS;
+    });
+
+    it("should detect no agent when all the ENV variables are undefined", () => {
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: false,
+        agents: [],
+      });
+    });
+
+    it("should detect claude-code via the ENV variable CLAUDECODE", () => {
+      process.env.CLAUDECODE = "1";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: true,
+        agents: ["claude-code"],
+      });
+    });
+
+    it("should detect claude-code via the ENV variable CLAUDE_CODE_ENTRYPOINT", () => {
+      process.env.CLAUDE_CODE_ENTRYPOINT = "cli";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: true,
+        agents: ["claude-code"],
+      });
+    });
+
+    it("should not duplicate claude-code when both of its ENV variables are set", () => {
+      process.env.CLAUDECODE = "1";
+      process.env.CLAUDE_CODE_ENTRYPOINT = "cli";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: true,
+        agents: ["claude-code"],
+      });
+    });
+
+    it("should detect codex via the ENV variable CODEX_THREAD_ID", () => {
+      process.env.CODEX_THREAD_ID = "019f2222-5970-7771-bbb8-af0972db9601";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: true,
+        agents: ["codex"],
+      });
+    });
+
+    it("should detect codex via the ENV variable CODEX_CI", () => {
+      process.env.CODEX_CI = "1";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: true,
+        agents: ["codex"],
+      });
+    });
+
+    it("should detect codex via the ENV variable CODEX_SANDBOX_NETWORK_DISABLED", () => {
+      process.env.CODEX_SANDBOX_NETWORK_DISABLED = "1";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: true,
+        agents: ["codex"],
+      });
+    });
+
+    it("should not detect currently unsupported agents (cursor, gemini-cli, amp)", () => {
+      process.env.CURSOR_AGENT = "1";
+      process.env.CURSOR_TRACE_ID = "abc123";
+      process.env.GEMINI_CLI = "1";
+      process.env.AGENT = "amp";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: false,
+        agents: [],
+      });
+    });
+
+    it("should report unknown when only the generic ENV variable AI_AGENT is set", () => {
+      process.env.AI_AGENT = "somethingnew_1-0-0_agent";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: true,
+        agents: ["unknown"],
+      });
+    });
+
+    it("should ignore the generic ENV variable AI_AGENT when a known agent was already detected", () => {
+      process.env.CLAUDECODE = "1";
+      process.env.AI_AGENT = "claude-code_2-1-198_agent";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: true,
+        agents: ["claude-code"],
+      });
+    });
+
+    it("should detect multiple agents in nested sessions", () => {
+      process.env.CLAUDECODE = "1";
+      process.env.CODEX_THREAD_ID = "019f2222-5970-7771-bbb8-af0972db9601";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: true,
+        agents: ["claude-code", "codex"],
+      });
+    });
+
+    it("should not detect an agent in a CI environment without agent ENV variables", () => {
+      process.env.CI = "true";
+      process.env.GITHUB_ACTIONS = "true";
+      assert.deepEqual(detectAgentEnvironment(), {
+        isAgent: false,
+        agents: [],
+      });
+    });
+  });
+
+  describe("isInteractive", () => {
+    beforeEach(() => {
+      process.stdin.isTTY = false;
+      process.stdout.isTTY = false;
+    });
+
+    after(() => {
+      // Restore original TTY states
+      process.stdin.isTTY = ORIGINAL_STDIN_IS_TTY;
+      process.stdout.isTTY = ORIGINAL_STDOUT_IS_TTY;
+    });
+
+    it("should be false when neither stdin nor stdout is a TTY", () => {
+      assert.equal(isInteractive(), false);
+    });
+
+    it("should be true when both stdin and stdout are TTYs", () => {
+      process.stdin.isTTY = true;
+      process.stdout.isTTY = true;
+      assert.equal(isInteractive(), true);
+    });
+
+    it("should be false when only stdout is a TTY", () => {
+      process.stdout.isTTY = true;
+      assert.equal(isInteractive(), false);
+    });
+
+    it("should be false when only stdin is a TTY", () => {
+      process.stdin.isTTY = true;
+      assert.equal(isInteractive(), false);
+    });
+  });
+});

--- a/packages/hardhat-utils/test/environment.ts
+++ b/packages/hardhat-utils/test/environment.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
-import { after, beforeEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 
 import { detectAgentEnvironment, isInteractive } from "../src/environment.js";
 
-// Get the original ENV variables and TTY states so they can be restored at
-// the end of the tests
+// Get the original ENV variables and TTY states so they can be restored
+// after each test
 const ORIGINAL_ENV_VARS = process.env;
 const ORIGINAL_STDIN_IS_TTY = process.stdin.isTTY;
 const ORIGINAL_STDOUT_IS_TTY = process.stdout.isTTY;
@@ -15,7 +15,7 @@ describe("environment", () => {
       process.env = {};
     });
 
-    after(() => {
+    afterEach(() => {
       // Restore original ENV variables
       process.env = ORIGINAL_ENV_VARS;
     });
@@ -129,7 +129,7 @@ describe("environment", () => {
       process.stdout.isTTY = false;
     });
 
-    after(() => {
+    afterEach(() => {
       // Restore original TTY states
       process.stdin.isTTY = ORIGINAL_STDIN_IS_TTY;
       process.stdout.isTTY = ORIGINAL_STDOUT_IS_TTY;


### PR DESCRIPTION
Adds a `detectAgentEnvironment()` util to `@nomicfoundation/hardhat-utils` (exported as `@nomicfoundation/hardhat-utils/environment`) that detects whether the current process is running inside a coding agent environment, based on the environment variables those tools set in the shells they spawn.

```ts
const { isAgent, agents } = detectAgentEnvironment();
// e.g. { isAgent: true, agents: ["claude-code", "codex"] }
```

- **Supported agents:** Currently Claude Code and Codex. Agents advertising themselves only via a generic variable are reported as `"unknown"`. Others (Cursor, Gemini CLI, …) can be added later.
- `agents` reports **all** detected agents: sessions can be nested.
- `isInteractive()` (stdin+stdout are TTYs) is exposed as a separate util: orthogonal to agent detection, but a useful hint of whether the process is running in an automated environment.

**Note:** this detection is cooperative — the markers can be trivially stripped or spoofed, and a human typing commands into an agent's embedded terminal is indistinguishable from the agent itself. It's intended for optimizations such as output tailoring and telemetry only, not for gating behavior.

No consumer is wired up in this PR; that will be added in follow-up PRs.

Verified end-to-end against the real binaries: Claude Code shell, `codex exec` (nested and standalone), scrubbed-env control, and a PTY-allocated run for the interactive case.

