### PR TITLE
Renovate 1 GitHub actions

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -26,7 +26,7 @@ runs:
       with:
         version: ${{ inputs.pnpm-version }}
     - id: setup-node
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache-save == 'true' && 'pnpm' || '' }}
@@ -36,7 +36,7 @@ runs:
       if: inputs.cache-save == 'false'
       run: pnpm store path --silent | xargs -I {} -0 echo "path={}" | tee -a $GITHUB_OUTPUT
       shell: bash
-    - uses: actions/cache/restore@v6
+    - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: cache-restore
       if: inputs.cache-save == 'false'
       with:

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -22,7 +22,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
       with:
         version: ${{ inputs.pnpm-version }}
     - id: setup-node

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -26,7 +26,7 @@ runs:
       with:
         version: ${{ inputs.pnpm-version }}
     - id: setup-node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache-save == 'true' && 'pnpm' || '' }}

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -36,7 +36,7 @@ runs:
       if: inputs.cache-save == 'false'
       run: pnpm store path --silent | xargs -I {} -0 echo "path={}" | tee -a $GITHUB_OUTPUT
       shell: bash
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@v6
       id: cache-restore
       if: inputs.cache-save == 'false'
       with:

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -22,7 +22,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
+    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       with:
         version: ${{ inputs.pnpm-version }}
     - id: setup-node

--- a/.github/workflows/add-label-to-new-issue.yml
+++ b/.github/workflows/add-label-to-new-issue.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const issue = await github.rest.issues.get({

--- a/.github/workflows/add-label-to-new-issue.yml
+++ b/.github/workflows/add-label-to-new-issue.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const issue = await github.rest.issues.get({

--- a/.github/workflows/autoassign-issues.yml
+++ b/.github/workflows/autoassign-issues.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // each user has a chance of (p - (previousP ?? 0)) to be assigned

--- a/.github/workflows/autoassign-issues.yml
+++ b/.github/workflows/autoassign-issues.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             // each user has a chance of (p - (previousP ?? 0)) to be assigned

--- a/.github/workflows/autoassign-prs.yml
+++ b/.github/workflows/autoassign-prs.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             // each user has a chance of (p - (previousP ?? 0)) to be assigned

--- a/.github/workflows/autoassign-prs.yml
+++ b/.github/workflows/autoassign-prs.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // each user has a chance of (p - (previousP ?? 0)) to be assigned

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         runner: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: env
         uses: ./.github/actions/setup-env
         with:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         runner: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - id: env
         uses: ./.github/actions/setup-env
         with:

--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/check-changeset-added.yml
+++ b/.github/workflows/check-changeset-added.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/check-links-to-docs.yml
+++ b/.github/workflows/check-links-to-docs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/check-links-to-docs.yml
+++ b/.github/workflows/check-links-to-docs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/check-peer-bumps.yml
+++ b/.github/workflows/check-peer-bumps.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/check-peer-bumps.yml
+++ b/.github/workflows/check-peer-bumps.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/check-v2-with-latest-dependencies.yml
+++ b/.github/workflows/check-v2-with-latest-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
         system: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.system }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: v2 # Checkout the `v2` branch
       - uses: ./.github/actions/setup-env

--- a/.github/workflows/check-v2-with-latest-dependencies.yml
+++ b/.github/workflows/check-v2-with-latest-dependencies.yml
@@ -34,12 +34,12 @@ jobs:
         run: pnpm test || (echo "===== Retry =====" && pnpm test)
       - name: Notify failures
         if: failure()
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
+          webhook: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "workflow_name": "${{ github.workflow }}",
               "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/check-v2-with-latest-dependencies.yml
+++ b/.github/workflows/check-v2-with-latest-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
         system: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.system }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: v2 # Checkout the `v2` branch
       - uses: ./.github/actions/setup-env

--- a/.github/workflows/check-v3-with-latest-dependencies.yml
+++ b/.github/workflows/check-v3-with-latest-dependencies.yml
@@ -37,12 +37,12 @@ jobs:
           NODE_OPTIONS: "--no-experimental-strip-types"
       - name: Notify failures
         if: failure()
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
+          webhook: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "workflow_name": "${{ github.workflow }}",
               "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/check-v3-with-latest-dependencies.yml
+++ b/.github/workflows/check-v3-with-latest-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
         system: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.system }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-env
       - name: Delete pnpm-lock.yaml
         run: "rm pnpm-lock.yaml"

--- a/.github/workflows/check-v3-with-latest-dependencies.yml
+++ b/.github/workflows/check-v3-with-latest-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
         system: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.system }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-env
       - name: Delete pnpm-lock.yaml
         run: "rm pnpm-lock.yaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Check if scripts or workflows have changed
         id: scripts-filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: |
             scripts:
