### PR TITLE
fix(bench): update `openzeppelin-contracts` benchmark after migration PR merged

### DIFF
--- a/end-to-end/openzeppelin-contracts/scenario.json
+++ b/end-to-end/openzeppelin-contracts/scenario.json
@@ -1,9 +1,9 @@
 {
   "$schema": "../../scripts/end-to-end/schema/scenario.schema.json",
-  "description": "OpenZeppelin's Hardhat 3 migration branch (PR #6542) including their Mocha test suite.",
+  "description": "OpenZeppelin contracts on Hardhat 3 including their Mocha test suite.",
   "tags": ["external-repo", "mocha"],
   "repo": "OpenZeppelin/openzeppelin-contracts",
-  "commit": "b12a51e14e0dd8232d4a8d6756a70e90a7387fea",
+  "commit": "cebdf7bf38f6bd8c3bd83beb1395bd069e3c04c9",
   "packageManager": "npm",
   "submodules": true,
   "preinstall": "./preinstall.sh",


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
This PR fixes a regression benchmark failure by updating the commit SHA following the merge of HH3 migration PR of `openzeppelin-contracts`. 