### PR TITLE
ci: add memory stats and filters for regression benchmark

### DIFF
--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -92,10 +92,12 @@ jobs:
 
       - uses: ./.github/actions/setup-env
 
-      - name: Install hyperfine
+      - name: Install system dependencies
+        # `time` is GNU /usr/bin/time — bench:regression wraps each benchmark in
+        # it to capture peak RSS (memory) alongside timing.
         run: |
           sudo apt-get update
-          sudo apt-get install -y hyperfine
+          sudo apt-get install -y hyperfine time
 
       - name: Configure E2E clone directory
         # Clone scenarios into the runner's temp dir instead of the default

--- a/end-to-end/1inch-aqua/scenario.json
+++ b/end-to-end/1inch-aqua/scenario.json
@@ -17,26 +17,32 @@
             "measure": false
           },
           "cold compile": {
-            "command": "npx hardhat compile"
+            "command": "npx hardhat compile",
+            "dependsOn": ["reset files & cache"]
           },
           "edit & compile Solidity test with min deps: test/AquaLifecycle.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaLifecycle.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaLifecycle.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity test with max deps: test/AquaStorageTest.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaStorageTest.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/AquaStorageTest.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity contract: src/Aqua.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/Aqua.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/Aqua.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           }
         }
       },
       "warm compile": {
         "runs": 2,
-        "command": "npx hardhat compile"
+        "command": "npx hardhat compile",
+        "dependsOn": ["cold compile"]
       },
       "test solidity": {
         "runs": 2,
-        "command": "npx hardhat test solidity --no-compile"
+        "command": "npx hardhat test solidity --no-compile",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/1inch-cross-chain-swap/scenario.json
+++ b/end-to-end/1inch-cross-chain-swap/scenario.json
@@ -20,26 +20,32 @@
             "measure": false
           },
           "cold compile": {
-            "command": "npx hardhat compile"
+            "command": "npx hardhat compile",
+            "dependsOn": ["reset files & cache"]
           },
           "edit & compile Solidity test with min deps: test/libraries/FeeCalcLib.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/FeeCalcLib.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/FeeCalcLib.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity test with max deps: test/integration/ResolverMock.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/integration/ResolverMock.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/integration/ResolverMock.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity contract: contracts/BaseEscrow.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/BaseEscrow.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/BaseEscrow.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           }
         }
       },
       "warm compile": {
         "runs": 2,
-        "command": "npx hardhat compile"
+        "command": "npx hardhat compile",
+        "dependsOn": ["cold compile"]
       },
       "test solidity": {
         "runs": 15,
-        "command": "npx hardhat test solidity --no-compile"
+        "command": "npx hardhat test solidity --no-compile",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -21,26 +21,32 @@
             "measure": false
           },
           "cold compile": {
-            "command": "npx hardhat compile"
+            "command": "npx hardhat compile",
+            "dependsOn": ["reset files & cache"]
           },
           "edit & compile Solidity test with min deps: test/ProtocolFeeProviderMock.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/ProtocolFeeProviderMock.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/ProtocolFeeProviderMock.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity test with max deps: test/TransferModesCombinations.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/TransferModesCombinations.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/TransferModesCombinations.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity contract: src/SwapVM.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/SwapVM.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/SwapVM.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           }
         }
       },
       "warm compile": {
         "runs": 2,
-        "command": "npx hardhat compile"
+        "command": "npx hardhat compile",
+        "dependsOn": ["cold compile"]
       },
       "test solidity": {
         "runs": 4,
-        "command": "npx hardhat test solidity --no-compile"
+        "command": "npx hardhat test solidity --no-compile",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -18,26 +18,32 @@
             "measure": false
           },
           "cold compile": {
-            "command": "npx hardhat compile"
+            "command": "npx hardhat compile",
+            "dependsOn": ["reset files & cache"]
           },
           "edit & compile Solidity test with min deps: tests/unit/WadRayMath.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/WadRayMath.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/WadRayMath.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity test with max deps: tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> tests/unit/Spoke/Liquidations/Spoke.LiquidationCall.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity contract: src/libraries/math/MathUtils.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/libraries/math/MathUtils.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/libraries/math/MathUtils.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           }
         }
       },
       "warm compile": {
         "runs": 2,
-        "command": "npx hardhat compile"
+        "command": "npx hardhat compile",
+        "dependsOn": ["cold compile"]
       },
       "test solidity": {
         "runs": 24,
-        "command": "npx hardhat test solidity --no-compile"
+        "command": "npx hardhat test solidity --no-compile",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/ens-verifiable-factory/scenario.json
+++ b/end-to-end/ens-verifiable-factory/scenario.json
@@ -20,26 +20,32 @@
             "measure": false
           },
           "cold compile": {
-            "command": "npx hardhat compile"
+            "command": "npx hardhat compile",
+            "dependsOn": ["reset files & cache"]
           },
           "edit & compile Solidity test with min deps: test/UUPSProxy.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/UUPSProxy.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/UUPSProxy.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity test with max deps: test/VerifiableFactory.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/VerifiableFactory.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/VerifiableFactory.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity contract: src/VerifiableFactory.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/VerifiableFactory.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/VerifiableFactory.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           }
         }
       },
       "warm compile": {
         "runs": 2,
-        "command": "npx hardhat compile"
+        "command": "npx hardhat compile",
+        "dependsOn": ["cold compile"]
       },
       "test solidity": {
         "runs": 2,
-        "command": "npx hardhat test solidity --no-compile"
+        "command": "npx hardhat test solidity --no-compile",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/lidofinance-dual-governance/scenario.json
+++ b/end-to-end/lidofinance-dual-governance/scenario.json
@@ -20,26 +20,32 @@
             "measure": false
           },
           "cold compile": {
-            "command": "npx hardhat compile"
+            "command": "npx hardhat compile",
+            "dependsOn": ["reset files & cache"]
           },
           "edit & compile Solidity test with min deps: test/unit/scripts/launch/TimeConstraints.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/unit/scripts/launch/TimeConstraints.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/unit/scripts/launch/TimeConstraints.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity test with max deps: test/scenario/mainnet-launch.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/scenario/mainnet-launch.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/scenario/mainnet-launch.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity contract: contracts/types/Timestamp.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/types/Timestamp.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> contracts/types/Timestamp.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           }
         }
       },
       "warm compile": {
         "runs": 2,
-        "command": "npx hardhat compile"
+        "command": "npx hardhat compile",
+        "dependsOn": ["cold compile"]
       },
       "test solidity": {
         "runs": 15,
-        "command": "npx hardhat test solidity --no-compile --grep=\"^(test_|testFuzz_)\""
+        "command": "npx hardhat test solidity --no-compile --grep=\"^(test_|testFuzz_)\"",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/openzeppelin-contracts/scenario.json
+++ b/end-to-end/openzeppelin-contracts/scenario.json
@@ -18,11 +18,13 @@
       },
       "warm compile": {
         "runs": 19,
-        "command": "npx hardhat compile"
+        "command": "npx hardhat compile",
+        "dependsOn": ["cold compile"]
       },
       "mocha test": {
         "runs": 3,
-        "command": "npx hardhat test mocha --no-compile"
+        "command": "npx hardhat test mocha --no-compile",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/uniswap-v4-core/scenario.json
+++ b/end-to-end/uniswap-v4-core/scenario.json
@@ -20,26 +20,32 @@
             "measure": false
           },
           "cold compile": {
-            "command": "npx hardhat compile"
+            "command": "npx hardhat compile",
+            "dependsOn": ["reset files & cache"]
           },
           "edit & compile Solidity test with min deps: test/libraries/BitMath.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/BitMath.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/libraries/BitMath.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity test with max deps: test/PoolManager.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/PoolManager.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/PoolManager.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity contract: src/types/Currency.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/types/Currency.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/types/Currency.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           }
         }
       },
       "warm compile": {
         "runs": 2,
-        "command": "npx hardhat compile"
+        "command": "npx hardhat compile",
+        "dependsOn": ["cold compile"]
       },
       "test solidity": {
         "runs": 9,
-        "command": "npx hardhat test solidity --no-compile"
+        "command": "npx hardhat test solidity --no-compile",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -20,26 +20,32 @@
             "measure": false
           },
           "cold compile": {
-            "command": "npx hardhat compile"
+            "command": "npx hardhat compile",
+            "dependsOn": ["reset files & cache"]
           },
           "edit & compile Solidity test with min deps: test/lib/CosignerLib.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/lib/CosignerLib.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/lib/CosignerLib.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity test with max deps: test/reactors/V3DutchOrderReactor.t.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/reactors/V3DutchOrderReactor.t.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> test/reactors/V3DutchOrderReactor.t.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           },
           "edit & compile Solidity contract: src/base/ReactorStructs.sol": {
-            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/base/ReactorStructs.sol && npx hardhat compile"
+            "command": "printf \"\\n// hardhat benchmark edit\\n\" >> src/base/ReactorStructs.sol && npx hardhat compile",
+            "dependsOn": ["cold compile"]
           }
         }
       },
       "warm compile": {
         "runs": 2,
-        "command": "npx hardhat compile"
+        "command": "npx hardhat compile",
+        "dependsOn": ["cold compile"]
       },
       "test solidity": {
         "runs": 2,
-        "command": "npx hardhat test solidity --no-compile"
+        "command": "npx hardhat test solidity --no-compile",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/scripts/benchmark/helpers/args.ts
+++ b/scripts/benchmark/helpers/args.ts
@@ -21,6 +21,7 @@ export interface BenchArgs {
   warmup: number;
   runs: number | undefined;
   exportJson: string | undefined;
+  memFile: string | undefined;
   e2eCloneDirectory: string;
 }
 
@@ -95,6 +96,7 @@ export function resolveAndValidateArgs(args: string[]): BenchArgs | undefined {
     warmup,
     runs,
     exportJson,
+    memFile: undefined,
     e2eCloneDirectory,
   };
 }

