### PR TITLE
fix(hardhat-viem-assertions): compare the sender address case-insensitively in balancesHaveChanged

### DIFF
--- a/.changeset/viem-assertions-checksummed-sender.md
+++ b/.changeset/viem-assertions-checksummed-sender.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-viem-assertions": patch
+---
+
+Fixed `balancesHaveChanged` not adding the gas fee back to the sender's balance when the sender address is passed in its checksummed form.

--- a/packages/hardhat-viem-assertions/src/internal/assertions/balances-have-changed.ts
+++ b/packages/hardhat-viem-assertions/src/internal/assertions/balances-have-changed.ts
@@ -29,7 +29,9 @@ export async function balancesHaveChanged<
     hash: resolvedTxHash,
   });
 
-  const senderAddress = receipt.from;
+  // `receipt.from` is returned lowercased by viem, while the user-provided
+  // addresses may be checksummed, so we normalize both sides before comparing.
+  const senderAddress = receipt.from.toLowerCase();
   const blockNrAfterTx = receipt.blockNumber;
 
   const beforeBalances = await Promise.all(
@@ -48,7 +50,7 @@ export async function balancesHaveChanged<
         blockNumber: blockNrAfterTx,
       });
 
-      if (address === senderAddress) {
+      if (address.toLowerCase() === senderAddress) {
         const senderGasFee = receipt.effectiveGasPrice * receipt.gasUsed;
         balance = balance + senderGasFee;
       }

--- a/packages/hardhat-viem-assertions/test/internal/assertions/balances-have-changed.ts
+++ b/packages/hardhat-viem-assertions/test/internal/assertions/balances-have-changed.ts
@@ -9,6 +9,7 @@ import {
 } from "@nomicfoundation/hardhat-test-utils";
 import hardhatViem from "@nomicfoundation/hardhat-viem";
 import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+import { getAddress } from "viem";
 
 import hardhatViemAssertions from "../../../src/index.js";
 import { isExpectedError } from "../../helpers/is-expected-error.js";
@@ -57,6 +58,29 @@ describe("balancesHaveChanged", () => {
         {
           address: aliceWalletClient.account.address,
           amount: 3333333333333333n,
+        },
+      ],
+    );
+  });
+
+  it("should account for the gas fee when the sender address is checksummed", async () => {
+    const [bobWalletClient, aliceWalletClient] = await viem.getWalletClients();
+
+    // `walletClient.account.address` is lowercased, but other common sources of
+    // addresses, like `walletClient.getAddresses()` or hardcoded literals, are
+    // checksummed. Both must be recognized as the sender, otherwise the gas fee
+    // is not added back and the assertion fails.
+    const checksummedBobAddress = getAddress(bobWalletClient.account.address);
+
+    await viem.assertions.balancesHaveChanged(
+      bobWalletClient.sendTransaction({
+        to: aliceWalletClient.account.address,
+        value: 3333333333333333n,
+      }),
+      [
+        {
+          address: checksummedBobAddress,
+          amount: -3333333333333333n,
         },
       ],
     );


### PR DESCRIPTION
- [x] Because this PR includes a **bug fix**, relevant tests have been included.

---

### Problem

`balancesHaveChanged` adds the transaction's gas fee back to the sender's balance, so that a caller only has to assert the value actually transferred. It identifies the sender with a case-sensitive comparison:

```ts
const senderAddress = receipt.from;
// ...
if (address === senderAddress) {
  const senderGasFee = receipt.effectiveGasPrice * receipt.gasUsed;
  balance = balance + senderGasFee;
}
```

`receipt.from` is returned lowercased by viem, but the addresses users pass in are frequently checksummed: `walletClient.account.address` is lowercased, while `walletClient.getAddresses()` returns the EIP-55 form (`0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`), and hardcoded address literals are conventionally checksummed too.

The sender then never matches, the gas fee is not added back, and this ordinary usage fails:

```ts
const [sender] = await bobWalletClient.getAddresses();

await viem.assertions.balancesHaveChanged(
  bobWalletClient.sendTransaction({
    to: aliceWalletClient.account.address,
    value: 3333333333333333n,
  }),
  [{ address: sender, amount: -3333333333333333n }],
);
```

```
For address "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", expected balance to change by
-3333333333333333 (from 10000000000000000000000 to 9999996666666666666667),
but got a change of -3356589192708333 instead.
```

The reported change is off by exactly the gas fee. The existing tests all pass `account.address`, which is already lowercased, which is why this path was never exercised.

### Fix

Lowercase both sides of the comparison, consistent with how addresses are already compared elsewhere in this package (`src/internal/assertions/emit/core.ts:58-60`, `src/internal/predicates.ts:46`).

### Tests

Added a regression test that passes the checksummed sender address. Running `packages/hardhat-viem-assertions/test/internal/assertions/balances-have-changed.ts`:

- before the fix: 6 pass, 1 fail (the new test, with the error quoted above)
- after the fix: 7 pass, 0 fail

`pnpm eslint` and `pnpm prettier --check` are clean for the changed files.
