### PR TITLE
test: add lidofinance-core & graph-horizon scenarios to solx benchmark

### DIFF
--- a/.github/workflows/solx-regression-benchmark.yml
+++ b/.github/workflows/solx-regression-benchmark.yml
@@ -49,10 +49,13 @@ jobs:
     # on/off twin, plus a solc optimizer-off legacy cell (the Foundry test-run
     # default, solc at its fastest). OZ skips the no-opt cell — the repo
     # doesn't compile unoptimized (see its wrapper config); that FAIL is the
-    # datum. OZ (~43-150 s per cell x 3 hyperfine runs) dominates, the other
-    # scenarios are smaller; plus the post-bench size/gas/dump passes — ~2.5h
-    # worst case in total.
-    timeout-minutes: 180
+    # datum. Two scenarios deviate: lidofinance-core-solx has no forge cells
+    # (the repo ships no foundry.toml) and scopes every cell to the modern
+    # vaults tree with --no-tests; graph-horizon-solx is a pnpm monorepo whose
+    # prime phase also builds workspace deps (unmeasured). OZ (~43-150 s per
+    # cell x 3 hyperfine runs) dominates, the other scenarios are smaller;
+    # plus the post-bench size/gas/dump passes — ~3h worst case in total.
+    timeout-minutes: 210
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:

--- a/.github/workflows/solx-regression-benchmark.yml
+++ b/.github/workflows/solx-regression-benchmark.yml
@@ -49,12 +49,13 @@ jobs:
     # on/off twin, plus a solc optimizer-off legacy cell (the Foundry test-run
     # default, solc at its fastest). OZ skips the no-opt cell — the repo
     # doesn't compile unoptimized (see its wrapper config); that FAIL is the
-    # datum. Two scenarios deviate: lidofinance-core-solx has no forge cells
-    # (the repo ships no foundry.toml) and scopes every cell to the modern
-    # vaults tree with --no-tests; graph-horizon-solx is a pnpm monorepo whose
-    # prime phase also builds workspace deps (unmeasured). OZ (~43-150 s per
-    # cell x 3 hyperfine runs) dominates, the other scenarios are smaller;
-    # plus the post-bench size/gas/dump passes — ~3h worst case in total.
+    # datum. Two scenarios deviate: lidofinance-core-solx scopes every cell to
+    # the modern vaults tree (via-IR only — the tree can't compile legacy) and
+    # reinstates the pre-migration foundry.toml for its forge cell;
+    # graph-horizon-solx is a pnpm monorepo whose prime phase also builds
+    # workspace deps (unmeasured). OZ (~43-150 s per cell x 3 hyperfine runs)
+    # dominates, the other scenarios are smaller; plus the post-bench
+    # size/gas/dump passes — ~3h worst case in total.
     timeout-minutes: 210
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/end-to-end/graph-horizon-solx/foundry.toml
+++ b/end-to-end/graph-horizon-solx/foundry.toml
@@ -1,0 +1,41 @@
+# Vendored by the graph-horizon-solx benchmark scenario: the pre-migration
+# foundry.toml from PR #1 (8d148f39), whose [profile.prod] matches the
+# hardhat cells' production-derived settings, plus the remappings block the
+# pinned commit's lint-only foundry.toml carries (forge doesn't auto-generate
+# either entry, and remappings.txt only maps contracts/).
+[profile.default]
+src = 'contracts'
+out = 'build'
+libs = ["node_modules"]
+remappings = [
+    "@graphprotocol/=node_modules/@graphprotocol/",
+    "forge-std/=node_modules/forge-std/src/",
+]
+test = 'test'
+cache_path = 'cache_forge'
+fs_permissions = [{ access = "read", path = "./" }]
+solc_version = '0.8.35'
+evm_version = 'cancun'
+# Suppress solc warnings emitted from third-party code we don't control
+# (e.g. @openzeppelin/foundry-upgrades' state-mutability suggestions).
+ignored_warnings_from = ["node_modules"]
+
+# Exclude test files from coverage reports
+no_match_coverage = "(^test/|/mocks/)"
+
+# Opt-in profile for production-matching bytecode (viaIR + optimizer).
+# Use FOUNDRY_PROFILE=prod for CI / pre-merge runs that should mirror what hardhat
+# compiles for deploy. Default profile stays optimizer-off / viaIR-off for fast iteration.
+[profile.prod]
+optimizer = true
+optimizer_runs = 100
+via_ir = true
+
+# Lint configuration
+[lint]
+# Disable lint-on-build: forge build's auto-lint scans test/ files which use bytes32("...")
+# literal IDs that trigger spurious unsafe-typecast warnings. `pnpm lint:forge` (scoped to
+# contracts/) remains the canonical lint path for production code.
+lint_on_build = false
+ignore = ["contracts/mocks/imports.sol"]
+exclude_lints = ["mixed-case-function", "mixed-case-variable", "block-timestamp"]

--- a/end-to-end/graph-horizon-solx/hardhat.config.solx.ts
+++ b/end-to-end/graph-horizon-solx/hardhat.config.solx.ts
@@ -1,0 +1,105 @@
+// Wrapper config dropped over packages/horizon/hardhat.config.ts of the
+// pinned graphprotocol contracts fork by preinstall.sh (which renames the
+// original to hardhat.config.base.ts). Unlike the other solx scenarios this
+// repo is a pnpm monorepo; the wrapper lives inside packages/horizon, so
+// import.meta.dirname-relative paths work exactly as in the single-package
+// scenarios.
+//
+// The fork's config has two profiles: a fast `default` (0.8.35, no optimizer,
+// no via-IR) for iteration and `production` (0.8.35, optimizer runs 100,
+// via-IR, cancun — from @graphprotocol/toolshed's base config), the deployed
+// configuration. We seed the benchmark's matrix of profiles — {solc, solx} x
+// {legacy, via-IR} — from the production settings, re-pinned to 0.8.34 (the
+// only version in hardhat-solx's Solidity→solx map; contracts and tests
+// carry ^0.8.27-style range pragmas, so no source patching). Upstream's fast
+// `default` profile is intentionally replaced: the wrapper's `default` is the
+// production-derived legacy cell, and the optimizer-off datum lives in
+// `solc-no-opt`. npmFilesToBuild (the two OZ proxy roots) is part of
+// upstream's build and is kept in every profile. Everything else (plugins,
+// tasks, networks, paths, typechain) is preserved from the base.
+import path from "node:path";
+
+import hardhatSolx from "@nomicfoundation/hardhat-solx";
+import baseConfig from "./hardhat.config.base.ts";
+
+const base = baseConfig as unknown as {
+  plugins: unknown[];
+  solidity: {
+    npmFilesToBuild: string[];
+    profiles: {
+      production: { version: string; settings: Record<string, unknown> };
+    };
+  };
+  [key: string]: unknown;
+};
+
+// Independent settings objects per profile so the solx profiles can't bleed into
+// the solc profile. The solx optimization level (-O1) and DWARF debug info both
+// come from the hardhat-solx plugin defaults: DWARF is force-emitted, so solx
+// maps sources just as solc does (Hardhat force-emits solc sourceMaps), keeping
+// the comparison apples-to-apples. We intentionally don't override the optimizer
+// here so the benchmark measures the realistic plugin-default config.
+const baseSettings = base.solidity.profiles.production?.settings;
+if (baseSettings === undefined) {
+  throw new Error(
+    "graph-horizon-solx: no production profile in the base config — the pinned commit may have changed",
+  );
+}
+
+const solcViaIRSettings = structuredClone(baseSettings);
+const solxViaIRSettings = structuredClone(baseSettings);
+
+// Legacy variants: same settings, only `viaIR` flips (the production default
+// is IR). Both solc and solx read `settings.viaIR` (there is no `--via-ir`
+// CLI flag — it's config-only).
+const solcSettings = { ...structuredClone(baseSettings), viaIR: false };
+const solxSettings = { ...structuredClone(baseSettings), viaIR: false };
+
+// Optimizer-off legacy solc — the Foundry test-run default and solc at its
+// fastest, so it's the real-world compile-time bar for a test-only compiler.
+// (Also the closest cell to upstream's own fast `default` profile.)
+const solcNoOptSettings = {
+  ...structuredClone(solcSettings),
+  optimizer: { enabled: false },
+};
+
+// The "solx" profiles always measure the version the plugin ships (its
+// Solidity→solx version map). The "solx-0.1.7" profiles pin a release under
+// comparison via the plugin's `path` compiler option; preinstall.sh downloads
+// the binary (see scripts/benchmark/download-solx.ts).
+const solx017Path = path.join(import.meta.dirname, ".solx", "solx-v0.1.7");
+
+export default {
+  ...base,
+  plugins: [...base.plugins, hardhatSolx],
+  // The plugin only allows type: "solx" in the profile named "solx"; this
+  // benchmark needs a second solx profile ("solx-via-ir") for the viaIR sweep,
+  // so opt out of that guard. Throwaway benchmark scenario, not production.
+  solx: { dangerouslyAllowSolxInProduction: true },
+  solidity: {
+    npmFilesToBuild: base.solidity.npmFilesToBuild,
+    profiles: {
+      default: { version: "0.8.34", settings: solcSettings },
+      "solc-no-opt": { version: "0.8.34", settings: solcNoOptSettings },
+      "solc-via-ir": { version: "0.8.34", settings: solcViaIRSettings },
+      solx: { type: "solx", version: "0.8.34", settings: solxSettings },
+      "solx-via-ir": {
+        type: "solx",
+        version: "0.8.34",
+        settings: solxViaIRSettings,
+      },
+      "solx-0.1.7": {
+        type: "solx",
+        version: "0.8.34",
+        path: solx017Path,
+        settings: structuredClone(solxSettings),
+      },
+      "solx-0.1.7-via-ir": {
+        type: "solx",
+        version: "0.8.34",
+        path: solx017Path,
+        settings: structuredClone(solxViaIRSettings),
+      },
+    },
+  },
+};

