### PR TITLE
feat(hardhat-slang-solx): map Solidity 0.8.34 to solx 0.1.8

### DIFF
--- a/.changeset/free-shoes-give.md
+++ b/.changeset/free-shoes-give.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-slang-solx": patch
+---
+
+Update the version of solx to 0.1.8

--- a/packages/hardhat-slang-solx/README.md
+++ b/packages/hardhat-slang-solx/README.md
@@ -137,7 +137,7 @@ slangSolx: {
 
 ### Supported Solidity versions
 
-solx maps each Solidity version to a specific solx binary version internally. Currently supported: `0.8.34` (solx 0.1.7). Earlier solx releases did not emit the DWARF debug info that EDR relies on for Solidity stack traces, so they are not supported by this plugin.
+solx maps each Solidity version to a specific solx binary version internally. Currently supported: `0.8.34` (solx 0.1.8). Earlier solx releases did not emit the DWARF debug info that EDR relies on for Solidity stack traces, so they are not supported by this plugin.
 
 ### EVM version support
 

--- a/packages/hardhat-slang-solx/src/internal/constants.ts
+++ b/packages/hardhat-slang-solx/src/internal/constants.ts
@@ -37,5 +37,5 @@ export const DEFAULT_SOLX_OPTIMIZER_MODE = "1";
 
 /** Maps Solidity versions to the solx version that embeds them. */
 export const SOLIDITY_TO_SOLX_VERSION_MAP: Record<string, string> = {
-  "0.8.34": "0.1.7",
+  "0.8.34": "0.1.8",
 };


### PR DESCRIPTION
Use solx 0.1.8 in the release mapping.

Only found one bit of documentation that needed updating, left a comment: https://github.com/NomicFoundation/hardhat-website/pull/293#pullrequestreview-4985900335

## Claude Summary

Bumps `SOLIDITY_TO_SOLX_VERSION_MAP` so Solidity 0.8.34 resolves to solx 0.1.8 (was 0.1.7), plus the matching README line. solx 0.1.8 embeds the same Solidity 0.8.34, so the map key is unchanged — only the binary the plugin downloads moves.

What 0.1.8 brings that this plugin cares about:

- **SELFDESTRUCT supported** (NomicFoundation/solx#665) — was the largest compatibility bucket in the #8538 Sourcify sweep (346 of the 594 rejected contracts).
- **BLOBHASH / BLOBBASEFEE supported** (NomicFoundation/solx#664) — closes the remaining Cancun-baseline opcode gap.
- **Worker fatal errors reported per contract** (NomicFoundation/solx#666) — recursive stack-too-deep failures now surface as standard JSON errors instead of exit 0 with a silently missing artifact, so Hardhat builds fail loudly instead of recording a build with a missing artifact.
- **Pre-serialized legacy assemblies parsed** (NomicFoundation/solx#662) — memory-usage reduction on the legacy pipeline.

Pre-release validation against the #8538 sweep counterexamples (release-candidate binary from NomicFoundation/solx#668): all 346 SELFDESTRUCT and both BLOBBASEFEE contracts now compile; 6 of 11 BLOBHASH contracts compile and the other 5 move into the known unannotated-assembly × stack-too-deep bucket (BLOBHASH itself no longer rejects). All 12 known silent-drop repros verified: 7 now report the LLVM stackification error, 5 compile outright.
