### PR TITLE
Hardhat solx internal release prepration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,6 @@
     "@nomicfoundation/config",
     "@nomicfoundation/example-project",
     "@nomicfoundation/template-package",
-    "@nomicfoundation/hardhat-slang-solx",
     "template-*"
   ],
   "fixed": [],

--- a/.changeset/hardhat-slang-solx-first-release.md
+++ b/.changeset/hardhat-slang-solx-first-release.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-slang-solx": major
+---
+
+Release of the hardhat-slang-solx plugin, providing experimental support for the Slang Solx compiler.

--- a/.changeset/strict-solx-checksum-verification.md
+++ b/.changeset/strict-solx-checksum-verification.md
@@ -1,5 +1,5 @@
 ---
-"@nomicfoundation/hardhat-errors": minor
+"@nomicfoundation/hardhat-errors": patch
 ---
 
 Added `HHE110003` and `HHE110004` for the `hardhat-slang-solx` plugin, raised when the checksum of a solx binary cannot be obtained and when a downloaded solx binary does not match it.

--- a/packages/hardhat-slang-solx/package.json
+++ b/packages/hardhat-slang-solx/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@nomicfoundation/hardhat-slang-solx",
-  "private": true,
   "version": "2.0.0",
   "description": "Hardhat plugin for using solx compiler in test builds",
   "homepage": "https://github.com/NomicFoundation/hardhat/tree/main/packages/hardhat-slang-solx",

--- a/packages/hardhat-slang-solx/src/internal/constants.ts
+++ b/packages/hardhat-slang-solx/src/internal/constants.ts
@@ -35,9 +35,22 @@ export const SUPPORTED_SOLX_EVM_VERSIONS: readonly string[] = [
 ] as const;
 
 /**
- * Default LLVM optimization level, passed to solx via `settings.optimizer.mode`
- * ("1"/"2"/"3"/"s"/"z"; users override per profile). Deliberately -O1 to
- * optimize for compile speed (solx's own default if unset is -O3).
+ * The LLVM optimization levels solx accepts in `settings.optimizer.mode`,
+ * lowercase as solx expects. There is no level that turns optimization
+ * off: "1" is the minimum.
+ */
+export const SUPPORTED_SOLX_OPTIMIZER_MODES: readonly string[] = [
+  "1",
+  "2",
+  "3",
+  "s",
+  "z",
+] as const;
+
+/**
+ * Default LLVM optimization level, passed to solx via `settings.optimizer.mode`.
+ * Deliberately -O1 to optimize for compile speed (solx's own default if
+ * unset is -O3).
  */
 export const DEFAULT_SOLX_OPTIMIZER_MODE = "1";
 

--- a/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
@@ -24,6 +24,7 @@ import {
   SOLIDITY_TO_SOLX_VERSION_MAP,
   SLANG_SOLX_COMPILER_TYPE,
   SUPPORTED_SOLX_EVM_VERSIONS,
+  SUPPORTED_SOLX_OPTIMIZER_MODES,
 } from "../constants.js";
 import { addSlangSolxDebugInfoSelectors } from "../slang-solx-compiler.js";
 
@@ -42,12 +43,24 @@ const supportedEvmVersionsType = z
     message: `Solx only supports EVM versions: ${SUPPORTED_SOLX_EVM_VERSIONS.join(", ")}`,
   });
 
+const supportedOptimizerModesType = z
+  .string()
+  .refine((val) => SUPPORTED_SOLX_OPTIMIZER_MODES.includes(val), {
+    message: `Solx only supports optimizer modes: ${SUPPORTED_SOLX_OPTIMIZER_MODES.join(", ")}`,
+  });
+
 const solxSolidityCompilerUserConfigType = z
   .object({
     version: z.string(),
     settings: z
       .object({
         evmVersion: supportedEvmVersionsType.optional(),
+        optimizer: z
+          .object({
+            mode: supportedOptimizerModesType.optional(),
+          })
+          .passthrough()
+          .optional(),
       })
       .passthrough()
       .optional(),

--- a/packages/hardhat-slang-solx/test/config.ts
+++ b/packages/hardhat-slang-solx/test/config.ts
@@ -840,3 +840,68 @@ describe("hardhat-slang-solx resolved config validation", () => {
     );
   });
 });
