### PR TITLE
Fix network options at cli

### DIFF
--- a/.changeset/node-cli-network-overrides.md
+++ b/.changeset/node-cli-network-overrides.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed the `hardhat node` task so the `--chain-id`, `--fork`, and `--fork-block-number` CLI options are applied to the network again.

--- a/packages/hardhat/src/internal/builtin-plugins/node/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/task-action.ts
@@ -1,5 +1,3 @@
-import type { EdrNetworkConfigOverride } from "../../../types/config.js";
-import type { ChainType } from "../../../types/network.js";
 import type { NewTaskActionFunction } from "../../../types/tasks.js";
 
 import path from "node:path";
@@ -12,7 +10,6 @@ import {
 import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
 import { ensureDir, exists } from "@nomicfoundation/hardhat-utils/fs";
 
-import { isSupportedChainType } from "../../edr/chain-type.js";
 import { BUILD_INFO_DIR_NAME } from "../artifacts/artifact-manager.js";
 import { EdrProvider } from "../network-manager/edr/edr-provider.js";
 
@@ -22,6 +19,7 @@ import {
   formatEdrNetworkConfigAccounts,
 } from "./helpers.js";
 import { JsonRpcServerImplementation } from "./json-rpc/server.js";
+import { resolveNodeConnectionParams } from "./utils/resolve-node-connection-params.js";
 
 const log = createDebug("hardhat:core:tasks:node");
 
@@ -56,55 +54,7 @@ const nodeAction: NewTaskActionFunction<NodeActionArguments> = async (
     });
   }
 
-  const connectionParams: {
-    network: string;
-    chainType?: ChainType;
-    override?: EdrNetworkConfigOverride;
-  } = {
-    network,
-  };
-
-  // NOTE: We create an empty network config override here. We add to it based
-  // on the result of arguments parsing. We can expand the list of arguments
-  // as much as needed.
-  const networkConfigOverride: EdrNetworkConfigOverride = {};
-
-  if (args.chainType !== undefined) {
-    if (!isSupportedChainType(args.chainType)) {
-      throw new HardhatError(
-        HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
-        {
-          value: args.chainType,
-          type: "ChainType",
-          name: "chainType",
-        },
-      );
-    }
-    connectionParams.chainType = args.chainType;
-  }
-
-  if (args.chainId !== -1) {
-    networkConfigOverride.chainId = args.chainId;
-  }
-
-  // NOTE: --fork-block-number is only valid if --fork is specified
-  if (args.fork !== undefined) {
-    networkConfigOverride.forking = {
-      enabled: true,
-      url: args.fork,
-      ...(args.forkBlockNumber !== -1
-        ? { blockNumber: args.forkBlockNumber }
-        : undefined),
-    };
-  } else if (args.forkBlockNumber !== -1) {
-    // NOTE: We could make the error more specific here.
-    throw new HardhatError(
-      HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
-      {
-        argument: "fork",
-      },
-    );
-  }
+  const connectionParams = resolveNodeConnectionParams(network, args);
 
   // NOTE: This is where we initialize the network; the create method returns
   // a fully resolved networkConfig object which might be useful for display

--- a/packages/hardhat/src/internal/builtin-plugins/node/utils/resolve-node-connection-params.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/utils/resolve-node-connection-params.ts
@@ -73,5 +73,7 @@ export function resolveNodeConnectionParams(
     );
   }
 
+  connectionParams.override = networkConfigOverride;
+
   return connectionParams;
 }

--- a/packages/hardhat/src/internal/builtin-plugins/node/utils/resolve-node-connection-params.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/utils/resolve-node-connection-params.ts
@@ -1,0 +1,77 @@
+import type { EdrNetworkConfigOverride } from "../../../../types/config.js";
+import type { ChainType } from "../../../../types/network.js";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+
+import { isSupportedChainType } from "../../../edr/chain-type.js";
+
+export interface NodeConnectionParams {
+  network: string;
+  chainType?: ChainType;
+  override?: EdrNetworkConfigOverride;
+}
+
+export interface NodeConnectionArguments {
+  chainType?: string;
+  chainId: number;
+  fork?: string;
+  forkBlockNumber: number;
+}
+
+/**
+ * Resolves the arguments passed to the `node` task into the connection
+ * parameters used to create the underlying network connection.
+ */
+export function resolveNodeConnectionParams(
+  network: string,
+  args: NodeConnectionArguments,
+): NodeConnectionParams {
+  const connectionParams: NodeConnectionParams = {
+    network,
+  };
+
+  // NOTE: We create an empty network config override here. We add to it based
+  // on the result of arguments parsing. We can expand the list of arguments
+  // as much as needed.
+  const networkConfigOverride: EdrNetworkConfigOverride = {};
+
+  if (args.chainType !== undefined) {
+    if (!isSupportedChainType(args.chainType)) {
+      throw new HardhatError(
+        HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+        {
+          value: args.chainType,
+          type: "ChainType",
+          name: "chainType",
+        },
+      );
+    }
+
+    connectionParams.chainType = args.chainType;
+  }
+
+  if (args.chainId !== -1) {
+    networkConfigOverride.chainId = args.chainId;
+  }
+
+  // NOTE: --fork-block-number is only valid if --fork is specified
+  if (args.fork !== undefined) {
+    networkConfigOverride.forking = {
+      enabled: true,
+      url: args.fork,
+      ...(args.forkBlockNumber !== -1
+        ? { blockNumber: args.forkBlockNumber }
+        : undefined),
+    };
+  } else if (args.forkBlockNumber !== -1) {
+    // NOTE: We could make the error more specific here.
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+      {
+        argument: "fork",
+      },
+    );
+  }
+
+  return connectionParams;
+}

