### PR TITLE
dependency updates for Hardhat 2

### DIFF
--- a/.changeset/hardhat-audit-dependency-bumps.md
+++ b/.changeset/hardhat-audit-dependency-bumps.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Update dependencies for `undici` and `adm-zip` and others, and drop `uuid` in favour of `node:crypto`.

--- a/.changeset/hardhat-verify-undici-6.md
+++ b/.changeset/hardhat-verify-undici-6.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Updated `undici` to v6.

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -137,7 +137,7 @@
     "stacktrace-parser": "^0.1.10",
     "tinyglobby": "^0.2.6",
     "tsort": "0.0.1",
-    "undici": "^5.14.0",
+    "undici": "^6.28.0",
     "uuid": "^8.3.2",
     "ws": "^7.4.6"
   },

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -77,7 +77,6 @@
     "@types/resolve": "^1.17.1",
     "@types/semver": "^6.0.2",
     "@types/sinon": "^9.0.8",
-    "@types/uuid": "^8.3.1",
     "@types/ws": "^7.2.1",
     "@typescript-eslint/eslint-plugin": "5.61.0",
     "@typescript-eslint/parser": "5.61.0",
@@ -138,7 +137,6 @@
     "tinyglobby": "^0.2.6",
     "tsort": "0.0.1",
     "undici": "^6.28.0",
-    "uuid": "^8.3.2",
     "ws": "^7.4.6"
   },
   "peerDependencies": {

--- a/packages/hardhat-core/package.json
+++ b/packages/hardhat-core/package.json
@@ -106,7 +106,7 @@
     "@nomicfoundation/edr": "0.12.0-next.23",
     "@nomicfoundation/solidity-analyzer": "^0.1.0",
     "@sentry/node": "^5.18.1",
-    "adm-zip": "^0.4.16",
+    "adm-zip": "^0.6.0",
     "aggregate-error": "^3.0.0",
     "ansi-escapes": "^4.3.0",
     "boxen": "^5.1.2",

--- a/packages/hardhat-core/src/internal/cli/analytics.ts
+++ b/packages/hardhat-core/src/internal/cli/analytics.ts
@@ -4,6 +4,7 @@ import debug from "debug";
 import os from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 
 import { isLocalDev } from "../core/execution-mode";
 import { isRunningOnCiServer } from "../util/ci-detection";
@@ -236,9 +237,8 @@ async function getClientId() {
       (await readFirstLegacyAnalyticsId());
 
     if (clientId === undefined) {
-      const { v4: uuid } = await import("uuid");
       log("Client Id not found, generating a new one");
-      clientId = uuid();
+      clientId = randomUUID();
     }
 
     await writeAnalyticsId(clientId);

--- a/packages/hardhat-verify/package.json
+++ b/packages/hardhat-verify/package.json
@@ -51,7 +51,7 @@
     "picocolors": "^1.1.0",
     "semver": "^6.3.0",
     "table": "^6.8.0",
-    "undici": "^5.14.0"
+    "undici": "^6.28.0"
   },
   "devDependencies": {
     "@nomicfoundation/eslint-plugin-hardhat-internal-rules": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,38 +43,7 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^5.61.0
-        version: 5.62.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@8.1.1)(typescript@5.9.3)
-      requireindex:
-        specifier: ^1.2.0
-        version: 1.2.0
-    devDependencies:
-      eslint:
-        specifier: ^8.44.0
-        version: 8.57.1(supports-color@5.5.0)
-      eslint-config-prettier:
-        specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@5.5.0))
-      eslint-doc-generator:
-        specifier: ^1.0.0
-        version: 1.7.1(eslint@8.57.1(supports-color@5.5.0))(supports-color@8.1.1)(typescript@5.9.3)
-      eslint-plugin-eslint-plugin:
-        specifier: ^5.0.0
-        version: 5.5.1(eslint@8.57.1(supports-color@5.5.0))
-      eslint-plugin-n:
-        specifier: ^16.6.2
-        version: 16.6.2(eslint@8.57.1(supports-color@5.5.0))
-      eslint-plugin-prettier:
-        specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@5.5.0)))(eslint@8.57.1(supports-color@5.5.0))(prettier@3.9.6)
-      mocha:
-        specifier: ^11.1.0
-        version: 11.7.5
-
-  packages/eslint-plugin-slow-imports:
-    dependencies:
-      eslint-module-utils:
-        specifier: ^2.8.0
-        version: 2.12.1(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 5.62.0(eslint@8.57.1(supports-color@8.1.1))(typescript@5.9.3)
       requireindex:
         specifier: ^1.2.0
         version: 1.2.0
@@ -87,13 +56,44 @@ importers:
         version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
       eslint-doc-generator:
         specifier: ^1.0.0
-        version: 1.7.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 1.7.1(eslint@8.57.1(supports-color@8.1.1))(typescript@5.9.3)
       eslint-plugin-eslint-plugin:
         specifier: ^5.0.0
         version: 5.5.1(eslint@8.57.1(supports-color@8.1.1))
       eslint-plugin-n:
         specifier: ^16.6.2
         version: 16.6.2(eslint@8.57.1(supports-color@8.1.1))
+      eslint-plugin-prettier:
+        specifier: 5.5.6
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+      mocha:
+        specifier: ^11.1.0
+        version: 11.7.5
+
+  packages/eslint-plugin-slow-imports:
+    dependencies:
+      eslint-module-utils:
+        specifier: ^2.8.0
+        version: 2.12.1(eslint@8.57.1)(supports-color@8.1.1)
+      requireindex:
+        specifier: ^1.2.0
+        version: 1.2.0
+    devDependencies:
+      eslint:
+        specifier: ^8.44.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: 10.1.8
+        version: 10.1.8(eslint@8.57.1)
+      eslint-doc-generator:
+        specifier: ^1.0.0
+        version: 1.7.1(eslint@8.57.1)(typescript@5.9.3)
+      eslint-plugin-eslint-plugin:
+        specifier: ^5.0.0
+        version: 5.5.1(eslint@8.57.1)
+      eslint-plugin-n:
+        specifier: ^16.6.2
+        version: 16.6.2(eslint@8.57.1)
       mocha:
         specifier: ^11.1.0
         version: 11.7.5
@@ -139,10 +139,10 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1)(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       bignumber.js:
         specifier: ^9.0.2
         version: 9.3.1
@@ -154,19 +154,19 @@ importers:
         version: 4.5.0
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1)(supports-color@8.1.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       ethers:
         specifier: ^6.14.0
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -368,10 +368,10 @@ importers:
         version: 7.4.7
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       bignumber.js:
         specifier: ^9.0.2
         version: 9.3.1
@@ -386,19 +386,19 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       ethers:
         specifier: ^6.14.0
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -462,10 +462,10 @@ importers:
         version: 9.0.11
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -474,19 +474,19 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       ethers:
         specifier: ^6.14.0
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -538,28 +538,28 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -605,7 +605,7 @@ importers:
     devDependencies:
       '@istanbuljs/nyc-config-typescript':
         specifier: 1.0.2
-        version: 1.0.2(nyc@15.1.0(supports-color@5.5.0))
+        version: 1.0.2(nyc@15.1.0)
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
         version: link:../eslint-plugin-hardhat-internal-rules
@@ -641,13 +641,13 @@ importers:
         version: 10.0.20
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.57.1
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/experimental-utils':
         specifier: ^5.62.0
-        version: 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^5.57.1
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.3.4
         version: 4.5.0
@@ -656,25 +656,25 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.38.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-import-resolver-typescript:
         specifier: ^3.5.5
-        version: 3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1)(supports-color@8.1.1)
       eslint-plugin-import:
         specifier: 2.29.0