+
+describe("hardhat-slang-solx optimizer mode validation", () => {
+  async function validateMode(mode: string) {
+    return await validateUserConfig({
+      solidity: {
+        profiles: {
+          slangSolx: {
+            compilers: [
+              {
+                version: "0.8.34",
+                type: "slangSolx",
+                settings: { optimizer: { mode } },
+              },
+            ],
+          },
+        },
+      },
+    });
+  }
+
+  for (const mode of ["1", "2", "3", "s", "z"]) {
+    it(`accepts the optimizer mode "${mode}"`, async () => {
+      assert.deepEqual(await validateMode(mode), []);
+    });
+  }
+
+  // The likeliest mistake: there is no mode that turns optimization off.
+  it('rejects the optimizer mode "0"', async () => {
+    const errors = await validateMode("0");
+
+    assert.ok(
+      errors.some((e) => e.message.includes("optimizer modes")),
+      `Expected an optimizer mode error, got: ${errors.map((e) => e.message).join(", ")}`,
+    );
+  });
+
+  it("rejects an uppercase size mode, which solx does not accept", async () => {
+    const errors = await validateMode("Z");
+
+    assert.ok(
+      errors.some((e) => e.message.includes("optimizer modes")),
+      `Expected an optimizer mode error, got: ${errors.map((e) => e.message).join(", ")}`,
+    );
+  });
+
+  it("leaves the other optimizer settings alone", async () => {
+    const errors = await validateUserConfig({
+      solidity: {
+        profiles: {
+          slangSolx: {
+            compilers: [
+              {
+                version: "0.8.34",
+                type: "slangSolx",
+                settings: { optimizer: { enabled: true, runs: 200 } },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(errors, []);
+  });
+});

--- a/scripts/verdaccio/publish.ts
+++ b/scripts/verdaccio/publish.ts
@@ -212,7 +212,6 @@ const EXCLUDED_PACKAGES = [
   "example-project",
   "template-package",
   "hardhat-test-utils",
-  "hardhat-slang-solx",
 ];
 
 /**


### PR DESCRIPTION
Prepare the `hardhat-slang-solx` plugin for npm publishing for internal testing at Nomic.

To do that we remove `"private": true` from the package.json. We also remove the package from the changesets `ignore` list and the verdaccio publisher's `EXCLUDED_PACKAGES`.

For the moment we are keeping a merge group exclusion in place until `3.0.0` is released.

## Manual testing

We ran the release end to end against a local registry, using the artifacts `pnpm version-for-release` actually produces rather than the source tree.

```shell
pnpm version-for-release
# confirm packages/hardhat-slang-solx/package.json is 3.0.0
# and that CHANGELOG.md was generated

pnpm verdaccio start
# In a different terminal
pnpm verdaccio publish
# @nomicfoundation/hardhat-slang-solx now appears in the published list
```

Then, in an empty directory pointed at the local registry:

```shell
echo "registry=http://localhost:4873" > .npmrc
pnpm dlx hardhat --init --template node-test-runner-viem
```

Add the plugin and a `slangSolx` profile to `hardhat.config.ts`:

```ts
import hardhatSlangSolx from "@nomicfoundation/hardhat-slang-solx";

export default defineConfig({
  plugins: [hardhatToolboxViemPlugin, hardhatSlangSolx],
  solidity: {
    profiles: {
      default: { version: "0.8.28" },
      slangSolx: {
        type: "slangSolx",
        version: "0.8.34",
      },
    },
  },
});
```

Then exercise the template under both profiles:

```shell
npx hardhat build
npx hardhat build --build-profile slangSolx

npx hardhat test
npx hardhat test --build-profile slangSolx

npx hardhat ignition deploy ./ignition/modules/Counter.ts
npx hardhat ignition deploy ./ignition/modules/Counter.ts --build-profile slangSolx
```

Finally, a deliberately failing Solidity test under solx, to confirm the compiler type translation still reaches EDR from a packaged install:

```
1) FailOnPurposeTest#test_ItReverts()
  Error: incBy: increment should be positive
    at Counter.incBy (contracts/Counter.sol:15)
    at FailOnPurposeTest.test_ItReverts (contracts/FailOnPurpose.t.sol:9)
```
