### PR TITLE
feat(scripts): add `pnpm profiler` for profiling e2e scenario commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "spellcheck:file": "node ./scripts/spellcheck-file.ts",
     "verdaccio": "node ./scripts/verdaccio/main.ts",
     "e2e": "node ./scripts/end-to-end/main.ts",
+    "profiler": "node ./scripts/profiler/main.ts",
+    "profiler:flamegraph": "node ./scripts/profiler/helpers/flamegraph.ts",
     "bench": "node ./scripts/benchmark/main.ts",
     "bench:regression": "node ./scripts/benchmark/regression.ts"
   }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,6 +17,18 @@ To support the development and maintenance of `./scripts`, the following npm scr
 
 `pnpm lint` and `pnpm lint:fix` at the repo root include `lint:scripts` automatically.
 
+## Scenario tooling layers
+
+The scenario-related scripts are layered, from low-level to high-level; each layer may only import from the layers below it:
+
+1. `end-to-end/` (`pnpm e2e`) — run a command on an e2e scenario.
+2. `profiler/` (`pnpm profiler`, `pnpm profiler:flamegraph`) — run a single e2e command once, for one or more scenarios, while profiling it (system-wide via Linux perf, or JavaScript-level via the JS engine's `--cpu-prof` profiler).
+3. `benchmark/` (`pnpm bench`, `pnpm bench:regression`) — run a command multiple times and report statistics; regression benchmarking runs a predefined harness of benchmark commands.
+
+### Profiler artifacts and trade-offs
+
+`pnpm profiler` writes several views of the same recording with different trade-offs (time-ordering, portability, size). Run `pnpm profiler` and `pnpm profiler:flamegraph` without arguments for the artifact list and how to choose between them.
+
 ## Writing new scripts
 
 **Language and runtime** — Write scripts as `.ts` files. Node 24 strips the types at runtime, so there is no compile step. The `scripts/tsconfig.json` handles type-checking via `pnpm tsc:scripts`.

--- a/scripts/benchmark/helpers/args.ts
+++ b/scripts/benchmark/helpers/args.ts
@@ -1,6 +1,9 @@
 import { log } from "node:console";
 import { normalizeScenarioPath } from "../../end-to-end/helpers/directory.ts";
-import { DEFAULT_CLONE_DIR } from "../../end-to-end/helpers/args.ts";
+import {
+  DEFAULT_CLONE_DIR,
+  getArgValue,
+} from "../../end-to-end/helpers/args.ts";
 import {
   ForceCheckout,
   ForcePublish,
@@ -99,10 +102,4 @@ export function resolveAndValidateArgs(args: string[]): BenchArgs | undefined {
     timeFile: undefined,
     e2eCloneDirectory,
   };
-}
-
-function getArgValue(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-
-  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
 }

--- a/scripts/end-to-end/helpers/args.ts
+++ b/scripts/end-to-end/helpers/args.ts
@@ -68,7 +68,7 @@ export function resolveAndValidateArgs(args: string[]) {
   };
 }
 
-function getArgValue(args: string[], flag: string): string | undefined {
+export function getArgValue(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
 
   return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;

--- a/scripts/end-to-end/helpers/scenario-setup.ts
+++ b/scripts/end-to-end/helpers/scenario-setup.ts
@@ -1,0 +1,37 @@
+import { existsSync } from "node:fs";
+
+import { loadScenario } from "./directory.ts";
+import {
+  init,
+  type ForceCheckout,
+  type ForcePublish,
+  type UseLocal,
+} from "../subcommands/init.ts";
+import type { Scenario } from "../types.ts";
+
+/**
+ * Loads a scenario, initializing it when its working directory does not
+ * exist yet or when `forceInit` is true.
+ */
+export async function ensureScenarioInitialized(
+  e2eCloneDirectory: string,
+  scenarioPath: string,
+  useLocal: UseLocal,
+  forceCheckout: ForceCheckout,
+  forcePublish: ForcePublish,
+  forceInit: boolean = false,
+): Promise<Scenario> {
+  const scenario = loadScenario(e2eCloneDirectory, scenarioPath);
+
+  if (forceInit || !existsSync(scenario.workingDir)) {
+    await init(
+      e2eCloneDirectory,
+      scenarioPath,
+      useLocal,
+      forceCheckout,
+      forcePublish,
+    );
+  }
+
+  return scenario;
+}

--- a/scripts/end-to-end/subcommands/exec.ts
+++ b/scripts/end-to-end/subcommands/exec.ts
@@ -1,7 +1,6 @@
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { loadScenario } from "../helpers/directory.ts";
-import { init, ForceCheckout, ForcePublish, UseLocal } from "./init.ts";
+import { ensureScenarioInitialized } from "../helpers/scenario-setup.ts";
+import type { ForceCheckout, ForcePublish, UseLocal } from "./init.ts";
 import { logStep } from "../helpers/log.ts";
 
 export async function exec(
@@ -12,17 +11,13 @@ export async function exec(
   forceCheckout: ForceCheckout,
   forcePublish: ForcePublish,
 ): Promise<void> {
-  const scenario = loadScenario(e2eCloneDirectory, scenarioPath);
-
-  if (!existsSync(scenario.workingDir)) {
-    await init(
-      e2eCloneDirectory,
-      scenarioPath,
-      useLocal,
-      forceCheckout,
-      forcePublish,
-    );
-  }
+  const scenario = await ensureScenarioInitialized(
+    e2eCloneDirectory,
+    scenarioPath,
+    useLocal,
+    forceCheckout,
+    forcePublish,
+  );
 
   const resolvedCommand = command ?? scenario.definition.defaultCommand;
 

--- a/scripts/profiler/helpers/args.test.ts
+++ b/scripts/profiler/helpers/args.test.ts
@@ -1,3 +1,4 @@
+// cSpell:ignore outpt -- a deliberate misspelling testing flag validation
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {

--- a/scripts/profiler/helpers/args.test.ts
+++ b/scripts/profiler/helpers/args.test.ts
@@ -1,0 +1,127 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  getAllArgValues,
+  parseEnvPairs,
+  parseMode,
+  parsePositionalArgs,
+  parseSampleRate,
+} from "./args.ts";
+
+describe("getAllArgValues", () => {
+  it("collects every occurrence in order", () => {
+    assert.deepEqual(
+      getAllArgValues(
+        ["--scenario", "a", "--mode", "js", "--scenario", "b"],
+        "--scenario",
+      ),
+      ["a", "b"],
+    );
+  });
+
+  it("returns an empty array when absent", () => {
+    assert.deepEqual(getAllArgValues(["--mode", "js"], "--scenario"), []);
+  });
+});
+
+describe("parsePositionalArgs", () => {
+  it("collects tokens that are neither flags nor flag values", () => {
+    assert.deepEqual(
+      parsePositionalArgs(
+        ["render", "/run-dir", "--title", "cpu profile"],
+        ["--title"],
+      ),
+      ["render", "/run-dir"],
+    );
+  });
+
+  it("excludes the value following a value flag", () => {
+    assert.deepEqual(
+      parsePositionalArgs(["--output", "out.svg", "fold"], ["--output"]),
+      ["fold"],
+    );
+  });
+
+  it("treats a boolean flag's neighbor as positional, not its value", () => {
+    assert.deepEqual(
+      parsePositionalArgs(["--dry-run", "stray"], [], ["--dry-run"]),
+      ["stray"],
+    );
+  });
+
+  it("returns an empty array for flag-only args", () => {
+    assert.deepEqual(
+      parsePositionalArgs(
+        ["--title", "x", "--dry-run"],
+        ["--title"],
+        ["--dry-run"],
+      ),
+      [],
+    );
+  });
+
+  it("rejects unknown flags", () => {
+    assert.throws(
+      () => parsePositionalArgs(["--outpt", "x"], ["--output"]),
+      /unknown option: --outpt/,
+    );
+  });
+
+  it("rejects a flag missing its value", () => {
+    assert.throws(
+      () => parsePositionalArgs(["--output"], ["--output"]),
+      /--output requires a value/,
+    );
+  });
+
+  it("rejects a flag whose value looks like a flag", () => {
+    assert.throws(
+      () =>
+        parsePositionalArgs(
+          ["--output", "--title", "x"],
+          ["--output", "--title"],
+        ),
+      /--output requires a value/,
+    );
+  });
+});
+
+describe("parseEnvPairs", () => {
+  it("parses KEY=VALUE pairs, allowing = in values", () => {
+    assert.deepEqual(parseEnvPairs(["A=1", "B=x=y"]), { A: "1", B: "x=y" });
+  });
+
+  it("rejects pairs without a key", () => {
+    assert.throws(() => parseEnvPairs(["=nope"]), /KEY=VALUE/);
+  });
+});
+
+describe("parseMode", () => {
+  it("defaults to both", () => {
+    assert.equal(parseMode(undefined), "both");
+  });
+
+  it("rejects unknown modes", () => {
+    assert.throws(() => parseMode("perf"), /--mode must be one of/);
+  });
+});
+
+describe("parseSampleRate", () => {
+  it("defaults to 999 Hz", () => {
+    assert.equal(parseSampleRate(undefined), 999);
+  });
+
+  it("rejects non-integers", () => {
+    assert.throws(() => parseSampleRate("99.5"), /--sample-rate/);
+  });
+
+  it("accepts the bounds", () => {
+    assert.equal(parseSampleRate("1"), 1);
+    assert.equal(parseSampleRate("100000"), 100_000);
+  });
+
+  it("rejects values outside the bounds", () => {
+    assert.throws(() => parseSampleRate("0"), /--sample-rate/);
+    assert.throws(() => parseSampleRate("100001"), /--sample-rate/);
+  });
+});

--- a/scripts/profiler/helpers/args.ts
+++ b/scripts/profiler/helpers/args.ts
@@ -1,0 +1,118 @@
+import { getArgValue } from "../../end-to-end/helpers/args.ts";
+
+export const Mode = {
+  Both: "both",
+  Js: "js",
+  System: "system",
+} as const;
+
+export type Mode = (typeof Mode)[keyof typeof Mode];
+
+export const DEFAULT_SAMPLE_RATE_HZ = 999;
+
+/** Collects every value of a repeatable flag, in order. */
+export function getAllArgValues(args: string[], flag: string): string[] {
+  const values: string[] = [];
+
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === flag) {
+      values.push(args[i + 1]);
+    }
+  }
+
+  return values;
+}
+
+/**
+ * Validates the flags and returns the positional arguments.
+ *
+ * Throws on an unknown `--flag`. Also throws on a value flag whose value is
+ * missing — absent, or another flag. The positional arguments are the
+ * remaining tokens: neither a flag nor a value consumed by one. Knowing each
+ * flag's arity lets a stray token after a boolean flag surface as a
+ * positional, instead of being mistaken for the flag's value.
+ */
+export function parsePositionalArgs(
+  args: string[],
+  valueFlags: string[],
+  booleanFlags: string[] = [],
+): string[] {
+  const positionals: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (!arg.startsWith("--")) {
+      positionals.push(arg);
+      continue;
+    }
+
+    if (booleanFlags.includes(arg)) {
+      continue;
+    }
+
+    if (!valueFlags.includes(arg)) {
+      throw new Error(`unknown option: ${arg}`);
+    }
+
+    const value = args[i + 1];
+
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`${arg} requires a value`);
+    }
+
+    i++;
+  }
+
+  return positionals;
+}
+
+/** Parses repeated `KEY=VALUE` pairs into an environment record. */
+export function parseEnvPairs(pairs: string[]): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  for (const pair of pairs) {
+    const separator = pair.indexOf("=");
+
+    if (separator <= 0) {
+      throw new Error(`--env expects KEY=VALUE, got: ${pair}`);
+    }
+
+    env[pair.slice(0, separator)] = pair.slice(separator + 1);
+  }
+
+  return env;
+}
+
+export function parseMode(value: string | undefined): Mode {
+  if (value === undefined) {
+    return Mode.Both;
+  }
+
+  if (value !== Mode.System && value !== Mode.Js && value !== Mode.Both) {
+    throw new Error(
+      `--mode must be one of: ${Mode.System}, ${Mode.Js}, ${Mode.Both}; ` +
+        `got "${value}"`,
+    );
+  }
+
+  return value;
+}
+
+export function parseSampleRate(value: string | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_SAMPLE_RATE_HZ;
+  }
+
+  const rate = Number(value);
+
+  if (!Number.isInteger(rate) || rate < 1 || rate > 100_000) {
+    throw new Error(
+      `--sample-rate must be an integer between 1 and 100000; got "${value}"`,
+    );
+  }
+
+  return rate;
+}
+
+export { getArgValue };

