### PR TITLE
build: upgrade EDR to v0.17.0

### DIFF
--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -93,7 +93,7 @@
     "typescript": "~6.0.3"
   },
   "dependencies": {
-    "@nomicfoundation/edr": "0.16.0",
+    "@nomicfoundation/edr": "0.17.0",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.17",
     "@nomicfoundation/hardhat-utils": "workspace:^4.1.6",
     "@nomicfoundation/hardhat-vendored": "workspace:^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
   packages/hardhat:
     dependencies:
       '@nomicfoundation/edr':
-        specifier: 0.16.0
-        version: 0.16.0
+        specifier: 0.17.0
+        version: 0.17.0
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.17
         version: link:../hardhat-errors
@@ -3008,36 +3008,54 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.16.0':
-    resolution: {integrity: sha512-ZbwHhCGIyxhot9PMgXhRTZBzAAqGyCUHDUCTECBF3crVnNAbM0s97G3fFEO3YDDeygLWxMlqQo6huRxAg2sxZw==}
+  '@nomicfoundation/edr-darwin-arm64@0.17.0':
+    resolution: {integrity: sha512-rw+lAEQ9/XB5kvTRlu9fs+bZ1byF3OIMOpNfkg6cSUDCZZeXXhgpbzCWVHnmY6VVcka0L/qUDbhsNPD6GmBFIw==}
     engines: {node: '>= 22'}
+    cpu: [arm64]
+    os: [darwin]
 
-  '@nomicfoundation/edr-darwin-x64@0.16.0':
-    resolution: {integrity: sha512-7QSrpHDhlbM8T+wQpdQwkdGGu+03U5AyUvsgfmOiVdMU5HVvM7f6VhdbZSGBHHs1QEaIVtnwlrq9c1k715AZdA==}
+  '@nomicfoundation/edr-darwin-x64@0.17.0':
+    resolution: {integrity: sha512-QLE4fnl0B8GK40H0QE4I4jXZ9rqG0P+QawZjlVjJAjl3mLcSCJNaNHVX1S5Z5Ee4Acrr6dfgAH8nRsTu6N8Zfw==}
     engines: {node: '>= 22'}
+    cpu: [x64]
+    os: [darwin]
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.16.0':
-    resolution: {integrity: sha512-E/KQrBZw8WgwF5vOQEmMA9XV5q8+HyJReTp3UNiKqVXkkWff+Nwk7u1HqhRq5eDeoWObJcnSAxUNT6J2eXyBvw==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.17.0':
+    resolution: {integrity: sha512-NzdxADNC7L1BfgfmrqUhzUddz4Cg3Uf1pkXbVlJ38Tvn3h09m/D7+VAlxXjkvrJ5M7OoaHmr114vSlQ9zNSFJw==}
     engines: {node: '>= 22'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.16.0':
-    resolution: {integrity: sha512-TOhJo0hXzNDF1oCE6sc8FMzFIbXKzwvSLrG2Dp6+9GnmHUhY/PYKV8gyAUNKeHFHgcy+6rjw5XUk20u1phXXDA==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.17.0':
+    resolution: {integrity: sha512-1o3LTouqc831tR+cr2dfckVRlEat8Om/dqYC58NFAaED/OVj52ndX4p+qvKg2qQ0AvW6wszjRZ4TY01F3VHZ/A==}
     engines: {node: '>= 22'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.16.0':
-    resolution: {integrity: sha512-sos4CK+BfYiqOwH+3tdRt/mOa2MByEJ+o6VvmlwfbyowgPT3SEa0mOKcfHyTBLtvA9GCb6IYX8OuJ5V0d9W5jQ==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.17.0':
+    resolution: {integrity: sha512-pDyvBR9tXBGL6u0Qc60Hi7szpjHq9xqa9aHgT81/qbcisTRkwpqEcHv6zFJ6ZIkCZa0+WYcziQ67Nho17btYvA==}
     engines: {node: '>= 22'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
-  '@nomicfoundation/edr-linux-x64-musl@0.16.0':
-    resolution: {integrity: sha512-7JtAmGcrwQoJuoDXxzvRulLmVQVtWff1TCddwYwCEMfCfvkCwZ47L4iRM+vkUUuqedGtGcrTysof+dq2uKab+w==}
+  '@nomicfoundation/edr-linux-x64-musl@0.17.0':
+    resolution: {integrity: sha512-AnPUwuhKUkbgDM7TDfU3q3R4uXP4P+0IG8+8hdph/sgo34LA0cFILWQhKKnR4eSdlgLiepG9bjpF84yXuydyuA==}
     engines: {node: '>= 22'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.16.0':
-    resolution: {integrity: sha512-JGWqzZWucXXDuyUcTX6mfKf3oQBrY7bUpTFwK3rb+5ZorGfG3yTlqsG2neJjFeyyseRzb/nrNeq5OMgkA0pA5g==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.17.0':
+    resolution: {integrity: sha512-buvHzzK/UzeXcgY7UD0izceM2GRxC5akKgBaCfPdcpQybOmSdJHUm9kSCEWmy/YTf4HVLLgA9EyrHCLqY2Tsrw==}
     engines: {node: '>= 22'}
+    cpu: [x64]
+    os: [win32]
 
-  '@nomicfoundation/edr@0.16.0':
-    resolution: {integrity: sha512-ab1MJd04FFLA13MS42QCYIks7JbA6oUkDgqhsifMoVlR0EkifKjQzsMaiTraLP/o0maqakHrM3BxFn38Ca08gA==}
+  '@nomicfoundation/edr@0.17.0':
+    resolution: {integrity: sha512-gnPDZEgIzkp5fwGMI8AVoRconp1BK8SGWiBTtQXq9G0+CAvS7hlz7Y9HiHptyv84cqKVacRSDqsS+7oN08su1Q==}
     engines: {node: '>= 22'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -8849,36 +8867,36 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.16.0':
+  '@nomicfoundation/edr-darwin-arm64@0.17.0':
     optional: true
 
-  '@nomicfoundation/edr-darwin-x64@0.16.0':
+  '@nomicfoundation/edr-darwin-x64@0.17.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.16.0':
+  '@nomicfoundation/edr-linux-arm64-gnu@0.17.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.16.0':
+  '@nomicfoundation/edr-linux-arm64-musl@0.17.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.16.0':
+  '@nomicfoundation/edr-linux-x64-gnu@0.17.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-x64-musl@0.16.0':
+  '@nomicfoundation/edr-linux-x64-musl@0.17.0':
     optional: true
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.16.0':
+  '@nomicfoundation/edr-win32-x64-msvc@0.17.0':
     optional: true
 
-  '@nomicfoundation/edr@0.16.0':
+  '@nomicfoundation/edr@0.17.0':
     optionalDependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.16.0
-      '@nomicfoundation/edr-darwin-x64': 0.16.0
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.16.0
-      '@nomicfoundation/edr-linux-arm64-musl': 0.16.0
-      '@nomicfoundation/edr-linux-x64-gnu': 0.16.0
-      '@nomicfoundation/edr-linux-x64-musl': 0.16.0
-      '@nomicfoundation/edr-win32-x64-msvc': 0.16.0
+      '@nomicfoundation/edr-darwin-arm64': 0.17.0
+      '@nomicfoundation/edr-darwin-x64': 0.17.0
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.17.0
+      '@nomicfoundation/edr-linux-arm64-musl': 0.17.0
+      '@nomicfoundation/edr-linux-x64-gnu': 0.17.0
+      '@nomicfoundation/edr-linux-x64-musl': 0.17.0
+      '@nomicfoundation/edr-win32-x64-msvc': 0.17.0
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true


### PR DESCRIPTION
Upgrades `@nomicfoundation/edr` from 0.16.0 to 0.17.0.

The EDR platform packages now declare `os`/`cpu`/`libc` in their manifests, so package managers only download the package matching the current platform instead of all seven optional platform packages.

I chose to leave out a changeset, as this merely fixes the change already [committed in the previous PR](https://github.com/NomicFoundation/hardhat/pull/8540/changes#diff-d29574f4c08b3d9bb3f0610e71e1302d9b92b3bf9cf014617dc02682aead1cf5).

[Release notes](https://github.com/NomicFoundation/edr/releases/tag/%40nomicfoundation%2Fedr%400.17.0)

### Validation

- Verified locally with pnpm: only `edr-linux-x64-gnu` is installed