--- a/end-to-end/graph-horizon-solx/preinstall.sh
+++ b/end-to-end/graph-horizon-solx/preinstall.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKDIR="$PWD"
+HORIZON="$WORKDIR/packages/horizon"
+MONOREPO_ROOT="$(cd "$E2E_TEST_DIR/../.." && pwd)"
+SOLX_PKG="$MONOREPO_ROOT/packages/hardhat-solx"
+
+# The repo pins `engines: { pnpm: "^10.28" }` and pnpm enforces engines.pnpm
+# unconditionally (engine-strict only gates engines.node), so the harness's
+# pnpm 11 would refuse to install. Drop the pin; fail loudly if it isn't the
+# expected one so pin drift is caught. Use node for the file transforms to
+# avoid BSD/GNU sed portability issues (matches the other scenarios'
+# preinstall scripts).
+node -e "
+const fs = require('fs');
+
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+if (pkg.engines?.pnpm === undefined || !pkg.engines.pnpm.startsWith('^10')) {
+  console.error(
+    'graph-horizon-solx preinstall: expected engines.pnpm ^10.x in the root ' +
+      'package.json — the pinned commit may have changed.',
+  );
+  process.exit(1);
+}
+delete pkg.engines.pnpm;
+
+// The rocketh patches pin exact versions that only the lockfile guarantees;
+// after the lockfile removal below their caret-ranged consumers
+// (packages/deployment, benchmark-irrelevant deploy tooling) resolve past
+// them and pnpm hard-errors with ERR_PNPM_UNUSED_PATCH. Drop the two
+// entries; the typechain patch targets an exactly-pinned version and stays.
+const patches = pkg.pnpm?.patchedDependencies ?? {};
+const rockethPatches = Object.keys(patches).filter((name) =>
+  name.startsWith('rocketh@') || name.startsWith('@rocketh/'),
+);
+if (rockethPatches.length === 0) {
+  console.error(
+    'graph-horizon-solx preinstall: no rocketh patchedDependencies in the ' +
+      'root package.json — the pinned commit may have changed.',
+  );
+  process.exit(1);
+}
+for (const name of rockethPatches) {
+  delete patches[name];
+}
+
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+# The workspace manifest sets minimumReleaseAge: 7200, which would reject the
+# minutes-old packages this run just published to Verdaccio if it ever takes
+# precedence over the harness's pnpm_config_minimum_release_age=0 env.
+# Belt-and-braces: strip the setting (and its typo'd exclude list) at the
+# text level; fail loudly if it's gone so pin drift is caught.
+node -e "
+const fs = require('fs');
+
+const manifest = fs.readFileSync('pnpm-workspace.yaml', 'utf8');
+if (!manifest.includes('minimumReleaseAge')) {
+  console.error(
+    'graph-horizon-solx preinstall: no minimumReleaseAge in ' +
+      'pnpm-workspace.yaml — the pinned commit may have changed.',
+  );
+  process.exit(1);
+}
+// Drop each min[iu]mumReleaseAge* top-level key together with its indented
+// block (the exclude key holds a list; leaving orphaned list items behind
+// would break the YAML).
+const lines = manifest.split('\n');
+const stripped = [];
+let inStrippedBlock = false;
+for (const line of lines) {
+  if (/^min[iu]mumReleaseAge/.test(line)) {
+    inStrippedBlock = true;
+    continue;
+  }
+  if (inStrippedBlock && /^\s+\S/.test(line)) {
+    continue;
+  }
+  inStrippedBlock = false;
+  stripped.push(line);
+}
+fs.writeFileSync('pnpm-workspace.yaml', stripped.join('\n'));
+"
+
+# Remove the lockfile: it pins the npmjs hardhat release, which satisfies
+# horizon's `hardhat: ^3.11.0` range, so pnpm would keep it and the run would
+# benchmark the released hardhat instead of the Verdaccio build published by
+# this run (--use-local's dependency bump only inspects the repo-root
+# package.json, which has no hardhat dependency in this monorepo). Deleting
+# forces a full re-resolution against Verdaccio; the range admits the bumped
+# local version, so no further patching is needed.
+rm -f pnpm-lock.yaml
+
+# hardhat-solx is `private` and excluded from the Verdaccio publish set, so it
+# never reaches the registry. Pack it instead (pack ignores `private`) and
+# consume the tarball as a file: dependency. `pnpm pack` — not `npm pack` —
+# rewrites the plugin's `workspace:` deps to real version ranges, so its own
+# dependencies (hardhat-errors/utils/zod-utils, peer hardhat) still resolve
+# from the registry like every other scenario dependency.
+if [ ! -d "$SOLX_PKG/dist/src" ]; then
+  echo "hardhat-solx dist not found at $SOLX_PKG/dist/src — run 'pnpm build' before benchmarking." >&2
+  exit 1
+fi
+
+# Start from an empty .solx so the glob below can only match the tarball we
+# just produced (a stale one from a prior run would make `mv` fail). The
+# plugin bits live under packages/horizon — the workspace package that
+# consumes them — not the repo root.
+rm -rf "$HORIZON/.solx"
+mkdir -p "$HORIZON/.solx"
+(cd "$SOLX_PKG" && pnpm pack --pack-destination "$HORIZON/.solx")
+# Name the tarball by content hash: npm never re-reads a changed `file:`
+# tarball when the spec and the packed version are unchanged (this froze
+# aave's shipped plugin at a stale version map on the persistent runner), so
+# a content change must change the spec. Hash via node for BSD/GNU portability.
+TARBALL="$(echo "$HORIZON/.solx/"nomicfoundation-hardhat-solx-*.tgz)"
+TARBALL_HASH="$(node -e "
+const { createHash } = require('crypto');
+const { readFileSync } = require('fs');
+console.log(createHash('sha256').update(readFileSync(process.argv[1])).digest('hex').slice(0, 12));
+" "$TARBALL")"
+mv "$TARBALL" "$HORIZON/.solx/hardhat-solx-$TARBALL_HASH.tgz"
+
+# `npm pkg set` only edits package.json (no lockfile involved). Run it inside
+# packages/horizon — not via --prefix — so the file: spec stays relative to
+# the declaring package, which is how pnpm resolves file: deps in a workspace.
+(cd "$HORIZON" && npm pkg set "devDependencies.@nomicfoundation/hardhat-solx=file:./.solx/hardhat-solx-$TARBALL_HASH.tgz")
+
+# Freshness oracle for the "assert fresh hardhat-solx" prime step: the
+# installed plugin must match this monorepo build byte-for-byte.
+cp -R "$SOLX_PKG/dist/src" "$HORIZON/.solx/expected-dist-src"
+
+# Pinned solx for the version-comparison cells: the wrapper config's
+# "solx-0.1.7" profiles point at this binary via the plugin's `path` option.
+node "$MONOREPO_ROOT/scripts/benchmark/download-solx.ts" --version 0.1.7 --out "$HORIZON/.solx/solx-v0.1.7"
+
+# Pinned forge (latest stable at pin time) for the cross-tool parity cells.
+# At 1.7.1 forge's codegen is solc (solar is lint-only), so with
+# FOUNDRY_SOLC=0.8.34 the compiler matches the hardhat cells. (FOUNDRY_SOLC,
+# not FOUNDRY_SOLC_VERSION, which forge misparses when an [etherscan] table
+# is present — see the aave-v4-solx scenario.)
+rm -rf "$HORIZON/.foundry"
+node "$MONOREPO_ROOT/scripts/benchmark/download-forge.ts" --version 1.7.1 --out "$HORIZON/.foundry/forge"
+
+# Swap in the wrapper config that adds the solx build profile. The original is
+# kept as hardhat.config.base.ts, which the wrapper composes with — see
+# hardhat.config.solx.ts. Both live in packages/horizon.
+mv "$HORIZON/hardhat.config.ts" "$HORIZON/hardhat.config.base.ts"
+cp "$E2E_TEST_DIR/hardhat.config.solx.ts" "$HORIZON/hardhat.config.ts"

--- a/end-to-end/graph-horizon-solx/preinstall.sh
+++ b/end-to-end/graph-horizon-solx/preinstall.sh
@@ -136,6 +136,18 @@ cp -R "$SOLX_PKG/dist/src" "$HORIZON/.solx/expected-dist-src"
 # "solx-0.1.7" profiles point at this binary via the plugin's `path` option.
 node "$MONOREPO_ROOT/scripts/benchmark/download-solx.ts" --version 0.1.7 --out "$HORIZON/.solx/solx-v0.1.7"
 
