### PR TITLE
feat(hardhat-solx): map Solidity 0.8.34 to solx 0.1.7

### DIFF
--- a/packages/hardhat-solx/README.md
+++ b/packages/hardhat-solx/README.md
@@ -137,7 +137,7 @@ solx: {
 
 ### Supported Solidity versions
 
-solx maps each Solidity version to a specific solx binary version internally. Currently supported: `0.8.34` (solx 0.1.6). Earlier solx releases did not emit the DWARF debug info that EDR relies on for Solidity stack traces, so they are not supported by this plugin.
+solx maps each Solidity version to a specific solx binary version internally. Currently supported: `0.8.34` (solx 0.1.7). Earlier solx releases did not emit the DWARF debug info that EDR relies on for Solidity stack traces, so they are not supported by this plugin.
 
 ### EVM version support
 

--- a/packages/hardhat-solx/src/internal/constants.ts
+++ b/packages/hardhat-solx/src/internal/constants.ts
@@ -24,5 +24,5 @@ export const DEFAULT_SOLX_OPTIMIZER_MODE = "1";
 
 /** Maps Solidity versions to the solx version that embeds them. */
 export const SOLIDITY_TO_SOLX_VERSION_MAP: Record<string, string> = {
-  "0.8.34": "0.1.6",
+  "0.8.34": "0.1.7",
 };


### PR DESCRIPTION
Use the latest solx 0.1.7 in the release mapping. This is hopefully the last release. 

## Claude Summary

Bumps `SOLIDITY_TO_SOLX_VERSION_MAP` so Solidity 0.8.34 resolves to solx 0.1.7 (was 0.1.6), plus the matching README line. solx 0.1.7 embeds the same Solidity 0.8.34, so the map key is unchanged — only the binary the plugin downloads moves.

What 0.1.7 brings that this plugin cares about:

- **Reproducible standard-JSON debug info** (NomicFoundation/solx#605) — the plugin's `debugInfo` augmentation feeds EDR's Solidity stack traces, and identical input now yields identical debug output.
- **Unresolved stack-too-deep surfaced as a standard JSON error** (NomicFoundation/solx#602) — reaches users through the plugin's normal compile-error path instead of an opaque failure.
- **Spill area placed above the memory guard** (NomicFoundation/solx#603) — codegen correctness fix.
- **`ruint` security bump** (NomicFoundation/solx#626).

## CI status

Green from the start, unlike the 0.1.6 bump. The releases mirror already serves all four 0.1.7 platform binaries and their `.sha256` sidecars, so the path-filtered `solx-mirror-availability` job and the cold-cache output-augmentation download both pass on this commit.

## Verification

- `mirror-availability` with `HARDHAT_RUN_MIRROR_TESTS=true`: passes — all four assets plus sidecars answer the 1-byte range request.
- Full `hardhat-solx` suite: 69 passing. The run downloads the real solx 0.1.7 binary and compiles every fixture project with it, so the `evm.bytecode.debugInfo` / `evm.deployedBytecode.debugInfo` assertions and the `-O1` default-mode check hold against the new binary, not a mock.
- prettier + eslint on `constants.ts`, cspell on the README: clean.

## Notes

- `@nomicfoundation/hardhat-solx` is private — no changeset.
- Nothing else in the package pins a solx version; the test suite references the Solidity version (`0.8.34`) only.
