### PR TITLE
fix: hardhat 2 viem resolution mode

### DIFF
--- a/.changeset/viem-resolution-mode-imports.md
+++ b/.changeset/viem-resolution-mode-imports.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem": patch
+---
+
+Added a `resolution-mode` import attribute to `viem`'s type-only imports, fixing a build failure against newer `viem` releases.

--- a/packages/hardhat-viem/src/internal/accounts.ts
+++ b/packages/hardhat-viem/src/internal/accounts.ts
@@ -1,5 +1,5 @@
 import type { EthereumProvider } from "hardhat/types";
-import type { Address } from "viem";
+import type { Address } from "viem" with { "resolution-mode": "import" };
 
 import memoize from "lodash.memoize";
 

--- a/packages/hardhat-viem/src/internal/bytecode.ts
+++ b/packages/hardhat-viem/src/internal/bytecode.ts
@@ -1,4 +1,4 @@
-import type * as viemT from "viem";
+import type * as viemT from "viem" with { "resolution-mode": "import" };
 import type { Artifact } from "hardhat/types/artifacts";
 
 import {
@@ -22,7 +22,9 @@ export async function linkBytecode(
   artifact: Artifact,
   libraries: Link[]
 ): Promise<viemT.Hex> {
-  const { isHex } = require("viem") as typeof import("viem");
+  const { isHex } = require("viem") as typeof import("viem", {
+    with: { "resolution-mode": "import" },
+  });
   let bytecode = artifact.bytecode;
 
   // TODO: measure performance impact

--- a/packages/hardhat-viem/src/internal/chains.ts
+++ b/packages/hardhat-viem/src/internal/chains.ts
@@ -1,5 +1,5 @@
 import type { EthereumProvider } from "hardhat/types";
-import type { Chain } from "viem";
+import type { Chain } from "viem" with { "resolution-mode": "import" };
 import type { TestClientMode } from "../types";
 
 import memoize from "lodash.memoize";
@@ -7,8 +7,12 @@ import memoize from "lodash.memoize";
 import { UnknownDevelopmentNetworkError, NetworkNotFoundError } from "./errors";
 
 export async function getChain(provider: EthereumProvider): Promise<Chain> {
-  const { extractChain } = require("viem") as typeof import("viem");
-  const chainsModule = require("viem/chains") as typeof import("viem/chains");
+  const { extractChain } = require("viem") as typeof import("viem", {
+    with: { "resolution-mode": "import" },
+  });
+  const chainsModule = require("viem/chains") as typeof import("viem/chains", {
+    with: { "resolution-mode": "import" },
+  });
   const chains = Object.values(chainsModule) as Chain[];
   const chainId = await getChainId(provider);
 

--- a/packages/hardhat-viem/src/internal/clients.ts
+++ b/packages/hardhat-viem/src/internal/clients.ts
@@ -5,7 +5,7 @@ import type {
   PublicClientConfig,
   WalletClientConfig,
   TestClientConfig,
-} from "viem";
+} from "viem" with { "resolution-mode": "import" };
 import type {
   PublicClient,
   TestClient,
@@ -56,7 +56,9 @@ export async function innerGetPublicClient(
   chain: Chain,
   publicClientConfig?: Partial<PublicClientConfig>
 ): Promise<PublicClient> {
-  const viem = require("viem") as typeof import("viem");
+  const viem = require("viem") as typeof import("viem", {
+    with: { "resolution-mode": "import" },
+  });
   const { clientParameters, transportParameters } = await getParameters(
     chain,
     publicClientConfig
@@ -97,7 +99,9 @@ export async function innerGetWalletClients(
   accounts: Address[],
   walletClientConfig?: Partial<WalletClientConfig>
 ): Promise<WalletClient[]> {
-  const viem = require("viem") as typeof import("viem");
+  const viem = require("viem") as typeof import("viem", {
+    with: { "resolution-mode": "import" },
+  });
   const { clientParameters, transportParameters } = await getParameters(
     chain,
     walletClientConfig
@@ -161,7 +165,9 @@ export async function innerGetTestClient(
   mode: TestClientMode,
   testClientConfig?: Partial<TestClientConfig>
 ): Promise<TestClient> {
-  const viem = require("viem") as typeof import("viem");
+  const viem = require("viem") as typeof import("viem", {
+    with: { "resolution-mode": "import" },
+  });
   const { clientParameters, transportParameters } = await getParameters(
     chain,
     testClientConfig

--- a/packages/hardhat-viem/src/internal/contracts.ts
+++ b/packages/hardhat-viem/src/internal/contracts.ts
@@ -2,7 +2,9 @@ import type {
   EthereumProvider,
   HardhatRuntimeEnvironment,
 } from "hardhat/types";
-import type { Abi, Address, Hex } from "viem";
+import type { Abi, Address, Hex } from "viem" with {
+  "resolution-mode": "import",
+};
 import type {
   DeployContractConfig,
   GetContractAtConfig,
@@ -191,7 +193,9 @@ async function innerSendDeploymentTransaction(
     hash: deploymentTxHash,
   });
 
-  const { getContractAddress } = require("viem") as typeof import("viem");
+  const { getContractAddress } = require("viem") as typeof import("viem", {
+    with: { "resolution-mode": "import" },
+  });
   const contractAddress = getContractAddress({
     from: walletClient.account.address,
     nonce: BigInt(deploymentTx.nonce),
@@ -234,7 +238,9 @@ async function innerGetContractAt(
   contractAbi: Abi,
   address: Address
 ): Promise<GetContractReturnType> {
-  const viem = require("viem") as typeof import("viem");
+  const viem = require("viem") as typeof import("viem", {
+    with: { "resolution-mode": "import" },
+  });
   const contract = viem.getContract({
     address,
     client: {

--- a/packages/hardhat-viem/src/types.ts
+++ b/packages/hardhat-viem/src/types.ts
@@ -1,4 +1,4 @@
-import type * as viemT from "viem";
+import type * as viemT from "viem" with { "resolution-mode": "import" };
 import type { ArtifactsMap } from "hardhat/types/artifacts";
 import type { Libraries } from "./internal/bytecode";
 

--- a/packages/hardhat-viem/test/chains.ts
+++ b/packages/hardhat-viem/test/chains.ts
@@ -2,7 +2,6 @@ import type { EthereumProvider } from "hardhat/types";
 
 import { expect, assert } from "chai";
 import sinon from "sinon";
-import * as chains from "viem/chains";
 
 import {
   getChain,
@@ -10,6 +9,10 @@ import {
   isDevelopmentNetwork,
 } from "../src/internal/chains";
 import { EthereumMockedProvider } from "./mocks/provider";
+
+const chains = require("viem/chains") as typeof import("viem/chains", {
+  with: { "resolution-mode": "import" },
+});
 
 describe("chains", () => {
   describe("getChain", () => {

--- a/packages/hardhat-viem/test/clients.ts
+++ b/packages/hardhat-viem/test/clients.ts
@@ -1,7 +1,6 @@
 import type { EthereumProvider } from "hardhat/types";
 
 import { assert, expect } from "chai";
-import * as chains from "viem/chains";
 
 import {
   innerGetPublicClient,
@@ -9,6 +8,10 @@ import {
   innerGetTestClient,
 } from "../src/internal/clients";
 import { EthereumMockedProvider } from "./mocks/provider";
+
+const chains = require("viem/chains") as typeof import("viem/chains", {
+  with: { "resolution-mode": "import" },
+});
 
 describe("clients", () => {
   describe("innerGetPublicClient", () => {

--- a/packages/hardhat-viem/test/integration.ts
+++ b/packages/hardhat-viem/test/integration.ts
@@ -1,15 +1,20 @@
-import type { Hex, TransactionReceipt } from "viem";
+import type { Hex, TransactionReceipt } from "viem" with {
+  "resolution-mode": "import",
+};
 import type { EthereumProvider } from "hardhat/types";
 
 import path from "path";
 import { assert, expect } from "chai";
 import sinon from "sinon";
-import { getAddress, parseEther } from "viem";
 
 import { TASK_CLEAN, TASK_COMPILE } from "hardhat/builtin-tasks/task-names";
 import { deployContract, innerDeployContract } from "../src/internal/contracts";
 import { EthereumMockedProvider } from "./mocks/provider";
 import { assertSnapshotMatch, sleep, useEnvironment } from "./helpers";
+
+const { getAddress, parseEther } = require("viem") as typeof import("viem", {
+  with: { "resolution-mode": "import" },
+});
 
 describe("Integration tests", function () {
   afterEach(function () {


### PR DESCRIPTION
`hardhat-viem` fails to build against the current `viem` release. A fresh `pnpm install` resolves `viem` to a version that ships a nested `node_modules/viem/_types/package.json` containing `{"type":"module"}`, which did not exist in the version pinned in the committed lockfile. `hardhat-viem` is a CommonJS package built with `moduleResolution: Node16`, and under that resolution mode TypeScript now treats `viem`'s type declarations as belonging to an ES module. Every top level `import type { ... } from "viem"`, and every `typeof import("viem")` type query, then needs an explicit `resolution-mode` import attribute:

```
error TS1541: Type-only import of an ECMAScript module from a CommonJS module must have a 'resolution-mode' attribute.
```

We add `with { "resolution-mode": "import" }` to the affected type-only imports and type queries in `hardhat-viem`'s `src` and `test` files:

```ts
import type { Address } from "viem" with { "resolution-mode": "import" };
```

This is a follow up to #8311, which fixed the same CommonJS/ESM interop problem for `viem`'s _value_ imports by rewriting `await import("viem")` to `require("viem") as typeof import("viem")`. That PR did not touch the type-only imports, and predates the `_types/package.json` change that made those start failing too. We add the same attribute to the type queries in that `require`/`typeof import` pattern, and to the equivalent value imports in the test files, which #8311 did not cover.

## Manual testing

To run the changes locally:

```shell
rm pnpm-lock.yaml
pnpm install --no-frozen-lockfile
pnpm build
pnpm --filter @nomicfoundation/hardhat-viem test
```