+# The Hardhat 3 migration stack reduced foundry.toml to a lint-only config;
+# reinstate the pre-migration one (vendored from PR #1's 8d148f39, which the
+# migration replaced) so the forge cells compile with upstream's own
+# settings — its [profile.prod] (optimizer runs 100, via-IR) matches the
+# hardhat cells' production-derived settings. Fail loudly if the shape
+# changes under the pin.
+if ! grep -q "lint_on_build" "$HORIZON/foundry.toml"; then
+  echo "graph-horizon-solx preinstall: packages/horizon/foundry.toml is not the expected lint-oriented config — the pinned commit may have changed." >&2
+  exit 1
+fi
+cp "$E2E_TEST_DIR/foundry.toml" "$HORIZON/foundry.toml"
+
 # Pinned forge (latest stable at pin time) for the cross-tool parity cells.
 # At 1.7.1 forge's codegen is solc (solar is lint-only), so with
 # FOUNDRY_SOLC=0.8.34 the compiler matches the hardhat cells. (FOUNDRY_SOLC,

--- a/end-to-end/graph-horizon-solx/scenario.json
+++ b/end-to-end/graph-horizon-solx/scenario.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
+  "description": "Graph Horizon (packages/horizon of the graphprotocol contracts pnpm monorepo — the first monorepo solx scenario) compiled at solc 0.8.34, tracking solx, solc, and forge compile times. Upstream's production profile is solc 0.8.35 + optimizer runs 100 + via-IR + cancun; the cells re-express it at 0.8.34, the only solx-mapped version (contracts and tests carry ^0.8.27-style range pragmas, so no source patching). Every command cds into packages/horizon; `workdir` points bench:dump-standard-json there. The forge cells mirror the production optimizer settings via FOUNDRY_ env vars — upstream's foundry.toml is lint-oriented and sets none — so the cross-tool parity row compares like with like. EVM_DISABLE_MEMORY_SAFE_ASM_CHECK lets solx spill the legacy cells' stack-too-deep past the unannotated assembly in RecurringCollector (see the aave-v4-solx scenario).",
+  "tags": ["external-repo", "solx"],
+  "repo": "NomicFoundation/graphprotocol-contracts",
+  "commit": "68661591b7e2e7d1672667769458aa8d84acc332",
+  "packageManager": "pnpm",
+  "submodules": false,
+  "workdir": "packages/horizon",
+  "preinstall": "./preinstall.sh",
+  "env": {
+    "pnpm_config_dangerously_allow_all_builds": "true",
+    "pnpm_config_frozen_lockfile": "false",
+    "pnpm_config_block_exotic_subdeps": "false",
+    "EVM_DISABLE_MEMORY_SAFE_ASM_CHECK": "1"
+  },
+  "defaultCommand": "cd packages/horizon && npx hardhat compile --build-profile solx",
+  "benchmark": {
+    "commands": {
+      "prime compilers": {
+        "runs": 1,
+        "steps": {
+          "build workspace deps": {
+            "command": "pnpm --filter '@graphprotocol/horizon^...' run build:self",
+            "measure": false
+          },
+          "assert fresh hardhat-solx": {
+            "command": "cd packages/horizon && diff -rq .solx/expected-dist-src node_modules/@nomicfoundation/hardhat-solx/dist/src",
+            "measure": false
+          },
+          "download solc + solx and warm caches": {
+            "command": "cd packages/horizon && npx hardhat compile && npx hardhat compile --build-profile solx && npx hardhat clean",
+            "measure": false
+          },
+          "warm forge solc cache": {
+            "command": "cd packages/horizon && FOUNDRY_SOLC=0.8.34 FOUNDRY_OPTIMIZER=true FOUNDRY_OPTIMIZER_RUNS=100 ./.foundry/forge build && ./.foundry/forge clean",
+            "measure": false
+          }
+        }
+      },
+      "cold compile solx-0.1.7": {
+        "runs": 2,
+        "dependsOn": [
+          "build workspace deps",
+          "assert fresh hardhat-solx",
+          "download solc + solx and warm caches"
+        ],
+        "prepare": "cd packages/horizon && npx hardhat clean",
+        "command": "cd packages/horizon && npx hardhat compile --build-profile solx-0.1.7"
+      },
+      "cold compile solx-0.1.7 via-ir": {
+        "runs": 2,
+        "dependsOn": [
+          "build workspace deps",
+          "assert fresh hardhat-solx",
+          "download solc + solx and warm caches"
+        ],
+        "prepare": "cd packages/horizon && npx hardhat clean",
+        "command": "cd packages/horizon && npx hardhat compile --build-profile solx-0.1.7-via-ir"
+      },
+      "cold compile solc": {
+        "runs": 2,
+        "dependsOn": [
+          "build workspace deps",
+          "assert fresh hardhat-solx",
+          "download solc + solx and warm caches"
+        ],
+        "prepare": "cd packages/horizon && npx hardhat clean",
+        "command": "cd packages/horizon && npx hardhat compile"
+      },
+      "cold compile solc no-opt": {
+        "runs": 2,
+        "dependsOn": [
+          "build workspace deps",
+          "assert fresh hardhat-solx",
+          "download solc + solx and warm caches"
+        ],
+        "prepare": "cd packages/horizon && npx hardhat clean",
+        "command": "cd packages/horizon && npx hardhat compile --build-profile solc-no-opt"
+      },
+      "cold compile solc via-ir": {
+        "runs": 2,
+        "dependsOn": [
+          "build workspace deps",
+          "assert fresh hardhat-solx",
+          "download solc + solx and warm caches"
+        ],
+        "prepare": "cd packages/horizon && npx hardhat clean",
+        "command": "cd packages/horizon && npx hardhat compile --build-profile solc-via-ir"
+      },
+      "cold compile forge-1.7.1": {
+        "runs": 2,
+        "dependsOn": ["build workspace deps", "warm forge solc cache"],
+        "prepare": "cd packages/horizon && ./.foundry/forge clean",
+        "command": "cd packages/horizon && FOUNDRY_SOLC=0.8.34 FOUNDRY_OPTIMIZER=true FOUNDRY_OPTIMIZER_RUNS=100 ./.foundry/forge build --offline"
+      }
+    }
+  }
+}

--- a/end-to-end/graph-horizon-solx/scenario.json
+++ b/end-to-end/graph-horizon-solx/scenario.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
-  "description": "Graph Horizon (packages/horizon of the graphprotocol contracts pnpm monorepo — the first monorepo solx scenario) compiled at solc 0.8.34, tracking solx, solc, and forge compile times. Upstream's production profile is solc 0.8.35 + optimizer runs 100 + via-IR + cancun; the cells re-express it at 0.8.34, the only solx-mapped version (contracts and tests carry ^0.8.27-style range pragmas, so no source patching). Every command cds into packages/horizon; `workdir` points bench:dump-standard-json there. The forge cells mirror the production optimizer settings via FOUNDRY_ env vars — upstream's foundry.toml is lint-oriented and sets none — so the cross-tool parity row compares like with like. EVM_DISABLE_MEMORY_SAFE_ASM_CHECK lets solx spill the legacy cells' stack-too-deep past the unannotated assembly in RecurringCollector (see the aave-v4-solx scenario).",
+  "description": "Graph Horizon (packages/horizon of the graphprotocol contracts pnpm monorepo — the first monorepo solx scenario) compiled at solc 0.8.34, tracking solx, solc, and forge compile times. Upstream's production profile is solc 0.8.35 + optimizer runs 100 + via-IR + cancun; the cells re-express it at 0.8.34, the only solx-mapped version (contracts and tests carry ^0.8.27-style range pragmas, so no source patching). Every command cds into packages/horizon; `workdir` points bench:dump-standard-json there. The migration stack reduced foundry.toml to a lint-only config; preinstall reinstates the pre-migration one from PR #1, whose [profile.prod] (optimizer runs 100, via-IR) matches the hardhat cells — the via-IR forge cell uses FOUNDRY_PROFILE=prod, and the legacy cell sets the same optimizer via FOUNDRY_ env on the optimizer-off default profile, so both cross-tool parity rows compare like with like. EVM_DISABLE_MEMORY_SAFE_ASM_CHECK lets solx spill the legacy cells' stack-too-deep past the unannotated assembly in RecurringCollector (see the aave-v4-solx scenario).",
   "tags": ["external-repo", "solx"],
   "repo": "NomicFoundation/graphprotocol-contracts",
   "commit": "68661591b7e2e7d1672667769458aa8d84acc332",
@@ -33,7 +33,7 @@
             "measure": false
           },
           "warm forge solc cache": {
-            "command": "cd packages/horizon && FOUNDRY_SOLC=0.8.34 FOUNDRY_OPTIMIZER=true FOUNDRY_OPTIMIZER_RUNS=100 ./.foundry/forge build && ./.foundry/forge clean",
+            "command": "cd packages/horizon && FOUNDRY_SOLC=0.8.34 FOUNDRY_PROFILE=prod ./.foundry/forge build && ./.foundry/forge clean",
             "measure": false
           }
         }
