### PR TITLE
fix: guard against solx download race

### DIFF
--- a/.changeset/solx-download-race.md
+++ b/.changeset/solx-download-race.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-slang-solx": patch
+---
+
+Fixed a race condition in the solx downloader that would show as `spawn ... EACCES`.

--- a/packages/example-project/hardhat.config.ts
+++ b/packages/example-project/hardhat.config.ts
@@ -16,6 +16,7 @@ import hardhatTypechain from "@nomicfoundation/hardhat-typechain";
 import hardhatIgnitionViem from "@nomicfoundation/hardhat-ignition-viem";
 import hardhatVerify from "@nomicfoundation/hardhat-verify";
 import hardhatLedger from "@nomicfoundation/hardhat-ledger";
+import hardhatSlangSolx from "@nomicfoundation/hardhat-slang-solx";
 import { ArgumentType } from "hardhat/types/arguments";
 
 util.inspect.defaultOptions.depth = null;
@@ -188,6 +189,7 @@ export default defineConfig({
     hardhatTypechain,
     hardhatIgnitionViem,
     hardhatLedger,
+    hardhatSlangSolx,
   ],
   paths: {
     tests: {
@@ -225,6 +227,15 @@ export default defineConfig({
       },
       coverage: {
         version: "0.8.2",
+      },
+      slangSolx: {
+        compilers: [
+          { type: "slangSolx", version: "0.8.34" },
+          { version: "0.8.22" },
+          { version: "0.7.1" },
+          { version: "0.8.26" },
+          { version: "0.8.33" },
+        ],
       },
     },
     npmFilesToBuild: [

--- a/packages/example-project/package.json
+++ b/packages/example-project/package.json
@@ -32,6 +32,7 @@
     "@nomicfoundation/hardhat-mocha": "workspace:^3.1.0",
     "@nomicfoundation/hardhat-network-helpers": "workspace:^3.0.11",
     "@nomicfoundation/hardhat-node-test-runner": "workspace:^3.1.0",
+    "@nomicfoundation/hardhat-slang-solx": "workspace:^",
     "@nomicfoundation/hardhat-typechain": "workspace:^3.1.1",
     "@nomicfoundation/hardhat-verify": "workspace:^3.0.21",
     "@nomicfoundation/hardhat-viem": "workspace:^3.0.9",

--- a/packages/example-project/tsconfig.json
+++ b/packages/example-project/tsconfig.json
@@ -47,6 +47,9 @@
     },
     {
       "path": "../hardhat-ledger"
+    },
+    {
+      "path": "../hardhat-slang-solx"
     }
   ]
 }

--- a/packages/hardhat-slang-solx/src/internal/downloader.ts
+++ b/packages/hardhat-slang-solx/src/internal/downloader.ts
@@ -13,6 +13,7 @@ import { ensureError } from "@nomicfoundation/hardhat-utils/error";
 import {
   chmod,
   exists,
+  move,
   readBinaryFile,
   remove,
 } from "@nomicfoundation/hardhat-utils/fs";
@@ -104,9 +105,6 @@ export async function downloadSolx(
     dispatcher,
   );
 
-  // invoke the callback to allow the caller to update the UI
-  onBinaryDownloadStart();
-
   log(`Downloading solx ${solxVersion} from ${url}`);
 
   for (let attempt = 1; attempt <= DOWNLOAD_RETRY_COUNT; attempt++) {
@@ -123,10 +121,18 @@ export async function downloadSolx(
           return binaryPath;
         }
 
-        await download(url, binaryPath, {}, dispatcher);
+        // Signal download start only on the first attempt
+        if (attempt === 1) {
+          onBinaryDownloadStart();
+        }
+
+        // Download to a temporary path, we move into place after verifying the checksum
+        const downloadPath = `${binaryPath}.tmp`;
+
+        await download(url, downloadPath, {}, dispatcher);
 
         const checksumValid = await verifyChecksum(
-          binaryPath,
+          downloadPath,
           expectedChecksum,
         );
 
@@ -139,8 +145,10 @@ export async function downloadSolx(
 
         // Set executable permission on Unix
         if (process.platform !== "win32") {
-          await chmod(binaryPath, 0o755);
+          await chmod(downloadPath, 0o755);
         }
+
+        await move(downloadPath, binaryPath);
 
         log(`Successfully downloaded solx ${solxVersion}`);
         return binaryPath;
@@ -179,27 +187,31 @@ export async function downloadSolx(
 
 /**
  * Compares a downloaded binary against its expected SHA-256 checksum. On a
- * mismatch the binary is deleted and false is returned, leaving the caller to
+ * mismatch the file is deleted and false is returned, leaving the caller to
  * raise the error.
+ *
+ * This runs against the path the binary was downloaded to, before it is
+ * published to the path callers read, so a mismatch is deleted without ever
+ * having been visible.
  */
 async function verifyChecksum(
-  binaryPath: string,
+  downloadPath: string,
   expectedChecksum: PrefixedHexString,
 ): Promise<boolean> {
-  const binaryContents = await readBinaryFile(binaryPath);
+  const binaryContents = await readBinaryFile(downloadPath);
   const actualChecksum = bytesToHexString(await sha256(binaryContents));
 
   if (expectedChecksum !== actualChecksum) {
     log(
-      `SHA-256 mismatch for ${binaryPath}: expected ${expectedChecksum}, got ${actualChecksum}`,
+      `SHA-256 mismatch for ${downloadPath}: expected ${expectedChecksum}, got ${actualChecksum}`,
     );
 
-    await remove(binaryPath);
+    await remove(downloadPath);
 
     return false;
   }
 
-  log(`SHA-256 checksum verified for ${binaryPath}`);
+  log(`SHA-256 checksum verified for ${downloadPath}`);
   return true;
 }
 

--- a/packages/hardhat-slang-solx/test/downloader.ts
+++ b/packages/hardhat-slang-solx/test/downloader.ts
@@ -237,6 +237,20 @@ describe("hardhat-slang-solx downloader", () => {
     );
   });
 
+  it("leaves no temporary file behind after a successful download", async () => {
+    interceptChecksum(mockedDispatcher, expectedDigest);
+    interceptBinary(mockedDispatcher, BINARY_CONTENTS);
+
+    const binaryPath = await downloadSolx(TEST_SOLX_VERSION, noop, {
+      dispatcher: mockedDispatcher,
+    });
+
+    assert.ok(
+      !(await exists(`${binaryPath}.tmp`)),
+      "the download path should have been renamed into place, not copied",
+    );
+  });
+
   it("returns a cached binary without making any request", async () => {
     // No interceptors at all: reaching the network would throw.
     const binaryPath = await getSolxBinaryPath(TEST_SOLX_VERSION);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@nomicfoundation/hardhat-node-test-runner':
         specifier: workspace:^3.1.0
         version: link:../hardhat-node-test-runner
+      '@nomicfoundation/hardhat-slang-solx':
+        specifier: workspace:^
+        version: link:../hardhat-slang-solx
       '@nomicfoundation/hardhat-typechain':
         specifier: workspace:^3.1.1
         version: link:../hardhat-typechain


### PR DESCRIPTION
The solx compiler download had a race condition, particularly when running in test suites. It was caused by a compiler download completing, but another test determining the
compiler was therefore cached and usable, before the first process ran the checksum and chmod.

We now download to a sibling of the final path, verify and chmod there,
and rename into place last.

The console logging order was slightly reworked to avoid printing starting download multiple times.

Note: I added the `slang-solx` plugin to the example project to ease testing.

## Review

> [!TIP]
> Review a commit at a time for speed.