@@ -163,7 +163,7 @@ jobs:
             tee -a $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       - id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           list-files: json
           filters: ${{ steps.generate.outputs.filters }}
@@ -253,7 +253,7 @@ jobs:
           done
           echo 'EOF' >> $GITHUB_OUTPUT
       - if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name && steps.download.outputs.count != '0'
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: bundle
           message: ${{ steps.comment.outputs.body }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check if we are in v3
         id: check
@@ -59,8 +59,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Run check
@@ -73,8 +73,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Run check
@@ -87,7 +87,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-env
         with:
           node-version: 24
@@ -114,7 +114,7 @@ jobs:
       run:
         working-directory: packages/hardhat-slang-solx
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-env
         with:
           node-version: 24
@@ -137,8 +137,8 @@ jobs:
       packages: ${{ steps.filter.outputs.changes }}
       should_bundle: ${{ contains(steps.filter.outputs.hardhat_files, '.github/workflows/ci.yml') || contains(steps.filter.outputs.hardhat_files, 'pnpm-lock.yaml') }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - run: yq -p yaml -o json pnpm-lock.yaml | tee pnpm-lock.json
@@ -189,7 +189,7 @@ jobs:
       run:
         working-directory: packages/${{ matrix.package }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-env
         with:
           node-version: 24
@@ -200,7 +200,7 @@ jobs:
       - name: Deploy
         run: |
           pnpm deploy --config.shamefully-hoist=true --config.hoist=true --config.node-linker=true --config.shared-workspace-lockfile=false --filter="$(jq -r .name package.json)" --prod --no-optional bundle
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.package }}
           path: |
@@ -226,7 +226,7 @@ jobs:
             exit 1
           fi
         shell: bash
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: needs.bundle.result == 'success'
         with:
           name: hardhat
@@ -281,7 +281,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-env
         with:
           node-version: 24
@@ -344,7 +344,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}
@@ -422,7 +422,7 @@ jobs:
       run:
         working-directory: packages/hardhat-node-test-reporter
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}
@@ -473,7 +473,7 @@ jobs:
       run:
         working-directory: packages/hardhat-ethers-chai-matchers
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
             exit 1
           fi
         shell: bash
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
       - id: download
         run: ls -1 | wc -l | xargs -I {} -0 echo "count={}" | tee -a $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
       - name: Run check
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
       - name: Run check
@@ -138,7 +138,7 @@ jobs:
       should_bundle: ${{ contains(steps.filter.outputs.hardhat_files, '.github/workflows/ci.yml') || contains(steps.filter.outputs.hardhat_files, 'pnpm-lock.yaml') }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
       - run: yq -p yaml -o json pnpm-lock.yaml | tee pnpm-lock.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Deploy
         run: |
           pnpm deploy --config.shamefully-hoist=true --config.hoist=true --config.node-linker=true --config.shared-workspace-lockfile=false --filter="$(jq -r .name package.json)" --prod --no-optional bundle
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.package }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,11 +227,16 @@ jobs:
           fi
         shell: bash
       - uses: actions/download-artifact@v8
+        if: needs.bundle.result == 'success'
+        with:
+          name: hardhat
+          path: bundles/hardhat
       - id: download
