### PR TITLE
feat(bench): allow specification of git branches in scenarios

### DIFF
--- a/scripts/end-to-end/helpers/directory.ts
+++ b/scripts/end-to-end/helpers/directory.ts
@@ -1,6 +1,9 @@
 import path, { basename, dirname, resolve } from "node:path";
 import type { Scenario, ScenarioDefinition } from "../types.ts";
-import { isScenarioDefinition } from "../schema/scenario-schema.ts";
+import {
+  isScenarioDefinition,
+  validateScenarioSource,
+} from "../schema/scenario-schema.ts";
 import { readFileSync } from "node:fs";
 import { resolveEnv } from "./env.ts";
 
@@ -56,6 +59,10 @@ export function normalizeScenarioPath(scenarioPath: string): string {
 
 function _readScenarioJson(scenarioFilePath: string): ScenarioDefinition {
   const raw = JSON.parse(readFileSync(scenarioFilePath, "utf-8")) as unknown;
+
+  // Throws targeted errors for commit/branch misuse; anything else malformed
+  // falls through to the generic guard error below.
+  validateScenarioSource(raw, scenarioFilePath);
 
   if (!isScenarioDefinition(raw)) {
     throw new Error(`Invalid scenario.json at ${scenarioFilePath}`);

--- a/scripts/end-to-end/schema/scenario-schema.test.ts
+++ b/scripts/end-to-end/schema/scenario-schema.test.ts
@@ -5,15 +5,20 @@ import {
   isCommandConfig,
   isScenarioDefinition,
   isStepConfig,
+  validateScenarioSource,
 } from "./scenario-schema.ts";
 
 const baseScenario = {
   description: "test",
   repo: "org/repo",
-  commit: "abc123",
   packageManager: "npm" as const,
   defaultCommand: "npx hardhat compile",
   tags: ["test"],
+};
+
+const scenarioWithCommit = {
+  ...baseScenario,
+  commit: "abc123",
 };
 
 describe("isScenarioDefinition", () => {
@@ -203,7 +208,7 @@ describe("isScenarioDefinition", () => {
   it("accepts benchmark: { skip: true }", () => {
     assert.equal(
       isScenarioDefinition({
-        ...baseScenario,
+        ...scenarioWithCommit,
         benchmark: { skip: true },
       }),
       true,
@@ -213,7 +218,7 @@ describe("isScenarioDefinition", () => {
   it("accepts benchmark.commands with one entry", () => {
     assert.equal(
       isScenarioDefinition({
-        ...baseScenario,
+        ...scenarioWithCommit,
         benchmark: {
           commands: {
             "warm compile": { runs: 10, command: "npx hardhat compile" },
@@ -227,7 +232,7 @@ describe("isScenarioDefinition", () => {
   it("accepts benchmark.commands with multiple ordered entries", () => {
     assert.equal(
       isScenarioDefinition({
-        ...baseScenario,
+        ...scenarioWithCommit,
         benchmark: {
           commands: {
             "cold compile": {
@@ -247,7 +252,7 @@ describe("isScenarioDefinition", () => {
   it("rejects benchmark.commands that is not an object", () => {
     assert.equal(
       isScenarioDefinition({
-        ...baseScenario,
+        ...scenarioWithCommit,
         benchmark: { commands: [] },
       }),
       false,
@@ -257,7 +262,7 @@ describe("isScenarioDefinition", () => {
   it("rejects an integer-like command key (would break order)", () => {
     assert.equal(
       isScenarioDefinition({
-        ...baseScenario,
+        ...scenarioWithCommit,
         benchmark: {
           commands: { "1": { runs: 1, command: "npx hardhat compile" } },
         },
@@ -268,8 +273,120 @@ describe("isScenarioDefinition", () => {
 
   it("rejects benchmark.skip values other than true", () => {
     assert.equal(
-      isScenarioDefinition({ ...baseScenario, benchmark: { skip: false } }),
+      isScenarioDefinition({
+        ...scenarioWithCommit,
+        benchmark: { skip: false },
+      }),
       false,
+    );
+  });
+
+  it("accepts a branch instead of a commit", () => {
+    assert.equal(
+      isScenarioDefinition({
+        ...baseScenario,
+        repo: "NomicFoundation/hardhat",
+        branch: "main",
+      }),
+      true,
+    );
+  });
+
+  it("rejects when both commit and branch are present", () => {
+    assert.equal(
+      isScenarioDefinition({ ...scenarioWithCommit, branch: "main" }),
+      false,
+    );
+  });
+
+  it("rejects when neither commit nor branch is present", () => {
+    assert.equal(isScenarioDefinition(baseScenario), false);
+  });
+
+  it("rejects a non-string branch", () => {
+    assert.equal(isScenarioDefinition({ ...baseScenario, branch: 42 }), false);
+  });
+});
+
+describe("validateScenarioSource", () => {
+  const scenarioFilePath = "end-to-end/some-scenario/scenario.json";
+
+  it("does not throw for a commit-only scenario in an external org", () => {
+    assert.doesNotThrow(() =>
+      validateScenarioSource(scenarioWithCommit, scenarioFilePath),
+    );
+  });
+
+  it("does not throw for a branch in the NomicFoundation org", () => {
+    assert.doesNotThrow(() =>
+      validateScenarioSource(
+        {
+          ...baseScenario,
+          repo: "NomicFoundation/hardhat",
+          branch: "main",
+        },
+        scenarioFilePath,
+      ),
+    );
+  });
+
+  it("compares the org case-insensitively", () => {
+    assert.doesNotThrow(() =>
+      validateScenarioSource(
+        {
+          ...baseScenario,
+          repo: "nomicfoundation/hardhat",
+          branch: "main",
+        },
+        scenarioFilePath,
+      ),
+    );
+  });
+
+  it("throws when both commit and branch are present", () => {
+    assert.throws(
+      () =>
+        validateScenarioSource(
+          { ...scenarioWithCommit, branch: "main" },
+          scenarioFilePath,
+        ),
+      /exactly one of "commit" or "branch"/,
+    );
+  });
+
+  it("throws when neither commit nor branch is present", () => {
+    assert.throws(
+      () => validateScenarioSource(baseScenario, scenarioFilePath),
+      /exactly one of "commit" or "branch"/,
+    );
+  });
+
+  it("throws for a branch in an external org", () => {
+    assert.throws(
+      () =>
+        validateScenarioSource(
+          {
+            ...baseScenario,
+            repo: "OpenZeppelin/openzeppelin-contracts",
+            branch: "master",
+          },
+          scenarioFilePath,
+        ),
+      /only allowed for repos in the NomicFoundation/,
+    );
+  });
+
+  it("includes the scenario file path in the error message", () => {
+    assert.throws(
+      () => validateScenarioSource(baseScenario, scenarioFilePath),
+      new RegExp(scenarioFilePath),
+    );
+  });
+
+  it("does not throw for null or non-object input (the guard's job)", () => {
+    assert.doesNotThrow(() => validateScenarioSource(null, scenarioFilePath));
+    assert.doesNotThrow(() =>
+      validateScenarioSource("not an object", scenarioFilePath),
     );
   });
 });

--- a/scripts/end-to-end/schema/scenario-schema.test.ts
+++ b/scripts/end-to-end/schema/scenario-schema.test.ts
@@ -205,6 +205,10 @@ describe("isScenarioDefinition", () => {
     assert.equal(isScenarioDefinition("not an object"), false);
   });
 
+  it("rejects arrays", () => {
+    assert.equal(isScenarioDefinition([]), false);
+  });
+
   it("accepts benchmark: { skip: true }", () => {
     assert.equal(
       isScenarioDefinition({
@@ -388,6 +392,10 @@ describe("validateScenarioSource", () => {
     assert.doesNotThrow(() =>
       validateScenarioSource("not an object", scenarioFilePath),
     );
+  });
+
+  it("does not throw for arrays (the guard's job)", () => {
+    assert.doesNotThrow(() => validateScenarioSource([], scenarioFilePath));
   });
 });
 

--- a/scripts/end-to-end/schema/scenario-schema.ts
+++ b/scripts/end-to-end/schema/scenario-schema.ts
@@ -55,7 +55,7 @@ export function isScenarioDefinition(
  *
  * - Exactly one of `commit` | `branch` must be specified.
  * - `branch` is only allowed for repos in the NomicFoundation GitHub
- *   organisation (compared case-insensitively, as GitHub org names are
+ *   organization (compared case-insensitively, as GitHub org names are
  *   case-insensitively unique).
  *
  * Anything else malformed is left to `isScenarioDefinition`'s generic error.
@@ -84,7 +84,7 @@ export function validateScenarioSource(
 
     if (org.toLowerCase() !== "nomicfoundation") {
       throw new Error(
-        `Invalid scenario.json at ${scenarioFilePath}: "branch" is only allowed for repos in the NomicFoundation GitHub organisation, but "repo" is "${obj.repo}". A branch checkout automatically tracks the branch's latest tip, so restricting it to NomicFoundation ensures a security breach in an external organisation or account cannot automatically affect our end-to-end scenarios. Pin external repos to a "commit" instead.`,
+        `Invalid scenario.json at ${scenarioFilePath}: "branch" is only allowed for repos in the NomicFoundation GitHub organization, but "repo" is "${obj.repo}". A branch checkout automatically tracks the branch's latest tip, so restricting it to NomicFoundation ensures a security breach in an external organization or account cannot automatically affect our end-to-end scenarios. Pin external repos to a "commit" instead.`,
       );
     }
   }

--- a/scripts/end-to-end/schema/scenario-schema.ts
+++ b/scripts/end-to-end/schema/scenario-schema.ts
@@ -20,10 +20,20 @@ export function isScenarioDefinition(
 
   const obj = value as Record<string, unknown>;
 
+  const hasCommit = "commit" in obj;
+  const hasBranch = "branch" in obj;
+
+  // Exactly one of `commit` | `branch` must be present.
+  if (hasCommit === hasBranch) {
+    return false;
+  }
+
   return (
     typeof obj.description === "string" &&
     typeof obj.repo === "string" &&
-    typeof obj.commit === "string" &&
+    (hasBranch
+      ? typeof obj.branch === "string"
+      : typeof obj.commit === "string") &&
     (obj.packageManager === "npm" ||
       obj.packageManager === "bun" ||
       obj.packageManager === "yarn" ||
@@ -38,6 +48,46 @@ export function isScenarioDefinition(
     (obj.disabled === undefined || obj.disabled === true) &&
     (obj.benchmark === undefined || isBenchmarkConfig(obj.benchmark))
   );
+}
+
+/**
+ * Throws a targeted error for commit/branch misuse in a scenario definition:
+ *
+ * - Exactly one of `commit` | `branch` must be specified.
+ * - `branch` is only allowed for repos in the NomicFoundation GitHub
+ *   organisation (compared case-insensitively, as GitHub org names are
+ *   case-insensitively unique).
+ *
+ * Anything else malformed is left to `isScenarioDefinition`'s generic error.
+ */
+export function validateScenarioSource(
+  value: unknown,
+  scenarioFilePath: string,
+): void {
+  if (typeof value !== "object" || value === null) {
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  const hasCommit = "commit" in obj;
+  const hasBranch = "branch" in obj;
+
+  if (hasCommit === hasBranch) {
+    throw new Error(
+      `Invalid scenario.json at ${scenarioFilePath}: exactly one of "commit" or "branch" must be specified`,
+    );
+  }
+
+  if (hasBranch && typeof obj.repo === "string") {
+    const org = obj.repo.split("/")[0];
+
+    if (org.toLowerCase() !== "nomicfoundation") {
+      throw new Error(
+        `Invalid scenario.json at ${scenarioFilePath}: "branch" is only allowed for repos in the NomicFoundation GitHub organisation, but "repo" is "${obj.repo}". A branch checkout automatically tracks the branch's latest tip, so restricting it to NomicFoundation ensures a security breach in an external organisation or account cannot automatically affect our end-to-end scenarios. Pin external repos to a "commit" instead.`,
+      );
+    }
+  }
 }
 
 export function isBenchmarkConfig(value: unknown): value is {

--- a/scripts/end-to-end/schema/scenario-schema.ts
+++ b/scripts/end-to-end/schema/scenario-schema.ts
@@ -64,7 +64,7 @@ export function validateScenarioSource(
   value: unknown,
   scenarioFilePath: string,
 ): void {
-  if (typeof value !== "object" || value === null) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return;
   }
 

--- a/scripts/end-to-end/schema/scenario.schema.json
+++ b/scripts/end-to-end/schema/scenario.schema.json
@@ -28,7 +28,7 @@
     },
     "branch": {
       "type": "string",
-      "description": "Branch to checkout; every init tracks its latest remote tip. Exactly one of \"commit\" or \"branch\" must be specified. Only allowed when the repo is in the NomicFoundation GitHub organisation (enforced at runtime, case-insensitively), so that a security breach in an external organisation or account cannot automatically affect our end-to-end scenarios."
+      "description": "Branch to checkout; every init tracks its latest remote tip. Exactly one of \"commit\" or \"branch\" must be specified. Only allowed when the repo is in the NomicFoundation GitHub organization (enforced at runtime, case-insensitively), so that a security breach in an external organization or account cannot automatically affect our end-to-end scenarios."
     },
     "packageManager": {
       "type": "string",

--- a/scripts/end-to-end/schema/scenario.schema.json
+++ b/scripts/end-to-end/schema/scenario.schema.json
@@ -6,12 +6,12 @@
   "required": [
     "description",
     "repo",
-    "commit",
     "packageManager",
     "defaultCommand",
     "tags"
   ],
   "additionalProperties": false,
+  "oneOf": [{ "required": ["commit"] }, { "required": ["branch"] }],
   "properties": {
     "$schema": { "type": "string" },
     "description": {
@@ -24,7 +24,11 @@
     },
     "commit": {
       "type": "string",
-      "description": "Full SHA or tag to checkout"
+      "description": "Full SHA or tag to checkout. Exactly one of \"commit\" or \"branch\" must be specified."
+    },
+    "branch": {
+      "type": "string",
+      "description": "Branch to checkout; every init tracks its latest remote tip. Exactly one of \"commit\" or \"branch\" must be specified. Only allowed when the repo is in the NomicFoundation GitHub organisation (enforced at runtime, case-insensitively), so that a security breach in an external organisation or account cannot automatically affect our end-to-end scenarios."
     },
     "packageManager": {
       "type": "string",

--- a/scripts/end-to-end/subcommands/init.ts
+++ b/scripts/end-to-end/subcommands/init.ts
@@ -129,18 +129,27 @@ function setupScenario(scenario: Scenario, forceCheckout: ForceCheckout): void {
   const { scenarioDir, workingDir, definition } = scenario;
   const submodules = definition.submodules ?? false;
 
+  // commit: pin exactly; branch: track the latest remote tip (detached).
+  const { fetchRef, checkoutRef } =
+    definition.branch !== undefined
+      ? {
+          fetchRef: definition.branch,
+          checkoutRef: `origin/${definition.branch}`,
+        }
+      : { fetchRef: definition.commit, checkoutRef: definition.commit };
+
   if (!existsSync(workingDir)) {
     // Fresh clone flow
     clone(workingDir, definition.repo);
-    checkout(workingDir, definition.commit, forceCheckout);
+    checkout(workingDir, checkoutRef, forceCheckout);
 
     if (submodules) {
       updateSubmodules(workingDir);
     }
   } else {
     // Re-init flow
-    fetch(workingDir, definition.repo, definition.commit);
-    checkout(workingDir, definition.commit, forceCheckout);
+    fetch(workingDir, definition.repo, fetchRef);
+    checkout(workingDir, checkoutRef, forceCheckout);
     clean(workingDir);
 
     if (submodules) {
@@ -318,14 +327,19 @@ function clone(scenarioWorkingDir: string, repo: string): void {
   );
 }
 
-function fetch(scenarioWorkingDir: string, repo: string, commit: string): void {
+function fetch(scenarioWorkingDir: string, repo: string, ref: string): void {
   logStep(`Fetching ${repo}`);
 
-  // Fetch the specific commit by SHA so that the checkout below succeeds even
-  // if the commit is no longer the tip of any branch (e.g. after a force-push
-  // that orphaned the previously-fetched commits, or when the SHA points at
-  // an intermediate commit on a long-lived branch).
-  git(["fetch", "origin", commit], scenarioWorkingDir);
+  // `ref` is either a commit SHA or a branch name:
+  //
+  // - SHA: fetching the specific commit makes the checkout below succeed even
+  //   if the commit is no longer the tip of any branch (e.g. after a
+  //   force-push that orphaned the previously-fetched commits, or when the
+  //   SHA points at an intermediate commit on a long-lived branch).
+  // - branch: the default clone refspec force-updates
+  //   `refs/remotes/origin/<branch>`, so the subsequent detached checkout of
+  //   `origin/<branch>` lands on the latest remote tip.
+  git(["fetch", "origin", ref], scenarioWorkingDir);
 }
 
 function updateSubmodules(scenarioWorkingDir: string): void {
@@ -336,12 +350,12 @@ function updateSubmodules(scenarioWorkingDir: string): void {
 
 function checkout(
   scenarioWorkingDir: string,
-  commit: string,
+  ref: string,
   force: ForceCheckout,
 ): void {
-  logStep(`Checking out ${commit}`);
+  logStep(`Checking out ${ref}`);
 
-  const args = ["checkout", commit];
+  const args = ["checkout", ref];
   if (force === ForceCheckout.Yes) {
     args.push("--force");
   }

--- a/scripts/end-to-end/types.ts
+++ b/scripts/end-to-end/types.ts
@@ -10,9 +10,9 @@ export interface Scenario {
  *
  * - `commit`: pin to a full SHA or tag.
  * - `branch`: track the branch's latest remote tip on every init. Only allowed
- *   for repos in the NomicFoundation GitHub organisation (enforced by
+ *   for repos in the NomicFoundation GitHub organization (enforced by
  *   `validateScenarioSource`), so that a security breach in an external
- *   organisation or account cannot automatically affect our end-to-end
+ *   organization or account cannot automatically affect our end-to-end
  *   scenarios.
  */
 export type ScenarioDefinition = ScenarioDefinitionBase &

--- a/scripts/end-to-end/types.ts
+++ b/scripts/end-to-end/types.ts
@@ -5,10 +5,22 @@ export interface Scenario {
   definition: ScenarioDefinition;
 }
 
-export interface ScenarioDefinition {
+/**
+ * Exactly one of `commit` | `branch` selects what to checkout:
+ *
+ * - `commit`: pin to a full SHA or tag.
+ * - `branch`: track the branch's latest remote tip on every init. Only allowed
+ *   for repos in the NomicFoundation GitHub organisation (enforced by
+ *   `validateScenarioSource`), so that a security breach in an external
+ *   organisation or account cannot automatically affect our end-to-end
+ *   scenarios.
+ */
+export type ScenarioDefinition = ScenarioDefinitionBase &
+  ({ commit: string; branch?: never } | { branch: string; commit?: never });
+
+interface ScenarioDefinitionBase {
   description: string;
   repo: string;
-  commit: string;
   packageManager: "npm" | "bun" | "yarn" | "pnpm";
   defaultCommand: string;
   preinstall?: string;


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Adds a `branch` field to `end-to-end/*/scenario.json` as an alternative to `commit`. Exactly one of the two must be specified:

- `commit` — pins the checkout to a SHA/tag, as before.
- `branch` — checks out `origin/<branch>` detached, so every init (fresh clone and re-init) tracks the branch's latest remote tip.

## Why

Some scenarios point at forks we maintain ourselves, where we want to follow the latest state of a branch instead of bumping a pinned SHA on every change.

Because a branch is a mutable ref, `branch` is **only allowed for repos in the NomicFoundation GitHub organisation** (compared case-insensitively — GitHub org names are case-insensitively unique). This ensures a security breach in an external organisation or account cannot automatically affect our end-to-end scenarios; external repos must stay pinned to a `commit`.

## How

- `ScenarioDefinition` is now a discriminated union (`commit` xor `branch`), following the existing `CommandConfig` precedent.
- `isScenarioDefinition` enforces the presence-XOR structurally; a new throwing `validateScenarioSource` runs before the guard in `loadScenario` and reports targeted errors for the XOR violation and the org restriction.
- `setupScenario` resolves a fetch ref and checkout ref (`origin/<branch>` for branches); `git fetch origin <branch>` force-updates the remote-tracking ref, so re-init always lands on the latest tip.
- `scenario.schema.json` mirrors the XOR via a top-level `oneOf` for editor feedback; the org rule is documented there and enforced in TS.

Purely additive — all existing scenarios use `commit` and are unaffected.

## Testing

- 18 new unit tests covering the XOR, the org restriction (incl. case-insensitivity), and error messages; `pnpm test:scripts` passes (120 tests).
- Validated all 12 existing scenario files plus both/neither/branch-only cases against the updated JSON schema with ajv.
- `pnpm lint:scripts` (prettier + tsc) clean.
