### PR TITLE
Bump Hardhat templates to solc 0.8.34

### DIFF
--- a/.changeset/templates-solc-0-8-34.md
+++ b/.changeset/templates-solc-0-8-34.md
@@ -1,0 +1,6 @@
+---
+"hardhat": minor
+#docs: https://github.com/NomicFoundation/hardhat-website/pull/294
+---
+
+The project templates have been updated to Solidity 0.8.34 and forge-std v1.16.2.

--- a/packages/example-project/package.json
+++ b/packages/example-project/package.json
@@ -44,7 +44,7 @@
     "@uniswap/v4-core": "1.0.2",
     "chai": "^6.2.2",
     "ethers": "^6.14.0",
-    "forge-std": "foundry-rs/forge-std#v1.9.4",
+    "forge-std": "foundry-rs/forge-std#v1.16.2",
     "hardhat": "workspace:^3.14.0",
     "mocha": "^11.0.0",
     "permit2": "uniswap/permit2#cc56ad0f3439c502c246fc5cfcc3db92bb8b7219",

--- a/packages/hardhat/templates/01-node-test-runner-viem/contracts/Counter.sol
+++ b/packages/hardhat/templates/01-node-test-runner-viem/contracts/Counter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.34;
 
 contract Counter {
   uint public x;

--- a/packages/hardhat/templates/01-node-test-runner-viem/contracts/Counter.t.sol
+++ b/packages/hardhat/templates/01-node-test-runner-viem/contracts/Counter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.34;
 
 import {Counter} from "./Counter.sol";
 import {Test} from "forge-std/Test.sol";

--- a/packages/hardhat/templates/01-node-test-runner-viem/hardhat.config.ts
+++ b/packages/hardhat/templates/01-node-test-runner-viem/hardhat.config.ts
@@ -6,10 +6,10 @@ export default defineConfig({
   solidity: {
     profiles: {
       default: {
-        version: "0.8.28",
+        version: "0.8.34",
       },
       production: {
-        version: "0.8.28",
+        version: "0.8.34",
         settings: {
           optimizer: {
             enabled: true,

--- a/packages/hardhat/templates/01-node-test-runner-viem/package.json
+++ b/packages/hardhat/templates/01-node-test-runner-viem/package.json
@@ -9,7 +9,7 @@
     "@nomicfoundation/hardhat-toolbox-viem": "workspace:^5.0.7",
     "@nomicfoundation/hardhat-ignition": "workspace:^3.1.8",
     "@types/node": "^22.8.5",
-    "forge-std": "foundry-rs/forge-std#v1.9.4",
+    "forge-std": "foundry-rs/forge-std#v1.16.2",
     "typescript": "~6.0.3",
     "viem": "^2.47.6"
   },

--- a/packages/hardhat/templates/02-mocha-ethers/contracts/Counter.sol
+++ b/packages/hardhat/templates/02-mocha-ethers/contracts/Counter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.34;
 
 contract Counter {
   uint public x;

--- a/packages/hardhat/templates/02-mocha-ethers/contracts/Counter.t.sol
+++ b/packages/hardhat/templates/02-mocha-ethers/contracts/Counter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.28;
+pragma solidity ^0.8.34;
 
 import {Counter} from "./Counter.sol";
 import {Test} from "forge-std/Test.sol";

--- a/packages/hardhat/templates/02-mocha-ethers/hardhat.config.ts
+++ b/packages/hardhat/templates/02-mocha-ethers/hardhat.config.ts
@@ -6,10 +6,10 @@ export default defineConfig({
   solidity: {
     profiles: {
       default: {
-        version: "0.8.28",
+        version: "0.8.34",
       },
       production: {
-        version: "0.8.28",
+        version: "0.8.34",
         settings: {
           optimizer: {
             enabled: true,

--- a/packages/hardhat/templates/02-mocha-ethers/package.json
+++ b/packages/hardhat/templates/02-mocha-ethers/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^22.8.5",
     "chai": "^6.2.2",
     "ethers": "^6.14.0",
-    "forge-std": "foundry-rs/forge-std#v1.9.4",
+    "forge-std": "foundry-rs/forge-std#v1.16.2",
     "mocha": "^11.0.0",
     "typescript": "~6.0.3"
   },

--- a/packages/hardhat/templates/03-minimal/hardhat.config.ts
+++ b/packages/hardhat/templates/03-minimal/hardhat.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "hardhat/config";
 
 export default defineConfig({
   solidity: {
-    version: "0.8.28",
+    version: "0.8.34",
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^6.14.0
         version: 6.15.0
       forge-std:
-        specifier: foundry-rs/forge-std#v1.9.4
-        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262
+        specifier: foundry-rs/forge-std#v1.16.2
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf647bd6046f2f7da30d0c2bf435e5c76a780c1b
       hardhat:
         specifier: workspace:^3.14.0
         version: link:../hardhat
@@ -1589,8 +1589,8 @@ importers:
         specifier: ^22.8.5
         version: 22.18.7
       forge-std:
-        specifier: foundry-rs/forge-std#v1.9.4
-        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262
+        specifier: foundry-rs/forge-std#v1.16.2
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf647bd6046f2f7da30d0c2bf435e5c76a780c1b
       hardhat:
         specifier: workspace:^3.14.0
         version: link:../..
@@ -1656,8 +1656,8 @@ importers:
         specifier: ^6.14.0
         version: 6.15.0
       forge-std:
-        specifier: foundry-rs/forge-std#v1.9.4
-        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262
+        specifier: foundry-rs/forge-std#v1.16.2
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf647bd6046f2f7da30d0c2bf435e5c76a780c1b
       hardhat:
         specifier: workspace:^3.14.0
         version: link:../..
@@ -5068,9 +5068,9 @@ packages:
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262:
-    resolution: {gitHosted: true, integrity: sha512-IVp2w0QgChqvkmynnc1d4Chu/7O2JDNSyz4isI1uaW8lbY35Z/nDNAv2lxZKCMwq4xrm2qKoBoQLdOoexUG7ww==, tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262}
-    version: 1.9.4
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf647bd6046f2f7da30d0c2bf435e5c76a780c1b:
+    resolution: {gitHosted: true, integrity: sha512-oHf+awjQrrLSzWgSdQv6exE1+0cmCHIxGGmzQJ9pX5F/pEQq1yHGwfkd++cC1lF7z9edarEX8GgHL5nq3MaF8A==, tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf647bd6046f2f7da30d0c2bf435e5c76a780c1b}
+    version: 1.16.2
 
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
@@ -11255,7 +11255,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262: {}
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/bf647bd6046f2f7da30d0c2bf435e5c76a780c1b: {}
 
   form-data-encoder@1.7.2: {}
 


### PR DESCRIPTION
The project templates compiled with Solidity 0.8.28, released in October 2024. This moves them to 0.8.34, and takes `forge-std` to its latest release.

`hardhat --init` now scaffolds a project on 0.8.34 with `forge-std v1.16.2`, and building it prints no warnings.

Resolves #8520.

## Technical decisions

1. A scaffolded project now compiles for `osaka` rather than `cancun`
2. `forge-std` bumped to include the memory-safe assembly changes and avoid the warning that solc 0.8.33 show for the old syntax.
3. Bump `forge-std` for the `package/example-project` as well

## Documentation

The website examples move to the same versions in [hardhat-website#294](https://github.com/NomicFoundation/hardhat-website/pull/294), so config snippets and pragmas a reader copies match what `hardhat --init` produces.

## Review

> [!TIP]
> Review a commit at a time

1. `chore: bump forge-std to v1.16.2` covers both Solidity-test templates and `example-project`.
2. `chore: bump the templates to solc 0.8.34` moves the `solidity` config and the contract pragmas together, because a pragma above the configured version does not compile.

## Manual testing

Run through a verdaccio install and init of the templates:

```shell
# Step 1
pnpm version-for-release
pnpm verdaccio start

# In another tab
pnpm verdaccio publish --no-git-checks
# [verdaccio]   hardhat 3.14.0

# Step 2
mkdir -p /tmp/end-to-end/new-viem && cd /tmp/end-to-end/new-viem
echo "registry=http://localhost:4873" > .npmrc
cat > pnpm-workspace.yaml <<'EOF'
minimumReleaseAgeExclude:
  - hardhat
  - "@nomicfoundation/*"
EOF
pnpm dlx hardhat --init --template node-test-runner-viem
pnpm hardhat --version
# 3.14.0

# Step 3
pnpm hardhat build
pnpm hardhat test
pnpm hardhat test --coverage --gas-stats
pnpm hardhat ignition deploy ./ignition/modules/Counter.ts
```

Do the same for `ether` swapping out Step 2 for:

```shell
mkdir -p /tmp/end-to-end/new-ethers && cd /tmp/end-to-end/new-ethers
echo "registry=http://localhost:4873" > .npmrc
cat > pnpm-workspace.yaml <<'EOF'
minimumReleaseAgeExclude:
  - hardhat
  - "@nomicfoundation/*"
EOF
pnpm dlx hardhat --init --template mocha-ethers
pnpm hardhat --version
# 3.14.0
```