@@ -93,6 +93,12 @@
         "dependsOn": ["build workspace deps", "warm forge solc cache"],
         "prepare": "cd packages/horizon && ./.foundry/forge clean",
         "command": "cd packages/horizon && FOUNDRY_SOLC=0.8.34 FOUNDRY_OPTIMIZER=true FOUNDRY_OPTIMIZER_RUNS=100 ./.foundry/forge build --offline"
+      },
+      "cold compile forge-1.7.1 via-ir": {
+        "runs": 2,
+        "dependsOn": ["build workspace deps", "warm forge solc cache"],
+        "prepare": "cd packages/horizon && ./.foundry/forge clean",
+        "command": "cd packages/horizon && FOUNDRY_SOLC=0.8.34 FOUNDRY_PROFILE=prod ./.foundry/forge build --offline"
       }
     }
   }

--- a/end-to-end/lidofinance-core-solx/foundry.toml
+++ b/end-to-end/lidofinance-core-solx/foundry.toml
@@ -1,0 +1,67 @@
+[profile.default]
+# The source directory
+src = 'contracts'
+
+# The artifact directory
+out = 'foundry/out'
+
+# A list of paths to look for libraries in
+libs = ['node_modules', 'foundry/lib']
+
+# The test directory
+test = 'test'
+
+# Whether to cache builds or not
+cache = true
+
+# The cache directory if enabled
+cache_path = 'foundry/cache'
+
+# Only run tests in contracts matching the specified glob pattern
+match_path = '**/test/**/*.t.sol'
+
+# Enable latest EVM features
+evm_version = "prague"
+optimizer = true
+optimizer_runs = 200
+
+fmt = { int_types = 'long' }
+
+# profiles required by compilation_restrictions
+additional_compiler_profiles = [
+    { name = "solc0424", optimizer = true, optimizer_runs = 200, evm_version = "constantinople" },
+    { name = "solc06x_089", optimizer = true, optimizer_runs = 200, evm_version = "istanbul" },
+    { name = "solc0825", optimizer = true, optimizer_runs = 200, via_ir = true, evm_version = "cancun" },
+    { name = "v3", optimizer = true, optimizer_runs = 200, via_ir = true, evm_version = "cancun" },
+    { name = "vaultHub", optimizer = true, optimizer_runs = 100, via_ir = true, evm_version = "cancun" },
+]
+
+# align compiler settings with hardhat.config.ts
+compilation_restrictions = [
+    { paths = "contracts/0.4.24/**", optimizer_runs = 200, evm_version = "constantinople" },
+    { paths = "contracts/0.6.11/**", optimizer_runs = 200, evm_version = "istanbul" },
+    { paths = "contracts/0.6.12/**", optimizer_runs = 200, evm_version = "istanbul" },
+    { paths = "contracts/0.8.9/**", optimizer_runs = 200, evm_version = "istanbul" },
+    { paths = "contracts/0.8.25/**", optimizer_runs = 200, via_ir = true, evm_version = "cancun" },
+    { paths = "contracts/upgrade/**", optimizer_runs = 200, via_ir = true, evm_version = "cancun" },
+    # NB: Foundry cannot safely mirror Hardhat's strict VaultHub runs=100 override
+    # together with a runs=200 rule on the same import graph, so we keep a merge-safe
+    # range here for compatibility.
+    { paths = "contracts/0.8.25/vaults/VaultHub.sol", min_optimizer_runs = 100, max_optimizer_runs = 200, via_ir = true, evm_version = "cancun" },
+]
+
+[profile.default.invariant]
+runs = 256
+depth = 500
+
+[profile.deep]
+# Inherits all settings from default profile
+# Used for certification runs (10,000 invariant runs)
+# Run with: FOUNDRY_PROFILE=deep forge test
+
+[profile.deep.fuzz]
+runs = 10000
+
+[profile.deep.invariant]
+runs = 10000
+depth = 500

--- a/end-to-end/lidofinance-core-solx/hardhat.config.solx.ts
+++ b/end-to-end/lidofinance-core-solx/hardhat.config.solx.ts
@@ -10,8 +10,9 @@
 // base's 0.8.25 compiler settings. Its transitive imports (contracts/common,
 // vendored + npm OpenZeppelin) carry range pragmas and compile at 0.8.34
 // unpatched. Upstream ships this tree via-IR only, and it cannot compile any
-// other way: RefSlotCache copies a struct array to storage, which solc's
-// legacy codegen rejects with an UnimplementedFeatureError (IR-only feature).
+// other way: SRLib hits stack-too-deep, and RefSlotCache copies a struct
+// array to storage, which solc's legacy codegen rejects with an
+// UnimplementedFeatureError (IR-only feature).
 // So only the via-IR cells are benchmarked; the legacy/no-opt profiles below
 // exist for the plugin's mandatory "solx" profile and for reproducing the
 // failure (`--build-profile solc-no-opt`), and their FAIL is the datum,

--- a/end-to-end/lidofinance-core-solx/hardhat.config.solx.ts
+++ b/end-to-end/lidofinance-core-solx/hardhat.config.solx.ts
@@ -1,0 +1,162 @@
+// Wrapper config dropped over the pinned Lido core fork's hardhat.config.ts
+// by preinstall.sh (which renames the original to hardhat.config.base.ts).
+//
+// The fork's config compiles five solc versions: 0.4.24-0.8.9 legacy trees
+// plus the modern vaults tree at 0.8.25 (via-IR, cancun). solx only embeds
+// 0.8.34, and the older trees predate the 0.8.x language era entirely, so
+// this benchmark scopes sources to contracts/0.8.25 — the one tree lido
+// could realistically move to solx — and re-expresses it as the benchmark's
+// matrix of profiles, {solc, solx} x {legacy, via-IR}, all seeded from the
+// base's 0.8.25 compiler settings. Its transitive imports (contracts/common,
+// vendored + npm OpenZeppelin) carry range pragmas and compile at 0.8.34
+// unpatched. Upstream ships this tree via-IR only, and it cannot compile any
+// other way: RefSlotCache copies a struct array to storage, which solc's
+// legacy codegen rejects with an UnimplementedFeatureError (IR-only feature).
+// So only the via-IR cells are benchmarked; the legacy/no-opt profiles below
+// exist for the plugin's mandatory "solx" profile and for reproducing the
+// failure (`--build-profile solc-no-opt`), and their FAIL is the datum,
+// annotated in render-solx-tables' CELL_NOTES. The base's
+// npmFilesToBuild (Aragon/OZ roots) belong to the dropped legacy trees; the
+// contract sizer's compile hook would time an unrelated post-compile pass in
+// every cell, so it's disabled. Everything else (plugins, tasks, test,
+// warnings) is preserved from the base.
+import path from "node:path";
+
+import hardhatSolx from "@nomicfoundation/hardhat-solx";
+import baseConfig from "./hardhat.config.base.ts";
+
+const base = baseConfig as unknown as {
+  plugins: unknown[];
+  paths: Record<string, unknown>;
+  contractSizer: Record<string, unknown>;
+  solidity: {
+    compilers: Array<{ version: string; settings: Record<string, unknown> }>;
+  };
+  [key: string]: unknown;
+};
+
+// Seed every profile from upstream's modern-tree entry (optimizer runs 200,
+// viaIR: true, evmVersion cancun — cancun is in solx's supported set).
+const modernEntry = base.solidity.compilers.find((c) => c.version === "0.8.25");
+if (modernEntry === undefined) {
+  throw new Error(
+    "lidofinance-core-solx: no 0.8.25 compiler entry in the base config — the pinned commit may have changed",
+  );
+}
+
+// Independent settings objects per profile so the solx profiles can't bleed into
+// the solc profile. The solx optimization level (-O1) and DWARF debug info both
+// come from the hardhat-solx plugin defaults: DWARF is force-emitted, so solx
+// maps sources just as solc does (Hardhat force-emits solc sourceMaps), keeping
+// the comparison apples-to-apples. We intentionally don't override the optimizer
+// here so the benchmark measures the realistic plugin-default config.
+const baseSettings = modernEntry.settings;
+const solcViaIRSettings = structuredClone(baseSettings);
+const solxViaIRSettings = structuredClone(baseSettings);
+
+// Legacy variants: same settings, only `viaIR` flips (the base default is IR).
+// Both solc and solx read `settings.viaIR` (there is no `--via-ir` CLI flag —
+// it's config-only).
+const solcSettings = { ...structuredClone(baseSettings), viaIR: false };
+const solxSettings = { ...structuredClone(baseSettings), viaIR: false };
+
+// Optimizer-off legacy solc — the Foundry test-run default and solc at its
+// fastest, so it's the real-world compile-time bar for a test-only compiler.
+const solcNoOptSettings = {
+  ...structuredClone(solcSettings),
+  optimizer: { enabled: false },
+};
+
+// The "solx" profiles always measure the version the plugin ships (its
+// Solidity→solx version map). The "solx-0.1.7" profiles pin a release under
+// comparison via the plugin's `path` compiler option; preinstall.sh downloads
+// the binary (see scripts/benchmark/download-solx.ts).
+const solx017Path = path.join(import.meta.dirname, ".solx", "solx-v0.1.7");
+
+// Upstream's single per-file escape hatch, re-pinned to 0.8.34: VaultHub
+// builds via-IR at optimizer runs 100 in every profile (upstream ships it
+// that way to keep the contract under the size limit; keeping it in the
+// legacy cells is the aave precedent for per-file via-IR overrides).
+function vaultHubOverride(type?: "solx", solxPath?: string) {
+  return {
+    "contracts/0.8.25/vaults/VaultHub.sol": {
+      ...(type === undefined ? {} : { type }),
+      ...(solxPath === undefined ? {} : { path: solxPath }),
+      version: "0.8.34",
+      settings: {
+        ...structuredClone(baseSettings),
+        optimizer: { enabled: true, runs: 100 },
+        viaIR: true,
+      },
+    },
+  };
+}
+
+export default {
+  ...base,
+  plugins: [...base.plugins, hardhatSolx],
+  // The plugin only allows type: "solx" in the profile named "solx"; this
+  // benchmark needs a second solx profile ("solx-via-ir") for the viaIR sweep,
+  // so opt out of that guard. Throwaway benchmark scenario, not production.
+  solx: { dangerouslyAllowSolxInProduction: true },
+  // Scope to the modern tree (see the header comment). test/ stays out via
+  // --no-tests on every cell: paths.tests.solidity defaults to test/, whose
+  // fixtures span 0.4.24-0.8.9.
+  paths: { ...base.paths, sources: { solidity: ["contracts/0.8.25"] } },
+  // Upstream runs the sizer on every compile unless SKIP_CONTRACT_SIZE is
+  // set; it would time an unrelated post-compile pass in every cell.
+  contractSizer: { ...base.contractSizer, runOnCompile: false },
+  solidity: {
+    // No npmFilesToBuild on purpose: the base's Aragon/OZ roots belong to the
+    // legacy trees; the modern tree's OpenZeppelin needs are ordinary imports
+    // that Hardhat resolves automatically.
+    profiles: {
+      default: {
+        compilers: [{ version: "0.8.34", settings: solcSettings }],
+        overrides: vaultHubOverride(),
+      },
+      "solc-no-opt": {
+        compilers: [{ version: "0.8.34", settings: solcNoOptSettings }],
+        overrides: vaultHubOverride(),
+      },
+      "solc-via-ir": {
+        compilers: [{ version: "0.8.34", settings: solcViaIRSettings }],
+        overrides: vaultHubOverride(),
+      },
+      solx: {
+        compilers: [
+          { type: "solx", version: "0.8.34", settings: solxSettings },
+        ],
+        overrides: vaultHubOverride("solx"),
+      },
+      "solx-via-ir": {
+        compilers: [
+          { type: "solx", version: "0.8.34", settings: solxViaIRSettings },
+        ],
+        overrides: vaultHubOverride("solx"),
+      },
+      "solx-0.1.7": {
+        compilers: [
+          {
+            type: "solx",
+            version: "0.8.34",
+            path: solx017Path,
+            settings: structuredClone(solxSettings),
+          },
+        ],
+        overrides: vaultHubOverride("solx", solx017Path),
+      },
+      "solx-0.1.7-via-ir": {
+        compilers: [
+          {
+            type: "solx",
+            version: "0.8.34",
+            path: solx017Path,
+            settings: structuredClone(solxViaIRSettings),
+          },
+        ],
+        overrides: vaultHubOverride("solx", solx017Path),
+      },
+    },
+  },
+};

