### PR TITLE
update amsterdam warning message

### DIFF
--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/hardfork.ts
@@ -61,8 +61,10 @@ export function warnIfExperimentalHardfork(
   warn(
     styleText(["bold", "yellow"], "Warning:") +
       ` you have configured the "${hardfork}" hardfork, which is experimental ` +
-      `and not yet finalized. Behavior may change or be incomplete. ` +
-      `The latest stable hardfork is "${latestStable}".\n`,
+      `and not yet finalized, so its behavior may change or be incomplete. ` +
+      `The latest stable hardfork is "${latestStable}". ` +
+      `Keep Hardhat up to date to track changes to "${hardfork}" and to pick up ` +
+      `its stable version once it activates on mainnet.\n`,
   );
 }
 


### PR DESCRIPTION
A user of an older version may switch to `amsterdam` when it deploys on mainnet and be surprised that it is showing as experimental.

The warning message now directs the user to update to the latest Hardhat in that case.