### PR TITLE
fix(ignition): don't treat a replacement tx as confirmed one block early

### DIFF
--- a/.changeset/ignition-nonce-sync-confirmation-boundary.md
+++ b/.changeset/ignition-nonce-sync-confirmation-boundary.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/ignition-core": patch
+---
+
+Fix an off-by-one in the nonce-sync confirmation check that could treat a user's replacement transaction as fully confirmed when it had one fewer than the required number of confirmations. A transaction count is a cardinality (the next nonce to use), so the transaction with a given nonce is only confirmed at the safe block when the safe count is strictly greater than the nonce; the check now uses `>` instead of `>=`.

--- a/.changeset/ignition-nonce-sync-confirmation-boundary.md
+++ b/.changeset/ignition-nonce-sync-confirmation-boundary.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/ignition-core": patch
 ---
 
-Fix an off-by-one in the nonce-sync confirmation check that could treat a user's replacement transaction as fully confirmed when it had one fewer than the required number of confirmations. A transaction count is a cardinality (the next nonce to use), so the transaction with a given nonce is only confirmed at the safe block when the safe count is strictly greater than the nonce; the check now uses `>` instead of `>=`.
+Fixed an off-by-one in Ignition's nonce sync that could let a deployment continue when a user's replacement transaction had one fewer than the required number of confirmations.

