### PR TITLE
docs(hardhat-slang-solx): optimizer.enabled is not the Yul optimizer

### DIFF
--- a/packages/hardhat-slang-solx/README.md
+++ b/packages/hardhat-slang-solx/README.md
@@ -99,10 +99,10 @@ export default defineConfig({
 
 solx optimizes via LLVM; set the level per profile with `settings.optimizer.mode` — one of `"1"`, `"2"`, `"3"` (best performance), `"s"` (optimize for size), or `"z"` (aggressively minimize size). The plugin defaults to `"1"` (solx's own default if left unset is `"3"`).
 
-solx has two independent optimizer knobs, and both affect the output:
+solx has two independent optimizer knobs:
 
 - `optimizer.mode` (above) is the LLVM backend level. There is **no "off"** — the minimum is `"1"`, so LLVM always optimizes.
-- `optimizer.enabled` is the Yul optimizer (standard solc semantics), `false` by default. Enabling it optimizes _on top of_ LLVM; it does not turn LLVM off.
+- `optimizer.enabled` is the embedded solc front end's own optimizer, `false` by default. It only affects the legacy pipeline, where it optimizes the EVM assembly solx translates. Under `viaIR: true` it changes nothing but the metadata hash: solx bypasses the Yul optimizer entirely, so the IR handed to LLVM is always unoptimized.
 
 For example, optimizing for size instead of performance:
 
@@ -125,7 +125,7 @@ export default defineConfig({
 });
 ```
 
-Or run the Yul optimizer as well, on top of LLVM `-O3` (both knobs on) — just the `slangSolx` profile:
+Or, on the legacy pipeline, run the front end's assembly optimizer before LLVM `-O3` (both knobs on) — just the `slangSolx` profile:
 
 ```typescript
 slangSolx: {


### PR DESCRIPTION
Small wording fix on what the optimizer actually is. 

# Claude summary
The README documented `settings.optimizer.enabled` as "the Yul optimizer (standard solc
semantics) … enabling it optimizes _on top of_ LLVM", with an example combining it with
`mode: "3"`. That has never been true for any solx version this plugin supports: solx
disabled Yul optimizations in matter-labs/solx#88 (shipped in 0.1.1), and the plugin's
floor is 0.1.4.

Verified against the solx 0.1.8 binary with `metadata: { bytecodeHash: "none" }`:

- **via-IR**: toggling `enabled` leaves the deployed bytecode byte-identical. Its only
  observable effect is perturbing the metadata hash (the settings are hashed into the CBOR
  tail — which is what makes the flag look live under naive testing).
- **legacy**: toggling `enabled` changes the output (545 → 526 B on a probe contract). The
  embedded solc front end's EVM-assembly optimizer runs before solx's translation.

The README now says exactly that, and the both-knobs example is scoped to the legacy
pipeline. Behavior is untouched — `enabled` defaults to `false` and is passed through to
the front end as before; only the documentation was wrong.
