### PR TITLE
fix: ignore insignificant whitespace in solidity version pragmas

### DIFF
--- a/.changeset/quiet-pragma-spaces.md
+++ b/.changeset/quiet-pragma-spaces.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed Solidity version matching so pragmas with insignificant whitespace (e.g. `^ 0.8 .0`) select a compatible compiler instead of failing with HHE909.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts
@@ -12,6 +12,22 @@ import { intersects, maxSatisfying, satisfies } from "semver";
 
 import { CompilationJobCreationErrorReason } from "../../../../types/solidity/build-system.js";
 
+
+/**
+ * Solidity tokenizes version pragmas, so whitespace inside a literal is
+ * insignificant (`^ 0.8 .0` means `^0.8.0`). npm `semver` does not treat
+ * interior whitespace that way, and `maxSatisfying` then returns null
+ * (Hardhat HHE909) even when a compatible compiler is enabled.
+ */
+function normalizeVersionPragma(pragma: string): string {
+  return pragma.replace(/\s+/g, "");
+}
+
+function joinVersionPragmas(pragmas: readonly string[]): string {
+  return Array.from(new Set(pragmas.map(normalizeVersionPragma))).join(" ");
+}
+
+
 export class SolcConfigSelector {
   readonly #buildProfileName: string;
   readonly #buildProfile: SolidityBuildProfileConfig;
@@ -60,7 +76,7 @@ export class SolcConfigSelector {
       .map(({ content }) => content.versionPragmas)
       .flat(1);
 
-    const versionRange = Array.from(new Set(allVersionPragmas)).join(" ");
+    const versionRange = joinVersionPragmas(allVersionPragmas);
 
     const overriddenCompiler = this.#buildProfile.overrides[userSourceName];
 
@@ -121,7 +137,7 @@ export class SolcConfigSelector {
     compilerVersions: string[],
     overridden: boolean,
   ): CompilationJobCreationError {
-    const rootVersionRange = root.content.versionPragmas.join(" ");
+    const rootVersionRange = joinVersionPragmas(root.content.versionPragmas);
 
     // This logic is pretty different depending if we are dealing with a config
     // override or not. If we are, we have a single compiler option, so things
@@ -147,7 +163,7 @@ export class SolcConfigSelector {
         dependencyGraph,
       )) {
         const depOwnRange =
-          transitiveDependency.dependency.content.versionPragmas.join(" ");
+          joinVersionPragmas(transitiveDependency.dependency.content.versionPragmas);
 
         if (maxSatisfying(compilerVersions, depOwnRange) === null) {
           return {
@@ -192,7 +208,7 @@ export class SolcConfigSelector {
     )) {
       const transitiveDependencyVersionRange =
         transitiveDependency.versionPragmasPath
-          .map((pragmas) => pragmas.join(" "))
+          .map((pragmas) => joinVersionPragmas(pragmas))
           .join(" ");
 
       const depOwnRange =

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/solc-config-selection.ts
@@ -223,6 +223,27 @@ describe("SolcConfigSelector", () => {
     });
 
     describe("without a compiler override", () => {
+
+      it("should match a compiler when a pragma has whitespace inside the version literal", () => {
+        root = createProjectResolvedFile("root.sol", ["^ 0.8 .0"]);
+        dependencyGraph = new DependencyGraphImplementation();
+        dependencyGraph.addRootFile(root.inputSourceName, root);
+
+        buildProfile.compilers.push({
+          version: "0.8.34",
+          settings: {},
+        });
+
+        const selector = new SolcConfigSelector(buildProfileName, buildProfile);
+        const config =
+          selector.selectBestSolcConfigForSingleRootGraph(dependencyGraph);
+
+        assert.deepEqual(config, {
+          success: true,
+          config: buildProfile.compilers[0],
+        });
+      });
+
       it("should return the config of the max satisfying compiler for a root with no dependencies", () => {
         buildProfile.compilers.push({
           version: "0.8.0",


### PR DESCRIPTION
Fixes #8535

solc tokenizes a pragma such as `pragma solidity ^ 0.8 .0;` as `^` + `0.8.0`, so the file compiles. Hardhat 3 takes the string `@nomicfoundation/solidity-analyzer` extracts (`"^ 0.8 .0"`) and feeds it to npm `semver` (`satisfies` / `maxSatisfying`). Interior whitespace is significant there, so a configured `0.8.34` does not match and the build reports HHE909.

This normalizes each extracted pragma by collapsing whitespace before every range check. Multiple pragmas are still joined with a space, so the AND between them is unchanged.

On current `main`, the new unit test returns `NO_COMPATIBLE_SOLC_VERSION_WITH_ROOT`. After the change it selects compiler `0.8.34`.