### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,7 +393,7 @@ jobs:
       - name: Setup node to be able to update npm
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
 
       - name: Update npm to make sure it supports Trusted Publishing
         run: npm install -g npm@latest


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `22`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `22` (using `22` where a concrete pin is needed).

- `.github/workflows/release.yml`
  - `node-version: 24` → `node-version: 22`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `22`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
