### PR TITLE
slang-solx validate the solx optimizer mode

### DIFF
--- a/packages/hardhat-slang-solx/src/internal/constants.ts
+++ b/packages/hardhat-slang-solx/src/internal/constants.ts
@@ -35,9 +35,22 @@ export const SUPPORTED_SOLX_EVM_VERSIONS: readonly string[] = [
 ] as const;
 
 /**
- * Default LLVM optimization level, passed to solx via `settings.optimizer.mode`
- * ("1"/"2"/"3"/"s"/"z"; users override per profile). Deliberately -O1 to
- * optimize for compile speed (solx's own default if unset is -O3).
+ * The LLVM optimization levels solx accepts in `settings.optimizer.mode`,
+ * lowercase as solx expects. There is no level that turns optimization
+ * off: "1" is the minimum.
+ */
+export const SUPPORTED_SOLX_OPTIMIZER_MODES: readonly string[] = [
+  "1",
+  "2",
+  "3",
+  "s",
+  "z",
+] as const;
+
+/**
+ * Default LLVM optimization level, passed to solx via `settings.optimizer.mode`.
+ * Deliberately -O1 to optimize for compile speed (solx's own default if
+ * unset is -O3).
  */
 export const DEFAULT_SOLX_OPTIMIZER_MODE = "1";
 

--- a/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
@@ -24,6 +24,7 @@ import {
   SOLIDITY_TO_SOLX_VERSION_MAP,
   SLANG_SOLX_COMPILER_TYPE,
   SUPPORTED_SOLX_EVM_VERSIONS,
+  SUPPORTED_SOLX_OPTIMIZER_MODES,
 } from "../constants.js";
 import { addSlangSolxDebugInfoSelectors } from "../slang-solx-compiler.js";
 
@@ -42,12 +43,24 @@ const supportedEvmVersionsType = z
     message: `Solx only supports EVM versions: ${SUPPORTED_SOLX_EVM_VERSIONS.join(", ")}`,
   });
 
+const supportedOptimizerModesType = z
+  .string()
+  .refine((val) => SUPPORTED_SOLX_OPTIMIZER_MODES.includes(val), {
+    message: `Solx only supports optimizer modes: ${SUPPORTED_SOLX_OPTIMIZER_MODES.join(", ")}`,
+  });
+
 const solxSolidityCompilerUserConfigType = z
   .object({
     version: z.string(),
     settings: z
       .object({
         evmVersion: supportedEvmVersionsType.optional(),
+        optimizer: z
+          .object({
+            mode: supportedOptimizerModesType.optional(),
+          })
+          .passthrough()
+          .optional(),
       })
       .passthrough()
       .optional(),

--- a/packages/hardhat-slang-solx/test/config.ts
+++ b/packages/hardhat-slang-solx/test/config.ts
@@ -840,3 +840,68 @@ describe("hardhat-slang-solx resolved config validation", () => {
     );
   });
 });
+
+describe("hardhat-slang-solx optimizer mode validation", () => {
+  async function validateMode(mode: string) {
+    return await validateUserConfig({
+      solidity: {
+        profiles: {
+          slangSolx: {
+            compilers: [
+              {
+                version: "0.8.34",
+                type: "slangSolx",
+                settings: { optimizer: { mode } },
+              },
+            ],
+          },
+        },
+      },
+    });
+  }
+
+  for (const mode of ["1", "2", "3", "s", "z"]) {
+    it(`accepts the optimizer mode "${mode}"`, async () => {
+      assert.deepEqual(await validateMode(mode), []);
+    });
+  }
+
+  // The likeliest mistake: there is no mode that turns optimization off.
+  it('rejects the optimizer mode "0"', async () => {
+    const errors = await validateMode("0");
+
+    assert.ok(
+      errors.some((e) => e.message.includes("optimizer modes")),
+      `Expected an optimizer mode error, got: ${errors.map((e) => e.message).join(", ")}`,
+    );
+  });
+
+  it("rejects an uppercase size mode, which solx does not accept", async () => {
+    const errors = await validateMode("Z");
+
+    assert.ok(
+      errors.some((e) => e.message.includes("optimizer modes")),
+      `Expected an optimizer mode error, got: ${errors.map((e) => e.message).join(", ")}`,
+    );
+  });
+
+  it("leaves the other optimizer settings alone", async () => {
+    const errors = await validateUserConfig({
+      solidity: {
+        profiles: {
+          slangSolx: {
+            compilers: [
+              {
+                version: "0.8.34",
+                type: "slangSolx",
+                settings: { optimizer: { enabled: true, runs: 200 } },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(errors, []);
+  });
+});


### PR DESCRIPTION
solx takes its LLVM optimization level from `settings.optimizer.mode`, which accepts `1`, `2`, `3`, `s` or `z`. The plugin passed whatever it was given straight through, so an unsupported value only failed once a build was under way:

```text
Error: unexpected optimization option '0': only values 1, 2, 3, s, z are supported
Error HHE910: Compilation failed
```

`"0"` is the likeliest invalid value, since there is no mode that turns optimization off and zero is what you would guess.

We now check the mode when the config is validated, along with the `evmVersion` check that was already there, so the same config fails before anything is compiled:

```text
Error HHE15: Invalid config:
	* Config error in config.solidity.profiles.slang-solx.compilers.0.settings.optimizer.mode: Solx only supports optimizer modes: 1, 2, 3, s, z
```

## Technical decisions

- **Runtime validation only** - `settings` is typed as `any` by hardhat, the `evmVersion` check has no type narrowing either and I followed that pattern.
- **Uppercase is rejected** - solx accepts only lowercase `s` and `z`, to reduce dissonance I have matched solx.

## Manual testing

Beyond the unit tests, set an invalid mode in a `slang-solx` profile and build.

Set up `packages/example-project` to compile and test under the renamed plugin:

```shell
cd packages/example-project
pnpm add -D @nomicfoundation/hardhat-slang-solx@workspace:^
```

Add to `hardhat.config.ts`:

```ts
import hardhatSlangSolx from "@nomicfoundation/hardhat-slang-solx";


export default defineConfig({
  // ...

  // Update plugins
  plugins: [..., hardhatSlangSolx]

  // Update profiles
  profiles: {
    // ...
    "slang-solx": {
      compilers: [
        {
          type: "slang-solx",
          version: "0.8.34",
          settings: { optimizer: { mode: "0" } }
         },
        { version: "0.8.22" },
        { version: "0.7.1" },
        { version: "0.8.26" },
        { version: "0.8.33" },
      ],
    },
  }
});
```

```shell
npx hardhat build --build-profile slang-solx
```

The build stops at config validation with `HHE15`, without downloading a compiler or compiling anything. Changing the mode to `z` builds as normal.
