### PR TITLE
fix(network): reject malformed HD derivation paths in HD_PATH_REGEX

### DIFF
--- a/.changeset/hd-path-ethers-reject.md
+++ b/.changeset/hd-path-ethers-reject.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-ethers": patch
+---
+
+Fixed the HD wallet derivation-path validator so malformed paths containing stray colons (e.g. `m:/44'/60'/0'/0`) are rejected with the `INVALID_HD_PATH` error.

--- a/.changeset/tidy-otters-reject.md
+++ b/.changeset/tidy-otters-reject.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed the HD wallet derivation-path validator so malformed paths containing stray colons (e.g. `m:/44'/60'/0'/0`) are rejected with the `INVALID_HD_PATH` error instead of being forwarded to the key-derivation library, which threw a low-level error.

--- a/.changeset/tidy-otters-reject.md
+++ b/.changeset/tidy-otters-reject.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Fixed the HD wallet derivation-path validator so malformed paths containing stray colons (e.g. `m:/44'/60'/0'/0`) are rejected with the `INVALID_HD_PATH` error instead of being forwarded to the key-derivation library, which threw a low-level error.
+Fixed the HD wallet derivation-path validator so malformed paths containing stray colons (e.g. `m:/44'/60'/0'/0`) are rejected with the `INVALID_HD_PATH` error.

--- a/packages/hardhat-ethers/src/internal/signers/derive-private-key.ts
+++ b/packages/hardhat-ethers/src/internal/signers/derive-private-key.ts
@@ -14,7 +14,7 @@ let mnemonicToSeedSync: typeof Bip39T.mnemonicToSeedSync | undefined;
 // ethereum-cryptography/hdkey is known to be slow to load, so we lazy load it
 let HDKey: typeof HDKeyT | undefined;
 
-const HD_PATH_REGEX = /^m(:?\/\d+'?)+\/?$/;
+const HD_PATH_REGEX = /^m(?:\/\d+'?)+\/?$/;
 
 export async function derivePrivateKeys(
   accounts: EdrNetworkHDAccountsConfig | HttpNetworkHDAccountsConfig,

--- a/packages/hardhat-ethers/test/derive-private-key.ts
+++ b/packages/hardhat-ethers/test/derive-private-key.ts
@@ -1,0 +1,53 @@
+import type {
+  EdrNetworkHDAccountsConfig,
+  HttpNetworkHDAccountsConfig,
+} from "hardhat/types/config";
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
+
+import { derivePrivateKeys } from "../src/internal/signers/derive-private-key.js";
+
+const MNEMONIC =
+  "couch hunt wisdom giant regret supreme issue sing enroll ankle type husband";
+
+function hdAccounts(
+  path: string,
+): EdrNetworkHDAccountsConfig | HttpNetworkHDAccountsConfig {
+  const accounts = {
+    mnemonic: { get: async () => MNEMONIC },
+    passphrase: { get: async () => "" },
+    count: 1,
+    initialIndex: 0,
+    path,
+  };
+
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  -- test stub: only the fields read by derivePrivateKeys are provided */
+  return accounts as unknown as HttpNetworkHDAccountsConfig;
+}
+
+describe("derivePrivateKeys", () => {
+  it("should derive a key for a valid path", async () => {
+    const [privateKey] = await derivePrivateKeys(hdAccounts("m/44'/60'/0'/0"));
+
+    assert.match(privateKey, /^0x[0-9a-f]{64}$/);
+  });
+
+  it("should reject malformed paths containing a stray colon", async () => {
+    await assertRejectsWithHardhatError(
+      derivePrivateKeys(hdAccounts("m:/44'/60'/0'/0")),
+      HardhatError.ERRORS.CORE.NETWORK.INVALID_HD_PATH,
+      { path: "m:/44'/60'/0'/0" },
+    );
+
+    await assertRejectsWithHardhatError(
+      derivePrivateKeys(hdAccounts("m/44':/60'/0'/0")),
+      HardhatError.ERRORS.CORE.NETWORK.INVALID_HD_PATH,
+      { path: "m/44':/60'/0'/0" },
+    );
+  });
+});

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/accounts/derive-private-keys.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/accounts/derive-private-keys.ts
@@ -10,7 +10,7 @@ let mnemonicToSeedSync: typeof Bip39T.mnemonicToSeedSync | undefined;
 // ethereum-cryptography/hdkey is known to be slow to load, so we lazy load it
 let HDKey: typeof HDKeyT | undefined;
 
-const HD_PATH_REGEX = /^m(:?\/\d+'?)+\/?$/;
+const HD_PATH_REGEX = /^m(?:\/\d+'?)+\/?$/;
 
 export async function derivePrivateKeys(
   mnemonic: string,

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/hd-wallet.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/hd-wallet.ts
@@ -171,6 +171,18 @@ describe("HDWalletHandler", () => {
         HardhatError.ERRORS.CORE.NETWORK.INVALID_HD_PATH,
         { path: "ghj" },
       );
+
+      await assertRejectsWithHardhatError(
+        HDWalletHandler.create(mockedProvider, mnemonic, "m:/44'/60'/0'/0"),
+        HardhatError.ERRORS.CORE.NETWORK.INVALID_HD_PATH,
+        { path: "m:/44'/60'/0'/0" },
+      );
+
+      await assertRejectsWithHardhatError(
+        HDWalletHandler.create(mockedProvider, mnemonic, "m/44':/60'/0'/0"),
+        HardhatError.ERRORS.CORE.NETWORK.INVALID_HD_PATH,
+        { path: "m/44':/60'/0'/0" },
+      );
     });
   });
 });


### PR DESCRIPTION
## Problem

`HD_PATH_REGEX` in `packages/hardhat/src/internal/builtin-plugins/network-manager/accounts/derive-private-keys.ts` uses a capturing group that begins with an optional-colon literal, `(:?`, instead of the intended non-capturing group `(?:`:

```ts
const HD_PATH_REGEX = /^m(:?\/\d+'?)+\/?$/;
```

Because `:?` matches an optional stray colon at the start of each segment, malformed BIP-32 paths are silently accepted. For example, both of these pass the validator:

- `m:/44'/60'/0'/0`
- `m/44':/60'/0'/0`

## Failing scenario

In `derivePrivateKeys()`, a path that fails `HD_PATH_REGEX.test(hdpath)` is supposed to throw the friendly `HardhatError` `CORE.NETWORK.INVALID_HD_PATH`. Because of the typo, a colon-containing path passes this check and is forwarded to `HDKey.derive()` (ethereum-cryptography / scure), which throws a low-level error such as `Invalid child index: m:` instead of the intended `INVALID_HD_PATH` error. This degrades the error surface for any HD-account configuration (the default account config and any `{ mnemonic, path }` network config) whenever the path is slightly malformed.

## Fix

Change `(:?` to `(?:`, making the group non-capturing as intended:

```ts
const HD_PATH_REGEX = /^m(?:\/\d+'?)+\/?$/;
```

Every valid path (`m/44'/60'/0'/0`, with or without a trailing slash, hardened segments, etc.) matches identically under both forms, so the change rejects only malformed input and preserves all valid behavior. The group was only used inside `.test()`, so making it non-capturing has no other effect.

## Test

Extends the existing `should throw if the path is invalid` test to also assert that colon-containing paths (`m:/44'/60'/0'/0` and `m/44':/60'/0'/0`) are rejected with `INVALID_HD_PATH`. These cases fail before the fix (the paths are accepted and instead surface a low-level derivation error) and pass after it; all pre-existing valid- and invalid-path assertions remain green.