### PR TITLE
fix: clean yarn berry persistent cache

### DIFF
--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -105,9 +105,31 @@ jobs:
         # runner. The "Clean up temp dir" step below removes it after the run.
         run: echo "E2E_CLONE_DIR=${RUNNER_TEMP:?}/hardhat-e2e-clones" >> "$GITHUB_ENV"
 
-      - name: Configure per-run bun cache
-        # Set the bun cache directory to a temp dir that is cleaned up at the end of the job.
-        run: echo "BUN_INSTALL_CACHE_DIR=${RUNNER_TEMP:?}/bun-install-cache" >> "$GITHUB_ENV"
+      - name: Configure per-run package-manager caches
+        # The benchmark republishes deterministic versions (e.g. hardhat@3.9.1)
+        # whose content changes each run (new @nomicfoundation/edr pin), so any
+        # package-manager cache that persists on the self-hosted runner can
+        # resolve a prior run's stale republish. Point these caches at temp dirs
+        # that are cleaned up at the end of the job (see "Clean up temp dir").
+        #
+        # Yarn berry: the global folder holds both the zip cache and the npm
+        # packument metadata cache. YARN_* env vars override any .yarnrc.yml.
+        #
+        # Yarn classic: no override is needed. It doesn't have a persistent
+        # metadata cache, and its tarball cache slug includes the tarball's
+        # sha1.
+        #
+        # All caches live under PACKAGE_MANAGER_CACHES so the cleanup step can
+        # remove that single directory without being updated for every cache
+        # added here.
+        run: |
+          set -euo pipefail
+          PACKAGE_MANAGER_CACHES="${RUNNER_TEMP:?}/package-manager-caches"
+          {
+            echo "PACKAGE_MANAGER_CACHES=$PACKAGE_MANAGER_CACHES"
+            echo "BUN_INSTALL_CACHE_DIR=$PACKAGE_MANAGER_CACHES/bun-install"
+            echo "YARN_GLOBAL_FOLDER=$PACKAGE_MANAGER_CACHES/yarn-global"
+          } >> "$GITHUB_ENV"
 
       - name: Install packages
         run: sfw pnpm install --frozen-lockfile --prefer-offline
@@ -199,7 +221,7 @@ jobs:
 
       - name: Clean up temp dir
         # Self-hosted runners don't automatically wipe the E2E_CLONE_DIR and
-        # BUN_INSTALL_CACHE_DIR written to RUNNER_TEMP between jobs, so we do
+        # PACKAGE_MANAGER_CACHES written to RUNNER_TEMP between jobs, so we do
         # this manually to avoid polluting future runs.
         if: always()
-        run: rm -rf "$E2E_CLONE_DIR" "$BUN_INSTALL_CACHE_DIR"
+        run: rm -rf "$E2E_CLONE_DIR" "$PACKAGE_MANAGER_CACHES"

--- a/cspell.dictionary.txt
+++ b/cspell.dictionary.txt
@@ -90,6 +90,7 @@ normalise
 NOTOK
 Numberish
 onuncaughtexception
+packument
 perché
 perché
 popd
@@ -153,6 +154,7 @@ xcom
 xdai
 yalc
 Yalc
+yarnrc
 zkevm
 zksync
 zoey


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Backports https://github.com/NomicFoundation/edr/pull/1592 from EDR to Hardhat's regression benchmarks.

## Problem

The HH3 regression benchmark's baseline run for `01e3c8df1` failed the "Validate scenarios used the local EDR build" step: the **lidofinance-core** scenario resolved `@nomicfoundation/edr@0.15.0-local.b0267ca7e2a7` (the build from a `/bench` run of `fix/call-trace-memory` two days earlier) instead of the expected `0.15.0-local.01e3c8df1f33`.

This is the same class of bug as the bun cache fix (#1588) — a package-manager cache persisting across runs on the self-hosted runner — but for **Yarn 4 (berry)**, which lidofinance-core alone uses.

## Root cause

The benchmark republishes a deterministic hardhat version (npm latest + 1, e.g. `3.12.1`) each run, with per-run content: the `@nomicfoundation/edr` dependency pin.

Yarn berry keeps a persistent per-user global folder (`~/.yarn/berry`) containing both its zip cache and an on-disk npm packument (metadata) cache. Berry's [`getPackageMetadata`](https://github.com/yarnpkg/berry/blob/master/packages/plugin-npm/sources/npmHttpUtils.ts) short-circuits: when the exact version being resolved already exists in the cached packument, it returns the cached metadata without any network request. Since the registry host (`127.0.0.1`) and the hardhat sentinel version were identical to the earlier run, yarn never asked this run's Verdaccio: it resolved the stale hardhat manifest, whose stale EDR pin (packument and zips also cached) installed as a fully self-consistent stale graph.

This also explains the validation split (Check A curls Verdaccio directly → fresh → pass; Check B inspects the installed `node_modules` → stale → fail) and why the yarn scenarios 1inch-aqua, 1inch-cross-chain-swap and aave-v4 passed: they use yarn **1.22.22** (Yarn Classic), which fetches packuments fresh on every install and keys its tarball cache by the tarball's sha1, so a same-version republish can never match a stale entry.

## Fix

Point yarn berry's global folder at a per-run temp dir, mirroring the bun fix.

## Verification

This fix cannot be validated until we've merged in into `main`. Once merged, I'll re-run the failing scenario to validate the fix.