--- a/scripts/profiler/helpers/flamegraph.test.ts
+++ b/scripts/profiler/helpers/flamegraph.test.ts
@@ -1,0 +1,61 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveArgs, Subcommand } from "./flamegraph.ts";
+
+describe("resolveArgs", () => {
+  it("returns undefined for empty args and --help", () => {
+    assert.equal(resolveArgs([]), undefined);
+    assert.equal(resolveArgs(["--help"]), undefined);
+    assert.equal(resolveArgs(["render", "/run-dir", "-h"]), undefined);
+  });
+
+  it("parses render with its options", () => {
+    assert.deepEqual(
+      resolveArgs(["render", "/run-dir", "--output", "o.svg", "--title", "t"]),
+      {
+        subcommand: Subcommand.Render,
+        runDir: "/run-dir",
+        output: "o.svg",
+        title: "t",
+      },
+    );
+  });
+
+  it("parses fold", () => {
+    assert.deepEqual(resolveArgs(["fold", "/run-dir"]), {
+      subcommand: Subcommand.Fold,
+      runDir: "/run-dir",
+      output: undefined,
+      title: undefined,
+    });
+  });
+
+  it("rejects a missing subcommand", () => {
+    assert.throws(
+      () => resolveArgs(["--output", "o.svg"]),
+      /missing subcommand/,
+    );
+  });
+
+  it("rejects unknown subcommands", () => {
+    assert.throws(
+      () => resolveArgs(["collapse", "/run-dir"]),
+      /unknown subcommand "collapse"/,
+    );
+  });
+
+  it("rejects a missing or extra run-dir", () => {
+    assert.throws(() => resolveArgs(["render"]), /exactly one <run-dir>/);
+    assert.throws(
+      () => resolveArgs(["render", "/a", "/b"]),
+      /exactly one <run-dir>/,
+    );
+  });
+
+  it("rejects unknown options", () => {
+    assert.throws(
+      () => resolveArgs(["render", "/run-dir", "--titel", "x"]),
+      /unknown option: --titel/,
+    );
+  });
+});

--- a/scripts/profiler/helpers/flamegraph.test.ts
+++ b/scripts/profiler/helpers/flamegraph.test.ts
@@ -1,3 +1,4 @@
+// cSpell:ignore titel -- a deliberate misspelling testing flag validation
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { resolveArgs, Subcommand } from "./flamegraph.ts";

