### PR TITLE
ci: add names to regression-test helper steps for readability

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -130,7 +130,8 @@ jobs:
         with:
           repository: NomicFoundation/edr
           ref: ${{ needs.inputs.outputs.edr-ref }}
-      - id: target
+      - name: Resolve Rust target for runner
+        id: target
         env:
           RUNNER: ${{ matrix.runner }}
         run: |
@@ -491,7 +492,8 @@ jobs:
             }
             details = details.replaceAll(`\${∑}`, sum);
             fs.writeFileSync('run.details', details);
-      - id: upload
+      - name: Prepare regression result artifact metadata
+        id: upload
         env:
           REPOSITORY: ${{ matrix.repository }}
           CONTEXT: |


### PR DESCRIPTION
## Problem

In `.github/workflows/regression-tests.yml`, helper `run` steps are unnamed and longer than **300 characters**. In the GitHub Actions UI those steps collapse into generic labels, which hurts readability when target resolution or artifact metadata prep fails.

## Changes

Semantics are unchanged: same step `id`s, same `GITHUB_OUTPUT` keys, and the same step output wiring.

- Add `name: Resolve Rust target for runner` to `id: target`
- Add `name: Prepare regression result artifact metadata` to `id: upload`

## Test plan
- [ ] Confirm later steps still use `steps.target.outputs.target`
- [ ] Confirm artifact upload still uses `steps.upload.outputs.repository`
