### PR TITLE
Update to EDR 0.16.0

### DIFF
--- a/.changeset/edr-16-update-1.md
+++ b/.changeset/edr-16-update-1.md
@@ -1,0 +1,5 @@
+---
+"hardhat": minor
+---
+
+EDR now uses platform specific `optionalDependencies`, reducing Hardhat's install size.

--- a/.changeset/edr-16-update-2.md
+++ b/.changeset/edr-16-update-2.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Fixed missing Solidity test stack trace when `setUp()` fails and stack traces are collected with `CollectStackTraces::Always`.

--- a/.changeset/slang-solx-edr-compiler-type.md
+++ b/.changeset/slang-solx-edr-compiler-type.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-slang-solx": patch
+---
+
+Upgraded to `@nomicfoundation/edr` 0.16.0 and switched the solx compiler type to `slangSolx`.

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -6,5 +6,11 @@
     "packages/hardhat/templates",
     "packages/config"
   ],
-  "bumps": []
+  "bumps": [
+    {
+      "package": "@nomicfoundation/hardhat-slang-solx",
+      "peer": "hardhat",
+      "reason": "#8539 the plugin now writes `compilerType: \"slangSolx\"` into its build infos, and only a Hardhat bundling EDR 0.16.0 or later understands that value. An older Hardhat degrades the artifact to solc and silently loses Solidity stack traces, so the plugin has to require the version that carries the EDR upgrade."
+    }
+  ]
 }

--- a/packages/hardhat-slang-solx/src/internal/constants.ts
+++ b/packages/hardhat-slang-solx/src/internal/constants.ts
@@ -1,29 +1,10 @@
 import type { SolidityCompilerType } from "hardhat/types/config";
 
 /**
- * The compiler type identifier registered by this plugin, and the one users
- * write in their config.
+ * The compiler type identifier registered by this plugin.
  * Typed as SolidityCompilerType for type-safe comparisons.
  */
 export const SLANG_SOLX_COMPILER_TYPE: SolidityCompilerType = "slangSolx";
-
-/**
- * The compiler type the resolved config carries, which is the name of the
- * compiler that actually runs.
- *
- * EDR decides how to read a build info from its `compilerType` field, and only
- * recognizes `"solc"` and `"solx"`. An unrecognized value falls back to
- * `"solc"`, where EDR looks for the `sourceMap` that solx does not emit, and
- * Solidity stack traces are silently lost. So the plugin rewrites
- * `"slangSolx"` to `"solx"` as it resolves each compiler entry, while users
- * keep writing {@link SLANG_SOLX_COMPILER_TYPE}.
- *
- * Remove this translation once EDR recognizes `"slangSolx"`.
- */
-/* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
-this is EDR's name for the compiler, not a type this plugin registers, so it
-is deliberately not part of SolidityCompilerTypeDefinitions */
-export const RESOLVED_SOLX_COMPILER_TYPE = "solx" as SolidityCompilerType;
 
 export const SOLX_RELEASES_BASE_URL =
   "https://solx-releases-mirror.hardhat.org";