-        version: 2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)(supports-color@8.1.1)
       eslint-plugin-mocha:
         specifier: ^9.0.0
-        version: 9.0.0(eslint@8.57.1(supports-color@8.1.1))
+        version: 9.0.0(eslint@8.57.1)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -683,7 +683,7 @@ importers:
         version: 11.7.5
       nyc:
         specifier: 15.1.0
-        version: 15.1.0(supports-color@5.5.0)
+        version: 15.1.0(supports-color@8.1.1)
       prettier:
         specifier: 3.9.6
         version: 3.9.6
@@ -735,7 +735,7 @@ importers:
     devDependencies:
       '@istanbuljs/nyc-config-typescript':
         specifier: 1.0.2
-        version: 1.0.2(nyc@15.1.0(supports-color@8.1.1))
+        version: 1.0.2(nyc@15.1.0)
       '@microsoft/api-extractor':
         specifier: 7.40.1
         version: 7.40.1(@types/node@20.19.41)
@@ -768,13 +768,13 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.57.1
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/experimental-utils':
         specifier: ^5.62.0
-        version: 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^5.57.1
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.3.4
         version: 4.5.0
@@ -783,25 +783,25 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.38.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-import-resolver-typescript:
         specifier: ^3.5.5
-        version: 3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1)(supports-color@8.1.1)
       eslint-plugin-import:
         specifier: 2.29.0
-        version: 2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)(supports-color@8.1.1)
       eslint-plugin-mocha:
         specifier: ^9.0.0
-        version: 9.0.0(eslint@8.57.1(supports-color@8.1.1))
+        version: 9.0.0(eslint@8.57.1)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.4
         version: link:../hardhat-core
@@ -828,7 +828,7 @@ importers:
     devDependencies:
       '@istanbuljs/nyc-config-typescript':
         specifier: 1.0.2
-        version: 1.0.2(nyc@15.1.0(supports-color@8.1.1))
+        version: 1.0.2(nyc@15.1.0)
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
         version: link:../eslint-plugin-hardhat-internal-rules
@@ -858,13 +858,13 @@ importers:
         version: 10.0.20
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.57.1
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/experimental-utils':
         specifier: ^5.62.0
-        version: 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^5.57.1
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.3.4
         version: 4.5.0
@@ -873,25 +873,25 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.38.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-import-resolver-typescript:
         specifier: ^3.5.5
-        version: 3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1)(supports-color@8.1.1)
       eslint-plugin-import:
         specifier: 2.29.0
-        version: 2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)(supports-color@8.1.1)
       eslint-plugin-mocha:
         specifier: ^9.0.0
-        version: 9.0.0(eslint@8.57.1(supports-color@8.1.1))
+        version: 9.0.0(eslint@8.57.1)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       ethers:
         specifier: ^6.14.0
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -948,10 +948,10 @@ importers:
         version: 5.1.26
       '@typescript-eslint/parser':
         specifier: ^5.57.1
-        version: 5.61.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
-        version: 4.7.0(supports-color@5.5.0)(vite@5.4.21(@types/node@22.7.5))
+        version: 4.7.0(vite@5.4.21(@types/node@22.7.5))
       chai:
         specifier: ^4.3.4
         version: 4.5.0
@@ -960,13 +960,13 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.38.0
-        version: 8.57.1(supports-color@5.5.0)
+        version: 8.57.1
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
-        version: 4.6.2(eslint@8.57.1(supports-color@5.5.0))
+        version: 4.6.2(eslint@8.57.1)
       eslint-plugin-react-refresh:
         specifier: ^0.3.4
-        version: 0.3.5(eslint@8.57.1(supports-color@5.5.0))
+        version: 0.3.5(eslint@8.57.1)
       mermaid:
         specifier: 10.9.3
         version: 10.9.3(supports-color@5.5.0)
@@ -990,7 +990,7 @@ importers:
         version: 3.0.2
       styled-components:
         specifier: 5.3.10