--- a/scripts/profiler/helpers/flamegraph.ts
+++ b/scripts/profiler/helpers/flamegraph.ts
@@ -1,0 +1,206 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { getArgValue, parsePositionalArgs } from "./args.ts";
+import { shellQuote } from "./shell.ts";
+import { toolAvailable } from "./perf-check.ts";
+
+/**
+ * The symbolized samples (`perf script` output) of a profiled run, written
+ * by `pnpm profiler` next to perf.data and gzipped once post-processing
+ * finishes. Unlike perf.data, it is self-contained — no DSOs or
+ * /tmp/perf-<pid>.map files needed — so it can be rendered on any machine.
+ * The .linux-perf.txt suffix is how profile viewers detect the format.
+ */
+export const PERF_SCRIPT_OUTPUT_FILENAME = "profile.linux-perf.txt";
+
+const USAGE = `
+scripts/profiler/helpers/flamegraph.ts — Flamegraph tooling for profiled runs
+
+DESCRIPTION
+  Processes the symbolized samples (${PERF_SCRIPT_OUTPUT_FILENAME}, gzipped
+  or not) of a \`pnpm profiler\` run. The render subcommand produces a
+  flamegraph SVG. The fold subcommand produces the collapsed stacks that
+  flamegraphs are built from.
+
+  The samples are system-agnostic, so both subcommands work on any machine,
+  at any time. They only require inferno (\`cargo install inferno\`) on the
+  PATH. When inferno is missing, the pipeline to run — once installed, or on
+  another machine — is printed instead.
+
+  Flamegraphs and folded stacks aggregate identical stacks, which discards
+  time-ordering. For a timeline view, open the samples file instead.
+
+USAGE
+  pnpm profiler:flamegraph render <run-dir> [--output <path>] [--title <text>]
+  pnpm profiler:flamegraph fold <run-dir> [--output <path>]
+
+SUBCOMMANDS
+  render  Render a flamegraph SVG from the run's symbolized samples
+  fold    Write the collapsed (folded) stacks, e.g. to compare two runs as
+          a differential flamegraph: inferno-diff-folded before/folded.txt
+          after/folded.txt | inferno-flamegraph > diff.svg
+
+OPTIONS
+  <run-dir>          A directory containing ${PERF_SCRIPT_OUTPUT_FILENAME}
+                     or the .gz thereof (an <out-dir>/<scenario> directory
+                     of pnpm profiler)
+  --output <path>    Output path, used verbatim (default:
+                     <run-dir>/flamegraph.svg or <run-dir>/folded.txt)
+  --title <text>     render only: flamegraph title (default:
+                     cpu profile — <run-dir name>)
+
+EXAMPLES
+  pnpm profiler:flamegraph render /tmp/hardhat-profile-abc123/uniswap-v4-core
+`;
+
+export const Subcommand = {
+  Fold: "fold",
+  Render: "render",
+} as const;
+
+export type Subcommand = (typeof Subcommand)[keyof typeof Subcommand];
+
+interface FlamegraphArgs {
+  subcommand: Subcommand;
+  runDir: string;
+  output: string | undefined;
+  title: string | undefined;
+}
+
+export function resolveArgs(args: string[]): FlamegraphArgs | undefined {
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    return undefined;
+  }
+
+  const positional = parsePositionalArgs(args, ["--output", "--title"]);
+
+  if (positional.length === 0) {
+    throw new Error("missing subcommand (expected: render or fold)");
+  }
+
+  const [subcommand, runDir] = positional;
+
+  if (subcommand !== Subcommand.Render && subcommand !== Subcommand.Fold) {
+    throw new Error(
+      `unknown subcommand "${subcommand}" (expected: render or fold)`,
+    );
+  }
+
+  if (positional.length !== 2 || runDir === undefined) {
+    throw new Error(`${subcommand} expects exactly one <run-dir>`);
+  }
+
+  return {
+    subcommand,
+    runDir,
+    output: getArgValue(args, "--output"),
+    title: getArgValue(args, "--title"),
+  };
+}
+
+function defaultFlamegraphTitle(runDir: string): string {
+  return `cpu profile — ${path.basename(path.resolve(runDir))}`;
+}
+
+interface FlamegraphPipeline {
+  pipeline: string;
+  outputPath: string;
+}
+
+/**
+ * Builds the shell pipeline rendering a run's symbolized samples, for running
+ * or printing, along with the path of the artifact it writes.
+ */
+export function buildFlamegraphPipeline(
+  args: FlamegraphArgs,
+): FlamegraphPipeline {
+  const samples = path.join(args.runDir, PERF_SCRIPT_OUTPUT_FILENAME);
+  const gzippedSamples = `${samples}.gz`;
+
+  const collapsed = existsSync(gzippedSamples)
+    ? `gunzip -c ${shellQuote(gzippedSamples)} | inferno-collapse-perf`
+    : `inferno-collapse-perf < ${shellQuote(samples)}`;
+
+  if (args.subcommand === Subcommand.Fold) {
+    const folded = args.output ?? path.join(args.runDir, "folded.txt");
+
+    return {
+      pipeline: `${collapsed} > ${shellQuote(folded)}`,
+      outputPath: folded,
+    };
+  }
+
+  const title = args.title ?? defaultFlamegraphTitle(args.runDir);
+  const output = args.output ?? path.join(args.runDir, "flamegraph.svg");
+
+  return {
+    pipeline: `${collapsed} | inferno-flamegraph --title ${shellQuote(title)} > ${shellQuote(output)}`,
+    outputPath: output,
+  };
+}
+
+async function cliMain(): Promise<void> {
+  let args: FlamegraphArgs | undefined;
+
+  try {
+    args = resolveArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  if (args === undefined) {
+    console.log(USAGE);
+    return;
+  }
+
+  if (args.subcommand === Subcommand.Fold && args.title !== undefined) {
+    console.error("--title is only supported by the render subcommand");
+    process.exit(1);
+  }
+
+  const samples = path.join(args.runDir, PERF_SCRIPT_OUTPUT_FILENAME);
+
+  if (!existsSync(samples) && !existsSync(`${samples}.gz`)) {
+    console.error(
+      `No ${PERF_SCRIPT_OUTPUT_FILENAME}(.gz) in ${args.runDir} — was the ` +
+        "run profiled with --mode system?",
+    );
+    process.exit(1);
+  }
+
+  const { pipeline, outputPath } = buildFlamegraphPipeline(args);
+
+  const requiredTools = ["inferno-collapse-perf"];
+
+  if (args.subcommand === Subcommand.Render) {
+    requiredTools.push("inferno-flamegraph");
+  }
+
+  const missing = requiredTools.filter((tool) => !toolAvailable(tool));
+
+  if (missing.length > 0) {
+    console.error(
+      `Missing tools on PATH: ${missing.join(", ")}. Install inferno ` +
+        "(cargo install inferno), or run this pipeline where it is available:",
+    );
+    console.error(`  ${pipeline}`);
+    process.exit(1);
+  }
+
+  const result = spawnSync("bash", ["-c", pipeline], { stdio: "inherit" });
+
+  if (result.status !== 0) {
+    console.error(`Pipeline failed (exit ${String(result.status)}):`);
+    console.error(`  ${pipeline}`);
+    process.exit(1);
+  }
+
+  console.log(outputPath);
+}
+
+if (import.meta.main) {
+  await cliMain();
+}

--- a/scripts/profiler/helpers/js-prof.test.ts
+++ b/scripts/profiler/helpers/js-prof.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  cpuProfFlags,
+  injectBunCpuProfFlags,
+  mergeNodeOptions,
+  sampleRateToIntervalUs,
+} from "./js-prof.ts";
+
+describe("sampleRateToIntervalUs", () => {
+  it("converts Hz to a microsecond interval", () => {
+    assert.equal(sampleRateToIntervalUs(999), 1001);
+    assert.equal(sampleRateToIntervalUs(10_000), 100);
+  });
+
+  it("never goes below 1 microsecond", () => {
+    assert.equal(sampleRateToIntervalUs(10_000_000), 1);
+  });
+});
+
+describe("mergeNodeOptions", () => {
+  it("returns the additions when nothing is set", () => {
+    assert.equal(mergeNodeOptions(undefined, "--cpu-prof"), "--cpu-prof");
+    assert.equal(mergeNodeOptions("", "--cpu-prof"), "--cpu-prof");
+  });
+
+  it("appends to an existing value", () => {
+    assert.equal(
+      mergeNodeOptions("--max-old-space-size=4096", "--cpu-prof"),
+      "--max-old-space-size=4096 --cpu-prof",
+    );
+  });
+});
+
+describe("injectBunCpuProfFlags", () => {
+  it("returns undefined for node commands", () => {
+    assert.equal(
+      injectBunCpuProfFlags("npx hardhat test", "/out", 999),
+      undefined,
+    );
+  });
+
+  it("injects flags after bun", () => {
+    assert.equal(
+      injectBunCpuProfFlags("bun run test", "/out", 1000),
+      'bun --cpu-prof --cpu-prof-interval=1000 --cpu-prof-dir="/out" run test',
+    );
+  });
+
+  it("rewrites bunx to bun x with flags", () => {
+    assert.equal(
+      injectBunCpuProfFlags("bunx vitest run", "/out", 1000),
+      'bun --cpu-prof --cpu-prof-interval=1000 --cpu-prof-dir="/out" x vitest run',
+    );
+  });
+
+  it("does not match bun as a substring", () => {
+    assert.equal(
+      injectBunCpuProfFlags("bundle exec rake", "/out", 999),
+      undefined,
+    );
+  });
+});
+
+describe("cpuProfFlags", () => {
+  it("derives the interval from the sample rate", () => {
+    assert.deepEqual(cpuProfFlags("/tmp/prof", 999), [
+      "--cpu-prof",
+      "--cpu-prof-interval=1001",
+      '--cpu-prof-dir="/tmp/prof"',
+    ]);
+  });
+});

