### PR TITLE
fix: don't reject a mining interval of 0, which disables interval mining

### DIFF
--- a/.changeset/edr-mining-interval-zero.md
+++ b/.changeset/edr-mining-interval-zero.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed the EDR network config validation rejecting `mining.interval: 0`, which disables interval mining and is also the resolved default.

--- a/.changeset/edr-mining-interval-zero.md
+++ b/.changeset/edr-mining-interval-zero.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Fixed the EDR network config validation rejecting `mining.interval: 0`, which disables interval mining and is also the resolved default.
+Fixed the EDR network config validation rejecting `mining.interval: 0`, a valid value which disables interval mining.

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -426,7 +426,15 @@ function refineEdrNetworkUserConfig(
       }
 
       const interval = network.mining?.interval;
-      if (typeof interval === "number" || Array.isArray(interval)) {
+      // A scalar `interval: 0` disables interval mining entirely, so no blocks
+      // are mined on a timer and their timestamps can't diverge from clock
+      // time. It's also the resolved default, and setting it explicitly is how
+      // interval mining is opted out of. An interval range always enables
+      // interval mining, so it is still checked even if its minimum is 0.
+      if (
+        (typeof interval === "number" && interval !== 0) ||
+        Array.isArray(interval)
+      ) {
         const minInterval =
           typeof interval === "number" ? interval : Math.min(...interval);
         if (

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -426,11 +426,7 @@ function refineEdrNetworkUserConfig(
       }
 
       const interval = network.mining?.interval;
-      // A scalar `interval: 0` disables interval mining entirely, so no blocks
-      // are mined on a timer and their timestamps can't diverge from clock
-      // time. It's also the resolved default, and setting it explicitly is how
-      // interval mining is opted out of. An interval range always enables
-      // interval mining, so it is still checked even if its minimum is 0.
+      // A scalar `interval: 0` disables interval mining entirely, so this validate is not appropriate
       if (
         (typeof interval === "number" && interval !== 0) ||
         Array.isArray(interval)

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts
@@ -426,7 +426,7 @@ function refineEdrNetworkUserConfig(
       }
 
       const interval = network.mining?.interval;
-      // A scalar `interval: 0` disables interval mining entirely, so this validate is not appropriate
+      // A scalar `interval: 0` disables interval mining entirely, so this validation is not appropriate
       if (
         (typeof interval === "number" && interval !== 0) ||
         Array.isArray(interval)

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -640,8 +640,6 @@ describe("network-manager/hook-handlers/config", () => {
     });
 
     it("should not throw when the mining interval is 0, as it disables interval mining", async () => {
-      // `mining: { auto: false, interval: 0 }` is how automatic mining is
-      // turned off completely, and `interval: 0` is also the resolved default.
       const config: HardhatUserConfig = {
         networks: {
           test: {

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts
@@ -621,6 +621,43 @@ describe("network-manager/hook-handlers/config", () => {
         makeConfig([1000, 1000], true),
       );
       assert.equal(validationErrors.length, 0);
+
+      // Interval of 0 disables interval mining, so it's always accepted
+      validationErrors = await validateNetworkUserConfig(makeConfig(0, false));
+      assert.equal(validationErrors.length, 0);
+
+      // An interval range enables interval mining, so a minimum of 0 is still
+      // an error
+      validationErrors = await validateNetworkUserConfig(
+        makeConfig([0, 5000], false),
+      );
+      assertValidationErrors(validationErrors, [
+        {
+          path: ["networks", "test", "mining", "interval"],
+          message: errorMessage,
+        },
+      ]);
+    });
+
+    it("should not throw when the mining interval is 0, as it disables interval mining", async () => {
+      // `mining: { auto: false, interval: 0 }` is how automatic mining is
+      // turned off completely, and `interval: 0` is also the resolved default.
+      const config: HardhatUserConfig = {
+        networks: {
+          test: {
+            type: "edr-simulated",
+            chainType: "l1",
+            mining: {
+              auto: false,
+              interval: 0,
+            },
+          },
+        },
+      };
+
+      const validationErrors = await validateNetworkUserConfig(config);
+
+      assert.equal(validationErrors.length, 0);
     });
 
     it("should accept a parseable initialDate string", async () => {


### PR DESCRIPTION
### Problem

The EDR network config validation rejects any `mining.interval` below 1000 ms
unless `allowBlocksWithSameTimestamp: true` is also set. That check exists to
stop block timestamps from running ahead of clock time (#6012).

A scalar `interval: 0` does not schedule blocks at all, so it can't cause that
divergence. It is how interval mining is turned off — and it is the value the
config resolution already defaults to. Writing it explicitly makes Hardhat
refuse to load the config:

```ts
// hardhat.config.ts
export default {
  networks: {
    dev: {
      type: "edr-simulated",
      mining: {
        auto: false,
        interval: 0, // turn off automatic mining, mine manually with evm_mine
      },
    },
  },
};
```

```
$ npx hardhat test
Error in networks.dev.mining.interval: mining.interval is set to less than
1000 ms. To avoid the block timestamp diverging from clock time, please set
allowBlocksWithSameTimestamp: true on the network config
```

The suggested workaround (`allowBlocksWithSameTimestamp: true`) changes
unrelated behaviour, and the message describes a risk that cannot occur when no
blocks are mined on a timer.

### Root cause

`refineEdrNetworkUserConfig` in
`packages/hardhat/src/internal/builtin-plugins/network-manager/type-validation.ts`
runs the minimum-interval check for every numeric interval, including `0`:

```ts
const interval = network.mining?.interval;
if (typeof interval === "number" || Array.isArray(interval)) {
  const minInterval =
    typeof interval === "number" ? interval : Math.min(...interval);
  if (minInterval < 1000 && network.allowBlocksWithSameTimestamp !== true) {
```

But `0` is the "interval mining disabled" sentinel elsewhere in the same
plugin:

- `hardhatMiningIntervalToEdrMiningInterval`
  (`edr/utils/convert-to-edr.ts`) maps a scalar `0` to `undefined` with the
  comment `// Is interval mining disabled?`.
- `resolveMiningConfig` (`config-resolution.ts`) resolves the default to
  `interval: 0`, and the existing default-config test asserts
  `mining === { auto: true, interval: 0, mempool: { order: "priority" } }`.

So the validation rejects a value the resolver produces by default.

### Fix

Skip the check only for a scalar `0`. An interval *range* always enables
interval mining, so `[0, 5000]` is still an error.

### Tests

Added to
`packages/hardhat/test/internal/builtin-plugins/network-manager/hook-handlers/config.ts`:

- `interval: 0` with `allowBlocksWithSameTimestamp: false` → no validation errors.
- `mining: { auto: false, interval: 0 }` → no validation errors.
- `interval: [0, 5000]` → still errors (ranges are unaffected).

Both new assertions fail on `main` (1 validation error where 0 is expected) and
pass with this change.
