### PR TITLE
ConfigVariable should have fallback value ( HH3 )

### DIFF
--- a/.changeset/petite-bags-tie.md
+++ b/.changeset/petite-bags-tie.md
@@ -1,7 +1,8 @@
 ---
+# docs: https://github.com/NomicFoundation/hardhat-website/pull/287
 "@nomicfoundation/hardhat-keystore": patch
 "@nomicfoundation/hardhat-zod-utils": patch
 "hardhat": patch
 ---
 
-Add a fallback for ConfigVariable.
+Add a fallback value for `configVariable`.

--- a/.changeset/petite-bags-tie.md
+++ b/.changeset/petite-bags-tie.md
@@ -1,0 +1,7 @@
+---
+"@nomicfoundation/hardhat-keystore": patch
+"@nomicfoundation/hardhat-zod-utils": patch
+"hardhat": patch
+---
+
+Add a fallback for ConfigVariable.

--- a/packages/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
+++ b/packages/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
@@ -47,6 +47,15 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
       if (process.env.HH_TEST === "true") {
         // When `fetchValue` is called from a test, we only allow the use of the development keystore
         // to avoid prompting for the production keystore password.
+        //
+        // If the variable declares a default value, delegate to the next handler
+        // so the built-in resolver can fall back to it. We must return here to
+        // avoid consulting the production keystore below (which would prompt for
+        // the production keystore password during tests).
+        if (variable.default !== undefined) {
+          return await next(context, variable);
+        }
+
         throw new HardhatError(
           HardhatError.ERRORS.HARDHAT_KEYSTORE.GENERAL.KEY_NOT_FOUND_DURING_TESTS_WITH_DEV_KEYSTORE,
           {
@@ -90,6 +99,20 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
     }
 
     const keystore = await keystoreLoader.loadKeystore();
+
+    // Unlocking the production keystore prompts for the password (the dev one
+    // reads it from a file). For a variable with a default, check the plaintext
+    // key names first: if the key isn't stored, skip the prompt and fall back
+    // to the default. Trade-off: this skips the HMAC integrity check on a miss,
+    // so a tampered (key removed) keystore falls back instead of erroring.
+    if (
+      !isDevKeystore &&
+      masterKey === undefined &&
+      variable.default !== undefined &&
+      !(await keystore.listUnverifiedKeys()).includes(variable.name)
+    ) {
+      return undefined;
+    }
 
     if (masterKey === undefined) {
       const { askPassword } = getPasswordHandlers(

--- a/packages/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
+++ b/packages/hardhat-keystore/src/internal/hook-handlers/configuration-variables.ts
@@ -48,11 +48,20 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
         // When `fetchValue` is called from a test, we only allow the use of the development keystore
         // to avoid prompting for the production keystore password.
         //
-        // If the variable declares a default value, delegate to the next handler
-        // so the built-in resolver can fall back to it. We must return here to
-        // avoid consulting the production keystore below (which would prompt for
-        // the production keystore password during tests).
-        if (variable.default !== undefined) {
+        // If the variable declares a default value and the key isn't stored in
+        // the production keystore either, delegate to the next handler so the
+        // built-in resolver can fall back to the default. We must return here
+        // to avoid consulting the production keystore below (which would
+        // prompt for the production keystore password during tests).
+        //
+        // If the key IS stored in the production keystore, we keep throwing:
+        // the user explicitly stored a value for it, and silently replacing it
+        // with the default during tests would be misleading. Checking the
+        // plaintext key names doesn't prompt for the password.
+        if (
+          variable.default !== undefined &&
+          !(await prodKeystoreContainsUnverifiedKey(context, variable))
+        ) {
           return await next(context, variable);
         }
 
@@ -75,6 +84,27 @@ export default async (): Promise<Partial<ConfigurationVariableHooks>> => {
       return await next(context, variable);
     },
   };
+
+  // Checks the plaintext key names of the production keystore, without
+  // unlocking it (so no password prompt). Trade-off: the key names' HMAC
+  // integrity isn't verified, so a tampered keystore (key removed) reads as
+  // a miss instead of erroring.
+  async function prodKeystoreContainsUnverifiedKey(
+    context: HookContext,
+    variable: ConfigurationVariable,
+  ): Promise<boolean> {
+    if (keystoreLoaderProd === undefined) {
+      keystoreLoaderProd = setupKeystoreLoaderFrom(context, false);
+    }
+
+    if (!(await keystoreLoaderProd.isKeystoreInitialized())) {
+      return false;
+    }
+
+    const keystore = await keystoreLoaderProd.loadKeystore();
+
+    return (await keystore.listUnverifiedKeys()).includes(variable.name);
+  }
 
   async function getValue(
     context: HookContext,

--- a/packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts
+++ b/packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts
@@ -342,6 +342,48 @@ describe("hook-handlers - configuration variables - fetchValue", () => {
           { key: "key3-prod" },
         );
       });
+
+      it("should delegate to the next handler (and use the default) instead of throwing when the key is missing but the variable has a default", async () => {
+        // `key4-prod` exists only in the production keystore, which must NOT be
+        // consulted in test mode. With a default set, the handler should
+        // delegate to the next handler (the built-in resolver) so the default
+        // is used, rather than throwing or reading/prompting the production
+        // keystore.
+        const res = await hre.hooks.runHandlerChain(
+          "configurationVariables",
+          "fetchValue",
+          [
+            {
+              _type: "ConfigurationVariable",
+              name: "key4-prod",
+              default: "the-default-value",
+            },
+          ],
+          async (_context, configVar) => {
+            // Mirrors the built-in terminal handler: env var, then default.
+            return process.env[configVar.name] ?? configVar.default ?? "unset";
+          },
+        );
+
+        assert.equal(res, "the-default-value");
+      });
+
+      it("should prefer the development keystore value over the default in test mode", async () => {
+        const res = await hre.hooks.runHandlerChain(
+          "configurationVariables",
+          "fetchValue",
+          [
+            {
+              _type: "ConfigurationVariable",
+              name: "key3-dev",
+              default: "the-default-value",
+            },
+          ],
+          async (_context, configVar) => configVar.default ?? "unset",
+        );
+
+        assert.equal(res, "value3-dev");
+      });
     });
 
     describe("when an environment variable is set for the same key", () => {
@@ -451,6 +493,110 @@ describe("hook-handlers - configuration variables - fetchValue", () => {
             "keystore should not be opened when env var is set",
           );
         });
+      });
+    });
+
+    describe("when the variable has a default and the production keystore would be opened", () => {
+      let passwordRequestCount: number;
+
+      beforeEach(async () => {
+        passwordRequestCount = 0;
+
+        const trackingPasswordPlugin: HardhatPlugin = {
+          id: "tracking-keystore-password",
+          hookHandlers: {
+            userInterruptions: async () => ({
+              default: async () => ({
+                requestSecretInput: async () => {
+                  passwordRequestCount++;
+                  return TEST_PASSWORD_PROD;
+                },
+              }),
+            }),
+          },
+        };
+
+        hre = await createHardhatRuntimeEnvironment({
+          plugins: [
+            hardhatKeystorePlugin,
+            setupKeystoreFileLocationOverrideAt(
+              configurationVariableProdKeystoreFilePath,
+              configurationVariableDevKeystoreFilePath,
+              configurationVariableDevKeystorePasswordFilePath,
+            ),
+            trackingPasswordPlugin,
+          ],
+        });
+      });
+
+      it("should resolve to the default without prompting for the production keystore password when the key is missing", async () => {
+        const res = await hre.hooks.runHandlerChain(
+          "configurationVariables",
+          "fetchValue",
+          [
+            {
+              _type: "ConfigurationVariable",
+              name: "non-existent-key-in-keystore",
+              default: "the-default-value",
+            },
+          ],
+          async (_context, configVar) =>
+            process.env[configVar.name] ?? configVar.default ?? "unset",
+        );
+
+        assert.equal(res, "the-default-value");
+        assert.equal(
+          passwordRequestCount,
+          0,
+          "the production keystore password should not be requested when the key is absent and a default is set",
+        );
+      });
+
+      it("should prefer the production keystore value over the default when the key is present", async () => {
+        // `key4-prod` exists only in the production keystore, so the keystore
+        // must be opened (prompting once) and its value wins over the default.
+        const res = await hre.hooks.runHandlerChain(
+          "configurationVariables",
+          "fetchValue",
+          [
+            {
+              _type: "ConfigurationVariable",
+              name: "key4-prod",
+              default: "the-default-value",
+            },
+          ],
+          async (_context, configVar) => configVar.default ?? "unset",
+        );
+
+        assert.equal(res, "value4-prod");
+        assert.equal(
+          passwordRequestCount,
+          1,
+          "the production keystore should be opened when it actually holds the key",
+        );
+      });
+
+      it("should still prompt for the password when the key is missing and no default is set", async () => {
+        // Without a default the behaviour is unchanged: the production keystore
+        // is opened (prompting for the password) before falling through.
+        const res = await hre.hooks.runHandlerChain(
+          "configurationVariables",
+          "fetchValue",
+          [
+            {
+              _type: "ConfigurationVariable",
+              name: "non-existent-key-in-keystore",
+            },
+          ],
+          async (_context, _configVar) => "value-from-next-handler",
+        );
+
+        assert.equal(res, "value-from-next-handler");
+        assert.equal(
+          passwordRequestCount,
+          1,
+          "without a default the production keystore is still opened",
+        );
       });
     });
 