--- a/scripts/profiler/helpers/js-prof.ts
+++ b/scripts/profiler/helpers/js-prof.ts
@@ -1,0 +1,59 @@
+/**
+ * Helpers for JS-level profiling via the `--cpu-prof` sampling-profiler
+ * flags, which node and bun both implement.
+ */
+
+/** Converts a sampling rate in Hz to the profiler's interval in microseconds. */
+export function sampleRateToIntervalUs(sampleRateHz: number): number {
+  return Math.max(1, Math.round(1_000_000 / sampleRateHz));
+}
+
+/** The `--cpu-prof` flag set for a given output directory and rate. */
+export function cpuProfFlags(
+  profileDir: string,
+  sampleRateHz: number,
+): string[] {
+  return [
+    "--cpu-prof",
+    `--cpu-prof-interval=${String(sampleRateToIntervalUs(sampleRateHz))}`,
+    // Double-quoted so that paths with spaces survive both NODE_OPTIONS
+    // splitting and the bash command line of rewritten bun commands.
+    `--cpu-prof-dir="${profileDir}"`,
+  ];
+}
+
+/** Appends additions to an existing NODE_OPTIONS value. */
+export function mergeNodeOptions(
+  existing: string | undefined,
+  additions: string,
+): string {
+  return existing === undefined || existing === ""
+    ? additions
+    : `${existing} ${additions}`;
+}
+
+/**
+ * bun does not reliably pick up profiling flags from NODE_OPTIONS, but it
+ * supports the same `--cpu-prof*` flags on its own command line. Rewrite a
+ * command whose first word is `bun` or `bunx` to pass them explicitly
+ * (`bunx <bin>` is shorthand for `bun x <bin>`). Returns undefined when the
+ * command does not start with bun.
+ */
+export function injectBunCpuProfFlags(
+  command: string,
+  profileDir: string,
+  sampleRateHz: number,
+): string | undefined {
+  const match = /^(\s*)(bunx?)(\s+)/.exec(command);
+  if (match === null) {
+    return undefined;
+  }
+
+  const [prefix, leading, executable] = [match[0], match[1], match[2]];
+  const rest = command.slice(prefix.length);
+  const flags = cpuProfFlags(profileDir, sampleRateHz).join(" ");
+
+  return executable === "bunx"
+    ? `${leading}bun ${flags} x ${rest}`
+    : `${leading}bun ${flags} ${rest}`;
+}

--- a/scripts/profiler/helpers/perf-check.ts
+++ b/scripts/profiler/helpers/perf-check.ts
@@ -1,0 +1,51 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { perfRecordArgs } from "./perf-record.ts";
+
+/** Whether a tool is available on the PATH. */
+export function toolAvailable(tool: string): boolean {
+  return spawnSync("which", [tool], { stdio: "ignore" }).status === 0;
+}
+
+/**
+ * Verifies that `perf record` actually works in this environment before
+ * spending minutes on a profiled run. Throws with actionable guidance when
+ * perf is missing or recording is blocked (kernel.perf_event_paranoid,
+ * container seccomp policy).
+ */
+export function ensurePerfRecordWorks(): void {
+  if (!toolAvailable("perf")) {
+    throw new Error(
+      "`perf` is not on the PATH. Install it first, e.g. " +
+        "`sudo apt-get install linux-perf` (Debian/WSL) or " +
+        "`sudo apt-get install linux-tools-generic` (Ubuntu).",
+    );
+  }
+
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "perf-selftest-"));
+  const perfData = path.join(tmpDir, "perf.data");
+
+  try {
+    const result = spawnSync(
+      "perf",
+      [...perfRecordArgs(perfData, 99), "--", "true"],
+      { encoding: "utf-8" },
+    );
+
+    if (result.status !== 0) {
+      throw new Error(
+        "`perf record` is blocked in this environment:\n" +
+          `${result.stderr.trim()}\n` +
+          "Likely causes: kernel.perf_event_paranoid disallows sampling, or " +
+          "a container seccomp policy denies perf_event_open. Try " +
+          "`sudo sysctl kernel.perf_event_paranoid=1`, or see the EDR " +
+          "book's profiling chapter (Permissions appendix) for fixes.",
+      );
+    }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/scripts/profiler/helpers/perf-record.test.ts
+++ b/scripts/profiler/helpers/perf-record.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { wrapWithPerfCpu } from "./perf-record.ts";
+import { shellQuote } from "./shell.ts";
+
+describe("wrapWithPerfCpu", () => {
+  it("wraps the command in a call-graph cpu-clock record", () => {
+    assert.equal(
+      wrapWithPerfCpu("npx hardhat compile", "/out/perf.data", 999),
+      "perf 'record' '-e' 'cpu-clock' '-F' '999' '-g' '-o' '/out/perf.data' -- bash -c 'npx hardhat compile'",
+    );
+  });
+
+  it("quotes embedded single quotes safely", () => {
+    const wrapped = wrapWithPerfCpu("echo 'hi'", "/out/perf.data", 99);
+    assert.ok(wrapped.includes(`bash -c 'echo '\\''hi'\\'''`));
+  });
+});
+
+describe("shellQuote", () => {
+  it("wraps in single quotes", () => {
+    assert.equal(shellQuote("plain"), "'plain'");
+  });
+
+  it("escapes embedded single quotes", () => {
+    assert.equal(shellQuote("a'b"), `'a'\\''b'`);
+  });
+});

--- a/scripts/profiler/helpers/perf-record.ts
+++ b/scripts/profiler/helpers/perf-record.ts
@@ -1,0 +1,51 @@
+import { shellQuote } from "./shell.ts";
+
+/**
+ * The `perf record` argument list for CPU-sampling a whole process tree.
+ *
+ * The software `cpu-clock` event is used instead of hardware `cycles` because
+ * it works everywhere `perf_event_open` does — virtualized environments such
+ * as WSL2 expose no PMU, where `cycles` cannot be opened. For CPU-time
+ * attribution the two are equivalent at the same sampling rate.
+ */
+export function perfRecordArgs(
+  perfDataPath: string,
+  sampleRateHz: number,
+): string[] {
+  return [
+    "record",
+    "-e",
+    "cpu-clock",
+    "-F",
+    String(sampleRateHz),
+    "-g",
+    "-o",
+    perfDataPath,
+  ];
+}
+
+/**
+ * Wraps a shell command in a CPU-sampling `perf record` of its whole process
+ * tree.
+ */
+export function wrapWithPerfCpu(
+  command: string,
+  perfDataPath: string,
+  sampleRateHz: number,
+): string {
+  return [
+    "perf",
+    ...perfRecordArgs(perfDataPath, sampleRateHz).map(shellQuote),
+    "--",
+    "bash -c",
+    shellQuote(command),
+  ].join(" ");
+}
+
+/**
+ * NODE_OPTIONS additions that make JavaScript frames visible to perf: V8
+ * writes /tmp/perf-<pid>.map files mapping JIT code addresses to function
+ * names, and interpreted frames are materialized on the native stack.
+ */
+export const PERF_JS_NODE_OPTIONS =
+  "--perf-basic-prof --interpreted-frames-native-stack";

--- a/scripts/profiler/helpers/resolve-command.test.ts
+++ b/scripts/profiler/helpers/resolve-command.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveCommand } from "./resolve-command.ts";
+import type { ScenarioDefinition } from "../../end-to-end/types.ts";
+
+const definition: ScenarioDefinition = {
+  description: "test",
+  repo: "org/repo",
+  commit: "abc",
+  packageManager: "npm",
+  defaultCommand: "npx hardhat test",
+  tags: [],
+  benchmark: {
+    commands: {
+      "compile sequence": {
+        runs: 2,
+        steps: {
+          "reset files & cache": {
+            command: "git checkout -- a.sol && npx hardhat clean",
+            measure: false,
+          },
+          "cold compile": { command: "npx hardhat compile" },
+        },
+      },
+      "warm compile": { runs: 2, command: "npx hardhat compile" },
+      "test solidity": {
+        runs: 2,
+        command: "npx hardhat test solidity --no-compile",
+        dependsOn: ["cold compile"],
+      },
+    },
+  },
+};
+
+describe("resolveCommand", () => {
+  it("resolves a top-level benchmark command name", () => {
+    const resolved = resolveCommand(definition, "test solidity");
+    assert.equal(resolved.command, "npx hardhat test solidity --no-compile");
+    assert.equal(resolved.resolvedFrom, "test solidity");
+  });
+
+  it("resolves a step name inside a step sequence", () => {
+    const resolved = resolveCommand(definition, "cold compile");
+    assert.equal(resolved.command, "npx hardhat compile");
+    assert.equal(resolved.resolvedFrom, "cold compile");
+  });
+
+  it("treats non-matching input as a literal shell command", () => {
+    const resolved = resolveCommand(definition, "npx hardhat compile --force");
+    assert.equal(resolved.command, "npx hardhat compile --force");
+    assert.equal(resolved.resolvedFrom, undefined);
+  });
+
+  it("treats everything as literal when the scenario has no benchmark", () => {
+    const bare = { ...definition, benchmark: undefined };
+    const resolved = resolveCommand(bare, "warm compile");
+    assert.equal(resolved.command, "warm compile");
+    assert.equal(resolved.resolvedFrom, undefined);
+  });
+});

