### PR TITLE
slang-solx strictly verify checksum

### DIFF
--- a/.changeset/strict-solx-checksum-verification.md
+++ b/.changeset/strict-solx-checksum-verification.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-errors": minor
+---
+
+Added `HHE110003` and `HHE110004` for the `hardhat-slang-solx` plugin, raised when the checksum of a solx binary cannot be obtained and when a downloaded solx binary does not match it.

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -3377,6 +3377,28 @@ Check your internet connection, ensure that the solx releases mirror (https://so
 
 Verify that the path in your Hardhat config points to a valid solx binary.`,
       },
+      CHECKSUM_DOWNLOAD_FAILED: {
+        number: 110003,
+        messageTemplate: `Couldn't download the checksum for solx {version} from {url}: {reason}`,
+        websiteTitle: "Couldn't obtain the solx checksum",
+        websiteDescription: `Every solx binary is published alongside a \`.sha256\` checksum file, which Hardhat uses to verify the download. Hardhat couldn't obtain that checksum, so it refused to use the binary.
+
+Check your internet connection, and ensure that the solx releases mirror (https://solx-releases-mirror.hardhat.org) is reachable from your environment. If you are behind a proxy that intercepts HTTPS traffic, it may be blocking or rewriting the request.`,
+      },
+      INVALID_DOWNLOAD: {
+        number: 110004,
+        messageTemplate: `Couldn't download solx {version}: Checksum verification failed.
+
+Please check your internet connection and try again.
+
+If this error persists, run "npx hardhat clean --global".`,
+        websiteTitle: "Downloaded solx checksum verification failed",
+        websiteDescription: `Hardhat downloaded a solx binary, and its checksum didn't match the one published alongside it. The binary was deleted instead of being used.
+
+The likeliest cause is a corrupted or incomplete download.
+
+Please check your internet connection and try again. If this error persists, run \`npx hardhat clean --global\`.`,
+      },
     },
   },
   HARDHAT_NODE_TEST_RUNNER: {

--- a/packages/hardhat-slang-solx/src/internal/downloader.ts
+++ b/packages/hardhat-slang-solx/src/internal/downloader.ts
@@ -38,59 +38,6 @@ export async function getSolxBinaryPath(solxVersion: string): Promise<string> {
 }
 
 /**
- * Verifies the SHA-256 checksum of a downloaded binary against a `.sha256`
- * sidecar file on the mirror. If the sidecar file is not available (e.g. for
- * stable releases), verification is skipped. If it is available and the
- * checksum doesn't match, the downloaded file is deleted and false is returned.
- */
-async function verifyChecksum(
-  binaryPath: string,
-  checksumUrl: string,
-): Promise<boolean> {
-  try {
-    const response = await getRequest(checksumUrl);
-
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      log(
-        `No .sha256 sidecar file at ${checksumUrl} (status ${response.statusCode}), skipping verification`,
-      );
-      return true;
-    }
-
-    // The sidecar file contains the hex-encoded SHA-256 hash, possibly with
-    // a filename suffix (like sha256sum output). We only need the hash part.
-    const text = (await response.body.text()).trim();
-    const expectedHash = text.split(/\s+/)[0].toLowerCase();
-
-    const { sha256 } = await import("@nomicfoundation/hardhat-utils/crypto");
-    const { bytesToHexString } =
-      await import("@nomicfoundation/hardhat-utils/hex");
-
-    const binaryContents = await readBinaryFile(binaryPath);
-    const actualHash = bytesToHexString(await sha256(binaryContents))
-      .slice(2) // remove 0x prefix
-      .toLowerCase();
-
-    if (expectedHash !== actualHash) {
-      log(
-        `SHA-256 mismatch for ${binaryPath}: expected ${expectedHash}, got ${actualHash}`,
-      );
-      await remove(binaryPath);
-      return false;
-    }
-
-    log(`SHA-256 checksum verified for ${binaryPath}`);
-    return true;
-  } catch (error) {
-    ensureError(error);
-    log(
-      `Could not verify checksum from ${checksumUrl}: ${error.message}, skipping verification`,
-    );
-    return true;
-  }
-}
-
-/**
  * Downloads the solx binary for the given version if not already cached.
  * Returns the path to the binary on disk.
  *
@@ -180,4 +127,57 @@ export async function downloadSolx(
     },
     lastError,
   );
+}
+
+/**
+ * Verifies the SHA-256 checksum of a downloaded binary against a `.sha256`
+ * sidecar file on the mirror. If the sidecar file is not available (e.g. for
+ * stable releases), verification is skipped. If it is available and the
+ * checksum doesn't match, the downloaded file is deleted and false is returned.
+ */
+async function verifyChecksum(
+  binaryPath: string,
+  checksumUrl: string,
+): Promise<boolean> {
+  try {
+    const response = await getRequest(checksumUrl);
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      log(
+        `No .sha256 sidecar file at ${checksumUrl} (status ${response.statusCode}), skipping verification`,
+      );
+      return true;
+    }
+
+    // The sidecar file contains the hex-encoded SHA-256 hash, possibly with
+    // a filename suffix (like sha256sum output). We only need the hash part.
+    const text = (await response.body.text()).trim();
+    const expectedHash = text.split(/\s+/)[0].toLowerCase();
+
+    const { sha256 } = await import("@nomicfoundation/hardhat-utils/crypto");
+    const { bytesToHexString } =
+      await import("@nomicfoundation/hardhat-utils/hex");
+
+    const binaryContents = await readBinaryFile(binaryPath);
+    const actualHash = bytesToHexString(await sha256(binaryContents))
+      .slice(2) // remove 0x prefix
+      .toLowerCase();
+
+    if (expectedHash !== actualHash) {
+      log(
+        `SHA-256 mismatch for ${binaryPath}: expected ${expectedHash}, got ${actualHash}`,
+      );
+      await remove(binaryPath);
+      return false;
+    }
+
+    log(`SHA-256 checksum verified for ${binaryPath}`);
+    return true;
+  } catch (error) {
+    ensureError(error);
+    log(
+      `Could not verify checksum from ${checksumUrl}: ${error.message}, skipping verification`,
+    );
+    return true;
+  }
 }

