### PR TITLE
fix: suggest relative import for bare-filename sibling Solidity imports

### DIFF
--- a/.changeset/bare-filename-local-import.md
+++ b/.changeset/bare-filename-local-import.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+When a Solidity file imports a sibling by bare filename (`import "Storage.sol"`), Hardhat now reports that as a local direct import and suggests `import "./Storage.sol"` instead of a misleading invalid-npm-syntax error.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -941,6 +941,25 @@ export class ResolverImplementation implements Resolver {
     from: ResolvedFile;
     importPath: string;
   }): Promise<ImportResolutionError | undefined> {
+    // Bare filenames like `import "Storage.sol"` cannot be expressed as a
+    // remapping prefix (those require a trailing `/`). If a sibling file
+    // exists, suggest the relative form instead of the misleading npm-syntax
+    // error.
+    if (!importPath.includes("/")) {
+      const siblingFsPath = path.join(path.dirname(from.fsPath), importPath);
+
+      if (await exists(siblingFsPath)) {
+        return {
+          type: ImportResolutionErrorType.DIRECT_IMPORT_TO_LOCAL_FILE,
+          fromFsPath: from.fsPath,
+          importPath,
+          suggestedRelativeImport: `./${importPath}`,
+        };
+      }
+
+      return undefined;
+    }
+
     let baseDir = path.dirname(from.fsPath);
     const firstDir = importPath.substring(0, importPath.indexOf("/"));
     // If there's no directory separator, or the import is just a directory

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/error-messages.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/error-messages.ts
@@ -151,7 +151,15 @@ If you want to use the remapping, write your import as "${error.directImport}" i
     }
 
     case ImportResolutionErrorType.DIRECT_IMPORT_TO_LOCAL_FILE: {
-      return `You are trying to import a local file with a direct import path instead of a relative one, and this is not allowed by Hardhat.
+      const intro = `You are trying to import a local file with a direct import path instead of a relative one, and this is not allowed by Hardhat.`;
+
+      if (error.suggestedRelativeImport !== undefined) {
+        return `${intro}
+
+If you meant to import a local file next to this one, write your import as "${error.suggestedRelativeImport}" instead.`;
+      }
+
+      return `${intro}
 
 If you still want to be able to do it, try adding this remapping "${error.suggestedRemapping}" to the "remappings.txt" file in the root of your project.`;
     }

--- a/packages/hardhat/src/types/solidity/errors.ts
+++ b/packages/hardhat/src/types/solidity/errors.ts
@@ -272,7 +272,17 @@ export interface DirectImportToLocalFileError {
   type: ImportResolutionErrorType.DIRECT_IMPORT_TO_LOCAL_FILE;
   fromFsPath: string;
   importPath: string;
-  suggestedRemapping: string;
+  /**
+   * A remapping that would make this direct import resolve. Present when the
+   * import path contains a directory prefix that can be remapped.
+   */
+  suggestedRemapping?: string;
+  /**
+   * A relative import that would resolve to the same local file. Present for
+   * slash-less (bare filename) imports of a sibling file, which remappings
+   * cannot express.
+   */
+  suggestedRelativeImport?: string;
 }
 
 export type ImportResolutionError =

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -3241,6 +3241,53 @@ submodule2/=lib/submodule2/src/`,
               "contracts/=contracts/",
             );
           });
+
+          it("Should suggest a relative import for a bare-filename sibling file", async () => {
+            const localTemplate: TestProjectTemplate = {
+              name: "bare-filename-direct-import-suggestion",
+              version: "1.0.0",
+              files: {
+                "contracts/Factory.sol": `Factory`,
+                "contracts/Storage.sol": `Storage`,
+              },
+            };
+
+            await using project = await useTestProjectTemplate(localTemplate);
+            const resolver = await ResolverImplementation.create(
+              project.path,
+              readUtf8File,
+            );
+
+            const factory = await resolver.resolveProjectFile(
+              path.join(project.path, "contracts/Factory.sol"),
+            );
+            assert.ok(factory.success, "Result should be successful");
+
+            assert.deepEqual(
+              await resolver.resolveImport(factory.value, "Storage.sol"),
+              {
+                success: false,
+                error: {
+                  type: ImportResolutionErrorType.DIRECT_IMPORT_TO_LOCAL_FILE,
+                  fromFsPath: factory.value.fsPath,
+                  importPath: "Storage.sol",
+                  suggestedRelativeImport: "./Storage.sol",
+                },
+              },
+            );
+
+            const missing = await resolver.resolveImport(
+              factory.value,
+              "Missing.sol",
+            );
+            assert.equal(missing.success, false);
+            if (missing.success === false) {
+              assert.equal(
+                missing.error.type,
+                ImportResolutionErrorType.IMPORT_WITH_INVALID_NPM_SYNTAX,
+              );
+            }
+          });
         });
 
         describe("From an npm file", () => {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/error-messages.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity/build-system/resolver/error-messages.ts
@@ -539,6 +539,22 @@ If you want to use the remapping, write your import as "contracts/Token.sol" ins
 If you still want to be able to do it, try adding this remapping "contracts/=contracts/" to the "remappings.txt" file in the root of your project.`,
         );
       });
+
+      it("Should suggest a relative import for a bare-filename sibling", () => {
+        const result = formatImportResolutionError({
+          type: ImportResolutionErrorType.DIRECT_IMPORT_TO_LOCAL_FILE,
+          fromFsPath: "/project/contracts/Factory.sol",
+          importPath: "Storage.sol",
+          suggestedRelativeImport: "./Storage.sol",
+        });
+
+        assert.equal(
+          result,
+          `You are trying to import a local file with a direct import path instead of a relative one, and this is not allowed by Hardhat.
+
+If you meant to import a local file next to this one, write your import as "./Storage.sol" instead.`,
+        );
+      });
     });
 
     describe("IMPORT_DOES_NOT_EXIST", () => {


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

Fixes #8537.

Hardhat 3 treats `import "Storage.sol"` (Remix-style sibling import, no `./`) as an npm module. That path is not valid npm syntax, so users get HHE902 ("You are trying to import an npm file but its syntax is invalid") even when `Storage.sol` sits next to the importer.

Direct imports that already contain a `/` already get `DIRECT_IMPORT_TO_LOCAL_FILE` with a remapping suggestion. Bare filenames cannot be expressed as a remapping prefix (those require a trailing `/`), so this change:

1. Detects when the import has no `/` and a sibling file exists.
2. Reports the same local-direct-import error, suggesting `import "./Storage.sol"` instead of the npm-syntax message.

If the sibling file does not exist, the previous invalid-npm-syntax error is unchanged.

Tests cover the resolver result and the formatted error message.
