### PR TITLE
Print fuzz test counterexample calldata as hex

### DIFF
--- a/.changeset/large-grapes-rest.md
+++ b/.changeset/large-grapes-rest.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed the format of fuzz test counterexamples: byte array values such as `calldata`, `sender` and `address` are now printed as hexadecimal strings (e.g. `0x3e2033b3...`) instead of comma-separated byte lists.

--- a/cspell.dictionary.txt
+++ b/cspell.dictionary.txt
@@ -125,6 +125,7 @@ supath
 synthetix
 Synthetix
 triaging
+trippable
 tset
 txts
 ufixed

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts
@@ -333,7 +333,7 @@ export async function* testReporter(
           yield* output(indenter.t`Counterexample:\n`);
           indenter.inc();
           for (const [key, value] of Object.entries(counterexample)) {
-            const counterExampleDetails = `${key}: ${Buffer.isBuffer(value) ? bytesToHexString(value) : value}`;
+            const counterExampleDetails = `${key}: ${value instanceof Uint8Array ? bytesToHexString(value) : value}`;
             yield* output(
               indenter.t`${colorize("grey", counterExampleDetails)}\n`,
             );

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
@@ -196,9 +196,11 @@ debug log
     });
 
     it("single suite, 1 failure with counterexample calldata printed as hex", async () => {
+      // `testFuzz_Inc(uint8)` called with 0: the 4-byte selector followed by a
+      // single ABI word
       const calldata = new Uint8Array([
         62, 32, 51, 179, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       ]);
 
       const result = await arrayifiedTestReporter(
@@ -229,7 +231,7 @@ debug log
   1) TestSuite#failing test
     Error: Unknown error
     Counterexample:
-      calldata: 0x3e2033b300000000000000000000000000000000000000000000000000000000
+      calldata: 0x3e2033b30000000000000000000000000000000000000000000000000000000000000000
       args: 0
 `.replace("\n", ""); // the first newline is only here to make the expected output more readable
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
@@ -5,6 +5,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  type BaseCounterExample,
   CallKind,
   TestStatus,
   type CallTrace,
@@ -58,6 +59,7 @@ interface MockSuite {
     consoleLogs?: string[];
     duration?: bigint;
     traces?: MockTrace[];
+    counterexample?: BaseCounterExample;
   }>;
 }
 
@@ -91,7 +93,7 @@ const mocker = {
                       );
                     },
                     reason: undefined,
-                    counterexample: undefined,
+                    counterexample: result.counterexample,
                     valueSnapshotGroups: undefined,
                   }) satisfies TestResult,
               )
@@ -188,6 +190,47 @@ debug log
 
   1) TestSuite#failing test
     Error: Unknown error
+`.replace("\n", ""); // the first newline is only here to make the expected output more readable
+
+      assert.deepEqual(result.join(""), expectedOutput);
+    });
+
+    it("single suite, 1 failure with counterexample calldata printed as hex", async () => {
+      const calldata = new Uint8Array([
+        62, 32, 51, 179, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      ]);
+
+      const result = await arrayifiedTestReporter(
+        mocker.tests([
+          {
+            source: "TestSuite.sol",
+            name: "TestSuite",
+            results: [
+              {
+                name: "failing test",
+                status: TestStatus.Failure,
+                counterexample: { calldata, args: "0" },
+              },
+            ],
+          },
+        ]),
+        3,
+      );
+
+      const expectedOutput = `
+  TestSuite.sol:TestSuite
+    1) failing test
+
+
+  0 passing
+  1 failing
+
+  1) TestSuite#failing test
+    Error: Unknown error
+    Counterexample:
+      calldata: 0x3e2033b300000000000000000000000000000000000000000000000000000000
+      args: 0
 `.replace("\n", ""); // the first newline is only here to make the expected output more readable
 
       assert.deepEqual(result.join(""), expectedOutput);

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/reporter.ts
@@ -9,8 +9,10 @@ import {
   CallKind,
   TestStatus,
   type CallTrace,
+  type CounterExampleSequence,
   type TestResult,
 } from "@nomicfoundation/edr";
+import { hexStringToBytes } from "@nomicfoundation/hardhat-utils/hex";
 
 import { testReporter } from "../../../../src/internal/builtin-plugins/solidity-test/reporter.js";
 
@@ -59,7 +61,7 @@ interface MockSuite {
     consoleLogs?: string[];
     duration?: bigint;
     traces?: MockTrace[];
-    counterexample?: BaseCounterExample;
+    counterexample?: BaseCounterExample | CounterExampleSequence;
   }>;
 }
 
@@ -233,7 +235,84 @@ debug log
     Counterexample:
       calldata: 0x3e2033b30000000000000000000000000000000000000000000000000000000000000000
       args: 0
-`.replace("\n", ""); // the first newline is only here to make the expected output more readable
+`.replace("\n", "");
+
+      assert.deepEqual(result.join(""), expectedOutput);
+    });
+
+    it("single suite, 1 failure with a counterexample sequence printed as hex", async () => {
+      const sender = hexStringToBytes(
+        "0x0000000000000000000000000000000000000f4d",
+      );
+      const address = hexStringToBytes(
+        "0x5615deb798bb3e4dfa0139dfa1b3d433cc23b72f",
+      );
+      const contractName = "project/contracts/Trippable.sol:Trippable";
+
+      const counterexample: CounterExampleSequence = {
+        originalSequenceSize: 5n,
+        sequence: [
+          {
+            calldata: hexStringToBytes(
+              `0xbe526409${"00".repeat(31)}0a`, // trip(uint8) called with 10
+            ),
+            sender,
+            address,
+            contractName,
+            signature: "trip(uint8)",
+            args: "10",
+          },
+          {
+            calldata: hexStringToBytes("0x2b58d143"), // reset(), no arguments
+            sender,
+            address,
+            contractName,
+            signature: "reset()",
+          },
+        ],
+      };
+
+      const result = await arrayifiedTestReporter(
+        mocker.tests([
+          {
+            source: "TestSuite.sol",
+            name: "TestSuite",
+            results: [
+              {
+                name: "failing test",
+                status: TestStatus.Failure,
+                counterexample,
+              },
+            ],
+          },
+        ]),
+        3,
+      );
+
+      const expectedOutput = `
+  TestSuite.sol:TestSuite
+    1) failing test
+
+
+  0 passing
+  1 failing
+
+  1) TestSuite#failing test
+    Error: Unknown error
+    Counterexample:
+      calldata: 0xbe526409000000000000000000000000000000000000000000000000000000000000000a
+      sender: 0x0000000000000000000000000000000000000f4d
+      address: 0x5615deb798bb3e4dfa0139dfa1b3d433cc23b72f
+      contractName: project/contracts/Trippable.sol:Trippable
+      signature: trip(uint8)
+      args: 10
+    Counterexample:
+      calldata: 0x2b58d143
+      sender: 0x0000000000000000000000000000000000000f4d
+      address: 0x5615deb798bb3e4dfa0139dfa1b3d433cc23b72f
+      contractName: project/contracts/Trippable.sol:Trippable
+      signature: reset()
+`.replace("\n", "");
 
       assert.deepEqual(result.join(""), expectedOutput);
     });


### PR DESCRIPTION
## Problem

The calldata of fuzz test counterexamples is printed as a comma-separated list of bytes:

```
Counterexample:
  calldata: 62,32,51,179,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
  args: 0
```

instead of the proper hex string `0x3e2033b300000000000000000000000000000000000000000000000000000000`.

## Root cause

In `packages/hardhat/src/internal/builtin-plugins/solidity-test/reporter.ts`, counterexample values are only hex-formatted when `Buffer.isBuffer(value)` is true. EDR returns the counterexample `calldata` (and the `sender`/`address` fields) as a `Uint8Array`, which is not a `Buffer`, so `Buffer.isBuffer` returns false and the raw bytes fall through to default string interpolation (`62,32,51,...`).

## Fix

Check `value instanceof Uint8Array` instead of `Buffer.isBuffer(value)`. `Buffer` is a subclass of `Uint8Array`, so this covers both cases and delegates to `bytesToHexString` to print a `0x`-prefixed hex string. The same pattern (`value instanceof Uint8Array`) is already used elsewhere in this file.

## Test

Added a reporter test that feeds a failing test result whose counterexample has a `Uint8Array` `calldata` and asserts the calldata is printed as `0x3e2033b3...` instead of the raw byte list.