### PR TITLE
fix: normalize whitespace in version pragmas before semver matching

### DIFF
--- a/.changeset/fix-pragma-whitespace.md
+++ b/.changeset/fix-pragma-whitespace.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Normalize whitespace in Solidity version pragmas before semver matching to fix HHE909 for files with spaces inside version literals (e.g. `pragma solidity ^ 0.8 .0`).

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/resolver/dependency-resolver.ts
@@ -1188,7 +1188,9 @@ export class ResolverImplementation implements Resolver {
     return {
       text,
       importPaths: imports,
-      versionPragmas,
+      versionPragmas: versionPragmas.map((p) =>
+        p.replace(/(\d)\s+\./g, "$1.").replace(/\.\s+(\d)/g, ".$1"),
+      ),
     };
   }
 }


### PR DESCRIPTION
## Problem

Solidity files with whitespace inside the version pragma (e.g. `pragma solidity ^ 0.8 .0;`) fail with **HHE909** even though `solc` itself compiles them fine.

`solidity-analyzer` extracts the pragma expression verbatim, preserving whitespace: `"^ 0.8 .0"`. While `solc` tokenizes the expression and treats whitespace between tokens as insignificant, npm `semver` silently fails to match:

```js
semver.satisfies("0.8.34", "^ 0.8 .0")  // false — no error, just no match
semver.satisfies("0.8.34", "^0.8.0")    // true
```

This causes every enabled compiler to silently fail to match, producing a misleading "no compatible solc version" error.

This is real on-chain code — the issue reporter found 57 affected contracts (~0.05%) in a corpus of 112,587 Sourcify-verified contracts.

Closes #8535

## Fix

Normalize extracted `versionPragmas` in `dependency-resolver.ts` immediately after `analyze()` returns, collapsing whitespace around `.` inside version numbers:

```typescript
versionPragmas: versionPragmas.map((p) =>
  p.replace(/(\d)\s+\./g, "$1.").replace(/\.\s+(\d)/g, ".$1"),
),
```

This is a single upstream normalization point — all downstream `semver.satisfies()`, `semver.maxSatisfying()`, and `semver.intersects()` calls in `solc-config-selection.ts` receive clean pragmas.

### What the regex does

- `(\d)\s+\.` — digit followed by whitespace then dot → collapse to `digit.`
- `\.\s+(\d)` — dot followed by whitespace then digit → collapse to `.digit`

### What it does NOT touch

- Operator spacing (`^ 0.8.0`) — `semver` already handles this
- Range separators (`>=0.8.0 <0.9.0`) — the space between ranges is preserved
- Non-version text — only digit-dot boundaries are affected

### Verified patterns

| Pragma | Before | After |
|--------|--------|-------|
| `^ 0.8 .0` | `false` | `true` |
| `>= 0.8 .0` | `false` | `true` |
| `>= 0.4 .22 < 0.9 .0` | `false` | `true` |
| `^0.8.0` (normal) | `true` | `true` (unchanged) |
| `>=0.8.0 <0.9.0` (normal) | `true` | `true` (unchanged) |