### PR TITLE
fix: don't copy build outputs from templates during init

### DIFF
--- a/.changeset/quick-owls-cheer.md
+++ b/.changeset/quick-owls-cheer.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed project initialization so that compilation and build output directories are never copied from a template into a new project.

--- a/packages/hardhat/src/internal/cli/init/template.ts
+++ b/packages/hardhat/src/internal/cli/init/template.ts
@@ -13,6 +13,21 @@ import {
   type PackageJson,
 } from "@nomicfoundation/hardhat-utils/package";
 
+// Directories that may exist inside a template dir (build/tooling output,
+// dependencies) but are never part of the template itself. They are all
+// gitignored in the templates, but `getAllFilesMatching` does not honor
+// .gitignore, so we must exclude them explicitly.
+const IGNORED_TEMPLATE_DIRS = new Set([
+  "node_modules",
+  "artifacts",
+  "cache",
+  "types",
+  "dist",
+  "bundle",
+  "coverage",
+  "snapshots",
+]);
+
 /**
  * This type describes a hardhat project template. It consists of:
  * - name: The name of the template;
@@ -75,7 +90,7 @@ export async function getTemplates(): Promise<Template[]> {
           }
           return true;
         },
-        (dir) => path.basename(dir) !== "node_modules",
+        (dir) => !IGNORED_TEMPLATE_DIRS.has(path.basename(dir)),
       );
 
       const files = matchingFiles.map((f) => path.relative(pathToTemplate, f));

--- a/packages/hardhat/test/internal/cli/init/template.ts
+++ b/packages/hardhat/test/internal/cli/init/template.ts
@@ -58,9 +58,7 @@ describe("getTemplates", () => {
         if (
           typeof pathToRead !== "string" ||
           options?.withFileTypes !== true ||
-          !pathToRead.includes(
-            `${path.sep}templates${path.sep}hardhat-3${path.sep}`,
-          )
+          !pathToRead.includes(`${path.sep}templates${path.sep}`)
         ) {
           return dirents;
         }
@@ -76,6 +74,66 @@ describe("getTemplates", () => {
         nodeModulesDirent.isSocket = () => false;
 
         return [...dirents, nodeModulesDirent];
+      },
+    );
+
+    try {
+      await getTemplates();
+    } finally {
+      readdirMock.mock.restore();
+    }
+  });
+
+  it("Regression test: should not descend into build output directories when reading template files", async () => {
+    // Build/tooling output dirs (artifacts, cache, types, ...) are gitignored in
+    // the templates but may exist on disk (e.g. a concurrent `hardhat compile`
+    // in the shared template dir during CI). They must never be treated as
+    // template files, otherwise `copyProjectFiles` can race with their deletion.
+    const buildOutputDirs = ["artifacts", "cache", "types"];
+
+    const originalReaddir = fsPromises.readdir;
+    const readdirMock = mock.method(
+      fsPromises,
+      "readdir",
+      async (...args: Parameters<typeof originalReaddir>) => {
+        const [pathToRead, options] = args;
+
+        if (
+          typeof pathToRead === "string" &&
+          buildOutputDirs.some((dir) =>
+            pathToRead.endsWith(`${path.sep}${dir}`),
+          ) &&
+          options?.withFileTypes === true
+        ) {
+          throw new Error(
+            "getTemplates should not recurse into build output directories",
+          );
+        }
+
+        const dirents = await Reflect.apply(originalReaddir, fsPromises, args);
+
+        if (
+          typeof pathToRead !== "string" ||
+          options?.withFileTypes !== true ||
+          !pathToRead.includes(`${path.sep}templates${path.sep}`)
+        ) {
+          return dirents;
+        }
+
+        const fakeDirents = buildOutputDirs.map((dir) => {
+          const dirent: Dirent = Object.create(dirents[0] ?? {});
+          dirent.name = dir;
+          dirent.isDirectory = () => true;
+          dirent.isFile = () => false;
+          dirent.isSymbolicLink = () => false;
+          dirent.isBlockDevice = () => false;
+          dirent.isCharacterDevice = () => false;
+          dirent.isFIFO = () => false;
+          dirent.isSocket = () => false;
+          return dirent;
+        });
+
+        return [...dirents, ...fakeDirents];
       },
     );
 


### PR DESCRIPTION
When you run `hardhat init`, Hardhat copies a template project into the new directory. To determine which files to copy, it scans the template directory, but it only ignored `node_modules`, not other generated directories like `artifacts`, `cache`, and `types`.

This caused two issues:

* If a template directory contained leftover build output, those files were copied into the newly created project.
* Our tests compile templates in place, creating `artifacts`, and clean them up afterward. If the scan happened while those files briefly existed, `init` could try to copy a file that had already been deleted, causing a `FileNotFoundError`.

This change makes `init` ignore generated directories entirely, so only actual template files are copied. It also adds a regression test covering these exclusions.