-        version: 5.3.10(@babel/core@7.29.0(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+        version: 5.3.10(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
       svg-pan-zoom:
         specifier: ^3.6.1
         version: 3.6.2
@@ -1011,7 +1011,7 @@ importers:
     devDependencies:
       '@istanbuljs/nyc-config-typescript':
         specifier: 1.0.2
-        version: 1.0.2(nyc@15.1.0(supports-color@8.1.1))
+        version: 1.0.2(nyc@15.1.0)
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
         version: link:../eslint-plugin-hardhat-internal-rules
@@ -1041,13 +1041,13 @@ importers:
         version: 10.0.20
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.57.1
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/experimental-utils':
         specifier: ^5.62.0
-        version: 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^5.57.1
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.3.4
         version: 4.5.0
@@ -1056,25 +1056,25 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.38.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-import-resolver-typescript:
         specifier: ^3.5.5
-        version: 3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1)(supports-color@8.1.1)
       eslint-plugin-import:
         specifier: 2.29.0
-        version: 2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)(supports-color@8.1.1)
       eslint-plugin-mocha:
         specifier: ^9.0.0
-        version: 9.0.0(eslint@8.57.1(supports-color@8.1.1))
+        version: 9.0.0(eslint@8.57.1)
       eslint-plugin-no-only-tests:
         specifier: 3.1.0
         version: 3.1.0
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -1165,28 +1165,28 @@ importers:
         version: 9.0.11
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -1238,10 +1238,10 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -1250,19 +1250,19 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       ethers-v5:
         specifier: npm:ethers@5
         version: ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -1323,28 +1323,28 @@ importers:
         version: 6.2.7
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.5
         version: link:../hardhat-core
@@ -1393,28 +1393,28 @@ importers:
         version: 9.0.11
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       fs-extra:
         specifier: ^7.0.1
         version: 7.0.1
@@ -1447,7 +1447,7 @@ importers:
         version: 7.0.1
       solpp:
         specifier: ^0.11.5
-        version: 0.11.5(debug@4.4.3(supports-color@8.1.1))
+        version: 0.11.5
     devDependencies:
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
@@ -1469,28 +1469,28 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -1550,28 +1550,28 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.4.1
         version: 4.5.0
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       ethers:
         specifier: ^6.14.0
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -1580,7 +1580,7 @@ importers:
         version: link:../hardhat-core
       hardhat-gas-reporter:
         specifier: ^2.3.0
-        version: 2.3.0(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(hardhat@packages+hardhat-core)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.3.0(bufferutil@4.1.0)(hardhat@packages+hardhat-core)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       mocha:
         specifier: ^11.1.0
         version: 11.7.5
@@ -1641,34 +1641,34 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.28.0
         version: link:../hardhat-core
       hardhat-gas-reporter:
         specifier: ^2.3.0
-        version: 2.3.0(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(hardhat@packages+hardhat-core)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.3.0(bufferutil@4.1.0)(hardhat@packages+hardhat-core)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       mocha:
         specifier: ^11.1.0
         version: 11.7.5
@@ -1732,25 +1732,25 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -1777,7 +1777,7 @@ importers:
     dependencies:
       '@nomiclabs/truffle-contract':
         specifier: ^4.2.23
-        version: 4.5.10(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@1.10.4)(web3-utils@1.10.4)(web3@1.10.4(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10))
+        version: 4.5.10(bufferutil@4.1.0)(supports-color@5.5.0)(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@1.10.4)(web3-utils@1.10.4)(web3@1.10.4(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10))
       '@types/chai':
         specifier: ^4.2.0
         version: 4.3.20
@@ -1814,25 +1814,25 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -1929,10 +1929,10 @@ importers:
         version: 3.2.12
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -1941,19 +1941,19 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       ethers:
         specifier: ^5.0.0
         version: 5.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -2023,10 +2023,10 @@ importers:
         version: 9.0.11
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -2035,19 +2035,19 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -2129,10 +2129,10 @@ importers:
         version: 6.2.7
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -2141,19 +2141,19 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -2192,28 +2192,28 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -2258,28 +2258,28 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -2324,10 +2324,10 @@ importers:
         version: 20.19.41
       '@typescript-eslint/eslint-plugin':
         specifier: 5.61.0
-        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 5.61.0
-        version: 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4.2.0
         version: 4.5.0
@@ -2336,19 +2336,19 @@ importers:
         version: 7.1.1(chai@4.5.0)
       eslint:
         specifier: ^8.44.0
-        version: 8.57.1(supports-color@8.1.1)
+        version: 8.57.1
       eslint-config-prettier:
         specifier: 10.1.8
-        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-mocha:
         specifier: 10.4.1
-        version: 10.4.1(eslint@8.57.1(supports-color@8.1.1))
+        version: 10.4.1(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: 5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6)
       hardhat:
         specifier: workspace:^2.26.0
         version: link:../hardhat-core
@@ -9032,36 +9032,16 @@ snapshots:
 
   '@babel/compat-data@7.29.3': {}
 
-  '@babel/core@7.29.0(supports-color@5.5.0)':
+  '@babel/core@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@5.5.0))(supports-color@5.5.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
-      '@babel/types': 7.29.0
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/core@7.29.0(supports-color@8.1.1)':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -9094,6 +9074,13 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@7.28.6(supports-color@5.5.0)':
     dependencies:
       '@babel/traverse': 7.29.0(supports-color@5.5.0)
@@ -9101,28 +9088,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.28.6(supports-color@8.1.1)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@5.5.0))(supports-color@5.5.0)':
-    dependencies:
-      '@babel/core': 7.29.0(supports-color@5.5.0)
-      '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.28.6(supports-color@8.1.1)
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9143,19 +9114,19 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0(supports-color@5.5.0))':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@5.5.0)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0(supports-color@5.5.0))':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@5.5.0)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0(supports-color@5.5.0))':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@5.5.0)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.29.2': {}
@@ -9166,6 +9137,18 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/traverse@7.29.0(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -9175,18 +9158,6 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@7.29.0(supports-color@8.1.1)':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9476,31 +9447,17 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1(supports-color@5.5.0))':
-    dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1(supports-color@8.1.1))':
     dependencies:
       eslint: 8.57.1(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.12.2': {}
-
-  '@eslint/eslintrc@2.1.4(supports-color@5.5.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
     dependencies:
-      ajv: 6.15.0
-      debug: 4.4.3(supports-color@5.5.0)
-      espree: 9.6.1
-      globals: 13.24.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.5
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/eslintrc@2.1.4(supports-color@8.1.1)':
     dependencies:
@@ -9841,14 +9798,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@humanwhocodes/config-array@0.13.0(supports-color@5.5.0)':
-    dependencies:
-      '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@5.5.0)
-      minimatch: 3.1.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@humanwhocodes/config-array@0.13.0(supports-color@8.1.1)':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -9885,12 +9834,7 @@ snapshots:
       js-yaml: 3.14.2
       resolve-from: 5.0.0
 
-  '@istanbuljs/nyc-config-typescript@1.0.2(nyc@15.1.0(supports-color@5.5.0))':
-    dependencies:
-      '@istanbuljs/schema': 0.1.6
-      nyc: 15.1.0(supports-color@5.5.0)
-
-  '@istanbuljs/nyc-config-typescript@1.0.2(nyc@15.1.0(supports-color@8.1.1))':
+  '@istanbuljs/nyc-config-typescript@1.0.2(nyc@15.1.0)':
     dependencies:
       '@istanbuljs/schema': 0.1.6
       nyc: 15.1.0(supports-color@8.1.1)
@@ -10220,16 +10164,16 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-linux-x64-musl': 0.1.2
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.2
 
-  '@nomiclabs/truffle-contract@4.5.10(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@1.10.4)(web3-utils@1.10.4)(web3@1.10.4(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10))':
+  '@nomiclabs/truffle-contract@4.5.10(bufferutil@4.1.0)(supports-color@5.5.0)(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@1.10.4)(web3-utils@1.10.4)(web3@1.10.4(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10))':
     dependencies:
       '@ensdomains/ensjs': 2.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@truffle/blockchain-utils': 0.1.9
       '@truffle/contract-schema': 3.4.16(supports-color@5.5.0)
       '@truffle/debug-utils': 6.0.57(supports-color@5.5.0)
       '@truffle/error': 0.1.1
-      '@truffle/interface-adapter': 0.5.37(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)
+      '@truffle/interface-adapter': 0.5.37(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       bignumber.js: 7.2.1
-      ethereum-ens: 0.8.0(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)
+      ethereum-ens: 0.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       ethers: 4.0.49
       source-map-support: 0.5.21
       web3: 1.10.4(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)
@@ -10604,11 +10548,11 @@ snapshots:
 
   '@truffle/error@0.2.2': {}
 
-  '@truffle/interface-adapter@0.5.37(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)':
+  '@truffle/interface-adapter@0.5.37(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
       bn.js: 5.2.3
       ethers: 4.0.49
-      web3: 1.10.0(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)
+      web3: 1.10.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -10869,15 +10813,15 @@ snapshots:
     dependencies:
       '@types/node': 20.19.41
 
-  '@typescript-eslint/eslint-plugin@5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1)(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 5.61.0
-      '@typescript-eslint/type-utils': 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 5.61.0(eslint@8.57.1)(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 5.61.0(eslint@8.57.1)(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 8.57.1(supports-color@8.1.1)
+      eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
@@ -10888,33 +10832,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@5.61.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      eslint: 8.57.1(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
-    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 5.61.0
-      '@typescript-eslint/types': 5.61.0
-      '@typescript-eslint/typescript-estree': 5.61.0(supports-color@5.5.0)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@5.5.0)
-      eslint: 8.57.1(supports-color@5.5.0)
+      '@typescript-eslint/type-utils': 5.61.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 5.61.0(eslint@8.57.1)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare-lite: 1.4.0
+      semver: 7.8.0
+      tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint: 8.57.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/parser@5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.61.0
       '@typescript-eslint/types': 5.61.0
       '@typescript-eslint/typescript-estree': 5.61.0(supports-color@8.1.1)(typescript@5.9.3)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1(supports-color@8.1.1)
+      eslint: 8.57.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10930,12 +10881,24 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
 
-  '@typescript-eslint/type-utils@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@5.61.0(eslint@8.57.1)(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.61.0(supports-color@8.1.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 5.61.0(eslint@8.57.1)(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 8.57.1(supports-color@8.1.1)
+      eslint: 8.57.1
+      tsutils: 3.21.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@5.61.0(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.61.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 5.61.0(eslint@8.57.1)(typescript@5.9.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -10945,20 +10908,6 @@ snapshots:
   '@typescript-eslint/types@5.61.0': {}
 
   '@typescript-eslint/types@5.62.0': {}
-
-  '@typescript-eslint/typescript-estree@5.61.0(supports-color@5.5.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 5.61.0
-      '@typescript-eslint/visitor-keys': 5.61.0
-      debug: 4.4.3(supports-color@5.5.0)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.8.0
-      tsutils: 3.21.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/typescript-estree@5.61.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
@@ -10974,7 +10923,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -10988,45 +10937,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@5.61.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.61.0
       '@typescript-eslint/types': 5.61.0
       '@typescript-eslint/typescript-estree': 5.61.0(supports-color@8.1.1)(typescript@5.9.3)
-      eslint: 8.57.1(supports-color@8.1.1)
+      eslint: 8.57.1
       eslint-scope: 5.1.1
       semver: 7.8.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@8.1.1)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@5.5.0))
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.7.1
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@5.9.3)
-      eslint: 8.57.1(supports-color@5.5.0)
-      eslint-scope: 5.1.1
-      semver: 7.8.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1(supports-color@8.1.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@8.1.1))
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
       eslint: 8.57.1(supports-color@8.1.1)
+      eslint-scope: 5.1.1
+      semver: 7.8.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.7.1
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.3)
+      eslint: 8.57.1
       eslint-scope: 5.1.1
       semver: 7.8.0
     transitivePeerDependencies:
