### PR TITLE
feat(hardhat-verify): support an optional apiKey for Blockscout

### DIFF
--- a/.changeset/blockscout-api-key.md
+++ b/.changeset/blockscout-api-key.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": minor
+---
+
+Added support for an optional `apiKey` in the `verify.blockscout` config, which is sent as the `apikey` query param of the Blockscout verification requests. This is required by Blockscout instances that don't expose a keyless API, like the Pro API.

--- a/.changeset/blockscout-api-key.md
+++ b/.changeset/blockscout-api-key.md
@@ -2,4 +2,4 @@
 "@nomicfoundation/hardhat-verify": minor
 ---
 
-Added support for an optional `apiKey` in the `verify.blockscout` config, which is sent as the `apikey` query param of the Blockscout verification requests. This is required by Blockscout instances that don't expose a keyless API, like the Pro API.
+Added support for an optional `apiKey` in the `verify.blockscout` config. This is required by Blockscout instances that don't expose a keyless API, like the Pro API.

--- a/packages/hardhat-verify/README.md
+++ b/packages/hardhat-verify/README.md
@@ -65,6 +65,32 @@ Run the `verify` task passing the network where it's deployed, the address of th
 npx hardhat verify --network mainnet DEPLOYED_CONTRACT_ADDRESS "Constructor argument 1"
 ```
 
+### Verifying on Blockscout
+
+Most Blockscout instances don't require an API key, so no extra config is needed to verify on them:
+
+```bash
+npx hardhat verify blockscout --network mainnet DEPLOYED_CONTRACT_ADDRESS "Constructor argument 1"
+```
+
+Some instances do require one, like the [Pro API](https://docs.blockscout.com/devs/pro-api). In that case, add the key to the Blockscout config in your `hardhat.config.ts` file:
+
+```typescript
+import { configVariable, defineConfig } from "hardhat/config";
+
+export default defineConfig({
+  verify: {
+    blockscout: {
+      // Your API key for Blockscout
+      // Obtain one at https://blockscout.com/
+      apiKey: configVariable("BLOCKSCOUT_API_KEY"),
+    },
+  },
+});
+```
+
+The key is sent as the `apikey` query param of the verification requests. Unlike Etherscan, the chain id isn't sent as a query param: the Blockscout instance is addressed by the `apiUrl` of its chain descriptor, which already encodes the chain id when the API requires it (e.g. `https://api.blockscout.com/{chainId}/api`).
+
 ### Programmatic verification
 
 You can also verify contracts programmatically by using the `verifyContract` function from the plugin:

--- a/packages/hardhat-verify/README.md
+++ b/packages/hardhat-verify/README.md
@@ -89,8 +89,6 @@ export default defineConfig({
 });
 ```
 
-The key is sent as the `apikey` query param of the verification requests. Unlike Etherscan, the chain id isn't sent as a query param: the Blockscout instance is addressed by the `apiUrl` of its chain descriptor, which already encodes the chain id when the API requires it (e.g. `https://api.blockscout.com/{chainId}/api`).
-
 ### Programmatic verification
 
 You can also verify contracts programmatically by using the `verifyContract` function from the plugin:

