### PR TITLE
ci: fix stale bun cache breaking regression-benchmark EDR resolution

### DIFF
--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -105,6 +105,10 @@ jobs:
         # runner. The "Clean up temp dir" step below removes it after the run.
         run: echo "E2E_CLONE_DIR=${RUNNER_TEMP:?}/hardhat-e2e-clones" >> "$GITHUB_ENV"
 
+      - name: Configure per-run bun cache
+        # Set the bun cache directory to a temp dir that is cleaned up at the end of the job.
+        run: echo "BUN_INSTALL_CACHE_DIR=${RUNNER_TEMP:?}/bun-install-cache" >> "$GITHUB_ENV"
+
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline
 
@@ -194,8 +198,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
 
       - name: Clean up temp dir
-        # Self-hosted runners don't automatically wipe the E2E_CLONE_DIR written
-        # to RUNNER_TEMP between jobs, so we do this manually to avoid polluting
-        # future runs.
+        # Self-hosted runners don't automatically wipe the E2E_CLONE_DIR and
+        # BUN_INSTALL_CACHE_DIR written to RUNNER_TEMP between jobs, so we do
+        # this manually to avoid polluting future runs.
         if: always()
-        run: rm -rf "$E2E_CLONE_DIR"
+        run: rm -rf "$E2E_CLONE_DIR" "$BUN_INSTALL_CACHE_DIR"


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Backports https://github.com/NomicFoundation/edr/pull/1588

## Problem

The regression benchmark [failed](https://github.com/NomicFoundation/edr/actions/runs/29945740917/job/90682342090) in "Validate scenarios used the local EDR build": the ens-contracts scenario resolved `@nomicfoundation/edr@0.15.0-local.c0ceeed37125` (a **previous** run's local build, from the `edr-0.15.0` release-PR commit) instead of the build under test.

## Cause

Each benchmark run republishes the same deterministic `hardhat@<sentinel>` version to a fresh Verdaccio with different content (the new EDR pin). bun reuses cached registry manifests without revalidating against the registry, so the self-hosted runner's persistent `~/.bun/install/cache` satisfied the scenario's `hardhat` dependency with the previous run's manifest — and with it that run's stale EDR pin. Verdaccio was never consulted.

ens-contracts is the only scenario that installs with bun, which is why it was the only one affected. This is the same staleness class as the pnpm metadata cache, which the workflow already clears; npm and yarn scenarios are protected by packument revalidation.

## Fix

Point `BUN_INSTALL_CACHE_DIR` at a directory inside `RUNNER_TEMP` so each run starts with a cold bun cache, and remove it in the existing temp-dir cleanup step.

