### PR TITLE
fix(ignition): handle null return data

### DIFF
--- a/.changeset/ignition-null-return-data.md
+++ b/.changeset/ignition-null-return-data.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/ignition-core": patch
+---
+
+Fixed a crash (`TypeError: Cannot read properties of null (reading 'startsWith')`) when a JSON-RPC server reported a failed `eth_call` without any usable return data. `decodeError` now treats a `null` return data the same as `"0x"`, returning a revert-without-reason result instead of throwing.

--- a/packages/ignition-core/src/internal/execution/abi.ts
+++ b/packages/ignition-core/src/internal/execution/abi.ts
@@ -415,7 +415,8 @@ export function getEventArgumentFromReceipt(
 /**
  * Decodes an error from a failed evm execution.
  *
- * @param returnData The data, as returned by the JSON-RPC.
+ * @param returnData The data, as returned by the JSON-RPC. `null` if the
+ *  JSON-RPC server reported the failure without any usable data.
  * @param customErrorReported A value indicating if the JSON-RPC error
  *  reported that it was due to a custom error.
  * @param decodeCustomError A function that decodes custom errors, returning
@@ -425,13 +426,13 @@ export function getEventArgumentFromReceipt(
  * @returns A `FailedEvmExecutionResult` with the decoded error.
  */
 export function decodeError(
-  returnData: string,
+  returnData: string | null,
   customErrorReported: boolean,
   decodeCustomError?: (
     returnData: string,
   ) => RevertWithCustomError | RevertWithInvalidData | undefined,
 ): FailedEvmExecutionResult {
-  if (returnData === "0x") {
+  if (returnData === null || returnData === "0x") {
     return { type: EvmExecutionResultTypes.REVERT_WITHOUT_REASON };
   }
 

--- a/packages/ignition-core/src/internal/execution/execution-strategy-helpers.ts
+++ b/packages/ignition-core/src/internal/execution/execution-strategy-helpers.ts
@@ -120,6 +120,11 @@ export async function* executeOnchainInteractionRequest(
     }
 
     if (decodeSuccessfulSimulationResult !== undefined) {
+      assertIgnitionInvariant(
+        firstResponse.result.returnData !== null,
+        `${assertionPrefix}Expected return data for a successful simulation result`,
+      );
+
       const result = decodeSuccessfulSimulationResult(
         firstResponse.result.returnData,
       );
@@ -184,6 +189,11 @@ export async function* executeStaticCallRequest(
       error,
     };
   }
+
+  assertIgnitionInvariant(
+    result.returnData !== null,
+    "Expected return data for a successful static call result",
+  );
 
   const decodedResult = decodeSuccessfulResult(result.returnData);
 

--- a/packages/ignition-core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/ignition-core/src/internal/execution/jsonrpc-client.ts
@@ -342,7 +342,9 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
       };
     } catch (error) {
       if (error instanceof Error) {
-        const errorWithData = error as { data?: string | { data?: string } };
+        const errorWithData = error as {
+          data?: string | null | { data?: string | null };
+        };
         const data =
           typeof errorWithData.data === "string"
             ? errorWithData.data

--- a/packages/ignition-core/src/internal/execution/types/jsonrpc.ts
+++ b/packages/ignition-core/src/internal/execution/types/jsonrpc.ts
@@ -3,9 +3,10 @@
  */
 export interface RawStaticCallResult {
   /**
-   * The data returned by the call.
+   * The data returned by the call. Some JSON-RPC servers report a failed
+   * call's error without any usable data, represented here as `null`.
    */
-  returnData: string;
+  returnData: string | null;
 
   /**
    * A boolean indicating whether the call was successful or not.

--- a/packages/ignition-core/test/execution/abi.ts
+++ b/packages/ignition-core/test/execution/abi.ts
@@ -244,16 +244,22 @@ describe("abi", () => {
         `No fixtures for ${contractName}.${functionName}`,
       );
 
+      const fixtureReturnData =
+        staticCallResultFixtures[contractName][functionName].returnData;
+      assert.isNotNull(
+        fixtureReturnData,
+        `Fixture ${contractName}.${functionName} is expected to have string return data`,
+      );
+
       const decoded = decodeArtifactFunctionCallResult(
         staticCallResultFixturesArtifacts[contractName],
         functionName,
-        staticCallResultFixtures[contractName][functionName].returnData,
+        fixtureReturnData,
       );
 
       return {
         decoded,
-        returnData:
-          staticCallResultFixtures[contractName][functionName].returnData,
+        returnData: fixtureReturnData,
       };
     }
 
@@ -514,11 +520,11 @@ describe("abi", () => {
   describe("decodeArtifactCustomError", () => {
     it("Should successfully decode a custom error", () => {
       const artifact = staticCallResultFixturesArtifacts.C;
+      const returnData =
+        staticCallResultFixtures.C.revertWithCustomError.returnData;
+      assert.isNotNull(returnData);
 
-      const decoded = decodeArtifactCustomError(
-        artifact,
-        staticCallResultFixtures.C.revertWithCustomError.returnData,
-      );
+      const decoded = decodeArtifactCustomError(artifact, returnData);
 
       assert.deepEqual(decoded, {
         type: EvmExecutionResultTypes.REVERT_WITH_CUSTOM_ERROR,
@@ -534,26 +540,25 @@ describe("abi", () => {
 
     it("Should return invalid data error if the custom error is recognized but can't be decoded", () => {
       const artifact = staticCallResultFixturesArtifacts.C;
+      const returnData =
+        staticCallResultFixtures.C.revertWithInvalidCustomError.returnData;
+      assert.isNotNull(returnData);
 
-      const decoded = decodeArtifactCustomError(
-        artifact,
-        staticCallResultFixtures.C.revertWithInvalidCustomError.returnData,
-      );
+      const decoded = decodeArtifactCustomError(artifact, returnData);
 
       assert.deepEqual(decoded, {
         type: EvmExecutionResultTypes.REVERT_WITH_INVALID_DATA,
-        data: staticCallResultFixtures.C.revertWithInvalidCustomError
-          .returnData,
+        data: returnData,
       });
     });
 
     it("Should return undefined if no custom error is recognized", () => {
       const artifact = staticCallResultFixturesArtifacts.C;
+      const returnData =
+        staticCallResultFixtures.C.revertWithUnknownCustomError.returnData;
+      assert.isNotNull(returnData);
 
-      const decoded = decodeArtifactCustomError(
-        artifact,
-        staticCallResultFixtures.C.revertWithUnknownCustomError.returnData,
-      );
+      const decoded = decodeArtifactCustomError(artifact, returnData);
 
       assert.isUndefined(decoded);
     });
@@ -564,8 +569,15 @@ describe("abi", () => {
       contractName: keyof typeof staticCallResultFixtures,
       functionName: keyof (typeof staticCallResultFixtures)[typeof contractName],
     ) {
+      const fixtureReturnData =
+        staticCallResultFixtures[contractName][functionName].returnData;
+      assert.isNotNull(
+        fixtureReturnData,
+        `Fixture ${contractName}.${functionName} is expected to have string return data`,
+      );
+
       const decoded = decodeError(
-        staticCallResultFixtures[contractName][functionName].returnData,
+        fixtureReturnData,
         staticCallResultFixtures[contractName][functionName]
           .customErrorReported,
         (returnData) =>
@@ -577,8 +589,7 @@ describe("abi", () => {
 
       return {
         decoded,
-        returnData:
-          staticCallResultFixtures[contractName][functionName].returnData,
+        returnData: fixtureReturnData,
       };
     }
 
@@ -597,6 +608,16 @@ describe("abi", () => {
         describe("When the function returns something and there's no clash", () => {
           it("should return RevertWithoutReason", async () => {
             const { decoded } = decode("C", "revertWithoutReasonWithoutClash");
+            assert.deepEqual(decoded, {
+              type: EvmExecutionResultTypes.REVERT_WITHOUT_REASON,
+            });
+          });
+        });
+
+        describe("When the JSON-RPC server reports the failure without any usable data", () => {
+          it("should return RevertWithoutReason instead of throwing", () => {
+            const decoded = decodeError(null, false);
+
             assert.deepEqual(decoded, {
               type: EvmExecutionResultTypes.REVERT_WITHOUT_REASON,
             });

--- a/packages/ignition-core/test/execution/jsonrpc-client.ts
+++ b/packages/ignition-core/test/execution/jsonrpc-client.ts
@@ -1,0 +1,33 @@
+import { assert } from "chai";
+
+import { EIP1193JsonRpcClient } from "../../src/internal/execution/jsonrpc-client.js";
+
+describe("EIP1193JsonRpcClient", () => {
+  describe("call", () => {
+    it("should preserve null return data from a nested JSON-RPC error", async () => {
+      const provider = {
+        request: async () => {
+          const error = new Error("execution reverted");
+          Object.assign(error, { data: { data: null } });
+          throw error;
+        },
+      };
+      const client = new EIP1193JsonRpcClient(provider);
+
+      const result = await client.call(
+        {
+          from: "0x0000000000000000000000000000000000000001",
+          value: 0n,
+          data: "0x",
+        },
+        "latest",
+      );
+
+      assert.deepEqual(result, {
+        success: false,
+        returnData: null,
+        customErrorReported: false,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6241

## Summary

- Preserve null return data from nested JSON-RPC errors.
- Treat null return data as a revert without reason during error decoding.
- Add regression coverage for the JSON-RPC client and error decoder.

## Tests

- pnpm --filter @nomicfoundation/ignition-core test:unit
- pnpm --filter @nomicfoundation/ignition-core build
- pnpm --filter @nomicfoundation/ignition-core lint
- git diff --check

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] I didn't do anything of this.