--- a/packages/hardhat-verify/src/internal/blockscout.ts
+++ b/packages/hardhat-verify/src/internal/blockscout.ts
@@ -50,6 +50,7 @@ export class Blockscout implements VerificationProvider {
   public readonly name: string;
   public readonly url: string;
   public readonly apiUrl: string;
+  public readonly apiKey?: string;
   public readonly dispatcherOrDispatcherOptions?:
     Dispatcher | DispatcherOptions;
   public readonly pollingIntervalMs: number;
@@ -58,6 +59,7 @@ export class Blockscout implements VerificationProvider {
     chainId,
     networkName,
     chainDescriptors,
+    verificationProvidersConfig,
     dispatcher,
     shouldUseCache = true,
   }: ResolveConfigOptions): Promise<CreateBlockscoutOptions> {
@@ -96,16 +98,19 @@ export class Blockscout implements VerificationProvider {
 
     return {
       blockExplorerConfig,
+      verificationProviderConfig: verificationProvidersConfig.blockscout,
       dispatcher,
     };
   }
 
   public static async create({
     blockExplorerConfig,
+    verificationProviderConfig,
     dispatcher,
   }: CreateBlockscoutOptions): Promise<Blockscout> {
     return new Blockscout({
       ...blockExplorerConfig,
+      apiKey: await verificationProviderConfig.apiKey?.get(),
       dispatcher,
     });
   }
@@ -167,6 +172,7 @@ export class Blockscout implements VerificationProvider {
     name?: string;
     url: string;
     apiUrl: string;
+    apiKey?: string;
     dispatcher?: Dispatcher;
   }) {
     this.name = blockscoutConfig.name ?? "Blockscout";
@@ -184,10 +190,37 @@ export class Blockscout implements VerificationProvider {
       blockscoutConfig.dispatcher !== undefined
         ? 0
         : VERIFICATION_STATUS_POLLING_SECONDS;
+
+    // The API key is optional, as most Blockscout instances don't require one,
+    // but an explicitly configured empty key is always a misconfiguration.
+    if (blockscoutConfig.apiKey === "") {
+      throw new HardhatError(
+        HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.EXPLORER_API_KEY_EMPTY,
+        {
+          verificationProvider: this.name,
+        },
+      );
+    }
+    this.apiKey = blockscoutConfig.apiKey;
   }
 
   public getContractUrl(address: string): string {
     return `${this.url}/address/${address}#code`;
+  }
+
+  /**
+   * Adds the API key to the given query params, if one is configured.
+   *
+   * Note that, unlike Etherscan, the chain id is never sent as a query param:
+   * Blockscout instances are addressed by their `apiUrl`, which already
+   * encodes the chain id when needed (e.g. `/{chainId}/api` in the Pro API).
+   */
+  #withApiKey(queryParams: Record<string, string>): Record<string, string> {
+    if (this.apiKey === undefined) {
+      return queryParams;
+    }
+
+    return { ...queryParams, apikey: this.apiKey };
   }
 
   public async isVerified(address: string): Promise<boolean> {
@@ -197,11 +230,11 @@ export class Blockscout implements VerificationProvider {
       response = await getRequest(
         this.apiUrl,
         {
-          queryParams: {
+          queryParams: this.#withApiKey({
             module: "contract",
             action: "getsourcecode",
             address,
-          },
+          }),
         },
         this.dispatcherOrDispatcherOptions,
       );
@@ -270,10 +303,10 @@ export class Blockscout implements VerificationProvider {
         this.apiUrl,
         body,
         {
-          queryParams: {
+          queryParams: this.#withApiKey({
             module: "contract",
             action: "verifysourcecode",
-          },
+          }),
         },
         this.dispatcherOrDispatcherOptions,
       );
@@ -371,11 +404,11 @@ export class Blockscout implements VerificationProvider {
       response = await getRequest(
         this.apiUrl,
         {
-          queryParams: {
+          queryParams: this.#withApiKey({
             module: "contract",
             action: "checkverifystatus",
             guid,
-          },
+          }),
         },
         this.dispatcherOrDispatcherOptions,
       );