--- a/end-to-end/lidofinance-core-solx/preinstall.sh
+++ b/end-to-end/lidofinance-core-solx/preinstall.sh
@@ -131,8 +131,26 @@ cp -R "$SOLX_PKG/dist/src" "$WORKDIR/.solx/expected-dist-src"
 # "solx-0.1.7" profiles point at this binary via the plugin's `path` option.
 node "$MONOREPO_ROOT/scripts/benchmark/download-solx.ts" --version 0.1.7 --out "$WORKDIR/.solx/solx-v0.1.7"
 
-# No pinned forge: the repo ships no foundry.toml, so there is no upstream
-# forge configuration to reproduce and the scenario has no forge cells.
+# The Hardhat 3 migration removed the repo's foundry.toml; reinstate the
+# pre-migration one (vendored from NomicFoundation/lido-core@242beb163) so
+# the forge cells compile with upstream's own per-tree settings — its
+# compilation_restrictions mirror hardhat.config.ts, including the 0.8.25
+# tree's via-IR/cancun. remappings.txt survives at the pin and resolves
+# forge-std from npm, so the removed foundry/lib submodule isn't needed for
+# builds. Fail loudly if the pin ships its own foundry.toml again.
+if [ -e foundry.toml ]; then
+  echo "lidofinance-core-solx preinstall: the pinned commit ships a foundry.toml — the pin may have changed; refusing to overwrite it." >&2
+  exit 1
+fi
+cp "$E2E_TEST_DIR/foundry.toml" foundry.toml
+
+# Pinned forge (latest stable at pin time) for the cross-tool parity cells.
+# At 1.7.1 forge's codegen is solc (solar is lint-only), so with
+# FOUNDRY_SOLC=0.8.34 the compiler matches the hardhat cells. (FOUNDRY_SOLC,
+# not FOUNDRY_SOLC_VERSION, which forge misparses when an [etherscan] table
+# is present — see the aave-v4-solx scenario.)
+rm -rf "$WORKDIR/.foundry"
+node "$MONOREPO_ROOT/scripts/benchmark/download-forge.ts" --version 1.7.1 --out "$WORKDIR/.foundry/forge"
 
 # Swap in the wrapper config that adds the solx build profile. The original is
 # kept as hardhat.config.base.ts, which the wrapper composes with — see

--- a/end-to-end/lidofinance-core-solx/preinstall.sh
+++ b/end-to-end/lidofinance-core-solx/preinstall.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKDIR="$PWD"
+MONOREPO_ROOT="$(cd "$E2E_TEST_DIR/../.." && pwd)"
+SOLX_PKG="$MONOREPO_ROOT/packages/hardhat-solx"
+
+# The benchmark profiles all pin solc 0.8.34 (the only version solx embeds),
+# but the modern vaults tree pins `pragma solidity 0.8.25;` exactly. Relax
+# those exact pragmas to caret ranges so the same sources compile under
+# 0.8.34. The walker also touches exact-0.8.25 files outside contracts/0.8.25
+# (tooling, upgrade helpers, tests) — harmless, the wrapper config's scoped
+# sources and --no-tests keep them out of every cell. The transitive imports
+# (contracts/common, vendored + npm OpenZeppelin) already carry range pragmas
+# and need no patching. Use node for the file transforms to avoid BSD/GNU sed
+# portability issues (matches the convention used by the other scenarios'
+# preinstall scripts).
+node -e "
+const fs = require('fs');
+const path = require('path');
+
+const FROM = 'pragma solidity 0.8.25;';
+const TO = 'pragma solidity ^0.8.25;';
+// Unlike aave's walker this one must NOT skip 'lib': the repo has no
+// submodules, and contracts/0.8.25/vaults/lib holds first-party sources
+// whose exact pragmas need relaxing too.
+const SKIP_DIRS = new Set(['node_modules', '.git']);
+
+let patched = 0;
+
+(function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) {
+        walk(entryPath);
+      }
+    } else if (entry.name.endsWith('.sol')) {
+      const source = fs.readFileSync(entryPath, 'utf8');
+      if (source.includes(FROM)) {
+        fs.writeFileSync(entryPath, source.replaceAll(FROM, TO));
+        patched++;
+      }
+    }
+  }
+})('.');
+
+if (patched === 0) {
+  console.error(
+    'lidofinance-core-solx preinstall: no \`' + FROM + '\` pragmas found — ' +
+      'the pinned commit may have changed. Refusing to benchmark an ' +
+      'unexpected source tree.',
+  );
+  process.exit(1);
+}
+
+console.log('lidofinance-core-solx preinstall: relaxed the pinned pragma in ' + patched + ' files');
+"
+
+# Same package.json fixups as the non-solx lidofinance-core scenario (which
+# shares this repo pin). Use node for the transforms to avoid BSD/GNU sed
+# portability issues.
+node -e "
+const fs = require('fs');
+
+// Allow Verdaccio-published hardhat to satisfy the dependency: the pin
+// declares an exact hardhat version that the locally published bump would
+// not satisfy.
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+pkg.devDependencies ??= {};
+pkg.devDependencies.hardhat = '^3.9.0';
+
+// Pin ethers tree-wide to the repo's exact version. The lockfile removal below
+// otherwise gives hardhat-ethers (ethers: ^6.14.0) a newer nested copy than the
+// repo's pin, and two ethers classes break the test helpers' \`instanceof
+// EventLog\` checks (findEvents in lib/event.ts finds no events).
+const ethersVersion = pkg.dependencies?.ethers ?? pkg.devDependencies?.ethers;
+if (ethersVersion === undefined) {
+  console.error(
+    'lidofinance-core-solx preinstall: expected an ethers pin in package.json — ' +
+      'the pinned commit may have changed. Refusing to run without a ' +
+      'tree-wide ethers resolution.',
+  );
+  process.exit(1);
+}
+pkg.resolutions = { ...pkg.resolutions, ethers: ethersVersion };
+
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+# Remove lockfile so yarn resolves the latest from Verdaccio instead of the pinned version
+rm -f yarn.lock
+
+# hardhat-solx is `private` and excluded from the Verdaccio publish set, so it
+# never reaches the registry. Pack it instead (pack ignores `private`) and
+# consume the tarball as a file: dependency. `pnpm pack` — not `npm pack` —
+# rewrites the plugin's `workspace:` deps to real version ranges, so its own
+# dependencies (hardhat-errors/utils/zod-utils, peer hardhat) still resolve
+# from the registry like every other scenario dependency.
+if [ ! -d "$SOLX_PKG/dist/src" ]; then
+  echo "hardhat-solx dist not found at $SOLX_PKG/dist/src — run 'pnpm build' before benchmarking." >&2
+  exit 1
+fi
+
+# Start from an empty .solx so the glob below can only match the tarball we
+# just produced (a stale one from a prior run would make `mv` fail).
+rm -rf "$WORKDIR/.solx"
+mkdir -p "$WORKDIR/.solx"
+(cd "$SOLX_PKG" && pnpm pack --pack-destination "$WORKDIR/.solx")
+# Name the tarball by content hash: npm never re-reads a changed `file:`
+# tarball when the spec and the packed version are unchanged (this froze
+# aave's shipped plugin at a stale version map on the persistent runner), so
+# a content change must change the spec. Hash via node for BSD/GNU portability.
+TARBALL="$(echo "$WORKDIR/.solx/"nomicfoundation-hardhat-solx-*.tgz)"
+TARBALL_HASH="$(node -e "
+const { createHash } = require('crypto');
+const { readFileSync } = require('fs');
+console.log(createHash('sha256').update(readFileSync(process.argv[1])).digest('hex').slice(0, 12));
+" "$TARBALL")"
+mv "$TARBALL" "$WORKDIR/.solx/hardhat-solx-$TARBALL_HASH.tgz"
+
+# `npm pkg set` only edits package.json (no lockfile involved), so it is safe
+# under yarn too; the subsequent `yarn install` resolves the new file: entry.
+npm pkg set "devDependencies.@nomicfoundation/hardhat-solx=file:./.solx/hardhat-solx-$TARBALL_HASH.tgz"
+
+# Freshness oracle for the "assert fresh hardhat-solx" prime step: the
+# installed plugin must match this monorepo build byte-for-byte.
+cp -R "$SOLX_PKG/dist/src" "$WORKDIR/.solx/expected-dist-src"
+
+# Pinned solx for the version-comparison cells: the wrapper config's
+# "solx-0.1.7" profiles point at this binary via the plugin's `path` option.
+node "$MONOREPO_ROOT/scripts/benchmark/download-solx.ts" --version 0.1.7 --out "$WORKDIR/.solx/solx-v0.1.7"
+
+# No pinned forge: the repo ships no foundry.toml, so there is no upstream
+# forge configuration to reproduce and the scenario has no forge cells.
+
+# Swap in the wrapper config that adds the solx build profile. The original is
+# kept as hardhat.config.base.ts, which the wrapper composes with — see
+# hardhat.config.solx.ts.
+mv hardhat.config.ts hardhat.config.base.ts
+cp "$E2E_TEST_DIR/hardhat.config.solx.ts" hardhat.config.ts

