### PR TITLE
ci: trigger regression benchmarks with `/bench` instead of the `ci:perf` label

### DIFF
--- a/.github/scripts/resolve-regression-trigger.test.ts
+++ b/.github/scripts/resolve-regression-trigger.test.ts
@@ -1,0 +1,284 @@
+// Unit tests for resolve-regression-trigger.ts.
+//
+// Run with Node's built-in test runner (no extra dependencies):
+//   node --test .github/scripts/resolve-regression-trigger.test.ts
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveRegressionTrigger } from "./resolve-regression-trigger.ts";
+
+const OWNER = "NomicFoundation";
+const REPO = "hardhat";
+const FULL = `${OWNER}/${REPO}`;
+
+interface WorkflowRun {
+  id: number;
+  status: string;
+  conclusion: string | null;
+}
+
+interface PullRequestData {
+  head: {
+    repo: { full_name: string };
+    sha: string;
+  };
+}
+
+// The record of side effects the module produced (outputs, logs, comments,
+// reactions).
+interface Captured {
+  outputs: Record<string, string>;
+  infos: string[];
+  warnings: string[];
+  comments: string[];
+  reactions: string[];
+}
+
+// Build a mocked { github, context, core } plus a `captured` record.
+function makeDeps({
+  eventName,
+  sha = "",
+  payload = {},
+  ci,
+  pr,
+}: {
+  eventName: string;
+  sha?: string;
+  payload?: object;
+  ci?: WorkflowRun;
+  pr?: PullRequestData;
+}) {
+  const captured: Captured = {
+    outputs: {},
+    infos: [],
+    warnings: [],
+    comments: [],
+    reactions: [],
+  };
+
+  const core = {
+    setOutput: (name: string, value: string) => {
+      captured.outputs[name] = value;
+    },
+    info: (message: string) => captured.infos.push(message),
+    warning: (message: string) => captured.warnings.push(message),
+  };
+
+  const github = {
+    rest: {
+      actions: {
+        listWorkflowRuns: async () => ({
+          data: { workflow_runs: ci === undefined ? [] : [ci] },
+        }),
+      },
+      pulls: {
+        get: async () => {
+          if (pr === undefined) {
+            throw new Error("pulls.get not expected");
+          }
+          return { data: pr };
+        },
+      },
+      issues: {
+        createComment: async ({ body }: { body: string }) =>
+          captured.comments.push(body),
+      },
+      reactions: {
+        createForIssueComment: async ({ content }: { content: string }) =>
+          captured.reactions.push(content),
+      },
+    },
+  };
+
+  const context = {
+    repo: { owner: OWNER, repo: REPO },
+    eventName,
+    sha,
+    serverUrl: "https://github.com",
+    runId: 123,
+    payload,
+  };
+
+  return { github, context, core, captured };
+}
+
+// A `/bench` comment on a same-repo PR, by an authorized author.
+function commentPayload(
+  body: string,
+  { assoc = "MEMBER", number = 7 }: { assoc?: string; number?: number } = {},
+) {
+  return {
+    comment: {
+      author_association: assoc,
+      user: { login: "dev" },
+      id: 99,
+      body,
+    },
+    issue: { number },
+  };
+}
+
+test("push → baseline run of the pushed HEAD", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "push",
+    sha: "deadbeefcafe1234",
+  });
+  await resolveRegressionTrigger(deps);
+  assert.deepEqual(captured.outputs, {
+    should_run: "true",
+    bench_ref: "deadbeefcafe1234",
+    is_baseline: "true",
+    // Baselines run the full suite: all projects, all benchmarks.
+    scenario_filter: "*",
+    benchmark_filter: "*",
+  });
+});
+
+test("workflow_dispatch → runs HEAD with default filters", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "workflow_dispatch",
+    sha: "abc123",
+    payload: { inputs: {} },
+  });
+  await resolveRegressionTrigger(deps);
+  assert.deepEqual(captured.outputs, {
+    should_run: "true",
+    bench_ref: "abc123",
+    is_baseline: "false",
+    // No filters given → full suite.
+    scenario_filter: "*",
+    benchmark_filter: "*",
+  });
+});
+
+test("workflow_dispatch → forwards explicit filters", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "workflow_dispatch",
+    sha: "abc123",
+    payload: {
+      inputs: {
+        "scenario-filter": "1inch*",
+        "benchmark-filter": "cold compile",
+      },
+    },
+  });
+  await resolveRegressionTrigger(deps);
+  assert.equal(captured.outputs.scenario_filter, "1inch*");
+  assert.equal(captured.outputs.benchmark_filter, "cold compile");
+});
+
+test("issue_comment → malformed payload throws", async () => {
+  // The workflow-level `if` guarantees comment + issue are present; their
+  // absence means the event contract changed, so the resolver fails loudly.
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: {},
+  });
+  await assert.rejects(
+    resolveRegressionTrigger(deps),
+    /Malformed issue_comment payload/,
+  );
+  assert.deepEqual(captured.outputs, {}); // failed before emitting outputs
+});
+
+test("issue_comment → unauthorized author does not run", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench", { assoc: "NONE" }),
+  });
+  await resolveRegressionTrigger(deps);
+  assert.equal(captured.outputs.should_run, "false");
+  assert.equal(captured.warnings.length, 1);
+  assert.deepEqual(captured.reactions, ["eyes"]); // request acknowledged
+  assert.deepEqual(captured.comments, []); // but nothing posted
+});
+
+test("issue_comment → fork PR is rejected", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench"),
+    pr: { head: { repo: { full_name: "attacker/hardhat" }, sha: "f0f0f0" } },
+  });
+  await resolveRegressionTrigger(deps);
+  assert.equal(captured.outputs.should_run, "false");
+  assert.equal(captured.comments.length, 1);
+  assert.match(captured.comments[0], /can only run for branches in/);
+});
+
+test("issue_comment → same-repo PR with green CI runs the full suite", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench"),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+  });
+  await resolveRegressionTrigger(deps);
+  assert.equal(captured.outputs.should_run, "true");
+  assert.equal(captured.outputs.bench_ref, "1234567890ab");
+  assert.equal(captured.outputs.is_baseline, "false");
+  assert.equal(captured.outputs.scenario_filter, "*"); // no scenarios= → all
+  assert.equal(captured.outputs.benchmark_filter, "*"); // no benchmarks= → all
+  assert.equal(captured.comments.length, 1);
+  assert.match(captured.comments[0], /Starting regression benchmark/);
+  // `*` (all) filters are not called out in the status comment.
+  assert.doesNotMatch(captured.comments[0], /projects matching/);
+  assert.doesNotMatch(captured.comments[0], /benchmarks matching/);
+});
+
+test("issue_comment → parses the 1inch* / test solidity example", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload(
+      '/bench scenarios=1inch* benchmarks="test solidity"',
+    ),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+  });
+  await resolveRegressionTrigger(deps);
+  assert.equal(captured.outputs.should_run, "true");
+  assert.equal(captured.outputs.scenario_filter, "1inch*");
+  assert.equal(captured.outputs.benchmark_filter, "test solidity");
+  assert.match(captured.comments[0], /projects matching/);
+  assert.match(captured.comments[0], /benchmarks matching/);
+});
+
+test("issue_comment → parses a quoted benchmarks= glob (spaces + commas preserved)", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload('/bench benchmarks="warm compile,test *"'),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+  });
+  await resolveRegressionTrigger(deps);
+  assert.equal(captured.outputs.should_run, "true");
+  // Quoted values preserve spaces and internal commas.
+  assert.equal(captured.outputs.benchmark_filter, "warm compile,test *");
+  assert.match(captured.comments[0], /benchmarks matching/);
+});
+
+test("issue_comment → parses an unquoted single-token filter", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench benchmarks=cold-compile"),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "success" },
+  });
+  await resolveRegressionTrigger(deps);
+  assert.equal(captured.outputs.benchmark_filter, "cold-compile");
+  // No scenarios= given → default `*` (all projects).
+  assert.equal(captured.outputs.scenario_filter, "*");
+});
+
+test("issue_comment → same-repo PR with failing CI does not run", async () => {
+  const { captured, ...deps } = makeDeps({
+    eventName: "issue_comment",
+    payload: commentPayload("/bench"),
+    pr: { head: { repo: { full_name: FULL }, sha: "1234567890ab" } },
+    ci: { id: 1, status: "completed", conclusion: "failure" },
+  });
+  await resolveRegressionTrigger(deps);
+  assert.equal(captured.outputs.should_run, "false");
+  assert.equal(captured.comments.length, 1);
+  assert.match(captured.comments[0], /hasn't passed yet/);
+});

--- a/.github/scripts/resolve-regression-trigger.ts
+++ b/.github/scripts/resolve-regression-trigger.ts
@@ -28,7 +28,7 @@ const DEFAULT_BENCHMARK_FILTER = "*";
 
 // Minimal structural types for the slice of the `actions/github-script`
 // injected globals this module uses.
-interface Core {
+interface GithubScriptCore {
   setOutput: (name: string, value: string) => void;
   info: (message: string) => void;
   warning: (message: string) => void;
@@ -109,7 +109,7 @@ export async function resolveRegressionTrigger({
 }: {
   github: GitHub;
   context: Context;
-  core: Core;
+  core: GithubScriptCore;
 }): Promise<void> {
   const { owner, repo } = context.repo;
   const fullName = `${owner}/${repo}`;

--- a/.github/scripts/resolve-regression-trigger.ts
+++ b/.github/scripts/resolve-regression-trigger.ts
@@ -1,0 +1,298 @@
+// Resolve the ref, authorize, and gate the regression benchmark trigger.
+//
+// By event:
+//   push              -> baseline run of the pushed main HEAD
+//   workflow_dispatch -> run of the dispatched ref's HEAD
+//   issue_comment     -> a `/bench` comment on a same-repo PR, gated on the
+//                        commenter's permissions and CI being green
+//
+// Loaded by `actions/github-script` in regression-benchmark.yml via
+// `require()`; Node's type stripping executes the TypeScript directly, so
+// only erasable syntax is used and no dependencies are available (the setup
+// job sparse-checkouts .github/scripts without installing packages).
+
+// How long to wait for the CI run to conclude before giving up, and how
+// often to re-check while waiting. Tunable independently.
+const CI_WAIT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const CI_POLL_INTERVAL_MS = 30 * 1000; // 30 seconds
+
+// Default filters when a run doesn't specify them. The resolver always emits a
+// concrete value for both (never empty), so the workflow can pass --scenarios /
+// --benchmarks unconditionally; `*` matches everything.
+//
+// Both default to the full suite: a Hardhat change can affect any part of the
+// suite. Narrow per run via the workflow inputs / `scenarios=`/`benchmarks=`
+// comment args.
+const DEFAULT_SCENARIO_FILTER = "*";
+const DEFAULT_BENCHMARK_FILTER = "*";
+
+// Minimal structural types for the slice of the `actions/github-script`
+// injected globals this module uses.
+interface Core {
+  setOutput: (name: string, value: string) => void;
+  info: (message: string) => void;
+  warning: (message: string) => void;
+}
+
+interface WorkflowRun {
+  id: number;
+  status: string;
+  conclusion: string | null;
+}
+
+interface PullRequestData {
+  head: {
+    repo: { full_name: string };
+    sha: string;
+  };
+}
+
+interface GitHub {
+  rest: {
+    actions: {
+      listWorkflowRuns: (params: {
+        owner: string;
+        repo: string;
+        workflow_id: string;
+        head_sha: string;
+        per_page: number;
+      }) => Promise<{ data: { workflow_runs: WorkflowRun[] } }>;
+    };
+    pulls: {
+      get: (params: {
+        owner: string;
+        repo: string;
+        pull_number: number;
+      }) => Promise<{ data: PullRequestData }>;
+    };
+    issues: {
+      createComment: (params: {
+        owner: string;
+        repo: string;
+        issue_number: number;
+        body: string;
+      }) => Promise<unknown>;
+    };
+    reactions: {
+      createForIssueComment: (params: {
+        owner: string;
+        repo: string;
+        comment_id: number;
+        content: string;
+      }) => Promise<unknown>;
+    };
+  };
+}
+
+interface Context {
+  repo: { owner: string; repo: string };
+  eventName: string;
+  sha: string;
+  serverUrl: string;
+  runId: number;
+  payload: {
+    inputs?: Record<string, string | undefined>;
+    comment?: {
+      author_association: string;
+      user: { login: string };
+      id: number;
+      body: string;
+    };
+    issue?: { number: number };
+  };
+}
+
+export async function resolveRegressionTrigger({
+  github,
+  context,
+  core,
+}: {
+  github: GitHub;
+  context: Context;
+  core: Core;
+}): Promise<void> {
+  const { owner, repo } = context.repo;
+  const fullName = `${owner}/${repo}`;
+  const eventName = context.eventName;
+  const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+  let shouldRun = false;
+  let benchRef = "";
+  let isBaseline = false;
+  // Glob(s) selecting which projects / benchmarks to run (forwarded verbatim to
+  // bench:regression's --scenarios / --benchmarks). Both default to their
+  // DEFAULT_* for every trigger (including the main baseline) and are
+  // overridable on dispatch/`/bench`.
+  let scenarioFilter = DEFAULT_SCENARIO_FILTER;
+  let benchmarkFilter = DEFAULT_BENCHMARK_FILTER;
+
+  // Wait for the CI workflow run for `sha` to conclude. Returns true only
+  // if it completed successfully. Polls until CI_WAIT_TIMEOUT_MS elapses.
+  async function waitForCi(sha: string): Promise<boolean> {
+    const deadline = Date.now() + CI_WAIT_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const { data } = await github.rest.actions.listWorkflowRuns({
+        owner,
+        repo,
+        workflow_id: "ci.yml",
+        head_sha: sha,
+        per_page: 1,
+      });
+      const run = data.workflow_runs[0];
+      if (run !== undefined && run.status === "completed") {
+        core.info(`CI run ${run.id} concluded: ${run.conclusion}`);
+        return run.conclusion === "success";
+      }
+      core.info(
+        `CI for ${sha.slice(0, 12)} not finished yet ` +
+          `(status: ${run?.status ?? "not started"}); waiting...`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, CI_POLL_INTERVAL_MS));
+    }
+    core.warning("Timed out waiting for CI to conclude");
+    return false;
+  }
+
+  // Cosmetic side effects (reactions, status comments) must never fail the job:
+  // the gating decision (`should_run`) is the only thing that matters. Run them
+  // through this wrapper so any API rejection — insufficient token permissions,
+  // rate limits, transient 5xx — degrades to a warning instead of aborting.
+  async function bestEffort(
+    description: string,
+    fn: () => Promise<unknown>,
+  ): Promise<void> {
+    try {
+      await fn();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      core.warning(`${description} failed (ignored): ${message}`);
+    }
+  }
+
+  async function postComment(body: string): Promise<void> {
+    if (eventName !== "issue_comment") {
+      return;
+    }
+    const issueNumber = context.payload.issue?.number;
+    if (issueNumber === undefined) {
+      return;
+    }
+    await bestEffort("Posting status comment", () =>
+      github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body,
+      }),
+    );
+  }
+
+  if (eventName === "push") {
+    shouldRun = true;
+    benchRef = context.sha;
+    isBaseline = true;
+  } else if (eventName === "workflow_dispatch") {
+    shouldRun = true;
+    benchRef = context.sha;
+    scenarioFilter =
+      context.payload.inputs?.["scenario-filter"] || DEFAULT_SCENARIO_FILTER;
+    benchmarkFilter =
+      context.payload.inputs?.["benchmark-filter"] || DEFAULT_BENCHMARK_FILTER;
+    isBaseline = false;
+  } else if (eventName === "issue_comment") {
+    const comment = context.payload.comment;
+    const issue = context.payload.issue;
+
+    if (comment === undefined || issue === undefined) {
+      throw new Error(
+        "Malformed issue_comment payload: missing comment or issue",
+      );
+    }
+
+    const assoc = comment.author_association;
+    const allowed = ["OWNER", "MEMBER", "COLLABORATOR"];
+
+    // Acknowledge the request.
+    await bestEffort("Adding reaction", () =>
+      github.rest.reactions.createForIssueComment({
+        owner,
+        repo,
+        comment_id: comment.id,
+        content: "eyes",
+      }),
+    );
+
+    if (!allowed.includes(assoc)) {
+      core.warning(
+        `Comment author ${comment.user.login} (${assoc}) is not ` +
+          `authorized to trigger benchmarks.`,
+      );
+    } else {
+      const { data: pr } = await github.rest.pulls.get({
+        owner,
+        repo,
+        pull_number: issue.number,
+      });
+
+      if (pr.head.repo.full_name !== fullName) {
+        await postComment(
+          "🚫 Regression benchmarks can only run for branches in " +
+            "this repository, not forks (the self-hosted runner must " +
+            "not execute untrusted code). Push your branch to " +
+            `\`${fullName}\` and comment \`/bench\` again.`,
+        );
+      } else {
+        benchRef = pr.head.sha;
+        isBaseline = false;
+
+        // Parse `key=value` or `key="value with spaces"` (command/step globs
+        // like "cold compile" contain spaces, so quotes are supported).
+        const parseParam = (key: string): string => {
+          const m = comment.body.match(
+            new RegExp(`${key}=(?:"([^"]*)"|(\\S+))`),
+          );
+          return m?.[1] ?? m?.[2] ?? "";
+        };
+
+        scenarioFilter = parseParam("scenarios") || DEFAULT_SCENARIO_FILTER;
+        benchmarkFilter = parseParam("benchmarks") || DEFAULT_BENCHMARK_FILTER;
+
+        // Gate on CI being green for the PR head before spending
+        // a lot of time on the self-hosted runner.
+        const green = await waitForCi(pr.head.sha);
+        if (green) {
+          shouldRun = true;
+          // Only mention a filter that actually narrows the run (`*` = all).
+          const filterNotes = [
+            scenarioFilter !== "*" && `projects matching \`${scenarioFilter}\``,
+            benchmarkFilter !== "*" &&
+              `benchmarks matching \`${benchmarkFilter}\``,
+          ].filter(Boolean);
+          const filterNote =
+            filterNotes.length > 0 ? ` (${filterNotes.join(", ")})` : "";
+          await postComment(
+            `🚀 [Starting regression benchmark](${runUrl}) for ` +
+              `\`${benchRef.slice(0, 12)}\`${filterNote}.`,
+          );
+        } else {
+          await postComment(
+            "⏳ CI for this commit hasn't passed yet, so the " +
+              "regression benchmark was not started. Comment " +
+              "`/bench` again once CI is green.",
+          );
+        }
+      }
+    }
+  }
+
+  core.setOutput("should_run", String(shouldRun));
+  core.setOutput("bench_ref", benchRef);
+  core.setOutput("is_baseline", String(isBaseline));
+  core.setOutput("scenario_filter", scenarioFilter);
+  core.setOutput("benchmark_filter", benchmarkFilter);
+  core.info(
+    `should_run=${shouldRun} bench_ref=${benchRef} ` +
+      `is_baseline=${isBaseline} scenario_filter=${scenarioFilter} ` +
+      `benchmark_filter=${benchmarkFilter}`,
+  );
+}

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -76,8 +76,6 @@ jobs:
           sparse-checkout: .github/scripts
           persist-credentials: false
 
