### PR TITLE
feat(hardhat-solx): map Solidity 0.8.34 to solx 0.1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       is_v3: ${{ steps.check.outputs.version_starts_with_3 }}
       scripts_changed: ${{ steps.scripts-filter.outputs.scripts }}
       workflows_changed: ${{ steps.scripts-filter.outputs.workflows }}
+      solx_mirror_changed: ${{ steps.scripts-filter.outputs.solx_mirror }}
 
     steps:
       - name: Checkout code
@@ -46,6 +47,9 @@ jobs:
               - '.github/scripts/**'
               - '.github/workflows/**'
               - '.github/actions/**'
+            solx_mirror:
+              - 'packages/hardhat-solx/src/internal/constants.ts'
+              - 'packages/hardhat-solx/test/mirror-availability.ts'
 
   check_dependencies:
     name: Check dependency versions
@@ -96,6 +100,31 @@ jobs:
         run: pnpm lint:workflows
       - name: Run workflow script tests
         run: pnpm test:workflows
+
+  solx-mirror-availability:
+    name: Check solx releases mirror availability
+    needs: is-v3
+    # Network check against an external service: only run when the version map
+    # or the check itself changes, not on every PR that rebuilds hardhat-solx.
+    if: ${{ needs.is-v3.outputs.is_v3 == 'true' && needs.is-v3.outputs.solx_mirror_changed == 'true' }}
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/hardhat-solx
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-env
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Build
+        run: pnpm build
+      - name: Check mirror availability
+        env:
+          HARDHAT_RUN_MIRROR_TESTS: true
+        run: node --import tsx/esm --test --test-reporter=@nomicfoundation/hardhat-node-test-reporter test/mirror-availability.ts
 
   list-packages:
     name: List packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
               - '.github/actions/**'
             solx_mirror:
               - 'packages/hardhat-solx/src/internal/constants.ts'
+              - 'packages/hardhat-solx/src/internal/platform.ts'
               - 'packages/hardhat-solx/test/mirror-availability.ts'
 
   check_dependencies:

--- a/packages/hardhat-solx/README.md
+++ b/packages/hardhat-solx/README.md
@@ -137,7 +137,7 @@ solx: {
 
 ### Supported Solidity versions
 
-solx maps each Solidity version to a specific solx binary version internally. Currently supported: `0.8.34` (solx 0.1.4). Earlier solx releases did not emit the DWARF debug info that EDR relies on for Solidity stack traces, so they are not supported by this plugin.
+solx maps each Solidity version to a specific solx binary version internally. Currently supported: `0.8.34` (solx 0.1.6). Earlier solx releases did not emit the DWARF debug info that EDR relies on for Solidity stack traces, so they are not supported by this plugin.
 
 ### EVM version support
 

--- a/packages/hardhat-solx/src/internal/constants.ts
+++ b/packages/hardhat-solx/src/internal/constants.ts
@@ -24,5 +24,5 @@ export const DEFAULT_SOLX_OPTIMIZER_MODE = "1";
 
 /** Maps Solidity versions to the solx version that embeds them. */
 export const SOLIDITY_TO_SOLX_VERSION_MAP: Record<string, string> = {
-  "0.8.34": "0.1.4",
+  "0.8.34": "0.1.6",
 };

--- a/packages/hardhat-solx/test/mirror-availability.ts
+++ b/packages/hardhat-solx/test/mirror-availability.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getRequest } from "@nomicfoundation/hardhat-utils/request";
+
+import {
+  SOLIDITY_TO_SOLX_VERSION_MAP,
+  SOLX_RELEASES_BASE_URL,
+} from "../src/internal/constants.js";
+
+// Every release asset the mirror must serve for a solx version (the
+// platform-specific names from platform.ts). A user on any supported
+// platform downloads exactly one of these, so a missing asset means a
+// broken compile for that platform. The `.sha256` sidecars are included
+// because the downloader treats a missing sidecar as a soft warning and
+// skips verification — this test is the only hard check that they exist.
+function assetNames(version: string): string[] {
+  return [
+    `solx-linux-amd64-gnu-v${version}`,
+    `solx-linux-arm64-gnu-v${version}`,
+    `solx-macosx-v${version}`,
+    `solx-windows-amd64-gnu-v${version}.exe`,
+  ];
+}
+
+describe(
+  "solx releases mirror availability",
+  { skip: process.env.HARDHAT_DISABLE_SLOW_TESTS === "true" },
+  () => {
+    for (const [solidityVersion, solxVersion] of Object.entries(
+      SOLIDITY_TO_SOLX_VERSION_MAP,
+    )) {
+      it(`serves every solx ${solxVersion} asset and checksum (mapped from Solidity ${solidityVersion})`, async () => {
+        const missing: string[] = [];
+        for (const asset of assetNames(solxVersion)) {
+          for (const file of [asset, `${asset}.sha256`]) {
+            // 1-byte range request: availability check without downloading
+            // the ~60 MB binaries.
+            const response = await getRequest(
+              `${SOLX_RELEASES_BASE_URL}/${file}`,
+              { extraHeaders: { Range: "bytes=0-0" } },
+            );
+            await response.body.text();
+            if (response.statusCode !== 200 && response.statusCode !== 206) {
+              missing.push(`${file} (${response.statusCode})`);
+            }
+          }
+        }
+        assert.deepEqual(
+          missing,
+          [],
+          `the mirror does not serve: ${missing.join(", ")} — the version map must not point at a solx release before solx-releases-mirror serves its assets`,
+        );
+      });
+    }
+  },
+);