--- a/packages/ignition-core/src/internal/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/ignition-core/src/internal/execution/nonce-management/get-nonce-sync-messages.ts
@@ -161,7 +161,7 @@ export async function getNonceSyncMessages(
       if (latestCount > nonce) {
         const hasEnoughConfirmations =
           safeConfirmationsCount !== undefined &&
-          safeConfirmationsCount >= nonce;
+          safeConfirmationsCount > nonce;
 
         // We know the ignition transaction was replaced, and the replacement
         // transaction has at least one confirmation.

--- a/packages/ignition-core/test/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/ignition-core/test/execution/nonce-management/get-nonce-sync-messages.ts
@@ -469,6 +469,44 @@ describe("execution - getNonceSyncMessages", () => {
           );
         });
 
+        it("should throw if the user replaced the transaction and the user transaction is mined exactly at the confirmation boundary (safe count equals the nonce)", async () => {
+          // set an arbitrary nonce
+          const nonce = 16;
+          // put the latest as bigger than the nonce being checked, so the
+          // replacement transaction is mined (Case 1 is entered)
+          const latest = nonce + 1;
+          // there are no pending
+          const pending = latest;
+          // The safe count is exactly equal to the nonce. A transaction count
+          // is a cardinality (the next nonce to use), so `safe === nonce` means
+          // only the transactions with nonces `0..nonce-1` are confirmed at the
+          // safe block: the replacement transaction with `nonce` itself is NOT
+          // yet safely confirmed and must not be treated as fully confirmed.
+          const safest = nonce;
+
+          await assertGetNonceSyncThrows(
+            {
+              ignitionModule: exampleModule,
+              deploymentState:
+                setupDeploymentStateBasedOnExampleModuleWithOneTranWith(nonce),
+              transactionCountEntries: {
+                [exampleAccounts[1]]: {
+                  pending,
+                  latest,
+                  number: () => safest,
+                },
+              },
+              latestBlockNumber,
+            },
+            HardhatError.ERRORS.IGNITION.EXECUTION.WAITING_FOR_NONCE,
+            {
+              sender: exampleAccounts[1],
+              nonce: 16,
+              requiredConfirmations: 5,
+            },
+          );
+        });
+
         it("should error if the user replaced the transaction and the user transaction is in the mempool but not mined (pending)", async () => {
           // Set latest to an arbitrary nonce
           const latestCount = 30;

--- a/packages/ignition-core/test/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/ignition-core/test/execution/nonce-management/get-nonce-sync-messages.ts
@@ -470,6 +470,13 @@ describe("execution - getNonceSyncMessages", () => {
         });
 
         it("should throw if the user replaced the transaction and the user transaction is mined exactly at the confirmation boundary (safe count equals the nonce)", async () => {
+          // This test requires a safe confirmations count, so we skip if
+          // the latest block number won't allow for that, and so no
+          // boundary to check.
+          if (latestBlockNumber < requiredConfirmations - 1) {
+            return;
+          }
+
           // set an arbitrary nonce
           const nonce = 16;
           // put the latest as bigger than the nonce being checked, so the


### PR DESCRIPTION
## Problem

In `getNonceSyncMessages` (`@nomicfoundation/ignition-core`), when Ignition detects that a user has **replaced** one of its transactions, it must not proceed until the user's replacement transaction has `requiredConfirmations` confirmations. The guard for this uses the sender's *safe* transaction count (the tx count `requiredConfirmations` blocks in the past):

```ts
if (latestCount > nonce) {
  const hasEnoughConfirmations =
    safeConfirmationsCount !== undefined &&
    safeConfirmationsCount >= nonce; // <-- off by one
  ...
```

`eth_getTransactionCount` returns a **cardinality** — the number of transactions the sender has, i.e. the *next* nonce to use. So the transaction with a given `nonce` is confirmed at the safe block only when `safeConfirmationsCount > nonce`. When `safeConfirmationsCount === nonce`, only the transactions with nonces `0..nonce-1` are confirmed at the safe block; the replacement transaction with `nonce` itself is **not** yet safely confirmed.

Because the check used `>=`, a replacement transaction that had **one fewer than the required number of confirmations** was treated as fully confirmed.

### Concrete failing example

- `requiredConfirmations = 5`, latest block `= 20`, so `confirmedBlockNumber = 20 - 5 + 1 = 16`.
- Ignition sent a tx with `nonce = 10`; the user replaced it (same nonce `10`), and the user's tx was mined in block `19` — that's only `20 - 19 + 1 = 2` confirmations.
- `latestCount` (at block 20) `= 11` → `11 > 10`, so **Case 1** is entered.
- `safeConfirmationsCount` (at block 16) `= 10` (nonces `0..9` are confirmed by block 16; nonce `10` was mined in block 19 > 16, so it is not counted) → `safeConfirmationsCount === nonce === 10`.
- Old code: `10 >= 10` → `hasEnoughConfirmations = true`. Ignition emits `ONCHAIN_INTERACTION_REPLACED_BY_USER`, which clears the nonce and re-sends, **while the user's replacement has only 2 of the required 5 confirmations** and could still be reorged out.

The same `>=` also treats a replacement mined in the *latest* block (a single confirmation) as fully confirmed.

## Fix

Use `>` so the check matches its two sibling comparisons against the same `nonce` in this function — `latestCount > nonce` (Case 1 entry, line above) and `pendingCount > nonce` (Case 2) — both of which already use `>` correctly:

```ts
safeConfirmationsCount > nonce;
```

With the fix, the example above throws `WAITING_FOR_NONCE` and waits until block `23`, where `safeConfirmationsCount` (at block `19`) `= 11 > 10`, i.e. the replacement genuinely has 5 confirmations.

## Test

Adds a regression test to `test/execution/nonce-management/get-nonce-sync-messages.ts` that pins the boundary: `latest = nonce + 1`, `safe = nonce`. It expects `WAITING_FOR_NONCE`.

- **Before** (`>=`): fails at the `latest block #10` iteration — the guard wrongly returns `REPLACED_BY_USER` instead of throwing.
- **After** (`>`): all 38 cases in the file pass.

Existing tests are unaffected — the two nearby cases use `safe = nonce + 1` (proceed) and `safe = nonce - 1` (throw); neither pinned the `safe === nonce` boundary.

Ran locally: `mocha test/execution/nonce-management/get-nonce-sync-messages.ts` → 38 passing.

A Changeset is included (`ignition-core`, patch).
