### PR TITLE
fix: remove the Holesky shipped chain descriptor

### DIFF
--- a/.changeset/remove-holesky-chain-descriptor.md
+++ b/.changeset/remove-holesky-chain-descriptor.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Removed the shipped chain descriptor for the Holesky testnet (chain id 17000). The network was shut down in September 2025 and the block explorers bundled for it no longer resolve.

--- a/.changeset/remove-holesky-chain-descriptor.md
+++ b/.changeset/remove-holesky-chain-descriptor.md
@@ -2,4 +2,4 @@
 "hardhat": patch
 ---
 
-Removed the shipped chain descriptor for the Holesky testnet (chain id 17000). The network was shut down in September 2025 and the block explorers bundled for it no longer resolve.
+Remove Holesky testnet (chain id 17000) as a supported chain as it has been shut down.

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/chain-descriptors.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/chain-descriptors.ts
@@ -24,23 +24,6 @@ export const DEFAULT_CHAIN_DESCRIPTORS: ChainDescriptorsConfig = new Map([
       },
     },
   ],
-  // holesky testnet
-  [
-    17_000n,
-    {
-      name: "Holesky",
-      chainType: L1_CHAIN_TYPE,
-      blockExplorers: {
-        etherscan: {
-          url: "https://holesky.etherscan.io",
-        },
-        blockscout: {
-          url: "https://eth-holesky.blockscout.com",
-          apiUrl: "https://eth-holesky.blockscout.com/api",
-        },
-      },
-    },
-  ],
   // hoodi testnet
   [
     560_048n,

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/config-resolution.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/config-resolution.ts
@@ -708,7 +708,7 @@ describe("config-resolution", () => {
     it("should only override the provided fields", async () => {
       const mainnetChainId = 1;
       const sepoliaChainId = 11_155_111;
-      const holeskyChainId = 17_000;
+      const opSepoliaChainId = 11_155_420;
       const hoodiChainId = 560_048;
 
       const chainDescriptorsUserConfig: ChainDescriptorsUserConfig = {
@@ -738,8 +738,8 @@ describe("config-resolution", () => {
             },
           } as BlockExplorersUserConfig,
         },
-        [holeskyChainId]: {
-          name: "Holesky Testnet",
+        [opSepoliaChainId]: {
+          name: "OP Sepolia Testnet",
           chainType: GENERIC_CHAIN_TYPE,
         },
         [hoodiChainId]: {
@@ -805,22 +805,22 @@ describe("config-resolution", () => {
         (sepoliaUserConfig.blockExplorers as any)?.customExplorer,
       );
 
-      const holeskyUserConfig = chainDescriptorsUserConfig[holeskyChainId];
-      const holeskyConfig = chainDescriptorsConfig.get(
-        toBigInt(holeskyChainId),
+      const opSepoliaUserConfig = chainDescriptorsUserConfig[opSepoliaChainId];
+      const opSepoliaConfig = chainDescriptorsConfig.get(
+        toBigInt(opSepoliaChainId),
       );
-      const holeskyDefault = DEFAULT_CHAIN_DESCRIPTORS.get(
-        toBigInt(holeskyChainId),
+      const opSepoliaDefault = DEFAULT_CHAIN_DESCRIPTORS.get(
+        toBigInt(opSepoliaChainId),
       );
-      assert.equal(holeskyConfig?.name, holeskyUserConfig.name);
-      assert.equal(holeskyConfig?.chainType, holeskyUserConfig.chainType);
+      assert.equal(opSepoliaConfig?.name, opSepoliaUserConfig.name);
+      assert.equal(opSepoliaConfig?.chainType, opSepoliaUserConfig.chainType);
       assert.deepEqual(
-        holeskyConfig?.hardforkHistory,
-        holeskyDefault?.hardforkHistory,
+        opSepoliaConfig?.hardforkHistory,
+        opSepoliaDefault?.hardforkHistory,
       );
       assert.deepEqual(
-        holeskyConfig?.blockExplorers,
-        holeskyDefault?.blockExplorers,
+        opSepoliaConfig?.blockExplorers,
+        opSepoliaDefault?.blockExplorers,
       );
 
       const hoodiUserConfig = chainDescriptorsUserConfig[hoodiChainId];


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

Fixes #8499.

The Ethereum Foundation shut the Holešky testnet down in September 2025
(https://blog.ethereum.org/2025/09/01/holesky-shutdown-announcement). Neither
block explorer we ship for chain id 17000 resolves any more, so the bundled
descriptor is dead config that can only send users somewhere broken. This
removes the 17000 entry from `DEFAULT_CHAIN_DESCRIPTORS`. `L1_CHAIN_TYPE` is
still used by other entries, so nothing else in the file changes.

One test had to move, so it is worth flagging rather than leaving a reviewer to
wonder. `config-resolution.ts`'s "should only override the provided fields" test
used chain 17000 as its fixture for merging a user chain descriptor over a
shipped default, so deleting the default broke it. It now uses OP Sepolia
(11155420), picked for three reasons:

- it still ships a default descriptor, so the merge path is really exercised;
- it carries both an etherscan and a blockscout explorer, matching Holesky's
  shape, so the `blockExplorers` assertion still covers both;
- its default chain type is OPTIMISM, which differs from the `GENERIC_CHAIN_TYPE`
  the fixture overrides it with, so the override assertion still compares two
  different values instead of collapsing into a self-comparison.

Every assertion is preserved as it was; only the identifiers and the fixture's
name string changed. I checked that the migrated test still binds by mutating the
source: removing the `chainType` override branch fails it, and making the default
lookup miss for 11155420 fails it on the `blockExplorers` assertion.

A patch changeset is included.
