### PR TITLE
Renovate 5 fast equals 6 - too fast too furious

### DIFF
--- a/.changeset/update-hardhat-utils-fast-equals.md
+++ b/.changeset/update-hardhat-utils-fast-equals.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-utils": patch
+---
+
+Update the `fast-equals` runtime dependency to its latest major version.

--- a/packages/hardhat-utils/package.json
+++ b/packages/hardhat-utils/package.json
@@ -85,7 +85,7 @@
     "@streamparser/json-node": "^0.0.22",
     "env-paths": "^4.0.0",
     "ethereum-cryptography": "^2.2.1",
-    "fast-equals": "^5.4.0",
+    "fast-equals": "^6.0.0",
     "json-stream-stringify": "^3.1.7",
     "rfdc": "^1.3.1",
     "undici": "^6.28.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1283,8 +1283,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.1
       fast-equals:
-        specifier: ^5.4.0
-        version: 5.4.0
+        specifier: ^6.0.0
+        version: 6.0.2
       json-stream-stringify:
         specifier: ^3.1.7
         version: 3.1.7
@@ -4950,10 +4950,6 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-equals@5.4.0:
-    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
-    engines: {node: '>=6.0.0'}
 
   fast-equals@6.0.2:
     resolution: {integrity: sha512-sAjhj9ZhOxYCGiNMnZLaucOqf5ZeFnHNoKoAZiD9thhJ0N8RP85qJK759/97C/3L7NzzmGVB5uiX9AUpySZmUQ==}
@@ -11131,8 +11127,6 @@ snapshots:
   extsprintf@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
-
-  fast-equals@5.4.0: {}
 
   fast-equals@6.0.2: {}
 


### PR DESCRIPTION
This updates `fast-equals` to version 6 in `hardhat-utils`. Deep equality comparisons behave exactly as
before, including for `Buffer`s — a manifest and lockfile change with no source changes at all.

Note: The `areTypedArraysEqual` override is still needed