-      # github-script v9 runs on node24, whose type stripping lets it
-      # `require()` the TypeScript resolver directly.
       - id: resolve
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -1,86 +1,108 @@
 name: Regression Benchmark
 
+# Benchmarks Hardhat's E2E regression scenarios and compares the results
+# against the baselines recorded from main.
+
 on:
-  # Deliberately do not run on merge_group
+  # Records baselines for main. Deliberately do not run on merge_group.
   push:
     branches:
       - "main"
-  pull_request:
-    # Include `labeled` so the workflow fires when the `ci:perf`
-    # label is added.
-    types: [opened, synchronize, reopened, labeled]
-    branches:
-      - "**"
+  # Manual runs of the dispatched ref's HEAD.
+  workflow_dispatch:
+    inputs:
+      scenario-filter:
+        description: "Glob(s) selecting which projects/scenarios to run, by directory name (e.g. `1inch*`). Comma-separated. Defaults to `*` (all projects). Forwarded to `bench:regression --scenarios`."
+        required: false
+        type: string
+        default: "*"
+      benchmark-filter:
+        description: "Glob(s) selecting which benchmarks to run within each project, by name — a command or step name, i.e. the part after `<project> /` in a report (e.g. `test solidity`, `cold compile`, `*compile*`). Comma-separated. Defaults to `*` (the full suite). Forwarded to `bench:regression --benchmarks`."
+        required: false
+        type: string
+        default: "*"
+  # ChatOps: comment `/bench` on a same-repo PR, optionally with
+  # `scenarios="<glob>[,<glob>...]"` and/or `benchmarks="<glob>[,<glob>...]"`
+  # to select which projects/benchmarks run (quote values containing spaces).
+  # Authorization + gating happens in `setup`.
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Don't cancel in-progress jobs on main so baselines aren't lost mid-run
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Group by PR (comment events) or ref (dispatch) so re-triggering `/bench`
+  # on a PR supersedes the previous run.
+  #
+  # Pushes to main are the exception: every commit must record its own baseline
+  # entry, so each push gets a group keyed by commit SHA. `cancel-in-progress`
+  # only protects the *in-progress* run, not runs *waiting* in the queue. A
+  # unique-per-commit group collides with nothing, so every commit's run is
+  # preserved and serialized by the self-hosted runner.
+  #
+  # Every comment triggers a workflow run. The job-level `if` skips non-`/bench`
+  # ones, but that runs after concurrency is evaluated, so an unrelated comment
+  # can cancel an in-progress benchmark. Give those skipped runs a unique group
+  # so they collide with nothing.
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.event.issue.number || github.ref }}${{ (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/bench')) && format('-skip-{0}', github.run_id) || '' }}
+  # Don't cancel in-progress baseline runs on main so baselines aren't lost.
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
-  tests:
-    name: Validate Hardhat works correctly
+  setup:
+    name: Resolve ref and authorize
     runs-on: ubuntu-latest
-    # Gate validation on the same conditions as the regression-benchmark
-    # job that depends on it: this is a PR event, carries the `ci:perf`
-    # label, and isn't from a fork. Main pushes skip this gate entirely
-    # (main is assumed-green); see the regression-benchmark `if:` for the
-    # corresponding propagation guard.
-    if: |
-      github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'ci:perf') &&
-      github.repository == github.event.pull_request.head.repo.full_name
+    timeout-minutes: 40
+    permissions:
+      contents: read # read PR head / checkout metadata
+      pull-requests: write # pulls.get + post status comments/reactions on the PR
+      issues: write # post status comments + reactions on the PR
+      actions: read # list CI workflow runs for the CI-green gate
+    # For comment events, only proceed for `/bench` comments on a PR. Other
+    # events (push/workflow_dispatch) always evaluate inside the script.
+    if: >-
+      github.event_name != 'issue_comment' || (github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/bench'))
 
+    outputs:
+      should_run: ${{ steps.resolve.outputs.should_run }}
+      bench_ref: ${{ steps.resolve.outputs.bench_ref }}
+      is_baseline: ${{ steps.resolve.outputs.is_baseline }}
+      scenario_filter: ${{ steps.resolve.outputs.scenario_filter }}
+      benchmark_filter: ${{ steps.resolve.outputs.benchmark_filter }}
     steps:
+      # Sparse-checkout only the workflow scripts so the github-script step can
+      # require the resolver module below.
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
+          sparse-checkout: .github/scripts
           persist-credentials: false
 
-      # cspell:disable-next-line
-      - uses: socketdev/action@4337a545deecc20f19a909e52db7a2f6ba292f42 # v1
+      # github-script v9 runs on node24, whose type stripping lets it
+      # `require()` the TypeScript resolver directly.
+      - id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          mode: firewall
-
-      - uses: ./.github/actions/setup-env
-
-      - name: Install packages
-        run: sfw pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Build
-        run: pnpm build
-
-      # pnpm 11 skips creating bin symlinks whose target isn't built at install
-      # time; relink workspace bins (e.g. hardhat) now that the build output
-      # exists. See pnpm/pnpm#10524.
-      - name: Recreate workspace bin links
-        run: pnpm rebuild -r
-
-      - name: Run tests
-        run: pnpm test
+          script: |
+            const { resolveRegressionTrigger } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/resolve-regression-trigger.ts`);
+            await resolveRegressionTrigger({ github, context, core });
 
   regression-benchmark:
     name: Regression benchmark
+    needs: setup
+    if: needs.setup.outputs.should_run == 'true'
     environment: github-action-benchmark
     # Use a self-hosted runner for stable benchmark measurements; the shared
     # GitHub runners produce noisy results that will generate false positives
     # against the configured alert-threshold.
     runs-on: hardhat-linux-amd64-self-hosted
-    # Only run for pushes to main, workflow_dispatch, or PRs that carry the
-    # `ci:perf` label.
-    #
-    # The fork-safety guard keeps untrusted forks off the self-hosted runner.
-    if: |
-      !cancelled() && !failure() &&
-      (github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'ci:perf')) &&
-      (github.ref == 'refs/heads/main' ||
-        github.repository == github.event.pull_request.head.repo.full_name)
-
-    needs: tests
     timeout-minutes: 180
+    permissions:
+      # Lets the short-lived GITHUB_TOKEN used on non-baseline runs read commit
+      # metadata via the REST API (see "Store benchmark result").
+      contents: read
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
+          ref: ${{ needs.setup.outputs.bench_ref }}
           persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
@@ -171,7 +193,19 @@ jobs:
       - name: Run regression benchmark
         env:
           ALCHEMY_URL: ${{ secrets.ALCHEMY_URL }}
-        run: pnpm bench:regression --use-local --force-checkout --output regression-report.json
+          # Scenario/benchmark glob filters, always set by the setup job (`*`
+          # matches all). Forwarded verbatim to bench:regression, which matches
+          # them against scenario directory / benchmark (command or step) names.
+          SCENARIO_FILTER: ${{ needs.setup.outputs.scenario_filter }}
+          BENCHMARK_FILTER: ${{ needs.setup.outputs.benchmark_filter }}
+        run: |
+          set -euo pipefail
+          pnpm bench:regression \
+            --use-local \
+            --force-checkout \
+            --output regression-report.json \
+            --scenarios "$SCENARIO_FILTER" \
+            --benchmarks "$BENCHMARK_FILTER"
 
       - name: Validate scenarios used the local Hardhat build
         # Diagnostic only: verifies each E2E scenario resolved the hardhat
@@ -191,24 +225,30 @@ jobs:
             || echo "(no regression-report.json produced)"
 
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           tool: customSmallerIsBetter
           output-file-path: regression-report.json
           gh-repository: github.com/nomic-foundation-automation/hardhat-benchmark-results
           gh-pages-branch: main
           benchmark-data-dir-path: hardhat3
-          github-token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
-          # Only push baseline on main-branch pushes; PRs only compare
-          auto-push: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+          # Baseline (main push) runs push to the external results repo, which
+          # needs the cross-repo PAT. Non-baseline runs (dispatch and the
+          # `/bench` issue_comment path) never push — the token is only used to
+          # read commit metadata and to clone the (public) results repo for
+          # comparison — so use the short-lived GITHUB_TOKEN.
+          github-token: ${{ needs.setup.outputs.is_baseline == 'true' && secrets.BENCHMARK_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          # Only push a new baseline on main-branch pushes; dispatch/`/bench`
+          # runs only compare.
+          auto-push: ${{ needs.setup.outputs.is_baseline == 'true' }}
           alert-threshold: "110%"
-          # Only fail on PRs; don't break CI on main
-          fail-on-alert: ${{ github.event_name == 'pull_request' }}
+          # Fail the run on a regression for comparisons; never break main.
+          fail-on-alert: ${{ needs.setup.outputs.is_baseline != 'true' }}
           summary-always: true
 
       - name: Notify failures
-        # Only ping Slack when a commit/merge to main fails
-        if: ${{ failure() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        # Only ping Slack for failed baseline runs (pushes to main)
+        if: ${{ failure() && needs.setup.outputs.is_baseline == 'true' }}
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
@@ -225,3 +265,45 @@ jobs:
         # this manually to avoid polluting future runs.
         if: always()
         run: rm -rf "$E2E_CLONE_DIR" "$PACKAGE_MANAGER_CACHES"
+
+  report:
+    name: Report result to PR
+    needs: [setup, regression-benchmark]
+    # 1. run on benchmark failure but skip when the run is superseded (concurrency)
+    # 2. Only report back to the PR for `/bench` comment triggers
+    # 3. Only report back if the benchmark actually started
+    # prettier-ignore
+    if: >-
+      !cancelled()
+        && github.event_name == 'issue_comment'
+        && needs.regression-benchmark.result != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # post the result comment on the PR
+      pull-requests: write # post status comments/reactions on the PR
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RESULT: ${{ needs.regression-benchmark.result }}
+          BENCH_REF: ${{ needs.setup.outputs.bench_ref }}
+        with:
+          script: |
+            const { RESULT, BENCH_REF } = process.env;
+            const runUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
+            const target = `\`${BENCH_REF.slice(0, 12)}\``;
+            const body =
+              RESULT === "success"
+                ? `✅ Regression benchmark passed for ${target}.\n\n` +
+                  `[View workflow run](${runUrl})`
+                : `❌ Regression benchmark failed for ${target}. This is either ` +
+                  `a detected performance regression or an infrastructure ` +
+                  `failure — see the run for details.\n\n` +
+                  `[View workflow run](${runUrl})`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body,
+            });


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Backports EDR's `/bench` ChatOps trigger (NomicFoundation/edr#1510, #1514 and follow-ups) to Hardhat's regression benchmark, **replacing the `ci:perf` label trigger**.

## Usage

Comment on a same-repo PR:

```
/bench
/bench scenarios=1inch* benchmarks="test solidity"
```

- `scenarios=` / `benchmarks=` take comma-separated globs (quote values with spaces); both default to `*` (full suite).
- The workflow reacts 👀, waits for the PR's CI to pass (up to 30 min), posts a 🚀 comment with a run link when the benchmark starts, and a ✅/❌ comment when it finishes.
- Each `/bench` runs once; re-comment to re-run (a re-trigger supersedes the previous in-progress run for that PR).
- `workflow_dispatch` is also available with `scenario-filter` / `benchmark-filter` inputs. Pushes to main still record baselines, unchanged.

## How it works

- A new `setup` job runs `.github/scripts/resolve-regression-trigger.ts` via `actions/github-script` (github-script v9 runs on node24, whose type stripping `require()`s the TypeScript directly). It authorizes the commenter (`OWNER`/`MEMBER`/`COLLABORATOR`), rejects fork PRs (the self-hosted runner must not execute untrusted code), gates on CI being green for the PR head, parses the filter args, and emits the outputs that gate the benchmark job.
- The previous `tests` job is removed: it duplicated the full test suite that `ci.yml` already runs on every PR; the CI-green gate replaces it.
- Concurrency now groups by PR number for comment events and by commit SHA for main pushes, so every baseline is preserved while `/bench` re-triggers supersede each other; unrelated comments get a unique group so they can't cancel a running benchmark.
- The cross-repo PAT (`BENCHMARK_GITHUB_TOKEN`) is now only used on baseline runs that push to the results repo; comparison runs use the short-lived `GITHUB_TOKEN`. `github-action-benchmark` is bumped to v1.22.1, the version this token split was validated on in EDR.

## Deviations from EDR

- Hardhat benches itself, so there's no second-repo checkout/repoint and no `hardhat-ref=` arg; the run always targets the PR head (or the pushed SHA).
- Filters default to `*` instead of EDR's `test solidity,mocha test`: a Hardhat change can affect any part of the suite, compilation included — matching what the `ci:perf` label ran.
- The resolver is TypeScript (repo convention for `.github/scripts`) instead of `.cjs`, with unit tests picked up by the existing `pnpm test:workflows`.

## Testing

- Resolver unit tests cover the baseline/dispatch/comment paths, authorization, fork rejection, the CI gate, and filter parsing (`pnpm test:workflows`).
- `pnpm lint:workflows` and spellcheck pass.
- The trigger paths can only be exercised post-merge (issue_comment workflows run from the default branch): comment `/bench` on a PR and verify the 👀 → 🚀 → ✅/❌ flow, and confirm the next main push records a baseline.