-        run: ls -1 | wc -l | xargs -I {} -0 echo "count={}" | tee -a $GITHUB_OUTPUT
+        run: mkdir -p bundles && ls -1 bundles | wc -l | xargs -I {} -0 echo "count={}" | tee -a $GITHUB_OUTPUT
         shell: bash
       - id: comment
         if: steps.download.outputs.count != '0'
+        working-directory: bundles
         run: |
           echo 'body<<EOF' >> $GITHUB_OUTPUT
           for bundle in *; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Check if we are in v3
         id: check
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: 24
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: 24
@@ -87,7 +87,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-env
         with:
           node-version: 24
@@ -114,7 +114,7 @@ jobs:
       run:
         working-directory: packages/hardhat-slang-solx
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-env
         with:
           node-version: 24
@@ -137,7 +137,7 @@ jobs:
       packages: ${{ steps.filter.outputs.changes }}
       should_bundle: ${{ contains(steps.filter.outputs.hardhat_files, '.github/workflows/ci.yml') || contains(steps.filter.outputs.hardhat_files, 'pnpm-lock.yaml') }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: 24
@@ -189,7 +189,7 @@ jobs:
       run:
         working-directory: packages/${{ matrix.package }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-env
         with:
           node-version: 24
@@ -276,7 +276,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-env
         with:
           node-version: 24
@@ -339,7 +339,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}
@@ -417,7 +417,7 @@ jobs:
       run:
         working-directory: packages/hardhat-node-test-reporter
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}
@@ -468,7 +468,7 @@ jobs:
       run:
         working-directory: packages/hardhat-ethers-chai-matchers
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/deploy-website-on-release.yml
+++ b/.github/workflows/deploy-website-on-release.yml
@@ -15,12 +15,12 @@ jobs:
         run: curl --silent --show-error --fail --output /dev/null -X POST "${{ secrets.VERCEL_DEPLOY_AFTER_HARDHAT_RELEASE_WEBHOOK }}"
       - name: Notify failures
         if: failure()
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
+          webhook: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "workflow_name": "${{ github.workflow }}",
               "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@b2726a6ae6f1e1b06eb0ff28f7e4fb5e4246bbca # v6.0.2
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           issue-inactive-days: "90"
           pr-inactive-days: "90"

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
+      - uses: dessant/lock-threads@b2726a6ae6f1e1b06eb0ff28f7e4fb5e4246bbca # v6.0.2
         with:
           issue-inactive-days: "90"
           pr-inactive-days: "90"

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -106,7 +106,7 @@ jobs:
           fetch-tags: true
 
       # cspell:disable-next-line
-      - uses: socketdev/action@4337a545deecc20f19a909e52db7a2f6ba292f42 # v1
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
           mode: firewall
 

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -247,15 +247,15 @@ jobs:
       - name: Notify failures
         # Only ping Slack for failed baseline runs (pushes to main)
         if: ${{ failure() && needs.setup.outputs.is_baseline == 'true' }}
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
+          webhook: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "workflow_name": "${{ github.workflow }}",
               "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
 
       - name: Clean up temp dir
         # Self-hosted runners don't automatically wipe the E2E_CLONE_DIR and

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       # Sparse-checkout only the workflow scripts so the github-script step can
       # require the resolver module below.
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github/scripts
           persist-credentials: false
@@ -98,7 +98,7 @@ jobs:
       # metadata via the REST API (see "Store benchmark result").
       contents: read
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.setup.outputs.bench_ref }}
           persist-credentials: false

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -77,7 +77,7 @@ jobs:
           persist-credentials: false
 
       - id: resolve
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           script: |
             const { resolveRegressionTrigger } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/resolve-regression-trigger.ts`);
@@ -280,7 +280,7 @@ jobs:
       issues: write # post the result comment on the PR
       pull-requests: write # post status comments/reactions on the PR
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
           RESULT: ${{ needs.regression-benchmark.result }}
           BENCH_REF: ${{ needs.setup.outputs.bench_ref }}

--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -77,7 +77,7 @@ jobs:
           persist-credentials: false
 
       - id: resolve
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { resolveRegressionTrigger } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/resolve-regression-trigger.ts`);
@@ -280,7 +280,7 @@ jobs:
       issues: write # post the result comment on the PR
       pull-requests: write # post status comments/reactions on the PR
     steps:
