### PR TITLE
chore: remote CI skip for npm released package

### DIFF
--- a/scripts/lib/packages.ts
+++ b/scripts/lib/packages.ts
@@ -13,7 +13,6 @@ export async function readAllReleasablePackages() {
         "example-project",
         "template-package",
         "hardhat-test-utils",
-        "hardhat-slang-solx",
       ].includes(file),
   );
 


### PR DESCRIPTION
With a full release, the merge queue can now deal with `hardhat-slang-solx` as a standard package.
