### PR TITLE
feat: bump EDR to 0.15.0

### DIFF
--- a/.changeset/update-edr-15-amsterdam-feature.md
+++ b/.changeset/update-edr-15-amsterdam-feature.md
@@ -1,0 +1,6 @@
+---
+"hardhat": minor
+#docs: https://github.com/NomicFoundation/hardhat-website/pull/289
+---
+
+Added experimental EIP-7843 support to the Amsterdam hardfork: blocks now include the `slotNumber` header field, and the `SLOTNUM` (`0x4b`) opcode returns it. EDR has no consensus layer, so the value is simulated: it increments by one per mined block, starting at 0 on a new chain, or from the forked block's slot number when forking.

--- a/.changeset/update-edr-15-tracing-bug-fix-1.md
+++ b/.changeset/update-edr-15-tracing-bug-fix-1.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed empty stack traces on Solidity test failures when running with `-vvv` or above.

--- a/.changeset/update-edr-15-tracing-bug-fix-2.md
+++ b/.changeset/update-edr-15-tracing-bug-fix-2.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed missing stack traces when an invariant already fails on its initial check, when running with `-vvv` or above.

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -93,7 +93,7 @@
     "typescript": "~6.0.3"
   },
   "dependencies": {
-    "@nomicfoundation/edr": "0.14.2",
+    "@nomicfoundation/edr": "0.15.0",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.17",
     "@nomicfoundation/hardhat-utils": "workspace:^4.1.6",
     "@nomicfoundation/hardhat-vendored": "workspace:^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
   packages/hardhat:
     dependencies:
       '@nomicfoundation/edr':
-        specifier: 0.14.2
-        version: 0.14.2
+        specifier: 0.15.0
+        version: 0.15.0
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.17
         version: link:../hardhat-errors
@@ -3008,36 +3008,36 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.14.2':
-    resolution: {integrity: sha512-8f2rYJTXbbN/NdzhXNwUiR+467Vr4R7VFJ/+1aeek1WBcvvBgzCBtmACC9ihqt1NKPv6QZQTC51bhcSUA8FVmg==}
+  '@nomicfoundation/edr-darwin-arm64@0.15.0':
+    resolution: {integrity: sha512-kFgoiou9yfzojAki3yOnOlFZfkC0oQeS8G3i/8lXaTnjEjQ2C1lLDgRQt8Q0kjSdVOs5daiC+eQx+8to4R5/ug==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-darwin-x64@0.14.2':
-    resolution: {integrity: sha512-qpoToApz1fFclWV7KVqFVwOJn020nCLBTbIRVVcaTcAVJr3N5DK5JInQe4Nch068zwl2sRbZ+NU9GE0mUhRJPA==}
+  '@nomicfoundation/edr-darwin-x64@0.15.0':
+    resolution: {integrity: sha512-vnFHCj2oxd7N8Eg760yY5gPAHz6tL7NB9Pt1nrP8/+XIutEdUJjpIDGadG0jsTHNmq303EvHh4nkpuO3zBCSZw==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.14.2':
-    resolution: {integrity: sha512-7oOWqMeZoOKwt9S3UZLGd8YeQVCLSsB+ysbe2uu1tIAThsYMmLvcPd79dF95ggs7mjNexvMEqE8ccM+i+S1/4A==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.15.0':
+    resolution: {integrity: sha512-klBqsMWl19NVok/9BOcX/PeV7M7DrTM4C7eSOQyc6wglZZRwKSm8tDtwQVh/bJkOCqqgVMO6IOi+IQ4xQbsgog==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.14.2':
-    resolution: {integrity: sha512-M+l+RiH4kwnYfdBBguLzlsKbPuOETjY1dJ/Qer3C6bdeNmP0nLDBkf0VM4m99HxzvEtSWg2JrT/YMV/6EZf1CQ==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.15.0':
+    resolution: {integrity: sha512-PQ6oqCCOjQaGCyDA1XFDWbpGrXGKZ8Fr3JQrd7cCCqVvIBshg68WrJ7gqlf4DdeidppIi3m9CNRsWsRfj9Y17w==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.14.2':
-    resolution: {integrity: sha512-N2I1mj5kCTzTvlVYsNnox9dxaypP6MggO6eOOj4dmNuTkFTQAO1JAszhHP8QgzySLoh5ayBKjlX54CqT0/jHZg==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.15.0':
+    resolution: {integrity: sha512-j89Ywivbs78xWjoSFcZLp+pUqe0p0p3vqiG1utGFj/fJ7zEgTQBcC+DUiyddFpYB3TE79TZMUoaAnEVdxTi4Xw==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.14.2':
-    resolution: {integrity: sha512-qCbvhbIar68x8DOfxjmadOAVYIEMrJLMET2eMWw+2ReTn3aXkMOievtTZwvgZQf7OiyX6dMiSXTUZdIhL1sbGg==}
+  '@nomicfoundation/edr-linux-x64-musl@0.15.0':
+    resolution: {integrity: sha512-bJuCPxihvSFyoGAxmYL5CyN9id5mqncyikywTa7+/+g7ge2Pnz+w7GHbim+tvHeMA9XQv1vSy4QgNkkZXGBzLg==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.14.2':
-    resolution: {integrity: sha512-1v+NTmjT2AlnxPaBJ5GswPH2TZgHjSFWdnefzDzOJ3Yy3zT4Miyoq1/SKIJky1nP0tCFFtTogj2xZ7+GpOSAHg==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.15.0':
+    resolution: {integrity: sha512-pnUdVgZ4VwqbZu9XTAxJeuGavAY1w3txd/HkpqiOuu43Yrt0nnsRO5gAdj4smXJmQ5Bzy2x2GJ0/68rP4T1Pgw==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr@0.14.2':
-    resolution: {integrity: sha512-DoSdwCP/oCGOVqx6yxggGSsKPqansPS76qxBRJAp0wvfBCM1ZXBITi+OGdCaN8CG3uDDV/u6UEpbPIISTcsKng==}
+  '@nomicfoundation/edr@0.15.0':
+    resolution: {integrity: sha512-RcBnQ0MYsrjhLsN+Kcu7q5mnRmBlxmv+Y0lxgrCsST6YTDH/l5RH3nG88J8sDEGmXyjVzX2HsXQBy9NxFJHFuw==}
     engines: {node: '>= 22'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -8794,29 +8794,29 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.14.2': {}
+  '@nomicfoundation/edr-darwin-arm64@0.15.0': {}
 
-  '@nomicfoundation/edr-darwin-x64@0.14.2': {}
+  '@nomicfoundation/edr-darwin-x64@0.15.0': {}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.14.2': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.15.0': {}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.14.2': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.15.0': {}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.14.2': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.15.0': {}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.14.2': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.15.0': {}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.14.2': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.15.0': {}
 
-  '@nomicfoundation/edr@0.14.2':
+  '@nomicfoundation/edr@0.15.0':
     dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.14.2
-      '@nomicfoundation/edr-darwin-x64': 0.14.2
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.14.2
-      '@nomicfoundation/edr-linux-arm64-musl': 0.14.2
-      '@nomicfoundation/edr-linux-x64-gnu': 0.14.2
-      '@nomicfoundation/edr-linux-x64-musl': 0.14.2
-      '@nomicfoundation/edr-win32-x64-msvc': 0.14.2
+      '@nomicfoundation/edr-darwin-arm64': 0.15.0
+      '@nomicfoundation/edr-darwin-x64': 0.15.0
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.15.0
+      '@nomicfoundation/edr-linux-arm64-musl': 0.15.0
+      '@nomicfoundation/edr-linux-x64-gnu': 0.15.0
+      '@nomicfoundation/edr-linux-x64-musl': 0.15.0
+      '@nomicfoundation/edr-win32-x64-msvc': 0.15.0
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true


### PR DESCRIPTION
Update the EDR version and add changeset equivalents to the EDR release.

The EDR release includes experimental Amsterdam support for EIP-7843, and a set of bug fixes for tracing.

Resolves #8471

## Docs

The docs PR is here: https://github.com/NomicFoundation/hardhat-website/pull/289
The Preview: https://hardhat-website-git-add-eip-7843-to-ams-33161e-nomic-foundation.vercel.app/docs/reference/amsterdam-support#eip-7843-slotnum-opcode