### PR TITLE
fix: return new request objects from network handlers

### DIFF
--- a/.changeset/immutable-network-request-handlers.md
+++ b/.changeset/immutable-network-request-handlers.md
@@ -1,0 +1,5 @@
+﻿---
+"hardhat": patch
+---
+
+Return new JSON-RPC request objects from network request handlers instead of mutating the caller's request

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -59,9 +59,8 @@ export default async (): Promise<Partial<NetworkHooks>> => {
         });
       }
 
-      // We previously cloned here, but the performance impact is significant.
-      // TODO: ensure the passed in request is not mutated by adapting the
-      // handlers being applied here. See https://github.com/NomicFoundation/hardhat/issues/8090
+      // Handlers return new request objects instead of mutating in place, so
+      // the caller's request remains unchanged. See #8090.
       let updatedRequest = jsonRpcRequest;
 
       for (const handler of requestHandlers) {

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/json-rpc.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/json-rpc.ts
@@ -145,3 +145,20 @@ export function getRequestParams(
     HardhatError.ERRORS.CORE.NETWORK.INVALID_REQUEST_PARAMS,
   );
 }
+
+/**
+ * Returns a shallow copy of `jsonRpcRequest` whose first params entry is
+ * replaced with `tx`. Used by request handlers so they can update transaction
+ * fields without mutating the caller's request object.
+ */
+export function replaceJsonRpcRequestTx(
+  jsonRpcRequest: JsonRpcRequest,
+  tx: Record<PropertyKey, any>,
+): JsonRpcRequest {
+  const params = getRequestParams(jsonRpcRequest);
+
+  return {
+    ...jsonRpcRequest,
+    params: [tx, ...params.slice(1)],
+  };
+}

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
@@ -78,9 +78,7 @@ export class LocalAccountsHandler extends ChainId implements RequestHandler {
       return response;
     }
 
-    await this.#modifyRequest(jsonRpcRequest);
-
-    return jsonRpcRequest;
+    return await this.#modifyRequest(jsonRpcRequest);
   }
 
   async #getAddressesAndPrivateKeysMap(): Promise<{
@@ -219,11 +217,18 @@ export class LocalAccountsHandler extends ChainId implements RequestHandler {
     return null;
   }
 