--- a/end-to-end/lidofinance-core-solx/scenario.json
+++ b/end-to-end/lidofinance-core-solx/scenario.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
+  "description": "Lido core's modern vaults tree (contracts/0.8.25 only) compiled at solc 0.8.34, tracking solx and solc compile times. The repo's older trees (0.4.24-0.8.9) predate the 0.8.x language era and can never compile under the 0.8.34 the solx cells require, so the wrapper config scopes sources to the one tree solx could realistically adopt. Via-IR cells only: the tree is IR-native (RefSlotCache copies a struct array to storage, an UnimplementedFeatureError in solc's legacy codegen), so no compiler has legacy or no-opt cells — that FAIL is the datum, annotated in CELL_NOTES. Every hardhat cell passes --no-tests: paths.tests.solidity defaults to test/, whose fixtures span 0.4.24-0.8.9. No forge cells: the repo ships no foundry.toml, so there is no upstream forge configuration to reproduce (the cross-tool parity table simply has no lido row). SKIP_LINT_SOLIDITY/SKIP_INTERFACES_CHECK are upstream's own escape hatches for its build-task override, which otherwise adds solhint + ABI checks to every timed compile (and the solhint lido/fixed-compiler-version rule rejects the caret pragmas preinstall introduces). EVM_DISABLE_MEMORY_SAFE_ASM_CHECK lets solx spill stack-too-deep despite the deprecated natspec memory-safe annotations in contracts/common's assembly (GIndex/SSZ/BLS; upstream OZ-style block annotations would lift the restriction — see the aave-v4-solx scenario).",
+  "tags": ["external-repo", "solx"],
+  "repo": "NomicFoundation/lidofinance-core",
+  "commit": "3d690c270cde8f0509e2a20d6ae659ef76e094e0",
+  "packageManager": "yarn",
+  "submodules": false,
+  "preinstall": "./preinstall.sh",
+  "env": {
+    "SKIP_LINT_SOLIDITY": "1",
+    "SKIP_INTERFACES_CHECK": "1",
+    "EVM_DISABLE_MEMORY_SAFE_ASM_CHECK": "1"
+  },
+  "defaultCommand": "npx hardhat compile --build-profile solx-via-ir --no-tests",
+  "benchmark": {
+    "commands": {
+      "prime compilers": {
+        "runs": 1,
+        "steps": {
+          "assert fresh hardhat-solx": {
+            "command": "diff -rq .solx/expected-dist-src node_modules/@nomicfoundation/hardhat-solx/dist/src",
+            "measure": false
+          },
+          "download solc + solx and warm caches": {
+            "command": "npx hardhat compile --build-profile solc-via-ir --no-tests && npx hardhat compile --build-profile solx-via-ir --no-tests && npx hardhat clean",
+            "measure": false
+          }
+        }
+      },
+      "cold compile solx-0.1.7 via-ir": {
+        "runs": 2,
+        "dependsOn": [
+          "assert fresh hardhat-solx",
+          "download solc + solx and warm caches"
+        ],
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile --build-profile solx-0.1.7-via-ir --no-tests"
+      },
+      "cold compile solc via-ir": {
+        "runs": 2,
+        "dependsOn": [
+          "assert fresh hardhat-solx",
+          "download solc + solx and warm caches"
+        ],
+        "prepare": "npx hardhat clean",
+        "command": "npx hardhat compile --build-profile solc-via-ir --no-tests"
+      }
+    }
+  }
+}

--- a/end-to-end/lidofinance-core-solx/scenario.json
+++ b/end-to-end/lidofinance-core-solx/scenario.json
@@ -1,9 +1,9 @@
 {
   "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
-  "description": "Lido core's modern vaults tree (contracts/0.8.25 only) compiled at solc 0.8.34, tracking solx and solc compile times. The repo's older trees (0.4.24-0.8.9) predate the 0.8.x language era and can never compile under the 0.8.34 the solx cells require, so the wrapper config scopes sources to the one tree solx could realistically adopt. Via-IR cells only: the tree is IR-native (RefSlotCache copies a struct array to storage, an UnimplementedFeatureError in solc's legacy codegen), so no compiler has legacy or no-opt cells — that FAIL is the datum, annotated in CELL_NOTES. Every hardhat cell passes --no-tests: paths.tests.solidity defaults to test/, whose fixtures span 0.4.24-0.8.9. No forge cells: the repo ships no foundry.toml, so there is no upstream forge configuration to reproduce (the cross-tool parity table simply has no lido row). SKIP_LINT_SOLIDITY/SKIP_INTERFACES_CHECK are upstream's own escape hatches for its build-task override, which otherwise adds solhint + ABI checks to every timed compile (and the solhint lido/fixed-compiler-version rule rejects the caret pragmas preinstall introduces). EVM_DISABLE_MEMORY_SAFE_ASM_CHECK lets solx spill stack-too-deep despite the deprecated natspec memory-safe annotations in contracts/common's assembly (GIndex/SSZ/BLS; upstream OZ-style block annotations would lift the restriction — see the aave-v4-solx scenario).",
+  "description": "Lido core's modern vaults tree (contracts/0.8.25 only) compiled at solc 0.8.34, tracking forge, solx, and solc compile times on the Hardhat 3 migration branch (lidofinance/core PR #1935). The repo's older trees (0.4.24-0.8.9) predate the 0.8.x language era and can never compile under the 0.8.34 the solx cells require, so the wrapper config scopes sources to the one tree solx could realistically adopt; the forge cells scope the same way via FOUNDRY_SRC. Hardhat cells are via-IR only: the tree is IR-native (SRLib hits stack-too-deep and RefSlotCache's struct-array copy to storage is an UnimplementedFeatureError in solc's legacy codegen), so no compiler has legacy or no-opt cells — that FAIL is the datum, annotated in CELL_NOTES. Every hardhat cell passes --no-tests, and the forge cells --skip 'test/**': test/ fixtures span 0.4.24-0.8.9. The migration removed the repo's foundry.toml; preinstall reinstates the pre-migration one (which aligns per-tree compiler settings with hardhat.config.ts via compilation_restrictions) so forge compiles the same sources with the same settings — the forge-std remapping resolves from npm, so the removed foundry/lib submodule isn't needed for builds. SKIP_LINT_SOLIDITY/SKIP_INTERFACES_CHECK are upstream's own escape hatches for its build-task override, which otherwise adds solhint + ABI checks to every timed compile (and the solhint lido/fixed-compiler-version rule rejects the caret pragmas preinstall introduces). EVM_DISABLE_MEMORY_SAFE_ASM_CHECK lets solx spill stack-too-deep despite the deprecated natspec memory-safe annotations in contracts/common's assembly (GIndex/SSZ/BLS; see the aave-v4-solx scenario).",
   "tags": ["external-repo", "solx"],
-  "repo": "NomicFoundation/lidofinance-core",
-  "commit": "3d690c270cde8f0509e2a20d6ae659ef76e094e0",
+  "repo": "NomicFoundation/lido-core",
+  "commit": "28bc9f7ff2c4425849bbd883b7e52820feecd4c6",
   "packageManager": "yarn",
   "submodules": false,
   "preinstall": "./preinstall.sh",
@@ -25,6 +25,10 @@
           "download solc + solx and warm caches": {
             "command": "npx hardhat compile --build-profile solc-via-ir --no-tests && npx hardhat compile --build-profile solx-via-ir --no-tests && npx hardhat clean",
             "measure": false
+          },
+          "warm forge solc cache": {
+            "command": "FOUNDRY_SOLC=0.8.34 FOUNDRY_SRC=contracts/0.8.25 ./.foundry/forge build --skip 'test/**' && ./.foundry/forge clean",
+            "measure": false
           }
         }
       },