--- a/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
@@ -20,7 +20,6 @@ import { z } from "zod";
 
 import {
   DEFAULT_SOLX_OPTIMIZER_MODE,
-  RESOLVED_SOLX_COMPILER_TYPE,
   SOLIDITY_TO_SOLX_VERSION_MAP,
   SLANG_SOLX_COMPILER_TYPE,
   SUPPORTED_SOLX_EVM_VERSIONS,
@@ -199,18 +198,15 @@ export async function resolveUserConfig(
     solidity: {
       ...resolvedConfig.solidity,
       profiles,
-      // Both names are registered: the one users write, and the one the
-      // resolved config carries for EDR's benefit. Hardhat validates the
-      // resolved config against this list, so the resolved name has to be in
-      // it; the user-facing one is kept so the error listing registered types
-      // still names what a user is meant to type.
-      registeredCompilerTypes: [
-        ...new Set([
-          ...resolvedConfig.solidity.registeredCompilerTypes,
+      registeredCompilerTypes:
+        resolvedConfig.solidity.registeredCompilerTypes.includes(
           SLANG_SOLX_COMPILER_TYPE,
-          RESOLVED_SOLX_COMPILER_TYPE,
-        ]),
-      ],
+        )
+          ? resolvedConfig.solidity.registeredCompilerTypes
+          : [
+              ...resolvedConfig.solidity.registeredCompilerTypes,
+              SLANG_SOLX_COMPILER_TYPE,
+            ],
     },
     slangSolx: resolveSolxConfig(userConfig.slangSolx),
   };
@@ -260,9 +256,6 @@ async function augmentIfSolx<
     : {};
   return {
     ...entry,
-    // Resolved to the compiler's own name, so that EDR can read the build
-    // info this ends up in. See RESOLVED_SOLX_COMPILER_TYPE.
-    type: RESOLVED_SOLX_COMPILER_TYPE,
     settings: {
       ...settings,
       // Defaults added here instead of in SlangSolxCompiler.compile so this reaches
@@ -311,7 +304,7 @@ export async function validateResolvedConfig(
     const solxInOtherProfileMessage = `Compiler type "slangSolx" is only supported in the "slangSolx" build profile. Remove type: "slangSolx" from the "${profileName}" profile compilers, or set slangSolx.dangerouslyAllowSlangSolxInProduction in the plugin config.`;
 
     for (const [i, compiler] of profile.compilers.entries()) {
-      if (compiler.type === RESOLVED_SOLX_COMPILER_TYPE) {
+      if (compiler.type === SLANG_SOLX_COMPILER_TYPE) {
         errors.push({
           path: ["solidity", "profiles", profileName, "compilers", i, "type"],
           message: solxInOtherProfileMessage,
@@ -320,7 +313,7 @@ export async function validateResolvedConfig(
     }
 
     for (const [key, override] of Object.entries(profile.overrides)) {
-      if (override.type === RESOLVED_SOLX_COMPILER_TYPE) {
+      if (override.type === SLANG_SOLX_COMPILER_TYPE) {
         errors.push({
           path: ["solidity", "profiles", profileName, "overrides", key, "type"],
           message: solxInOtherProfileMessage,

--- a/packages/hardhat-slang-solx/src/internal/hook-handlers/solidity.ts
+++ b/packages/hardhat-slang-solx/src/internal/hook-handlers/solidity.ts
@@ -12,7 +12,7 @@ import { exists } from "@nomicfoundation/hardhat-utils/fs";
 
 import {
   SOLIDITY_TO_SOLX_VERSION_MAP,
-  RESOLVED_SOLX_COMPILER_TYPE,
+  SLANG_SOLX_COMPILER_TYPE,
 } from "../constants.js";
 import { downloadSolx, getSolxBinaryPath } from "../downloader.js";
 import { SlangSolxCompiler } from "../slang-solx-compiler.js";
@@ -42,7 +42,7 @@ async function getSolxVersionFromBinary(binaryPath: string): Promise<string> {
 export default async (): Promise<Partial<SolidityHooks>> => ({
   downloadCompilers: async (_context, compilerConfigs, quiet) => {
     const solxConfigs = compilerConfigs.filter(
-      (c) => c.type === RESOLVED_SOLX_COMPILER_TYPE,
+      (c) => c.type === SLANG_SOLX_COMPILER_TYPE,
     );
 
     if (solxConfigs.length === 0) {
@@ -85,7 +85,7 @@ export default async (): Promise<Partial<SolidityHooks>> => ({
   },
 
   getCompiler: async (context, compilerConfig, next) => {
-    if (compilerConfig.type !== RESOLVED_SOLX_COMPILER_TYPE) {
+    if (compilerConfig.type !== SLANG_SOLX_COMPILER_TYPE) {
       return await next(context, compilerConfig);
     }
 

--- a/packages/hardhat-slang-solx/test/config.ts
+++ b/packages/hardhat-slang-solx/test/config.ts
@@ -114,9 +114,10 @@ describe("hardhat-slang-solx plugin config resolution", () => {
       }),
     );
 
-    assert.ok(
-      resolvedConfig.solidity.registeredCompilerTypes.includes("slangSolx"),
-      "registeredCompilerTypes should contain 'slangSolx'",
+    assert.deepEqual(
+      resolvedConfig.solidity.registeredCompilerTypes,
+      ["solc", "slangSolx"],
+      "the plugin registers 'slangSolx' and leaves core's 'solc' in place, and registers nothing else",
     );
   });
 
@@ -664,9 +665,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
       solidity: {
         profiles,
         npmFilesToBuild: [],
-        // Both the name the user writes and the name the resolved config
-        // carries, matching what resolveUserConfig registers.
-        registeredCompilerTypes: ["solc", "slangSolx", "solx"],
+        registeredCompilerTypes: ["solc", "slangSolx"],
       },
       slangSolx: {
         dangerouslyAllowSlangSolxInProduction:
@@ -705,7 +704,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
         slangSolx: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
           overrides: {},
         },
       }),
@@ -719,13 +718,13 @@ describe("hardhat-slang-solx resolved config validation", () => {
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
           overrides: {},
         },
         slangSolx: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
           overrides: {},
         },
       }),
@@ -752,7 +751,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
           overrides: {
             "MyContract.sol": {
               version: "0.8.34",
-              type: "solx",
+              type: "slangSolx",
               settings: {},
             },
           },
@@ -760,7 +759,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
         slangSolx: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
           overrides: {},
         },
       }),
@@ -784,13 +783,13 @@ describe("hardhat-slang-solx resolved config validation", () => {
           default: {
             isolated: false,
             preferWasm: false,
-            compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+            compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
             overrides: {},
           },
           slangSolx: {
             isolated: false,
             preferWasm: false,
-            compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+            compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
             overrides: {},
           },
         },
@@ -812,7 +811,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
         slangSolx: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
           overrides: {},
         },
       }),
@@ -827,7 +826,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
           default: {
             isolated: false,
             preferWasm: false,
-            compilers: [{ version: "0.8.34", type: "solx", settings: {} }],
+            compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
             overrides: {},
           },
         },

--- a/packages/hardhat-slang-solx/test/hook-handlers/solidity.ts
+++ b/packages/hardhat-slang-solx/test/hook-handlers/solidity.ts
@@ -8,7 +8,6 @@ import { describe, it } from "node:test";
 
 import { assertRejectsWithHardhatError } from "@nomicfoundation/hardhat-test-utils";
 
-import { RESOLVED_SOLX_COMPILER_TYPE } from "../../src/internal/constants.js";
 import { parseSolxVersion } from "../../src/internal/hook-handlers/solidity.js";
 
 // Helper to create a compiler config
@@ -127,10 +126,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
       const context = { config: {} } as any;
 
       const configs: SolidityCompilerConfig[] = [
-        createSolidityCompilerConfig({
-          type: RESOLVED_SOLX_COMPILER_TYPE,
-          version: "0.8.34",
-        }),
+        createSolidityCompilerConfig({ type: "slangSolx", version: "0.8.34" }),
       ];
 
       // This will fail to download (no network in tests), but we can
@@ -211,7 +207,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
 
       const context = { config: {} } as any;
       const compilerConfig = createSolidityCompilerConfig({
-        type: RESOLVED_SOLX_COMPILER_TYPE,
+        type: "slangSolx",
         version: "0.8.99",
       });
       const mockNext = createGetCompilerMockNext();
@@ -234,7 +230,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
 
       const context = { config: {} } as any;
       const compilerConfig = createSolidityCompilerConfig({
-        type: RESOLVED_SOLX_COMPILER_TYPE,
+        type: "slangSolx",
         version: "0.8.34",
         path: "/nonexistent/path/to/solx",
       });
@@ -266,7 +262,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
 
       const context = { config: {} } as any;
       const compilerConfig = createSolidityCompilerConfig({
-        type: RESOLVED_SOLX_COMPILER_TYPE,
+        type: "slangSolx",
         version: "0.8.34",
         path: cachedPath,
       });
@@ -299,7 +295,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
 
       const configs: SolidityCompilerConfig[] = [
         createSolidityCompilerConfig({
-          type: RESOLVED_SOLX_COMPILER_TYPE,
+          type: "slangSolx",
           version: "0.8.34",
           path: "/custom/path/to/solx",
         }),

--- a/packages/hardhat-slang-solx/test/integration.ts
+++ b/packages/hardhat-slang-solx/test/integration.ts
@@ -75,17 +75,18 @@ describe("hardhat-slang-solx integration", () => {
     const slangSolxProfile = hre.config.solidity.profiles.slangSolx;
     assert.equal(
       slangSolxProfile.compilers[0].type,
-      "solx",
-      "the resolved compiler carries the name EDR reads from the build info, not the one the user wrote",
+      "slangSolx",
+      "slangSolx profile compiler should have type: 'slangSolx'",
     );
   });
 
   it("registers 'slangSolx' as a compiler type", async () => {
     const hre = await createHre();
 
-    assert.ok(
-      hre.config.solidity.registeredCompilerTypes.includes("slangSolx"),
-      "registeredCompilerTypes should include 'slangSolx'",
+    assert.deepEqual(
+      hre.config.solidity.registeredCompilerTypes,
+      ["solc", "slangSolx"],
+      "the plugin registers 'slangSolx' and leaves core's 'solc' in place, and registers nothing else",
     );
   });
 });

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -93,7 +93,7 @@
     "typescript": "~6.0.3"
   },
   "dependencies": {
-    "@nomicfoundation/edr": "0.15.0",
+    "@nomicfoundation/edr": "0.16.0",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.17",
     "@nomicfoundation/hardhat-utils": "workspace:^4.1.6",
     "@nomicfoundation/hardhat-vendored": "workspace:^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
   packages/hardhat:
     dependencies:
       '@nomicfoundation/edr':
-        specifier: 0.15.0
-        version: 0.15.0
+        specifier: 0.16.0
+        version: 0.16.0
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.17
         version: link:../hardhat-errors
@@ -3008,36 +3008,36 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.15.0':
-    resolution: {integrity: sha512-kFgoiou9yfzojAki3yOnOlFZfkC0oQeS8G3i/8lXaTnjEjQ2C1lLDgRQt8Q0kjSdVOs5daiC+eQx+8to4R5/ug==}
+  '@nomicfoundation/edr-darwin-arm64@0.16.0':
+    resolution: {integrity: sha512-ZbwHhCGIyxhot9PMgXhRTZBzAAqGyCUHDUCTECBF3crVnNAbM0s97G3fFEO3YDDeygLWxMlqQo6huRxAg2sxZw==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-darwin-x64@0.15.0':
-    resolution: {integrity: sha512-vnFHCj2oxd7N8Eg760yY5gPAHz6tL7NB9Pt1nrP8/+XIutEdUJjpIDGadG0jsTHNmq303EvHh4nkpuO3zBCSZw==}
+  '@nomicfoundation/edr-darwin-x64@0.16.0':
+    resolution: {integrity: sha512-7QSrpHDhlbM8T+wQpdQwkdGGu+03U5AyUvsgfmOiVdMU5HVvM7f6VhdbZSGBHHs1QEaIVtnwlrq9c1k715AZdA==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.15.0':
-    resolution: {integrity: sha512-klBqsMWl19NVok/9BOcX/PeV7M7DrTM4C7eSOQyc6wglZZRwKSm8tDtwQVh/bJkOCqqgVMO6IOi+IQ4xQbsgog==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.16.0':
+    resolution: {integrity: sha512-E/KQrBZw8WgwF5vOQEmMA9XV5q8+HyJReTp3UNiKqVXkkWff+Nwk7u1HqhRq5eDeoWObJcnSAxUNT6J2eXyBvw==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.15.0':
-    resolution: {integrity: sha512-PQ6oqCCOjQaGCyDA1XFDWbpGrXGKZ8Fr3JQrd7cCCqVvIBshg68WrJ7gqlf4DdeidppIi3m9CNRsWsRfj9Y17w==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.16.0':
+    resolution: {integrity: sha512-TOhJo0hXzNDF1oCE6sc8FMzFIbXKzwvSLrG2Dp6+9GnmHUhY/PYKV8gyAUNKeHFHgcy+6rjw5XUk20u1phXXDA==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.15.0':
-    resolution: {integrity: sha512-j89Ywivbs78xWjoSFcZLp+pUqe0p0p3vqiG1utGFj/fJ7zEgTQBcC+DUiyddFpYB3TE79TZMUoaAnEVdxTi4Xw==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.16.0':
+    resolution: {integrity: sha512-sos4CK+BfYiqOwH+3tdRt/mOa2MByEJ+o6VvmlwfbyowgPT3SEa0mOKcfHyTBLtvA9GCb6IYX8OuJ5V0d9W5jQ==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-linux-x64-musl@0.15.0':
-    resolution: {integrity: sha512-bJuCPxihvSFyoGAxmYL5CyN9id5mqncyikywTa7+/+g7ge2Pnz+w7GHbim+tvHeMA9XQv1vSy4QgNkkZXGBzLg==}
+  '@nomicfoundation/edr-linux-x64-musl@0.16.0':
+    resolution: {integrity: sha512-7JtAmGcrwQoJuoDXxzvRulLmVQVtWff1TCddwYwCEMfCfvkCwZ47L4iRM+vkUUuqedGtGcrTysof+dq2uKab+w==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.15.0':
-    resolution: {integrity: sha512-pnUdVgZ4VwqbZu9XTAxJeuGavAY1w3txd/HkpqiOuu43Yrt0nnsRO5gAdj4smXJmQ5Bzy2x2GJ0/68rP4T1Pgw==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.16.0':
+    resolution: {integrity: sha512-JGWqzZWucXXDuyUcTX6mfKf3oQBrY7bUpTFwK3rb+5ZorGfG3yTlqsG2neJjFeyyseRzb/nrNeq5OMgkA0pA5g==}
     engines: {node: '>= 22'}
 
-  '@nomicfoundation/edr@0.15.0':
-    resolution: {integrity: sha512-RcBnQ0MYsrjhLsN+Kcu7q5mnRmBlxmv+Y0lxgrCsST6YTDH/l5RH3nG88J8sDEGmXyjVzX2HsXQBy9NxFJHFuw==}
+  '@nomicfoundation/edr@0.16.0':
+    resolution: {integrity: sha512-ab1MJd04FFLA13MS42QCYIks7JbA6oUkDgqhsifMoVlR0EkifKjQzsMaiTraLP/o0maqakHrM3BxFn38Ca08gA==}
     engines: {node: '>= 22'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -8849,29 +8849,36 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.15.0': {}
+  '@nomicfoundation/edr-darwin-arm64@0.16.0':
+    optional: true
 
-  '@nomicfoundation/edr-darwin-x64@0.15.0': {}
+  '@nomicfoundation/edr-darwin-x64@0.16.0':
+    optional: true
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.15.0': {}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.16.0':
+    optional: true
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.15.0': {}
+  '@nomicfoundation/edr-linux-arm64-musl@0.16.0':
+    optional: true
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.15.0': {}
+  '@nomicfoundation/edr-linux-x64-gnu@0.16.0':
+    optional: true
 
-  '@nomicfoundation/edr-linux-x64-musl@0.15.0': {}
+  '@nomicfoundation/edr-linux-x64-musl@0.16.0':
+    optional: true
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.15.0': {}
+  '@nomicfoundation/edr-win32-x64-msvc@0.16.0':
+    optional: true
 
-  '@nomicfoundation/edr@0.15.0':
-    dependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.15.0
-      '@nomicfoundation/edr-darwin-x64': 0.15.0
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.15.0
-      '@nomicfoundation/edr-linux-arm64-musl': 0.15.0
-      '@nomicfoundation/edr-linux-x64-gnu': 0.15.0
-      '@nomicfoundation/edr-linux-x64-musl': 0.15.0
-      '@nomicfoundation/edr-win32-x64-msvc': 0.15.0
+  '@nomicfoundation/edr@0.16.0':
+    optionalDependencies:
+      '@nomicfoundation/edr-darwin-arm64': 0.16.0
+      '@nomicfoundation/edr-darwin-x64': 0.16.0
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.16.0
+      '@nomicfoundation/edr-linux-arm64-musl': 0.16.0
+      '@nomicfoundation/edr-linux-x64-gnu': 0.16.0
+      '@nomicfoundation/edr-linux-x64-musl': 0.16.0
+      '@nomicfoundation/edr-win32-x64-msvc': 0.16.0
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true


### PR DESCRIPTION
[EDR 0.16.0](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.16.0) accepts compilation artifacts whose `compilerType` is `slangSolx`, and no longer accepts `solx`. This PR upgrades Hardhat to `edr@0.16.0` and moves the `hardhat-slang-solx` plugin onto the new `slangSolx` value.

The `hardhat-slang-solx` plugin previously hacked around the fact that the compiler type was `slangSolx` but EDR accepted `solx` by changing the compiler type during config resolution. This allowed artifacts built by the plugin to be used in EDR to add tracing information.

The rewrite step is reverted by this PR. Build infos carry the compiler type the user actually wrote (i.e. `slangSolx`), that type is passed to EDR which now accepts it and stack traces work.

Resolves #8539.

## Technical decisions

- I peer bumped the `hardhat-slang-solx` plugin's dependency on Hardhat so that it always has edr `>= 0.16.0`, but I kept the change as a `patch` (it is still in internal testing).

## Review

> [!TIP]
> Review a commit at a time

1. `build: upgrade to @nomicfoundation/edr 0.16.0` is the version change and the lockfile.
2. `Revert "fix: temporary convert the compiler type"` undoes the workaround: `RESOLVED_SOLX_COMPILER_TYPE` goes, `augmentIfSolx` stops overwriting `type`, and the `validateResolvedConfig` guards and both `solidity` hook comparisons go back to `SLANG_SOLX_COMPILER_TYPE`. The commit being reverted predates the rename to `slangSolx`, so it also updates the fifteen `"slang-solx"` literals the revert restored in tests.

## Manual testing

### Build and test works under the updated EDR

Set up `packages/example-project` to compile and test under the renamed plugin:

```shell
cd packages/example-project
pnpm add -D @nomicfoundation/hardhat-slang-solx@workspace:^
```

Add to `hardhat.config.ts`:

```ts
import hardhatSlangSolx from "@nomicfoundation/hardhat-slang-solx";


export default defineConfig({
  // ...

  // Update plugins
  plugins: [..., hardhatSlangSolx]

  // Update profiles
  profiles: {
    // ...
    slangSolx: {
      compilers: [
        { type: "slangSolx", version: "0.8.34" },
        { version: "0.8.22" },
        { version: "0.7.1" },
        { version: "0.8.26" },
        { version: "0.8.33" },
      ],
    },
  }
});
```

Clear the cached compilers, then build to prove your building with solx:

```shell
pnpm hardhat clean --global
pnpm hardhat build --build-profile slangSolx
```

Then run the tests:

```shell
pnpm hardhat test --build-profile slangSolx
```

### Tracing works under the updated EDR

Check that tracing (which requires EDR to parse the `slangSolx` compiler type) is working:

Add a contract example:

```solidity
// packages/example-project/test/contracts/SlangSolxTrace.t.sol
contract Target {
  function boom(uint256 n) external pure returns (uint256) {
    require(n > 0, "Target: n must be positive");
    return n;
  }
}

contract SlangSolxTraceTest {
  function test_TraceThroughARevert() external {
    Target t = new Target();
    t.boom(0);
  }
}
```

```shell
pnpm hardhat build --build-profile slangSolx
# Compiled 22 Solidity files with slangSolx 0.1.7 (Solidity 0.8.34) (evm target: osaka)

pnpm hardhat test solidity --build-profile slangSolx
```

```text
1) SlangSolxTraceTest#test_TraceThroughARevert()
  Error: Target: n must be positive
    at Target.boom (test/contracts/SlangSolxTrace.t.sol:6)
    at SlangSolxTraceTest.test_TraceThroughARevert (test/contracts/SlangSolxTrace.t.sol:14)
```
