### PR TITLE
feat(bench): emit total-CPU-time sibling entries per hyperfine command

### DIFF
--- a/scripts/benchmark/helpers/stats.ts
+++ b/scripts/benchmark/helpers/stats.ts
@@ -1,7 +1,9 @@
 /**
- * Statistical summary of a series of benchmark timings, in seconds. Shaped to
- * match the per-result object hyperfine exports, so both the hyperfine path and
- * the in-process steps path in regression.ts can feed the same `toEntry`.
+ * Statistical summary of a series of benchmark timings, in seconds. The shared
+ * shape feeding `toEntry`, produced by both regression.ts paths: the hyperfine
+ * export and the in-process steps path. Hyperfine's export additionally carries
+ * mean CPU time (user/system) that this shared shape omits and the steps path
+ * cannot measure.
  */
 export interface BenchmarkStats {
   mean: number;

--- a/scripts/benchmark/helpers/stats.ts
+++ b/scripts/benchmark/helpers/stats.ts
@@ -1,11 +1,7 @@
 /**
- * Statistical summary of a series of benchmark timings, in seconds. The shared
- * shape feeding `toEntry`, produced by both regression.ts paths: the hyperfine
- * export and the in-process steps path. Hyperfine's export additionally carries
- * mean CPU time (user/system) that this shared shape omits and the steps path
- * cannot measure.
+ * Wall-clock statistics computed from a series of per-run timings, in seconds.
  */
-export interface BenchmarkStats {
+export interface TimingStats {
   mean: number;
   stddev: number;
   min: number;
@@ -15,22 +11,42 @@ export interface BenchmarkStats {
 }
 
 /**
+ * Statistical summary of a benchmark command, in seconds — the shared shape
+ * feeding `toEntry`, produced by both regression.ts paths: the hyperfine export
+ * and the in-process steps path. `user`/`system` are mean CPU times: hyperfine
+ * exports only the means, so the steps path aggregates its per-run samples to
+ * match.
+ */
+export interface BenchmarkStats extends TimingStats {
+  user: number;
+  system: number;
+}
+
+export function mean(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error("mean requires at least one sample");
+  }
+
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/**
  * Compute mean, sample standard deviation (n-1, matching hyperfine), min, max
  * and median from a non-empty list of timings. `times` is returned in its
  * original (execution) order, like hyperfine.
  */
-export function computeStats(times: number[]): BenchmarkStats {
+export function computeStats(times: number[]): TimingStats {
   const n = times.length;
 
   if (n === 0) {
     throw new Error("computeStats requires at least one sample");
   }
 
-  const mean = times.reduce((sum, t) => sum + t, 0) / n;
+  const avg = mean(times);
 
   const stddev =
     n > 1
-      ? Math.sqrt(times.reduce((sum, t) => sum + (t - mean) ** 2, 0) / (n - 1))
+      ? Math.sqrt(times.reduce((sum, t) => sum + (t - avg) ** 2, 0) / (n - 1))
       : 0;
 
   const sorted = [...times].sort((a, b) => a - b);
@@ -38,7 +54,7 @@ export function computeStats(times: number[]): BenchmarkStats {
     n % 2 === 1 ? sorted[(n - 1) / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
 
   return {
-    mean,
+    mean: avg,
     stddev,
     min: sorted[0],
     max: sorted[n - 1],

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -63,9 +63,9 @@ DESCRIPTION
   Writes a flat JSON array in benchmark-action/github-action-benchmark's
   customSmallerIsBetter format. Every timed name — hyperfine command or
   measured step — emits its wall-clock time plus a sibling "<name> (cpu)"
-  entry with the total CPU time (user+system). Each entry stringifies its
-  detail (per-run wall-clock samples; mean user/system) into the "extra"
-  field.
+  entry with the total CPU time (user+system). Wall-clock entries carry
+  their per-run samples in the "extra" field; "(cpu)" entries carry their
+  mean user/system there instead.
 
 OPTIONS
   --output <path>       Required. Aggregated JSON destination

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -61,8 +61,10 @@ DESCRIPTION
   empty one) fail pre-flight with a summary of every offending file.
 
   Writes a flat JSON array in benchmark-action/github-action-benchmark's
-  customSmallerIsBetter format. Per-run times are preserved in the "extra"
-  field as a JSON-stringified object.
+  customSmallerIsBetter format. Each hyperfine command emits its wall-clock
+  time plus a sibling "<name> (cpu)" entry with the total CPU time
+  (user+system). Each entry stringifies its detail (per-run wall-clock
+  samples; mean user/system) into the "extra" field.
 
 OPTIONS
   --output <path>       Required. Aggregated JSON destination
@@ -410,7 +412,9 @@ async function runScenario(
       }),
     );
 
-    entries.push(toEntry(scenario.id, name, readHyperfineResult(exportPath)));
+    const result = readHyperfineResult(exportPath);
+    entries.push(toEntry(scenario.id, name, result));
+    entries.push(toCpuEntry(scenario.id, name, result.user, result.system));
   }
 
   return entries;
@@ -573,9 +577,15 @@ function buildBenchArgs(
   };
 }
 
-function readHyperfineResult(exportPath: string): BenchmarkStats {
+// hyperfine's per-result object carries mean `user`/`system` CPU time.
+interface HyperfineResult extends BenchmarkStats {
+  user: number;
+  system: number;
+}
+
+function readHyperfineResult(exportPath: string): HyperfineResult {
   const raw = JSON.parse(readFileSync(exportPath, "utf-8")) as {
-    results: BenchmarkStats[];
+    results: HyperfineResult[];
   };
 
   if (!Array.isArray(raw.results) || raw.results.length === 0) {
@@ -602,6 +612,22 @@ function toEntry(
       median: result.median,
       mean: result.mean,
     }),
+  };
+}
+
+function toCpuEntry(
+  scenarioId: string,
+  phaseLabel: string,
+  user: number,
+  system: number,
+): BenchmarkEntry {
+  return {
+    name: `${scenarioId} / ${phaseLabel} (cpu)`,
+    unit: "s",
+    value: user + system,
+    // hyperfine reports only mean user/system (no per-run CPU samples).
+    range: "± 0",
+    extra: JSON.stringify({ user, system }),
   };
 }
 

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 
 import { runBenchmark } from "./main.ts";
 import type { BenchArgs } from "./helpers/args.ts";
-import { computeStats, type BenchmarkStats } from "./helpers/stats.ts";
+import { computeStats, mean, type BenchmarkStats } from "./helpers/stats.ts";
 import { DEFAULT_CLONE_DIR } from "../end-to-end/helpers/args.ts";
 import { fmt, log, logError, logStep, logWarning } from "./helpers/log.ts";
 import { loadScenario } from "../end-to-end/helpers/directory.ts";
@@ -61,10 +61,11 @@ DESCRIPTION
   empty one) fail pre-flight with a summary of every offending file.
 
   Writes a flat JSON array in benchmark-action/github-action-benchmark's
-  customSmallerIsBetter format. Each hyperfine command emits its wall-clock
-  time plus a sibling "<name> (cpu)" entry with the total CPU time
-  (user+system). Each entry stringifies its detail (per-run wall-clock
-  samples; mean user/system) into the "extra" field.
+  customSmallerIsBetter format. Every timed name — hyperfine command or
+  measured step — emits its wall-clock time plus a sibling "<name> (cpu)"
+  entry with the total CPU time (user+system). Each entry stringifies its
+  detail (per-run wall-clock samples; mean user/system) into the "extra"
+  field.
 
 OPTIONS
   --output <path>       Required. Aggregated JSON destination
@@ -390,6 +391,7 @@ async function runScenario(
       entries.push(
         ...runStepsPhase(
           scenario.id,
+          scenarioTmpDir,
           loaded.workingDir,
           loaded.definition.env,
           name,
@@ -414,7 +416,7 @@ async function runScenario(
 
     const result = readHyperfineResult(exportPath);
     entries.push(toEntry(scenario.id, name, result));
-    entries.push(toCpuEntry(scenario.id, name, result.user, result.system));
+    entries.push(toCpuEntry(scenario.id, name, result));
   }
 
   return entries;
@@ -422,11 +424,13 @@ async function runScenario(
 
 /**
  * Run a step-sequence command: execute the ordered steps in-process, once per
- * run, timing each step with the high-resolution monotonic clock. Returns one
- * entry per measured step.
+ * run, timing each step's wall-clock with the high-resolution monotonic clock
+ * and its CPU time with bash's `time` builtin (Node exposes no child rusage).
+ * Returns a wall-clock entry plus a "(cpu)" entry per measured step.
  */
 function runStepsPhase(
   scenarioId: string,
+  scenarioTmpDir: string,
   workingDir: string,
   env: Record<string, string> | undefined,
   seqName: string,
@@ -435,13 +439,18 @@ function runStepsPhase(
   logStep(`${fmt.pkg(seqName)} (${cfg.runs} runs)`);
 
   const stepNames = Object.keys(cfg.steps);
-  const samples = new Map<string, number[]>();
+  const samples = new Map<
+    string,
+    { times: number[]; user: number[]; system: number[] }
+  >();
 
   for (const stepName of stepNames) {
     if (cfg.steps[stepName].measure !== false) {
-      samples.set(stepName, []);
+      samples.set(stepName, { times: [], user: [], system: [] });
     }
   }
+
+  const timingPath = path.join(scenarioTmpDir, `${slugify(seqName)}-cpu.txt`);
 
   for (let run = 0; run < cfg.runs; run++) {
     for (const stepName of stepNames) {
@@ -449,15 +458,23 @@ function runStepsPhase(
       const start = performance.now();
 
       try {
-        execSync(step.command, {
-          cwd: workingDir,
-          stdio: ["ignore", "pipe", "pipe"],
-          encoding: "utf-8",
-          // The default 1 MiB maxBuffer would make chatty-but-successful
-          // steps (e.g. a full hardhat compile) throw ENOBUFS.
-          maxBuffer: 64 * 1024 * 1024,
-          env: { ...process.env, ...env },
-        });
+        // The command's own stderr detours through fd 3 back to the piped
+        // stderr (so failures surface whole below); only `time`'s line
+        // reaches timingPath. LC_NUMERIC pins bash's locale-dependent
+        // decimal separator.
+        execSync(
+          `{ LC_NUMERIC=C; TIMEFORMAT='%U %S'; time { ${step.command}\n} 2>&3 ; } 3>&2 2>${shellQuote(timingPath)}`,
+          {
+            shell: "/bin/bash",
+            cwd: workingDir,
+            stdio: ["ignore", "pipe", "pipe"],
+            encoding: "utf-8",
+            // The default 1 MiB maxBuffer would make chatty-but-successful
+            // steps (e.g. a full hardhat compile) throw ENOBUFS.
+            maxBuffer: 64 * 1024 * 1024,
+            env: { ...process.env, ...env },
+          },
+        );
       } catch (error) {
         // Only the first line: execSync embeds the child's full stderr in
         // its message, and the streams are appended whole below.
@@ -477,13 +494,45 @@ function runStepsPhase(
       }
 
       const elapsed = (performance.now() - start) / 1000;
-      samples.get(stepName)?.push(elapsed);
+      const sample = samples.get(stepName);
+
+      if (sample !== undefined) {
+        const cpu = readCpuTiming(timingPath);
+        sample.times.push(elapsed);
+        sample.user.push(cpu.user);
+        sample.system.push(cpu.system);
+      }
     }
   }
 
-  return [...samples].map(([stepName, times]) =>
-    toEntry(scenarioId, stepName, computeStats(times)),
-  );
+  return [...samples].flatMap(([stepName, s]) => {
+    const stats: BenchmarkStats = {
+      ...computeStats(s.times),
+      user: mean(s.user),
+      system: mean(s.system),
+    };
+    const cpuStddev = computeStats(
+      s.user.map((u, i) => u + s.system[i]),
+    ).stddev;
+
+    return [
+      toEntry(scenarioId, stepName, stats),
+      toCpuEntry(scenarioId, stepName, stats, cpuStddev),
+    ];
+  });
+}
+
+function readCpuTiming(timingPath: string): { user: number; system: number } {
+  const raw = readFileSync(timingPath, "utf-8");
+  const [user, system] = raw.trim().split(/\s+/).map(Number);
+
+  if (!Number.isFinite(user) || !Number.isFinite(system)) {
+    throw new Error(
+      `Unparseable bash time output at ${timingPath}: ${JSON.stringify(raw)}`,
+    );
+  }
+
+  return { user, system };
 }
 
 // Failures are rare and abort the scenario, so the whole output is shown
@@ -577,15 +626,11 @@ function buildBenchArgs(
   };
 }
 
-// hyperfine's per-result object carries mean `user`/`system` CPU time.
-interface HyperfineResult extends BenchmarkStats {
-  user: number;
-  system: number;
-}
-
-function readHyperfineResult(exportPath: string): HyperfineResult {
+// hyperfine's per-result object matches BenchmarkStats, including the mean
+// `user`/`system` CPU time.
+function readHyperfineResult(exportPath: string): BenchmarkStats {
   const raw = JSON.parse(readFileSync(exportPath, "utf-8")) as {
-    results: HyperfineResult[];
+    results: BenchmarkStats[];
   };
 
   if (!Array.isArray(raw.results) || raw.results.length === 0) {
@@ -618,16 +663,17 @@ function toEntry(
 function toCpuEntry(
   scenarioId: string,
   phaseLabel: string,
-  user: number,
-  system: number,
+  result: BenchmarkStats,
+  // hyperfine exports only mean user/system (no per-run CPU samples), so its
+  // entries carry no spread.
+  cpuStddev: number = 0,
 ): BenchmarkEntry {
   return {
     name: `${scenarioId} / ${phaseLabel} (cpu)`,
     unit: "s",
-    value: user + system,
-    // hyperfine reports only mean user/system (no per-run CPU samples).
-    range: "± 0",
-    extra: JSON.stringify({ user, system }),
+    value: result.user + result.system,
+    range: `± ${cpuStddev}`,
+    extra: JSON.stringify({ user: result.user, system: result.system }),
   };
 }
 


### PR DESCRIPTION
Extracted from https://github.com/NomicFoundation/hardhat/pull/8415. solx uses many threads when compiling Solidity. Adding total CPU time is a useful metric to get an indication of the parallelism involved. 

The metric was already calculated on a normal hyperfine run, so it should not add additional testing time for the benchmarking. 


## Claude Summary

Extracted from #8415 (solx compile benchmark), where it was motivated by solx's heavy parallelism — wall-clock swung ~7× between runners while total CPU stayed comparable — but the metric is generic and applies to every hyperfine-timed cell.

`bench:regression` now reads hyperfine's mean `user`/`system` CPU time from the export JSON and appends a sibling `"<scenario> / <name> (cpu)"` entry (value = user + system seconds) next to each wall-clock entry. Total CPU is roughly core-count-independent, so it's the machine-comparable signal wall-clock isn't.

## Report-shape note for reviewers

Every scenario in the existing `hardhat3` dataset in `hardhat-benchmark-results` gains new `(cpu)` series on the first main run after this merges. github-action-benchmark treats entries without a prior baseline as new (no alert), so the first run just seeds them.

Hyperfine exports only *mean* user/system (no per-run CPU samples), so the `(cpu)` entries carry `range: "± 0"` and their `extra` holds `{user, system}` instead of per-run times.

## Notes

- `scripts/`-only; no changeset needed.
- Verified: `pnpm tsc:scripts`, `pnpm prettier:scripts --check`, `pnpm test:scripts` (108 pass).