--- a/scripts/profiler/helpers/resolve-command.ts
+++ b/scripts/profiler/helpers/resolve-command.ts
@@ -1,0 +1,43 @@
+import type { ScenarioDefinition } from "../../end-to-end/types.ts";
+
+export interface ResolvedCommand {
+  /** The shell command to run. */
+  command: string;
+  /**
+   * The `benchmark.commands` entry (or step) name the input resolved to, or
+   * undefined when the input was taken as a literal shell command.
+   */
+  resolvedFrom: string | undefined;
+}
+
+/**
+ * Resolves a `--command`/`--prepare` value: when it names an entry in the
+ * scenario's `benchmark.commands` — a top-level command name (e.g.
+ * "warm compile") or a step name inside a step sequence (e.g. "cold compile")
+ * — the entry's command string is used; otherwise the value is taken as a
+ * literal shell command.
+ *
+ * Resolution does not execute `dependsOn` prerequisites: profiling runs a
+ * single command, and required state (e.g. compiled artifacts) must already
+ * exist or be produced via `--prepare`.
+ */
+export function resolveCommand(
+  definition: ScenarioDefinition,
+  commandOrName: string,
+): ResolvedCommand {
+  const commands = definition.benchmark?.commands ?? {};
+
+  for (const [name, config] of Object.entries(commands)) {
+    if ("steps" in config) {
+      for (const [stepName, step] of Object.entries(config.steps)) {
+        if (stepName === commandOrName) {
+          return { command: step.command, resolvedFrom: stepName };
+        }
+      }
+    } else if (name === commandOrName) {
+      return { command: config.command, resolvedFrom: name };
+    }
+  }
+
+  return { command: commandOrName, resolvedFrom: undefined };
+}

