### PR TITLE
Fix segment-aware containment checks in the Solidity resolver

### DIFF
--- a/.changeset/clean-ravens-resolve.md
+++ b/.changeset/clean-ravens-resolve.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed Solidity resolver containment checks for paths whose names share a prefix with the project root, a package source-name root, or `node_modules`.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -58,6 +58,16 @@ import {
 
 const NPM_PACKAGES_WITH_SIMULATED_PACKAGE_EXPORTS = new Set(["forge-std"]);
 
+function isInputSourceNameWithinRoot(
+  inputSourceName: string,
+  inputSourceNameRoot: string,
+): boolean {
+  return (
+    inputSourceName === inputSourceNameRoot ||
+    inputSourceName.startsWith(`${inputSourceNameRoot}/`)
+  );
+}
+
 export class ResolverImplementation implements Resolver {
   readonly #projectRoot: string;
   readonly #npmPackageGraph: RemappedNpmPackagesGraphImplementation;
@@ -174,7 +184,13 @@ export class ResolverImplementation implements Resolver {
   async #resolveProjectFile(
     absoluteFilePath: string,
   ): Promise<Result<ProjectResolvedFile, ProjectRootResolutionError>> {
-    if (!absoluteFilePath.startsWith(this.#projectRoot)) {
+    const relativeFilePath = path.relative(this.#projectRoot, absoluteFilePath);
+
+    if (
+      relativeFilePath === ".." ||
+      relativeFilePath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeFilePath)
+    ) {
       return {
         success: false,
         error: {
@@ -183,8 +199,6 @@ export class ResolverImplementation implements Resolver {
         },
       };
     }
-
-    const relativeFilePath = path.relative(this.#projectRoot, absoluteFilePath);
 
     // We first check if the file has already been resolved.
     //
@@ -438,7 +452,12 @@ export class ResolverImplementation implements Resolver {
 
     if (isRelativeImport) {
       // If the import is relative, it shouldn't leave its package
-      if (!directImport.startsWith(from.package.inputSourceNameRoot)) {
+      if (
+        !isInputSourceNameWithinRoot(
+          directImport,
+          from.package.inputSourceNameRoot,
+        )
+      ) {
         return {
           success: false,
           error: {
@@ -451,7 +470,8 @@ export class ResolverImplementation implements Resolver {
 
       // It also shouldn't get into its package's node_modules
       if (
-        directImport.startsWith(
+        isInputSourceNameWithinRoot(
+          directImport,
           sourceNamePathJoin(from.package.inputSourceNameRoot, "node_modules"),
         )
       ) {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -63,6 +63,25 @@ describe("Dependency resolver", () => {
       });
     });
 
+    it("Should error if the file is in a sibling directory whose name shares the project root prefix", async () => {
+      await using project = await useTestProjectTemplate(projectTemplate);
+      const resolver = await ResolverImplementation.create(
+        project.path,
+        readUtf8File,
+      );
+
+      const absoluteFilePath = path.join(project.path + "-sibling", "A.sol");
+      const expectedError: ProjectRootResolutionError = {
+        type: RootResolutionErrorType.PROJECT_ROOT_FILE_NOT_IN_PROJECT,
+        absoluteFilePath,
+      };
+
+      assert.deepEqual(await resolver.resolveProjectFile(absoluteFilePath), {
+        success: false,
+        error: expectedError,
+      });
+    });
+
     it("Should error if the file doesn't exist", async () => {
       await using project = await useTestProjectTemplate(projectTemplate);
       const resolver = await ResolverImplementation.create(
@@ -1237,6 +1256,83 @@ a/=b`,
               success: false,
               error: expectedError,
             },
+          );
+        });
+
+        it("Should error when an import escapes into a source name root with a shared prefix", async () => {
+          const prefixCollisionTemplate: TestProjectTemplate = {
+            name: "relative-import-prefix-collision",
+            version: "1.0.0",
+            files: {
+              "contracts/sub/A.sol": `A`,
+              "x/File.sol": `F`,
+            },
+          };
+
+          await using project = await useTestProjectTemplate(
+            prefixCollisionTemplate,
+          );
+          const resolver = await ResolverImplementation.create(
+            project.path,
+            readUtf8File,
+          );
+          const absoluteFilePath = path.join(
+            project.path,
+            "contracts/sub/A.sol",
+          );
+          const result = await resolver.resolveProjectFile(absoluteFilePath);
+          assert.ok(result.success, "Result should be successful");
+
+          const importPath = "../../../project2x/File.sol";
+          const expectedError: ImportResolutionError = {
+            type: ImportResolutionErrorType.ILLEGAL_RELATIVE_IMPORT,
+            fromFsPath: absoluteFilePath,
+            importPath,
+          };
+
+          assert.deepEqual(
+            await resolver.resolveImport(result.value, importPath),
+            {
+              success: false,
+              error: expectedError,
+            },
+          );
+        });
+
+        it("Should allow relative imports into a directory whose name shares the node_modules prefix", async () => {
+          const nodeModulesPrefixTemplate: TestProjectTemplate = {
+            name: "relative-import-node-modules-prefix",
+            version: "1.0.0",
+            files: {
+              "contracts/A.sol": `A`,
+              "node_modules2/File.sol": `F`,
+            },
+          };
+
+          await using project = await useTestProjectTemplate(
+            nodeModulesPrefixTemplate,
+          );
+          const resolver = await ResolverImplementation.create(
+            project.path,
+            readUtf8File,
+          );
+          const absoluteFilePath = path.join(project.path, "contracts/A.sol");
+          const result = await resolver.resolveProjectFile(absoluteFilePath);
+          assert.ok(result.success, "Result should be successful");
+
+          const imported = await resolver.resolveImport(
+            result.value,
+            "../node_modules2/File.sol",
+          );
+
+          assert.ok(imported.success, "Result should be successful");
+          assert.equal(
+            imported.value.file.inputSourceName,
+            "project/node_modules2/File.sol",
+          );
+          assert.equal(
+            imported.value.file.fsPath,
+            path.join(project.path, "node_modules2/File.sol"),
           );
         });
 


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->


Fixes  https://github.com/NomicFoundation/hardhat/issues/8513

## Description

The Solidity resolver used raw `startsWith` checks to determine whether source names and filesystem paths were contained within a package or project root.

These checks treated sibling names with a shared prefix as descendants. For example, `project2/File.sol` was considered to be inside the `project` source name root. After the package prefix was removed, the resolver could map that source name to `<projectRoot>/File.sol`, allowing one physical Solidity file to be represented by an invalid source unit name.

This PR makes the relevant checks path-segment-aware:

- relative imports must remain within the importing package's source-name root;
- `node_modules2` is no longer mistaken for `node_modules`;
- project root files are checked with `path.relative`, so sibling-prefix paths
  are reported as outside the project.

Regression tests cover all three prefix-collision cases.



- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
