### PR TITLE
Upgrade to EDR 0.14.0 and expose experimental `Amsterdam` hardfork

### DIFF
--- a/.changeset/fifty-snakes-pump.md
+++ b/.changeset/fifty-snakes-pump.md
@@ -1,5 +1,6 @@
 ---
 "hardhat": minor
+# docs: https://github.com/NomicFoundation/hardhat-website/pull/283
 ---
 
 Add support for the new experimental `amsterdam` L1 hardfork, which currently implements EIP-7708 (ETH transfers emit logs).

--- a/.changeset/fifty-snakes-pump.md
+++ b/.changeset/fifty-snakes-pump.md
@@ -2,4 +2,4 @@
 "hardhat": minor
 ---
 
-Add support for the new experimental `amsterdam` L1 hardfork, which currently implements EIP-7708 (ETH transfers emit logs). It's opt-in via the `hardfork` config and is not the default — the latest stable hardfork remains `osaka`. Selecting `amsterdam`, or any hardfork beyond the latest stable one, now prints a warning that it's experimental and may change.
+Add support for the new experimental `amsterdam` L1 hardfork, which currently implements EIP-7708 (ETH transfers emit logs).

--- a/.changeset/fifty-snakes-pump.md
+++ b/.changeset/fifty-snakes-pump.md
@@ -1,0 +1,5 @@
+---
+"hardhat": minor
+---
+
+Add support for the new experimental `amsterdam` L1 hardfork, which currently implements EIP-7708 (ETH transfers emit logs). It's opt-in via the `hardfork` config and is not the default — the latest stable hardfork remains `osaka`. Selecting `amsterdam`, or any hardfork beyond the latest stable one, now prints a warning that it's experimental and may change.

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -93,7 +93,7 @@
     "typescript": "~6.0.3"
   },
   "dependencies": {
-    "@nomicfoundation/edr": "0.12.1",
+    "@nomicfoundation/edr": "0.14.0",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.16",
     "@nomicfoundation/hardhat-utils": "workspace:^4.1.4",
     "@nomicfoundation/hardhat-vendored": "workspace:^3.0.4",

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -59,6 +59,7 @@ import {
   hardhatForkingConfigToEdrForkConfig,
   resolveDefaultTransactionGasLimit,
 } from "./utils/convert-to-edr.js";
+import { warnIfExperimentalHardfork } from "./utils/hardfork.js";
 import { printLine, replaceLastLine } from "./utils/logger.js";
 
 const log = createDebug("hardhat:core:network-manager:edr:provider");
@@ -108,6 +109,8 @@ export class EdrProvider extends BaseProvider {
   }: EdrProviderConfig): Promise<EdrProvider> {
     const printLineFn = loggerConfig.printLineFn ?? printLine;
     const replaceLastLineFn = loggerConfig.replaceLastLineFn ?? replaceLastLine;
+
+    warnIfExperimentalHardfork(networkConfig.hardfork, networkConfig.chainType);
 
     const providerConfig = await getProviderConfig(
       networkConfig,

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/solidity-stack-trace.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/stack-traces/solidity-stack-trace.ts
@@ -42,7 +42,6 @@ import {
 } from "@nomicfoundation/edr";
 
 export {
-  SourceReference,
   StackTraceEntryType,
   CheatcodeErrorCode,
   stackTraceEntryTypeToString,
@@ -56,6 +55,7 @@ export {
 };
 
 export type {
+  SourceReference,
   CallstackEntryStackTraceEntry,
   UnrecognizedCreateCallstackEntryStackTraceEntry,
   UnrecognizedContractCallstackEntryStackTraceEntry,

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/types/hardfork.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/types/hardfork.ts
@@ -22,9 +22,6 @@ export enum L1HardforkName {
   CANCUN = "cancun",
   PRAGUE = "prague",
   OSAKA = "osaka",
-  // Selectable but NOT the default hardfork: EDR keeps `l1HardforkLatest()`
-  // pinned to Osaka, so Amsterdam is still experimental. See
-  // `L1_LATEST_STABLE_HARDFORK` and `warnIfExperimentalHardfork`.
   AMSTERDAM = "amsterdam",
 }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/types/hardfork.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/types/hardfork.ts
@@ -22,6 +22,10 @@ export enum L1HardforkName {
   CANCUN = "cancun",
   PRAGUE = "prague",
   OSAKA = "osaka",
+  // Selectable but NOT the default hardfork: EDR keeps `l1HardforkLatest()`
+  // pinned to Osaka, so Amsterdam is still experimental. See
+  // `L1_LATEST_STABLE_HARDFORK` and `warnIfExperimentalHardfork`.
+  AMSTERDAM = "amsterdam",
 }
 
 export enum OpHardforkName {
@@ -44,10 +48,26 @@ export function getHardforks(chainType: ChainType): string[] {
     : L1_HARDFORK_ORDER;
 }
 
+/**
+ * The latest *stable* hardforks. These are hardcoded (rather than derived from
+ * EDR's `l1HardforkLatest()`/`opLatestHardfork()`) so this module stays free of
+ * the native `@nomicfoundation/edr` addon on the config-resolution bootstrap
+ * path — see commit 2568ed1ba.
+ *
+ * They are NOT necessarily the last entry of the enum: the enum can contain
+ * experimental forks (e.g. Amsterdam) that EDR ships but hasn't promoted to
+ * latest yet. The invariant test in
+ * `test/.../edr/types/hardfork.ts` asserts these equal EDR's
+ * `l1HardforkLatest()`/`opLatestHardfork()` — bump them together when EDR
+ * promotes a fork.
+ */
+export const L1_LATEST_STABLE_HARDFORK: L1HardforkName = L1HardforkName.OSAKA;
+export const OP_LATEST_STABLE_HARDFORK: OpHardforkName = OpHardforkName.ISTHMUS;
+
 export function getCurrentHardfork(chainType: ChainType): string {
-  const order =
-    chainType === OPTIMISM_CHAIN_TYPE ? OP_HARDFORK_ORDER : L1_HARDFORK_ORDER;
-  return order[order.length - 1];
+  return chainType === OPTIMISM_CHAIN_TYPE
+    ? OP_LATEST_STABLE_HARDFORK
+    : L1_LATEST_STABLE_HARDFORK;
 }
 
 /**

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -40,6 +40,7 @@ import {
   CANCUN,
   PRAGUE,
   OSAKA,
+  AMSTERDAM,
   BEDROCK,
   REGOLITH,
   CANYON,
@@ -114,6 +115,8 @@ export function edrL1HardforkToHardhatL1HardforkName(
       return L1HardforkName.PRAGUE;
     case SpecId.Osaka:
       return L1HardforkName.OSAKA;
+    case SpecId.Amsterdam:
+      return L1HardforkName.AMSTERDAM;
     // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- trust but verify
     default:
       const _exhaustiveCheck: never = hardfork;
@@ -235,6 +238,8 @@ function hardhatL1HardforkToEdrSpecId(hardfork: string): string {
       return PRAGUE;
     case L1HardforkName.OSAKA:
       return OSAKA;
+    case L1HardforkName.AMSTERDAM:
+      return AMSTERDAM;
 
     // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- we want to print the fork
     default:

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
@@ -59,12 +59,10 @@ export function warnIfExperimentalHardfork(
   warnedHardforks.add(key);
 
   warn(
-    styleText(
-      ["yellow", "bold"],
-      `⚠️ You have configured the "${hardfork}" hardfork, which is experimental ` +
-        `and not yet finalized in Hardhat. Behavior may change or be incomplete. ` +
-        `The latest stable hardfork is "${latestStable}".`,
-    ),
+    styleText(["bold", "yellow"], "Warning:") +
+      ` you have configured the "${hardfork}" hardfork, which is experimental ` +
+      `and not yet finalized. Behavior may change or be incomplete. ` +
+      `The latest stable hardfork is "${latestStable}".`,
   );
 }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
@@ -1,6 +1,15 @@
+import type { ChainType } from "../../../../../types/network.js";
+
+import { styleText } from "node:util";
+
 import { assertHardhatInvariant } from "@nomicfoundation/hardhat-errors";
 
-import { L1HardforkName, OpHardforkName } from "../types/hardfork.js";
+import {
+  getCurrentHardfork,
+  hardforkGte,
+  L1HardforkName,
+  OpHardforkName,
+} from "../types/hardfork.js";
 
 export function getL1HardforkName(name: string): L1HardforkName {
   const hardforkName =
@@ -14,6 +23,50 @@ export function getL1HardforkName(name: string): L1HardforkName {
   );
 
   return hardforkName;
+}
+
+// Tracks which (chainType, hardfork) pairs have already been warned about, so
+// we only print the experimental-hardfork warning once per process.
+const warnedHardforks = new Set<string>();
+
+/**
+ * Prints a warning if `hardfork` is strictly beyond the latest stable hardfork
+ * for the given chain type (i.e. an experimental fork that EDR supports but
+ * hasn't promoted to latest yet). The warning is emitted at
+ * most once per (chainType, hardfork) pair for the lifetime of the process.
+ *
+ * We use `console.warn` (rather than the EDR logger, which is gated behind
+ * `loggingEnabled`) so the warning is always visible, including under
+ * `hardhat test`.
+ */
+export function warnIfExperimentalHardfork(
+  hardfork: string,
+  chainType: ChainType,
+): void {
+  const latestStable = getCurrentHardfork(chainType);
+
+  // Only warn for hardforks strictly beyond the latest stable one.
+  if (
+    hardfork === latestStable ||
+    !hardforkGte(hardfork, latestStable, chainType)
+  ) {
+    return;
+  }
+
+  const key = `${chainType}:${hardfork}`;
+  if (warnedHardforks.has(key)) {
+    return;
+  }
+  warnedHardforks.add(key);
+
+  console.warn(
+    styleText(
+      ["yellow", "bold"],
+      `⚠️ You have configured the "${hardfork}" hardfork, which is experimental ` +
+        `and not yet finalized in Hardhat. Behavior may change or be incomplete. ` +
+        `The latest stable hardfork is "${latestStable}".`,
+    ),
+  );
 }
 
 export function getOpHardforkName(name: string): OpHardforkName {

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
@@ -38,7 +38,7 @@ const warnedHardforks = new Set<string>();
 export function warnIfExperimentalHardfork(
   hardfork: string,
   chainType: ChainType,
-  warn: (message: string) => void = (message) => console.warn(message),
+  warn: (message: string) => void = (message) => console.error(message),
 ): void {
   const latestStable = getCurrentHardfork(chainType);
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
@@ -62,7 +62,7 @@ export function warnIfExperimentalHardfork(
     styleText(["bold", "yellow"], "Warning:") +
       ` you have configured the "${hardfork}" hardfork, which is experimental ` +
       `and not yet finalized. Behavior may change or be incomplete. ` +
-      `The latest stable hardfork is "${latestStable}".`,
+      `The latest stable hardfork is "${latestStable}".\n`,
   );
 }
 

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
@@ -34,14 +34,11 @@ const warnedHardforks = new Set<string>();
  * for the given chain type (i.e. an experimental fork that EDR supports but
  * hasn't promoted to latest yet). The warning is emitted at
  * most once per (chainType, hardfork) pair for the lifetime of the process.
- *
- * We use `console.warn` (rather than the EDR logger, which is gated behind
- * `loggingEnabled`) so the warning is always visible, including under
- * `hardhat test`.
  */
 export function warnIfExperimentalHardfork(
   hardfork: string,
   chainType: ChainType,
+  warn: (message: string) => void = (message) => console.warn(message),
 ): void {
   const latestStable = getCurrentHardfork(chainType);
 
@@ -54,12 +51,14 @@ export function warnIfExperimentalHardfork(
   }
 
   const key = `${chainType}:${hardfork}`;
+
   if (warnedHardforks.has(key)) {
     return;
   }
+
   warnedHardforks.add(key);
 
-  console.warn(
+  warn(
     styleText(
       ["yellow", "bold"],
       `⚠️ You have configured the "${hardfork}" hardfork, which is experimental ` +

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -25,6 +25,7 @@ import { hexStringToBytes } from "@nomicfoundation/hardhat-utils/hex";
 import { DEFAULT_VERBOSITY, OPTIMISM_CHAIN_TYPE } from "../../constants.js";
 import { resolveHardfork } from "../network-manager/config-resolution.js";
 import { hardhatHardforkToEdrSpecId } from "../network-manager/edr/utils/convert-to-edr.js";
+import { warnIfExperimentalHardfork } from "../network-manager/edr/utils/hardfork.js";
 import { verbosityToIncludeTraces } from "../network-manager/edr/utils/trace-formatters.js";
 
 import { formatArtifactId } from "./formatters.js";
@@ -88,8 +89,11 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
   const txOrigin = hexToBytes(config.txOrigin);
   const blockCoinbase = hexToBytes(config.coinbase);
 
+  const resolvedHardforkName = resolveHardfork(hardfork, chainType);
+  warnIfExperimentalHardfork(resolvedHardforkName, chainType);
+
   const resolvedHardfork = hardhatHardforkToEdrSpecId(
-    resolveHardfork(hardfork, chainType),
+    resolvedHardforkName,
     chainType,
   );
 

--- a/packages/hardhat/test/internal/builtin-plugins/gas-analytics/suite-result-helpers.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/gas-analytics/suite-result-helpers.ts
@@ -22,6 +22,9 @@ export function createStandardTestResult(
     },
     stackTrace: () => null,
     callTraces: () => [],
+    reason: undefined,
+    counterexample: undefined,
+    valueSnapshotGroups: undefined,
   };
 }
 
@@ -43,6 +46,9 @@ export function createFuzzTestResult(
     },
     stackTrace: () => null,
     callTraces: () => [],
+    reason: undefined,
+    counterexample: undefined,
+    valueSnapshotGroups: undefined,
   };
 }
 
@@ -65,6 +71,9 @@ export function createInvariantTestResult(
     },
     stackTrace: () => null,
     callTraces: () => [],
+    reason: undefined,
+    counterexample: undefined,
+    valueSnapshotGroups: undefined,
   };
 }
 
@@ -87,6 +96,8 @@ export function createTestResultWithSnapshots(
     },
     stackTrace: () => null,
     callTraces: () => [],
+    reason: undefined,
+    counterexample: undefined,
     valueSnapshotGroups,
   };
 }

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -29,11 +29,11 @@ import {
   EdrProvider,
   getProviderConfig,
 } from "../../../../../src/internal/builtin-plugins/network-manager/edr/edr-provider.js";
+import { L1HardforkName } from "../../../../../src/internal/builtin-plugins/network-manager/edr/types/hardfork.js";
 import {
   InvalidArgumentsError,
   ProviderError,
 } from "../../../../../src/internal/builtin-plugins/network-manager/provider-errors.js";
-import { L1HardforkName } from "../../../../../src/internal/builtin-plugins/network-manager/edr/types/hardfork.js";
 import { EDR_NETWORK_REVERT_SNAPSHOT_EVENT } from "../../../../../src/internal/constants.js";
 import { FixedValueConfigurationVariable } from "../../../../../src/internal/core/configuration-variables.js";
 
@@ -413,11 +413,14 @@ describe("edr-provider", () => {
       "should emit notification and message events for each result of the SubscriptionEvent",
       { timeout: 1000 },
       async () => {
+        // `SubscriptionEvent.result` is typed as `unknown`, so we keep the
+        // payload in a typed local to read its length and assert against it.
+        const eventResult = ["0x1", "0x2"];
         const event: SubscriptionEvent = {
           filterId: 1n,
-          result: ["0x1", "0x2"],
+          result: eventResult,
         };
-        const eventResultLength = event.result.length;
+        const eventResultLength = eventResult.length;
         const notificationEventResults: string[] = [];
         const messageEventResults: string[] = [];
 
@@ -454,8 +457,8 @@ describe("edr-provider", () => {
         notificationEventResults.sort();
         messageEventResults.sort();
 
-        assert.deepEqual(notificationEventResults, event.result);
-        assert.deepEqual(messageEventResults, event.result);
+        assert.deepEqual(notificationEventResults, eventResult);
+        assert.deepEqual(messageEventResults, eventResult);
       },
     );
   });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -8,7 +8,7 @@ import type {
 
 import assert from "node:assert/strict";
 import { once } from "node:events";
-import { before, describe, it } from "node:test";
+import { afterEach, before, beforeEach, describe, it } from "node:test";
 
 import {
   assertHardhatInvariant,
@@ -33,6 +33,7 @@ import {
   InvalidArgumentsError,
   ProviderError,
 } from "../../../../../src/internal/builtin-plugins/network-manager/provider-errors.js";
+import { L1HardforkName } from "../../../../../src/internal/builtin-plugins/network-manager/edr/types/hardfork.js";
 import { EDR_NETWORK_REVERT_SNAPSHOT_EVENT } from "../../../../../src/internal/constants.js";
 import { FixedValueConfigurationVariable } from "../../../../../src/internal/core/configuration-variables.js";
 
@@ -776,6 +777,36 @@ describe("edr-provider", () => {
 
         assert.equal(providerConfig.transactionGasCap, false);
       });
+    });
+  });
+
+  describe("experimental hardfork warning", () => {
+    let originalWarn: typeof console.warn;
+    let warnings: string[];
+
+    beforeEach(() => {
+      originalWarn = console.warn;
+      warnings = [];
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args.map(String).join(" "));
+      };
+    });
+
+    afterEach(() => {
+      console.warn = originalWarn;
+    });
+
+    it("warns exactly once when creating a provider with an experimental hardfork", async () => {
+      await hre.network.create({
+        override: {
+          hardfork: L1HardforkName.AMSTERDAM,
+        },
+      });
+
+      const experimentalWarnings = warnings.filter((w) =>
+        w.includes(L1HardforkName.AMSTERDAM),
+      );
+      assert.equal(experimentalWarnings.length, 1);
     });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/edr-provider.ts
@@ -784,19 +784,19 @@ describe("edr-provider", () => {
   });
 
   describe("experimental hardfork warning", () => {
-    let originalWarn: typeof console.warn;
+    let originalError: typeof console.error;
     let warnings: string[];
 
     beforeEach(() => {
-      originalWarn = console.warn;
+      originalError = console.error;
       warnings = [];
-      console.warn = (...args: unknown[]) => {
+      console.error = (...args: unknown[]) => {
         warnings.push(args.map(String).join(" "));
       };
     });
 
     afterEach(() => {
-      console.warn = originalWarn;
+      console.error = originalError;
     });
 
     it("warns exactly once when creating a provider with an experimental hardfork", async () => {

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/types/hardfork.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/types/hardfork.ts
@@ -3,7 +3,11 @@ import { describe, it } from "node:test";
 
 import { l1HardforkLatest, opLatestHardfork } from "@nomicfoundation/edr";
 
-import { getCurrentHardfork } from "../../../../../../src/internal/builtin-plugins/network-manager/edr/types/hardfork.js";
+import {
+  getCurrentHardfork,
+  isValidHardforkName,
+  L1HardforkName,
+} from "../../../../../../src/internal/builtin-plugins/network-manager/edr/types/hardfork.js";
 import {
   edrL1HardforkToHardhatL1HardforkName,
   edrOpHardforkToHardhatOpHardforkName,
@@ -13,19 +17,30 @@ import {
   OPTIMISM_CHAIN_TYPE,
 } from "../../../../../../src/internal/constants.js";
 
-// `getCurrentHardfork` returns the last value of the hardfork enum
-// instead of asking `@nomicfoundation/edr` at runtime (keeping the native
-// addon off the bootstrap path). These tests guard the invariant: if
-// someone bumps EDR to a version that adds a new hardfork but forgets to
-// append it to the enum in hardfork.ts, these assertions fail.
+// `getCurrentHardfork` returns a hardcoded latest-stable marker instead of
+// asking `@nomicfoundation/edr` at runtime (keeping the native addon off the
+// bootstrap path — see commit 2568ed1ba). The marker is NOT necessarily the
+// last enum entry: the enum can contain experimental forks (e.g. Amsterdam)
+// that EDR ships but hasn't promoted to latest. These tests guard the
+// invariant: if someone bumps EDR to a version that promotes a new hardfork
+// but forgets to bump the marker in hardfork.ts, these assertions fail.
 describe("getCurrentHardfork invariant with @nomicfoundation/edr", () => {
-  it("L1: enum's last value matches EDR's l1HardforkLatest()", () => {
+  it("L1: latest-stable marker matches EDR's l1HardforkLatest()", () => {
     const fromEdr = edrL1HardforkToHardhatL1HardforkName(l1HardforkLatest());
     assert.equal(getCurrentHardfork(L1_CHAIN_TYPE), fromEdr);
   });
 
-  it("OP: enum's last value matches EDR's opLatestHardfork()", () => {
+  it("OP: latest-stable marker matches EDR's opLatestHardfork()", () => {
     const fromEdr = edrOpHardforkToHardhatOpHardforkName(opLatestHardfork());
     assert.equal(getCurrentHardfork(OPTIMISM_CHAIN_TYPE), fromEdr);
+  });
+});
+
+describe("Amsterdam is a selectable L1 hardfork", () => {
+  it("is a valid L1 hardfork name", () => {
+    assert.equal(
+      isValidHardforkName(L1HardforkName.AMSTERDAM, L1_CHAIN_TYPE),
+      true,
+    );
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -1,12 +1,18 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { AMSTERDAM, SpecId } from "@nomicfoundation/edr";
+
 import {
   getCurrentHardfork,
   L1HardforkName,
   OpHardforkName,
 } from "../../../../../../src/internal/builtin-plugins/network-manager/edr/types/hardfork.js";
-import { resolveDefaultTransactionGasLimit } from "../../../../../../src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.js";
+import {
+  edrL1HardforkToHardhatL1HardforkName,
+  hardhatHardforkToEdrSpecId,
+  resolveDefaultTransactionGasLimit,
+} from "../../../../../../src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.js";
 import {
   L1_CHAIN_TYPE,
   OPTIMISM_CHAIN_TYPE,
@@ -135,5 +141,21 @@ describe("resolveDefaultTransactionGasLimit", () => {
         ARBITRARY_BLOCK_GAS_LIMIT,
       );
     });
+  });
+});
+
+describe("Amsterdam L1 hardfork conversion round-trip", () => {
+  it("maps the AMSTERDAM name to EDR's Amsterdam spec id", () => {
+    assert.equal(
+      hardhatHardforkToEdrSpecId(L1HardforkName.AMSTERDAM, L1_CHAIN_TYPE),
+      AMSTERDAM,
+    );
+  });
+
+  it("maps EDR's Amsterdam spec id back to the AMSTERDAM name", () => {
+    assert.equal(
+      edrL1HardforkToHardhatL1HardforkName(SpecId.Amsterdam),
+      L1HardforkName.AMSTERDAM,
+    );
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
@@ -41,8 +41,14 @@ describe("warnIfExperimentalHardfork", () => {
   it("warns exactly once for an experimental hardfork, then dedupes", () => {
     warnIfExperimentalHardfork(L1HardforkName.AMSTERDAM, L1_CHAIN_TYPE);
     assert.equal(warnings.length, 1);
-    assert.ok(warnings[0].includes(L1HardforkName.AMSTERDAM));
-    assert.ok(warnings[0].includes(getCurrentHardfork(L1_CHAIN_TYPE)));
+    assert.ok(
+      warnings[0].includes(L1HardforkName.AMSTERDAM),
+      "warning should mention the selected experimental hardfork",
+    );
+    assert.ok(
+      warnings[0].includes(getCurrentHardfork(L1_CHAIN_TYPE)),
+      "warning should mention the latest stable hardfork",
+    );
 
     // Repeated calls for the same (chainType, hardfork) are deduped.
     warnIfExperimentalHardfork(L1HardforkName.AMSTERDAM, L1_CHAIN_TYPE);

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import {
+  getCurrentHardfork,
+  L1HardforkName,
+} from "../../../../../../src/internal/builtin-plugins/network-manager/edr/types/hardfork.js";
+import { warnIfExperimentalHardfork } from "../../../../../../src/internal/builtin-plugins/network-manager/edr/utils/hardfork.js";
+import { L1_CHAIN_TYPE } from "../../../../../../src/internal/constants.js";
+
+describe("warnIfExperimentalHardfork", () => {
+  let originalWarn: typeof console.warn;
+  let warnings: string[];
+
+  beforeEach(() => {
+    originalWarn = console.warn;
+    warnings = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+
+  it("does not warn for the latest stable hardfork", () => {
+    warnIfExperimentalHardfork(
+      getCurrentHardfork(L1_CHAIN_TYPE),
+      L1_CHAIN_TYPE,
+    );
+    assert.equal(warnings.length, 0);
+  });
+
+  it("does not warn for hardforks earlier than the latest stable one", () => {
+    warnIfExperimentalHardfork(L1HardforkName.LONDON, L1_CHAIN_TYPE);
+    warnIfExperimentalHardfork(L1HardforkName.PRAGUE, L1_CHAIN_TYPE);
+    assert.equal(warnings.length, 0);
+  });
+
+  it("warns exactly once for an experimental hardfork, then dedupes", () => {
+    warnIfExperimentalHardfork(L1HardforkName.AMSTERDAM, L1_CHAIN_TYPE);
+    assert.equal(warnings.length, 1);
+    assert.ok(warnings[0].includes(L1HardforkName.AMSTERDAM));
+    assert.ok(warnings[0].includes(getCurrentHardfork(L1_CHAIN_TYPE)));
+
+    // Repeated calls for the same (chainType, hardfork) are deduped.
+    warnIfExperimentalHardfork(L1HardforkName.AMSTERDAM, L1_CHAIN_TYPE);
+    assert.equal(warnings.length, 1);
+  });
+});

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { afterEach, beforeEach, describe, it } from "node:test";
+import { beforeEach, describe, it } from "node:test";
 
 import {
   getCurrentHardfork,
@@ -9,37 +9,36 @@ import { warnIfExperimentalHardfork } from "../../../../../../src/internal/built
 import { L1_CHAIN_TYPE } from "../../../../../../src/internal/constants.js";
 
 describe("warnIfExperimentalHardfork", () => {
-  let originalWarn: typeof console.warn;
   let warnings: string[];
 
-  beforeEach(() => {
-    originalWarn = console.warn;
-    warnings = [];
-    console.warn = (...args: unknown[]) => {
-      warnings.push(args.map(String).join(" "));
-    };
-  });
+  const warn = (message: string) => {
+    warnings.push(message);
+  };
 
-  afterEach(() => {
-    console.warn = originalWarn;
+  beforeEach(() => {
+    warnings = [];
   });
 
   it("does not warn for the latest stable hardfork", () => {
     warnIfExperimentalHardfork(
       getCurrentHardfork(L1_CHAIN_TYPE),
       L1_CHAIN_TYPE,
+      warn,
     );
+
     assert.equal(warnings.length, 0);
   });
 
   it("does not warn for hardforks earlier than the latest stable one", () => {
-    warnIfExperimentalHardfork(L1HardforkName.LONDON, L1_CHAIN_TYPE);
-    warnIfExperimentalHardfork(L1HardforkName.PRAGUE, L1_CHAIN_TYPE);
+    warnIfExperimentalHardfork(L1HardforkName.LONDON, L1_CHAIN_TYPE, warn);
+    warnIfExperimentalHardfork(L1HardforkName.PRAGUE, L1_CHAIN_TYPE, warn);
+
     assert.equal(warnings.length, 0);
   });
 
   it("warns exactly once for an experimental hardfork, then dedupes", () => {
-    warnIfExperimentalHardfork(L1HardforkName.AMSTERDAM, L1_CHAIN_TYPE);
+    warnIfExperimentalHardfork(L1HardforkName.AMSTERDAM, L1_CHAIN_TYPE, warn);
+
     assert.equal(warnings.length, 1);
     assert.ok(
       warnings[0].includes(L1HardforkName.AMSTERDAM),
@@ -51,7 +50,8 @@ describe("warnIfExperimentalHardfork", () => {
     );
 
     // Repeated calls for the same (chainType, hardfork) are deduped.
-    warnIfExperimentalHardfork(L1HardforkName.AMSTERDAM, L1_CHAIN_TYPE);
+    warnIfExperimentalHardfork(L1HardforkName.AMSTERDAM, L1_CHAIN_TYPE, warn);
+
     assert.equal(warnings.length, 1);
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
@@ -90,6 +90,9 @@ const mocker = {
                         mocker.trace(trace),
                       );
                     },
+                    reason: undefined,
+                    counterexample: undefined,
+                    valueSnapshotGroups: undefined,
                   }) satisfies TestResult,
               )
               .reverse(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
   packages/hardhat:
     dependencies:
       '@nomicfoundation/edr':
-        specifier: 0.12.1
-        version: 0.12.1
+        specifier: 0.14.0
+        version: 0.14.0
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.16
         version: link:../hardhat-errors
@@ -2939,37 +2939,37 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.1':
-    resolution: {integrity: sha512-KRB7oRupR2CqGHTACDhdS/EJGLN2rft1+5UNeimbXYe9nS3usUNGjNJyIjvoxzFthqnFM3+vaDQwyIZfq/eRjw==}
-    engines: {node: '>= 20'}
+  '@nomicfoundation/edr-darwin-arm64@0.14.0':
+    resolution: {integrity: sha512-WeIfUKa270gPWssrDYWQM8GcjeYHGuzr2P2oPtBJIKhU5UOsEbF0RM9JFtcy2zp7ZBn2iQp7BHZc6kboz5Pd5w==}
+    engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.1':
-    resolution: {integrity: sha512-h6J3otsX5ib1md5V/M281ZS37FC6mAH8QlxVi3YMe9wOpEOpBRkqfhQAeFCekdx+5pqNHO/STi5OyKwCd4YAfw==}
-    engines: {node: '>= 20'}
+  '@nomicfoundation/edr-darwin-x64@0.14.0':
+    resolution: {integrity: sha512-V/cftSD8hl1mr37tCrZ1Rd4eSppAWGUFAZNNBeEUWw4VAA80at26cdboR66TWj5wy4LmbAMMu12apVs5nlOAMw==}
+    engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.1':
-    resolution: {integrity: sha512-yqJcBgusn+MQFCemVrm7VIYjqQLaFouo0DBAbApE0GHQ7MnVFmbW2d2WCEln3jZOZgY0FH0tfnQw/NfK2xo2zg==}
-    engines: {node: '>= 20'}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.14.0':
+    resolution: {integrity: sha512-wydy0IGuVzK5K69Nbj+Vhw9CegabE6Ib9MbepOB/l4hKxxV0dZSFO3d2xUme12+94GS3gZVJ7l8OkyjENLkiLA==}
+    engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.1':
-    resolution: {integrity: sha512-JPkUOazqotQMvU2wsOQymxusCKyWaWdqHyxQKqwrqz81O+jOEXvMHUp20a6cRbVGOoGHx334ORj+daSGKvt5og==}
-    engines: {node: '>= 20'}
+  '@nomicfoundation/edr-linux-arm64-musl@0.14.0':
+    resolution: {integrity: sha512-D2GI/IP+8KBG4wljRSaHxzvEmmaJc2AmGj3vL6wEPWmP8k09p/ZxasxvH077Yh6e72CxrcRmVsfGSDAMmc/6yA==}
+    engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.1':
-    resolution: {integrity: sha512-pM3cP316WgSUUy6MW2FuWgjZuonCYULED8Mn1mIK6NfwzTKooves/KjBDzIzr7Mvht9SwF/tT0KRjHPf/9E8gg==}
-    engines: {node: '>= 20'}
+  '@nomicfoundation/edr-linux-x64-gnu@0.14.0':
+    resolution: {integrity: sha512-Y5mTwLUZd6W3WfLrv/sw9TNE3+wzzPEy9Pz+euB/XLoWeX/QNpYy+0tck+CB4kUUWG7dz2a2nCyobbp4Plo3WQ==}
+    engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.1':
-    resolution: {integrity: sha512-Rw7hhyk8PdZy3bBYVJrQX1M1AIBhy4vFnWPfbdY50c+ZfX/c82PYVg+B92+XaC5avMon/KiIhfB2fNLcyJy4uw==}
-    engines: {node: '>= 20'}
+  '@nomicfoundation/edr-linux-x64-musl@0.14.0':
+    resolution: {integrity: sha512-LM1zWgi0ZytlHccBXDC8q0+mQQkbc0zpJJ5qSAFeUPn3qKXW4XRel4HzEkZOOO8NWCstdPqU589lIRrfPIzbUw==}
+    engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.1':
-    resolution: {integrity: sha512-z2ILUf8P/oqG8t2tkPCpmhzSpo+LMZylLFUPGMgugHwe8OX1GyU11g0bQU8SoIwHozy7MLzTMX0NZ/14LWSN7Q==}
-    engines: {node: '>= 20'}
+  '@nomicfoundation/edr-win32-x64-msvc@0.14.0':
+    resolution: {integrity: sha512-0SfpLVuzZZwHVY7ptMqshtEFByRJlfF9XLJ9MjLoAlGjhf6jHLSgltw3Mos+6bukUXLbLaxeNHfDaTLMnX+N4g==}
+    engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr@0.12.1':
-    resolution: {integrity: sha512-1U8C+kiVMIbVkOW+Sa7sUm9glSaB5cMe7UJ9wCOHFPpBBUQgStgrgAOWOahRL0vKRUjHUpuQpg47cRcUSdmW/A==}
-    engines: {node: '>= 20'}
+  '@nomicfoundation/edr@0.14.0':
+    resolution: {integrity: sha512-Cgg1IZv+i2itOa3Unc8wX9y8TCuzpofdxga8ekEJ3DPsaVGBhjsuaBqf/65TyF3ExogUpUdk5rHKZmnpKcfACg==}
+    engines: {node: '>= 22'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     resolution: {integrity: sha512-JaqcWPDZENCvm++lFFGjrDd8mxtf+CtLd2MiXvMNTBD33dContTZ9TWETwNFwg7JTJT5Q9HEecH7FA+HTSsIUw==}
@@ -8509,29 +8509,29 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.12.1': {}
+  '@nomicfoundation/edr-darwin-arm64@0.14.0': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.12.1': {}
+  '@nomicfoundation/edr-darwin-x64@0.14.0': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.12.1': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.14.0': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.12.1': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.14.0': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.12.1': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.14.0': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.12.1': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.14.0': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.12.1': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.14.0': {}
 
-  '@nomicfoundation/edr@0.12.1':
+  '@nomicfoundation/edr@0.14.0':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.12.1
-      '@nomicfoundation/edr-darwin-x64': 0.12.1
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.12.1
-      '@nomicfoundation/edr-linux-arm64-musl': 0.12.1
-      '@nomicfoundation/edr-linux-x64-gnu': 0.12.1
-      '@nomicfoundation/edr-linux-x64-musl': 0.12.1
-      '@nomicfoundation/edr-win32-x64-msvc': 0.12.1
+      '@nomicfoundation/edr-darwin-arm64': 0.14.0
+      '@nomicfoundation/edr-darwin-x64': 0.14.0
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.14.0
+      '@nomicfoundation/edr-linux-arm64-musl': 0.14.0
+      '@nomicfoundation/edr-linux-x64-gnu': 0.14.0
+      '@nomicfoundation/edr-linux-x64-musl': 0.14.0
+      '@nomicfoundation/edr-win32-x64-msvc': 0.14.0
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team. 
  - New amsterdam experimental hardfork support approach discussed in [slack channel](https://manas.slack.com/archives/C097CC8P8RW/p1782486471149129)
- [x] I didn't do anything of this.

---

Bumps `@nomicfoundation/edr` from `0.12.1` to `0.14.0` and makes the new **Amsterdam** hardfork selectable.

closes #8430.
supersedes #8258


## Changes

- **Bump `@nomicfoundation/edr` to `0.14.0`.**
  - **Adapt to EDR 0.14.0's TypeScript surface** — napi-rs v3 changes: `TestResult` optional fields are now getters, and `SubscriptionEvent.result` is `unknown` (was `any`).
  - The `TestResult` fixture fix and the `SourceReference` type-only re-export from #8258 have been **cherry-picked** here (commits `f62fee4105`, `111e53ebe3`), so #8258 can be closed.
- **Expose the experimental `Amsterdam` L1 hardfork.** It's selectable via config but is **not** the default — EDR still pins the latest stable hardfork to Osaka, since Amsterdam is unfinished (currently only EIP-7708, *ETH transfers emit logs*). The default stays Osaka.
- **Warn on experimental hardforks.** Explicitly selecting a hardfork beyond the latest stable one now prints a one-time warning (both `hardhat node`/JS-test/script runs and the Solidity test runner).


> [!WARNING]
> **Implementation provenance:** the implementation in this branch was produced with Claude (AI-assisted) and is intended as a **kickoff / placeholder implementation** to unblock the upgrade. It builds, lints, and passes the affected tests, but it should be **reviewed and refined by a Hardhat team member with proper TypeScript and Hardhat knowledge** before merging.