--- a/packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts
+++ b/packages/hardhat-keystore/test/hook-handlers/configuration-variables.ts
@@ -343,19 +343,14 @@ describe("hook-handlers - configuration variables - fetchValue", () => {
         );
       });
 
-      it("should delegate to the next handler (and use the default) instead of throwing when the key is missing but the variable has a default", async () => {
-        // `key4-prod` exists only in the production keystore, which must NOT be
-        // consulted in test mode. With a default set, the handler should
-        // delegate to the next handler (the built-in resolver) so the default
-        // is used, rather than throwing or reading/prompting the production
-        // keystore.
+      it("should delegate to the next handler (and use the default) when the key is in neither keystore and the variable has a default", async () => {
         const res = await hre.hooks.runHandlerChain(
           "configurationVariables",
           "fetchValue",
           [
             {
               _type: "ConfigurationVariable",
-              name: "key4-prod",
+              name: "non-existent-key-in-keystore",
               default: "the-default-value",
             },
           ],
@@ -368,21 +363,83 @@ describe("hook-handlers - configuration variables - fetchValue", () => {
         assert.equal(res, "the-default-value");
       });
 
-      it("should prefer the development keystore value over the default in test mode", async () => {
+      it("should delegate to the next handler (and use the default) when the production keystore is not initialized and the variable has a default", async () => {
+        await remove(configurationVariableProdKeystoreFilePath);
+
         const res = await hre.hooks.runHandlerChain(
           "configurationVariables",
           "fetchValue",
           [
             {
               _type: "ConfigurationVariable",
-              name: "key3-dev",
+              name: "non-existent-key-in-keystore",
               default: "the-default-value",
             },
           ],
           async (_context, configVar) => configVar.default ?? "unset",
         );
 
-        assert.equal(res, "value3-dev");
+        assert.equal(res, "the-default-value");
+      });
+
+      it("should throw instead of using the default when the key exists in the production keystore, without prompting for the password", async () => {
+        // `key4-prod` exists only in the production keystore. Even though the
+        // variable declares a default, the stored value must not be silently
+        // replaced by it, so the handler keeps throwing. The check reads the
+        // production keystore's plaintext key names, so no password is
+        // requested.
+        let passwordRequested = false;
+
+        const trackingPasswordPlugin: HardhatPlugin = {
+          id: "tracking-keystore-password",
+          hookHandlers: {
+            userInterruptions: async () => ({
+              default: async () => ({
+                requestSecretInput: async () => {
+                  passwordRequested = true;
+                  return TEST_PASSWORD_PROD;
+                },
+              }),
+            }),
+          },
+        };
+
+        const localHre = await createHardhatRuntimeEnvironment({
+          plugins: [
+            hardhatKeystorePlugin,
+            setupKeystoreFileLocationOverrideAt(
+              configurationVariableProdKeystoreFilePath,
+              configurationVariableDevKeystoreFilePath,
+              configurationVariableDevKeystorePasswordFilePath,
+            ),
+            trackingPasswordPlugin,
+          ],
+        });
+
+        await assertRejectsWithHardhatError(
+          () =>
+            localHre.hooks.runHandlerChain(
+              "configurationVariables",
+              "fetchValue",
+              [
+                {
+                  _type: "ConfigurationVariable",
+                  name: "key4-prod",
+                  default: "the-default-value",
+                },
+              ],
+              async (_context, configVar) => configVar.default ?? "unset",
+            ),
+          HardhatError.ERRORS.HARDHAT_KEYSTORE.GENERAL
+            .KEY_NOT_FOUND_DURING_TESTS_WITH_DEV_KEYSTORE,
+          { key: "key4-prod" },
+        );
+
+        assert.equal(
+          passwordRequested,
+          false,
+          "the production keystore password should not be requested when checking for the key's existence",
+        );
       });
     });
 

--- a/packages/hardhat-zod-utils/src/index.ts
+++ b/packages/hardhat-zod-utils/src/index.ts
@@ -150,6 +150,8 @@ export const incompatibleFieldType = (errorMessage = "Unexpected field") =>
 export const configurationVariableSchema = z.object({
   _type: z.literal("ConfigurationVariable"),
   name: z.string(),
+  format: z.string().optional(),
+  default: z.string().optional(),
 });
 
 /**

--- a/packages/hardhat/src/internal/core/config.ts
+++ b/packages/hardhat/src/internal/core/config.ts
@@ -23,18 +23,51 @@ import {
 
 /**
  * Creates a configuration variable, which will be fetched at runtime.
+ *
+ * The second argument is an options object with an optional `format` (a
+ * template that must include the `{variable}` marker) and an optional
+ * `default` value. The default is used as a fallback when the variable can't
+ * be resolved from any other source (see {@link ConfigurationVariable.default}).
  */
 export function configVariable(
   name: string,
-  format: string = CONFIGURATION_VARIABLE_MARKER,
+  options?: { format?: string; default?: string },
+): ConfigurationVariable;
+/**
+ * @deprecated Passing the `format` as a string is deprecated. Pass an options
+ * object instead: `configVariable(name, { format })`.
+ */
+export function configVariable(
+  name: string,
+  format: string,
+): ConfigurationVariable;
+export function configVariable(
+  name: string,
+  formatOrOptions: string | { format?: string; default?: string } = {},
 ): ConfigurationVariable {
+  const { format = CONFIGURATION_VARIABLE_MARKER, default: defaultValue } =
+    typeof formatOrOptions === "string"
+      ? { format: formatOrOptions }
+      : formatOrOptions;
+
   if (!format.includes(CONFIGURATION_VARIABLE_MARKER)) {
     throw new HardhatError(
       HardhatError.ERRORS.CORE.GENERAL.CONFIG_VARIABLE_FORMAT_MUST_INCLUDE_VARIABLE,
       { format, marker: CONFIGURATION_VARIABLE_MARKER },
     );
   }
-  return { _type: "ConfigurationVariable", name, format };
+
+  const configurationVariable: ConfigurationVariable = {
+    _type: "ConfigurationVariable",
+    name,
+    format,
+  };
+
+  if (defaultValue !== undefined) {
+    configurationVariable.default = defaultValue;
+  }
+
+  return configurationVariable;
 }
 
 /**

--- a/packages/hardhat/src/internal/core/configuration-variables.ts
+++ b/packages/hardhat/src/internal/core/configuration-variables.ts
@@ -125,7 +125,9 @@ export class LazyResolvedConfigurationVariable extends BaseResolvedConfiguration
           "fetchValue",
           [this.#variable],
           async (_context, v) => {
-            const value = process.env[v.name];
+            // Fall back to the default only when the env var is unset. An empty
+            // string still takes precedence
+            const value = process.env[v.name] ?? v.default;
 
             if (typeof value !== "string") {
               throw new HardhatError(

--- a/packages/hardhat/src/types/config.ts
+++ b/packages/hardhat/src/types/config.ts
@@ -13,9 +13,11 @@ export interface ConfigurationVariable {
    * An optional fallback value, used only when the variable can't be resolved
    * from any other source (e.g. an environment variable or the keystore).
    *
-   * The resolution order is: environment variable, then any plugin source
-   * (like hardhat-keystore), and finally this default. If none of them provide
-   * a value and no default is set, resolving the variable throws.
+   * By default, the value is resolved from the environment variable first, then
+   * any plugin source (like hardhat-keystore), and finally this default. Plugins
+   * can customize this, but the built-in resolver and bundled plugins follow this
+   * order. If none of them provide a value and no default is set, resolving the
+   * variable throws.
    */
   default?: string;
 }

--- a/packages/hardhat/src/types/config.ts
+++ b/packages/hardhat/src/types/config.ts
@@ -8,6 +8,16 @@ export interface ConfigurationVariable {
   _type: "ConfigurationVariable";
   name: string;
   format?: string;
+
+  /**
+   * An optional fallback value, used only when the variable can't be resolved
+   * from any other source (e.g. an environment variable or the keystore).
+   *
+   * The resolution order is: environment variable, then any plugin source
+   * (like hardhat-keystore), and finally this default. If none of them provide
+   * a value and no default is set, resolving the variable throws.
+   */
+  default?: string;
 }
 
 /**

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/config-resolution.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/config-resolution.ts
@@ -111,6 +111,24 @@ describe("config-resolution", () => {
       assert.equal(httpNetworkConfig.timeout, 300_000);
       assert.deepEqual(httpNetworkConfig.httpHeaders, {});
     });
+
+    it("should resolve a url configuration variable to its default value when it is not set", async () => {
+      const userConfig: HttpNetworkUserConfig = {
+        type: "http",
+        url: configVariable("CONFIG_RESOLUTION_RPC_URL", {
+          default: "http://localhost:8545",
+        }),
+      };
+      const httpNetworkConfig = resolveHttpNetwork(
+        userConfig,
+        configVarResolver,
+      );
+
+      assert.equal(
+        await httpNetworkConfig.url.getUrl(),
+        "http://localhost:8545",
+      );
+    });
   });
 
   describe("resolveEdrNetwork", () => {

--- a/packages/hardhat/test/internal/core/configuration-variables/configuration-variables.ts
+++ b/packages/hardhat/test/internal/core/configuration-variables/configuration-variables.ts
@@ -69,6 +69,53 @@ describe("ResolvedConfigurationVariable", () => {
     );
   });
 
+  it("should return the default value when the environment variable is not set", async () => {
+    const variable = new LazyResolvedConfigurationVariable(
+      hre.hooks,
+      configVariable("DEFAULT_TEST_UNSET", { default: "the-default" }),
+    );
+
+    assert.equal(await variable.get(), "the-default");
+  });
+
+  it("should prefer the environment variable over the default value", async () => {
+    const variable = new LazyResolvedConfigurationVariable(
+      hre.hooks,
+      configVariable("DEFAULT_TEST_ENV", { default: "the-default" }),
+    );
+
+    process.env.DEFAULT_TEST_ENV = "from-env";
+
+    assert.equal(await variable.get(), "from-env");
+
+    delete process.env.DEFAULT_TEST_ENV;
+  });
+
+  it("should prefer an empty-string environment variable over the default value", async () => {
+    const variable = new LazyResolvedConfigurationVariable(
+      hre.hooks,
+      configVariable("DEFAULT_TEST_EMPTY", { default: "the-default" }),
+    );
+
+    process.env.DEFAULT_TEST_EMPTY = "";
+
+    assert.equal(await variable.get(), "");
+
+    delete process.env.DEFAULT_TEST_EMPTY;
+  });
+
+  it("should apply the format to the default value", async () => {
+    const variable = new LazyResolvedConfigurationVariable(
+      hre.hooks,
+      configVariable("DEFAULT_TEST_FORMAT", {
+        format: `variable: ${CONFIGURATION_VARIABLE_MARKER}`,
+        default: "the-default",
+      }),
+    );
+
+    assert.equal(await variable.get(), "variable: the-default");
+  });
+
   it("should return the cached value if called multiple times", async () => {
     const variable = new LazyResolvedConfigurationVariable(
       hre.hooks,
@@ -180,10 +227,47 @@ describe("configVariable", function () {
     assert.equal(variable.format, "var: {variable}");
   });
 
+  it("should not set a default value when none is provided", async () => {
+    assert.equal(configVariable("foo").default, undefined);
+    assert.equal(configVariable("foo", "var: {variable}").default, undefined);
+  });
+
+  it("should return a configuration variable with a default value", async () => {
+    const variable = configVariable("foo", { default: "bar" });
+
+    assert.equal(variable.name, "foo");
+    assert.equal(variable._type, "ConfigurationVariable");
+    assert.equal(variable.format, CONFIGURATION_VARIABLE_MARKER);
+    assert.equal(variable.default, "bar");
+  });
+
+  it("should return a configuration variable with a format and a default value", async () => {
+    const variable = configVariable("foo", {
+      format: "var: {variable}",
+      default: "bar",
+    });
+
+    assert.equal(variable.name, "foo");
+    assert.equal(variable._type, "ConfigurationVariable");
+    assert.equal(variable.format, "var: {variable}");
+    assert.equal(variable.default, "bar");
+  });
+
   it("throws an error when format doesn't include the variable marker", async () => {
     assertThrowsHardhatError(
       () => {
         configVariable("foo", "missing_marker");
+      },
+      HardhatError.ERRORS.CORE.GENERAL
+        .CONFIG_VARIABLE_FORMAT_MUST_INCLUDE_VARIABLE,
+      { format: "missing_marker", marker: "{variable}" },
+    );
+  });
+
+  it("throws an error when the format in the options object doesn't include the variable marker", async () => {
+    assertThrowsHardhatError(
+      () => {
+        configVariable("foo", { format: "missing_marker" });
       },
       HardhatError.ERRORS.CORE.GENERAL
         .CONFIG_VARIABLE_FORMAT_MUST_INCLUDE_VARIABLE,


### PR DESCRIPTION
Fixes: https://github.com/NomicFoundation/hardhat/issues/7227

Updated docs PR: https://github.com/NomicFoundation/hardhat-website/pull/287

To summarize, this is the behvior:
• env var set → always wins, keystore never touched
• key in dev keystore → that value is used (beats the default)
• key in prod keystore (not in test mode) → that value is used (beats the default)
• test mode (HH_TEST=true):
   - key in dev keystore → used as normal
   - key in prod keystore → throws like before, even if a default is set (no silent fallback, no password prompt — checked via plaintext key names)
   - key nowhere + default set → default is used, no prompt
   - key nowhere + no default → throws like before
• not in test mode, key nowhere + default set → default is used, without prompting for the prod keystore password
• key nowhere + no default → falls through to the built-in resolver (ENV_VAR_NOT_FOUND error)