@@ -11104,11 +11053,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@4.7.0(supports-color@5.5.0)(vite@5.4.21(@types/node@22.7.5))':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.7.5))':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@5.5.0)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0(supports-color@5.5.0))
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0(supports-color@5.5.0))
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -11346,9 +11295,9 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@0.21.4(debug@4.4.3(supports-color@8.1.1)):
+  axios@0.21.4:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@5.5.0))
     transitivePeerDependencies:
       - debug
 
@@ -11368,22 +11317,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.16.0(debug@4.4.3(supports-color@8.1.1)):
-    dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  babel-plugin-styled-components@2.1.4(@babel/core@7.29.0(supports-color@5.5.0))(styled-components@5.3.10(@babel/core@7.29.0(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.29.0)(styled-components@5.3.10(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@5.5.0))
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       lodash: 4.17.21
       picomatch: 2.3.2
-      styled-components: 5.3.10(@babel/core@7.29.0(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      styled-components: 5.3.10(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -12590,34 +12531,34 @@ snapshots:
     optionalDependencies:
       source-map: 0.2.0
 
-  eslint-compat-utils@0.5.1(eslint@8.57.1(supports-color@5.5.0)):
-    dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
-      semver: 7.8.0
-
   eslint-compat-utils@0.5.1(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
       eslint: 8.57.1(supports-color@8.1.1)
       semver: 7.8.0
 
-  eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@5.5.0)):
+  eslint-compat-utils@0.5.1(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
+      eslint: 8.57.1
+      semver: 7.8.0
 
   eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
       eslint: 8.57.1(supports-color@8.1.1)
 
-  eslint-doc-generator@1.7.1(eslint@8.57.1(supports-color@5.5.0))(supports-color@8.1.1)(typescript@5.9.3):
+  eslint-config-prettier@10.1.8(eslint@8.57.1):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1(supports-color@5.5.0))(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 8.57.1
+
+  eslint-doc-generator@1.7.1(eslint@8.57.1(supports-color@8.1.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(typescript@5.9.3)
       ajv: 8.20.0
       boolean: 3.2.0
       commander: 10.0.1
       cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
       dot-prop: 7.2.0
-      eslint: 8.57.1(supports-color@5.5.0)
+      eslint: 8.57.1(supports-color@8.1.1)
       jest-diff: 29.7.0
       json-schema-traverse: 1.0.0
       markdown-table: 3.0.4
@@ -12627,16 +12568,16 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-doc-generator@1.7.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
+  eslint-doc-generator@1.7.1(eslint@8.57.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       ajv: 8.20.0
       boolean: 3.2.0
       commander: 10.0.1
       cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
       dot-prop: 7.2.0
-      eslint: 8.57.1(supports-color@8.1.1)
+      eslint: 8.57.1
       jest-diff: 29.7.0
       json-schema-traverse: 1.0.0
       markdown-table: 3.0.4
@@ -12654,38 +12595,49 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1)(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1(supports-color@8.1.1)
+      eslint: 8.57.1
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
-      eslint: 8.57.1(supports-color@8.1.1)
+      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-es-x@7.8.0(eslint@8.57.1(supports-color@5.5.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@5.5.0))
-      '@eslint-community/regexpp': 4.12.2
-      eslint: 8.57.1(supports-color@5.5.0)
-      eslint-compat-utils: 0.5.1(eslint@8.57.1(supports-color@5.5.0))
+      debug: 3.2.7(supports-color@8.1.1)
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.29.0)(eslint@8.57.1)(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint@8.57.1)(supports-color@8.1.1):
+    dependencies:
+      debug: 3.2.7(supports-color@8.1.1)
+    optionalDependencies:
+      eslint: 8.57.1
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-es-x@7.8.0(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
@@ -12694,11 +12646,12 @@ snapshots:
       eslint: 8.57.1(supports-color@8.1.1)
       eslint-compat-utils: 0.5.1(eslint@8.57.1(supports-color@8.1.1))
 
-  eslint-plugin-eslint-plugin@5.5.1(eslint@8.57.1(supports-color@5.5.0)):
+  eslint-plugin-es-x@7.8.0(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
-      eslint-utils: 3.0.0(eslint@8.57.1(supports-color@5.5.0))
-      estraverse: 5.3.0
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@eslint-community/regexpp': 4.12.2
+      eslint: 8.57.1
+      eslint-compat-utils: 0.5.1(eslint@8.57.1)
 
   eslint-plugin-eslint-plugin@5.5.1(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
@@ -12706,16 +12659,22 @@ snapshots:
       eslint-utils: 3.0.0(eslint@8.57.1(supports-color@8.1.1))
       estraverse: 5.3.0
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-eslint-plugin@5.5.1(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+      eslint-utils: 3.0.0(eslint@8.57.1)
+      estraverse: 5.3.0
+
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1)(supports-color@8.1.1):
     dependencies:
       array-includes: 3.1.9
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
-      eslint: 8.57.1(supports-color@8.1.1)
+      eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint@8.57.1)
       has: 1.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -12725,13 +12684,38 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7(supports-color@8.1.1)
+      doctrine: 2.1.0
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      has: 1.0.4
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.values: 1.2.1
+      resolve: 1.22.12
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.29.0(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)(supports-color@8.1.1):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
@@ -12739,9 +12723,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
-      eslint: 8.57.1(supports-color@8.1.1)
+      eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -12752,39 +12736,24 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.61.0(eslint@8.57.1)(supports-color@8.1.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-mocha@10.4.1(eslint@8.57.1(supports-color@8.1.1)):
+  eslint-plugin-mocha@10.4.1(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.1(supports-color@8.1.1)
-      eslint-utils: 3.0.0(eslint@8.57.1(supports-color@8.1.1))
+      eslint: 8.57.1
+      eslint-utils: 3.0.0(eslint@8.57.1)
       globals: 13.24.0
       rambda: 7.5.0
 
-  eslint-plugin-mocha@9.0.0(eslint@8.57.1(supports-color@8.1.1)):
+  eslint-plugin-mocha@9.0.0(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.1(supports-color@8.1.1)
-      eslint-utils: 3.0.0(eslint@8.57.1(supports-color@8.1.1))
+      eslint: 8.57.1
+      eslint-utils: 3.0.0(eslint@8.57.1)
       ramda: 0.27.2
-
-  eslint-plugin-n@16.6.2(eslint@8.57.1(supports-color@5.5.0)):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@5.5.0))
-      builtins: 5.1.0
-      eslint: 8.57.1(supports-color@5.5.0)
-      eslint-plugin-es-x: 7.8.0(eslint@8.57.1(supports-color@5.5.0))
-      get-tsconfig: 4.14.0
-      globals: 13.24.0
-      ignore: 5.3.2
-      is-builtin-module: 3.2.1
-      is-core-module: 2.16.2
-      minimatch: 3.1.5
-      resolve: 1.22.12
-      semver: 7.8.0
 
   eslint-plugin-n@16.6.2(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
@@ -12801,16 +12770,22 @@ snapshots:
       resolve: 1.22.12
       semver: 7.8.0
 
-  eslint-plugin-no-only-tests@3.1.0: {}
-
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@5.5.0)))(eslint@8.57.1(supports-color@5.5.0))(prettier@3.9.6):
+  eslint-plugin-n@16.6.2(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
-      prettier: 3.9.6
-      prettier-linter-helpers: 1.0.1
-      synckit: 0.11.13
-    optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@8.57.1(supports-color@5.5.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      builtins: 5.1.0
+      eslint: 8.57.1
+      eslint-plugin-es-x: 7.8.0(eslint@8.57.1)
+      get-tsconfig: 4.14.0
+      globals: 13.24.0
+      ignore: 5.3.2
+      is-builtin-module: 3.2.1
+      is-core-module: 2.16.2
+      minimatch: 3.1.5
+      resolve: 1.22.12
+      semver: 7.8.0
+
+  eslint-plugin-no-only-tests@3.1.0: {}
 
   eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.6):
     dependencies:
@@ -12821,13 +12796,22 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
 
-  eslint-plugin-react-hooks@4.6.2(eslint@8.57.1(supports-color@5.5.0)):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.6):
     dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
+      eslint: 8.57.1
+      prettier: 3.9.6
+      prettier-linter-helpers: 1.0.1
+      synckit: 0.11.13
+    optionalDependencies:
+      eslint-config-prettier: 10.1.8(eslint@8.57.1)
 
-  eslint-plugin-react-refresh@0.3.5(eslint@8.57.1(supports-color@5.5.0)):
+  eslint-plugin-react-hooks@4.6.2(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
+      eslint: 8.57.1
+
+  eslint-plugin-react-refresh@0.3.5(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
 
   eslint-scope@5.1.1:
     dependencies:
@@ -12839,34 +12823,34 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-utils@3.0.0(eslint@8.57.1(supports-color@5.5.0)):
-    dependencies:
-      eslint: 8.57.1(supports-color@5.5.0)
-      eslint-visitor-keys: 2.1.0
-
   eslint-utils@3.0.0(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
       eslint: 8.57.1(supports-color@8.1.1)
+      eslint-visitor-keys: 2.1.0
+
+  eslint-utils@3.0.0(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
       eslint-visitor-keys: 2.1.0
 
   eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint@8.57.1(supports-color@5.5.0):
+  eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@5.5.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/eslintrc': 2.1.4(supports-color@5.5.0)
+      '@eslint/eslintrc': 2.1.4(supports-color@8.1.1)
       '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0(supports-color@5.5.0)
+      '@humanwhocodes/config-array': 0.13.0(supports-color@8.1.1)
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.1
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -13034,7 +13018,7 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
 
-  ethereum-ens@0.8.0(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10):
+  ethereum-ens@0.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       bluebird: 3.7.2
       eth-ens-namehash: 2.0.8
@@ -13190,7 +13174,7 @@ snapshots:
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2(supports-color@8.1.1)
-      serve-static: 1.16.3(supports-color@8.1.1)
+      serve-static: 1.16.3
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -13303,10 +13287,6 @@ snapshots:
   follow-redirects@1.16.0(debug@4.4.3(supports-color@5.5.0)):
     optionalDependencies:
       debug: 4.4.3(supports-color@5.5.0)
-
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -13637,13 +13617,13 @@ snapshots:
       ajv: 6.15.0
       har-schema: 2.0.0
 
-  hardhat-gas-reporter@2.3.0(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(hardhat@packages+hardhat-core)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  hardhat-gas-reporter@2.3.0(bufferutil@4.1.0)(hardhat@packages+hardhat-core)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/bytes': 5.8.0
       '@ethersproject/units': 5.8.0
       '@solidity-parser/parser': 0.20.2
-      axios: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      axios: 1.16.0(debug@4.4.3(supports-color@5.5.0))
       brotli-wasm: 2.0.1
       chalk: 4.1.2
       cli-table3: 0.6.5
@@ -14053,9 +14033,9 @@ snapshots:
     dependencies:
       append-transform: 2.0.0
 
-  istanbul-lib-instrument@4.0.3(supports-color@8.1.1):
+  istanbul-lib-instrument@4.0.3:
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -14076,14 +14056,6 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
-
-  istanbul-lib-source-maps@4.0.1(supports-color@5.5.0):
-    dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
-      istanbul-lib-coverage: 3.2.2
-      source-map: 0.6.1
-    transitivePeerDependencies:
-      - supports-color
 
   istanbul-lib-source-maps@4.0.1(supports-color@8.1.1):
     dependencies:
@@ -14835,38 +14807,6 @@ snapshots:
       bn.js: 4.11.6
       strip-hex-prefix: 1.0.0
 
-  nyc@15.1.0(supports-color@5.5.0):
-    dependencies:
-      '@istanbuljs/load-nyc-config': 1.1.0
-      '@istanbuljs/schema': 0.1.6
-      caching-transform: 4.0.0
-      convert-source-map: 1.9.0
-      decamelize: 1.2.0
-      find-cache-dir: 3.3.2
-      find-up: 4.1.0
-      foreground-child: 2.0.0
-      get-package-type: 0.1.0
-      glob: 7.2.3
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-hook: 3.0.0
-      istanbul-lib-instrument: 4.0.3(supports-color@8.1.1)
-      istanbul-lib-processinfo: 2.0.3
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1(supports-color@5.5.0)
-      istanbul-reports: 3.2.0
-      make-dir: 3.1.0
-      node-preload: 0.2.1
-      p-map: 3.0.0
-      process-on-spawn: 1.1.0
-      resolve-from: 5.0.0
-      rimraf: 3.0.2
-      signal-exit: 3.0.7
-      spawn-wrap: 2.0.0
-      test-exclude: 6.0.0
-      yargs: 15.4.1
-    transitivePeerDependencies:
-      - supports-color
-
   nyc@15.1.0(supports-color@8.1.1):
     dependencies:
       '@istanbuljs/load-nyc-config': 1.1.0
@@ -14881,7 +14821,7 @@ snapshots:
       glob: 7.2.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-hook: 3.0.0
-      istanbul-lib-instrument: 4.0.3(supports-color@8.1.1)
+      istanbul-lib-instrument: 4.0.3
       istanbul-lib-processinfo: 2.0.3
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 4.0.1(supports-color@8.1.1)
@@ -15705,7 +15645,7 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  serve-static@1.16.3(supports-color@8.1.1):
+  serve-static@1.16.3:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -15934,10 +15874,10 @@ snapshots:
       shelljs: 0.8.5
       web3-utils: 1.10.4
 
-  solpp@0.11.5(debug@4.4.3(supports-color@8.1.1)):
+  solpp@0.11.5:
     dependencies:
       antlr4: 4.8.0
-      axios: 0.21.4(debug@4.4.3(supports-color@8.1.1))
+      axios: 0.21.4
       bn-str-256: 1.9.1
       commander: 2.20.3
       ethereumjs-util: 6.2.1
@@ -16112,14 +16052,14 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-components@5.3.10(@babel/core@7.29.0(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1):
+  styled-components@5.3.10(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1):
     dependencies:
       '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
       '@babel/traverse': 7.29.0(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.4.0
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.29.0(supports-color@5.5.0))(styled-components@5.3.10(@babel/core@7.29.0(supports-color@5.5.0))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0)
+      babel-plugin-styled-components: 2.1.4(@babel/core@7.29.0)(styled-components@5.3.10(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0)
       css-to-react-native: 3.2.0
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
@@ -16653,7 +16593,7 @@ snapshots:
 
   web-worker@1.5.0: {}
 
-  web3-bzz@1.10.0(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10):
+  web3-bzz@1.10.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@types/node': 12.20.55
       got: 12.1.0
@@ -16707,24 +16647,24 @@ snapshots:
     dependencies:
       eventemitter3: 4.0.4
 
-  web3-core-requestmanager@1.10.0(supports-color@8.1.1):
+  web3-core-requestmanager@1.10.0:
     dependencies:
       util: 0.12.5
       web3-core-helpers: 1.10.0
       web3-providers-http: 1.10.0
       web3-providers-ipc: 1.10.0
-      web3-providers-ws: 1.10.0(supports-color@8.1.1)
+      web3-providers-ws: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  web3-core-requestmanager@1.10.4(supports-color@8.1.1):
+  web3-core-requestmanager@1.10.4:
     dependencies:
       util: 0.12.5
       web3-core-helpers: 1.10.4
       web3-providers-http: 1.10.4
       web3-providers-ipc: 1.10.4
-      web3-providers-ws: 1.10.4(supports-color@8.1.1)
+      web3-providers-ws: 1.10.4
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -16739,27 +16679,27 @@ snapshots:
       eventemitter3: 4.0.4
       web3-core-helpers: 1.10.4
 
-  web3-core@1.10.0(supports-color@8.1.1):
+  web3-core@1.10.0:
     dependencies:
       '@types/bn.js': 5.2.0
       '@types/node': 12.20.55
       bignumber.js: 9.3.1
       web3-core-helpers: 1.10.0
       web3-core-method: 1.10.0
-      web3-core-requestmanager: 1.10.0(supports-color@8.1.1)
+      web3-core-requestmanager: 1.10.0
       web3-utils: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  web3-core@1.10.4(supports-color@8.1.1):
+  web3-core@1.10.4:
     dependencies:
       '@types/bn.js': 5.2.0
       '@types/node': 12.20.55
       bignumber.js: 9.3.1
       web3-core-helpers: 1.10.4
       web3-core-method: 1.10.4
-      web3-core-requestmanager: 1.10.4(supports-color@8.1.1)
+      web3-core-requestmanager: 1.10.4
       web3-utils: 1.10.4
     transitivePeerDependencies:
       - encoding
@@ -16807,7 +16747,7 @@ snapshots:
       - typescript
       - zod
 
-  web3-eth-accounts@1.10.0(supports-color@8.1.1):
+  web3-eth-accounts@1.10.0:
     dependencies:
       '@ethereumjs/common': 2.5.0
       '@ethereumjs/tx': 3.3.2
@@ -16815,7 +16755,7 @@ snapshots:
       ethereumjs-util: 7.1.5
       scrypt-js: 3.0.1
       uuid: 9.0.1
-      web3-core: 1.10.0(supports-color@8.1.1)
+      web3-core: 1.10.0
       web3-core-helpers: 1.10.0
       web3-core-method: 1.10.0
       web3-utils: 1.10.0
@@ -16823,7 +16763,7 @@ snapshots:
       - encoding
       - supports-color
 
-  web3-eth-accounts@1.10.4(supports-color@8.1.1):
+  web3-eth-accounts@1.10.4:
     dependencies:
       '@ethereumjs/common': 2.6.5
       '@ethereumjs/tx': 3.5.2
@@ -16831,7 +16771,7 @@ snapshots:
       eth-lib: 0.2.8
       scrypt-js: 3.0.1
       uuid: 9.0.1
-      web3-core: 1.10.4(supports-color@8.1.1)
+      web3-core: 1.10.4
       web3-core-helpers: 1.10.4
       web3-core-method: 1.10.4
       web3-utils: 1.10.4
@@ -16849,10 +16789,10 @@ snapshots:
       web3-utils: 4.3.3
       web3-validator: 2.0.6
 
-  web3-eth-contract@1.10.0(supports-color@8.1.1):
+  web3-eth-contract@1.10.0:
     dependencies:
       '@types/bn.js': 5.2.0
-      web3-core: 1.10.0(supports-color@8.1.1)
+      web3-core: 1.10.0
       web3-core-helpers: 1.10.0
       web3-core-method: 1.10.0
       web3-core-promievent: 1.10.0
@@ -16863,10 +16803,10 @@ snapshots:
       - encoding
       - supports-color
 
-  web3-eth-contract@1.10.4(supports-color@8.1.1):
+  web3-eth-contract@1.10.4:
     dependencies:
       '@types/bn.js': 5.2.0
-      web3-core: 1.10.4(supports-color@8.1.1)
+      web3-core: 1.10.4
       web3-core-helpers: 1.10.4
       web3-core-method: 1.10.4
       web3-core-promievent: 1.10.4
@@ -16894,29 +16834,29 @@ snapshots:
       - utf-8-validate
       - zod
 
-  web3-eth-ens@1.10.0(supports-color@8.1.1):
+  web3-eth-ens@1.10.0:
     dependencies:
       content-hash: 2.5.2
       eth-ens-namehash: 2.0.8
-      web3-core: 1.10.0(supports-color@8.1.1)
+      web3-core: 1.10.0
       web3-core-helpers: 1.10.0
       web3-core-promievent: 1.10.0
       web3-eth-abi: 1.10.0
-      web3-eth-contract: 1.10.0(supports-color@8.1.1)
+      web3-eth-contract: 1.10.0
       web3-utils: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  web3-eth-ens@1.10.4(supports-color@8.1.1):
+  web3-eth-ens@1.10.4:
     dependencies:
       content-hash: 2.5.2
       eth-ens-namehash: 2.0.8
-      web3-core: 1.10.4(supports-color@8.1.1)
+      web3-core: 1.10.4
       web3-core-helpers: 1.10.4
       web3-core-promievent: 1.10.4
       web3-eth-abi: 1.10.4
-      web3-eth-contract: 1.10.4(supports-color@8.1.1)
+      web3-eth-contract: 1.10.4
       web3-utils: 1.10.4
     transitivePeerDependencies:
       - encoding
@@ -16957,25 +16897,25 @@ snapshots:
       web3-utils: 4.3.3
       web3-validator: 2.0.6
 
-  web3-eth-personal@1.10.0(supports-color@8.1.1):
+  web3-eth-personal@1.10.0:
     dependencies:
       '@types/node': 12.20.55
-      web3-core: 1.10.0(supports-color@8.1.1)
+      web3-core: 1.10.0
       web3-core-helpers: 1.10.0
       web3-core-method: 1.10.0
-      web3-net: 1.10.0(supports-color@8.1.1)
+      web3-net: 1.10.0
       web3-utils: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  web3-eth-personal@1.10.4(supports-color@8.1.1):
+  web3-eth-personal@1.10.4:
     dependencies:
       '@types/node': 12.20.55
-      web3-core: 1.10.4(supports-color@8.1.1)
+      web3-core: 1.10.4
       web3-core-helpers: 1.10.4
       web3-core-method: 1.10.4
-      web3-net: 1.10.4(supports-color@8.1.1)
+      web3-net: 1.10.4
       web3-utils: 1.10.4
     transitivePeerDependencies:
       - encoding
@@ -16996,37 +16936,37 @@ snapshots:
       - utf-8-validate
       - zod
 
-  web3-eth@1.10.0(supports-color@8.1.1):
+  web3-eth@1.10.0:
     dependencies:
-      web3-core: 1.10.0(supports-color@8.1.1)
+      web3-core: 1.10.0
       web3-core-helpers: 1.10.0
       web3-core-method: 1.10.0
       web3-core-subscriptions: 1.10.0
       web3-eth-abi: 1.10.0
-      web3-eth-accounts: 1.10.0(supports-color@8.1.1)
-      web3-eth-contract: 1.10.0(supports-color@8.1.1)
-      web3-eth-ens: 1.10.0(supports-color@8.1.1)
+      web3-eth-accounts: 1.10.0
+      web3-eth-contract: 1.10.0
+      web3-eth-ens: 1.10.0
       web3-eth-iban: 1.10.0
-      web3-eth-personal: 1.10.0(supports-color@8.1.1)
-      web3-net: 1.10.0(supports-color@8.1.1)
+      web3-eth-personal: 1.10.0
+      web3-net: 1.10.0
       web3-utils: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  web3-eth@1.10.4(supports-color@8.1.1):
+  web3-eth@1.10.4:
     dependencies:
-      web3-core: 1.10.4(supports-color@8.1.1)
+      web3-core: 1.10.4
       web3-core-helpers: 1.10.4
       web3-core-method: 1.10.4
       web3-core-subscriptions: 1.10.4
       web3-eth-abi: 1.10.4
-      web3-eth-accounts: 1.10.4(supports-color@8.1.1)
-      web3-eth-contract: 1.10.4(supports-color@8.1.1)
-      web3-eth-ens: 1.10.4(supports-color@8.1.1)
+      web3-eth-accounts: 1.10.4
+      web3-eth-contract: 1.10.4
+      web3-eth-ens: 1.10.4
       web3-eth-iban: 1.10.4
-      web3-eth-personal: 1.10.4(supports-color@8.1.1)
-      web3-net: 1.10.4(supports-color@8.1.1)
+      web3-eth-personal: 1.10.4
+      web3-net: 1.10.4
       web3-utils: 1.10.4
     transitivePeerDependencies:
       - encoding
@@ -17052,18 +16992,18 @@ snapshots:
       - utf-8-validate
       - zod
 
-  web3-net@1.10.0(supports-color@8.1.1):
+  web3-net@1.10.0:
     dependencies:
-      web3-core: 1.10.0(supports-color@8.1.1)
+      web3-core: 1.10.0
       web3-core-method: 1.10.0
       web3-utils: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  web3-net@1.10.4(supports-color@8.1.1):
+  web3-net@1.10.4:
     dependencies:
-      web3-core: 1.10.4(supports-color@8.1.1)
+      web3-core: 1.10.4
       web3-core-method: 1.10.4
       web3-utils: 1.10.4
     transitivePeerDependencies:
@@ -17125,19 +17065,19 @@ snapshots:
       web3-utils: 4.3.3
     optional: true
 
-  web3-providers-ws@1.10.0(supports-color@8.1.1):
+  web3-providers-ws@1.10.0:
     dependencies:
       eventemitter3: 4.0.4
       web3-core-helpers: 1.10.0
-      websocket: 1.0.35(supports-color@8.1.1)
+      websocket: 1.0.35
     transitivePeerDependencies:
       - supports-color
 
-  web3-providers-ws@1.10.4(supports-color@8.1.1):
+  web3-providers-ws@1.10.4:
     dependencies:
       eventemitter3: 4.0.4
       web3-core-helpers: 1.10.4
-      websocket: 1.0.35(supports-color@8.1.1)
+      websocket: 1.0.35
     transitivePeerDependencies:
       - supports-color
 
@@ -17176,22 +17116,22 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  web3-shh@1.10.0(supports-color@8.1.1):
+  web3-shh@1.10.0:
     dependencies:
-      web3-core: 1.10.0(supports-color@8.1.1)
+      web3-core: 1.10.0
       web3-core-method: 1.10.0
       web3-core-subscriptions: 1.10.0
-      web3-net: 1.10.0(supports-color@8.1.1)
+      web3-net: 1.10.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  web3-shh@1.10.4(supports-color@8.1.1):
+  web3-shh@1.10.4:
     dependencies:
-      web3-core: 1.10.4(supports-color@8.1.1)
+      web3-core: 1.10.4
       web3-core-method: 1.10.4
       web3-core-subscriptions: 1.10.4
-      web3-net: 1.10.4(supports-color@8.1.1)
+      web3-net: 1.10.4
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -17251,14 +17191,14 @@ snapshots:
       xhr2-cookies: 1.1.0
       xmlhttprequest: 1.8.0
 
-  web3@1.10.0(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10):
+  web3@1.10.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
-      web3-bzz: 1.10.0(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)
-      web3-core: 1.10.0(supports-color@8.1.1)
-      web3-eth: 1.10.0(supports-color@8.1.1)
-      web3-eth-personal: 1.10.0(supports-color@8.1.1)
-      web3-net: 1.10.0(supports-color@8.1.1)
-      web3-shh: 1.10.0(supports-color@8.1.1)
+      web3-bzz: 1.10.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      web3-core: 1.10.0
+      web3-eth: 1.10.0
+      web3-eth-personal: 1.10.0
+      web3-net: 1.10.0
+      web3-shh: 1.10.0
       web3-utils: 1.10.0
     transitivePeerDependencies:
       - bufferutil
@@ -17269,11 +17209,11 @@ snapshots:
   web3@1.10.4(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10):
     dependencies:
       web3-bzz: 1.10.4(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)
-      web3-core: 1.10.4(supports-color@8.1.1)
-      web3-eth: 1.10.4(supports-color@8.1.1)
-      web3-eth-personal: 1.10.4(supports-color@8.1.1)
-      web3-net: 1.10.4(supports-color@8.1.1)
-      web3-shh: 1.10.4(supports-color@8.1.1)
+      web3-core: 1.10.4
+      web3-eth: 1.10.4
+      web3-eth-personal: 1.10.4
+      web3-net: 1.10.4
+      web3-shh: 1.10.4
       web3-utils: 1.10.4
     transitivePeerDependencies:
       - bufferutil
@@ -17309,7 +17249,7 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  websocket@1.0.35(supports-color@8.1.1):
+  websocket@1.0.35:
     dependencies:
       bufferutil: 4.1.0
       debug: 2.6.9(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,8 +210,8 @@ importers:
         specifier: ^5.18.1
         version: 5.30.0(supports-color@5.5.0)
       adm-zip:
-        specifier: ^0.4.16
-        version: 0.4.16
+        specifier: ^0.6.0
+        version: 0.6.0
       aggregate-error:
         specifier: ^3.0.0
         version: 3.1.0
@@ -4000,9 +4000,9 @@ packages:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
 
-  adm-zip@0.4.16:
-    resolution: {integrity: sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==}
-    engines: {node: '>=0.3.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
@@ -11106,7 +11106,7 @@ snapshots:
 
   address@1.2.2: {}
 
-  adm-zip@0.4.16: {}
+  adm-zip@0.6.0: {}
 
   aes-js@3.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,8 +303,8 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
       undici:
-        specifier: ^5.14.0
-        version: 5.29.0
+        specifier: ^6.28.0
+        version: 6.28.0
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -8328,6 +8328,10 @@ packages:
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
+
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -16435,6 +16439,8 @@ snapshots:
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
+
+  undici@6.28.0: {}
 
   undici@7.25.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1882,8 +1882,8 @@ importers:
         specifier: ^6.8.0
         version: 6.9.0
       undici:
-        specifier: ^5.14.0
-        version: 5.29.0
+        specifier: ^6.28.0
+        version: 6.28.0
     devDependencies:
       '@nomicfoundation/eslint-plugin-hardhat-internal-rules':
         specifier: workspace:^
@@ -2849,10 +2849,6 @@ packages:
 
   '@ethersproject/wordlists@5.8.0':
     resolution: {integrity: sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -8316,10 +8312,6 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
@@ -9767,8 +9759,6 @@ snapshots:
       '@ethersproject/logger': 5.8.0
       '@ethersproject/properties': 5.8.0
       '@ethersproject/strings': 5.8.0
-
-  '@fastify/busboy@2.1.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -16424,10 +16414,6 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
-
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
 
   undici@6.28.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,9 +305,6 @@ importers:
       undici:
         specifier: ^6.28.0
         version: 6.28.0
-      uuid:
-        specifier: ^8.3.2
-        version: 8.3.2
       ws:
         specifier: ^7.4.6
         version: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -360,9 +357,6 @@ importers:
       '@types/sinon':
         specifier: ^9.0.8
         version: 9.0.11
-      '@types/uuid':
-        specifier: ^8.3.1
-        version: 8.3.4
       '@types/ws':
         specifier: ^7.2.1
         version: 7.4.7
@@ -3725,9 +3719,6 @@ packages:
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
-
-  '@types/uuid@8.3.4':
-    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
 
   '@types/w3c-web-usb@1.0.14':
     resolution: {integrity: sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==}
@@ -10804,8 +10795,6 @@ snapshots:
       '@types/node': 20.19.41
 
   '@types/unist@2.0.11': {}
-
-  '@types/uuid@8.3.4': {}
 
   '@types/w3c-web-usb@1.0.14': {}
 


### PR DESCRIPTION
Update the Hardhat 2 dependencies to the latest versions. Only a subset of the dependencies are being bumped, those that require only minimal code intervention.

Note, we switched out `UUID` as a package and instead use `randomUUID` from `node:crypto`.