--- a/scripts/benchmark/helpers/memory.test.ts
+++ b/scripts/benchmark/helpers/memory.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  formatTimeCommand,
+  gnuTimeAvailable,
+  readPeakRssMb,
+  wrapWithTime,
+} from "./memory.ts";
+
+const tmp = mkdtempSync(path.join(tmpdir(), "mem-test-"));
+const memFileWith = (name: string, contents: string) => {
+  const p = path.join(tmp, name);
+  writeFileSync(p, contents);
+  return p;
+};
+
+describe("formatTimeCommand", () => {
+  it("wraps a lone program without an inner shell", () => {
+    assert.equal(
+      formatTimeCommand(
+        "hyperfine --runs 3 'npx hardhat compile'",
+        "/t/m",
+        false,
+      ),
+      "/usr/bin/time -o '/t/m' -f %M hyperfine --runs 3 'npx hardhat compile'",
+    );
+  });
+
+  it("wraps a shell command under sh -c so operators are covered", () => {
+    assert.equal(
+      formatTimeCommand("printf x >> f && npx hardhat compile", "/t/m", true),
+      `/usr/bin/time -o '/t/m' -f %M sh -c 'printf x >> f && npx hardhat compile'`,
+    );
+  });
+
+  it("escapes single quotes in the wrapped command", () => {
+    assert.equal(
+      formatTimeCommand("echo 'hi'", "/t/m", true),
+      `/usr/bin/time -o '/t/m' -f %M sh -c 'echo '\\''hi'\\'''`,
+    );
+  });
+});
+
+describe("wrapWithTime", () => {
+  it("is a no-op when GNU time is unavailable (returns the command unchanged)", () => {
+    // This sandbox has no /usr/bin/time; assert the graceful fallback.
+    if (!gnuTimeAvailable()) {
+      assert.equal(
+        wrapWithTime("npx hardhat compile", "/t/m", false),
+        "npx hardhat compile",
+      );
+    } else {
+      assert.match(
+        wrapWithTime("npx hardhat compile", "/t/m", false),
+        /^\/usr\/bin\/time /,
+      );
+    }
+  });
+});
+
+describe("readPeakRssMb", () => {
+  it("parses KB and rounds to MB", () => {
+    assert.equal(readPeakRssMb(memFileWith("a", "1268340\n")), 1239);
+  });
+
+  it("ignores a trailing 'Command exited' line (takes the first integer)", () => {
+    const p = memFileWith(
+      "b",
+      "524288\nCommand exited with non-zero status 1\n",
+    );
+    assert.equal(readPeakRssMb(p), 512);
+  });
+
+  it("returns undefined for a missing file", () => {
+    assert.equal(readPeakRssMb(path.join(tmp, "does-not-exist")), undefined);
+  });
+
+  it("returns undefined for non-numeric content", () => {
+    assert.equal(readPeakRssMb(memFileWith("c", "no digits here")), undefined);
+  });
+});

--- a/scripts/benchmark/helpers/memory.test.ts
+++ b/scripts/benchmark/helpers/memory.test.ts
@@ -75,11 +75,11 @@ describe("readPeakRssMb", () => {
     assert.equal(readPeakRssMb(p), 512);
   });
 
