### PR TITLE
fix: accept hex digit f/F in int, bigint and float CLI argument types

### DIFF
--- a/.changeset/hex-f-cli-argument-types.md
+++ b/.changeset/hex-f-cli-argument-types.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed the `int`, `bigint` and `float` CLI argument types rejecting hexadecimal values containing the digit `f`/`F` (e.g. `0xff`, `0xdeadbeef`).

--- a/packages/hardhat-core/src/internal/core/params/argumentTypes.ts
+++ b/packages/hardhat-core/src/internal/core/params/argumentTypes.ts
@@ -86,7 +86,7 @@ export const int: CLIArgumentType<number> = {
   name: "int",
   parse: (argName, strValue) => {
     const decimalPattern = /^\d+(?:[eE]\d+)?$/;
-    const hexPattern = /^0[xX][\dABCDEabcde]+$/;
+    const hexPattern = /^0[xX][\dA-Fa-f]+$/;
 
     if (
       strValue.match(decimalPattern) === null &&
@@ -130,7 +130,7 @@ export const bigint: CLIArgumentType<bigint> = {
   name: "bigint",
   parse: (argName, strValue) => {
     const decimalPattern = /^\d+(?:n)?$/;
-    const hexPattern = /^0[xX][\dABCDEabcde]+$/;
+    const hexPattern = /^0[xX][\dA-Fa-f]+$/;
 
     if (
       strValue.match(decimalPattern) === null &&
@@ -174,7 +174,7 @@ export const float: CLIArgumentType<number> = {
   name: "float",
   parse: (argName, strValue) => {
     const decimalPattern = /^(?:\d+(?:\.\d*)?|\.\d+)(?:[eE]\d+)?$/;
-    const hexPattern = /^0[xX][\dABCDEabcde]+$/;
+    const hexPattern = /^0[xX][\dA-Fa-f]+$/;
 
     if (
       strValue.match(decimalPattern) === null &&

--- a/packages/hardhat-core/test/internal/core/params/argumentTypes.ts
+++ b/packages/hardhat-core/test/internal/core/params/argumentTypes.ts
@@ -77,6 +77,11 @@ describe("argumentTypes", () => {
       assert.equal(types.int.parse("arg", "0xA"), 0xa);
       assert.equal(types.int.parse("arg", "0xa"), 0xa);
       assert.equal(types.int.parse("arg", "0x0a"), 0x0a);
+      assert.equal(types.int.parse("arg", "0xF"), 0xf);
+      assert.equal(types.int.parse("arg", "0xf"), 0xf);
+      assert.equal(types.int.parse("arg", "0xff"), 0xff);
+      assert.equal(types.int.parse("arg", "0xdeadbeef"), 0xdeadbeef);
+      assert.equal(types.int.parse("arg", "0xABCDEF"), 0xabcdef);
     });
 
     it("should work with decimal scientific notation", () => {
@@ -124,6 +129,10 @@ describe("argumentTypes", () => {
         () => types.int.parse("arg", "x123"),
         ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE
       );
+      expectHardhatError(
+        () => types.int.parse("arg", "0xg"),
+        ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE
+      );
     });
   });
 
@@ -145,6 +154,11 @@ describe("argumentTypes", () => {
       assert.equal(types.bigint.parse("arg", "0xA"), BigInt(0xa));
       assert.equal(types.bigint.parse("arg", "0xa"), BigInt(0xa));
       assert.equal(types.bigint.parse("arg", "0x0a"), BigInt(0x0a));
+      assert.equal(types.bigint.parse("arg", "0xF"), BigInt(0xf));
+      assert.equal(types.bigint.parse("arg", "0xf"), BigInt(0xf));
+      assert.equal(types.bigint.parse("arg", "0xff"), BigInt(0xff));
+      assert.equal(types.bigint.parse("arg", "0xdeadbeef"), BigInt(0xdeadbeef));
+      assert.equal(types.bigint.parse("arg", "0xABCDEF"), BigInt(0xabcdef));
       assert.equal(
         types.bigint.parse("arg", "0x20000000000000"),
         BigInt("0x20000000000000")
@@ -193,6 +207,10 @@ describe("argumentTypes", () => {
         ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE
       );
       expectHardhatError(
+        () => types.bigint.parse("arg", "0xg"),
+        ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE
+      );
+      expectHardhatError(
         () => types.bigint.parse("arg", "1e0"),
         ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE
       );
@@ -224,6 +242,11 @@ describe("argumentTypes", () => {
       assert.equal(types.float.parse("arg", "0xA"), 0xa);
       assert.equal(types.float.parse("arg", "0xa"), 0xa);
       assert.equal(types.float.parse("arg", "0x0a"), 0x0a);
+      assert.equal(types.float.parse("arg", "0xF"), 0xf);
+      assert.equal(types.float.parse("arg", "0xf"), 0xf);
+      assert.equal(types.float.parse("arg", "0xff"), 0xff);
+      assert.equal(types.float.parse("arg", "0xdeadbeef"), 0xdeadbeef);
+      assert.equal(types.float.parse("arg", "0xABCDEF"), 0xabcdef);
     });
 
     it("should work with decimal scientific notation", () => {
@@ -280,6 +303,10 @@ describe("argumentTypes", () => {
       );
       expectHardhatError(
         () => types.float.parse("arg", "x123"),
+        ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE
+      );
+      expectHardhatError(
+        () => types.float.parse("arg", "0xg"),
         ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE
       );
     });


### PR DESCRIPTION
## Problem

The `int`, `bigint` and `float` CLI argument types each validate hex input with the same pattern in `packages/hardhat-core/src/internal/core/params/argumentTypes.ts`:

```js
const hexPattern = /^0[xX][\dABCDEabcde]+$/;
```

The character class spells out `ABCDE` and `abcde` — every hex digit except `f`/`F`.

So any hex argument containing an `f` is rejected as invalid:

| value | accepted today |
|---|---|
| `0xa`, `0x0a`, `0xABCDE` | ✅ |
| `0xF`, `0xf` | ❌ |
| `0xff` | ❌ |
| `0xdeadbeef` | ❌ |
| `0xABCDEF` | ❌ |

`f` shows up in about half of all multi-digit hex values, so this rejects a large share of legitimate input — a task taking `--value 0xff` fails with `Invalid value for argument`.

It reads like a hand-enumerated class where the last digit was simply missed.

## Fix

```js
const hexPattern = /^0[xX][\dA-Fa-f]+$/;
```

Applied at all three call sites (`int`, `bigint`, `float`).

Worth noting this matches what Hardhat 3 already does — `packages/hardhat/src/internal/core/arguments.ts` on `main` defines `VALID_HEX_PATTERN = /^0[xX][\dA-Fa-f]+$/`. The rewrite got it right; this brings v2 in line.

## Tests

Extended the existing `argumentTypes` suite rather than adding a new one — five positive cases per type (`0xF`, `0xf`, `0xff`, `0xdeadbeef`, `0xABCDEF`) and one negative (`0xg`) to pin down that widening the class doesn't start accepting non-hex.

Every one of the positive cases fails on `v2` today; the negative cases and the existing `0xa` / `0x0a` / `x123` assertions are unchanged.

## Note

I originally raised this against the wrong base by mistake. This is the same fix rebuilt cleanly on the current `v2` head — `packages/hardhat-core` only exists on this branch, and the bug is still present in all three places there.