--- a/packages/hardhat-slang-solx/src/internal/downloader.ts
+++ b/packages/hardhat-slang-solx/src/internal/downloader.ts
@@ -1,6 +1,13 @@
+import type { PrefixedHexString } from "@nomicfoundation/hardhat-utils/hex";
+import type { Dispatcher } from "@nomicfoundation/hardhat-utils/request";
+
 import path from "node:path";
 
-import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import {
+  assertHardhatInvariant,
+  HardhatError,
+} from "@nomicfoundation/hardhat-errors";
+import { sha256 } from "@nomicfoundation/hardhat-utils/crypto";
 import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
 import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import {
@@ -10,7 +17,15 @@ import {
   remove,
 } from "@nomicfoundation/hardhat-utils/fs";
 import { getCacheDir } from "@nomicfoundation/hardhat-utils/global-dir";
-import { download, getRequest } from "@nomicfoundation/hardhat-utils/request";
+import {
+  bytesToHexString,
+  getPrefixedHexString,
+} from "@nomicfoundation/hardhat-utils/hex";
+import {
+  download,
+  getRequest,
+  ResponseStatusCodeError,
+} from "@nomicfoundation/hardhat-utils/request";
 import { MultiProcessMutex } from "@nomicfoundation/hardhat-utils/synchronization";
 
 import { SOLX_RELEASES_BASE_URL } from "./constants.js";
@@ -37,18 +52,33 @@ export async function getSolxBinaryPath(solxVersion: string): Promise<string> {
   );
 }
 