-      - uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RESULT: ${{ needs.regression-benchmark.result }}
           BENCH_REF: ${{ needs.setup.outputs.bench_ref }}

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: crates/edr_napi/artifacts
       - name: Install sponge
@@ -236,7 +236,7 @@ jobs:
           pnpm install --frozen-lockfile --prefer-offline
       - name: Download EDR
         if: needs.inputs.outputs.edr-ref != ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: edr
           path: packages/hardhat
@@ -357,7 +357,7 @@ jobs:
           node-version: 22
       - name: Download Hardhat
         if: (startsWith(matrix.command, 'hardhat ') && needs.inputs.outputs.hardhat-ref != 'next' && !startsWith(needs.inputs.outputs.hardhat-ref, '3'))
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: hardhat
       - name: Fix Hardhat on Windows
@@ -521,7 +521,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download the results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: "repository-*;command-*;runner-*"
       - name: Summarize the results

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -145,7 +145,7 @@ jobs:
           fi
       - uses: ./.github/actions/setup-node
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - name: Add Rust cross-compilation target

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -393,7 +393,7 @@ jobs:
           hardhat --version
       - name: Install Forge
         if: startsWith(matrix.command, 'forge')
-        uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         with:
           version: ${{ fromJSON(steps.config.outputs.repository).forge-version }}
           cache: false

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -352,7 +352,7 @@ jobs:
               command: commandConfig,
             });
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
       - name: Download Hardhat

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -145,7 +145,7 @@ jobs:
           fi
       - uses: ./.github/actions/setup-node
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: stable
       - name: Add Rust cross-compilation target

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -85,7 +85,7 @@ jobs:
       commands: ${{ inputs.commands || toJson(fromJson(steps.config.outputs.preset).commands) }}
     steps:
       - id: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: NomicFoundation/hardhat
           ref: ${{ inputs.ref || github.ref }}
@@ -126,7 +126,7 @@ jobs:
         shell: bash
         working-directory: crates/edr_napi
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           repository: NomicFoundation/edr
           ref: ${{ needs.inputs.outputs.edr-ref }}
@@ -177,7 +177,7 @@ jobs:
         shell: bash
         working-directory: crates/edr_napi
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           repository: NomicFoundation/edr
           ref: ${{ needs.inputs.outputs.edr-ref }}
@@ -226,7 +226,7 @@ jobs:
         shell: bash
         working-directory: packages/hardhat
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           repository: NomicFoundation/hardhat
           ref: ${{ needs.inputs.outputs.hardhat-ref }}