--- a/packages/hardhat-solx/test/mirror-availability.ts
+++ b/packages/hardhat-solx/test/mirror-availability.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { getRequest } from "@nomicfoundation/hardhat-utils/request";
+import {
+  getRequest,
+  ResponseStatusCodeError,
+} from "@nomicfoundation/hardhat-utils/request";
 
 import {
   SOLIDITY_TO_SOLX_VERSION_MAP,
@@ -35,14 +38,22 @@ describe(
         for (const asset of assetNames(solxVersion)) {
           for (const file of [asset, `${asset}.sha256`]) {
             // 1-byte range request: availability check without downloading
-            // the ~60 MB binaries.
-            const response = await getRequest(
-              `${SOLX_RELEASES_BASE_URL}/${file}`,
-              { extraHeaders: { Range: "bytes=0-0" } },
-            );
-            await response.body.text();
-            if (response.statusCode !== 200 && response.statusCode !== 206) {
-              missing.push(`${file} (${response.statusCode})`);
+            // the ~60 MB binaries. getRequest throws on status >= 400.
+            try {
+              const response = await getRequest(
+                `${SOLX_RELEASES_BASE_URL}/${file}`,
+                { extraHeaders: { Range: "bytes=0-0" } },
+                { timeout: 30_000 },
+              );
+              if (response.statusCode !== 200 && response.statusCode !== 206) {
+                missing.push(`${file} (${response.statusCode})`);
+              }
+              await response.body.text();
+            } catch (error) {
+              if (!(error instanceof ResponseStatusCodeError)) {
+                throw error;
+              }
+              missing.push(`${file} (${error.statusCode})`);
             }
           }
         }

--- a/packages/hardhat-solx/test/mirror-availability.ts
+++ b/packages/hardhat-solx/test/mirror-availability.ts
@@ -11,12 +11,7 @@ import {
   SOLX_RELEASES_BASE_URL,
 } from "../src/internal/constants.js";
 
-// Every release asset the mirror must serve for a solx version (the
-// platform-specific names from platform.ts). A user on any supported
-// platform downloads exactly one of these, so a missing asset means a
-// broken compile for that platform. The `.sha256` sidecars are included
-// because the downloader treats a missing sidecar as a soft warning and
-// skips verification — this test is the only hard check that they exist.
+// Mirrors the per-platform asset names built in src/internal/platform.ts.
 function assetNames(version: string): string[] {
   return [
     `solx-linux-amd64-gnu-v${version}`,
@@ -36,13 +31,15 @@ describe(
       it(`serves every solx ${solxVersion} asset and checksum (mapped from Solidity ${solidityVersion})`, async () => {
         const missing: string[] = [];
         for (const asset of assetNames(solxVersion)) {
+          // Sidecars too: a missing one only soft-warns in the downloader.
           for (const file of [asset, `${asset}.sha256`]) {
-            // 1-byte range request: availability check without downloading
-            // the ~60 MB binaries. getRequest throws on status >= 400.
             try {
               const response = await getRequest(
                 `${SOLX_RELEASES_BASE_URL}/${file}`,
+                // 1-byte range: don't pull the ~60 MB binaries.
                 { extraHeaders: { Range: "bytes=0-0" } },
+                // isTestDispatcher drops keep-alive to 10ms; these dispatchers
+                // are never closed and would otherwise hang the suite.
                 { timeout: 30_000, isTestDispatcher: true },
               );
               if (response.statusCode !== 200 && response.statusCode !== 206) {
@@ -50,6 +47,7 @@ describe(
               }
               await response.body.text();
             } catch (error) {
+              // getRequest throws on >= 400 instead of returning the status.
               if (!(error instanceof ResponseStatusCodeError)) {
                 throw error;
               }

--- a/packages/hardhat-solx/test/mirror-availability.ts
+++ b/packages/hardhat-solx/test/mirror-availability.ts
@@ -43,7 +43,7 @@ describe(
               const response = await getRequest(
                 `${SOLX_RELEASES_BASE_URL}/${file}`,
                 { extraHeaders: { Range: "bytes=0-0" } },
-                { timeout: 30_000 },
+                { timeout: 30_000, isTestDispatcher: true },
               );
               if (response.statusCode !== 200 && response.statusCode !== 206) {
                 missing.push(`${file} (${response.statusCode})`);

--- a/packages/hardhat-solx/test/mirror-availability.ts
+++ b/packages/hardhat-solx/test/mirror-availability.ts
@@ -23,7 +23,9 @@ function assetNames(version: string): string[] {
 
 describe(
   "solx releases mirror availability",
-  { skip: process.env.HARDHAT_DISABLE_SLOW_TESTS === "true" },
+  // Opt-in: run by the path-filtered solx-mirror-availability job in ci.yml,
+  // not on every PR that rebuilds this package.
+  { skip: process.env.HARDHAT_RUN_MIRROR_TESTS !== "true" },
   () => {
     for (const [solidityVersion, solxVersion] of Object.entries(
       SOLIDITY_TO_SOLX_VERSION_MAP,


### PR DESCRIPTION
Change mapping of 0.8.34 of solx to the latest release (0.1.6). Unblocked by https://github.com/NomicFoundation/solx-releases-mirror/pull/10.

Adds a smoke test to test mirror availability (to avoid accidentally breaking the mapping in the future). 


## Claude Summary

Bumps `SOLIDITY_TO_SOLX_VERSION_MAP` so Solidity 0.8.34 resolves to solx 0.1.6 (was 0.1.4), plus the matching README line. 0.1.6 fixes the DWARF line attribution for inline assembly and `invalid()` (NomicFoundation/solx#583), which EDR's parity sweep currently pins as divergences — the EDR-side pin removal and scenarios fixture regeneration ride this same bump.

Also adds a mirror-availability test: for every map entry, it issues 1-byte range requests against all four platform assets **and their `.sha256` sidecars** on the releases mirror. The sidecar half matters because the downloader treats a missing sidecar as a soft warning and skips checksum verification — this test is the only hard check that checksums exist.

## When the check runs

The test is opt-in (`HARDHAT_RUN_MIRROR_TESTS=true`), so the regular `ci` matrix never contacts the mirror — hardhat-solx's suite runs on most core PRs via its `hardhat` dependency, and an external service's state shouldn't red unrelated PRs (raised by @kanej in review). A dedicated single-runner job in `ci.yml` runs just this test file, path-filtered to `src/internal/constants.ts`, `src/internal/platform.ts` (the asset-name construction the test mirrors), and the test itself — the only changes that can break the mapping.

## Blocker cleared

solx-releases-mirror#10 merged 2026-07-27, so the mirror now serves the 0.1.6 assets. The two jobs that gated merge ordering — the new mirror-availability test, and output-augmentation's binary download on cold-cache runners — no longer have a reason to fail. Nothing left to change here.

## Verification

- Compiled all fixtures with a real solx 0.1.6 binary via the output-augmentation suite; the `debugInfo` assertions hold.
- Mirror test proven red at 0.1.6 while the mirror still 404'd, and green against the 0.1.4 assets it did serve. Re-run 2026-07-28 after mirror#10: green — all eight files (four binaries + four sidecars) answer 200/206 in ~3s.
- The new gate proven both ways: without the env var the suite reports SKIP; with it, green against the live mirror. `actionlint` on the edited `ci.yml` shows the same 26 pre-existing findings as `main` (none new), and `pnpm lint:workflows` / `pnpm test:workflows` pass.

## Review

Copilot raised three points, all addressed:

- Unbounded body buffering and first-failure-only reporting — `getRequest` sets undici's `throwOnError`, so a 404 threw before the status check ran and the test died on the first missing file. Now caught per file with the status collected, status checked before the drain, and 30s per request instead of undici's 300s default (baed9060b).
- Dispatcher keep-alive outliving the suite — `isTestDispatcher: true` drops it to 10ms, which is what this test wants since every `getRequest` builds a dispatcher that is never closed (cf7385bfe).
- Stale comment above `assetNames()` — it claimed the sidecars were included while the function returns only binaries. Trimmed the block to one-liners sitting on the lines they explain (982a088b).

kanej flagged that a continual release-mirror check doesn't belong in standard CI — addressed by the path-filtered opt-in job above (34dcf8e04, ba6ccf8c7).

## Notes

- `@nomicfoundation/hardhat-solx` is private — no changeset.
