### PR TITLE
fix(e2e): disable yarn's hardened mode for scenario installs

### DIFF
--- a/scripts/end-to-end/helpers/install.ts
+++ b/scripts/end-to-end/helpers/install.ts
@@ -166,9 +166,12 @@ function writeRegistryConfig(
     // init calls stay idempotent.
     const cleaned = existing
       .replace(/^npmRegistryServer:.*\n?/m, "")
-      .replace(/^unsafeHttpWhitelist:\n(?:\s+-.*\n?)*/m, "");
+      .replace(/^unsafeHttpWhitelist:\n(?:\s+-.*\n?)*/m, "")
+      .replace(/^enableHardenedMode:.*\n?/m, "");
 
-    const registryConfig = `npmRegistryServer: "${VERDACCIO_URL}"\nunsafeHttpWhitelist:\n  - "localhost"\n  - "127.0.0.1"\n`;
+    // Disable hardened mode (auto-enabled on GitHub CI) because it
+    // refuses the lockfile drift that Verdaccio's republishes cause (YN0028).
+    const registryConfig = `npmRegistryServer: "${VERDACCIO_URL}"\nunsafeHttpWhitelist:\n  - "localhost"\n  - "127.0.0.1"\nenableHardenedMode: false\n`;
 
     writeFileSync(
       yarnrcPath,


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Yarn Berry auto-enables hardened mode on GitHub PR runs. In this mode, yarn refuses any install that would modify the lockfile (`YN0028`).

The benchmark harness installs scenarios from a local Verdaccio registry. `--use-local` republishes some packages at unchanged version numbers, but with different metadata (e.g. bumped `hardhat` peer ranges). Yarn sees this as lockfile drift and aborts the install.

This failed the first CI run of #8521. The `lidofinance-core` scenario on `main` is exposed to the same failure.

### Fix

The harness already writes a `.yarnrc.yml` per scenario to point yarn at Verdaccio. It now also sets `enableHardenedMode: false` there.

This is yarn's documented opt-out. The auto-enable is only a default, so the explicit setting wins on CI. Yarn Classic ignores `.yarnrc.yml` and has no hardened mode, so other yarn scenarios are unaffected.