@@ -45,6 +49,12 @@
         ],
         "prepare": "npx hardhat clean",
         "command": "npx hardhat compile --build-profile solc-via-ir --no-tests"
+      },
+      "cold compile forge-1.7.1 via-ir": {
+        "runs": 2,
+        "dependsOn": ["warm forge solc cache"],
+        "prepare": "./.foundry/forge clean",
+        "command": "FOUNDRY_SOLC=0.8.34 FOUNDRY_SRC=contracts/0.8.25 ./.foundry/forge build --skip 'test/**' --offline"
       }
     }
   }

--- a/scripts/benchmark/dump-standard-json.ts
+++ b/scripts/benchmark/dump-standard-json.ts
@@ -4,6 +4,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -163,6 +164,9 @@ function main(): void {
 
   for (const jsonPath of scenarioPaths) {
     const { id, workingDir, definition } = loadScenario(cloneDir, jsonPath);
+    // Monorepo scenarios keep their Hardhat project in a subdirectory; the
+    // scenario's `workdir` points the direct hardhat invocations below there.
+    const compileCwd = path.join(workingDir, definition.workdir ?? ".");
     const scenarioOutDir = path.join(outDir, id);
     const manifestScenario: ManifestScenario = {
       repo: definition.repo,
@@ -177,20 +181,36 @@ function main(): void {
 
     for (const { file, flags, env } of variantsFor(definition)) {
       const dumpPath = path.join(scenarioOutDir, file);
-      execSync("npx hardhat clean", { cwd: workingDir, stdio: "ignore" });
+      execSync("npx hardhat clean", { cwd: compileCwd, stdio: "ignore" });
       // definition.env carries scenario-level compile requirements (e.g.
       // aave-v4-solx's EVM_DISABLE_MEMORY_SAFE_ASM_CHECK); without it the
       // dump compile fails where the benchmarked cells succeed.
-      execSync(["npx", "hardhat", "compile", ...flags].join(" "), {
-        cwd: workingDir,
-        stdio: "ignore",
-        env: {
-          ...process.env,
-          ...definition.env,
-          ...env,
-          SOLX_STANDARD_JSON_DEBUG: dumpPath,
-        },
-      });
+      try {
+        execSync(["npx", "hardhat", "compile", ...flags].join(" "), {
+          cwd: compileCwd,
+          stdio: "ignore",
+          env: {
+            ...process.env,
+            ...definition.env,
+            ...env,
+            SOLX_STANDARD_JSON_DEBUG: dumpPath,
+          },
+        });
+      } catch {
+        // A variant may be legitimately uncompilable (lidofinance-core-solx's
+        // vaults tree is IR-only, so its plugin-mandated legacy "solx" profile
+        // can't build). Skip the variant — leaving it out of the manifest —
+        // instead of aborting the run, which would lose every other
+        // scenario's dumps and block the corpus publish. solx dumps the
+        // standard JSON before compiling, so a failed compile can still leave
+        // a file behind; remove it or the corpus copy would pick up an
+        // unmanifested dump.
+        rmSync(dumpPath, { force: true });
+        console.warn(
+          `${id}/${file}: compile failed — skipping this dump variant`,
+        );
+        continue;
+      }
 
       if (!existsSync(dumpPath)) {
         throw new Error(

--- a/scripts/benchmark/render-solx-tables.test.ts
+++ b/scripts/benchmark/render-solx-tables.test.ts
@@ -123,6 +123,24 @@ describe("renderSolxTables", () => {
         system: 0.2,
       },
     ),
+    entry("lidofinance-core-solx / cold compile solc via-ir", 21.3, {
+      times: [21.2, 21.4],
+    }),
+    entry("lidofinance-core-solx / cold compile solc via-ir (cpu)", 22.0, {
+      user: 21.5,
+      system: 0.5,
+    }),
+    entry("lidofinance-core-solx / cold compile solx-0.1.7 via-ir", 9.4, {
+      times: [9.3, 9.5],
+    }),
+    entry(
+      "lidofinance-core-solx / cold compile solx-0.1.7 via-ir (cpu)",
+      25.1,
+      {
+        user: 24.6,
+        system: 0.5,
+      },
+    ),
     entry("openzeppelin-contracts-0.34 / cold compile solc parity", 40.0, {
       times: [39.8, 40.1, 40.1],
     }),
@@ -186,6 +204,23 @@ describe("renderSolxTables", () => {
     assert.match(
       md,
       /### solady-solx[\s\S]*?\| legacy, no optimizer \| ✗ does not compile¹ \|/,
+    );
+  });
+
+  it("annotates lido's IR-only legacy rows for both compilers", () => {
+    // The scenario benchmarks via-IR cells only; the legacy and no-opt rows
+    // exist purely as annotated FAILs (the vaults tree is IR-only).
+    assert.match(
+      md,
+      /### lidofinance-core-solx[\s\S]*?\| legacy \| ✗ does not compile¹ \| ✗ does not compile¹ \|/,
+    );
+    assert.match(
+      md,
+      /### lidofinance-core-solx[\s\S]*?\| legacy, no optimizer \| ✗ does not compile¹ \| — \|/,
+    );
+    assert.match(
+      md,
+      /### lidofinance-core-solx[\s\S]*?\| via-IR \| 21\.3 \/ 22\.0 \| 9\.4 \/ 25\.1 \|/,
     );
   });
 

--- a/scripts/benchmark/render-solx-tables.ts
+++ b/scripts/benchmark/render-solx-tables.ts
@@ -130,11 +130,12 @@ const CELL_NOTES: Record<string, string> = {
 const FOOTNOTES = [
   "¹ the legacy pipeline rejects these sources: solc no-opt hits " +
     "stack-too-deep (OZ: the P256/WebAuthn-family files; solady: " +
-    "test/RedBlackTree.t.sol), and lido's vaults tree copies a struct array " +
-    "to storage — an UnimplementedFeatureError outside via-IR, for solx " +
-    "too. Reproduce with `--build-profile solc-no-opt` (or lido's plain " +
-    "`solx`) in the scenario. The failure, not a time, is the datum — see " +
-    "the scenario's wrapper config.",
+    "test/RedBlackTree.t.sol), and lido's vaults tree is IR-only — " +
+    "stack-too-deep in SRLib plus a struct-array copy to storage that is " +
+    "an UnimplementedFeatureError outside via-IR, for solx too. Reproduce " +
+    "with `--build-profile solc-no-opt` (or lido's plain `solx`) in the " +
+    "scenario. The failure, not a time, is the datum — see the scenario's " +
+    "wrapper config.",
 ];
 
 export function renderSolxTables(

--- a/scripts/benchmark/render-solx-tables.ts
+++ b/scripts/benchmark/render-solx-tables.ts
@@ -122,13 +122,19 @@ function wallCpu(d: CellData | undefined): string {
 const CELL_NOTES: Record<string, string> = {
   "openzeppelin-contracts-0.34|solc no-opt": "✗ does not compile¹",
   "solady-solx|solc no-opt": "✗ does not compile¹",
+  "lidofinance-core-solx|solc": "✗ does not compile¹",
+  "lidofinance-core-solx|solc no-opt": "✗ does not compile¹",
+  "lidofinance-core-solx|solx-0.1.7": "✗ does not compile¹",
 };
 
 const FOOTNOTES = [
-  "¹ solc legacy/no-opt hits stack-too-deep (OZ: the P256/WebAuthn-family " +
-    "files; solady: test/RedBlackTree.t.sol); reproduce with " +
-    "`--build-profile solc-no-opt` in the scenario. The failure, not a " +
-    "time, is the datum — see the scenario's wrapper config.",
+  "¹ the legacy pipeline rejects these sources: solc no-opt hits " +
+    "stack-too-deep (OZ: the P256/WebAuthn-family files; solady: " +
+    "test/RedBlackTree.t.sol), and lido's vaults tree copies a struct array " +
+    "to storage — an UnimplementedFeatureError outside via-IR, for solx " +
+    "too. Reproduce with `--build-profile solc-no-opt` (or lido's plain " +
+    "`solx`) in the scenario. The failure, not a time, is the datum — see " +
+    "the scenario's wrapper config.",
 ];
 
 export function renderSolxTables(

--- a/scripts/end-to-end/schema/scenario-schema.test.ts
+++ b/scripts/end-to-end/schema/scenario-schema.test.ts
@@ -47,10 +47,25 @@ describe("isScenarioDefinition", () => {
       tags: ["solidity-compile"],
       env: { FOO: "bar" },
       submodules: true,
+      workdir: "packages/horizon",
       disabled: true,
     };
 
     assert.equal(isScenarioDefinition(value), true);
+  });
+
+  it("rejects a non-string workdir", () => {
+    const value = {
+      description: "Compile a monorepo package",
+      repo: "NomicFoundation/graphprotocol-contracts",
+      commit: "abc123",
+      packageManager: "pnpm",
+      defaultCommand: "cd packages/horizon && npx hardhat compile",
+      tags: ["solx"],
+      workdir: 42,
+    };
+
+    assert.equal(isScenarioDefinition(value), false);
   });
 
   it("accepts bun as a package manager", () => {

--- a/scripts/end-to-end/schema/scenario-schema.ts
+++ b/scripts/end-to-end/schema/scenario-schema.ts
@@ -45,6 +45,7 @@ export function isScenarioDefinition(
     (obj.preinstall === undefined || typeof obj.preinstall === "string") &&
     (obj.install === undefined || typeof obj.install === "string") &&
     (obj.submodules === undefined || typeof obj.submodules === "boolean") &&
+    (obj.workdir === undefined || typeof obj.workdir === "string") &&
     (obj.disabled === undefined || obj.disabled === true) &&
     (obj.benchmark === undefined || isBenchmarkConfig(obj.benchmark))
   );

--- a/scripts/end-to-end/schema/scenario.schema.json
+++ b/scripts/end-to-end/schema/scenario.schema.json
@@ -62,6 +62,10 @@
       "type": "boolean",
       "description": "Initialize git submodules recursively (default: false)"
     },
+    "workdir": {
+      "type": "string",
+      "description": "Directory, relative to the repo root, containing the Hardhat project (monorepo scenarios). Used by tools that invoke hardhat directly in the initialized checkout (e.g. bench:dump-standard-json). Benchmark commands and defaultCommand still run at the repo root and must cd themselves."
+    },
     "disabled": {
       "type": "boolean",
       "const": true,

--- a/scripts/end-to-end/types.ts
+++ b/scripts/end-to-end/types.ts
@@ -28,6 +28,13 @@ interface ScenarioDefinitionBase {
   tags: string[];
   env?: Record<string, string>;
   submodules?: boolean;
+  /**
+   * Directory, relative to the repo root, containing the Hardhat project
+   * (monorepo scenarios). Used by tools that invoke hardhat directly in the
+   * initialized checkout (e.g. bench:dump-standard-json). Benchmark commands
+   * and defaultCommand still run at the repo root and must cd themselves.
+   */
+  workdir?: string;
   disabled?: true;
   benchmark?: {
     /**


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Adds `lidofinance-core-solx` and `graph-horizon-solx` to the solx regression benchmark, plus a small harness change they need. The goal is a three-way comparison — forge vs hardhat+solc vs hardhat+solx — on repos whose Hardhat 3 migrations removed their Foundry setups, so each scenario reinstates the pre-migration `foundry.toml` for its forge cells. Verified end-to-end locally: `bench:regression`, `bench:dump-standard-json`, and table rendering all produce the expected output.

### `lidofinance-core-solx`

Lido core on the Hardhat 3 migration branch (lidofinance/core#1935, pinned at `NomicFoundation/lido-core@28bc9f7ff`), scoped to the modern vaults tree (`contracts/0.8.25`) at solc 0.8.34.

- The older trees (0.4.24–0.8.9) predate the 0.8.x language era and can never compile at 0.8.34, so only the one tree lido could realistically move to solx is benchmarked. The forge cell scopes identically via `FOUNDRY_SRC`.
- **Via-IR cells only.** The vaults tree is IR-only (stack-too-deep in `SRLib`, plus `RefSlotCache`'s struct-array copy to storage — an `UnimplementedFeatureError` in legacy codegen, for solc and solx alike). The legacy/no-opt rows render as annotated FAILs; that failure is the datum.
- The forge cell uses the pre-migration `foundry.toml` (vendored from `lido-core@242beb163`), whose `compilation_restrictions` mirror `hardhat.config.ts` per tree. forge-std resolves from npm via the pin's `remappings.txt`, so the removed `foundry/lib` submodule isn't needed.
- Every hardhat cell passes `--no-tests` and uses upstream's own `SKIP_LINT_SOLIDITY` / `SKIP_INTERFACES_CHECK` hatches (lido's build task otherwise adds solhint + ABI checks to every timed compile).

Local numbers (mean wall-clock time / total CPU time; 2 runs per cell):

| pipeline | hardhat + solc 0.8.34 | hardhat + solx 0.1.7 | forge 1.7.1 + solc 0.8.34 |
|---|---|---|---|
| via-IR | 14.6 / 21.0 s | **4.0 / 13.2 s** | 12.7 / 14.0 s |
| legacy | ✗ does not compile | ✗ does not compile | — |

### `graph-horizon-solx`

Graph Horizon (`packages/horizon` of `NomicFoundation/graphprotocol-contracts`, pinned to the Hardhat 3 migration stack tip) — the first pnpm-monorepo scenario. Full 6-cell hardhat matrix plus two forge cells.

- All commands `cd packages/horizon`; an unmeasured prime step builds the workspace dists the hardhat config imports.
- Hardhat cells are seeded from upstream's **production** profile (optimizer 100, via-IR, cancun) at solc 0.8.34 (the only solx-mapped version; ranged `^0.8.27` pragmas need no patching).
- The forge cells use the pre-migration `foundry.toml` from PR #1, whose `[profile.prod]` matches those settings exactly (`FOUNDRY_PROFILE=prod` for the via-IR cell; the legacy cell sets the same optimizer via env on the optimizer-off default profile). The pin's lint-only toml only contributed its remappings block, which forge can't auto-generate.
- Preinstall works around four monorepo quirks: `engines.pnpm` (enforced unconditionally by pnpm), `minimumReleaseAge: 7200` (would reject Verdaccio's fresh publishes), version-exact `rocketh` patches orphaned by lockfile re-resolution, and the lockfile itself (its npmjs hardhat pin would otherwise satisfy `^3.11.0` and dodge the local build).

Local numbers (mean wall-clock time / total CPU time; 2 runs per cell):

| pipeline | hardhat + solc 0.8.34 | hardhat + solx 0.1.7 | forge 1.7.1 + solc 0.8.34 |
|---|---|---|---|
| via-IR | 292.8 / 320.9 s | **25.3 / 154.1 s** | 291.9 / 318.5 s |
| legacy | 38.9 / 44.0 s | 32.7 / 161.1 s | 31.8 / 34.7 s |

### Harness change

- Scenarios can declare `workdir` (schema + types): `bench:dump-standard-json` now compiles inside that package directory instead of the repo root. Benchmark commands still run at the repo root and `cd` themselves.
- A dump variant that fails to compile is skipped with a warning (partial dump removed) instead of aborting the run. Without this, lido's plugin-mandated but uncompilable legacy `solx` profile would have killed the dumps — and the corpus publish — for every scenario.

### Caveats

- Both scenarios compile at 0.8.34 while upstream ships 0.8.25 (lido) / 0.8.35 (horizon) — the usual price of solx's single mapped version; both pin `evmVersion: cancun`, so the delta is compiler-internal.
- Both need `EVM_DISABLE_MEMORY_SAFE_ASM_CHECK=1`: solx can only auto-spill stack-too-deep when no assembly block looks memory-unsafe, and both repos have unannotated assembly (aave precedent).
- Horizon's solx **legacy** cell peaks at ~10 GB RSS locally (LLVM stack-spill on `RecurringCollector`) — worth watching on the shared runner.
- The reinstated foundry.toml files are vendored snapshots; if the pins move, the fail-loud preinstall guards catch the drift.
- Workflow timeout raised 180 → 210 min; horizon's two ~5-min via-IR compilers (solc and forge) dominate the added cost.
- The gas-compare and replay subsets deliberately stay on the existing scenarios.