-  it("returns undefined for a missing file", () => {
-    assert.equal(readPeakRssMb(path.join(tmp, "does-not-exist")), undefined);
+  it("throws for a missing file", () => {
+    assert.throws(() => readPeakRssMb(path.join(tmp, "does-not-exist")));
   });
 
-  it("returns undefined for non-numeric content", () => {
-    assert.equal(readPeakRssMb(memFileWith("c", "no digits here")), undefined);
+  it("throws for non-numeric content", () => {
+    assert.throws(() => readPeakRssMb(memFileWith("c", "no digits here")));
   });
 });

--- a/scripts/benchmark/helpers/memory.ts
+++ b/scripts/benchmark/helpers/memory.ts
@@ -52,19 +52,26 @@ export function formatTimeCommand(
 
 /**
  * Read the peak RSS (rounded to MB) that {@link wrapWithTime} wrote to
- * `memFile`. Returns `undefined` when the file is missing or unparseable (e.g.
- * GNU time was unavailable so nothing ran, or the command crashed before time
- * could write). GNU time may append a "Command exited with non-zero status"
- * line, so we take the first integer — the `%M` value, in KB.
+ * `memFile` via GNU time's `%M` value (in KB). GNU time may append a "Command
+ * exited with non-zero status" line, so we take the first integer.
+ *
+ * Throws when the file is missing or holds no parseable number. Only call
+ * this for a file GNU time was actually asked to write: guard with
+ * {@link gnuTimeAvailable} first, since an unavailable GNU time runs the command
+ * unwrapped and writes nothing.
  */
-export function readPeakRssMb(memFile: string): number | undefined {
+export function readPeakRssMb(memFile: string): number {
   if (!existsSync(memFile)) {
-    return undefined;
+    throw new Error(`Peak RSS memory file not found: ${memFile}`);
   }
 
   const match = readFileSync(memFile, "utf-8").match(/\d+/);
 
-  return match === null ? undefined : Math.round(parseInt(match[0], 10) / 1024);
+  if (match === null) {
+    throw new Error(`No peak RSS value found in memory file: ${memFile}`);
+  }
+
+  return Math.round(parseInt(match[0], 10) / 1024);
 }
 
 function shellQuote(value: string): string {

--- a/scripts/benchmark/helpers/memory.ts
+++ b/scripts/benchmark/helpers/memory.ts
@@ -1,10 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 
 // GNU time (the `time` apt package). We use it to capture peak RSS cheaply:
-// wait4() returns RUSAGE_BOTH (the process plus every child it reaped), so
-// wrapping a command records the peak RSS of its whole synchronous subtree —
-// the largest single process, not the concurrent sum. Negligible runtime
-// overhead (one fork+exec), unlike a sampling memory profiler.
+// it reports the maximum resident set size used by the wrapped command (in KB).
+// Negligible runtime overhead (one fork+exec), unlike a sampling memory profiler.
 const GNU_TIME = "/usr/bin/time";
 
 let cachedAvailable: boolean | undefined;

--- a/scripts/benchmark/helpers/memory.ts
+++ b/scripts/benchmark/helpers/memory.ts
@@ -1,0 +1,74 @@
+import { existsSync, readFileSync } from "node:fs";
+
+// GNU time (the `time` apt package). We use it to capture peak RSS cheaply:
+// wait4() returns RUSAGE_BOTH (the process plus every child it reaped), so
+// wrapping a command records the peak RSS of its whole synchronous subtree —
+// the largest single process, not the concurrent sum. Negligible runtime
+// overhead (one fork+exec), unlike a sampling memory profiler.
+const GNU_TIME = "/usr/bin/time";
+
+let cachedAvailable: boolean | undefined;
+
+// Whether GNU time is installed. Memory measurement is best-effort: when it is
+// absent (e.g. a dev machine without the `time` package) callers fall back to
+// running unwrapped and reporting no memory, rather than failing the benchmark.
+export function gnuTimeAvailable(): boolean {
+  if (cachedAvailable === undefined) {
+    cachedAvailable = existsSync(GNU_TIME);
+  }
+
+  return cachedAvailable;
+}
+
+/**
+ * Wrap a shell command so GNU time writes its peak RSS (in KB) to `memFile`.
+ * Returns the command unchanged when GNU time is unavailable.
+ *
+ * Set `wrapInShell` when `command` contains shell operators (`&&`, `>>`, `|`):
+ * it is then run under `sh -c` so the measurement covers the whole command, not
+ * just its first program. A lone program (e.g. a `hyperfine …` invocation)
+ * needs no inner shell.
+ */
+export function wrapWithTime(
+  command: string,
+  memFile: string,
+  wrapInShell: boolean,
+): string {
+  if (!gnuTimeAvailable()) {
+    return command;
+  }
+
+  return formatTimeCommand(command, memFile, wrapInShell);
+}
+
+// The pure wrapping (no availability check), split out for testing.
+export function formatTimeCommand(
+  command: string,
+  memFile: string,
+  wrapInShell: boolean,
+): string {
+  const inner = wrapInShell ? `sh -c ${shellQuote(command)}` : command;
+
+  return `${GNU_TIME} -o ${shellQuote(memFile)} -f %M ${inner}`;
+}
+
+/**
+ * Read the peak RSS (rounded to MB) that {@link wrapWithTime} wrote to
+ * `memFile`. Returns `undefined` when the file is missing or unparseable (e.g.
+ * GNU time was unavailable so nothing ran, or the command crashed before time
+ * could write). GNU time may append a "Command exited with non-zero status"
+ * line, so we take the first integer — the `%M` value, in KB.
+ */
+export function readPeakRssMb(memFile: string): number | undefined {
+  if (!existsSync(memFile)) {
+    return undefined;
+  }
+
+  const match = readFileSync(memFile, "utf-8").match(/\d+/);
+
+  return match === null ? undefined : Math.round(parseInt(match[0], 10) / 1024);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/scripts/benchmark/helpers/plan.test.ts
+++ b/scripts/benchmark/helpers/plan.test.ts
@@ -43,14 +43,15 @@ function fixture(): Record<string, CommandConfig> {
   };
 }
 
-// Compact view: what each planned command runs and reports.
+// Compact view: what each planned command runs and reports. Step sequences
+// carry `run` (ordered steps to execute) and an `emit` list of reported steps;
+// single commands carry only a boolean `emit`.
 function summarize(plan: ReturnType<typeof planCommands>) {
-  return plan.map((p) => ({
-    name: p.name,
-    runStepNames: p.runStepNames,
-    emit: p.emit,
-    emitSteps: p.emitSteps,
-  }));
+  return plan.map((p) =>
+    "run" in p
+      ? { name: p.name, run: p.run, emit: p.emit }
+      : { name: p.name, emit: p.emit },
+  );
 }
 
 describe("globToRegExp", () => {
@@ -81,26 +82,16 @@ describe("planCommands", () => {
     assert.deepEqual(plan, [
       {
         name: "compile sequence",
-        runStepNames: [
-          "reset files & cache",
-          "cold compile",
-          "edit min",
-          "edit max",
-        ],
-        emit: false,
-        emitSteps: ["cold compile", "edit min", "edit max"],
+        run: ["reset files & cache", "cold compile", "edit min", "edit max"],
+        emit: ["cold compile", "edit min", "edit max"],
       },
       {
         name: "warm compile",
-        runStepNames: undefined,
         emit: true,
-        emitSteps: [],
       },
       {
         name: "test solidity",
-        runStepNames: undefined,
         emit: true,
-        emitSteps: [],
       },
     ]);
   });
@@ -111,15 +102,12 @@ describe("planCommands", () => {
       {
         name: "compile sequence",
         // reset + cold compile pulled in via dependsOn; edit steps skipped.
-        runStepNames: ["reset files & cache", "cold compile"],
-        emit: false,
-        emitSteps: [], // prerequisites only — not reported
+        run: ["reset files & cache", "cold compile"],
+        emit: [], // prerequisites only — not reported
       },
       {
         name: "test solidity",
-        runStepNames: undefined,
         emit: true,
-        emitSteps: [],
       },
     ]);
   });
@@ -129,15 +117,12 @@ describe("planCommands", () => {
     assert.deepEqual(plan, [
       {
         name: "compile sequence",
-        runStepNames: ["reset files & cache", "cold compile"],
-        emit: false,
-        emitSteps: [],
+        run: ["reset files & cache", "cold compile"],
+        emit: [],
       },
       {
         name: "warm compile",
-        runStepNames: undefined,
         emit: true,
-        emitSteps: [],
       },
       // "test solidity" is neither selected nor a prerequisite → dropped.
     ]);
@@ -148,9 +133,8 @@ describe("planCommands", () => {
     assert.deepEqual(plan, [
       {
         name: "compile sequence",
-        runStepNames: ["reset files & cache", "cold compile"],
-        emit: false,
-        emitSteps: ["cold compile"],
+        run: ["reset files & cache", "cold compile"],
+        emit: ["cold compile"],
       },
     ]);
   });
@@ -164,15 +148,12 @@ describe("planCommands", () => {
     assert.deepEqual(plan, [
       {
         name: "compile sequence",
-        runStepNames: ["reset files & cache", "cold compile"],
-        emit: false,
-        emitSteps: ["cold compile"],
+        run: ["reset files & cache", "cold compile"],
+        emit: ["cold compile"],
       },
       {
         name: "test solidity",
-        runStepNames: undefined,
         emit: true,
-        emitSteps: [],
       },
     ]);
   });
@@ -181,7 +162,7 @@ describe("planCommands", () => {
     const plan = summarize(planCommands(fixture(), ["*compile*"]));
     // "cold compile" (a step) and "warm compile" (a command) match; the
     // "edit min"/"edit max" steps and "test solidity" do not.
-    assert.deepEqual(plan[0].emitSteps, ["cold compile"]);
+    assert.deepEqual(plan[0].emit, ["cold compile"]);
     assert.equal(plan.find((p) => p.name === "warm compile")?.emit, true);
     assert.equal(
       plan.find((p) => p.name === "test solidity"),
@@ -195,9 +176,8 @@ describe("planCommands", () => {
       {
         name: "compile sequence",
         // edit max dependsOn cold compile (not edit min) → edit min is skipped.
-        runStepNames: ["reset files & cache", "cold compile", "edit max"],
-        emit: false,
-        emitSteps: ["edit max"],
+        run: ["reset files & cache", "cold compile", "edit max"],
+        emit: ["edit max"],
       },
     ]);
   });
@@ -225,9 +205,7 @@ describe("planCommands", () => {
       // "compile sequence" is entirely skipped — nothing selected depends on it.
       {
         name: "test solidity",
-        runStepNames: undefined,
         emit: true,
-        emitSteps: [],
       },
     ]);
   });

--- a/scripts/benchmark/helpers/plan.test.ts
+++ b/scripts/benchmark/helpers/plan.test.ts
@@ -1,0 +1,247 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { globToRegExp, parseGlobList, planCommands } from "./plan.ts";
+import type { CommandConfig } from "../../end-to-end/types.ts";
+
+// Mirrors the real uniswap-v4-core shape with dependsOn wired the way the
+// scenarios are annotated: a compile sequence, then warm compile and test
+// solidity that only need a cold compile (not the edit&compile steps).
+function fixture(): Record<string, CommandConfig> {
+  return {
+    "compile sequence": {
+      runs: 2,
+      steps: {
+        "reset files & cache": {
+          command: "git checkout . && clean",
+          measure: false,
+        },
+        "cold compile": {
+          command: "compile",
+          dependsOn: ["reset files & cache"],
+        },
+        "edit min": {
+          command: "edit a && compile",
+          dependsOn: ["cold compile"],
+        },
+        "edit max": {
+          command: "edit b && compile",
+          dependsOn: ["cold compile"],
+        },
+      },
+    },
+    "warm compile": {
+      runs: 3,
+      command: "compile",
+      dependsOn: ["cold compile"],
+    },
+    "test solidity": {
+      runs: 3,
+      command: "test --no-compile",
+      dependsOn: ["cold compile"],
+    },
+  };
+}
+
+// Compact view: what each planned command runs and reports.
+function summarize(plan: ReturnType<typeof planCommands>) {
+  return plan.map((p) => ({
+    name: p.name,
+    runStepNames: p.runStepNames,
+    emit: p.emit,
+    emitSteps: p.emitSteps,
+  }));
+}
+
+describe("globToRegExp", () => {
+  it("matches literally and supports * and ?", () => {
+    assert.ok(globToRegExp("cold compile").test("cold compile"));
+    assert.ok(!globToRegExp("cold compile").test("warm compile"));
+    assert.ok(globToRegExp("*compile*").test("edit & compile min deps"));
+    assert.ok(globToRegExp("test *").test("test solidity"));
+    assert.ok(globToRegExp("co?d compile").test("cold compile"));
+  });
+
+  it("is anchored (no partial matches)", () => {
+    assert.ok(!globToRegExp("compile").test("warm compile"));
+  });
+});
+
+describe("parseGlobList", () => {
+  it("returns undefined when absent; splits + trims otherwise", () => {
+    assert.equal(parseGlobList(undefined), undefined);
+    assert.deepEqual(parseGlobList("a-*, b-* ,c"), ["a-*", "b-*", "c"]);
+    assert.equal(parseGlobList(" , "), undefined);
+  });
+});
+
+describe("planCommands", () => {
+  it("no filter → runs and reports everything, in order", () => {
+    const plan = summarize(planCommands(fixture(), undefined));
+    assert.deepEqual(plan, [
+      {
+        name: "compile sequence",
+        runStepNames: [
+          "reset files & cache",
+          "cold compile",
+          "edit min",
+          "edit max",
+        ],
+        emit: false,
+        emitSteps: ["cold compile", "edit min", "edit max"],
+      },
+      {
+        name: "warm compile",
+        runStepNames: undefined,
+        emit: true,
+        emitSteps: [],
+      },
+      {
+        name: "test solidity",
+        runStepNames: undefined,
+        emit: true,
+        emitSteps: [],
+      },
+    ]);
+  });
+
+  it("'test solidity' (a single command) → runs only cold compile (+reset) then test solidity", () => {
+    const plan = summarize(planCommands(fixture(), ["test solidity"]));
+    assert.deepEqual(plan, [
+      {
+        name: "compile sequence",
+        // reset + cold compile pulled in via dependsOn; edit steps skipped.
+        runStepNames: ["reset files & cache", "cold compile"],
+        emit: false,
+        emitSteps: [], // prerequisites only — not reported
+      },
+      {
+        name: "test solidity",
+        runStepNames: undefined,
+        emit: true,
+        emitSteps: [],
+      },
+    ]);
+  });
+
+  it("'warm compile' → skips the edit steps and test solidity", () => {
+    const plan = summarize(planCommands(fixture(), ["warm compile"]));
+    assert.deepEqual(plan, [
+      {
+        name: "compile sequence",
+        runStepNames: ["reset files & cache", "cold compile"],
+        emit: false,
+        emitSteps: [],
+      },
+      {
+        name: "warm compile",
+        runStepNames: undefined,
+        emit: true,
+        emitSteps: [],
+      },
+      // "test solidity" is neither selected nor a prerequisite → dropped.
+    ]);
+  });
+
+  it("'cold compile' (a step) → runs reset + cold compile, reports cold compile", () => {
+    const plan = summarize(planCommands(fixture(), ["cold compile"]));
+    assert.deepEqual(plan, [
+      {
+        name: "compile sequence",
+        runStepNames: ["reset files & cache", "cold compile"],
+        emit: false,
+        emitSteps: ["cold compile"],
+      },
+    ]);
+  });
+
+  it("one filter matches commands and steps alike (no level distinction)", () => {
+    // "test solidity" is a single command; "cold compile" is a step — both are
+    // selected by the same flag and reported.
+    const plan = summarize(
+      planCommands(fixture(), ["cold compile", "test solidity"]),
+    );
+    assert.deepEqual(plan, [
+      {
+        name: "compile sequence",
+        runStepNames: ["reset files & cache", "cold compile"],
+        emit: false,
+        emitSteps: ["cold compile"],
+      },
+      {
+        name: "test solidity",
+        runStepNames: undefined,
+        emit: true,
+        emitSteps: [],
+      },
+    ]);
+  });
+
+  it("glob '*compile*' selects compile-named entries across levels", () => {
+    const plan = summarize(planCommands(fixture(), ["*compile*"]));
+    // "cold compile" (a step) and "warm compile" (a command) match; the
+    // "edit min"/"edit max" steps and "test solidity" do not.
+    assert.deepEqual(plan[0].emitSteps, ["cold compile"]);
+    assert.equal(plan.find((p) => p.name === "warm compile")?.emit, true);
+    assert.equal(
+      plan.find((p) => p.name === "test solidity"),
+      undefined,
+    );
+  });
+
+  it("'edit max' → pulls in its prereqs but skips the unrelated 'edit min'", () => {
+    const plan = summarize(planCommands(fixture(), ["edit max"]));
+    assert.deepEqual(plan, [
+      {
+        name: "compile sequence",
+        // edit max dependsOn cold compile (not edit min) → edit min is skipped.
+        runStepNames: ["reset files & cache", "cold compile", "edit max"],
+        emit: false,
+        emitSteps: ["edit max"],
+      },
+    ]);
+  });
+
+  it("no matches → empty plan (scenario skipped)", () => {
+    assert.deepEqual(planCommands(fixture(), ["nope-*"]), []);
+    // A measure:false step can never be selected on its own.
+    assert.deepEqual(planCommands(fixture(), ["reset files & cache"]), []);
+  });
+
+  it("falls back to all-preceding entries when an entry declares no dependsOn", () => {
+    const commands: Record<string, CommandConfig> = {
+      "compile sequence": {
+        runs: 1,
+        steps: {
+          reset: { command: "reset", measure: false },
+          cold: { command: "compile" }, // no dependsOn
+        },
+      },
+      // No dependsOn → conservatively runs everything before it.
+      "test solidity": { runs: 1, command: "test --no-compile" },
+    };
+    const plan = summarize(planCommands(commands, ["test solidity"]));
+    assert.deepEqual(plan, [
+      {
+        name: "compile sequence",
+        runStepNames: ["reset", "cold"], // all preceding steps run
+        emit: false,
+        emitSteps: [],
+      },
+      {
+        name: "test solidity",
+        runStepNames: undefined,
+        emit: true,
+        emitSteps: [],
+      },
+    ]);
+  });
+
+  it("throws on a dependsOn that names a nonexistent entry", () => {
+    const commands: Record<string, CommandConfig> = {
+      a: { runs: 1, command: "x" },
+      b: { runs: 1, command: "y", dependsOn: ["ghost"] },
+    };
+    assert.throws(() => planCommands(commands, ["b"]), /dependsOn "ghost"/);
+  });
+});

--- a/scripts/benchmark/helpers/plan.test.ts
+++ b/scripts/benchmark/helpers/plan.test.ts
@@ -208,7 +208,7 @@ describe("planCommands", () => {
     assert.deepEqual(planCommands(fixture(), ["reset files & cache"]), []);
   });
 
-  it("falls back to all-preceding entries when an entry declares no dependsOn", () => {
+  it("runs an entry with no dependsOn in isolation — no implicit prerequisites", () => {
     const commands: Record<string, CommandConfig> = {
       "compile sequence": {
         runs: 1,
@@ -217,17 +217,12 @@ describe("planCommands", () => {
           cold: { command: "compile" }, // no dependsOn
         },
       },
-      // No dependsOn → conservatively runs everything before it.
+      // No dependsOn → runs alone; the preceding sequence is NOT pulled in.
       "test solidity": { runs: 1, command: "test --no-compile" },
     };
     const plan = summarize(planCommands(commands, ["test solidity"]));
     assert.deepEqual(plan, [
-      {
-        name: "compile sequence",
-        runStepNames: ["reset", "cold"], // all preceding steps run
-        emit: false,
-        emitSteps: [],
-      },
+      // "compile sequence" is entirely skipped — nothing selected depends on it.
       {
         name: "test solidity",
         runStepNames: undefined,
@@ -243,5 +238,27 @@ describe("planCommands", () => {
       b: { runs: 1, command: "y", dependsOn: ["ghost"] },
     };
     assert.throws(() => planCommands(commands, ["b"]), /dependsOn "ghost"/);
+  });
+
+  it("throws when a dependency is declared after the dependent entry", () => {
+    const commands: Record<string, CommandConfig> = {
+      // "a" depends on "b", but "b" is declared later — invalid ordering.
+      a: { runs: 1, command: "x", dependsOn: ["b"] },
+      b: { runs: 1, command: "y" },
+    };
+    assert.throws(
+      () => planCommands(commands, ["a"]),
+      /must be declared before the dependent entry/,
+    );
+  });
+
+  it("throws on a self-dependency", () => {
+    const commands: Record<string, CommandConfig> = {
+      a: { runs: 1, command: "x", dependsOn: ["a"] },
+    };
+    assert.throws(
+      () => planCommands(commands, ["a"]),
+      /must be declared before the dependent entry/,
+    );
   });
 });

--- a/scripts/benchmark/helpers/plan.test.ts
+++ b/scripts/benchmark/helpers/plan.test.ts
@@ -163,7 +163,7 @@ describe("planCommands", () => {
     // "cold compile" (a step) and "warm compile" (a command) match; the
     // "edit min"/"edit max" steps and "test solidity" do not.
     assert.deepEqual(plan[0].emit, ["cold compile"]);
-    assert.equal(plan.find((p) => p.name === "warm compile")?.emit, true);
+    assert.equal(plan.find((p) => p.name === "warm compile")!.emit, true);
     assert.equal(
       plan.find((p) => p.name === "test solidity"),
       undefined,

--- a/scripts/benchmark/helpers/plan.test.ts
+++ b/scripts/benchmark/helpers/plan.test.ts
@@ -189,7 +189,7 @@ describe("planCommands", () => {
     );
   });
 
-  it("'edit max' → pulls in its prereqs but skips the unrelated 'edit min'", () => {
+  it("'edit max' → pulls in its prerequisites but skips the unrelated 'edit min'", () => {
     const plan = summarize(planCommands(fixture(), ["edit max"]));
     assert.deepEqual(plan, [
       {

--- a/scripts/benchmark/helpers/plan.ts
+++ b/scripts/benchmark/helpers/plan.ts
@@ -1,19 +1,36 @@
-import type { CommandConfig } from "../../end-to-end/types.ts";
+import type {
+  CommandConfig,
+  CommandVariant,
+  StepsVariant,
+} from "../../end-to-end/types.ts";
 
 /**
- * One command to execute as part of a run plan (see {@link planCommands}).
- * For step sequences, `runStepNames` lists the steps to execute in order (a
- * subset — selected steps plus their prerequisites) and `emitSteps` the measured
- * steps to report; steps run but not in `emitSteps` are prerequisites only. For
- * single commands, `emit` says whether to report it (it may run purely as a
- * prerequisite of a later command).
+ * One command to execute as part of a run plan (see {@link planCommands}),
+ * either a single command ({@link CommandData}) or a step sequence
+ * ({@link StepData}).
  */
-export interface PlannedCommand {
+export type PlannedCommand = CommandData | StepData;
+
+/**
+ * A single command benchmarked with hyperfine. `emit` says whether to report it
+ * (it may run purely as a prerequisite of a later command).
+ */
+export interface CommandData {
   name: string;
-  cfg: CommandConfig;
-  runStepNames: string[] | undefined;
+  cfg: CommandVariant;
   emit: boolean;
-  emitSteps: string[];
+}
+
+/**
+ * A step sequence run in-process. `run` lists the steps to execute in order (a
+ * subset — selected steps plus their prerequisites); `emit` lists the measured
+ * steps to report. Steps in `run` but not in `emit` are prerequisites only.
+ */
+export interface StepData {
+  name: string;
+  cfg: StepsVariant;
+  run: string[];
+  emit: string[];
 }
 
 // Convert a glob (supporting `*` and `?`) to an anchored RegExp. Every other
@@ -190,29 +207,17 @@ export function planCommands(
   for (const [cmdName, cfg] of Object.entries(commands)) {
     if ("steps" in cfg) {
       const stepNames = Object.keys(cfg.steps);
-      const runStepNames = stepNames.filter((n) => runSet.has(n));
-      if (runStepNames.length === 0) {
+      const run = stepNames.filter((n) => runSet.has(n));
+      if (run.length === 0) {
         continue;
       }
-      const emitSteps = stepNames.filter((n) => selected.has(n));
-      plan.push({
-        name: cmdName,
-        cfg,
-        runStepNames,
-        emit: false,
-        emitSteps,
-      });
+      const emit = stepNames.filter((n) => selected.has(n));
+      plan.push({ name: cmdName, cfg, run, emit });
     } else {
       if (!runSet.has(cmdName)) {
         continue;
       }
-      plan.push({
-        name: cmdName,
-        cfg,
-        runStepNames: undefined,
-        emit: selected.has(cmdName),
-        emitSteps: [],
-      });
+      plan.push({ name: cmdName, cfg, emit: selected.has(cmdName) });
     }
   }
 

--- a/scripts/benchmark/helpers/plan.ts
+++ b/scripts/benchmark/helpers/plan.ts
@@ -115,17 +115,18 @@ function flattenEntries(commands: Record<string, CommandConfig>): Entry[] {
  * measured step's name. The step-sequence container name is not itself an entry.
  *
  * Prerequisites (what must also *run*, unreported): commands/steps are a
- * stateful pipeline. For each selected entry we add the entries it needs:
- *   - if it declares `dependsOn`, the transitive closure of those declared
- *     entries only (minimal — skips unrelated work);
- *   - otherwise, conservatively, every entry declared before it (so unannotated
- *     scenarios still measure correctly, just without skipping anything).
+ * stateful pipeline, so each selected entry pulls in the transitive closure of
+ * its declared `dependsOn` entries (they run but are only reported if also
+ * selected). There are no implicit prerequisites: an entry with no `dependsOn`
+ * runs in isolation. Declaring what an entry depends on is the scenario author's
+ * responsibility.
  *
  * Entries run in declared order; only entries in the resulting run set run, and
  * only selected entries are reported. Returns `[]` when nothing is selected
  * (the scenario is skipped before any expensive init).
  *
- * Throws if a `dependsOn` names an entry that doesn't exist in this scenario.
+ * Throws if a `dependsOn` names a nonexistent entry, or one declared after the
+ * dependent (dependencies must precede their dependents).
  */
 export function planCommands(
   commands: Record<string, CommandConfig>,
@@ -138,9 +139,15 @@ export function planCommands(
 
   for (const e of entries) {
     for (const dep of e.dependsOn ?? []) {
-      if (!byName.has(dep)) {
+      const depEntry = byName.get(dep);
+      if (depEntry === undefined) {
         throw new Error(
           `Entry "${e.name}" dependsOn "${dep}", which is not a command or step in this scenario`,
+        );
+      }
+      if (depEntry.index >= e.index) {
+        throw new Error(
+          `Entry "${e.name}" dependsOn "${dep}", but dependencies must be declared before the dependent entry`,
         );
       }
     }
@@ -157,8 +164,9 @@ export function planCommands(
     return [];
   }
 
-  // Grow the run set from the selection: declared deps (transitive) when an
-  // entry declares them, else every preceding entry.
+  // Grow the run set from the selection: each selected entry plus the
+  // transitive closure of its declared dependencies. There are no implicit
+  // prerequisites — an entry with no `dependsOn` runs in isolation.
   const runSet = new Set<string>();
 
   const addDeclared = (name: string): void => {
@@ -172,18 +180,8 @@ export function planCommands(
   };
 
   for (const e of entries) {
-    if (!selected.has(e.name)) {
-      continue;
-    }
-    if (e.dependsOn !== undefined) {
+    if (selected.has(e.name)) {
       addDeclared(e.name);
-    } else {
-      runSet.add(e.name);
-      for (const other of entries) {
-        if (other.index < e.index) {
-          runSet.add(other.name);
-        }
-      }
     }
   }
 

--- a/scripts/benchmark/helpers/plan.ts
+++ b/scripts/benchmark/helpers/plan.ts
@@ -144,6 +144,8 @@ function flattenEntries(commands: Record<string, CommandConfig>): Entry[] {
  *
  * Throws if a `dependsOn` names a nonexistent entry, or one declared after the
  * dependent (dependencies must precede their dependents).
+ *
+ * This also prevents cyclic dependencies.
  */
 export function planCommands(
   commands: Record<string, CommandConfig>,

--- a/scripts/benchmark/helpers/plan.ts
+++ b/scripts/benchmark/helpers/plan.ts
@@ -1,0 +1,222 @@
+import type { CommandConfig } from "../../end-to-end/types.ts";
+
+/**
+ * One command to execute as part of a run plan (see {@link planCommands}).
+ * For step sequences, `runStepNames` lists the steps to execute in order (a
+ * subset — selected steps plus their prerequisites) and `emitSteps` the measured
+ * steps to report; steps run but not in `emitSteps` are prerequisites only. For
+ * single commands, `emit` says whether to report it (it may run purely as a
+ * prerequisite of a later command).
+ */
+export interface PlannedCommand {
+  name: string;
+  cfg: CommandConfig;
+  runStepNames: string[] | undefined;
+  emit: boolean;
+  emitSteps: string[];
+}
+
+// Convert a glob (supporting `*` and `?`) to an anchored RegExp. Every other
+// character is matched literally, so command/step names with spaces, `&`, `:`,
+// `/`, `.` etc. work as-is.
+export function globToRegExp(glob: string): RegExp {
+  let source = "";
+
+  for (const ch of glob) {
+    if (ch === "*") {
+      source += ".*";
+    } else if (ch === "?") {
+      source += ".";
+    } else {
+      source += ch.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+
+  return new RegExp(`^${source}$`);
+}
+
+// `undefined` filters mean "no filter" and match everything.
+export function compilePatterns(
+  patterns: string[] | undefined,
+): RegExp[] | undefined {
+  return patterns?.map(globToRegExp);
+}
+
+export function matchesAny(
+  name: string,
+  patterns: RegExp[] | undefined,
+): boolean {
+  return patterns === undefined || patterns.some((re) => re.test(name));
+}
+
+export function parseGlobList(raw: string | undefined): string[] | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const list = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  return list.length > 0 ? list : undefined;
+}
+
+/**
+ * A benchmark entry, flattened across commands in declared order. A single
+ * command is one entry (`command` name); a step sequence contributes one entry
+ * per step (`step` name), tagged with its owning command (`owner`).
+ */
+interface Entry {
+  name: string;
+  index: number;
+  kind: "single" | "step";
+  owner: string;
+  measure: boolean;
+  dependsOn: string[] | undefined;
+}
+
+function flattenEntries(commands: Record<string, CommandConfig>): Entry[] {
+  const entries: Entry[] = [];
+
+  for (const [cmdName, cfg] of Object.entries(commands)) {
+    if ("steps" in cfg) {
+      for (const [stepName, step] of Object.entries(cfg.steps)) {
+        entries.push({
+          name: stepName,
+          index: entries.length,
+          kind: "step",
+          owner: cmdName,
+          measure: step.measure !== false,
+          dependsOn: step.dependsOn,
+        });
+      }
+    } else {
+      entries.push({
+        name: cmdName,
+        index: entries.length,
+        kind: "single",
+        owner: cmdName,
+        measure: true,
+        dependsOn: cfg.dependsOn,
+      });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Build the run plan for one scenario's commands under `--benchmarks`.
+ *
+ * Selection (which entries the user asked to *report*): an entry is selected
+ * when it is measured and its name matches `--benchmarks` (unset matches all).
+ * "Name" is the report label's second segment — a single command's name, or a
+ * measured step's name. The step-sequence container name is not itself an entry.
+ *
+ * Prerequisites (what must also *run*, unreported): commands/steps are a
+ * stateful pipeline. For each selected entry we add the entries it needs:
+ *   - if it declares `dependsOn`, the transitive closure of those declared
+ *     entries only (minimal — skips unrelated work);
+ *   - otherwise, conservatively, every entry declared before it (so unannotated
+ *     scenarios still measure correctly, just without skipping anything).
+ *
+ * Entries run in declared order; only entries in the resulting run set run, and
+ * only selected entries are reported. Returns `[]` when nothing is selected
+ * (the scenario is skipped before any expensive init).
+ *
+ * Throws if a `dependsOn` names an entry that doesn't exist in this scenario.
+ */
+export function planCommands(
+  commands: Record<string, CommandConfig>,
+  benchmarkFilters: string[] | undefined,
+): PlannedCommand[] {
+  const res = compilePatterns(benchmarkFilters);
+
+  const entries = flattenEntries(commands);
+  const byName = new Map(entries.map((e) => [e.name, e]));
+
+  for (const e of entries) {
+    for (const dep of e.dependsOn ?? []) {
+      if (!byName.has(dep)) {
+        throw new Error(
+          `Entry "${e.name}" dependsOn "${dep}", which is not a command or step in this scenario`,
+        );
+      }
+    }
+  }
+
+  // A single command's name, or a measured step's name, matched against the
+  // filter. measure:false steps (setup/reset) are never selected on their own.
+  const isSelected = (e: Entry): boolean =>
+    e.measure && matchesAny(e.name, res);
+
+  const selected = new Set(entries.filter(isSelected).map((e) => e.name));
+
+  if (selected.size === 0) {
+    return [];
+  }
+
+  // Grow the run set from the selection: declared deps (transitive) when an
+  // entry declares them, else every preceding entry.
+  const runSet = new Set<string>();
+
+  const addDeclared = (name: string): void => {
+    if (runSet.has(name)) {
+      return;
+    }
+    runSet.add(name);
+    for (const dep of byName.get(name)?.dependsOn ?? []) {
+      addDeclared(dep);
+    }
+  };
+
+  for (const e of entries) {
+    if (!selected.has(e.name)) {
+      continue;
+    }
+    if (e.dependsOn !== undefined) {
+      addDeclared(e.name);
+    } else {
+      runSet.add(e.name);
+      for (const other of entries) {
+        if (other.index < e.index) {
+          runSet.add(other.name);
+        }
+      }
+    }
+  }
+
+  const plan: PlannedCommand[] = [];
+
+  for (const [cmdName, cfg] of Object.entries(commands)) {
+    if ("steps" in cfg) {
+      const stepNames = Object.keys(cfg.steps);
+      const runStepNames = stepNames.filter((n) => runSet.has(n));
+      if (runStepNames.length === 0) {
+        continue;
+      }
+      const emitSteps = stepNames.filter((n) => selected.has(n));
+      plan.push({
+        name: cmdName,
+        cfg,
+        runStepNames,
+        emit: false,
+        emitSteps,
+      });
+    } else {
+      if (!runSet.has(cmdName)) {
+        continue;
+      }
+      plan.push({
+        name: cmdName,
+        cfg,
+        runStepNames: undefined,
+        emit: selected.has(cmdName),
+        emitSteps: [],
+      });
+    }
+  }
+
+  return plan;
+}

--- a/scripts/benchmark/main.ts
+++ b/scripts/benchmark/main.ts
@@ -3,6 +3,7 @@ import { exec as e2eExec } from "../end-to-end/subcommands/exec.ts";
 import { loadScenario } from "../end-to-end/helpers/directory.ts";
 import { resolveAndValidateArgs, type BenchArgs } from "./helpers/args.ts";
 import { fmt, log, logStep, logError, logWarning } from "./helpers/log.ts";
+import { wrapWithTime } from "./helpers/memory.ts";
 
 const USAGE = `
 scripts/benchmark/main.ts — Benchmark Hardhat scenarios with hyperfine
@@ -66,6 +67,7 @@ export async function runBenchmark(benchArgs: BenchArgs): Promise<void> {
     showOutput,
     warmup,
     exportJson,
+    memFile,
     e2eCloneDirectory,
   } = benchArgs;
 
@@ -116,10 +118,18 @@ export async function runBenchmark(benchArgs: BenchArgs): Promise<void> {
   log(`Benchmarking: ${fmt.pkg(benchCommand)}`);
   log(`Warmup: ${warmup}, Runs: ${runs}`);
 
+  // Wrap the whole hyperfine run in GNU time to capture peak RSS across all
+  // runs (hyperfine reaps each run, so wait4's RUSAGE_BOTH folds them up). This
+  // doesn't perturb hyperfine's own per-run timing.
+  const commandToRun =
+    memFile !== undefined
+      ? wrapWithTime(hyperfineCommand, memFile, false)
+      : hyperfineCommand;
+
   await e2eExec(
     e2eCloneDirectory,
     scenarioPath,
-    hyperfineCommand,
+    commandToRun,
     useLocal,
     forceCheckout,
     forcePublish,

--- a/scripts/benchmark/main.ts
+++ b/scripts/benchmark/main.ts
@@ -119,8 +119,7 @@ export async function runBenchmark(benchArgs: BenchArgs): Promise<void> {
   log(`Warmup: ${warmup}, Runs: ${runs}`);
 
   // Wrap the whole hyperfine run in GNU time to capture peak RSS across all
-  // runs (hyperfine reaps each run, so wait4's RUSAGE_BOTH folds them up). This
-  // doesn't perturb hyperfine's own per-run timing.
+  // runs. This doesn't perturb hyperfine's own per-run timing.
   const commandToRun =
     memFile !== undefined
       ? wrapWithTime(hyperfineCommand, memFile, false)

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -492,7 +492,9 @@ async function runScenario(
           scenario.id,
           planned.name,
           readHyperfineResult(exportPath),
-          memFile !== undefined ? readPeakRssMb(memFile) : undefined,
+          memFile !== undefined && gnuTimeAvailable()
+            ? readPeakRssMb(memFile)
+            : undefined,
         ),
       );
     }
@@ -585,11 +587,9 @@ function runStepsPhase(
       const elapsed = (performance.now() - start) / 1000;
       samples.get(stepName)?.push(elapsed);
 
-      if (emit.has(stepName)) {
+      if (emit.has(stepName) && gnuTimeAvailable()) {
         const rss = readPeakRssMb(memFile(stepName));
-        if (rss !== undefined) {
-          peakRssMb.set(stepName, Math.max(peakRssMb.get(stepName) ?? 0, rss));
-        }
+        peakRssMb.set(stepName, Math.max(peakRssMb.get(stepName) ?? 0, rss));
       }
     }
   }

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -446,7 +446,7 @@ async function runScenario(
   const entries: BenchmarkEntry[] = [];
 
   for (const planned of plan) {
-    if ("steps" in planned.cfg) {
+    if ("run" in planned) {
       entries.push(
         ...runStepsPhase(
           scenario.id,
@@ -454,9 +454,8 @@ async function runScenario(
           loaded.definition.env,
           planned.name,
           planned.cfg,
-          // runStepNames is always defined for step sequences.
-          new Set(planned.runStepNames ?? Object.keys(planned.cfg.steps)),
-          new Set(planned.emitSteps),
+          new Set(planned.run),
+          new Set(planned.emit),
           scenarioTmpDir,
         ),
       );

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -79,7 +79,7 @@ DESCRIPTION
   capture peak RSS (the largest resident set size any process in its subtree
   reached, in MB). This is emitted as a separate "<scenarioId> / <name> (peak
   RSS)" entry (unit MB) and also embedded as "peakRssMb" in the time entry's
-  extra. If GNU time is missing, memory is silently skipped.
+  extra. If GNU time is missing, memory is skipped and a warning is printed.
 
 OPTIONS
   --output <path>       Required. Aggregated JSON destination

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -102,13 +102,13 @@ OPTIONS
   --e2e-clone-dir <p>   Override clone directory (default: same as pnpm e2e)
   --fail-fast           Abort on the first scenario failure
 
-  --benchmarks SELECTS which measured entries you want reported. Because entries
+  --benchmarks selects which measured entries you want reported. Because entries
   run as a stateful pipeline (later ones depend on earlier ones having run — e.g.
   "test solidity" runs with --no-compile and needs a prior compile), selected
   entries are not run in isolation. Each entry may declare "dependsOn" in
   scenario.json listing the entries it needs; when you select an entry, its
   declared prerequisites also run (unreported) and everything else is skipped. An
-  entry with no "dependsOn" conservatively runs every entry declared before it.
+  entry with no "dependsOn" has no prerequisites and runs in isolation.
   Entries run in declared order; only selected entries are reported. So
   --benchmarks "test solidity" runs just (cold compile + test solidity), skipping
   the edit&compile steps and warm compile it doesn't depend on.

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -25,6 +25,11 @@ import {
   parseGlobList,
   planCommands,
 } from "./helpers/plan.ts";
+import {
+  gnuTimeAvailable,
+  readPeakRssMb,
+  wrapWithTime,
+} from "./helpers/memory.ts";
 import { isVerdaccioRunning } from "../verdaccio/helpers/shell.ts";
 import {
   publish as verdaccioPublish,
@@ -69,6 +74,12 @@ DESCRIPTION
   Writes a flat JSON array in benchmark-action/github-action-benchmark's
   customSmallerIsBetter format. Per-run times are preserved in the "extra"
   field as a JSON-stringified object.
+
+  When GNU time (/usr/bin/time) is available, each benchmark is wrapped in it to
+  capture peak RSS (the largest resident set size any process in its subtree
+  reached, in MB). This is emitted as a separate "<scenarioId> / <name> (peak
+  RSS)" entry (unit MB) and also embedded as "peakRssMb" in the time entry's
+  extra. If GNU time is missing, memory is silently skipped.
 
 OPTIONS
   --output <path>       Required. Aggregated JSON destination
@@ -151,6 +162,13 @@ async function main(): Promise<void> {
   if (scenarios.length === 0) {
     logError("No scenarios matched the provided filters");
     process.exit(1);
+  }
+
+  if (!gnuTimeAvailable()) {
+    logWarning(
+      "GNU time (/usr/bin/time) not found — peak RSS will not be measured. " +
+        "Install the `time` package to enable memory measurements.",
+    );
   }
 
   const results: BenchmarkEntry[] = [];
@@ -439,6 +457,7 @@ async function runScenario(
           // runStepNames is always defined for step sequences.
           new Set(planned.runStepNames ?? Object.keys(planned.cfg.steps)),
           new Set(planned.emitSteps),
+          scenarioTmpDir,
         ),
       );
 
@@ -449,6 +468,10 @@ async function runScenario(
       scenarioTmpDir,
       `${slugify(planned.name)}.json`,
     );
+    // Only reported commands need a memory reading; prerequisites run unwrapped.
+    const memFile = planned.emit
+      ? path.join(scenarioTmpDir, `${slugify(planned.name)}.mem`)
+      : undefined;
 
     await runPhase(
       planned.name,
@@ -457,6 +480,7 @@ async function runScenario(
         prepare: planned.cfg.prepare,
         runs: planned.cfg.runs,
         exportJson: exportPath,
+        memFile,
       }),
     );
 
@@ -464,7 +488,12 @@ async function runScenario(
     // later selected command) but are not reported.
     if (planned.emit) {
       entries.push(
-        toEntry(scenario.id, planned.name, readHyperfineResult(exportPath)),
+        ...toEntries(
+          scenario.id,
+          planned.name,
+          readHyperfineResult(exportPath),
+          memFile !== undefined ? readPeakRssMb(memFile) : undefined,
+        ),
       );
     }
   }
@@ -480,6 +509,8 @@ async function runScenario(
  * `runSteps` is the set of step names to execute (selected steps plus their
  * prerequisites); other steps are skipped. `emit` is the subset of those to
  * time and report — steps that run but aren't in `emit` are prerequisites only.
+ * Emitted steps are wrapped in GNU time (into `tmpDir`) to capture peak RSS;
+ * the wrapper's fork+exec is negligible against multi-second compiles.
  */
 function runStepsPhase(
   scenarioId: string,
@@ -489,6 +520,7 @@ function runStepsPhase(
   cfg: StepsVariant,
   runSteps: Set<string>,
   emit: Set<string>,
+  tmpDir: string,
 ): BenchmarkEntry[] {
   const totalSteps = Object.keys(cfg.steps).length;
   const stepNames = Object.keys(cfg.steps).filter((n) => runSteps.has(n));
@@ -502,6 +534,9 @@ function runStepsPhase(
   );
 
   const samples = new Map<string, number[]>();
+  const peakRssMb = new Map<string, number>();
+  const memFile = (stepName: string) =>
+    path.join(tmpDir, `${slugify(seqName)}-${slugify(stepName)}.mem`);
 
   for (const stepName of stepNames) {
     if (emit.has(stepName)) {
@@ -512,10 +547,15 @@ function runStepsPhase(
   for (let run = 0; run < cfg.runs; run++) {
     for (const stepName of stepNames) {
       const step = cfg.steps[stepName];
+      // Measure memory only for reported steps; the step command has shell
+      // operators (&&, >>) so it must run under an inner shell to be covered.
+      const command = emit.has(stepName)
+        ? wrapWithTime(step.command, memFile(stepName), true)
+        : step.command;
       const start = performance.now();
 
       try {
-        execSync(step.command, {
+        execSync(command, {
           cwd: workingDir,
           stdio: ["ignore", "pipe", "pipe"],
           encoding: "utf-8",
@@ -544,11 +584,23 @@ function runStepsPhase(
 
       const elapsed = (performance.now() - start) / 1000;
       samples.get(stepName)?.push(elapsed);
+
+      if (emit.has(stepName)) {
+        const rss = readPeakRssMb(memFile(stepName));
+        if (rss !== undefined) {
+          peakRssMb.set(stepName, Math.max(peakRssMb.get(stepName) ?? 0, rss));
+        }
+      }
     }
   }
 
-  return [...samples].map(([stepName, times]) =>
-    toEntry(scenarioId, stepName, computeStats(times)),
+  return [...samples].flatMap(([stepName, times]) =>
+    toEntries(
+      scenarioId,
+      stepName,
+      computeStats(times),
+      peakRssMb.get(stepName),
+    ),
   );
 }
 
@@ -623,6 +675,7 @@ function buildBenchArgs(
     prepare: string | undefined;
     runs: number;
     exportJson: string;
+    memFile: string | undefined;
   },
 ): BenchArgs {
   return {
@@ -639,6 +692,7 @@ function buildBenchArgs(
     warmup: 0,
     runs: phase.runs,
     exportJson: phase.exportJson,
+    memFile: phase.memFile,
     e2eCloneDirectory: args.e2eCloneDirectory,
   };
 }
@@ -655,12 +709,16 @@ function readHyperfineResult(exportPath: string): BenchmarkStats {
   return raw.results[0];
 }
 
-function toEntry(
+// One benchmark produces a timing entry and, when peak RSS was captured, a
+// separate memory entry (its own MB series, independently charted + alerted).
+// The RSS is also embedded in the timing entry's `extra` for convenience.
+function toEntries(
   scenarioId: string,
   phaseLabel: string,
   result: BenchmarkStats,
-): BenchmarkEntry {
-  return {
+  peakRssMb: number | undefined,
+): BenchmarkEntry[] {
+  const timeEntry: BenchmarkEntry = {
     name: `${scenarioId} / ${phaseLabel}`,
     unit: "s",
     value: result.mean,
@@ -671,8 +729,23 @@ function toEntry(
       max: result.max,
       median: result.median,
       mean: result.mean,
+      ...(peakRssMb !== undefined ? { peakRssMb } : {}),
     }),
   };
+
+  if (peakRssMb === undefined) {
+    return [timeEntry];
+  }
+
+  const memEntry: BenchmarkEntry = {
+    name: `${scenarioId} / ${phaseLabel} (peak RSS)`,
+    unit: "MB",
+    value: peakRssMb,
+    range: "± 0",
+    extra: "",
+  };
+
+  return [timeEntry, memEntry];
 }
 
 function writeOutput(outputPath: string, entries: BenchmarkEntry[]): void {

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -19,6 +19,12 @@ import {
 } from "../end-to-end/subcommands/init.ts";
 import { isScenarioDefinition } from "../end-to-end/schema/scenario-schema.ts";
 import type { ScenarioDefinition, StepsVariant } from "../end-to-end/types.ts";
+import {
+  compilePatterns,
+  matchesAny,
+  parseGlobList,
+  planCommands,
+} from "./helpers/plan.ts";
 import { isVerdaccioRunning } from "../verdaccio/helpers/shell.ts";
 import {
   publish as verdaccioPublish,
@@ -66,8 +72,13 @@ DESCRIPTION
 
 OPTIONS
   --output <path>       Required. Aggregated JSON destination
-  --scenarios <csv>     Filter by scenario id (directory basename)
+  --scenarios <globs>   Select scenarios by id (directory basename), as
+                        comma-separated glob patterns (e.g. "1inch*"). Default: all.
   --tag <tag>           Filter by a tag present in scenario.json tags
+  --benchmarks <globs>  Select which measured entries to report, by name
+                        (comma-separated globs, e.g. "test solidity" or
+                        "*compile*"). A name is the report label's second segment
+                        (single command name or step name). Default: all.
   --use-local           Detect packages changed since their release tag, bump
                         versions, publish to Verdaccio, and pin scenario deps to
                         the published versions.
@@ -80,9 +91,22 @@ OPTIONS
   --e2e-clone-dir <p>   Override clone directory (default: same as pnpm e2e)
   --fail-fast           Abort on the first scenario failure
 
+  --benchmarks SELECTS which measured entries you want reported. Because entries
+  run as a stateful pipeline (later ones depend on earlier ones having run — e.g.
+  "test solidity" runs with --no-compile and needs a prior compile), selected
+  entries are not run in isolation. Each entry may declare "dependsOn" in
+  scenario.json listing the entries it needs; when you select an entry, its
+  declared prerequisites also run (unreported) and everything else is skipped. An
+  entry with no "dependsOn" conservatively runs every entry declared before it.
+  Entries run in declared order; only selected entries are reported. So
+  --benchmarks "test solidity" runs just (cold compile + test solidity), skipping
+  the edit&compile steps and warm compile it doesn't depend on.
+
 EXAMPLES
   pnpm bench:regression --output /tmp/regression.json
   pnpm bench:regression --scenarios uniswap-v4-core,aave-v4 --output /tmp/r.json
+  pnpm bench:regression --benchmarks "cold compile" --output /tmp/r.json
+  pnpm bench:regression --scenarios "1inch*" --benchmarks "test solidity" --output /tmp/r.json
 `;
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..");
@@ -92,6 +116,7 @@ interface RegressionArgs {
   output: string;
   scenarios: string[] | undefined;
   tag: string | undefined;
+  benchmarks: string[] | undefined;
   useLocal: UseLocal;
   forceCheckout: ForceCheckout;
   forcePublish: ForcePublish;
@@ -209,6 +234,11 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  if (args.benchmarks !== undefined && results.length === 0) {
+    logError("No benchmarks matched the provided --benchmarks filter");
+    process.exit(1);
+  }
+
   log(
     fmt.success(
       `Regression benchmark complete — wrote ${results.length} entries to ${args.output}`,
@@ -234,6 +264,8 @@ function resolveArgs(argv: string[]): RegressionArgs | undefined {
 
   const tag = getArgValue(argv, "--tag");
 
+  const benchmarks = parseGlobList(getArgValue(argv, "--benchmarks"));
+
   const useLocal = argv.includes("--use-local") ? UseLocal.Yes : UseLocal.No;
 
   const forceCheckout = argv.includes("--force-checkout")
@@ -255,6 +287,7 @@ function resolveArgs(argv: string[]): RegressionArgs | undefined {
     output: path.resolve(output),
     scenarios,
     tag,
+    benchmarks,
     useLocal,
     forceCheckout,
     forcePublish,
@@ -266,6 +299,7 @@ function resolveArgs(argv: string[]): RegressionArgs | undefined {
 function collectScenarios(args: RegressionArgs): ScenarioEntry[] {
   const entries: ScenarioEntry[] = [];
   const invalid: string[] = [];
+  const scenarioRes = compilePatterns(args.scenarios);
 
   for (const entry of readdirSync(END_TO_END_DIR, { withFileTypes: true })) {
     if (!entry.isDirectory()) {
@@ -318,7 +352,7 @@ function collectScenarios(args: RegressionArgs): ScenarioEntry[] {
       continue;
     }
 
-    if (args.scenarios !== undefined && !args.scenarios.includes(entry.name)) {
+    if (!matchesAny(entry.name, scenarioRes)) {
       continue;
     }
 
@@ -360,6 +394,16 @@ async function runScenario(
     );
   }
 
+  const plan = planCommands(commands, args.benchmarks);
+
+  if (plan.length === 0) {
+    logWarning(
+      `Skipping "${scenario.id}" (no commands or steps matched the filters)`,
+    );
+
+    return [];
+  }
+
   const scenarioTmpDir = path.join(tmpdir(), "hardhat-regression", scenario.id);
   mkdirSync(scenarioTmpDir, { recursive: true });
 
@@ -383,34 +427,46 @@ async function runScenario(
 
   const entries: BenchmarkEntry[] = [];
 
-  for (const [name, cfg] of Object.entries(commands)) {
-    if ("steps" in cfg) {
+  for (const planned of plan) {
+    if ("steps" in planned.cfg) {
       entries.push(
         ...runStepsPhase(
           scenario.id,
           loaded.workingDir,
           loaded.definition.env,
-          name,
-          cfg,
+          planned.name,
+          planned.cfg,
+          // runStepNames is always defined for step sequences.
+          new Set(planned.runStepNames ?? Object.keys(planned.cfg.steps)),
+          new Set(planned.emitSteps),
         ),
       );
 
       continue;
     }
 
-    const exportPath = path.join(scenarioTmpDir, `${slugify(name)}.json`);
+    const exportPath = path.join(
+      scenarioTmpDir,
+      `${slugify(planned.name)}.json`,
+    );
 
     await runPhase(
-      name,
+      planned.name,
       buildBenchArgs(scenario.scenarioJsonPath, args, {
-        command: cfg.command,
-        prepare: cfg.prepare,
-        runs: cfg.runs,
+        command: planned.cfg.command,
+        prepare: planned.cfg.prepare,
+        runs: planned.cfg.runs,
         exportJson: exportPath,
       }),
     );
 
-    entries.push(toEntry(scenario.id, name, readHyperfineResult(exportPath)));
+    // Non-selected single commands still run above (state prerequisites for a
+    // later selected command) but are not reported.
+    if (planned.emit) {
+      entries.push(
+        toEntry(scenario.id, planned.name, readHyperfineResult(exportPath)),
+      );
+    }
   }
 
   return entries;
@@ -419,7 +475,11 @@ async function runScenario(
 /**
  * Run a step-sequence command: execute the ordered steps in-process, once per
  * run, timing each step with the high-resolution monotonic clock. Returns one
- * entry per measured step.
+ * entry per emitted step.
+ *
+ * `runSteps` is the set of step names to execute (selected steps plus their
+ * prerequisites); other steps are skipped. `emit` is the subset of those to
+ * time and report — steps that run but aren't in `emit` are prerequisites only.
  */
 function runStepsPhase(
   scenarioId: string,
@@ -427,14 +487,24 @@ function runStepsPhase(
   env: Record<string, string> | undefined,
   seqName: string,
   cfg: StepsVariant,
+  runSteps: Set<string>,
+  emit: Set<string>,
 ): BenchmarkEntry[] {
-  logStep(`${fmt.pkg(seqName)} (${cfg.runs} runs)`);
+  const totalSteps = Object.keys(cfg.steps).length;
+  const stepNames = Object.keys(cfg.steps).filter((n) => runSteps.has(n));
 
-  const stepNames = Object.keys(cfg.steps);
+  logStep(
+    `${fmt.pkg(seqName)} (${cfg.runs} runs${
+      stepNames.length < totalSteps
+        ? `, ${stepNames.length} of ${totalSteps} steps`
+        : ""
+    })`,
+  );
+
   const samples = new Map<string, number[]>();
 
   for (const stepName of stepNames) {
-    if (cfg.steps[stepName].measure !== false) {
+    if (emit.has(stepName)) {
       samples.set(stepName, []);
     }
   }

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -741,7 +741,7 @@ function toEntries(
     name: `${scenarioId} / ${phaseLabel} (peak RSS)`,
     unit: "MB",
     value: peakRssMb,
-    range: "± 0",
+    range: "",
     extra: "",
   };
 

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -755,7 +755,7 @@ function toEntries(
     // Peak RSS is a max within each run; across runs we track the highest peak
     // and expose the spread (mean/stddev/…) in `extra`.
     value: rss.max,
-    range: `± ${rss.stddev}`,
+    range: "",
     extra: JSON.stringify({
       values: rss.times,
       min: rss.min,

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -78,8 +78,12 @@ DESCRIPTION
   When GNU time (/usr/bin/time) is available, each benchmark is wrapped in it to
   capture peak RSS (the largest resident set size any process in its subtree
   reached, in MB). This is emitted as a separate "<scenarioId> / <name> (peak
-  RSS)" entry (unit MB) and also embedded as "peakRssMb" in the time entry's
-  extra. If GNU time is missing, memory is skipped and a warning is printed.
+  RSS)" entry (unit MB): its value is the highest peak observed, with the per-run
+  peaks and their statistics (mean/stddev/min/max/median) in the entry's extra.
+  Step sequences record one peak per run; hyperfine single commands record a
+  single aggregate peak across all runs. The highest peak is also embedded as
+  "peakRssMb" in the time entry's extra. If GNU time is missing, memory is
+  skipped and a warning is printed.
 
 OPTIONS
   --output <path>       Required. Aggregated JSON destination
@@ -492,7 +496,7 @@ async function runScenario(
           planned.name,
           readHyperfineResult(exportPath),
           memFile !== undefined && gnuTimeAvailable()
-            ? readPeakRssMb(memFile)
+            ? [readPeakRssMb(memFile)]
             : undefined,
         ),
       );
@@ -535,13 +539,14 @@ function runStepsPhase(
   );
 
   const samples = new Map<string, number[]>();
-  const peakRssMb = new Map<string, number>();
+  const peakRssMb = new Map<string, number[]>();
   const memFile = (stepName: string) =>
     path.join(tmpDir, `${slugify(seqName)}-${slugify(stepName)}.mem`);
 
   for (const stepName of stepNames) {
     if (emit.has(stepName)) {
       samples.set(stepName, []);
+      peakRssMb.set(stepName, []);
     }
   }
 
@@ -587,8 +592,7 @@ function runStepsPhase(
       samples.get(stepName)?.push(elapsed);
 
       if (emit.has(stepName) && gnuTimeAvailable()) {
-        const rss = readPeakRssMb(memFile(stepName));
-        peakRssMb.set(stepName, Math.max(peakRssMb.get(stepName) ?? 0, rss));
+        peakRssMb.get(stepName)?.push(readPeakRssMb(memFile(stepName)));
       }
     }
   }
@@ -710,13 +714,22 @@ function readHyperfineResult(exportPath: string): BenchmarkStats {
 
 // One benchmark produces a timing entry and, when peak RSS was captured, a
 // separate memory entry (its own MB series, independently charted + alerted).
-// The RSS is also embedded in the timing entry's `extra` for convenience.
+// `peakRssMb` holds one peak per run (a single aggregate value for hyperfine
+// single commands, one per outer run for step sequences). The tracked value
+// is the highest peak; the full per-run distribution goes in the entry's
+// `extra`, and the peak is also embedded in the timing entry's `extra`
+// for convenience.
 function toEntries(
   scenarioId: string,
   phaseLabel: string,
   result: BenchmarkStats,
-  peakRssMb: number | undefined,
+  peakRssMb: number[] | undefined,
 ): BenchmarkEntry[] {
+  const rss =
+    peakRssMb !== undefined && peakRssMb.length > 0
+      ? computeStats(peakRssMb)
+      : undefined;
+
   const timeEntry: BenchmarkEntry = {
     name: `${scenarioId} / ${phaseLabel}`,
     unit: "s",
@@ -728,20 +741,29 @@ function toEntries(
       max: result.max,
       median: result.median,
       mean: result.mean,
-      ...(peakRssMb !== undefined ? { peakRssMb } : {}),
+      ...(rss !== undefined ? { peakRssMb: rss.max } : {}),
     }),
   };
 
-  if (peakRssMb === undefined) {
+  if (rss === undefined) {
     return [timeEntry];
   }
 
   const memEntry: BenchmarkEntry = {
     name: `${scenarioId} / ${phaseLabel} (peak RSS)`,
     unit: "MB",
-    value: peakRssMb,
-    range: "",
-    extra: "",
+    // Peak RSS is a max within each run; across runs we track the highest peak
+    // and expose the spread (mean/stddev/…) in `extra`.
+    value: rss.max,
+    range: `± ${rss.stddev}`,
+    extra: JSON.stringify({
+      values: rss.times,
+      min: rss.min,
+      max: rss.max,
+      median: rss.median,
+      mean: rss.mean,
+      stddev: rss.stddev,
+    }),
   };
 
   return [timeEntry, memEntry];

--- a/scripts/benchmark/regression.ts
+++ b/scripts/benchmark/regression.ts
@@ -806,7 +806,7 @@ function toEntries(
     value: rss.max,
     range: "",
     extra: JSON.stringify({
-      values: rss.times,
+      times: rss.times,
       min: rss.min,
       max: rss.max,
       median: rss.median,

--- a/scripts/end-to-end/schema/scenario-schema.ts
+++ b/scripts/end-to-end/schema/scenario-schema.ts
@@ -105,7 +105,7 @@ export function isCommandConfig(value: unknown): value is CommandConfig {
 }
 
 function isCommandVariant(obj: Record<string, unknown>): boolean {
-  const allowedKeys = new Set(["runs", "prepare", "command"]);
+  const allowedKeys = new Set(["runs", "prepare", "command", "dependsOn"]);
 
   for (const key of Object.keys(obj)) {
     if (!allowedKeys.has(key)) {
@@ -118,7 +118,18 @@ function isCommandVariant(obj: Record<string, unknown>): boolean {
     typeof obj.command === "string" &&
     obj.command.length > 0 &&
     (obj.prepare === undefined ||
-      (typeof obj.prepare === "string" && obj.prepare.length > 0))
+      (typeof obj.prepare === "string" && obj.prepare.length > 0)) &&
+    isDependsOn(obj.dependsOn)
+  );
+}
+
+// `dependsOn`, when present, is a non-empty list of non-empty entry names.
+function isDependsOn(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (Array.isArray(value) &&
+      value.length > 0 &&
+      value.every((v) => typeof v === "string" && v.length > 0))
   );
 }
 
@@ -160,7 +171,7 @@ export function isStepConfig(value: unknown): value is StepConfig {
   }
 
   const obj = value as Record<string, unknown>;
-  const allowedKeys = new Set(["command", "measure"]);
+  const allowedKeys = new Set(["command", "measure", "dependsOn"]);
 
   for (const key of Object.keys(obj)) {
     if (!allowedKeys.has(key)) {
@@ -171,7 +182,8 @@ export function isStepConfig(value: unknown): value is StepConfig {
   return (
     typeof obj.command === "string" &&
     obj.command.length > 0 &&
-    (obj.measure === undefined || typeof obj.measure === "boolean")
+    (obj.measure === undefined || typeof obj.measure === "boolean") &&
+    isDependsOn(obj.dependsOn)
   );
 }
 

--- a/scripts/end-to-end/schema/scenario.schema.json
+++ b/scripts/end-to-end/schema/scenario.schema.json
@@ -102,6 +102,12 @@
                     "type": "string",
                     "minLength": 1,
                     "description": "Shell command to benchmark"
+                  },
+                  "dependsOn": {
+                    "type": "array",
+                    "items": { "type": "string", "minLength": 1 },
+                    "minItems": 1,
+                    "description": "Names of other entries (command or step names in this scenario) that must run before this one for its measurement to be valid. Used by bench:regression's --benchmarks filter to run prerequisites and skip unrelated work."
                   }
                 }
               },
@@ -135,6 +141,12 @@
                         "measure": {
                           "type": "boolean",
                           "description": "Emit a benchmark entry for this step (default true)"
+                        },
+                        "dependsOn": {
+                          "type": "array",
+                          "items": { "type": "string", "minLength": 1 },
+                          "minItems": 1,
+                          "description": "Names of other entries (step names in this sequence, or command names) that must run before this step for its measurement to be valid. Used by bench:regression's --benchmarks filter to run prerequisites and skip unrelated work."
                         }
                       }
                     },

--- a/scripts/end-to-end/types.ts
+++ b/scripts/end-to-end/types.ts
@@ -52,6 +52,15 @@ export interface CommandVariant {
    * The command to benchmark in the regression harness.
    */
   command: string;
+  /**
+   * Names of other entries (command names or step names within this scenario)
+   * that must run before this one to make its measurement valid — e.g. a
+   * `--no-compile` command depends on a prior compile. Used by the regression
+   * harness's `--benchmarks` filter: when this entry is selected, its declared
+   * prerequisites run (but are not reported) and everything else is skipped.
+   * When omitted, filtering conservatively runs every preceding entry.
+   */
+  dependsOn?: string[];
 }
 
 export interface StepsVariant {
@@ -79,4 +88,10 @@ export interface StepConfig {
    * to `false` for setup/reset steps that should run but not be measured.
    */
   measure?: boolean;
+  /**
+   * Names of other entries (step names within the same sequence, or command
+   * names) that must run before this step for its measurement to be valid. See
+   * {@link CommandVariant.dependsOn}.
+   */
+  dependsOn?: string[];
 }

--- a/scripts/end-to-end/types.ts
+++ b/scripts/end-to-end/types.ts
@@ -58,7 +58,8 @@ export interface CommandVariant {
    * `--no-compile` command depends on a prior compile. Used by the regression
    * harness's `--benchmarks` filter: when this entry is selected, its declared
    * prerequisites run (but are not reported) and everything else is skipped.
-   * When omitted, filtering conservatively runs every preceding entry.
+   * Dependencies must be declared before the dependent entry. When omitted, the
+   * entry has no prerequisites and runs in isolation when selected.
    */
   dependsOn?: string[];
 }


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

This PR adds peak RSS memory measurements to the regression benchmark stats. 

It also adds the ability to filter which commands/steps and which scenarios run as part of the regression benchmark via glob patterns. Since some steps depend on previous steps being executed (i.e. `test solidity` runs with `--no-compile` and requires `cold compile` to have run beforehand), it adds a dependency list which allows the workflow to only run the required steps. Stats are only emitted for  filtered commands/steps. This is useful in EDR to check solidity test performance (see https://github.com/NomicFoundation/edr/pull/1563).

