### PR TITLE
chore: remove wkhtmltopdf from setup script

### DIFF
--- a/cspell.dictionary.txt
+++ b/cspell.dictionary.txt
@@ -145,6 +145,8 @@ Viem
 VIEM
 visualising
 WAAIT
+wkhtmltoimage
+wkhtmltox
 withargs
 wordz
 xcom

--- a/packages/hardhat-node-test-reporter/integration-tests/README.md
+++ b/packages/hardhat-node-test-reporter/integration-tests/README.md
@@ -18,8 +18,9 @@ You can run each of the fixture test manually from the package root by building 
 
 ## Re-generating the expected results
 
-Re-generating the fixtures requires two external tools that are **not** installed by `scripts/setup.sh`, as they are only needed for this task and not for running the tests:
+Re-generating the fixtures requires a few external tools. `aha` and `wkhtmltoimage` are **not** installed by `scripts/setup.sh`, as they are only needed for this task and not for running the tests:
 
+- [`jq`](https://jqlang.org) — used by `scripts/regenerate-fixtures.sh` to read `options.json`. Install with `sudo apt install jq` or an equivalent.
 - [`aha`](https://github.com/theZiz/aha) — converts the reporter's ANSI-colored output into HTML. Install with `sudo apt install aha` or an equivalent.
 - [`wkhtmltoimage`](https://wkhtmltopdf.org) (shipped in the `wkhtmltopdf` package) — renders that HTML into the `result.svg` snapshot. Install it from the [wkhtmltopdf releases](https://github.com/wkhtmltopdf/packaging/releases), e.g.:
 

--- a/packages/hardhat-node-test-reporter/integration-tests/README.md
+++ b/packages/hardhat-node-test-reporter/integration-tests/README.md
@@ -18,6 +18,19 @@ You can run each of the fixture test manually from the package root by building 
 
 ## Re-generating the expected results
 
+Re-generating the fixtures requires two external tools that are **not** installed by `scripts/setup.sh`, as they are only needed for this task and not for running the tests:
+
+- [`aha`](https://github.com/theZiz/aha) — converts the reporter's ANSI-colored output into HTML. Install with `sudo apt install aha` or an equivalent.
+- [`wkhtmltoimage`](https://wkhtmltopdf.org) (shipped in the `wkhtmltopdf` package) — renders that HTML into the `result.svg` snapshot. Install it from the [wkhtmltopdf releases](https://github.com/wkhtmltopdf/packaging/releases), e.g.:
+
+  ```bash
+  curl -sL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_amd64.deb -o /tmp/wkhtmltox.deb
+  sudo apt install -y /tmp/wkhtmltox.deb
+  rm /tmp/wkhtmltox.deb
+  ```
+
+The `result.svg` files are human-review snapshots of the colored output; the automated tests only compare `result.txt`.
+
 If you want to re-generate all the expected results, you can run the following script from the package root:
 
 ```bash

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,13 +6,6 @@ sudo apt update
 # libudev-dev is required by hardhat-ledger
 sudo apt install -y libudev-dev
 
-# aha and wkhtmltoimage (included in the wkhtmltopdf package) are used in the integration tests of the node:test reporter
-sudo apt install -y aha
-
-curl -sL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_amd64.deb -o /tmp/wkhtmltox.deb
-sudo apt install -y /tmp/wkhtmltox.deb
-rm /tmp/wkhtmltox.deb
-
 # Used for performance measurement
 sudo apt install -y hyperfine
 


### PR DESCRIPTION
The install script used to include wkhtltopdf and aha, used in the node test runner integration test suite to generate snaphot svgs.

The setup is ugly when running with trixie, so rather than complicate the standard devcontainer, we include install instructions in the README of the test suite.
