### PR TITLE
fix: only forward grep options to subtasks that declare them

### DIFF
--- a/packages/hardhat/src/internal/builtin-plugins/test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/test/task-action.ts
@@ -99,10 +99,16 @@ const runAllTests: NewTaskActionFunction<TestActionArguments> = async (
 
     const args: TaskArguments = {
       testFiles: files,
-      grep,
-      grepExclude,
       noCompile: subtask.options.has("noCompile"),
     };
+
+    if (subtask.options.has("grep")) {
+      args.grep = grep;
+    }
+
+    if (subtask.options.has("grepExclude")) {
+      args.grepExclude = grepExclude;
+    }
 
     if (subtask.options.has("chainType")) {
       args.chainType = chainType;


### PR DESCRIPTION
Task validation rejects an undeclared argument by name even when its value is undefined, so passing `grep`/`grepExclude` unconditionally broke `hardhat test` for test runner plugins predating those options.