### PR TITLE
test: re-pin to the merged Hardhat 3 migration on master

### DIFF
--- a/end-to-end/openzeppelin-contracts/scenario.json
+++ b/end-to-end/openzeppelin-contracts/scenario.json
@@ -1,9 +1,9 @@
 {
   "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
-  "description": "OpenZeppelin's Hardhat 3 migration branch (PR #6542) including their Mocha test suite.",
+  "description": "OpenZeppelin's Hardhat 3 migration (PR #6542, merged) including their Mocha test suite.",
   "tags": ["external-repo", "mocha"],
   "repo": "OpenZeppelin/openzeppelin-contracts",
-  "commit": "b12a51e14e0dd8232d4a8d6756a70e90a7387fea",
+  "commit": "cebdf7bf38f6bd8c3bd83beb1395bd069e3c04c9",
   "packageManager": "npm",
   "submodules": true,
   "preinstall": "./preinstall.sh",


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

OpenZeppelin merged the Hardhat 3 migration (https://github.com/OpenZeppelin/openzeppelin-contracts/pull/6542) as a squash, so the scenario's pinned PR-head commit `b12a51e14` no longer resolves in a fresh clone (`git checkout: 'reference is not a tree'` seen in [EDR regression benchmark on 2026-08-15](https://github.com/NomicFoundation/edr/actions/runs/31893537117/job/95033272449)).

This PR pins the merge commit on OpenZeppelin's `master` branch instead. The benchmark's edit-and-recompile target files, the hardhat range (^3.9.1), and the `forge-std/erc4626/halmos` submodules are all unchanged at the new commit.
