### PR TITLE
Improve error message for npm optional deps and platforms bug

### DIFF
--- a/.changeset/native-binding-load-error.md
+++ b/.changeset/native-binding-load-error.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-errors": minor
+"hardhat": minor
+---
+
+Added detection and custom error for failed native binding loads (`HHE27`) of `@nomicfoundation/edr` or `@nomicfoundation/solidity-analyzer`.

--- a/cspell.dictionary.txt
+++ b/cspell.dictionary.txt
@@ -35,6 +35,8 @@ DISTROS
 dorny
 dsari
 dtolnay
+eabi
+EBADENGINE
 elif
 enero
 esac
@@ -45,6 +47,7 @@ fqns
 Fqns
 FQNs
 gcda
+gnueabihf
 hdkey
 hdpath
 heco
@@ -98,10 +101,12 @@ PREVRANDAO
 pushd
 randao
 Randao
+recategorize
 recompiles
 reconciliable
 reconiliation
 reserialized
+riscv
 sarasa
 schaable
 sokol

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -561,6 +561,28 @@ Remove them or move them to a different place and try again.`,
         websiteTitle: "Non-interactive init failed due to existing files",
         websiteDescription: `The non-interactive project initialization refuses to overwrite existing files. Remove the conflicting files and retry.`,
       },
+      NATIVE_BINDING_LOAD_FAILED: {
+        number: 27,
+        messageTemplate: `Hardhat couldn't load the native binding for {parentPackage}.
+
+Missing platform package: {missingPackage}
+
+This is usually caused by a known npm bug with optional dependencies (https://github.com/npm/cli/issues/4828), fixed in npm 11.3.0. Node.js 22 bundles npm 10, which doesn't include the fix.
+
+To fix it, update npm and reinstall your dependencies:
+
+  npm install --global npm@latest
+  rm -rf node_modules package-lock.json
+  npm install
+
+If that command fails with EBADENGINE, update Node.js to its latest patch release first (or to a newer major), then retry.`,
+        websiteTitle: "Native binding failed to load",
+        websiteDescription: `Hardhat depends on packages that ship prebuilt native binaries, one per platform, declared as optional dependencies. The binary for your platform is missing from your installation.
+
+This is usually caused by a known npm bug with optional dependencies (https://github.com/npm/cli/issues/4828), which npm fixed in version 11.3.0. Node.js 22 bundles npm 10, which never received the backport, so it can write a lockfile that omits the platform packages.
+
+Updating npm to 11.3.0 or later and regenerating the lockfile fixes it. Note that the npm fix is not retroactive: an already-affected lockfile has to be regenerated at least once. If updating npm fails with an EBADENGINE error, update Node.js to a newer version first, then retry.`,
+      },
     },
     INTERNAL: {
       ASSERTION_ERROR: {

--- a/packages/hardhat-verify/src/internal/tasks/verify/task-action.ts
+++ b/packages/hardhat-verify/src/internal/tasks/verify/task-action.ts
@@ -71,7 +71,7 @@ export async function internalVerifyAction(
     } catch (error) {
       ensureError(error);
       // It would be nice to use printErrorMessages
-      // from packages/hardhat/src/internal/cli/error-handler.ts
+      // from packages/hardhat/src/internal/cli/error-handling/error-handler.ts
       // for consistent error formatting
       console.error(styleText("red", error.message));
       errorOccurred = true;

--- a/packages/hardhat/src/internal/cli/error-handling/error-handler.ts
+++ b/packages/hardhat/src/internal/cli/error-handling/error-handler.ts
@@ -9,6 +9,8 @@ import {
 
 import { HARDHAT_NAME, HARDHAT_WEBSITE_URL } from "../../constants.js";
 
+import { detectNativeBindingFailure } from "./native-binding-error.js";
+
 // The classifier may import many unrelated things top-level to do its job, so
 // we load it lazily.
 let classifierModule: typeof ClassifierT | undefined;
@@ -162,6 +164,21 @@ async function getErrorWithCategory(error: Error): Promise<ErrorWithCategory> {
     return {
       category: ErrorCategory.COMMUNITY_PLUGIN,
       categorizedError: error,
+    };
+  }
+
+  const nativeBindingFailure = detectNativeBindingFailure(error);
+  if (nativeBindingFailure !== undefined) {
+    return {
+      category: ErrorCategory.HARDHAT,
+      categorizedError: new HardhatError(
+        HardhatError.ERRORS.CORE.GENERAL.NATIVE_BINDING_LOAD_FAILED,
+        {
+          parentPackage: nativeBindingFailure.parentPackage,
+          missingPackage: nativeBindingFailure.missingPackage,
+        },
+        error,
+      ),
     };
   }
 

--- a/packages/hardhat/src/internal/cli/error-handling/error-handler.ts
+++ b/packages/hardhat/src/internal/cli/error-handling/error-handler.ts
@@ -1,4 +1,4 @@
-import type * as ClassifierT from "./telemetry/error-classification/classifier.js";
+import type * as ClassifierT from "../telemetry/error-classification/classifier.js";
 
 import { styleText } from "node:util";
 
@@ -7,7 +7,7 @@ import {
   HardhatPluginError,
 } from "@nomicfoundation/hardhat-errors";
 
-import { HARDHAT_NAME, HARDHAT_WEBSITE_URL } from "../constants.js";
+import { HARDHAT_NAME, HARDHAT_WEBSITE_URL } from "../../constants.js";
 
 // The classifier may import many unrelated things top-level to do its job, so
 // we load it lazily.
@@ -167,7 +167,7 @@ async function getErrorWithCategory(error: Error): Promise<ErrorWithCategory> {
 
   if (classifierModule === undefined) {
     classifierModule =
-      await import("./telemetry/error-classification/classifier.js");
+      await import("../telemetry/error-classification/classifier.js");
   }
 
   // Pass `ignoreDevelopmentTimeFilter=true` so the migration footer also shows

--- a/packages/hardhat/src/internal/cli/error-handling/native-binding-error.ts
+++ b/packages/hardhat/src/internal/cli/error-handling/native-binding-error.ts
@@ -1,0 +1,78 @@
+/**
+ * The platform triple that napi-rs appends to the platform package name, e.g.
+ * `@nomicfoundation/edr-linux-x64-gnu`, `@scope/pkg-darwin-arm64`.
+ */
+const PLATFORM_SUFFIX_REGEX =
+  /-(?:android|darwin|freebsd|linux|win32)-(?:arm|arm64|ia32|x64|riscv64|ppc64|s390x)(?:-(?:gnu|musl|msvc|eabi|gnueabihf))?$/;
+
+/**
+ * Matches both the CJS (`Cannot find module 'x'`) and ESM
+ * (`Cannot find package 'x' imported from y`) forms.
+ */
+const MISSING_MODULE_REGEX = /Cannot find (?:module|package) '([^']+)'/g;
+
+/**
+ * The packages Hardhat itself ships a native binding for.
+ */
+const HARDHAT_NATIVE_BINDING_PACKAGES = [
+  "@nomicfoundation/edr",
+  "@nomicfoundation/solidity-analyzer",
+];
+
+export interface NativeBindingFailure {
+  /** The package whose loader failed, e.g. `@nomicfoundation/edr`. */
+  parentPackage: string;
+  /** The platform package that couldn't be found. */
+  missingPackage: string;
+}
+
+/**
+ * Detect whether a given error is a napi-rs native binding load failure.
+ *
+ * Packages like `@nomicfoundation/edr` and `@nomicfoundation/solidity-analyzer`
+ * ship one prebuilt binary per platform in a separate package, and their
+ * generated loader `require`s the one matching the current platform. When that
+ * package is missing from the installation the loader throws at import time, so
+ * the failure surfaces as an opaque `MODULE_NOT_FOUND` from deep inside
+ * `node_modules`.
+ */
+export function detectNativeBindingFailure(
+  error: Error,
+): NativeBindingFailure | undefined {
+  const chain = errorChain(error);
+
+  // Some link in the chain names the missing platform package.
+  for (const chainedError of chain) {
+    for (const match of chainedError.message.matchAll(MISSING_MODULE_REGEX)) {
+      const moduleName = match[1];
+
+      if (!PLATFORM_SUFFIX_REGEX.test(moduleName)) {
+        continue;
+      }
+
+      const parentPackage = moduleName.replace(PLATFORM_SUFFIX_REGEX, "");
+
+      if (!HARDHAT_NATIVE_BINDING_PACKAGES.includes(parentPackage)) {
+        continue;
+      }
+
+      return { missingPackage: moduleName, parentPackage };
+    }
+  }
+
+  return undefined;
+}
+
+function errorChain(error: Error): Error[] {
+  const chain: Error[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    chain.push(current);
+    current = current.cause;
+  }
+
+  return chain;
+}

--- a/packages/hardhat/src/internal/cli/hhu.ts
+++ b/packages/hardhat/src/internal/cli/hhu.ts
@@ -19,7 +19,7 @@ import { globalFlag } from "../core/config.js";
 import { TaskManagerImplementation } from "../core/tasks/task-manager.js";
 import { getHardhatVersion } from "../utils/package.js";
 
-import { printErrorMessages } from "./error-handler.js";
+import { printErrorMessages } from "./error-handling/error-handler.js";
 import { getGlobalHelpString } from "./help/get-global-help-string.js";
 import { getHelpString } from "./help/get-help-string.js";
 import {

--- a/packages/hardhat/src/internal/cli/main.ts
+++ b/packages/hardhat/src/internal/cli/main.ts
@@ -28,7 +28,7 @@ import { warnAboutUnusedLoadedPlugins } from "../core/plugins/unused-plugins-war
 import { setGlobalHardhatRuntimeEnvironment } from "../global-hre-instance.js";
 import { createHardhatRuntimeEnvironment } from "../hre-initialization.js";
 
-import { printErrorMessages } from "./error-handler.js";
+import { printErrorMessages } from "./error-handling/error-handler.js";
 import { getGlobalHelpString } from "./help/get-global-help-string.js";
 import { getHelpString } from "./help/get-help-string.js";
 import {

--- a/packages/hardhat/test/internal/cli/error-handling/error-handler.ts
+++ b/packages/hardhat/test/internal/cli/error-handling/error-handler.ts
@@ -14,6 +14,9 @@ import {
 } from "../../../../src/internal/constants.js";
 import { UsingHardhat2PluginError } from "../../../../src/internal/using-hardhat2-plugin-errors.js";
 
+const nativeBindingErrorDescriptor =
+  HardhatError.ERRORS.CORE.GENERAL.NATIVE_BINDING_LOAD_FAILED;
+
 const mockCoreErrorDescriptor = {
   number: 123,
   messageTemplate: "error message",
@@ -288,6 +291,55 @@ describe("error-handler", () => {
           lines[4],
           `It looks like you are migrating from Hardhat 2 to Hardhat 3. The following error often shows up during this kind of migration.\nPlease read https://hardhat.org/migrate-from-hardhat2 to learn how to migrate your project to Hardhat 3.`,
         );
+      });
+    });
+
+    describe("with a native binding load failure", () => {
+      it("is categorized as HHE27, with the original error preserved for the stack trace", async () => {
+        const cause = new Error(
+          "Cannot find module '@nomicfoundation/edr-linux-arm64-gnu'",
+        );
+        const error = new Error(
+          "Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828).",
+          { cause },
+        );
+        const expected = new HardhatError(nativeBindingErrorDescriptor, {
+          parentPackage: "@nomicfoundation/edr",
+          missingPackage: "@nomicfoundation/edr-linux-arm64-gnu",
+        });
+
+        const lines: Array<string | Error> = [];
+        await printErrorMessages(error, false, (msg: string | Error) => {
+          lines.push(msg);
+        });
+
+        assert.equal(lines.length, 3);
+        assert.equal(
+          lines[0],
+          `${styleText(["red", "bold"], `Error ${expected.errorCode}:`)} ${expected.formattedMessage}`,
+        );
+        assert.equal(lines[1], "");
+        assert.equal(
+          lines[2],
+          `For more info go to ${HARDHAT_WEBSITE_URL}${expected.errorCode} or run ${HARDHAT_NAME} with --show-stack-traces`,
+        );
+      });
+
+      it("still prints the original (uncategorized) error for the stack trace", async () => {
+        const cause = new Error(
+          "Cannot find module '@nomicfoundation/edr-linux-arm64-gnu'",
+        );
+        const error = new Error(
+          "Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828).",
+          { cause },
+        );
+
+        const lines: Array<string | Error> = [];
+        await printErrorMessages(error, true, (msg: string | Error) => {
+          lines.push(msg);
+        });
+
+        assert.equal(lines[2], error);
       });
     });
   });