--- a/packages/hardhat/src/internal/builtin-plugins/node/utils/resolve-node-connection-params.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/node/utils/resolve-node-connection-params.ts
@@ -5,17 +5,17 @@ import { HardhatError } from "@nomicfoundation/hardhat-errors";
 
 import { isSupportedChainType } from "../../../edr/chain-type.js";
 
-export interface NodeConnectionParams {
-  network: string;
-  chainType?: ChainType;
-  override?: EdrNetworkConfigOverride;
-}
-
 export interface NodeConnectionArguments {
   chainType?: string;
   chainId: number;
   fork?: string;
   forkBlockNumber: number;
+}
+
+export interface ResolvedNodeConnectionParams {
+  network: string;
+  chainType?: ChainType;
+  override?: EdrNetworkConfigOverride;
 }
 
 /**
@@ -25,8 +25,8 @@ export interface NodeConnectionArguments {
 export function resolveNodeConnectionParams(
   network: string,
   args: NodeConnectionArguments,
-): NodeConnectionParams {
-  const connectionParams: NodeConnectionParams = {
+): ResolvedNodeConnectionParams {
+  const connectionParams: ResolvedNodeConnectionParams = {
     network,
   };
 

--- a/packages/hardhat/test/internal/builtin-plugins/node/utils/resolve-node-connection-params.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/node/utils/resolve-node-connection-params.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assertThrowsHardhatError } from "@nomicfoundation/hardhat-test-utils";
+
+import { resolveNodeConnectionParams } from "../../../../../src/internal/builtin-plugins/node/utils/resolve-node-connection-params.js";
+
+describe("resolveNodeConnectionParams", () => {
+  // Mirrors the option defaults registered by the `node` task: chainId and
+  // forkBlockNumber use -1 as the "not set" sentinel.
+  const baseArgs = { chainId: -1, forkBlockNumber: -1 };
+
+  it("sets the network name", () => {
+    const result = resolveNodeConnectionParams("node", { ...baseArgs });
+
+    assert.equal(result.network, "node");
+  });
+
+  it("sets override.chainId when chainId is provided", () => {
+    const result = resolveNodeConnectionParams("node", {
+      ...baseArgs,
+      chainId: 1234,
+    });
+
+    assert.equal(result.override?.chainId, 1234);
+  });
+
+  it("does not set chainId when it is the -1 sentinel", () => {
+    const result = resolveNodeConnectionParams("node", { ...baseArgs });
+
+    assert.equal(result.override?.chainId, undefined);
+  });
+
+  it("sets override.forking when a fork url is provided", () => {
+    const result = resolveNodeConnectionParams("node", {
+      ...baseArgs,
+      fork: "https://example.com/rpc",
+    });
+
+    assert.equal(result.override?.forking?.enabled, true);
+    assert.equal(result.override?.forking?.url, "https://example.com/rpc");
+    assert.equal(result.override?.forking?.blockNumber, undefined);
+  });
+
+  it("sets override.forking.blockNumber when fork and forkBlockNumber are provided", () => {
+    const result = resolveNodeConnectionParams("node", {
+      ...baseArgs,
+      fork: "https://example.com/rpc",
+      forkBlockNumber: 42,
+    });
+
+    assert.equal(result.override?.forking?.blockNumber, 42);
+  });
+
+  it("throws when forkBlockNumber is provided without a fork url", () => {
+    assertThrowsHardhatError(
+      () =>
+        resolveNodeConnectionParams("node", {
+          ...baseArgs,
+          forkBlockNumber: 42,
+        }),
+      HardhatError.ERRORS.CORE.ARGUMENTS.MISSING_VALUE_FOR_ARGUMENT,
+      { argument: "fork" },
+    );
+  });
+
+  it("sets chainType when a supported chainType is provided", () => {
+    const result = resolveNodeConnectionParams("node", {
+      ...baseArgs,
+      chainType: "l1",
+    });
+
+    assert.equal(result.chainType, "l1");
+  });
+
+  it("throws for an unsupported chainType", () => {
+    assertThrowsHardhatError(
+      () =>
+        resolveNodeConnectionParams("node", {
+          ...baseArgs,
+          chainType: "not-a-chain-type",
+        }),
+      HardhatError.ERRORS.CORE.ARGUMENTS.INVALID_VALUE_FOR_TYPE,
+      { value: "not-a-chain-type", type: "ChainType", name: "chainType" },
+    );
+  });
+});


### PR DESCRIPTION
The `npx hardhat node` command was ignoring a subset of cli options, including `--fork`. This fix now passes all the cli options to the initialization of the EDR network within the standalone network node.

The dropped cli options that are now fixed:

* `--chain-id`
* `--fork`
* `--fork-block-number`

Fixes #8436.

## Reviewing

> [!TIP]
> Review a commit at a time

This PR, pulls out the mapping code for the EDR connection setting into a helper function, adds tests across the helper function, then re-adds the missing overridden connection settings fixing the bug.

## Manual testing

To test this PR locally you can use the `./packages/example-project`.

To test that cli commands are coming through run in one terminal:

```shell
pnpm hardhat node --chain-id 22
```

In another run the script:

```ts
import hre from "hardhat";

const connection = await hre.network.create("localhost");

// Get the chain id
const chainId = await connection.provider.request({ method: "eth_chainId" });

console.log("Chain ID:", Number(chainId));
```