--- a/scripts/profiler/helpers/shell.ts
+++ b/scripts/profiler/helpers/shell.ts
@@ -1,0 +1,4 @@
+/** Quote a string for safe interpolation into a bash command line. */
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/scripts/profiler/main.ts
+++ b/scripts/profiler/main.ts
@@ -165,6 +165,7 @@ interface RunRecord {
   mode: Mode;
   exitCode: number | null;
   signal: NodeJS.Signals | null;
+  spawnError: string | null;
   wallSeconds: number;
   artifactDir: string;
   /** Whether perf script succeeded; only set for system-mode runs. */
@@ -313,12 +314,7 @@ export async function runProfile(args: ProfileArgs): Promise<void> {
   logStep("Profiling complete");
 
   for (const run of runs) {
-    const outcome =
-      run.exitCode === 0
-        ? fmt.success("ok")
-        : run.signal !== null
-          ? `killed by ${run.signal}`
-          : `exit ${String(run.exitCode)}`;
+    const outcome = runOutcome(run);
     log(
       `${run.scenario} · ${run.resolvedFrom ?? run.command} · ${run.mode}: ` +
         `${outcome}, ${run.wallSeconds.toFixed(1)}s → ${run.artifactDir}`,
@@ -341,6 +337,25 @@ export async function runProfile(args: ProfileArgs): Promise<void> {
   if (runs.some((run) => run.exitCode !== 0 || run.symbolized === false)) {
     process.exitCode = 1;
   }
+}
+
+/** The summary-line outcome of a run, e.g. "ok" or "killed by SIGKILL". */
+function runOutcome(run: RunRecord): string {
+  if (run.exitCode === 0) {
+    return fmt.success("ok");
+  }
+
+  if (run.signal !== null) {
+    return `killed by ${run.signal}`;
+  }
+
+  if (run.exitCode === null) {
+    return run.spawnError !== null
+      ? `failed to spawn (${run.spawnError})`
+      : "failed to spawn";
+  }
+
+  return `exit ${String(run.exitCode)}`;
 }
 
 /** The flamegraph title for a run, e.g. "uniswap-v4-core — test solidity". */
@@ -436,14 +451,40 @@ function profileSystem(
 
 /** Runs a post-processing shell pipeline; returns whether it succeeded. */
 function runPostProcess(pipeline: string): boolean {
-  const result = spawnSync("bash", ["-c", pipeline], { stdio: "ignore" });
+  // The pipelines write their data to files themselves, so only stderr —
+  // which carries the diagnosis on failure — is captured. perf can emit
+  // megabytes of non-fatal stderr noise even on success, so the buffer is
+  // sized well above the default to not kill a healthy pipeline.
+  const result = spawnSync("bash", ["-c", pipeline], {
+    stdio: ["ignore", "ignore", "pipe"],
+    encoding: "utf-8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
 
   if (result.status !== 0) {
-    logWarning(`post-processing failed: ${pipeline}`);
+    logWarning(
+      `post-processing failed (exit ${String(result.status)}): ${pipeline}\n` +
+        `    ${stderrTail(result.stderr)}`,
+    );
     return false;
   }
 
   return true;
+}
+
+/**
+ * The last few stderr lines of a failed command, as an indented block for a
+ * warning message.
+ *
+ * The tail is taken — not the head — because perf prints the fatal error
+ * last, after any warning noise. Five lines fit the diagnosis without
+ * drowning the run output. An empty stderr is made explicit, so that the
+ * reader knows capturing worked.
+ */
+function stderrTail(stderr: string | null): string {
+  const tail = (stderr ?? "").trim().split("\n").slice(-5).join("\n    ");
+
+  return tail === "" ? "(no stderr)" : tail;
 }
 
 function profileJs(
@@ -502,6 +543,7 @@ function profileJs(
 interface CommandOutcome {
   exitCode: number | null;
   signal: NodeJS.Signals | null;
+  spawnError: string | null;
   wallSeconds: number;
 }
 
@@ -543,7 +585,12 @@ function runInScenario(
     logWarning(`command exited with ${String(result.status)}: ${command}`);
   }
 
-  return { exitCode: result.status, signal: result.signal, wallSeconds };
+  return {
+    exitCode: result.status,
+    signal: result.signal,
+    spawnError: result.error?.message ?? null,
+    wallSeconds,
+  };
 }
 
 function toRunRecord(
@@ -560,6 +607,7 @@ function toRunRecord(
     mode,
     exitCode: outcome.exitCode,
     signal: outcome.signal,
+    spawnError: outcome.spawnError,
     wallSeconds: outcome.wallSeconds,
     artifactDir: runDir,
   };

--- a/scripts/profiler/main.ts
+++ b/scripts/profiler/main.ts
@@ -1,0 +1,597 @@
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { DEFAULT_CLONE_DIR, getArgValue } from "../end-to-end/helpers/args.ts";
+import { normalizeScenarioPath } from "../end-to-end/helpers/directory.ts";
+import { ensureScenarioInitialized } from "../end-to-end/helpers/scenario-setup.ts";
+import {
+  fmt,
+  log,
+  logStep,
+  logError,
+  logWarning,
+} from "../end-to-end/helpers/log.ts";
+import {
+  ForceCheckout,
+  ForcePublish,
+  UseLocal,
+} from "../end-to-end/subcommands/init.ts";
+import type { Scenario } from "../end-to-end/types.ts";
+
+import {
+  DEFAULT_SAMPLE_RATE_HZ,
+  getAllArgValues,
+  Mode,
+  parseEnvPairs,
+  parseMode,
+  parsePositionalArgs,
+  parseSampleRate,
+} from "./helpers/args.ts";
+import { PERF_SCRIPT_OUTPUT_FILENAME } from "./helpers/flamegraph.ts";
+import {
+  cpuProfFlags,
+  injectBunCpuProfFlags,
+  mergeNodeOptions,
+} from "./helpers/js-prof.ts";
+import { ensurePerfRecordWorks } from "./helpers/perf-check.ts";
+import {
+  PERF_JS_NODE_OPTIONS,
+  wrapWithPerfCpu,
+} from "./helpers/perf-record.ts";
+import {
+  resolveCommand,
+  type ResolvedCommand,
+} from "./helpers/resolve-command.ts";
+import { shellQuote } from "./helpers/shell.ts";
+
+const USAGE = `
+scripts/profiler/main.ts — Profile a command on e2e scenarios
+
+DESCRIPTION
+  Runs a single command once per scenario while recording where its time is
+  spent. Two complementary measurements are available:
+
+  system  Samples the whole process tree with Linux perf: one profile spanning
+          JavaScript, the EDR native runtime (Rust), and subprocesses such as
+          solc. Shows where overall CPU time goes, across languages, with
+          coarse JavaScript function names.
+  js      Samples JavaScript execution by passing \`--cpu-prof\` to the JS
+          engine: precise per-function attribution of JavaScript/TypeScript
+          code. Time spent inside EDR, solc or other subprocesses is not
+          attributed — the JavaScript thread shows as idle while it waits on
+          them.
+
+  To attribute time inside EDR by function name, build it for profiling
+  (\`pnpm build:perf-js\` in edr's crates/edr_napi) and load that binary via
+  NAPI_RS_NATIVE_LIBRARY_PATH, or publish it to the running Verdaccio.
+
+OPTIONS
+  --scenario <path>     Scenario folder or scenario.json (required, repeatable:
+                        the command is profiled once per scenario)
+  --command <cmd|name>  Command to profile (required). Either a shell command
+                        or the name of an entry in the scenario's
+                        benchmark.commands (e.g. "test solidity",
+                        "cold compile"). Prerequisite state is NOT set up
+                        automatically — use --prepare
+  --prepare <cmd|name>  Unmeasured command to run before each measurement
+                        (same name shorthand, e.g. --prepare "cold compile")
+  --mode <mode>         system, js, or both (default: both; measurements run
+                        sequentially, never at the same time)
+  --sample-rate <hz>    Samples per second for both measurements
+                        (default: ${String(DEFAULT_SAMPLE_RATE_HZ)}). Internally: perf -F <hz>;
+                        JS engine --cpu-prof-interval=round(1e6/hz) µs
+  --out-dir <path>      Artifact directory (default: a fresh temp directory)
+  --env KEY=VALUE       Extra environment for the prepare and profiled
+                        commands (repeatable), e.g.
+                        --env NAPI_RS_NATIVE_LIBRARY_PATH=/path/to/edr.node
+  --init                Force (re-)initialization of the scenario
+  --use-local           Publish locally changed packages to Verdaccio and pin
+                        the scenario to them (only applies when init runs)
+  --force-checkout      Force git checkouts despite uncommitted scenario changes
+  --force-publish       Force publishing to a running Verdaccio instance
+  --show-output         Stream the profiled command's output to the terminal
+                        instead of capturing it to cmd.<mode>.log
+  --keep-perf-data      Keep the raw perf.data after post-processing; by
+                        default it is deleted once the symbolized samples are
+                        written. Can be used for perf report/annotate sessions
+  --e2e-clone-dir <p>   Scenario clone directory (default: the E2E_CLONE_DIR
+                        environment variable, or ${DEFAULT_CLONE_DIR})
+
+ARTIFACTS  (<out-dir>/<scenario>/; re-running with the same --out-dir and a
+           different command overwrites that scenario's artifacts, though
+           previously rendered flamegraph outputs (flamegraph.svg,
+           folded.txt) are left in place)
+  system: profile.linux-perf.txt.gz — every symbolized sample; the only
+          portable system-mode artifact that preserves time-ordering. Open it
+          in https://profiler.firefox.com (reads the .gz directly), gunzip it
+          for https://speedscope.app, or render an aggregate flamegraph from
+          it on any machine with pnpm profiler:flamegraph (requires inferno;
+          the exact command is printed per run)
+          perf.data — raw samples; only usable by perf on this machine and
+          deleted after post-processing unless --keep-perf-data is passed
+          or symbolization failed
+          dso.txt / report.txt — plain-text per-binary / per-symbol CPU splits
+  js:     cpuprof/*.cpuprofile — preserves time-ordering. Open it in
+          https://profiler.firefox.com, https://speedscope.app or Chrome
+          DevTools. Written per process on GRACEFUL exit only: processes that
+          are killed (e.g. mocha parallel-mode workers) lose their profile.
+  cmd.<mode>.log per run dir records the profiled command's output and exit
+  code (with --show-output, the output goes to the terminal instead)
+  status.json at the out-dir root records this invocation's runs (rewritten
+  after each run, replaced by the next invocation)
+
+EXAMPLES
+  pnpm profiler --scenario ./end-to-end/uniswap-v4-core \\
+    --prepare "cold compile" --command "test solidity"
+
+  NAPI_RS_NATIVE_LIBRARY_PATH=~/edr/crates/edr_napi/edr.linux-x64-gnu.node \\
+    pnpm profiler --scenario ./end-to-end/openzeppelin-contracts \\
+    --command "test mocha" --mode system
+
+  pnpm profiler --scenario ./end-to-end/uniswap-x \\
+    --scenario ./end-to-end/aave-v4 \\
+    --command "npx hardhat compile" --mode js --sample-rate 10000
+`;
+
+interface ProfileArgs {
+  scenarioPaths: string[];
+  commandOrName: string;
+  prepareOrName: string | undefined;
+  mode: Mode;
+  sampleRateHz: number;
+  outDir: string | undefined;
+  env: Record<string, string>;
+  init: boolean;
+  useLocal: UseLocal;
+  forceCheckout: ForceCheckout;
+  forcePublish: ForcePublish;
+  showOutput: boolean;
+  keepPerfData: boolean;
+  e2eCloneDirectory: string;
+}
+
+interface RunRecord {
+  scenario: string;
+  command: string;
+  resolvedFrom: string | undefined;
+  mode: Mode;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  wallSeconds: number;
+  artifactDir: string;
+  /** Whether perf script succeeded; only set for system-mode runs. */
+  symbolized?: boolean;
+}
+
+const VALUE_FLAGS = [
+  "--scenario",
+  "--command",
+  "--prepare",
+  "--mode",
+  "--sample-rate",
+  "--out-dir",
+  "--env",
+  "--e2e-clone-dir",
+];
+
+const BOOLEAN_FLAGS = [
+  "--init",
+  "--use-local",
+  "--force-checkout",
+  "--force-publish",
+  "--show-output",
+  "--keep-perf-data",
+];
+
+export function resolveAndValidateArgs(
+  args: string[],
+): ProfileArgs | undefined {
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    return undefined;
+  }
+
+  const stray = parsePositionalArgs(args, VALUE_FLAGS, BOOLEAN_FLAGS);
+
+  if (stray.length > 0) {
+    throw new Error(`unexpected argument: ${stray[0]}`);
+  }
+
+  const scenarioPaths = getAllArgValues(args, "--scenario").map(
+    normalizeScenarioPath,
+  );
+
+  if (scenarioPaths.length === 0) {
+    throw new Error(
+      "--scenario is required (run pnpm profiler with no arguments for usage)",
+    );
+  }
+
+  const commandOrName = getArgValue(args, "--command");
+
+  if (commandOrName === undefined) {
+    throw new Error(
+      "--command is required (run pnpm profiler with no arguments for usage)",
+    );
+  }
+
+  return {
+    scenarioPaths,
+    commandOrName,
+    prepareOrName: getArgValue(args, "--prepare"),
+    mode: parseMode(getArgValue(args, "--mode")),
+    sampleRateHz: parseSampleRate(getArgValue(args, "--sample-rate")),
+    outDir: getArgValue(args, "--out-dir"),
+    env: parseEnvPairs(getAllArgValues(args, "--env")),
+    init: args.includes("--init"),
+    useLocal: args.includes("--use-local") ? UseLocal.Yes : UseLocal.No,
+    forceCheckout: args.includes("--force-checkout")
+      ? ForceCheckout.Yes
+      : ForceCheckout.No,
+    forcePublish: args.includes("--force-publish")
+      ? ForcePublish.Yes
+      : ForcePublish.No,
+    showOutput: args.includes("--show-output"),
+    keepPerfData: args.includes("--keep-perf-data"),
+    e2eCloneDirectory:
+      getArgValue(args, "--e2e-clone-dir") ??
+      process.env.E2E_CLONE_DIR ??
+      DEFAULT_CLONE_DIR,
+  };
+}
+
+export async function runProfile(args: ProfileArgs): Promise<void> {
+  const modes: ("system" | "js")[] =
+    args.mode === Mode.Both ? [Mode.System, Mode.Js] : [args.mode];
+
+  if (modes.includes(Mode.System)) {
+    ensurePerfRecordWorks();
+  }
+
+  const outDir =
+    args.outDir ?? mkdtempSync(path.join(tmpdir(), "hardhat-profile-"));
+  const runs: RunRecord[] = [];
+
+  for (const scenarioPath of args.scenarioPaths) {
+    const scenario = await ensureScenarioInitialized(
+      args.e2eCloneDirectory,
+      scenarioPath,
+      args.useLocal,
+      args.forceCheckout,
+      args.forcePublish,
+      args.init,
+    );
+
+    if (scenario.definition.disabled === true) {
+      logWarning(`Scenario "${scenario.id}" is disabled — skipping`);
+      continue;
+    }
+
+    const resolved = resolveCommand(scenario.definition, args.commandOrName);
+
+    if (resolved.resolvedFrom !== undefined) {
+      log(
+        `[${scenario.id}] "${resolved.resolvedFrom}" resolved from ` +
+          `benchmark.commands to: ${resolved.command}`,
+      );
+    }
+
+    const runDir = path.join(outDir, scenario.id);
+    mkdirSync(runDir, { recursive: true });
+
+    const baseEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...scenario.definition.env,
+      ...args.env,
+    };
+
+    for (const mode of modes) {
+      // Run before every measurement, so that with --mode both the second
+      // measurement does not silently profile state the first one mutated.
+      if (args.prepareOrName !== undefined) {
+        const prepare = resolveCommand(scenario.definition, args.prepareOrName);
+        logStep(`[${scenario.id}] Preparing (unmeasured): ${prepare.command}`);
+        runInScenario(prepare.command, scenario, baseEnv, undefined, true);
+      }
+
+      runs.push(
+        mode === Mode.System
+          ? profileSystem(scenario, resolved, runDir, baseEnv, args)
+          : profileJs(scenario, resolved, runDir, baseEnv, args),
+      );
+      writeStatusFile(outDir, runs);
+    }
+  }
+
+  logStep("Profiling complete");
+
+  for (const run of runs) {
+    const outcome =
+      run.exitCode === 0
+        ? fmt.success("ok")
+        : run.signal !== null
+          ? `killed by ${run.signal}`
+          : `exit ${String(run.exitCode)}`;
+    log(
+      `${run.scenario} · ${run.resolvedFrom ?? run.command} · ${run.mode}: ` +
+        `${outcome}, ${run.wallSeconds.toFixed(1)}s → ${run.artifactDir}`,
+    );
+
+    if (run.mode === Mode.System) {
+      if (run.symbolized === false) {
+        log("  flamegraph: unavailable — symbolization failed (see warning)");
+      } else {
+        log(
+          `  flamegraph: pnpm profiler:flamegraph render ${shellQuote(run.artifactDir)} ` +
+            `--title ${shellQuote(flamegraphTitle(run))}`,
+        );
+      }
+    }
+  }
+
+  // Let shell chains and CI detect a profile of a failed or killed command,
+  // or one whose samples never got symbolized.
+  if (runs.some((run) => run.exitCode !== 0 || run.symbolized === false)) {
+    process.exitCode = 1;
+  }
+}
+
+/** The flamegraph title for a run, e.g. "uniswap-v4-core — test solidity". */
+function flamegraphTitle(run: RunRecord): string {
+  return `${run.scenario} — ${run.resolvedFrom ?? run.command}`;
+}
+
+/**
+ * Records every run so far to `<out-dir>/status.json`.
+ *
+ * Rewritten after each run so that a crashed or interrupted session still
+ * leaves an accurate record of what completed.
+ */
+function writeStatusFile(outDir: string, runs: RunRecord[]): void {
+  writeFileSync(
+    path.join(outDir, "status.json"),
+    JSON.stringify({ runs }, null, 2),
+  );
+}
+
+/** The per-mode log file capturing the profiled command's output. */
+function commandLogPath(runDir: string, mode: Mode): string {
+  return path.join(runDir, `cmd.${mode}.log`);
+}
+
+function profileSystem(
+  scenario: Scenario,
+  resolved: ResolvedCommand,
+  runDir: string,
+  baseEnv: NodeJS.ProcessEnv,
+  args: ProfileArgs,
+): RunRecord {
+  const perfData = path.join(runDir, "perf.data");
+  const wrapped = wrapWithPerfCpu(
+    resolved.command,
+    perfData,
+    args.sampleRateHz,
+  );
+
+  const env: NodeJS.ProcessEnv = {
+    ...baseEnv,
+    NODE_OPTIONS: mergeNodeOptions(baseEnv.NODE_OPTIONS, PERF_JS_NODE_OPTIONS),
+  };
+
+  logStep(`[${scenario.id}] system profile: ${resolved.command}`);
+  const record = runInScenario(
+    wrapped,
+    scenario,
+    env,
+    commandLogPath(runDir, Mode.System),
+    args.showOutput,
+  );
+
+  // Resolving JS frame names depends on the /tmp/perf-<pid>.map files the
+  // profiled processes just wrote. Symbolize to ensure output is
+  // self-contained.
+  const samples = path.join(runDir, PERF_SCRIPT_OUTPUT_FILENAME);
+
+  // Remove artifacts from a previous run in the same --out-dir, so that a
+  // crash between symbolizing and compressing does not leave stale samples
+  // behind.
+  rmSync(`${samples}.gz`, { force: true });
+
+  const symbolized = runPostProcess(
+    `perf script -i ${shellQuote(perfData)} > ${shellQuote(samples)}`,
+  );
+
+  runPostProcess(
+    `perf report -i ${shellQuote(perfData)} --stdio --no-children --no-call-graph --sort dso > ${shellQuote(path.join(runDir, "dso.txt"))}`,
+  );
+  runPostProcess(
+    `perf report -i ${shellQuote(perfData)} --stdio --no-children --no-call-graph --sort dso,sym --percent-limit 0.05 > ${shellQuote(path.join(runDir, "report.txt"))}`,
+  );
+
+  if (symbolized) {
+    runPostProcess(`gzip -f ${shellQuote(samples)}`);
+  } else {
+    // A truncated samples file would masquerade as a complete profile.
+    rmSync(samples, { force: true });
+  }
+
+  // perf.data is machine-bound and large, so only keep it if the user
+  // explicitly requested it or if symbolization failed
+  if (!args.keepPerfData && symbolized) {
+    rmSync(perfData, { force: true });
+  }
+
+  return {
+    ...toRunRecord(scenario, resolved, Mode.System, runDir, record),
+    symbolized,
+  };
+}
+
+/** Runs a post-processing shell pipeline; returns whether it succeeded. */
+function runPostProcess(pipeline: string): boolean {
+  const result = spawnSync("bash", ["-c", pipeline], { stdio: "ignore" });
+
+  if (result.status !== 0) {
+    logWarning(`post-processing failed: ${pipeline}`);
+    return false;
+  }
+
+  return true;
+}
+
+function profileJs(
+  scenario: Scenario,
+  resolved: ResolvedCommand,
+  runDir: string,
+  baseEnv: NodeJS.ProcessEnv,
+  args: ProfileArgs,
+): RunRecord {
+  const profileDir = path.join(runDir, "cpuprof");
+
+  // The engine names each .cpuprofile uniquely, so profiles from a previous
+  // run in the same --out-dir would otherwise accumulate and mix with this
+  // run's.
+  rmSync(profileDir, { recursive: true, force: true });
+  mkdirSync(profileDir, { recursive: true });
+
+  const bunCommand = injectBunCpuProfFlags(
+    resolved.command,
+    profileDir,
+    args.sampleRateHz,
+  );
+
+  const env: NodeJS.ProcessEnv = { ...baseEnv };
+
+  if (bunCommand === undefined) {
+    env.NODE_OPTIONS = mergeNodeOptions(
+      baseEnv.NODE_OPTIONS,
+      cpuProfFlags(profileDir, args.sampleRateHz).join(" "),
+    );
+  }
+
+  logStep(`[${scenario.id}] js profile: ${resolved.command}`);
+  const record = runInScenario(
+    bunCommand ?? resolved.command,
+    scenario,
+    env,
+    commandLogPath(runDir, Mode.Js),
+    args.showOutput,
+  );
+
+  const profiles = readdirSync(profileDir).filter((f) =>
+    f.endsWith(".cpuprofile"),
+  );
+
+  if (profiles.length === 0) {
+    logWarning(
+      `no .cpuprofile written for "${resolved.command}" — the process may ` +
+        "not be node/bun, or it exited non-gracefully",
+    );
+  }
+
+  return toRunRecord(scenario, resolved, Mode.Js, runDir, record);
+}
+
+interface CommandOutcome {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  wallSeconds: number;
+}
+
+function runInScenario(
+  command: string,
+  scenario: Scenario,
+  env: NodeJS.ProcessEnv,
+  logFile: string | undefined,
+  showOutput: boolean,
+): CommandOutcome {
+  const started = Date.now();
+  const result = spawnSync("bash", ["-c", command], {
+    cwd: scenario.workingDir,
+    env,
+    stdio: showOutput ? "inherit" : "pipe",
+    encoding: "utf-8",
+    maxBuffer: 512 * 1024 * 1024,
+  });
+  const wallSeconds = (Date.now() - started) / 1000;
+
+  if (logFile !== undefined) {
+    const output = showOutput
+      ? "(output streamed to the terminal via --show-output)"
+      : `${result.stdout ?? ""}\n--- stderr ---\n${result.stderr ?? ""}`;
+
+    const signalNote = result.signal !== null ? ` signal=${result.signal}` : "";
+
+    writeFileSync(
+      logFile,
+      `$ ${command}\nexit=${String(result.status)}${signalNote}\n\n${output}`,
+    );
+  }
+
+  if (result.error !== undefined) {
+    logWarning(`command failed to spawn (${result.error.message}): ${command}`);
+  } else if (result.signal !== null) {
+    logWarning(`command was killed by ${result.signal}: ${command}`);
+  } else if (result.status !== 0) {
+    logWarning(`command exited with ${String(result.status)}: ${command}`);
+  }
+
+  return { exitCode: result.status, signal: result.signal, wallSeconds };
+}
+
+function toRunRecord(
+  scenario: Scenario,
+  resolved: ResolvedCommand,
+  mode: Mode,
+  runDir: string,
+  outcome: CommandOutcome,
+): RunRecord {
+  return {
+    scenario: scenario.id,
+    command: resolved.command,
+    resolvedFrom: resolved.resolvedFrom,
+    mode,
+    exitCode: outcome.exitCode,
+    signal: outcome.signal,
+    wallSeconds: outcome.wallSeconds,
+    artifactDir: runDir,
+  };
+}
+
+async function cliMain(): Promise<void> {
+  let profileArgs: ProfileArgs | undefined;
+
+  try {
+    profileArgs = resolveAndValidateArgs(process.argv.slice(2));
+  } catch (error) {
+    logError(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  if (profileArgs === undefined) {
+    console.log(USAGE);
+    return;
+  }
+
+  try {
+    await runProfile(profileArgs);
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
+
+    logError(error.message);
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  await cliMain();
+}


### PR DESCRIPTION
- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

Adds a profiler layer between `end-to-end` and `benchmark` (see `scripts/README.md`): run a single command once per scenario while recording where its time is spent.

**Two measurements** (`--mode both` by default, run sequentially):

- **system** — Linux `perf` samples the whole process tree: JS, EDR native (Rust), and subprocesses like solc.
- **js** — the JS engine's `--cpu-prof` sampler (node and bun) for precise per-function JS attribution.

**Artifacts** land in `<out-dir>/<scenario>/`. The system samples are symbolized immediately and persisted as `profile.linux-perf.txt.gz` — self-contained and time-order-preserving, so they open in Firefox Profiler/speedscope and render on any machine, at any time. `perf.data` is deleted after post-processing (`--keep-perf-data` to opt out). `status.json` records every run.

**Rendering is a separate step**: `pnpm profiler:flamegraph render|fold <run-dir>` (requires only inferno); each profiled run prints the exact render command, title included. `fold` output feeds differential flamegraphs via `inferno-diff-folded`.

Robustness: a `perf record` self-test fails fast with actionable guidance, arg parsing rejects unknown flags and missing values, `--prepare` re-runs before each measurement, and the exit code reflects failed or unsymbolized runs.

Also extracts shared pieces into the e2e layer: `ensureScenarioInitialized` (reused by `exec`) and an exported `getArgValue`.

```sh
pnpm profiler --scenario ./end-to-end/uniswap-v4-core \
  --prepare "cold compile" --command "test solidity"
```