@@ -293,7 +293,7 @@ jobs:
         runner: ${{ fromJSON(needs.inputs.outputs.runners) }}
         command: ${{ fromJSON(needs.inputs.outputs.commands) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           repository: NomicFoundation/hardhat
           path: NomicFoundation/hardhat
@@ -398,7 +398,7 @@ jobs:
           version: ${{ fromJSON(steps.config.outputs.repository).forge-version }}
           cache: false
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           repository: ${{ matrix.repository }}

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -98,7 +98,7 @@ jobs:
         env:
           PRESET: ${{ inputs.preset }}
           CONFIG: ${{ toJSON(fromJSON(steps.workflow.outputs.config)) }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -312,7 +312,7 @@ jobs:
           RUNNER: ${{ matrix.runner }}
           COMMAND: ${{ matrix.command }}
           CONFIG: ${{ toJSON(fromJSON(steps.workflow.outputs.config)) }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -464,7 +464,7 @@ jobs:
           set -e
           echo '{"status": '"$status"', "time": '"$((after - before))"'}' > run.result
       - name: Run the command post-hook
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PATTERN: ${{ fromJSON(steps.config.outputs.command).pattern }}
           TEMPLATE: ${{ fromJSON(steps.config.outputs.command).template }}
@@ -529,7 +529,7 @@ jobs:
         env:
           HARDHAT_REF: ${{ needs.inputs.outputs.hardhat-ref }}
           EDR_REF: ${{ needs.inputs.outputs.edr-ref }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -85,7 +85,7 @@ jobs:
       commands: ${{ inputs.commands || toJson(fromJson(steps.config.outputs.preset).commands) }}
     steps:
       - id: checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: NomicFoundation/hardhat
           ref: ${{ inputs.ref || github.ref }}
@@ -98,7 +98,7 @@ jobs:
         env:
           PRESET: ${{ inputs.preset }}
           CONFIG: ${{ toJSON(fromJSON(steps.workflow.outputs.config)) }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -126,7 +126,7 @@ jobs:
         shell: bash
         working-directory: crates/edr_napi
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: NomicFoundation/edr
           ref: ${{ needs.inputs.outputs.edr-ref }}
@@ -161,7 +161,7 @@ jobs:
         if: runner.os == 'MacOS'
         run: strip -x *.node
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: edr-${{ matrix.runner }}
           path: crates/edr_napi/edr.*.node
@@ -177,7 +177,7 @@ jobs:
         shell: bash
         working-directory: crates/edr_napi
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: NomicFoundation/edr
           ref: ${{ needs.inputs.outputs.edr-ref }}
@@ -185,7 +185,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: crates/edr_napi/artifacts
       - name: Install sponge
@@ -209,7 +209,7 @@ jobs:
       - name: Create the package
         run: pnpm pack --config.node-linker=hoisted
       - name: Upload the package
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: edr
           path: crates/edr_napi/*.tgz
@@ -226,7 +226,7 @@ jobs:
         shell: bash
         working-directory: packages/hardhat
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: NomicFoundation/hardhat
           ref: ${{ needs.inputs.outputs.hardhat-ref }}
@@ -236,7 +236,7 @@ jobs:
           pnpm install --frozen-lockfile --prefer-offline
       - name: Download EDR
         if: needs.inputs.outputs.edr-ref != ''
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: edr
           path: packages/hardhat
@@ -274,7 +274,7 @@ jobs:
       - name: Pack
         run: npm pack
         working-directory: bundle
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: hardhat
           path: bundle/hardhat-*.tgz
@@ -293,7 +293,7 @@ jobs:
         runner: ${{ fromJSON(needs.inputs.outputs.runners) }}
         command: ${{ fromJSON(needs.inputs.outputs.commands) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: NomicFoundation/hardhat
           path: NomicFoundation/hardhat
@@ -312,7 +312,7 @@ jobs:
           RUNNER: ${{ matrix.runner }}
           COMMAND: ${{ matrix.command }}
           CONFIG: ${{ toJSON(fromJSON(steps.workflow.outputs.config)) }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -352,12 +352,12 @@ jobs:
               command: commandConfig,
             });
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
       - name: Download Hardhat
         if: (startsWith(matrix.command, 'hardhat ') && needs.inputs.outputs.hardhat-ref != 'next' && !startsWith(needs.inputs.outputs.hardhat-ref, '3'))
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: hardhat
       - name: Fix Hardhat on Windows
@@ -398,7 +398,7 @@ jobs:
           version: ${{ fromJSON(steps.config.outputs.repository).forge-version }}
           cache: false
       - name: Checkout the repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           repository: ${{ matrix.repository }}
@@ -464,7 +464,7 @@ jobs:
           set -e
           echo '{"status": '"$status"', "time": '"$((after - before))"'}' > run.result
       - name: Run the command post-hook
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PATTERN: ${{ fromJSON(steps.config.outputs.command).pattern }}
           TEMPLATE: ${{ fromJSON(steps.config.outputs.command).template }}
@@ -504,7 +504,7 @@ jobs:
           echo "repository=${REPOSITORY//\//_}" | tee -a $GITHUB_OUTPUT
           echo "$CONTEXT" > run.context
       - name: Upload the result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: repository-${{ steps.upload.outputs.repository }};command-${{ matrix.command }};runner-${{ matrix.runner }}
           path: |
@@ -521,7 +521,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download the results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "repository-*;command-*;runner-*"
       - name: Summarize the results
@@ -529,7 +529,7 @@ jobs:
         env:
           HARDHAT_REF: ${{ needs.inputs.outputs.hardhat-ref }}
           EDR_REF: ${{ needs.inputs.outputs.edr-ref }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -161,7 +161,7 @@ jobs:
         if: runner.os == 'MacOS'
         run: strip -x *.node
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: edr-${{ matrix.runner }}
           path: crates/edr_napi/edr.*.node
@@ -209,7 +209,7 @@ jobs:
       - name: Create the package
         run: pnpm pack --config.node-linker=hoisted
       - name: Upload the package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: edr
           path: crates/edr_napi/*.tgz
@@ -274,7 +274,7 @@ jobs:
       - name: Pack
         run: npm pack
         working-directory: bundle
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: hardhat
           path: bundle/hardhat-*.tgz
@@ -504,7 +504,7 @@ jobs:
           echo "repository=${REPOSITORY//\//_}" | tee -a $GITHUB_OUTPUT
           echo "$CONTEXT" > run.context
       - name: Upload the result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: repository-${{ steps.upload.outputs.repository }};command-${{ matrix.command }};runner-${{ matrix.runner }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           # NOTE: If we use the default GITHUB_TOKEN to create the release PR, the checks on the release PR will not be triggered automatically
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
-        uses: changesets/action@v1
+        uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
         with:
           title: Version Packages (v3)
           version: pnpm version-for-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,7 @@ jobs:
       - name: Notify pre-deploy
         continue-on-error: true
         timeout-minutes: 1
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -337,7 +337,7 @@ jobs:
       - name: Notify deployment approved
         continue-on-error: true
         timeout-minutes: 1
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook: ${{ secrets.PUBLISHING_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,7 +391,7 @@ jobs:
           path: tarballs
 
       - name: Setup node to be able to update npm
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           # NOTE: If we use the default GITHUB_TOKEN to create the release PR, the checks on the release PR will not be triggered automatically
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
-        uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           title: Version Packages (v3)
           version: pnpm version-for-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       issues: write # Needed for posting/updating docs comments on release PRs
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
@@ -158,7 +158,7 @@ jobs:
       hasPackages: ${{ steps.detect.outputs.hasPackages }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env
@@ -424,7 +424,7 @@ jobs:
       contents: write # needed to create releases (no dedicated releases scope exists)
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,13 +219,13 @@ jobs:
       actions: read # To download the tarballs to review
     steps:
       - name: Download pnpm list json
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: pnpm-publish-summary.json
           path: .
 
       - name: Download tarballs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: tarballs
           path: tarballs
@@ -379,13 +379,13 @@ jobs:
             }
 
       - name: Download pnpm list json
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: pnpm-publish-summary.json
           path: .
 
       - name: Download tarballs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: tarballs
           path: tarballs
@@ -446,7 +446,7 @@ jobs:
         run: git push --follow-tags
 
       - name: Download pnpm publish summary
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: pnpm-publish-summary.json
           path: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Find package versions PR
         if: steps.pr.outputs.hasChangesets == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         id: find
         with:
           script: |
@@ -76,7 +76,7 @@ jobs:
 
       - name: Convert to draft
         if: steps.pr.outputs.hasChangesets == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { number } = ${{ steps.find.outputs.result }};
@@ -103,7 +103,7 @@ jobs:
 
       - name: Sync docs comment on release PR
         if: steps.pr.outputs.hasChangesets == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           HAS_DOCS: ${{ steps.docs.outputs.has_docs }}
           COMMENT_BODY: ${{ steps.docs.outputs.comment_body }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       issues: write # Needed for posting/updating docs comments on release PRs
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
@@ -62,7 +62,7 @@ jobs:
 
       - name: Find package versions PR
         if: steps.pr.outputs.hasChangesets == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: find
         with:
           script: |
@@ -76,7 +76,7 @@ jobs:
 
       - name: Convert to draft
         if: steps.pr.outputs.hasChangesets == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { number } = ${{ steps.find.outputs.result }};
@@ -103,7 +103,7 @@ jobs:
 
       - name: Sync docs comment on release PR
         if: steps.pr.outputs.hasChangesets == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           HAS_DOCS: ${{ steps.docs.outputs.has_docs }}
           COMMENT_BODY: ${{ steps.docs.outputs.comment_body }}
@@ -158,7 +158,7 @@ jobs:
       hasPackages: ${{ steps.detect.outputs.hasPackages }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env
@@ -173,7 +173,7 @@ jobs:
         run: pnpm publish --filter "./packages/**" -r --no-git-checks --access public --dry-run --report-summary
 
       - name: Store the package list to be published
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pnpm-publish-summary.json
           path: pnpm-publish-summary.json
@@ -201,7 +201,7 @@ jobs:
           done
 
       - name: Upload packed tarballs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.detect.outputs.hasPackages == 'true'
         with:
           name: tarballs
@@ -219,13 +219,13 @@ jobs:
       actions: read # To download the tarballs to review
     steps:
       - name: Download pnpm list json
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pnpm-publish-summary.json
           path: .
 
       - name: Download tarballs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tarballs
           path: tarballs
@@ -379,19 +379,19 @@ jobs:
             }
 
       - name: Download pnpm list json
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pnpm-publish-summary.json
           path: .
 
       - name: Download tarballs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tarballs
           path: tarballs
 
       - name: Setup node to be able to update npm
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -424,7 +424,7 @@ jobs:
       contents: write # needed to create releases (no dedicated releases scope exists)
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -446,7 +446,7 @@ jobs:
         run: git push --follow-tags
 
       - name: Download pnpm publish summary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pnpm-publish-summary.json
           path: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
         run: pnpm publish --filter "./packages/**" -r --no-git-checks --access public --dry-run --report-summary
 
       - name: Store the package list to be published
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pnpm-publish-summary.json
           path: pnpm-publish-summary.json
@@ -201,7 +201,7 @@ jobs:
           done
 
       - name: Upload packed tarballs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: steps.detect.outputs.hasPackages == 'true'
         with:
           name: tarballs

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -15,11 +15,11 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
This PR brings Hardhat's GitHub Actions up to date:

1. every `actions/*` action to its current major
2. every pinned third-party action to a current digest
3. the three third-party actions that were still on tags pinned
4. `slackapi/slack-github-action` migrated from v1 to v4

Three actions were being used at **two different versions simultaneously**, which this also fixes:

- `actions/setup-node` at v4 and v5
- `actions/download-artifact` at v4 and v5
- `slackapi/slack-github-action` at v1.26.0 and v2.1.1

## Technical decisions

### **`actions/*` stay on major tags; third-party actions are pinned by digest.**

This is continuing the existing pattern for the repo, but maybe we should consider completely swapping to SHAs even for github's own actions. This appears to be the EDR move.

### The Slack migration to the v2 API

The break is entirely between v1 and v2: v1 read the webhook URL from a `SLACK_WEBHOOK_URL` environment
variable and inferred what to do with the payload, whereas from v2 the URL is a `webhook` input and the
mode is explicit in `webhook-type`. Everything after that is quiet — v3's only breaking change is its
Node 24 runtime, and v4's is an internal change to proxied fetch configuration.

## Review

> [!TIP]
> Review a commit at a time for easier review

- **Pin the remaining third-party actions** — establishes the convention the rest of the branch follows.
- **`setup-node` → v7** and **`download-artifact` → v8** — each also unifies two versions that were in use
  at once.
- **`upload-artifact` → v7**, **`checkout` → v7**, **`github-script` → v9 and `cache/restore` → v6** —
  version numbers and runtimes only.
- **Refresh the pinned third-party digests** — five of six were behind, one by three majors, which is the
  cost of pinning without a bot to move them.
- **Migrate `slack-github-action` to v4** — the one with a behavioural trap in it.
- **Fix to our own bundle action** - the artifact downloader changed the layout of downloads