--- a/packages/hardhat-verify/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-verify/src/internal/hook-handlers/config.ts
@@ -32,6 +32,7 @@ const userConfigType = z.object({
     .object({
       blockscout: z
         .object({
+          apiKey: sensitiveStringSchema.optional(),
           enabled: z.boolean().optional(),
         })
         .optional(),
@@ -86,7 +87,10 @@ export async function resolveUserConfig(
     ...resolvedConfig,
     verify: {
       ...resolvedConfig.verify,
-      blockscout: resolveBlockscoutConfig(userConfig.verify?.blockscout),
+      blockscout: resolveBlockscoutConfig(
+        userConfig.verify?.blockscout,
+        resolveConfigurationVariable,
+      ),
       etherscan: resolveEtherscanConfig(
         userConfig.verify?.etherscan,
         resolveConfigurationVariable,
@@ -100,8 +104,15 @@ function resolveBlockscoutConfig(
   blockscoutConfig: BlockscoutUserConfig | undefined = {
     enabled: true,
   },
+  resolveConfigurationVariable: ConfigurationVariableResolver,
 ): BlockscoutConfig {
   return {
+    // Unlike Etherscan, the Blockscout API key is optional, so it's left
+    // undefined when the user doesn't configure one.
+    apiKey:
+      blockscoutConfig.apiKey !== undefined
+        ? resolveConfigurationVariable(blockscoutConfig.apiKey)
+        : undefined,
     enabled: blockscoutConfig.enabled ?? true,
   };
 }

--- a/packages/hardhat-verify/src/internal/types.ts
+++ b/packages/hardhat-verify/src/internal/types.ts
@@ -2,6 +2,7 @@ import type { Dispatcher } from "@nomicfoundation/hardhat-utils/request";
 import type {
   BlockExplorerBlockscoutConfig,
   BlockExplorerEtherscanConfig,
+  BlockscoutConfig,
   ChainDescriptorsConfig,
   EtherscanConfig,
   SourcifyConfig,
@@ -48,6 +49,7 @@ export interface ResolveConfigOptions {
 
 export interface CreateBlockscoutOptions {
   blockExplorerConfig: BlockExplorerBlockscoutConfig;
+  verificationProviderConfig: BlockscoutConfig;
   dispatcher?: Dispatcher;
   shouldUseCache?: boolean;
 }

--- a/packages/hardhat-verify/src/type-extensions.ts
+++ b/packages/hardhat-verify/src/type-extensions.ts
@@ -12,6 +12,11 @@ declare module "hardhat/types/config" {
   }
 
   export interface BlockscoutUserConfig {
+    /**
+     * The API key is optional: most Blockscout instances expose a public API
+     * that doesn't require one, but the Pro API does.
+     */
+    apiKey?: SensitiveString;
     enabled?: boolean;
   }
 
@@ -41,6 +46,7 @@ declare module "hardhat/types/config" {
   }
 
   export interface BlockscoutConfig {
+    apiKey?: ResolvedConfigurationVariable;
     enabled: boolean;
   }
 

--- a/packages/hardhat-verify/test/blockscout.ts
+++ b/packages/hardhat-verify/test/blockscout.ts
@@ -8,7 +8,10 @@ import querystring from "node:querystring";
 import { beforeEach, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
-import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
+import {
+  assertRejectsWithHardhatError,
+  assertThrowsHardhatError,
+} from "@nomicfoundation/hardhat-test-utils";
 import { getDispatcher } from "@nomicfoundation/hardhat-utils/request";
 
 import { Blockscout } from "../src/internal/blockscout.js";
@@ -50,6 +53,7 @@ describe("blockscout", () => {
     const constructorArguments = "";
     /* cspell:disable-next-line */
     const guid = "a7lpxkm9kpcpicx7daftmjifrfhiuhf5vqqnawhkfhzfrcpnxj";
+    const apiKey = "someApiKey";
 
     describe("constructor", () => {
       it("should create an instance with the correct properties", () => {
@@ -58,6 +62,30 @@ describe("blockscout", () => {
         assert.equal(blockscout.name, blockscoutConfig.name);
         assert.equal(blockscout.url, blockscoutConfig.url);
         assert.equal(blockscout.apiUrl, blockscoutConfig.apiUrl);
+        assert.equal(blockscout.apiKey, undefined);
+      });
+
+      it("should create an instance with an apiKey if one is provided", () => {
+        const blockscout = new Blockscout({
+          ...blockscoutConfig,
+          apiKey,
+        });
+
+        assert.equal(blockscout.apiKey, apiKey);
+      });
+
+      it("should throw an error if the apiKey is empty", () => {
+        assertThrowsHardhatError(
+          () =>
+            new Blockscout({
+              ...blockscoutConfig,
+              apiKey: "",
+            }),
+          HardhatError.ERRORS.HARDHAT_VERIFY.GENERAL.EXPLORER_API_KEY_EMPTY,
+          {
+            verificationProvider: blockscoutConfig.name,
+          },
+        );
       });
 
       it('should default to "Blockscout" if no name is provided', () => {
@@ -253,6 +281,38 @@ describe("blockscout", () => {
         );
       });
 
+      it("should send the apiKey as a query param if one is configured", async () => {
+        const blockscout = new Blockscout({
+          ...blockscoutConfig,
+          apiKey,
+          dispatcher: testDispatcher.interceptable,
+        });
+
+        // The interceptor query is matched exactly, so this only replies if
+        // the apikey query param is sent
+        testDispatcher.interceptable
+          .intercept({
+            path: "/api",
+            method: "GET",
+            query: {
+              module: "contract",
+              action: "getsourcecode",
+              address,
+              apikey: apiKey,
+            },
+          })
+          .reply(200, {
+            status: "1",
+            result: [
+              {
+                SourceCode: sourceCode,
+              },
+            ],
+          });
+
+        assert.equal(await blockscout.isVerified(address), true);
+      });
+
       it("should throw an error if the response status code is 300-399", async () => {
         const blockscout = new Blockscout({
           ...blockscoutConfig,
@@ -326,6 +386,50 @@ describe("blockscout", () => {
         } catch {
           assert.fail("Expected verify to not throw an error");
         }
+
+        assert.equal(response, guid);
+      });
+
+      it("should send the apiKey as a query param if one is configured", async () => {
+        const blockscout = new Blockscout({
+          ...blockscoutConfig,
+          apiKey,
+          dispatcher: testDispatcher.interceptable,
+        });
+
+        // The interceptor query is matched exactly, so this only replies if
+        // the apikey query param is sent
+        testDispatcher.interceptable
+          .intercept({
+            path: "/api",
+            method: "POST",
+            query: {
+              module: "contract",
+              action: "verifysourcecode",
+              apikey: apiKey,
+            },
+            body: querystring.stringify({
+              contractaddress: address,
+              sourceCode: JSON.stringify(compilerInput),
+              codeformat: "solidity-standard-json-input",
+              contractname: contract,
+              compilerversion: compilerVersion,
+              constructorArguments,
+            }),
+          })
+          .reply(200, {
+            status: "1",
+            message: "OK",
+            result: guid,
+          });
+
+        const response = await blockscout.verify({
+          contractAddress: address,
+          compilerInput,
+          contractName: contract,
+          compilerVersion,
+          constructorArguments,
+        });
 
         assert.equal(response, guid);
       });
@@ -632,6 +736,40 @@ describe("blockscout", () => {
         assert.equal(callCount, 3);
       });
 
+      it("should send the apiKey as a query param if one is configured", async () => {
+        const blockscout = new Blockscout({
+          ...blockscoutConfig,
+          apiKey,
+          dispatcher: testDispatcher.interceptable,
+        });
+
+        // The interceptor query is matched exactly, so this only replies if
+        // the apikey query param is sent
+        testDispatcher.interceptable
+          .intercept({
+            path: "/api",
+            method: "GET",
+            query: {
+              module: "contract",
+              action: "checkverifystatus",
+              guid,
+              apikey: apiKey,
+            },
+          })
+          .reply(200, {
+            status: "1",
+            result: "Pass - Verified",
+          });
+
+        const response = await blockscout.pollVerificationStatus(
+          guid,
+          address,
+          contract,
+        );
+
+        assert.equal(response.success, true);
+      });
+
       it("should throw an error if the request fails", async () => {
         const blockscout = new Blockscout({
           ...blockscoutConfig,
@@ -804,6 +942,44 @@ describe("blockscout", () => {
         result.blockExplorerConfig,
         testChainDescriptor.blockExplorers.blockscout,
       );
+      assert.deepEqual(
+        result.verificationProviderConfig,
+        verificationProvidersConfig.blockscout,
+      );
+    });
+
+    it("should return the blockscout verification provider config, including the apiKey", async () => {
+      const testChainDescriptor: ChainDescriptorConfig = {
+        name: "TestNet",
+        chainType: "l1",
+        blockExplorers: {
+          blockscout: {
+            url: "https://blockscout.test.com",
+            apiUrl: "https://api.blockscout.test.com/api",
+          },
+        },
+      };
+
+      const chainDescriptors: ChainDescriptorsConfig = new Map([
+        [123n, testChainDescriptor],
+      ]);
+
+      const blockscoutConfig = {
+        enabled: true,
+        apiKey: new MockResolvedConfigurationVariable("blockscout-key"),
+      };
+
+      const result = await Blockscout.resolveConfig({
+        chainId: 123,
+        networkName: "testnet",
+        chainDescriptors,
+        verificationProvidersConfig: {
+          ...verificationProvidersConfig,
+          blockscout: blockscoutConfig,
+        },
+      });
+
+      assert.deepEqual(result.verificationProviderConfig, blockscoutConfig);
     });
 
     it("should fetch from API when chain not in descriptors", async () => {
@@ -929,6 +1105,38 @@ describe("blockscout", () => {
           chainId: 100,
         },
       );
+    });
+  });
+
+  describe("create", () => {
+    const blockExplorerConfig = {
+      url: "https://blockscout.test.com",
+      apiUrl: "https://blockscout.test.com/api",
+    };
+
+    it("should create an instance with the resolved apiKey", async () => {
+      const blockscout = await Blockscout.create({
+        blockExplorerConfig,
+        verificationProviderConfig: {
+          enabled: true,
+          apiKey: new MockResolvedConfigurationVariable("blockscout-key"),
+        },
+      });
+
+      assert.equal(blockscout.apiKey, "blockscout-key");
+    });
+
+    it("should create an instance without an apiKey when none is configured", async () => {
+      const blockscout = await Blockscout.create({
+        blockExplorerConfig,
+        verificationProviderConfig: {
+          enabled: true,
+        },
+      });
+
+      assert.equal(blockscout.apiKey, undefined);
+      assert.equal(blockscout.url, blockExplorerConfig.url);
+      assert.equal(blockscout.apiUrl, blockExplorerConfig.apiUrl);
     });
   });
 

--- a/packages/hardhat-verify/test/hook-handlers/config.ts
+++ b/packages/hardhat-verify/test/hook-handlers/config.ts
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
 import { assertValidationErrors } from "@nomicfoundation/hardhat-test-utils";
+import { configVariable } from "hardhat/config";
 
 import {
   resolveUserConfig,
@@ -67,6 +68,54 @@ describe("hook-handlers/config", () => {
         const validationErrors = await validateUserConfig(config as any);
 
         assertValidationErrors(validationErrors, []);
+      });
+
+      it("should pass if the apiKey is provided", async () => {
+        let config: HardhatUserConfig = {
+          verify: {
+            blockscout: {
+              apiKey: "some-api-key",
+              enabled: true,
+            },
+          },
+        };
+
+        let validationErrors = await validateUserConfig(config);
+
+        assertValidationErrors(validationErrors, []);
+
+        config = {
+          verify: {
+            blockscout: {
+              apiKey: configVariable("BLOCKSCOUT_API_KEY"),
+            },
+          },
+        };
+
+        validationErrors = await validateUserConfig(config);
+
+        assertValidationErrors(validationErrors, []);
+      });
+
+      it("should throw if apiKey is not a string", async () => {
+        const config = {
+          verify: {
+            blockscout: {
+              apiKey: 1,
+            },
+          },
+        };
+
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      -- testing invalid network type for js users */
+        const validationErrors = await validateUserConfig(config as any);
+
+        assertValidationErrors(validationErrors, [
+          {
+            path: ["verify", "blockscout", "apiKey"],
+            message: "Expected a string or a Configuration Variable",
+          },
+        ]);
       });
 
       it("should throw if blockscout is not an object", async () => {
@@ -296,6 +345,7 @@ describe("hook-handlers/config", () => {
 
       assert.deepEqual(resolvedConfig.verify, {
         blockscout: {
+          apiKey: undefined,
           enabled: true,
         },
         etherscan: {
@@ -313,6 +363,7 @@ describe("hook-handlers/config", () => {
       const userConfig: HardhatUserConfig = {
         verify: {
           blockscout: {
+            apiKey: "some-blockscout-api-key",
             enabled: false,
           },
           etherscan: {
@@ -336,6 +387,9 @@ describe("hook-handlers/config", () => {
 
       assert.deepEqual(resolvedConfig.verify, {
         blockscout: {
+          apiKey: new MockResolvedConfigurationVariable(
+            "some-blockscout-api-key",
+          ),
           enabled: false,
         },
         etherscan: {
@@ -346,6 +400,29 @@ describe("hook-handlers/config", () => {
           apiUrl: "https://sourcify.custom.url",
           enabled: false,
         },
+      });
+    });
+
+    it("should leave the blockscout apiKey undefined if it is not provided", async () => {
+      const userConfig: HardhatUserConfig = {
+        verify: {
+          blockscout: {
+            enabled: false,
+          },
+        },
+      };
+
+      const resolvedConfig = await resolveUserConfig(
+        userConfig,
+        /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        -- Cast for simplicity as we won't test this */
+        (variable) => configurationVariableResolver(variable as string),
+        next,
+      );
+
+      assert.deepEqual(resolvedConfig.verify.blockscout, {
+        apiKey: undefined,
+        enabled: false,
       });
     });
 
@@ -372,6 +449,7 @@ describe("hook-handlers/config", () => {
 
       assert.deepEqual(resolvedConfig.verify, {
         blockscout: {
+          apiKey: undefined,
           enabled: true,
         },
         etherscan: {


### PR DESCRIPTION
Blockscout supports both the keyless per-instance API and the multichain Pro API, which requires an API key. Mirror what the Etherscan provider already does, while keeping the key optional so instances that don't require one continue working unchanged.

- `verify.blockscout.apiKey` accepts a string or a config variable, and resolves to an optional `ResolvedConfigurationVariable`.
- `Blockscout.resolveConfig`/`create` forward the resolved key to the instance, and the key is sent as the `apikey` query param of the `getsourcecode`, `verifysourcecode` and `checkverifystatus` requests. It's omitted entirely when no key is configured.
- An explicitly configured empty key throws EXPLORER_API_KEY_EMPTY, as it does for Etherscan.

Unlike Etherscan, the chain id isn't sent as a query param: the Blockscout instance is addressed by the `apiUrl` of its chain descriptor, which already encodes the chain id when the API needs it (e.g. `https://api.blockscout.com/{chainId}/api`).

<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