-  async #modifyRequest(jsonRpcRequest: JsonRpcRequest): Promise<void> {
+  async #modifyRequest(
+    jsonRpcRequest: JsonRpcRequest,
+  ): Promise<JsonRpcRequest> {
     const params = getRequestParams(jsonRpcRequest);
 
     if (jsonRpcRequest.method === "eth_sendTransaction" && params.length > 0) {
-      const [txRequest] = validateParams(params, rpcTransactionRequest);
+      const [validatedTxRequest] = validateParams(
+        params,
+        rpcTransactionRequest,
+      );
+      // Copy so nonce backfill does not mutate the caller's transaction object.
+      const txRequest = { ...validatedTxRequest };
 
       if (txRequest.gas === undefined) {
         throw new HardhatError(
@@ -291,9 +296,14 @@ export class LocalAccountsHandler extends ChainId implements RequestHandler {
         privateKey,
       );
 
-      jsonRpcRequest.method = "eth_sendRawTransaction";
-      jsonRpcRequest.params = [bytesToHexString(rawTransaction)];
+      return {
+        ...jsonRpcRequest,
+        method: "eth_sendRawTransaction",
+        params: [bytesToHexString(rawTransaction)],
+      };
     }
+
+    return jsonRpcRequest;
   }
 
   async #initializeAddressesFromPrivateKeys(

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/sender.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/sender.ts
@@ -8,7 +8,10 @@ import type { RequestHandler } from "../../types.js";
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { getRequestParams } from "../../../json-rpc.js";
+import {
+  getRequestParams,
+  replaceJsonRpcRequestTx,
+} from "../../../json-rpc.js";
 
 /**
  * This class modifies JSON-RPC requests.
@@ -49,7 +52,10 @@ export abstract class SenderHandler implements RequestHandler {
       const senderAccount = await this.getSender();
 
       if (senderAccount !== undefined) {
-        tx.from = senderAccount;
+        return replaceJsonRpcRequestTx(jsonRpcRequest, {
+          ...tx,
+          from: senderAccount,
+        });
       } else if (method === "eth_sendTransaction") {
         throw new HardhatError(
           HardhatError.ERRORS.CORE.NETWORK.NO_REMOTE_ACCOUNT_AVAILABLE,

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts
@@ -7,7 +7,10 @@ import type { RequestHandler } from "../../types.js";
 
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { getRequestParams } from "../../../json-rpc.js";
+import {
+  getRequestParams,
+  replaceJsonRpcRequestTx,
+} from "../../../json-rpc.js";
 
 import { MultipliedGasEstimation } from "./multiplied-gas-estimation.js";
 
@@ -49,7 +52,10 @@ export class AutomaticGasHandler
     const [tx] = params;
 
     if (isObject(tx) && tx.gas === undefined) {
-      tx.gas = await this.getMultipliedGasEstimation(params);
+      return replaceJsonRpcRequestTx(jsonRpcRequest, {
+        ...tx,
+        gas: await this.getMultipliedGasEstimation(params),
+      });
     }
 
     return jsonRpcRequest;

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts
@@ -12,7 +12,10 @@ import {
 } from "@nomicfoundation/hardhat-utils/hex";
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { getRequestParams } from "../../../json-rpc.js";
+import {
+  getRequestParams,
+  replaceJsonRpcRequestTx,
+} from "../../../json-rpc.js";
 
 /**
  * This class automatically adjusts transaction requests to include appropriately estimated gas prices.
@@ -72,8 +75,10 @@ export class AutomaticGasPriceHandler implements RequestHandler {
       tx.maxPriorityFeePerGas === undefined &&
       suggestedEip1559Values === undefined
     ) {
-      tx.gasPrice = numberToHexString(await this.#getGasPrice());
-      return jsonRpcRequest;
+      return replaceJsonRpcRequestTx(jsonRpcRequest, {
+        ...tx,
+        gasPrice: numberToHexString(await this.#getGasPrice()),
+      });
     }
 
     // If eth_feeHistory failed, but the user still wants to send an EIP-1559 tx
@@ -101,10 +106,11 @@ export class AutomaticGasPriceHandler implements RequestHandler {
       maxFeePerGas += maxPriorityFeePerGas;
     }
 
-    tx.maxFeePerGas = numberToHexString(maxFeePerGas);
-    tx.maxPriorityFeePerGas = numberToHexString(maxPriorityFeePerGas);
-
-    return jsonRpcRequest;
+    return replaceJsonRpcRequestTx(jsonRpcRequest, {
+      ...tx,
+      maxFeePerGas: numberToHexString(maxFeePerGas),
+      maxPriorityFeePerGas: numberToHexString(maxPriorityFeePerGas),
+    });
   }
 
   async #getGasPrice(): Promise<bigint> {

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
@@ -7,7 +7,10 @@ import type { PrefixedHexString } from "@nomicfoundation/hardhat-utils/hex";
 
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { getRequestParams } from "../../../json-rpc.js";
+import {
+  getRequestParams,
+  replaceJsonRpcRequestTx,
+} from "../../../json-rpc.js";
 
 /**
  * This class ensures that a fixed gas is applied to transaction requests.
@@ -37,7 +40,10 @@ export class FixedGasHandler implements RequestHandler {
     const [tx] = params;
 
     if (isObject(tx) && tx.gas === undefined) {
-      tx.gas = this.#gas;
+      return replaceJsonRpcRequestTx(jsonRpcRequest, {
+        ...tx,
+        gas: this.#gas,
+      });
     }
 
     return jsonRpcRequest;

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts
@@ -7,7 +7,10 @@ import type { PrefixedHexString } from "@nomicfoundation/hardhat-utils/hex";
 
 import { isObject } from "@nomicfoundation/hardhat-utils/lang";
 
-import { getRequestParams } from "../../../json-rpc.js";
+import {
+  getRequestParams,
+  replaceJsonRpcRequestTx,
+} from "../../../json-rpc.js";
 
 /**
  * This class ensures that a fixed gas price is applied to transaction requests.
@@ -43,7 +46,10 @@ export class FixedGasPriceHandler implements RequestHandler {
       tx.maxFeePerGas === undefined &&
       tx.maxPriorityFeePerGas === undefined
     ) {
-      tx.gasPrice = this.#gasPrice;
+      return replaceJsonRpcRequestTx(jsonRpcRequest, {
+        ...tx,
+        gasPrice: this.#gasPrice,
+      });
     }
 
     return jsonRpcRequest;

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -17,6 +17,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { deepClone } from "@nomicfoundation/hardhat-utils/lang";
 
 import factory from "../../../../../src/internal/builtin-plugins/network-manager/hook-handlers/network.js";
 import { EthereumMockedProvider } from "../request-handlers/ethereum-mocked-provider.js";
@@ -96,7 +97,7 @@ describe("network hook handler", () => {
         },
       ],
     };
-    const originalParams = structuredClone(request.params);
+    const originalParams = await deepClone(request.params);
 
     await handlers.onRequest(context, connection, request, next);
 

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/network.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/network.ts
@@ -76,6 +76,33 @@ describe("network hook handler", () => {
     assert.equal(provider.getNumberOfCalls("eth_chainId"), 1);
   });
 
+  
+  it("should not mutate the original JSON-RPC request when handlers fill gas fields", async () => {
+    const handlers = await createHandlersFromFactory();
+    const { connection, context, next } = setupRequestMocks({
+      gas: 100n,
+      gasPrice: 200n,
+    });
+
+    const request = {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      method: "eth_sendTransaction",
+      params: [
+        {
+          from: "0x0000000000000000000000000000000000000011",
+          to: "0x0000000000000000000000000000000000000011",
+          value: "0x1",
+        },
+      ],
+    };
+    const originalParams = structuredClone(request.params);
+
+    await handlers.onRequest(context, connection, request, next);
+
+    assert.deepEqual(request.params, originalParams);
+  });
+
   it("should create separate handlers for different connections", async () => {
     const handlers = await createHandlersFromFactory();
     const { context, next } = setupRequestMocks();

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/automatic-sender-handler.ts
@@ -47,9 +47,9 @@ describe("AutomaticSenderHandler", function () {
   it("should set the from value into the transaction", async () => {
     const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-    await automaticSenderHandler.handle(jsonRpcRequest);
-
-    const [requestTx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await automaticSenderHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [requestTx] = getRequestParams(updatedRequest);
     assert.ok(isObject(requestTx), "tx is not an object");
     assert.equal(requestTx.from, "0x123006d4548a3ac17d72b372ae1e416bf65b8eaf");
   });
@@ -59,9 +59,9 @@ describe("AutomaticSenderHandler", function () {
 
     const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-    await automaticSenderHandler.handle(jsonRpcRequest);
-
-    const [requestTx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await automaticSenderHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [requestTx] = getRequestParams(updatedRequest);
     assert.ok(isObject(requestTx), "tx is not an object");
     assert.equal(requestTx.from, "0x000006d4548a3ac17d72b372ae1e416bf65b8ead");
   });
@@ -113,9 +113,9 @@ describe("AutomaticSenderHandler", function () {
 
     const jsonRpcRequest = getJsonRpcRequest(1, "eth_call", [tx]);
 
-    await automaticSenderHandler.handle(jsonRpcRequest);
-
-    const [requestTx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await automaticSenderHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [requestTx] = getRequestParams(updatedRequest);
     assert.ok(isObject(requestTx), "tx is not an object");
     assert.equal(requestTx.value, "asd");
   });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/fixed-sender-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/fixed-sender-handler.ts
@@ -43,9 +43,9 @@ describe("FixedSenderHandler", function () {
   it("should set the from value into the transaction", async () => {
     const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-    await fixedSenderHandler.handle(jsonRpcRequest);
-
-    const [requestTx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await fixedSenderHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [requestTx] = getRequestParams(updatedRequest);
     assert.ok(isObject(requestTx), "tx is not an object");
     assert.equal(requestTx.from, "0x2a97a65d5673a2c61e95ce33cecadf24f654f96d");
   });
@@ -55,9 +55,9 @@ describe("FixedSenderHandler", function () {
 
     const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-    await fixedSenderHandler.handle(jsonRpcRequest);
-
-    const [requestTx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await fixedSenderHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [requestTx] = getRequestParams(updatedRequest);
     assert.ok(isObject(requestTx), "tx is not an object");
     assert.equal(requestTx.from, "0x000006d4548a3ac17d72b372ae1e416bf65b8ead");
   });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/accounts/local-accounts.ts
@@ -478,14 +478,15 @@ describe("LocalAccountsHandler", () => {
             tx,
           ]);
 
-          await localAccountsHandler.handle(jsonRpcRequest);
+          const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
+          assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
           assert.ok(
-            Array.isArray(jsonRpcRequest.params),
+            Array.isArray(updatedRequest.params),
             "params should be an array",
           );
 
-          const rawTransaction = hexStringToBytes(jsonRpcRequest.params[0]);
+          const rawTransaction = hexStringToBytes(updatedRequest.params[0]);
           // The tx type is encoded in the first byte, and it must be the EIP-1559 one
           assert.equal(rawTransaction[0], 2);
         });
@@ -529,7 +530,7 @@ describe("LocalAccountsHandler", () => {
         },
       ]);
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
       // This transaction was submitted to a blockchain and accepted, so the signature must be valid
       const expectedRaw =
@@ -538,7 +539,10 @@ describe("LocalAccountsHandler", () => {
         "adc1a53a3ebe8c4d1f0aa06aebf2fbbe82703e5075965c65c776a9caeeff4b637f203" +
         "d65383e1ed2e22654";
 
-      assert.deepEqual(jsonRpcRequest, {
+
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+
+      assert.deepEqual(updatedRequest, {
         jsonrpc: "2.0",
         id: 1,
         method: "eth_sendRawTransaction",
@@ -560,14 +564,15 @@ describe("LocalAccountsHandler", () => {
 
       const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
       assert.ok(
-        Array.isArray(jsonRpcRequest.params),
+        Array.isArray(updatedRequest.params),
         "params should be an array",
       );
 
-      const rawTransaction = hexStringToBytes(jsonRpcRequest.params[0]);
+      const rawTransaction = hexStringToBytes(updatedRequest.params[0]);
 
       // The tx type is encoded in the first byte, and it must be the EIP-1559 one
       assert.equal(rawTransaction[0], 2);
@@ -596,14 +601,15 @@ describe("LocalAccountsHandler", () => {
 
       const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
       assert.ok(
-        Array.isArray(jsonRpcRequest.params),
+        Array.isArray(updatedRequest.params),
         "params should be an array",
       );
 
-      const rawTransaction = jsonRpcRequest.params[0];
+      const rawTransaction = updatedRequest.params[0];
 
       const expectedRaw =
         "0x04f8ca7b80843b9aca008502540be400830186a094f39fd6e51aad88f6" +
@@ -631,14 +637,15 @@ describe("LocalAccountsHandler", () => {
 
       const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
       assert.ok(
-        Array.isArray(jsonRpcRequest.params),
+        Array.isArray(updatedRequest.params),
         "params should be an array",
       );
 
-      const rawTransaction = jsonRpcRequest.params[0];
+      const rawTransaction = updatedRequest.params[0];
 
       const expectedRaw =
         "0x02f8517b80020c830186a08001821234c080a0299e6b620a0a42fa7d56" +
@@ -662,14 +669,15 @@ describe("LocalAccountsHandler", () => {
 
       const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
       assert.ok(
-        Array.isArray(jsonRpcRequest.params),
+        Array.isArray(updatedRequest.params),
         "params should be an array",
       );
 
-      const rawTransaction = jsonRpcRequest.params[0];
+      const rawTransaction = updatedRequest.params[0];
 
       const expectedRaw =
         "0x02f8637b80020c830186a094b5bc06d4548a3ac17d72b372ae1e416bf6" +
@@ -751,14 +759,15 @@ describe("LocalAccountsHandler", () => {
 
       const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
       assert.ok(
-        Array.isArray(jsonRpcRequest.params),
+        Array.isArray(updatedRequest.params),
         "params should be an array",
       );
 
-      const rawTransaction = jsonRpcRequest.params[0];
+      const rawTransaction = updatedRequest.params[0];
 
       assert.equal(rawTransaction, EXPECTED_RAW_TX);
 
@@ -785,14 +794,15 @@ describe("LocalAccountsHandler", () => {
 
       const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
       assert.ok(
-        Array.isArray(jsonRpcRequest.params),
+        Array.isArray(updatedRequest.params),
         "params should be an array",
       );
 
-      const rawTransaction = jsonRpcRequest.params[0];
+      const rawTransaction = updatedRequest.params[0];
 
       assert.equal(rawTransaction, EXPECTED_RAW_TX);
 
@@ -812,14 +822,15 @@ describe("LocalAccountsHandler", () => {
       };
       const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [tx]);
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
       assert.ok(
-        Array.isArray(jsonRpcRequest.params),
+        Array.isArray(updatedRequest.params),
         "params should be an array",
       );
 
-      const rawTransaction = jsonRpcRequest.params[0];
+      const rawTransaction = updatedRequest.params[0];
 
       // BigInt(2 ** 32) is 0x + 100000000
       const expectedRaw =
@@ -979,9 +990,10 @@ describe("LocalAccountsHandler", () => {
 
       const jsonRpcRequest = { ...originalJsonRpcRequest };
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
-      assert.deepEqual(jsonRpcRequest, originalJsonRpcRequest);
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+      assert.deepEqual(updatedRequest, originalJsonRpcRequest);
     });
 
     it("should not modify the json rpc request if no address is given", async () => {
@@ -989,9 +1001,10 @@ describe("LocalAccountsHandler", () => {
 
       const jsonRpcRequest = { ...originalJsonRpcRequest };
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
-      assert.deepEqual(jsonRpcRequest, originalJsonRpcRequest);
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+      assert.deepEqual(updatedRequest, originalJsonRpcRequest);
     });
 
     it("should not modify the json rpc request if the address isn't one of the local ones", async () => {
@@ -1003,9 +1016,10 @@ describe("LocalAccountsHandler", () => {
 
       const jsonRpcRequest = { ...originalJsonRpcRequest };
 
-      await localAccountsHandler.handle(jsonRpcRequest);
+      const updatedRequest = await localAccountsHandler.handle(jsonRpcRequest);
 
-      assert.deepEqual(jsonRpcRequest, originalJsonRpcRequest);
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+      assert.deepEqual(updatedRequest, originalJsonRpcRequest);
     });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-handler.ts
@@ -48,8 +48,9 @@ describe("AutomaticGasHandler", () => {
       },
     ]);
 
-    await automaticGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await automaticGasHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(
@@ -74,8 +75,9 @@ describe("AutomaticGasHandler", () => {
       GAS_MULTIPLIER2,
     );
 
-    await automaticGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await automaticGasHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(
@@ -95,8 +97,9 @@ describe("AutomaticGasHandler", () => {
 
     automaticGasHandler = new AutomaticGasHandler(mockedProvider);
 
-    await automaticGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await automaticGasHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(
@@ -115,8 +118,9 @@ describe("AutomaticGasHandler", () => {
       },
     ]);
 
-    await automaticGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await automaticGasHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(tx.gas, 567);
@@ -131,8 +135,9 @@ describe("AutomaticGasHandler", () => {
       },
     ]);
 
-    await automaticGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await automaticGasHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(tx.gas, undefined);

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/automatic-gas-price-handler.ts
@@ -39,8 +39,9 @@ describe("AutomaticGasPriceHandler", () => {
         },
       ]);
 
-      await automaticGasPriceHandler.handle(jsonRpcRequest);
-      const [tx] = getRequestParams(jsonRpcRequest);
+      const updatedRequest = await automaticGasPriceHandler.handle(jsonRpcRequest);
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+      const [tx] = getRequestParams(updatedRequest);
 
       assert.ok(isObject(tx), "tx is not an object");
       assert.equal(tx.gasPrice, 456);
@@ -57,8 +58,9 @@ describe("AutomaticGasPriceHandler", () => {
         },
       ]);
 
-      await automaticGasPriceHandler.handle(jsonRpcRequest);
-      const [tx] = getRequestParams(jsonRpcRequest);
+      const updatedRequest = await automaticGasPriceHandler.handle(jsonRpcRequest);
+      assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+      const [tx] = getRequestParams(updatedRequest);
 
       assert.ok(isObject(tx), "tx is not an object");
       assert.equal(tx.maxFeePerGas, 456);
@@ -96,8 +98,9 @@ describe("AutomaticGasPriceHandler", () => {
           },
         ]);
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const updatedRequest = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+        const [tx] = getRequestParams(updatedRequest);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.maxPriorityFeePerGas, "0x4");
@@ -114,8 +117,9 @@ describe("AutomaticGasPriceHandler", () => {
           },
         ]);
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const updatedRequest = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+        const [tx] = getRequestParams(updatedRequest);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.maxPriorityFeePerGas, "0x4");
@@ -140,8 +144,9 @@ describe("AutomaticGasPriceHandler", () => {
               ),
         );
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const updatedRequest = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+        const [tx] = getRequestParams(updatedRequest);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.maxPriorityFeePerGas, "0x1");
@@ -185,8 +190,9 @@ describe("AutomaticGasPriceHandler", () => {
               ),
         );
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const updatedRequest = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+        const [tx] = getRequestParams(updatedRequest);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.maxPriorityFeePerGas, "0x1");
@@ -232,8 +238,9 @@ describe("AutomaticGasPriceHandler", () => {
               ),
         );
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const updatedRequest = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+        const [tx] = getRequestParams(updatedRequest);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.maxPriorityFeePerGas, "0x12");
@@ -282,8 +289,9 @@ describe("AutomaticGasPriceHandler", () => {
           },
         ]);
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const updatedRequest = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+        const [tx] = getRequestParams(updatedRequest);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(tx.gasPrice, numberToHexString(FIXED_GAS_PRICE));
@@ -299,8 +307,9 @@ describe("AutomaticGasPriceHandler", () => {
           },
         ]);
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const updatedRequest = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+        const [tx] = getRequestParams(updatedRequest);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(
@@ -320,8 +329,9 @@ describe("AutomaticGasPriceHandler", () => {
           },
         ]);
 
-        await automaticGasPriceHandler.handle(jsonRpcRequest);
-        const [tx] = getRequestParams(jsonRpcRequest);
+        const updatedRequest = await automaticGasPriceHandler.handle(jsonRpcRequest);
+        assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+        const [tx] = getRequestParams(updatedRequest);
 
         assert.ok(isObject(tx), "tx is not an object");
         assert.equal(

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
@@ -28,8 +28,9 @@ describe("FixedGasHandler", () => {
       },
     ]);
 
-    await fixedGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await fixedGasHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(tx.gas, numberToHexString(FIXED_GAS_LIMIT));
@@ -45,11 +46,33 @@ describe("FixedGasHandler", () => {
       },
     ]);
 
-    await fixedGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await fixedGasHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(tx.gas, 1456);
+  });
+
+  
+  it("should not mutate the original request object", async () => {
+    const jsonRpcRequest = getJsonRpcRequest(1, "eth_sendTransaction", [
+      {
+        from: "0x0000000000000000000000000000000000000011",
+        to: "0x0000000000000000000000000000000000000011",
+        value: 1,
+      },
+    ]);
+
+    const originalParams = structuredClone(jsonRpcRequest.params);
+    const updatedRequest = await fixedGasHandler.handle(jsonRpcRequest);
+
+    assert.deepEqual(jsonRpcRequest.params, originalParams);
+    assert.notEqual(updatedRequest, jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
+    assert.ok(isObject(tx), "tx is not an object");
+    assert.equal(tx.gas, numberToHexString(FIXED_GAS_LIMIT));
   });
 
   it("should forward the other calls and not modify the gas", async () => {
@@ -61,8 +84,9 @@ describe("FixedGasHandler", () => {
       },
     ]);
 
-    await fixedGasHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await fixedGasHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(tx.gas, undefined);

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-handler.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { beforeEach, describe, it } from "node:test";
 
 import { numberToHexString } from "@nomicfoundation/hardhat-utils/hex";
-import { isObject } from "@nomicfoundation/hardhat-utils/lang";
+import { deepClone, isObject } from "@nomicfoundation/hardhat-utils/lang";
 
 import {
   getJsonRpcRequest,
@@ -64,7 +64,7 @@ describe("FixedGasHandler", () => {
       },
     ]);
 
-    const originalParams = structuredClone(jsonRpcRequest.params);
+    const originalParams = await deepClone(jsonRpcRequest.params);
     const updatedRequest = await fixedGasHandler.handle(jsonRpcRequest);
 
     assert.deepEqual(jsonRpcRequest.params, originalParams);

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/request-handlers/handlers/gas/fixed-gas-price-handler.ts
@@ -30,8 +30,9 @@ describe("FixedGasPriceHandler", () => {
       },
     ]);
 
-    await fixedGasPriceHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await fixedGasPriceHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(tx.gasPrice, numberToHexString(FIXED_GAS_PRICE));
@@ -47,8 +48,9 @@ describe("FixedGasPriceHandler", () => {
       },
     ]);
 
-    await fixedGasPriceHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await fixedGasPriceHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(tx.gasPrice, 14567);
@@ -63,8 +65,9 @@ describe("FixedGasPriceHandler", () => {
       },
     ]);
 
-    await fixedGasPriceHandler.handle(jsonRpcRequest);
-    const [tx] = getRequestParams(jsonRpcRequest);
+    const updatedRequest = await fixedGasPriceHandler.handle(jsonRpcRequest);
+    assert.ok(!("result" in updatedRequest) && !("error" in updatedRequest), "expected a JSON-RPC request");
+    const [tx] = getRequestParams(updatedRequest);
 
     assert.ok(isObject(tx), "tx is not an object");
     assert.equal(tx.gas, undefined);


### PR DESCRIPTION
## Summary
- Network manager request handlers now return shallow-copied JSON-RPC requests when filling gas / sender / local-account fields instead of mutating the caller's object.
- Adds `replaceJsonRpcRequestTx` helper and regression tests that the original request remains unchanged through `onRequest`.

Closes #8090

## Test plan
- [x] `tsx --test` for network-manager gas, accounts, and hook-handler suites (84 passing)