### PR TITLE
Add Node 26-specific fixture for async-describe-test

### DIFF
--- a/packages/hardhat-node-test-reporter/integration-tests/fixture-tests/async-describe-test/result.v26.txt
+++ b/packages/hardhat-node-test-reporter/integration-tests/fixture-tests/async-describe-test/result.v26.txt
@@ -1,0 +1,31 @@
+  describe.async
+    [32m✔[39m[90m describe.async.it.only[39m
+    describe.async.describe.only.async
+      [32m✔[39m[90m describe.async.describe.only.async.it.only[39m
+    describe.async.describe
+      [32m✔[39m[90m describe.async.describe.it.only[39m
+
+  describe.only.async
+    [32m✔[39m[90m describe.only.async.it.only[39m
+    describe.only.async.describe.only.async
+      [32m✔[39m[90m describe.only.async.describe.only.async.it.only[39m
+    describe.only.async.describe
+      [32m✔[39m[90m describe.only.async.describe.it.only[39m
+
+  describe.only
+    [32m✔[39m[90m describe.only.it.only[39m
+    describe.only.describe.only.async
+      [32m✔[39m[90m describe.only.describe.only.async.it.only[39m
+    describe.only.describe
+      [32m✔[39m[90m describe.only.describe.it.only[39m
+
+  describe
+    [32m✔[39m[90m describe.it.only[39m
+    describe.describe.only.async
+      [32m✔[39m[90m describe.describe.only.async.it.only[39m
+    describe.describe
+      [32m✔[39m[90m describe.describe.it.only[39m
+
+
+  [32m12 passing[39m[90m (80ms)[39m
+

--- a/packages/hardhat-node-test-reporter/scripts/regenerate-fixtures.sh
+++ b/packages/hardhat-node-test-reporter/scripts/regenerate-fixtures.sh
@@ -35,8 +35,11 @@ for dir in $dirs; do
   # we should either add a more robust way of detecting such tests or version
   # all the test result files.
   result_file_name="result"
-  if [ "$dir" == "integration-tests/fixture-tests/nested-test" ] || [ "$dir" == "integration-tests/fixture-tests/async-describe-test" ]; then
-    node_major_version="$(node --version | cut -d. -f1)"
+  node_major_version="$(node --version | cut -d. -f1)"
+  if [ "$dir" == "integration-tests/fixture-tests/nested-test" ]; then
+    result_file_name="result.$node_major_version"
+  elif [ "$dir" == "integration-tests/fixture-tests/async-describe-test" ] && [ "$node_major_version" == "v26" ]; then
+    # Only v26 currently diverges from the generic result.txt for this fixture.
     result_file_name="result.$node_major_version"
   fi
 

--- a/packages/hardhat-node-test-reporter/scripts/regenerate-fixtures.sh
+++ b/packages/hardhat-node-test-reporter/scripts/regenerate-fixtures.sh
@@ -35,7 +35,7 @@ for dir in $dirs; do
   # we should either add a more robust way of detecting such tests or version
   # all the test result files.
   result_file_name="result"
-  if [ "$dir" == "integration-tests/fixture-tests/nested-test" ]; then
+  if [ "$dir" == "integration-tests/fixture-tests/nested-test" ] || [ "$dir" == "integration-tests/fixture-tests/async-describe-test" ]; then
     node_major_version="$(node --version | cut -d. -f1)"
     result_file_name="result.$node_major_version"
   fi


### PR DESCRIPTION
Node 26.7.0's test_runner fix for filtered async suites (nodejs/node#64208) changes how a plain async `describe` with a nested `.only` test behaves under `only`-filtering: the nested `.only` test is no longer entered at all, instead of erroring with "test could not be started because its parent finished" as on every other currently supported major (including earlier 26.x patches).

It is not obvious that this will become the new normal on Node 26 (the other majors retain the previous behaviour here). For the moment we are adding a `result.v26.txt` override, and matching the new output, we can revert if a subsequent Node 26 changes back.
