### PR TITLE
fix(bench): surface step command output on failure

### DIFF
--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -448,7 +448,7 @@ function runStepsPhase(
         execSync(step.command, {
           cwd: workingDir,
           stdio: ["ignore", "pipe", "pipe"],
-          encoding: "utf8",
+          encoding: "utf-8",
           // The default 1 MiB maxBuffer would make chatty-but-successful
           // steps (e.g. a full hardhat compile) throw ENOBUFS.
           maxBuffer: 64 * 1024 * 1024,

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -483,6 +483,7 @@ function runStepsPhase(
 }
 
 const OUTPUT_TAIL_LINES = 50;
+const ERROR_LINE_LIMIT = 20;
 
 function formatOutputTails(streams: {
   stdout?: string;
@@ -499,7 +500,22 @@ function formatOutputTails(streams: {
         omitted > 0
           ? `  --- ${name} (last ${OUTPUT_TAIL_LINES} of ${lines.length} lines) ---`
           : `  --- ${name} ---`;
-      return `${header}\n${kept.join("\n")}`;
+      // A compiler error ("Error: ...", "Error HHE910: ...") can sit thousands
+      // of warning lines above the tail; surface those lines separately so the
+      // failure is diagnosable from the log alone.
+      const errorLines = lines
+        .slice(0, omitted)
+        .filter((line) => /^Error[ :]/.test(line));
+      const shown = errorLines.slice(0, ERROR_LINE_LIMIT);
+      const errorSection =
+        shown.length > 0
+          ? `  --- ${name} error lines (above the tail) ---\n${shown.join("\n")}` +
+            (errorLines.length > shown.length
+              ? `\n  ... ${errorLines.length - shown.length} more`
+              : "") +
+            "\n"
+          : "";
+      return `${errorSection}${header}\n${kept.join("\n")}`;
     })
     .join("\n");
 }

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -456,7 +456,7 @@ function runStepsPhase(
         });
       } catch (error) {
         // Only the first line: execSync embeds the child's full stderr in
-        // its message, which would bypass the tail limit below.
+        // its message, and the streams are appended whole below.
         const original = (
           error instanceof Error ? error.message : String(error)
         ).split("\n", 1)[0];
@@ -467,7 +467,7 @@ function runStepsPhase(
         throw new Error(
           `${scenarioId} / ${seqName}: step "${stepName}" failed on run ${run + 1}/${cfg.runs}: ${original}\n` +
             `  Reproduce with: cd ${shellQuote(workingDir)} && ${step.command}\n` +
-            formatOutputTails({ stdout, stderr }),
+            formatOutput({ stdout, stderr }),
           { cause: error },
         );
       }
@@ -482,41 +482,14 @@ function runStepsPhase(
   );
 }
 
-const OUTPUT_TAIL_LINES = 50;
-const ERROR_LINE_LIMIT = 20;
-
-function formatOutputTails(streams: {
-  stdout?: string;
-  stderr?: string;
-}): string {
+// Failures are rare and abort the scenario, so the whole output is shown
+// rather than a tail — a compiler error can sit thousands of warning lines
+// above the end.
+function formatOutput(streams: { stdout?: string; stderr?: string }): string {
   return Object.entries(streams)
     .map(([name, text]) => [name, (text ?? "").trimEnd()] as const)
     .filter(([, text]) => text !== "")
-    .map(([name, text]) => {
-      const lines = text.split("\n");
-      const kept = lines.slice(-OUTPUT_TAIL_LINES);
-      const omitted = lines.length - kept.length;
-      const header =
-        omitted > 0
-          ? `  --- ${name} (last ${OUTPUT_TAIL_LINES} of ${lines.length} lines) ---`
-          : `  --- ${name} ---`;
-      // A compiler error ("Error: ...", "Error HHE910: ...") can sit thousands
-      // of warning lines above the tail; surface those lines separately so the
-      // failure is diagnosable from the log alone.
-      const errorLines = lines
-        .slice(0, omitted)
-        .filter((line) => /^Error[ :]/.test(line));
-      const shown = errorLines.slice(0, ERROR_LINE_LIMIT);
-      const errorSection =
-        shown.length > 0
-          ? `  --- ${name} error lines (above the tail) ---\n${shown.join("\n")}` +
-            (errorLines.length > shown.length
-              ? `\n  ... ${errorLines.length - shown.length} more`
-              : "") +
-            "\n"
-          : "";
-      return `${errorSection}${header}\n${kept.join("\n")}`;
-    })
+    .map(([name, text]) => `  --- ${name} ---\n${text}`)
     .join("\n");
 }
 

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -447,14 +447,27 @@ function runStepsPhase(
       try {
         execSync(step.command, {
           cwd: workingDir,
-          stdio: "ignore",
+          stdio: ["ignore", "pipe", "pipe"],
+          encoding: "utf8",
+          // The default 1 MiB maxBuffer would make chatty-but-successful
+          // steps (e.g. a full hardhat compile) throw ENOBUFS.
+          maxBuffer: 64 * 1024 * 1024,
           env: { ...process.env, ...env },
         });
       } catch (error) {
-        const original = error instanceof Error ? error.message : String(error);
+        // Only the first line: execSync embeds the child's full stderr in
+        // its message, which would bypass the tail limit below.
+        const original = (
+          error instanceof Error ? error.message : String(error)
+        ).split("\n", 1)[0];
+        const { stdout, stderr } = error as {
+          stdout?: string;
+          stderr?: string;
+        };
         throw new Error(
           `${scenarioId} / ${seqName}: step "${stepName}" failed on run ${run + 1}/${cfg.runs}: ${original}\n` +
-            `  Reproduce with: cd ${shellQuote(workingDir)} && ${step.command}`,
+            `  Reproduce with: cd ${shellQuote(workingDir)} && ${step.command}\n` +
+            formatOutputTails({ stdout, stderr }),
           { cause: error },
         );
       }
@@ -467,6 +480,28 @@ function runStepsPhase(
   return [...samples].map(([stepName, times]) =>
     toEntry(scenarioId, stepName, computeStats(times)),
   );
+}
+
+const OUTPUT_TAIL_LINES = 50;
+
+function formatOutputTails(streams: {
+  stdout?: string;
+  stderr?: string;
+}): string {
+  return Object.entries(streams)
+    .map(([name, text]) => [name, (text ?? "").trimEnd()] as const)
+    .filter(([, text]) => text !== "")
+    .map(([name, text]) => {
+      const lines = text.split("\n");
+      const kept = lines.slice(-OUTPUT_TAIL_LINES);
+      const omitted = lines.length - kept.length;
+      const header =
+        omitted > 0
+          ? `  --- ${name} (last ${OUTPUT_TAIL_LINES} of ${lines.length} lines) ---`
+          : `  --- ${name} ---`;
+      return `${header}\n${kept.join("\n")}`;
+    })
+    .join("\n");
 }
 
 function slugify(name: string): string {


### PR DESCRIPTION
Added output on failure as it was quite hard to debug solx benchmarks (in progress here: https://github.com/NomicFoundation/hardhat/pull/8415).  Tested locally by deliberately causing an error in a benchmark and testing the error logs. 

## Claude Summary

Extracted from #8415 (solx compile benchmark), where debugging scenario failures in CI motivated this — but the fix is compiler-agnostic and benefits every `bench:regression` scenario.

Scenario steps ran with `stdio: "ignore"`, so a failing step reported only execSync's one-line `Command failed` with the compiler's actual error list discarded (e.g. run [28863010299](https://github.com/NomicFoundation/hardhat/actions/runs/28863010299) — a failed priming compile with nothing to diagnose). Now stdout/stderr are piped and, on failure, appended whole to the thrown error.

- Showing everything (rather than a tail) keeps the logic trivial and has no blind spots: a real failure printed the solx error above 4000 memory-unsafe-assembly warnings, which a fixed-size tail would cut off. Failures are rare and abort the scenario, so verbosity is fine.
- `maxBuffer` is raised to 64 MiB because the 1 MiB default would make chatty-but-successful steps (a full `hardhat compile`) throw `ENOBUFS`.
- execSync's own message is trimmed to its first line since it embeds the full stderr, which is now appended separately.

## Notes

- `scripts/`-only; no changeset needed.
- Verified: `pnpm tsc:scripts`, `pnpm prettier:scripts --check`, `pnpm test:scripts` (108 pass).



## Proof

Ran the real runner on this branch against a temporarily sabotaged `1inch-swap-vm` scenario (`pnpm bench:regression --scenarios 1inch-swap-vm --fail-fast`), with two synthetic steps:

1. a `measure: false` step printing 2 MiB to stdout (`seq 1 300000`), which **passed** — under the old 1 MiB `maxBuffer` default it would have thrown `ENOBUFS`;
2. a step printing 100 warnings to stdout and an `Error:` line to stderr before `exit 1`.

The failure report (stdout section elided for brevity):

```
[bench] Error: Scenario "1inch-swap-vm" failed: 1inch-swap-vm / demo sequence: step "failing compile (error buried above warnings)" failed on run 1/1: Command failed: for i in $(seq 1 100); do ...
  Reproduce with: cd /tmp/end-to-end/1inch-swap-vm && for i in $(seq 1 100); do ...
  --- stdout ---
Warning: unsafe assembly block in contracts/Demo.sol (1)
[... 98 similar lines ...]
Warning: unsafe assembly block in contracts/Demo.sol (100)
  --- stderr ---
Error: not found: import "./Missing.sol" in contracts/Demo.sol
```
