### PR TITLE
feat: add analytics per unique network chain type

### DIFF
--- a/.changeset/polite-words-take.md
+++ b/.changeset/polite-words-take.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Report chain type to Google Analytics

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/network-manager.ts
@@ -32,6 +32,7 @@ import { exists, readBinaryFile } from "@nomicfoundation/hardhat-utils/fs";
 import { deepMerge } from "@nomicfoundation/hardhat-utils/lang";
 import { AsyncMutex } from "@nomicfoundation/hardhat-utils/synchronization";
 
+import { sendNetworkAnalytics } from "../../cli/telemetry/analytics/analytics.js";
 import { resolveUserConfigToHardhatConfig } from "../../core/hre.js";
 import { isSupportedChainType } from "../../edr/chain-type.js";
 import { JsonRpcServerImplementation } from "../node/json-rpc/server.js";
@@ -72,6 +73,8 @@ export class NetworkManagerImplementation implements NetworkManager {
     string,
     Map<string, NetworkConnection<ChainType | string>>
   >();
+
+  readonly #chainTypesWithSentAnalytics = new Set<string>();
 
   constructor(
     defaultNetwork: string,
@@ -123,6 +126,13 @@ export class NetworkManagerImplementation implements NetworkManager {
           override,
         ),
     );
+
+    if (!this.#chainTypesWithSentAnalytics.has(networkConnection.chainType)) {
+      this.#chainTypesWithSentAnalytics.add(networkConnection.chainType);
+      // Fire-and-forget: analytics must never delay or break connection
+      // creation
+      void sendNetworkAnalytics(networkConnection.chainType).catch(() => {});
+    }
 
     /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     -- Cast to NetworkConnection<ChainTypeT> because we know it's valid */

--- a/packages/hardhat/src/internal/cli/telemetry/analytics/analytics.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/analytics/analytics.ts
@@ -81,6 +81,19 @@ export async function sendProjectTypeAnalytics(
   return await sendAnalytics(initAnalyticsEvent);
 }
 
+export async function sendNetworkAnalytics(
+  chainType: string,
+): Promise<boolean> {
+  const networkAnalyticsEvent: AnalyticsEvent = {
+    name: "network",
+    params: {
+      chainType,
+    },
+  };
+
+  return await sendAnalytics(networkAnalyticsEvent);
+}
+
 // Return a boolean for testing purposes to confirm whether analytics were sent based on the consent value and not in CI environments
 async function sendAnalytics(analyticsEvent: AnalyticsEvent): Promise<boolean> {
   if (!(await isTelemetryAllowed())) {

--- a/packages/hardhat/src/internal/cli/telemetry/analytics/types.ts
+++ b/packages/hardhat/src/internal/cli/telemetry/analytics/types.ts
@@ -48,6 +48,12 @@ export type AnalyticsEvent =
         hardhatVersion: "hardhat-3";
         template: string;
       };
+    }
+  | {
+      name: "network";
+      params: {
+        chainType: string;
+      };
     };
 
 export interface Payload extends BasePayload {

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/network-manager.ts
@@ -1,3 +1,4 @@
+import type { Payload } from "../../../../src/internal/cli/telemetry/analytics/types.js";
 import type {
   ChainDescriptorsConfig,
   EdrNetworkConfigOverride,
@@ -20,13 +21,20 @@ import type { HardhatPlugin } from "../../../../src/types/plugins.js";
 import type { ExpectedValidationError } from "@nomicfoundation/hardhat-test-utils";
 
 import assert from "node:assert/strict";
-import { beforeEach, describe, it } from "node:test";
+import path from "node:path";
+import { after, afterEach, before, beforeEach, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
   assertRejectsWithHardhatError,
   assertValidationErrors,
 } from "@nomicfoundation/hardhat-test-utils";
+import {
+  exists,
+  readJsonFile,
+  remove,
+} from "@nomicfoundation/hardhat-utils/fs";
+import { sleep } from "@nomicfoundation/hardhat-utils/lang";
 import { expectTypeOf } from "expect-type";
 
 import { createHardhatRuntimeEnvironment } from "../../../../src/hre.js";
@@ -53,6 +61,10 @@ import {
   FixedValueConfigurationVariable,
   resolveConfigurationVariable,
 } from "../../../../src/internal/core/configuration-variables.js";
+import {
+  checkIfSubprocessWasExecuted,
+  ROOT_PATH_TO_FIXTURE,
+} from "../../cli/telemetry/helpers.js";
 
 describe("NetworkManagerImplementation", () => {
   let hre: HardhatRuntimeEnvironment;
@@ -148,6 +160,73 @@ describe("NetworkManagerImplementation", () => {
       hre.config.paths.root,
       hre.globalOptions.verbosity,
     );
+  });
+
+  describe("chain type analytics", () => {
+    const RESULT_FILE_PATH = path.join(
+      ROOT_PATH_TO_FIXTURE,
+      "analytics",
+      "network-manager-analytics-result.json",
+    );
+
+    before(() => {
+      process.env.HARDHAT_TEST_INTERACTIVE_ENV = "true";
+      process.env.HARDHAT_TEST_TELEMETRY_ENABLED = "true";
+      process.env.HARDHAT_TEST_SUBPROCESS_RESULT_PATH = RESULT_FILE_PATH;
+    });
+
+    after(() => {
+      delete process.env.HARDHAT_TEST_INTERACTIVE_ENV;
+      delete process.env.HARDHAT_TEST_TELEMETRY_ENABLED;
+      delete process.env.HARDHAT_TEST_SUBPROCESS_RESULT_PATH;
+    });
+
+    beforeEach(async () => {
+      await remove(RESULT_FILE_PATH);
+    });
+
+    afterEach(async () => {
+      await remove(RESULT_FILE_PATH);
+    });
+
+    it("should send network analytics only once per chain type", async () => {
+      await networkManager.create();
+
+      await checkIfSubprocessWasExecuted(RESULT_FILE_PATH);
+
+      let result: Payload = await readJsonFile(RESULT_FILE_PATH);
+
+      assert.equal(result.events[0].name, "network");
+      assert(
+        "chainType" in result.events[0].params,
+        "params should have a chainType field",
+      );
+      assert.equal(result.events[0].params.chainType, GENERIC_CHAIN_TYPE);
+
+      await remove(RESULT_FILE_PATH);
+
+      // A second connection with the same chain type shouldn't send analytics
+      // again. No subprocess is spawned in that case, so after a short wait
+      // the result file should still be missing.
+      await networkManager.create();
+      await sleep(0.5);
+
+      assert.equal(await exists(RESULT_FILE_PATH), false);
+
+      // A connection with a new chain type should send analytics again
+      await networkManager.create({ network: "myNetwork" });
+
+      await checkIfSubprocessWasExecuted(RESULT_FILE_PATH);
+
+      result = await readJsonFile(RESULT_FILE_PATH);
+
+      assert.equal(result.events[0].name, "network");
+      assert(
+        "chainType" in result.events[0].params,
+        "params should have a chainType field",
+      );
+      assert.equal(result.events[0].params.chainType, OPTIMISM_CHAIN_TYPE);
+    });
   });
 
   describe("create", () => {

--- a/packages/hardhat/test/internal/cli/telemetry/analytics/analytics.ts
+++ b/packages/hardhat/test/internal/cli/telemetry/analytics/analytics.ts
@@ -7,6 +7,7 @@ import { after, afterEach, before, beforeEach, describe, it } from "node:test";
 import { readJsonFile, remove } from "@nomicfoundation/hardhat-utils/fs";
 
 import {
+  sendNetworkAnalytics,
   sendProjectTypeAnalytics,
   sendTaskAnalytics,
   sendTelemetryConfigAnalytics,
@@ -170,6 +171,35 @@ describe("analytics", () => {
       );
       assert.equal(result.events[0].params.hardhatVersion, "hardhat-3");
       assert.equal(result.events[0].params.template, "mocha-ethers");
+    });
+
+    it("should create the correct payload for the network analytics", async () => {
+      const wasSent = await sendNetworkAnalytics("op");
+
+      await checkIfSubprocessWasExecuted(RESULT_FILE_PATH);
+
+      const result: Payload = await readJsonFile(RESULT_FILE_PATH);
+
+      assert.equal(wasSent, true);
+
+      // Check payload properties
+      assert.notEqual(result.client_id, undefined);
+      assert.notEqual(result.user_id, undefined);
+      assert.equal(result.user_properties.projectId.value, "hardhat-project");
+      assert.equal(
+        result.user_properties.hardhatVersion.value,
+        await getHardhatVersion(),
+      );
+      assert.notEqual(result.user_properties.operatingSystem.value, undefined);
+      assert.notEqual(result.user_properties.nodeVersion.value, undefined);
+      assert.equal(result.events[0].name, "network");
+      assert.equal(result.events[0].params.engagement_time_msec, "10000");
+      assert.notEqual(result.events[0].params.session_id, undefined);
+      assert(
+        "chainType" in result.events[0].params,
+        "params should have a chainType field",
+      );
+      assert.equal(result.events[0].params.chainType, "op");
     });
 
     it("should not send analytics because the user explicitly opted out of telemetry", async () => {


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Adds a `network` analytics event that records which chain type (`generic`, `l1`, `op`, or a custom plugin-defined value) users configure when creating a network connection.

### Changes

- **New `network` analytics event** — added a variant to the `AnalyticsEvent` union (`src/internal/cli/telemetry/analytics/types.ts`) with `params: { chainType: string }`. The chain type is reported as a raw string so custom plugin-defined chain types are visible too.
- **New `sendNetworkAnalytics(chainType)` sender** (`src/internal/cli/telemetry/analytics/analytics.ts`) — a stateless sibling of `sendTaskAnalytics`/`sendProjectTypeAnalytics` that reuses the existing consent-gated `sendAnalytics` pipeline (telemetry permission check + detached subprocess).
- **Instrumented `NetworkManagerImplementation.create`** (`src/internal/builtin-plugins/network-manager/network-manager.ts`) — after the connection is built (so the *resolved* chain type is known), the event is sent **once per chain type per process** via an instance-level `Set`, and fire-and-forget so it never delays or breaks connection creation. `connect`, `getOrCreate` cache-misses, and `createServer` all funnel through `create`, so they're all covered.

### Performance considerations

- **Bootstrap time is unaffected.** The analytics import in `network-manager.ts` is a static import, which is correct per our import rules because that module is itself lazily loaded (the `hre` hook handler dynamically imports it on first `hre.network.*` use). Verified with a module-load trace: `hardhat --version` does not load `network-manager.js`.
- **Steady-state overhead per `create()` call** is a single `Set.has()` string lookup. The dedupe `Set` is marked before the consent check, so when telemetry is disabled, repeat connections skip even the consent-file read. The subprocess spawn happens at most once per distinct chain type per process.

### Tests

- Payload-shape test for `sendNetworkAnalytics`, mirroring the existing sender tests (`test/internal/cli/telemetry/analytics/analytics.ts`).
- Dedupe test verifying that a second `create()` with the same chain type sends nothing, while a connection with a new chain type sends a second event (`test/internal/builtin-plugins/network-manager/network-manager.ts`).

### Notes for reviewer

Are newly added analytics mentioned in the changesets of Hardhat?