--- a/packages/hardhat/test/internal/cli/error-handling/error-handler.ts
+++ b/packages/hardhat/test/internal/cli/error-handling/error-handler.ts
@@ -7,12 +7,12 @@ import {
   HardhatPluginError,
 } from "@nomicfoundation/hardhat-errors";
 
-import { printErrorMessages } from "../../../src/internal/cli/error-handler.js";
+import { printErrorMessages } from "../../../../src/internal/cli/error-handling/error-handler.js";
 import {
   HARDHAT_NAME,
   HARDHAT_WEBSITE_URL,
-} from "../../../src/internal/constants.js";
-import { UsingHardhat2PluginError } from "../../../src/internal/using-hardhat2-plugin-errors.js";
+} from "../../../../src/internal/constants.js";
+import { UsingHardhat2PluginError } from "../../../../src/internal/using-hardhat2-plugin-errors.js";
 
 const mockCoreErrorDescriptor = {
   number: 123,

--- a/packages/hardhat/test/internal/cli/error-handling/native-binding-error.ts
+++ b/packages/hardhat/test/internal/cli/error-handling/native-binding-error.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { detectNativeBindingFailure } from "../../../../src/internal/cli/error-handling/native-binding-error.js";
+
+describe("native-binding-error", () => {
+  describe("detectNativeBindingFailure", () => {
+    it("detects the EDR shape: a top-level message with a cause chain naming the missing module", () => {
+      const cause = new Error(
+        "Cannot find module '@nomicfoundation/edr-linux-arm64-gnu'",
+      );
+      const error = new Error(
+        "Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828).",
+        { cause },
+      );
+
+      assert.deepEqual(detectNativeBindingFailure(error), {
+        parentPackage: "@nomicfoundation/edr",
+        missingPackage: "@nomicfoundation/edr-linux-arm64-gnu",
+      });
+    });
+
+    it("detects the ESM message form of the EDR shape", () => {
+      const error = new Error(
+        "Cannot find package '@nomicfoundation/edr-darwin-arm64' imported from /project/index.js",
+      );
+
+      assert.deepEqual(detectNativeBindingFailure(error), {
+        parentPackage: "@nomicfoundation/edr",
+        missingPackage: "@nomicfoundation/edr-darwin-arm64",
+      });
+    });
+
+    it("detects the solidity-analyzer shape: a bare MODULE_NOT_FOUND with no cause", () => {
+      const error = new Error(
+        "Cannot find module '@nomicfoundation/solidity-analyzer-linux-arm64-gnu'",
+      );
+
+      assert.deepEqual(detectNativeBindingFailure(error), {
+        parentPackage: "@nomicfoundation/solidity-analyzer",
+        missingPackage: "@nomicfoundation/solidity-analyzer-linux-arm64-gnu",
+      });
+    });
+
+    it("ignores a platform-shaped missing module that isn't a known binding package", () => {
+      const error = new Error("Cannot find module 'some-app-linux-x64-gnu'");
+
+      assert.equal(detectNativeBindingFailure(error), undefined);
+    });
+
+    it("ignores a missing module with no platform suffix", () => {
+      const error = new Error("Cannot find module '@nomicfoundation/edr'");
+
+      assert.equal(detectNativeBindingFailure(error), undefined);
+    });
+
+    it("ignores the loader's own local binding probe", () => {
+      const error = new Error(
+        "Cannot find module './edr.linux-arm64-gnu.node'",
+      );
+
+      assert.equal(detectNativeBindingFailure(error), undefined);
+    });
+
+    // We only detect the native binding for the specific NPM bug, everything else goes through
+    it("does not detect a wrapper message that doesn't name a missing module", () => {
+      const error = new Error("Cannot find native binding");
+
+      assert.equal(detectNativeBindingFailure(error), undefined);
+    });
+
+    it("ignores an unrelated error", () => {
+      const error = new Error("something else went wrong");
+
+      assert.equal(detectNativeBindingFailure(error), undefined);
+    });
+  });
+});


### PR DESCRIPTION
Hardhat users have repeatedly hit a known npm bug ([npm/cli#4828](https://github.com/npm/cli/issues/4828)):

> npm versions before 11.3.0 rewrite `package-lock.json` from the `node_modules` on whichever machine last ran `install`, and in doing so drop the _other_ platforms' optional-dependency entries. The next `install` on one of those platforms then has no lockfile entry telling it to fetch its native binary, so nothing gets installed — not the wrong platform's binary, none at all — and the loader throws a `Cannot find module` inside `node_modules`.

We currently work around this for `@nomicfoundation/edr` by shipping all seven platform packages as regular dependencies instead of `optionalDependencies`, which costs every install ~165-175MB. We want to roll that workaround back as the npm bug is resolved in later npm versions (>= 11.3.0), but Node 22 (Hardhat's minimum supported version) still bundles npm 10 by default, so some users would hit a broken install with no explanation.

This PR means we now detect a failed native-binding load in Hardhat's central error-printing path and report it as a `HardhatError` (`HHE27`) naming the missing package and how to fix it i.e. update to a more recent version of npm.

Resolves #8489.

## Preview

```shell
$ npx hardhat compile
Error HHE27: Hardhat couldn't load the native binding for @nomicfoundation/edr.

Missing platform package: @nomicfoundation/edr-linux-arm64-gnu

This is usually caused by a known npm bug with optional dependencies (https://github.com/npm/cli/issues/4828), fixed in npm 11.3.0. Node.js 22 bundles npm 10, which doesn't include the fix.

To fix it, update npm and reinstall your dependencies:

  npm install --global npm@latest
  rm -rf node_modules package-lock.json
  npm install

If that command fails with EBADENGINE, update Node.js to its latest patch release first (or to a newer major), then retry.

For more info go to https://hardhat.org/HHE27 or run Hardhat with --show-stack-traces
```

## Technical decisions

- **Central detection over wrapping the five `@nomicfoundation/edr` `await import` boundaries.** `EDR` is already fully behind lazy dynamic imports, so each boundary could in principle be wrapped in a try/catch. We instead hook into the existing `getErrorWithCategory` function in `error-handler.ts`. Central detection also catches `solidity-analyzer`'s failures. The one thing central detection does _not_ cover is a consumer embedding `hardhat` as a library and driving task actions directly, bypassing `main.ts`/`hhu.ts`.
- **An explicit allowlist (`@nomicfoundation/edr`, `@nomicfoundation/solidity-analyzer`) rather than looser regex matching.** A platform-suffix-shaped module name alone isn't enough, a user's own dependency named e.g. `some-app-linux-x64-gnu` would otherwise misclassify as a Hardhat native-binding failure. See `native-binding-error.test.ts`'s allowlist-blocked cases.

## Review

> [!TIP]
> Review a commit at a time for easier review

- `refactor: move error-handler to cli/error-handling/`moves the error handler in to a subdirectory, to give a natural place for additional error handling utils in the following commits
- `feat: detect and report failed native binding loads as HHE27` is the feature: the descriptor, `native-binding-error.ts`, and the `error-handler.ts` wiring.
- `test: cover detectNativeBindingFailure...` is worth reading against the message shapes it's asserting on — those come from the two loaders' actual output, not synthesized.

## Manual testing

Use verdaccio (after `pnpm version-for-release`) to do a local clean install with `npm`, then manually remove the EDR and solidity-analyzer packages for the platform you're on:

```shell
pnpm version-for-release
pnpm verdaccio start

# In a different terminal
pnpm verdaccio publish --no-git-checks
mkdir /tmp/example-hardhat-install && cd /tmp/example-hardhat-install

# Point npm/npx at the local registry for everything run from this directory -
# without this, npx would just fetch the real, unpatched hardhat from npmjs.org
echo "registry=http://127.0.0.1:4873" > .npmrc

# Run the install, I find giving the version just installed in verdaccio
# reduces your risk of using a cached version
npx hardhat@3.14.0 --init --template node-test-runner-viem

# Confirm working
npx hardhat test

# remove a different platform (windows), and everything continues to work
rm -rf node_modules/@nomicfoundation/edr-win32-x64-msvc
npx hardhat test

# remove your platform's EDR binary and see the new error
rm -rf node_modules/@nomicfoundation/edr-linux-arm64-gnu
npx hardhat test

# restore
npm install
npx hardhat test

# same thing, but for solidity-analyzer's binary
rm -rf node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-gnu
npx hardhat test

# restore, then tear down verdaccio and the version-for-release changes
npm install
npx hardhat test
pnpm verdaccio stop
git restore .
```