+export interface DownloadSolxOptions {
+  /**
+   * The dispatcher used for the checksum and binary requests. Intended for
+   * tests.
+   */
+  dispatcher?: Dispatcher;
+
+  /**
+   * How long to wait between download attempts. Intended for tests.
+   */
+  retryDelayMs?: number;
+}
+
 /**
  * Downloads the solx binary for the given version if not already cached.
  * Returns the path to the binary on disk.
  *
  * @param solxVersion - The solx version to download (e.g. "0.1.3")
- * @param downloadFunction - Optional injectable download function for testing.
- *   Defaults to the real `download` from `@nomicfoundation/hardhat-utils/request`.
+ * @param onBinaryDownloadStart - A callback invoked once the compiler download is about to start
+ * @param options - See {@link DownloadSolxOptions}.
  */
 export async function downloadSolx(
   solxVersion: string,
-  downloadFunction: typeof download = download,
+  onBinaryDownloadStart: () => void,
+  options: DownloadSolxOptions = {},
 ): Promise<string> {
+  const { dispatcher, retryDelayMs = DOWNLOAD_RETRY_DELAY_MS } = options;
   const binaryPath = await getSolxBinaryPath(solxVersion);
 
   // Return cached binary if it already exists
@@ -63,31 +93,45 @@ export async function downloadSolx(
   );
   const assetName = getSolxAssetName(solxVersion);
   const url = `${SOLX_RELEASES_BASE_URL}/${assetName}`;
+
+  // The checksum is required, we fail immediately if we can't get it.
+  const expectedChecksum = await downloadExpectedChecksum(
+    solxVersion,
+    `${url}.sha256`,
+    dispatcher,
+  );
+
+  // invoke the callback to allow the caller to update the UI
+  onBinaryDownloadStart();
+
   log(`Downloading solx ${solxVersion} from ${url}`);
 
-  let lastError: Error | undefined;
-
   for (let attempt = 1; attempt <= DOWNLOAD_RETRY_COUNT; attempt++) {
-    // Use a mutex per retry iteration so other processes can proceed
-    // between retries
-    const result = await mutex.use(async () => {
-      // Check if another process downloaded it while we waited for the mutex
-      if (await exists(binaryPath)) {
-        log(
-          `Using cached solx binary at ${binaryPath} (downloaded by another process)`,
+    try {
+      // Use a mutex per retry iteration so other processes can proceed
+      // between retries
+      return await mutex.use(async () => {
+        // Check if another process downloaded it while we waited for the mutex
+        if (await exists(binaryPath)) {
+          log(
+            `Using cached solx binary at ${binaryPath} (downloaded by another process)`,
+          );
+
+          return binaryPath;
+        }
+
+        await download(url, binaryPath, {}, dispatcher);
+
+        const checksumValid = await verifyChecksum(
+          binaryPath,
+          expectedChecksum,
         );
-        return binaryPath;
-      }
 
-      try {
-        await downloadFunction(url, binaryPath);
-
-        // Verify SHA-256 checksum if a sidecar file is available
-        const checksumUrl = `${SOLX_RELEASES_BASE_URL}/${assetName}.sha256`;
-        const checksumValid = await verifyChecksum(binaryPath, checksumUrl);
         if (!checksumValid) {
-          lastError = new Error("SHA-256 checksum verification failed");
-          return undefined;
+          throw new HardhatError(
+            HardhatError.ERRORS.HARDHAT_SLANG_SOLX.GENERAL.INVALID_DOWNLOAD,
+            { version: solxVersion },
+          );
         }
 
         // Set executable permission on Unix
@@ -97,87 +141,107 @@ export async function downloadSolx(
 
         log(`Successfully downloaded solx ${solxVersion}`);
         return binaryPath;
-      } catch (error) {
-        ensureError(error);
-        lastError = error;
-        log(
-          `Download attempt ${attempt}/${DOWNLOAD_RETRY_COUNT} failed: ${lastError.message}`,
-        );
-        return undefined;
-      }
-    });
-
-    if (result !== undefined) {
-      return result;
-    }
-
-    if (attempt < DOWNLOAD_RETRY_COUNT) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, DOWNLOAD_RETRY_DELAY_MS),
+      });
+    } catch (error) {
+      ensureError(error);
+      log(
+        `Download attempt ${attempt}/${DOWNLOAD_RETRY_COUNT} failed: ${error.message}`,
       );
+
+      if (attempt === DOWNLOAD_RETRY_COUNT) {
+        if (HardhatError.isHardhatError(error)) {
+          throw error;
+        }
+
+        throw new HardhatError(
+          HardhatError.ERRORS.HARDHAT_SLANG_SOLX.GENERAL.DOWNLOAD_FAILED,
+          {
+            version: solxVersion,
+            attempts: DOWNLOAD_RETRY_COUNT.toString(),
+            reason: error.message,
+          },
+          error,
+        );
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     }
   }
 
-  throw new HardhatError(
-    HardhatError.ERRORS.HARDHAT_SLANG_SOLX.GENERAL.DOWNLOAD_FAILED,
-    {
-      version: solxVersion,
-      attempts: DOWNLOAD_RETRY_COUNT.toString(),
-      reason: lastError?.message ?? "unknown error",
-    },
-    lastError,
+  assertHardhatInvariant(
+    false,
+    "the retry loop always returns or throws on its last attempt",
   );
 }
 
 /**
- * Verifies the SHA-256 checksum of a downloaded binary against a `.sha256`
- * sidecar file on the mirror. If the sidecar file is not available (e.g. for
- * stable releases), verification is skipped. If it is available and the
- * checksum doesn't match, the downloaded file is deleted and false is returned.
+ * Compares a downloaded binary against its expected SHA-256 checksum. On a
+ * mismatch the binary is deleted and false is returned, leaving the caller to
+ * raise the error.
  */
 async function verifyChecksum(
   binaryPath: string,
-  checksumUrl: string,
+  expectedChecksum: PrefixedHexString,
 ): Promise<boolean> {
-  try {
-    const response = await getRequest(checksumUrl);
+  const binaryContents = await readBinaryFile(binaryPath);
+  const actualChecksum = bytesToHexString(await sha256(binaryContents));
 
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      log(
-        `No .sha256 sidecar file at ${checksumUrl} (status ${response.statusCode}), skipping verification`,
-      );
-      return true;
-    }
+  if (expectedChecksum !== actualChecksum) {
+    log(
+      `SHA-256 mismatch for ${binaryPath}: expected ${expectedChecksum}, got ${actualChecksum}`,
+    );
+
+    await remove(binaryPath);
+
+    return false;
+  }
+
+  log(`SHA-256 checksum verified for ${binaryPath}`);
+  return true;
+}
+
+/**
+ * Downloads the expected SHA-256 checksum of a solx asset from its `.sha256`
+ * sidecar file on the mirror.
+ */
+async function downloadExpectedChecksum(
+  solxVersion: string,
+  checksumUrl: string,
+  dispatcher?: Dispatcher,
+): Promise<PrefixedHexString> {
+  try {
+    const response = await getRequest(checksumUrl, {}, dispatcher);
 
     // The sidecar file contains the hex-encoded SHA-256 hash, possibly with
     // a filename suffix (like sha256sum output). We only need the hash part.
     const text = (await response.body.text()).trim();
-    const expectedHash = text.split(/\s+/)[0].toLowerCase();
+    const expectedChecksum = text.split(/\s+/)[0].toLowerCase();
 
-    const { sha256 } = await import("@nomicfoundation/hardhat-utils/crypto");
-    const { bytesToHexString } =
-      await import("@nomicfoundation/hardhat-utils/hex");
-
-    const binaryContents = await readBinaryFile(binaryPath);
-    const actualHash = bytesToHexString(await sha256(binaryContents))
-      .slice(2) // remove 0x prefix
-      .toLowerCase();
-
-    if (expectedHash !== actualHash) {
-      log(
-        `SHA-256 mismatch for ${binaryPath}: expected ${expectedHash}, got ${actualHash}`,
-      );
-      await remove(binaryPath);
-      return false;
-    }
-
-    log(`SHA-256 checksum verified for ${binaryPath}`);
-    return true;
+    return getPrefixedHexString(expectedChecksum);
   } catch (error) {
     ensureError(error);
-    log(
-      `Could not verify checksum from ${checksumUrl}: ${error.message}, skipping verification`,
+
+    throw new HardhatError(
+      HardhatError.ERRORS.HARDHAT_SLANG_SOLX.GENERAL.CHECKSUM_DOWNLOAD_FAILED,
+      {
+        version: solxVersion,
+        url: checksumUrl,
+        reason: describeChecksumRequestFailure(error),
+      },
+      error,
     );
-    return true;
   }
+}
+
+function describeChecksumRequestFailure(error: Error): string {
+  if (error instanceof ResponseStatusCodeError) {
+    return `the mirror responded with status ${error.statusCode}`;
+  }
+
+  const { cause } = error;
+  if (cause instanceof Error && cause.message !== "") {
+    return cause.message;
+  }
+
+  return error.message;
 }

--- a/packages/hardhat-slang-solx/src/internal/downloader.ts
+++ b/packages/hardhat-slang-solx/src/internal/downloader.ts
@@ -20,6 +20,8 @@ import { getCacheDir } from "@nomicfoundation/hardhat-utils/global-dir";
 import {
   bytesToHexString,
   getPrefixedHexString,
+  getUnprefixedHexString,
+  isHexString,
 } from "@nomicfoundation/hardhat-utils/hex";
 import {
   download,
@@ -34,6 +36,7 @@ import { getSolxAssetName } from "./platform.js";
 const log = createDebug("hardhat:slang-solx:downloader");
 
 const DOWNLOAD_RETRY_COUNT = 3;
+const SHA256_HEX_DIGEST_LENGTH = 64;
 const DOWNLOAD_RETRY_DELAY_MS = 2000;
 
 /**
@@ -209,15 +212,12 @@ async function downloadExpectedChecksum(
   checksumUrl: string,
   dispatcher?: Dispatcher,
 ): Promise<PrefixedHexString> {
+  let body: string;
+
   try {
     const response = await getRequest(checksumUrl, {}, dispatcher);
 
-    // The sidecar file contains the hex-encoded SHA-256 hash, possibly with
-    // a filename suffix (like sha256sum output). We only need the hash part.
-    const text = (await response.body.text()).trim();
-    const expectedChecksum = text.split(/\s+/)[0].toLowerCase();
-
-    return getPrefixedHexString(expectedChecksum);
+    body = (await response.body.text()).trim();
   } catch (error) {
     ensureError(error);
 
@@ -231,6 +231,28 @@ async function downloadExpectedChecksum(
       error,
     );
   }
+
+  // The sidecar file contains the hex-encoded SHA-256 digest, possibly with a
+  // filename suffix, the way sha256sum writes it. We only need the digest.
+  const expectedChecksum = body.split(/\s+/)[0].toLowerCase();
+
+  // This is a guard against a failed HTTP lookup returning an HTML error rather
+  // than the expected digest.
+  if (
+    !isHexString(expectedChecksum) ||
+    getUnprefixedHexString(expectedChecksum).length !== SHA256_HEX_DIGEST_LENGTH
+  ) {
+    throw new HardhatError(
+      HardhatError.ERRORS.HARDHAT_SLANG_SOLX.GENERAL.CHECKSUM_DOWNLOAD_FAILED,
+      {
+        version: solxVersion,
+        url: checksumUrl,
+        reason: "the response didn't contain a SHA-256 digest",
+      },
+    );
+  }
+
+  return getPrefixedHexString(expectedChecksum);
 }
 
 function describeChecksumRequestFailure(error: Error): string {

--- a/packages/hardhat-slang-solx/src/internal/hook-handlers/solidity.ts
+++ b/packages/hardhat-slang-solx/src/internal/hook-handlers/solidity.ts
@@ -72,11 +72,13 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
           return;
         }
 
-        if (!quiet) {
-          console.log(`Downloading solx ${solxVersion}`);
-        }
+        const solxPath = await downloadSolx(solxVersion, () => {
+          if (quiet) {
+            return;
+          }
 
-        const solxPath = await downloadSolx(solxVersion);
+          console.log(`Downloading solx ${solxVersion}`);
+        });
         log(`Downloaded solx ${solxVersion} to ${solxPath}`);
       }),
     );

--- a/packages/hardhat-slang-solx/test/downloader.ts
+++ b/packages/hardhat-slang-solx/test/downloader.ts
@@ -176,6 +176,27 @@ describe("hardhat-slang-solx downloader", () => {
     );
   });
 
+  it("fails when the sidecar isn't a digest, without downloading the binary", async () => {
+    // A proxy serving its own error page with a 200 is the realistic case.
+    interceptChecksum(mockedDispatcher, "<html><body>Not Found</body></html>");
+
+    await assertRejectsWithHardhatError(
+      downloadSolx(TEST_SOLX_VERSION, noop, { dispatcher: mockedDispatcher }),
+      HardhatError.ERRORS.HARDHAT_SLANG_SOLX.GENERAL.CHECKSUM_DOWNLOAD_FAILED,
+      {
+        version: TEST_SOLX_VERSION,
+        url: `${SOLX_RELEASES_BASE_URL}/${assetName}.sha256`,
+        reason: "the response didn't contain a SHA-256 digest",
+      },
+    );
+
+    assert.equal(
+      await exists(await getSolxBinaryPath(TEST_SOLX_VERSION)),
+      false,
+      "no binary should be left behind",
+    );
+  });
+
   it("deletes the binary and fails when the digest doesn't match", async () => {
     interceptChecksum(mockedDispatcher, expectedDigest, RETRY_COUNT);
     interceptBinary(

--- a/packages/hardhat-slang-solx/test/downloader.ts
+++ b/packages/hardhat-slang-solx/test/downloader.ts
@@ -1,0 +1,233 @@
+import type {
+  Interceptable,
+  TestDispatcher,
+} from "@nomicfoundation/hardhat-utils/request";
+
+import assert from "node:assert/strict";
+import { stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import {
+  assertRejectsWithHardhatError,
+  makeWorkspaceTmpDir,
+  safeRemoveTmpDir,
+} from "@nomicfoundation/hardhat-test-utils";
+import { sha256 } from "@nomicfoundation/hardhat-utils/crypto";
+import { ensureDir, exists } from "@nomicfoundation/hardhat-utils/fs";
+import {
+  resetMockCacheDir,
+  setMockCacheDir,
+} from "@nomicfoundation/hardhat-utils/global-dir";
+import { bytesToHexString } from "@nomicfoundation/hardhat-utils/hex";
+import { getTestDispatcher } from "@nomicfoundation/hardhat-utils/request";
+
+import { SOLX_RELEASES_BASE_URL } from "../src/internal/constants.js";
+import { downloadSolx, getSolxBinaryPath } from "../src/internal/downloader.js";
+import { getSolxAssetName } from "../src/internal/platform.js";
+
+const TEST_SOLX_VERSION = "0.0.1-test";
+
+const BINARY_CONTENTS = "#!/bin/sh\necho solx 0.0.1-test\n";
+
+const RETRY_COUNT = 3;
+
+const noop = (): void => {};
+
+describe("hardhat-slang-solx downloader", () => {
+  let tmpDir: string;
+  let mockAgent: TestDispatcher;
+  let assetName: string;
+  let expectedDigest: string;
+
+  let mockedDispatcher: Interceptable;
+
+  function interceptChecksum(
+    dispatcher: Interceptable,
+    body: string,
+    times = 1,
+  ): void {
+    dispatcher
+      .intercept({ path: `/${assetName}.sha256`, method: "GET" })
+      .reply(200, body)
+      .times(times);
+  }
+
+  function interceptBinary(
+    dispatcher: Interceptable,
+    body: string,
+    times = 1,
+  ): void {
+    dispatcher
+      .intercept({ path: `/${assetName}`, method: "GET" })
+      .reply(200, body)
+      .times(times);
+  }
+
+  beforeEach(async () => {
+    tmpDir = await makeWorkspaceTmpDir("slang-solx-downloader");
+    setMockCacheDir(tmpDir);
+
+    assetName = getSolxAssetName(TEST_SOLX_VERSION);
+    expectedDigest = bytesToHexString(
+      await sha256(Buffer.from(BINARY_CONTENTS)),
+    ).slice(2);
+
+    mockAgent = await getTestDispatcher();
+    mockedDispatcher = mockAgent.get(SOLX_RELEASES_BASE_URL);
+
+    // Any request the tests don't intercept is a bug, not a network call.
+    mockAgent.disableNetConnect();
+  });
+
+  afterEach(async () => {
+    resetMockCacheDir();
+
+    await safeRemoveTmpDir(tmpDir);
+  });
+
+  it("should successfully verify the download against the sidecar and keep the binary", async () => {
+    interceptChecksum(mockedDispatcher, expectedDigest);
+    interceptBinary(mockedDispatcher, BINARY_CONTENTS);
+
+    const binaryPath = await downloadSolx(TEST_SOLX_VERSION, noop, {
+      dispatcher: mockedDispatcher,
+    });
+
+    assert.equal(binaryPath, await getSolxBinaryPath(TEST_SOLX_VERSION));
+    assert.ok(await exists(binaryPath), "the binary should have been kept");
+
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const { mode } = await stat(binaryPath);
+    assert.equal(
+      mode.toString(8).slice(-3),
+      "755",
+      "the binary should be executable",
+    );
+  });
+
+  it("should accept a sha256sum-style sidecar, with the filename after the digest", async () => {
+    interceptChecksum(mockedDispatcher, `${expectedDigest}  ${assetName}`);
+    interceptBinary(mockedDispatcher, BINARY_CONTENTS);
+
+    const binaryPath = await downloadSolx(TEST_SOLX_VERSION, noop, {
+      dispatcher: mockedDispatcher,
+    });
+
+    assert.ok(
+      await exists(binaryPath),
+      "the digest should have been read from before the filename",
+    );
+  });
+
+  it("should accept an uppercase digest", async () => {
+    interceptChecksum(mockedDispatcher, expectedDigest.toUpperCase());
+    interceptBinary(mockedDispatcher, BINARY_CONTENTS);
+
+    const binaryPath = await downloadSolx(TEST_SOLX_VERSION, noop, {
+      dispatcher: mockedDispatcher,
+    });
+
+    assert.ok(
+      await exists(binaryPath),
+      "digest comparison should be case-insensitive",
+    );
+  });
+
+  it("fails when the sidecar request errors", async () => {
+    mockedDispatcher
+      .intercept({ path: `/${assetName}.sha256`, method: "GET" })
+      .replyWithError(new Error("socket hang up"));
+
+    await assertRejectsWithHardhatError(
+      downloadSolx(TEST_SOLX_VERSION, noop, { dispatcher: mockedDispatcher }),
+      HardhatError.ERRORS.HARDHAT_SLANG_SOLX.GENERAL.CHECKSUM_DOWNLOAD_FAILED,
+      {
+        version: TEST_SOLX_VERSION,
+        url: `${SOLX_RELEASES_BASE_URL}/${assetName}.sha256`,
+        reason: "socket hang up",
+      },
+    );
+  });
+
+  it("should fail without downloading the binary when the sidecar is missing", async () => {
+    mockedDispatcher
+      .intercept({ path: `/${assetName}.sha256`, method: "GET" })
+      .reply(404, "Not Found");
+
+    await assertRejectsWithHardhatError(
+      downloadSolx(TEST_SOLX_VERSION, noop, { dispatcher: mockedDispatcher }),
+      HardhatError.ERRORS.HARDHAT_SLANG_SOLX.GENERAL.CHECKSUM_DOWNLOAD_FAILED,
+      {
+        version: TEST_SOLX_VERSION,
+        url: `${SOLX_RELEASES_BASE_URL}/${assetName}.sha256`,
+        reason: "the mirror responded with status 404",
+      },
+    );
+
+    assert.equal(
+      await exists(await getSolxBinaryPath(TEST_SOLX_VERSION)),
+      false,
+      "no binary should be left behind",
+    );
+  });
+
+  it("deletes the binary and fails when the digest doesn't match", async () => {
+    interceptChecksum(mockedDispatcher, expectedDigest, RETRY_COUNT);
+    interceptBinary(
+      mockedDispatcher,
+      "a different binary entirely",
+      RETRY_COUNT,
+    );
+
+    await assertRejectsWithHardhatError(
+      downloadSolx(TEST_SOLX_VERSION, noop, {
+        dispatcher: mockedDispatcher,
+        retryDelayMs: 0,
+      }),
+      HardhatError.ERRORS.HARDHAT_SLANG_SOLX.GENERAL.INVALID_DOWNLOAD,
+      { version: TEST_SOLX_VERSION },
+    );
+
+    assert.equal(
+      await exists(await getSolxBinaryPath(TEST_SOLX_VERSION)),
+      false,
+      "a binary that failed verification must not be left on disk",
+    );
+  });
+
+  it("recovers when a retry downloads the binary correctly", async () => {
+    interceptChecksum(mockedDispatcher, expectedDigest, 2);
+    interceptBinary(mockedDispatcher, "truncated");
+    interceptBinary(mockedDispatcher, BINARY_CONTENTS);
+
+    const binaryPath = await downloadSolx(TEST_SOLX_VERSION, noop, {
+      dispatcher: mockedDispatcher,
+      retryDelayMs: 0,
+    });
+
+    assert.ok(
+      await exists(binaryPath),
+      "the retry should have replaced the truncated download",
+    );
+  });
+
+  it("returns a cached binary without making any request", async () => {
+    // No interceptors at all: reaching the network would throw.
+    const binaryPath = await getSolxBinaryPath(TEST_SOLX_VERSION);
+
+    await ensureDir(path.dirname(binaryPath));
+    await writeFile(binaryPath, BINARY_CONTENTS);
+
+    assert.equal(
+      await downloadSolx(TEST_SOLX_VERSION, noop, {
+        dispatcher: mockedDispatcher,
+      }),
+      binaryPath,
+    );
+  });
+});

--- a/packages/hardhat-slang-solx/test/mirror-availability.ts
+++ b/packages/hardhat-slang-solx/test/mirror-availability.ts
@@ -33,7 +33,7 @@ describe(
       it(`serves every solx ${solxVersion} asset and checksum (mapped from Solidity ${solidityVersion})`, async () => {
         const missing: string[] = [];
         for (const asset of assetNames(solxVersion)) {
-          // Sidecars too: a missing one only soft-warns in the downloader.
+          // Sidecars too: the downloader refuses to use a binary it can't verify
           for (const file of [asset, `${asset}.sha256`]) {
             try {
               const response = await getRequest(


### PR DESCRIPTION
The `hardhat-slang-solx` plugin downloads the solx compiler and verifies it against the `.sha256` checksum published beside it on the releases mirror.

However, because earlier versions of `solx` such as `0.1.13` and earlier did not have a published sha file, when the .sha256 file was not found, this was logged but did not stop the compilation process or result in a HardhatError. 

We have since updated the plugin to include remove older versions and add only newer solx versions `0.1.4` and above which always have a .sha256 file , so the best-effort sha check can now be converted to a hard requirement. 

Resolves #8497.

## Technical decisions

- **The checksum is fetched first and failure is immediate** - this dodges downloading a file we can't verify.
- **The function now uses dependency injection to allow testing** - there are other config options added as well to let us adjust time checks.
- **The sidecar's content is checked** - we now check the content of the sidecar to give a better error if a proxy has mangled the response.

## Review

> [!TIP]
> Review a commit at a time for easier review, **also ignore whitespace**

1. `feat(hardhat-errors)` adds the two descriptors, and stands alone.
2. refactor on downloader to reorganize functions, with helper functions moved to the end (easier reviews).
3. `fix(hardhat-slang-solx)` is the substance: `downloadExpectedChecksum` is new, `verifyChecksum` loses its request and now only compares, and the retry loop in `downloadSolx` moves its `try`/`catch` outside `mutex.use` so the last attempt throws from inside the catch.
4. `fix(hardhat-slang-solx)` requires the sidecar to contain a real digest. Kept separate so the security fix does not depend on it.

## Manual testing

Set up `packages/example-project` to compile and test under the renamed plugin:

```shell
cd packages/example-project
pnpm add -D @nomicfoundation/hardhat-slang-solx@workspace:^
```

Add to `hardhat.config.ts`:

```ts
import hardhatSlangSolx from "@nomicfoundation/hardhat-slang-solx";


export default defineConfig({
  // ...

  // Update plugins
  plugins: [..., hardhatSlangSolx]

  // Update profiles
  profiles: {
    // ...
    "slang-solx": {
      compilers: [
        { type: "slang-solx", version: "0.8.34" },
        { version: "0.8.22" },
        { version: "0.7.1" },
        { version: "0.8.26" },
        { version: "0.8.33" },
      ],
    },
  }
});
```

Clear the cached compilers, then build to prove your building with solx:

```shell
npx hardhat clean --global
npx hardhat build --build-profile slang-solx
```

To see the the fix, hack the sidecar at a URL the mirror doesn't serve, in `downloadSolx`:

```ts
const expectedChecksum = await downloadExpectedChecksum(
  solxVersion,
  `${url}.sha256-broken`,
  dispatcher,
);
```

Rebuild the plugin, `npx hardhat clean --global` again, and build. The build now stops instead of installing an unverified compiler:

```text
Error HHE110003 in plugin hardhat-slang-solx: Couldn't download the checksum for solx 0.1.7 from
https://solx-releases-mirror.hardhat.org/solx-linux-arm64-gnu-v0.1.7.sha256-broken: the mirror responded with status 404
```
