### PR TITLE
rename compiler type to `slang-solx`

### DIFF
--- a/.changeset/rename-compiler-type-slang-solx.md
+++ b/.changeset/rename-compiler-type-slang-solx.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-slang-solx": patch
+"hardhat": patch
+---
+
+Rename the solx compiler type from `slangSolx` to `slang-solx`.

--- a/.peer-bumps.json
+++ b/.peer-bumps.json
@@ -6,5 +6,11 @@
     "packages/hardhat/templates",
     "packages/config"
   ],
-  "bumps": []
+  "bumps": [
+    {
+      "package": "@nomicfoundation/hardhat-slang-solx",
+      "peer": "hardhat",
+      "reason": "The plugin requires the latest Hardhat for the additional support for build info file names with hyphens."
+    }
+  ]
 }

--- a/packages/example-project/hardhat.config.ts
+++ b/packages/example-project/hardhat.config.ts
@@ -228,7 +228,7 @@ export default defineConfig({
       coverage: {
         version: "0.8.2",
       },
-      slangSolx: {
+      "slang-solx": {
         compilers: [
           { type: "slangSolx", version: "0.8.34" },
           { version: "0.8.22" },

--- a/packages/example-project/hardhat.config.ts
+++ b/packages/example-project/hardhat.config.ts
@@ -230,7 +230,7 @@ export default defineConfig({
       },
       "slang-solx": {
         compilers: [
-          { type: "slangSolx", version: "0.8.34" },
+          { type: "slang-solx", version: "0.8.34" },
           { version: "0.8.22" },
           { version: "0.7.1" },
           { version: "0.8.26" },

--- a/packages/hardhat-slang-solx/README.md
+++ b/packages/hardhat-slang-solx/README.md
@@ -24,7 +24,7 @@ export default defineConfig({
         version: "0.8.29",
       },
       "slang-solx": {
-        type: "slangSolx",
+        type: "slang-solx",
         version: "0.8.34",
       },
     },
@@ -32,7 +32,7 @@ export default defineConfig({
 });
 ```
 
-The `default` profile uses solc as usual. The `slang-solx` profile uses the solx compiler, identified by `type: "slangSolx"`. Your `.sol` files should have compatible pragmas, for example `pragma solidity ^0.8.29;`. Strict pragmas for unsupported Solidity versions, for example `pragma solidity 0.8.28;`, will currently not compile with this hardhat-slang-solx plugin. See more details below for the currently supported Solidity versions and EVM versions.
+The `default` profile uses solc as usual. The `slang-solx` profile uses the solx compiler, identified by `type: "slang-solx"`. Your `.sol` files should have compatible pragmas, for example `pragma solidity ^0.8.29;`. Strict pragmas for unsupported Solidity versions, for example `pragma solidity 0.8.28;`, will currently not compile with this hardhat-slang-solx plugin. See more details below for the currently supported Solidity versions and EVM versions.
 
 ## Usage
 
@@ -53,7 +53,7 @@ hardhat build    # uses solc (default profile)
 
 ### Multi-version example
 
-You can configure the `slang-solx` profile with multiple compilers. Compilers without `type: "slangSolx"` will use solc:
+You can configure the `slang-solx` profile with multiple compilers. Compilers without `type: "slang-solx"` will use solc:
 
 ```typescript
 export default defineConfig({
@@ -65,7 +65,7 @@ export default defineConfig({
       },
       "slang-solx": {
         compilers: [
-          { type: "slangSolx", version: "0.8.34" },
+          { type: "slang-solx", version: "0.8.34" },
           { version: "0.8.20" }, // uses solc, solx doesn't support this version
         ],
       },
@@ -76,7 +76,7 @@ export default defineConfig({
 
 ### Options
 
-- `dangerouslyAllowSlangSolxInProduction` (`boolean`, default: `false`), allows compiler type `"slangSolx"` in build profiles other than `slang-solx`. By default, using `type: "slangSolx"` in any other profile (e.g. `default`, `production`) will produce a validation error.
+- `dangerouslyAllowSlangSolxInProduction` (`boolean`, default: `false`), allows compiler type `"slang-solx"` in build profiles other than `slang-solx`. By default, using `type: "slang-solx"` in any other profile (e.g. `default`, `production`) will produce a validation error.
 
 ```typescript
 export default defineConfig({
@@ -84,13 +84,13 @@ export default defineConfig({
   solidity: {
     profiles: {
       default: {
-        type: "slangSolx", // returns a validation error.
+        type: "slang-solx", // returns a validation error.
         version: "0.8.34",
       },
     },
   },
   slangSolx: {
-    dangerouslyAllowSlangSolxInProduction: false, // default false, switching this to true will allow `type: "slangSolx"` on the default profile.
+    dangerouslyAllowSlangSolxInProduction: false, // default false, switching this to true will allow `type: "slang-solx"` on the default profile.
   },
 });
 ```
@@ -116,7 +116,7 @@ export default defineConfig({
     profiles: {
       default: { version: "0.8.34" },
       "slang-solx": {
-        type: "slangSolx",
+        type: "slang-solx",
         version: "0.8.34",
         settings: { optimizer: { mode: "z" } }, // optimize for size
       },
@@ -129,7 +129,7 @@ Or, on the legacy pipeline, run the front end's assembly optimizer before LLVM `
 
 ```typescript
 "slang-solx": {
-  type: "slangSolx",
+  type: "slang-solx",
   version: "0.8.34",
   settings: { optimizer: { enabled: true, mode: "3" } },
 },
@@ -141,4 +141,4 @@ solx maps each Solidity version to a specific solx binary version internally. Cu
 
 ### EVM version support
 
-solx supports EVM versions `cancun`, `prague`, and `osaka`. Using an older EVM target (e.g., `paris`, `shanghai`) with compiler type `"slangSolx"` will result in a validation error.
+solx supports EVM versions `cancun`, `prague`, and `osaka`. Using an older EVM target (e.g., `paris`, `shanghai`) with compiler type `"slang-solx"` will result in a validation error.

--- a/packages/hardhat-slang-solx/README.md
+++ b/packages/hardhat-slang-solx/README.md
@@ -89,7 +89,7 @@ export default defineConfig({
       },
     },
   },
-  slangSolx: {
+  "slang-solx": {
     dangerouslyAllowSlangSolxInProduction: false, // default false, switching this to true will allow `type: "slang-solx"` on the default profile.
   },
 });

--- a/packages/hardhat-slang-solx/README.md
+++ b/packages/hardhat-slang-solx/README.md
@@ -10,7 +10,7 @@ The `solx` compiler is currently experimental and is not ready for production us
 npm install --save-dev @nomicfoundation/hardhat-slang-solx
 ```
 
-Then add the plugin to your `hardhat.config.ts` and create a `slangSolx` build profile. You must use the build profiles config format, which requires both a `default` and a `slangSolx` profile:
+Then add the plugin to your `hardhat.config.ts` and create a `slang-solx` build profile. You must use the build profiles config format, which requires both a `default` and a `slang-solx` profile:
 
 ```typescript
 import { defineConfig } from "hardhat/config";
@@ -23,7 +23,7 @@ export default defineConfig({
       default: {
         version: "0.8.29",
       },
-      slangSolx: {
+      "slang-solx": {
         type: "slangSolx",
         version: "0.8.34",
       },
@@ -32,15 +32,15 @@ export default defineConfig({
 });
 ```
 
-The `default` profile uses solc as usual. The `slangSolx` profile uses the solx compiler, identified by `type: "slangSolx"`. Your `.sol` files should have compatible pragmas, for example `pragma solidity ^0.8.29;`. Strict pragmas for unsupported Solidity versions, for example `pragma solidity 0.8.28;`, will currently not compile with this hardhat-slang-solx plugin. See more details below for the currently supported Solidity versions and EVM versions.
+The `default` profile uses solc as usual. The `slang-solx` profile uses the solx compiler, identified by `type: "slangSolx"`. Your `.sol` files should have compatible pragmas, for example `pragma solidity ^0.8.29;`. Strict pragmas for unsupported Solidity versions, for example `pragma solidity 0.8.28;`, will currently not compile with this hardhat-slang-solx plugin. See more details below for the currently supported Solidity versions and EVM versions.
 
 ## Usage
 
 Run tests or compile using the solx-powered build profile:
 
 ```bash
-hardhat test --build-profile slangSolx
-hardhat build --build-profile slangSolx
+hardhat test --build-profile slang-solx
+hardhat build --build-profile slang-solx
 ```
 
 The default profile continues to use solc as usual:
@@ -53,7 +53,7 @@ hardhat build    # uses solc (default profile)
 
 ### Multi-version example
 
-You can configure the `slangSolx` profile with multiple compilers. Compilers without `type: "slangSolx"` will use solc:
+You can configure the `slang-solx` profile with multiple compilers. Compilers without `type: "slangSolx"` will use solc:
 
 ```typescript
 export default defineConfig({
@@ -63,7 +63,7 @@ export default defineConfig({
       default: {
         compilers: [{ version: "0.8.34" }, { version: "0.8.20" }],
       },
-      slangSolx: {
+      "slang-solx": {
         compilers: [
           { type: "slangSolx", version: "0.8.34" },
           { version: "0.8.20" }, // uses solc, solx doesn't support this version
@@ -76,7 +76,7 @@ export default defineConfig({
 
 ### Options
 
-- `dangerouslyAllowSlangSolxInProduction` (`boolean`, default: `false`), allows compiler type `"slangSolx"` in build profiles other than `slangSolx`. By default, using `type: "slangSolx"` in any other profile (e.g. `default`, `production`) will produce a validation error.
+- `dangerouslyAllowSlangSolxInProduction` (`boolean`, default: `false`), allows compiler type `"slangSolx"` in build profiles other than `slang-solx`. By default, using `type: "slangSolx"` in any other profile (e.g. `default`, `production`) will produce a validation error.
 
 ```typescript
 export default defineConfig({
@@ -115,7 +115,7 @@ export default defineConfig({
   solidity: {
     profiles: {
       default: { version: "0.8.34" },
-      slangSolx: {
+      "slang-solx": {
         type: "slangSolx",
         version: "0.8.34",
         settings: { optimizer: { mode: "z" } }, // optimize for size
@@ -125,10 +125,10 @@ export default defineConfig({
 });
 ```
 
-Or, on the legacy pipeline, run the front end's assembly optimizer before LLVM `-O3` (both knobs on) — just the `slangSolx` profile:
+Or, on the legacy pipeline, run the front end's assembly optimizer before LLVM `-O3` (both knobs on) — just the `slang-solx` profile:
 
 ```typescript
-slangSolx: {
+"slang-solx": {
   type: "slangSolx",
   version: "0.8.34",
   settings: { optimizer: { enabled: true, mode: "3" } },

--- a/packages/hardhat-slang-solx/src/internal/constants.ts
+++ b/packages/hardhat-slang-solx/src/internal/constants.ts
@@ -4,7 +4,7 @@ import type { SolidityCompilerType } from "hardhat/types/config";
  * The compiler type identifier registered by this plugin.
  * Typed as SolidityCompilerType for type-safe comparisons.
  */
-export const SLANG_SOLX_COMPILER_TYPE: SolidityCompilerType = "slangSolx";
+export const SLANG_SOLX_COMPILER_TYPE: SolidityCompilerType = "slang-solx";
 
 export const SOLX_RELEASES_BASE_URL =
   "https://solx-releases-mirror.hardhat.org";

--- a/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
@@ -277,19 +277,19 @@ export async function validateResolvedConfig(
 ): Promise<HardhatConfigValidationError[]> {
   const errors: HardhatConfigValidationError[] = [];
 
-  // Check that the user defined a "slangSolx" build profile
-  if (resolvedConfig.solidity.profiles.slangSolx === undefined) {
+  // Check that the user defined a "slang-solx" build profile
+  if (resolvedConfig.solidity.profiles["slang-solx"] === undefined) {
     errors.push({
       path: ["solidity"],
       message:
-        'The hardhat-slang-solx plugin has been installed, but no "slangSolx" build profile was found in the Solidity configuration. Please read the plugin documentation for information on how to create a "slangSolx" build profile.',
+        'The hardhat-slang-solx plugin has been installed, but no "slang-solx" build profile was found in the Solidity configuration. Please read the plugin documentation for information on how to create a "slang-solx" build profile.',
     });
   }
 
-  // Check that type: "slangSolx" is not used in non-slangSolx profiles
+  // Check that type: "slangSolx" is not used in non-slang-solx profiles
   if (resolvedConfig.slangSolx.dangerouslyAllowSlangSolxInProduction) {
     log(
-      "Skipping non-slangSolx profile validation: dangerouslyAllowSlangSolxInProduction is true",
+      "Skipping non-slang-solx profile validation: dangerouslyAllowSlangSolxInProduction is true",
     );
     return errors;
   }
@@ -297,11 +297,11 @@ export async function validateResolvedConfig(
   for (const [profileName, profile] of Object.entries(
     resolvedConfig.solidity.profiles,
   )) {
-    if (profileName === "slangSolx") {
+    if (profileName === "slang-solx") {
       continue;
     }
 
-    const solxInOtherProfileMessage = `Compiler type "slangSolx" is only supported in the "slangSolx" build profile. Remove type: "slangSolx" from the "${profileName}" profile compilers, or set slangSolx.dangerouslyAllowSlangSolxInProduction in the plugin config.`;
+    const solxInOtherProfileMessage = `Compiler type "slangSolx" is only supported in the "slang-solx" build profile. Remove type: "slangSolx" from the "${profileName}" profile compilers, or set slangSolx.dangerouslyAllowSlangSolxInProduction in the plugin config.`;
 
     for (const [i, compiler] of profile.compilers.entries()) {
       if (compiler.type === SLANG_SOLX_COMPILER_TYPE) {

--- a/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
@@ -78,7 +78,10 @@ const solxSolidityCompilerUserConfigType = z
 const solidityCompilerUserConfigType = conditionalUnionType(
   [
     [
-      (data) => isObject(data) && "type" in data && data.type === "slangSolx",
+      (data) =>
+        isObject(data) &&
+        "type" in data &&
+        data.type === SLANG_SOLX_COMPILER_TYPE,
       solxSolidityCompilerUserConfigType,
     ],
     [(_data) => true, z.any()],
@@ -89,7 +92,10 @@ const solidityCompilerUserConfigType = conditionalUnionType(
 const singleVersionSolidityUserConfigType = conditionalUnionType(
   [
     [
-      (data) => isObject(data) && "type" in data && data.type === "slangSolx",
+      (data) =>
+        isObject(data) &&
+        "type" in data &&
+        data.type === SLANG_SOLX_COMPILER_TYPE,
       solxSolidityCompilerUserConfigType,
     ],
     [(_data) => true, z.any()],
@@ -105,7 +111,10 @@ const multiVersionSolidityUserConfigType = z.object({
 const singleVersionBuildProfileUserConfigType = conditionalUnionType(
   [
     [
-      (data) => isObject(data) && "type" in data && data.type === "slangSolx",
+      (data) =>
+        isObject(data) &&
+        "type" in data &&
+        data.type === SLANG_SOLX_COMPILER_TYPE,
       solxSolidityCompilerUserConfigType,
     ],
     [(_data) => true, z.any()],
@@ -213,9 +222,9 @@ export async function resolveUserConfig(
 }
 
 /**
- * For each compiler entry whose `type === "slangSolx"`, augments
+ * For each compiler entry whose `type === "slang-solx"`, augments
  * `settings.outputSelection` with the solx debugInfo selectors.
- * Non-slangSolx entries pass through unchanged.
+ * Non-slang-solx entries pass through unchanged.
  */
 async function augmentSolxOutputSelectionInProfiles(
   profiles: HardhatConfig["solidity"]["profiles"],
@@ -286,7 +295,7 @@ export async function validateResolvedConfig(
     });
   }
 
-  // Check that type: "slangSolx" is not used in non-slang-solx profiles
+  // Check that type: "slang-solx" is not used in non-slang-solx profiles
   if (resolvedConfig.slangSolx.dangerouslyAllowSlangSolxInProduction) {
     log(
       "Skipping non-slang-solx profile validation: dangerouslyAllowSlangSolxInProduction is true",
@@ -301,7 +310,7 @@ export async function validateResolvedConfig(
       continue;
     }
 
-    const solxInOtherProfileMessage = `Compiler type "slangSolx" is only supported in the "slang-solx" build profile. Remove type: "slangSolx" from the "${profileName}" profile compilers, or set slangSolx.dangerouslyAllowSlangSolxInProduction in the plugin config.`;
+    const solxInOtherProfileMessage = `Compiler type "slang-solx" is only supported in the "slang-solx" build profile. Remove type: "slang-solx" from the "${profileName}" profile compilers, or set slangSolx.dangerouslyAllowSlangSolxInProduction in the plugin config.`;
 
     for (const [i, compiler] of profile.compilers.entries()) {
       if (compiler.type === SLANG_SOLX_COMPILER_TYPE) {

--- a/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
+++ b/packages/hardhat-slang-solx/src/internal/hook-handlers/config.ts
@@ -167,7 +167,7 @@ const solidityUserConfigType = conditionalUnionType(
 
 const solxUserConfigType = z.object({
   solidity: solidityUserConfigType.optional(),
-  slangSolx: z
+  "slang-solx": z
     .object({
       dangerouslyAllowSlangSolxInProduction: z.boolean().optional(),
     })
@@ -217,7 +217,7 @@ export async function resolveUserConfig(
               SLANG_SOLX_COMPILER_TYPE,
             ],
     },
-    slangSolx: resolveSolxConfig(userConfig.slangSolx),
+    "slang-solx": resolveSolxConfig(userConfig["slang-solx"]),
   };
 }
 
@@ -296,7 +296,7 @@ export async function validateResolvedConfig(
   }
 
   // Check that type: "slang-solx" is not used in non-slang-solx profiles
-  if (resolvedConfig.slangSolx.dangerouslyAllowSlangSolxInProduction) {
+  if (resolvedConfig["slang-solx"].dangerouslyAllowSlangSolxInProduction) {
     log(
       "Skipping non-slang-solx profile validation: dangerouslyAllowSlangSolxInProduction is true",
     );
@@ -310,7 +310,7 @@ export async function validateResolvedConfig(
       continue;
     }
 
-    const solxInOtherProfileMessage = `Compiler type "slang-solx" is only supported in the "slang-solx" build profile. Remove type: "slang-solx" from the "${profileName}" profile compilers, or set slangSolx.dangerouslyAllowSlangSolxInProduction in the plugin config.`;
+    const solxInOtherProfileMessage = `Compiler type "slang-solx" is only supported in the "slang-solx" build profile. Remove type: "slang-solx" from the "${profileName}" profile compilers, or set dangerouslyAllowSlangSolxInProduction in the "slang-solx" plugin config.`;
 
     for (const [i, compiler] of profile.compilers.entries()) {
       if (compiler.type === SLANG_SOLX_COMPILER_TYPE) {

--- a/packages/hardhat-slang-solx/src/type-extensions.ts
+++ b/packages/hardhat-slang-solx/src/type-extensions.ts
@@ -58,10 +58,12 @@ declare module "hardhat/types/config" {
   }
 
   export interface HardhatUserConfig {
-    slangSolx?: SlangSolxUserConfig;
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- the plugin config namespace is kebab-case to match the plugin name
+    "slang-solx"?: SlangSolxUserConfig;
   }
 
   export interface HardhatConfig {
-    slangSolx: SlangSolxConfig;
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- the plugin config namespace is kebab-case to match the plugin name
+    "slang-solx": SlangSolxConfig;
   }
 }

--- a/packages/hardhat-slang-solx/src/type-extensions.ts
+++ b/packages/hardhat-slang-solx/src/type-extensions.ts
@@ -13,23 +13,26 @@ declare module "hardhat/types/solidity" {
 
 declare module "hardhat/types/config" {
   export interface SolidityCompilerTypeDefinitions {
-    slangSolx: true;
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- the compiler type discriminator is kebab-case to match the plugin name
+    "slang-solx": true;
   }
 
   export interface SlangSolxSolidityCompilerUserConfig extends CommonSolidityCompilerUserConfig {
-    type: "slangSolx";
+    type: "slang-solx";
   }
 
   export interface SolidityCompilerUserConfigPerType {
-    slangSolx: SlangSolxSolidityCompilerUserConfig;
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- the compiler type discriminator is kebab-case to match the plugin name
+    "slang-solx": SlangSolxSolidityCompilerUserConfig;
   }
 
   export interface SlangSolxSolidityCompilerConfig extends CommonSolidityCompilerConfig {
-    type: "slangSolx";
+    type: "slang-solx";
   }
 
   export interface SolidityCompilerConfigPerType {
-    slangSolx: SlangSolxSolidityCompilerConfig;
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- the compiler type discriminator is kebab-case to match the plugin name
+    "slang-solx": SlangSolxSolidityCompilerConfig;
   }
 
   export interface SlangSolxSingleVersionSolidityUserConfig
@@ -38,13 +41,14 @@ declare module "hardhat/types/config" {
       CommonSingleVersionSolidityUserConfig {}
 
   export interface SingleVersionSolidityUserConfigPerType {
-    slangSolx: SlangSolxSingleVersionSolidityUserConfig;
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- the compiler type discriminator is kebab-case to match the plugin name
+    "slang-solx": SlangSolxSingleVersionSolidityUserConfig;
   }
 
   export interface SlangSolxUserConfig {
     /**
-     * Allow compiler type `"slangSolx"` in the production build profile.
-     * By default, `"slangSolx"` in production is rejected as a safeguard.
+     * Allow compiler type `"slang-solx"` in the production build profile.
+     * By default, `"slang-solx"` in production is rejected as a safeguard.
      */
     dangerouslyAllowSlangSolxInProduction?: boolean;
   }

--- a/packages/hardhat-slang-solx/test/config.ts
+++ b/packages/hardhat-slang-solx/test/config.ts
@@ -144,7 +144,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
       {},
       undefined as any,
       makeNext({
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [
@@ -160,7 +160,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
 
     const slangSolxCompiler =
-      resolvedConfig.solidity.profiles.slangSolx.compilers[0];
+      resolvedConfig.solidity.profiles["slang-solx"].compilers[0];
     const wildcardSelectors = slangSolxCompiler.settings.outputSelection["*"][
       "*"
     ] as string[];
@@ -212,7 +212,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
       {},
       undefined as any,
       makeNext({
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
@@ -228,7 +228,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
 
     const override =
-      resolvedConfig.solidity.profiles.slangSolx.overrides[
+      resolvedConfig.solidity.profiles["slang-solx"].overrides[
         "contracts/Special.sol"
       ];
     const wildcardSelectors = override.settings.outputSelection["*"][
@@ -247,7 +247,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
       {},
       undefined as any,
       makeNext({
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
@@ -257,7 +257,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
 
     const slangSolxCompiler =
-      resolvedConfig.solidity.profiles.slangSolx.compilers[0];
+      resolvedConfig.solidity.profiles["slang-solx"].compilers[0];
     assert.equal(slangSolxCompiler.settings.optimizer.mode, "1");
   });
 
@@ -266,7 +266,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
       {},
       undefined as any,
       makeNext({
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [
@@ -282,7 +282,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
 
     const slangSolxCompiler =
-      resolvedConfig.solidity.profiles.slangSolx.compilers[0];
+      resolvedConfig.solidity.profiles["slang-solx"].compilers[0];
     assert.deepEqual(slangSolxCompiler.settings.optimizer, {
       enabled: true,
       mode: "z",
@@ -294,7 +294,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
       {},
       undefined as any,
       makeNext({
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [
@@ -310,7 +310,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
 
     const slangSolxCompiler =
-      resolvedConfig.solidity.profiles.slangSolx.compilers[0];
+      resolvedConfig.solidity.profiles["slang-solx"].compilers[0];
     assert.deepEqual(slangSolxCompiler.settings.optimizer, {
       enabled: true,
       mode: "1",
@@ -322,7 +322,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
       {},
       undefined as any,
       makeNext({
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [
@@ -338,7 +338,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
 
     const slangSolxCompiler =
-      resolvedConfig.solidity.profiles.slangSolx.compilers[0];
+      resolvedConfig.solidity.profiles["slang-solx"].compilers[0];
     assert.equal(slangSolxCompiler.settings.optimizer.mode, "1");
   });
 
@@ -347,7 +347,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
       {},
       undefined as any,
       makeNext({
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
@@ -363,10 +363,10 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
 
     const slangSolxCompiler =
-      resolvedConfig.solidity.profiles.slangSolx.compilers[0];
+      resolvedConfig.solidity.profiles["slang-solx"].compilers[0];
     assert.equal(slangSolxCompiler.settings.viaIR, false);
     const override =
-      resolvedConfig.solidity.profiles.slangSolx.overrides[
+      resolvedConfig.solidity.profiles["slang-solx"].overrides[
         "contracts/ViaIR.sol"
       ];
     assert.equal(override.settings.viaIR, true);
@@ -378,7 +378,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
       {},
       undefined as any,
       makeNext({
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [
@@ -394,7 +394,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
 
     const slangSolxCompiler =
-      resolvedConfig.solidity.profiles.slangSolx.compilers[0];
+      resolvedConfig.solidity.profiles["slang-solx"].compilers[0];
     // An arbitrary user solc setting survives config resolution untouched...
     assert.equal(slangSolxCompiler.settings.evmVersion, "prague");
     // ...alongside a default the plugin fills in (the mode default has its own test).
@@ -407,7 +407,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [
               {
                 version: "0.8.34",
@@ -430,7 +430,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [
               {
                 version: "0.8.34",
@@ -449,7 +449,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [
               {
                 version: "0.8.34",
@@ -468,7 +468,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [
               {
                 version: "0.8.34",
@@ -487,7 +487,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [
               {
                 version: "0.8.34",
@@ -506,7 +506,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [{ version: "0.8.34", type: "slangSolx" }],
           },
         },
@@ -519,7 +519,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [
               {
                 version: "0.8.34",
@@ -538,7 +538,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [{ version: "0.8.34" }],
             overrides: {
               "contracts/Old.sol": {
@@ -564,7 +564,7 @@ describe("hardhat-slang-solx Solidity version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [{ version: "0.8.28", type: "slangSolx" }],
           },
         },
@@ -580,7 +580,7 @@ describe("hardhat-slang-solx Solidity version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [{ version: "0.8.34", type: "slangSolx" }],
           },
         },
@@ -596,7 +596,7 @@ describe("hardhat-slang-solx Solidity version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [
               {
                 version: "0.8.34",
@@ -618,7 +618,7 @@ describe("hardhat-slang-solx Solidity version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [
               {
                 version: "0.8.35",
@@ -640,7 +640,7 @@ describe("hardhat-slang-solx Solidity version validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [{ version: "0.8.35", type: "slangSolx", path: "" }],
           },
         },
@@ -674,7 +674,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
     };
   }
 
-  it("errors when no 'slangSolx' build profile exists", async () => {
+  it("errors when no 'slang-solx' build profile exists", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig({
         default: {
@@ -687,12 +687,12 @@ describe("hardhat-slang-solx resolved config validation", () => {
     );
     assert.ok(errors.length > 0, "Should have validation errors");
     assert.ok(
-      errors.some((e) => e.message.includes('no "slangSolx" build profile')),
-      `Expected missing slangSolx profile error, got: ${errors.map((e) => e.message).join(", ")}`,
+      errors.some((e) => e.message.includes('no "slang-solx" build profile')),
+      `Expected missing slang-solx profile error, got: ${errors.map((e) => e.message).join(", ")}`,
     );
   });
 
-  it("passes when 'slangSolx' build profile exists", async () => {
+  it("passes when 'slang-solx' build profile exists", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig({
         default: {
@@ -701,7 +701,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
           compilers: [{ version: "0.8.34", settings: {} }],
           overrides: {},
         },
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
@@ -712,7 +712,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
     assert.deepEqual(errors, []);
   });
 
-  it("errors when type: 'slangSolx' appears in a non-slangSolx profile", async () => {
+  it("errors when type: 'slangSolx' appears in a non-slang-solx profile", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig({
         default: {
@@ -721,7 +721,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
           compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
           overrides: {},
         },
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
@@ -731,9 +731,9 @@ describe("hardhat-slang-solx resolved config validation", () => {
     );
     assert.ok(
       errors.some((e) =>
-        e.message.includes('only supported in the "slangSolx" build profile'),
+        e.message.includes('only supported in the "slang-solx" build profile'),
       ),
-      `Expected non-slangSolx profile error, got: ${errors.map((e) => e.message).join(", ")}`,
+      `Expected non-slang-solx profile error, got: ${errors.map((e) => e.message).join(", ")}`,
     );
     assert.ok(
       errors.some((e) => e.path.includes("default")),
@@ -741,7 +741,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
     );
   });
 
-  it("errors when type: 'slangSolx' appears in non-slangSolx profile overrides", async () => {
+  it("errors when type: 'slangSolx' appears in non-slang-solx profile overrides", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig({
         default: {
@@ -756,7 +756,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
             },
           },
         },
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
@@ -766,9 +766,9 @@ describe("hardhat-slang-solx resolved config validation", () => {
     );
     assert.ok(
       errors.some((e) =>
-        e.message.includes('only supported in the "slangSolx" build profile'),
+        e.message.includes('only supported in the "slang-solx" build profile'),
       ),
-      `Expected non-slangSolx profile error, got: ${errors.map((e) => e.message).join(", ")}`,
+      `Expected non-slang-solx profile error, got: ${errors.map((e) => e.message).join(", ")}`,
     );
     assert.ok(
       errors.some((e) => e.path.includes("overrides")),
@@ -776,7 +776,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
     );
   });
 
-  it("allows type: 'slangSolx' in non-slangSolx profiles with dangerouslyAllowSlangSolxInProduction", async () => {
+  it("allows type: 'slangSolx' in non-slang-solx profiles with dangerouslyAllowSlangSolxInProduction", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig(
         {
@@ -786,7 +786,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
             compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
             overrides: {},
           },
-          slangSolx: {
+          "slang-solx": {
             isolated: false,
             preferWasm: false,
             compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
@@ -799,7 +799,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
     assert.deepEqual(errors, []);
   });
 
-  it("allows type: 'slangSolx' in the slangSolx profile", async () => {
+  it("allows type: 'slangSolx' in the slang-solx profile", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig({
         default: {
@@ -808,7 +808,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
           compilers: [{ version: "0.8.34", settings: {} }],
           overrides: {},
         },
-        slangSolx: {
+        "slang-solx": {
           isolated: false,
           preferWasm: false,
           compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
@@ -819,7 +819,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
     assert.deepEqual(errors, []);
   });
 
-  it("still requires slangSolx profile even with dangerouslyAllowSlangSolxInProduction", async () => {
+  it("still requires slang-solx profile even with dangerouslyAllowSlangSolxInProduction", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig(
         {
@@ -834,8 +834,8 @@ describe("hardhat-slang-solx resolved config validation", () => {
       ),
     );
     assert.ok(
-      errors.some((e) => e.message.includes('no "slangSolx" build profile')),
-      `Should still require slangSolx profile, got: ${errors.map((e) => e.message).join(", ")}`,
+      errors.some((e) => e.message.includes('no "slang-solx" build profile')),
+      `Should still require slang-solx profile, got: ${errors.map((e) => e.message).join(", ")}`,
     );
   });
 });
@@ -845,7 +845,7 @@ describe("hardhat-slang-solx optimizer mode validation", () => {
     return await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [
               {
                 version: "0.8.34",
@@ -888,7 +888,7 @@ describe("hardhat-slang-solx optimizer mode validation", () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
-          slangSolx: {
+          "slang-solx": {
             compilers: [
               {
                 version: "0.8.34",

--- a/packages/hardhat-slang-solx/test/config.ts
+++ b/packages/hardhat-slang-solx/test/config.ts
@@ -12,7 +12,7 @@ import { SOLX_DEBUG_INFO_SELECTORS } from "../src/internal/slang-solx-compiler.j
 describe("hardhat-slang-solx plugin config validation", () => {
   it("accepts valid config with dangerouslyAllowSlangSolxInProduction", async () => {
     const errors = await validateUserConfig({
-      slangSolx: {
+      "slang-solx": {
         dangerouslyAllowSlangSolxInProduction: true,
       },
     });
@@ -21,7 +21,7 @@ describe("hardhat-slang-solx plugin config validation", () => {
 
   it("accepts empty plugin config", async () => {
     const errors = await validateUserConfig({
-      slangSolx: {},
+      "slang-solx": {},
     });
     assert.deepEqual(errors, []);
   });
@@ -33,14 +33,14 @@ describe("hardhat-slang-solx plugin config validation", () => {
 
   it("rejects invalid dangerouslyAllowSlangSolxInProduction type", async () => {
     const errors = await validateUserConfig({
-      slangSolx: { dangerouslyAllowSlangSolxInProduction: "yes" as any },
+      "slang-solx": { dangerouslyAllowSlangSolxInProduction: "yes" as any },
     });
     assert.ok(errors.length > 0, "Should have validation errors");
   });
 
   it("rejects non-boolean dangerouslyAllowSlangSolxInProduction", async () => {
     const errors = await validateUserConfig({
-      slangSolx: {
+      "slang-solx": {
         dangerouslyAllowSlangSolxInProduction: 1 as any,
       },
     });
@@ -75,14 +75,14 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
 
     assert.equal(
-      resolvedConfig.slangSolx.dangerouslyAllowSlangSolxInProduction,
+      resolvedConfig["slang-solx"].dangerouslyAllowSlangSolxInProduction,
       false,
     );
   });
 
   it("resolves dangerouslyAllowSlangSolxInProduction from user config", async () => {
     const resolvedConfig = await resolveUserConfig(
-      { slangSolx: { dangerouslyAllowSlangSolxInProduction: true } },
+      { "slang-solx": { dangerouslyAllowSlangSolxInProduction: true } },
       undefined as any,
       makeNext({
         default: {
@@ -95,7 +95,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
 
     assert.equal(
-      resolvedConfig.slangSolx.dangerouslyAllowSlangSolxInProduction,
+      resolvedConfig["slang-solx"].dangerouslyAllowSlangSolxInProduction,
       true,
     );
   });
@@ -667,7 +667,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
         npmFilesToBuild: [],
         registeredCompilerTypes: ["solc", "slang-solx"],
       },
-      slangSolx: {
+      "slang-solx": {
         dangerouslyAllowSlangSolxInProduction:
           opts?.dangerouslyAllowSlangSolxInProduction ?? false,
       },

--- a/packages/hardhat-slang-solx/test/config.ts
+++ b/packages/hardhat-slang-solx/test/config.ts
@@ -100,7 +100,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
   });
 
-  it("registers 'slangSolx' as a compiler type", async () => {
+  it("registers 'slang-solx' as a compiler type", async () => {
     const resolvedConfig = await resolveUserConfig(
       {},
       undefined as any,
@@ -116,8 +116,8 @@ describe("hardhat-slang-solx plugin config resolution", () => {
 
     assert.deepEqual(
       resolvedConfig.solidity.registeredCompilerTypes,
-      ["solc", "slangSolx"],
-      "the plugin registers 'slangSolx' and leaves core's 'solc' in place, and registers nothing else",
+      ["solc", "slang-solx"],
+      "the plugin registers 'slang-solx' and leaves core's 'solc' in place, and registers nothing else",
     );
   });
 
@@ -139,7 +139,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     assert.deepEqual(profileNames, ["default"]);
   });
 
-  it("adds solx debugInfo selectors to slangSolx-typed compilers in resolved config", async () => {
+  it("adds solx debugInfo selectors to slang-solx-typed compilers in resolved config", async () => {
     const resolvedConfig = await resolveUserConfig(
       {},
       undefined as any,
@@ -150,7 +150,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
           compilers: [
             {
               version: "0.8.34",
-              type: "slangSolx",
+              type: "slang-solx",
               settings: { outputSelection: { "*": { "*": ["abi"] } } },
             },
           ],
@@ -176,7 +176,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     );
   });
 
-  it("does NOT add solx selectors to non-slangSolx compilers", async () => {
+  it("does NOT add solx selectors to non-slang-solx compilers", async () => {
     const resolvedConfig = await resolveUserConfig(
       {},
       undefined as any,
@@ -207,7 +207,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     }
   });
 
-  it("augments slangSolx-typed override entries too", async () => {
+  it("augments slang-solx-typed override entries too", async () => {
     const resolvedConfig = await resolveUserConfig(
       {},
       undefined as any,
@@ -215,11 +215,11 @@ describe("hardhat-slang-solx plugin config resolution", () => {
         "slang-solx": {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slang-solx", settings: {} }],
           overrides: {
             "contracts/Special.sol": {
               version: "0.8.34",
-              type: "slangSolx",
+              type: "slang-solx",
               settings: {},
             },
           },
@@ -242,7 +242,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     }
   });
 
-  it("defaults the optimizer mode on slangSolx-typed compilers in resolved config", async () => {
+  it("defaults the optimizer mode on slang-solx-typed compilers in resolved config", async () => {
     const resolvedConfig = await resolveUserConfig(
       {},
       undefined as any,
@@ -250,7 +250,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
         "slang-solx": {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slang-solx", settings: {} }],
           overrides: {},
         },
       }),
@@ -272,7 +272,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
           compilers: [
             {
               version: "0.8.34",
-              type: "slangSolx",
+              type: "slang-solx",
               settings: { optimizer: { enabled: true, mode: "z" } },
             },
           ],
@@ -300,7 +300,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
           compilers: [
             {
               version: "0.8.34",
-              type: "slangSolx",
+              type: "slang-solx",
               settings: { optimizer: { enabled: true } },
             },
           ],
@@ -328,7 +328,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
           compilers: [
             {
               version: "0.8.34",
-              type: "slangSolx",
+              type: "slang-solx",
               settings: { optimizer: { enabled: true, mode: undefined } },
             },
           ],
@@ -342,7 +342,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
     assert.equal(slangSolxCompiler.settings.optimizer.mode, "1");
   });
 
-  it("defaults viaIR to false on slangSolx-typed compilers, letting a user value win", async () => {
+  it("defaults viaIR to false on slang-solx-typed compilers, letting a user value win", async () => {
     const resolvedConfig = await resolveUserConfig(
       {},
       undefined as any,
@@ -350,11 +350,11 @@ describe("hardhat-slang-solx plugin config resolution", () => {
         "slang-solx": {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slang-solx", settings: {} }],
           overrides: {
             "contracts/ViaIR.sol": {
               version: "0.8.34",
-              type: "slangSolx",
+              type: "slang-solx",
               settings: { viaIR: true },
             },
           },
@@ -384,7 +384,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
           compilers: [
             {
               version: "0.8.34",
-              type: "slangSolx",
+              type: "slang-solx",
               settings: { evmVersion: "prague" },
             },
           ],
@@ -403,7 +403,7 @@ describe("hardhat-slang-solx plugin config resolution", () => {
 });
 
 describe("hardhat-slang-solx EVM version validation", () => {
-  it("rejects type: 'slangSolx' with pre-cancun evmVersion", async () => {
+  it("rejects type: 'slang-solx' with pre-cancun evmVersion", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
@@ -411,7 +411,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
             compilers: [
               {
                 version: "0.8.34",
-                type: "slangSolx",
+                type: "slang-solx",
                 settings: { evmVersion: "paris" },
               },
             ],
@@ -426,7 +426,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     );
   });
 
-  it("rejects type: 'slangSolx' with shanghai evmVersion", async () => {
+  it("rejects type: 'slang-solx' with shanghai evmVersion", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
@@ -434,7 +434,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
             compilers: [
               {
                 version: "0.8.34",
-                type: "slangSolx",
+                type: "slang-solx",
                 settings: { evmVersion: "shanghai" },
               },
             ],
@@ -445,7 +445,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     assert.ok(errors.length > 0, "Should have validation errors");
   });
 
-  it("accepts type: 'slangSolx' with cancun evmVersion", async () => {
+  it("accepts type: 'slang-solx' with cancun evmVersion", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
@@ -453,7 +453,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
             compilers: [
               {
                 version: "0.8.34",
-                type: "slangSolx",
+                type: "slang-solx",
                 settings: { evmVersion: "cancun" },
               },
             ],
@@ -464,7 +464,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     assert.deepEqual(errors, []);
   });
 
-  it("accepts type: 'slangSolx' with prague evmVersion", async () => {
+  it("accepts type: 'slang-solx' with prague evmVersion", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
@@ -472,7 +472,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
             compilers: [
               {
                 version: "0.8.34",
-                type: "slangSolx",
+                type: "slang-solx",
                 settings: { evmVersion: "prague" },
               },
             ],
@@ -483,7 +483,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     assert.deepEqual(errors, []);
   });
 
-  it("accepts type: 'slangSolx' with osaka evmVersion", async () => {
+  it("accepts type: 'slang-solx' with osaka evmVersion", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
@@ -491,7 +491,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
             compilers: [
               {
                 version: "0.8.34",
-                type: "slangSolx",
+                type: "slang-solx",
                 settings: { evmVersion: "osaka" },
               },
             ],
@@ -502,12 +502,12 @@ describe("hardhat-slang-solx EVM version validation", () => {
     assert.deepEqual(errors, []);
   });
 
-  it("accepts type: 'slangSolx' without evmVersion", async () => {
+  it("accepts type: 'slang-solx' without evmVersion", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
           "slang-solx": {
-            compilers: [{ version: "0.8.34", type: "slangSolx" }],
+            compilers: [{ version: "0.8.34", type: "slang-solx" }],
           },
         },
       },
@@ -515,7 +515,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
     assert.deepEqual(errors, []);
   });
 
-  it("ignores evmVersion on non-slangSolx compiler entries", async () => {
+  it("ignores evmVersion on non-slang-solx compiler entries", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
@@ -543,7 +543,7 @@ describe("hardhat-slang-solx EVM version validation", () => {
             overrides: {
               "contracts/Old.sol": {
                 version: "0.8.34",
-                type: "slangSolx",
+                type: "slang-solx",
                 settings: { evmVersion: "london" },
               },
             },
@@ -560,12 +560,12 @@ describe("hardhat-slang-solx EVM version validation", () => {
 });
 
 describe("hardhat-slang-solx Solidity version validation", () => {
-  it("rejects type: 'slangSolx' with unsupported Solidity version", async () => {
+  it("rejects type: 'slang-solx' with unsupported Solidity version", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
           "slang-solx": {
-            compilers: [{ version: "0.8.28", type: "slangSolx" }],
+            compilers: [{ version: "0.8.28", type: "slang-solx" }],
           },
         },
       },
@@ -576,12 +576,12 @@ describe("hardhat-slang-solx Solidity version validation", () => {
     );
   });
 
-  it("accepts type: 'slangSolx' with supported Solidity version 0.8.34", async () => {
+  it("accepts type: 'slang-solx' with supported Solidity version 0.8.34", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
           "slang-solx": {
-            compilers: [{ version: "0.8.34", type: "slangSolx" }],
+            compilers: [{ version: "0.8.34", type: "slang-solx" }],
           },
         },
       },
@@ -592,7 +592,7 @@ describe("hardhat-slang-solx Solidity version validation", () => {
     assert.deepEqual(versionErrors, []);
   });
 
-  it("accepts type: 'slangSolx' with supported version and custom path", async () => {
+  it("accepts type: 'slang-solx' with supported version and custom path", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
@@ -600,7 +600,7 @@ describe("hardhat-slang-solx Solidity version validation", () => {
             compilers: [
               {
                 version: "0.8.34",
-                type: "slangSolx",
+                type: "slang-solx",
                 path: "/tmp/solx-custom",
               },
             ],
@@ -614,7 +614,7 @@ describe("hardhat-slang-solx Solidity version validation", () => {
     assert.deepEqual(versionErrors, []);
   });
 
-  it("accepts type: 'slangSolx' with unsupported version when path is set", async () => {
+  it("accepts type: 'slang-solx' with unsupported version when path is set", async () => {
     const errors = await validateUserConfig({
       solidity: {
         profiles: {
@@ -622,7 +622,7 @@ describe("hardhat-slang-solx Solidity version validation", () => {
             compilers: [
               {
                 version: "0.8.35",
-                type: "slangSolx",
+                type: "slang-solx",
                 path: "/tmp/solx-nightly",
               },
             ],
@@ -641,7 +641,7 @@ describe("hardhat-slang-solx Solidity version validation", () => {
       solidity: {
         profiles: {
           "slang-solx": {
-            compilers: [{ version: "0.8.35", type: "slangSolx", path: "" }],
+            compilers: [{ version: "0.8.35", type: "slang-solx", path: "" }],
           },
         },
       },
@@ -665,7 +665,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
       solidity: {
         profiles,
         npmFilesToBuild: [],
-        registeredCompilerTypes: ["solc", "slangSolx"],
+        registeredCompilerTypes: ["solc", "slang-solx"],
       },
       slangSolx: {
         dangerouslyAllowSlangSolxInProduction:
@@ -704,7 +704,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
         "slang-solx": {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slang-solx", settings: {} }],
           overrides: {},
         },
       }),
@@ -712,19 +712,19 @@ describe("hardhat-slang-solx resolved config validation", () => {
     assert.deepEqual(errors, []);
   });
 
-  it("errors when type: 'slangSolx' appears in a non-slang-solx profile", async () => {
+  it("errors when type: 'slang-solx' appears in a non-slang-solx profile", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig({
         default: {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slang-solx", settings: {} }],
           overrides: {},
         },
         "slang-solx": {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slang-solx", settings: {} }],
           overrides: {},
         },
       }),
@@ -741,7 +741,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
     );
   });
 
-  it("errors when type: 'slangSolx' appears in non-slang-solx profile overrides", async () => {
+  it("errors when type: 'slang-solx' appears in non-slang-solx profile overrides", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig({
         default: {
@@ -751,7 +751,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
           overrides: {
             "MyContract.sol": {
               version: "0.8.34",
-              type: "slangSolx",
+              type: "slang-solx",
               settings: {},
             },
           },
@@ -759,7 +759,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
         "slang-solx": {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slang-solx", settings: {} }],
           overrides: {},
         },
       }),
@@ -776,20 +776,24 @@ describe("hardhat-slang-solx resolved config validation", () => {
     );
   });
 
-  it("allows type: 'slangSolx' in non-slang-solx profiles with dangerouslyAllowSlangSolxInProduction", async () => {
+  it("allows type: 'slang-solx' in non-slang-solx profiles with dangerouslyAllowSlangSolxInProduction", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig(
         {
           default: {
             isolated: false,
             preferWasm: false,
-            compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+            compilers: [
+              { version: "0.8.34", type: "slang-solx", settings: {} },
+            ],
             overrides: {},
           },
           "slang-solx": {
             isolated: false,
             preferWasm: false,
-            compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+            compilers: [
+              { version: "0.8.34", type: "slang-solx", settings: {} },
+            ],
             overrides: {},
           },
         },
@@ -799,7 +803,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
     assert.deepEqual(errors, []);
   });
 
-  it("allows type: 'slangSolx' in the slang-solx profile", async () => {
+  it("allows type: 'slang-solx' in the slang-solx profile", async () => {
     const errors = await validateResolvedConfig(
       makeResolvedConfig({
         default: {
@@ -811,7 +815,7 @@ describe("hardhat-slang-solx resolved config validation", () => {
         "slang-solx": {
           isolated: false,
           preferWasm: false,
-          compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+          compilers: [{ version: "0.8.34", type: "slang-solx", settings: {} }],
           overrides: {},
         },
       }),
@@ -826,7 +830,9 @@ describe("hardhat-slang-solx resolved config validation", () => {
           default: {
             isolated: false,
             preferWasm: false,
-            compilers: [{ version: "0.8.34", type: "slangSolx", settings: {} }],
+            compilers: [
+              { version: "0.8.34", type: "slang-solx", settings: {} },
+            ],
             overrides: {},
           },
         },
@@ -849,7 +855,7 @@ describe("hardhat-slang-solx optimizer mode validation", () => {
             compilers: [
               {
                 version: "0.8.34",
-                type: "slangSolx",
+                type: "slang-solx",
                 settings: { optimizer: { mode } },
               },
             ],
@@ -892,7 +898,7 @@ describe("hardhat-slang-solx optimizer mode validation", () => {
             compilers: [
               {
                 version: "0.8.34",
-                type: "slangSolx",
+                type: "slang-solx",
                 settings: { optimizer: { enabled: true, runs: 200 } },
               },
             ],

--- a/packages/hardhat-slang-solx/test/fixture-projects/simple/hardhat.config.ts
+++ b/packages/hardhat-slang-solx/test/fixture-projects/simple/hardhat.config.ts
@@ -9,7 +9,7 @@ const config: HardhatUserConfig = {
         version: "0.8.34",
       },
       "slang-solx": {
-        type: "slangSolx",
+        type: "slang-solx",
         version: "0.8.34",
       },
     },

--- a/packages/hardhat-slang-solx/test/fixture-projects/simple/hardhat.config.ts
+++ b/packages/hardhat-slang-solx/test/fixture-projects/simple/hardhat.config.ts
@@ -8,7 +8,7 @@ const config: HardhatUserConfig = {
       default: {
         version: "0.8.34",
       },
-      slangSolx: {
+      "slang-solx": {
         type: "slangSolx",
         version: "0.8.34",
       },

--- a/packages/hardhat-slang-solx/test/fixture-projects/with-debug-info/hardhat.config.ts
+++ b/packages/hardhat-slang-solx/test/fixture-projects/with-debug-info/hardhat.config.ts
@@ -9,7 +9,7 @@ const config: HardhatUserConfig = {
         version: "0.8.34",
       },
       "slang-solx": {
-        type: "slangSolx",
+        type: "slang-solx",
         version: "0.8.34",
       },
     },

--- a/packages/hardhat-slang-solx/test/fixture-projects/with-debug-info/hardhat.config.ts
+++ b/packages/hardhat-slang-solx/test/fixture-projects/with-debug-info/hardhat.config.ts
@@ -8,7 +8,7 @@ const config: HardhatUserConfig = {
       default: {
         version: "0.8.34",
       },
-      slangSolx: {
+      "slang-solx": {
         type: "slangSolx",
         version: "0.8.34",
       },

--- a/packages/hardhat-slang-solx/test/hook-handlers/solidity.ts
+++ b/packages/hardhat-slang-solx/test/hook-handlers/solidity.ts
@@ -93,7 +93,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
       );
     });
 
-    it("does nothing when no slangSolx-typed compilers present", async () => {
+    it("does nothing when no slang-solx-typed compilers present", async () => {
       const hookHandlerModule =
         await import("../../src/internal/hook-handlers/solidity.js");
       const hooks = await hookHandlerModule.default();
@@ -126,7 +126,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
       const context = { config: {} } as any;
 
       const configs: SolidityCompilerConfig[] = [
-        createSolidityCompilerConfig({ type: "slangSolx", version: "0.8.34" }),
+        createSolidityCompilerConfig({ type: "slang-solx", version: "0.8.34" }),
       ];
 
       // This will fail to download (no network in tests), but we can
@@ -161,7 +161,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
       );
     });
 
-    it("passes through to next for non-slangSolx compiler configs", async () => {
+    it("passes through to next for non-slang-solx compiler configs", async () => {
       const hookHandlerModule =
         await import("../../src/internal/hook-handlers/solidity.js");
       const hooks = await hookHandlerModule.default();
@@ -207,7 +207,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
 
       const context = { config: {} } as any;
       const compilerConfig = createSolidityCompilerConfig({
-        type: "slangSolx",
+        type: "slang-solx",
         version: "0.8.99",
       });
       const mockNext = createGetCompilerMockNext();
@@ -230,7 +230,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
 
       const context = { config: {} } as any;
       const compilerConfig = createSolidityCompilerConfig({
-        type: "slangSolx",
+        type: "slang-solx",
         version: "0.8.34",
         path: "/nonexistent/path/to/solx",
       });
@@ -262,7 +262,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
 
       const context = { config: {} } as any;
       const compilerConfig = createSolidityCompilerConfig({
-        type: "slangSolx",
+        type: "slang-solx",
         version: "0.8.34",
         path: cachedPath,
       });
@@ -276,7 +276,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
 
       assert.ok(
         !mockNext.wasCalled(),
-        "next should NOT have been called for slangSolx type",
+        "next should NOT have been called for slang-solx type",
       );
       assert.equal(compiler.compilerPath, cachedPath);
       // Version should be parsed from the binary, not from config
@@ -295,7 +295,7 @@ describe("hardhat-slang-solx solidity hook handler", () => {
 
       const configs: SolidityCompilerConfig[] = [
         createSolidityCompilerConfig({
-          type: "slangSolx",
+          type: "slang-solx",
           version: "0.8.34",
           path: "/custom/path/to/solx",
         }),

--- a/packages/hardhat-slang-solx/test/integration.ts
+++ b/packages/hardhat-slang-solx/test/integration.ts
@@ -33,7 +33,7 @@ describe("hardhat-slang-solx integration", () => {
             version: "0.8.34",
           },
           "slang-solx": {
-            type: "slangSolx",
+            type: "slang-solx",
             version: "0.8.34",
           },
         },
@@ -75,18 +75,18 @@ describe("hardhat-slang-solx integration", () => {
     const slangSolxProfile = hre.config.solidity.profiles["slang-solx"];
     assert.equal(
       slangSolxProfile.compilers[0].type,
-      "slangSolx",
-      "slang-solx profile compiler should have type: 'slangSolx'",
+      "slang-solx",
+      "slang-solx profile compiler should have type: 'slang-solx'",
     );
   });
 
-  it("registers 'slangSolx' as a compiler type", async () => {
+  it("registers 'slang-solx' as a compiler type", async () => {
     const hre = await createHre();
 
     assert.deepEqual(
       hre.config.solidity.registeredCompilerTypes,
-      ["solc", "slangSolx"],
-      "the plugin registers 'slangSolx' and leaves core's 'solc' in place, and registers nothing else",
+      ["solc", "slang-solx"],
+      "the plugin registers 'slang-solx' and leaves core's 'solc' in place, and registers nothing else",
     );
   });
 });

--- a/packages/hardhat-slang-solx/test/integration.ts
+++ b/packages/hardhat-slang-solx/test/integration.ts
@@ -32,7 +32,7 @@ describe("hardhat-slang-solx integration", () => {
           default: {
             version: "0.8.34",
           },
-          slangSolx: {
+          "slang-solx": {
             type: "slangSolx",
             version: "0.8.34",
           },
@@ -63,20 +63,20 @@ describe("hardhat-slang-solx integration", () => {
     );
   });
 
-  it("includes 'slangSolx' build profile in resolved config", async () => {
+  it("includes 'slang-solx' build profile in resolved config", async () => {
     const hre = await createHre();
 
     const profileNames = Object.keys(hre.config.solidity.profiles);
     assert.ok(
-      profileNames.includes("slangSolx"),
-      `Expected "slangSolx" profile in: ${profileNames.join(", ")}`,
+      profileNames.includes("slang-solx"),
+      `Expected "slang-solx" profile in: ${profileNames.join(", ")}`,
     );
 
-    const slangSolxProfile = hre.config.solidity.profiles.slangSolx;
+    const slangSolxProfile = hre.config.solidity.profiles["slang-solx"];
     assert.equal(
       slangSolxProfile.compilers[0].type,
       "slangSolx",
-      "slangSolx profile compiler should have type: 'slangSolx'",
+      "slang-solx profile compiler should have type: 'slangSolx'",
     );
   });
 

--- a/packages/hardhat-slang-solx/test/integration.ts
+++ b/packages/hardhat-slang-solx/test/integration.ts
@@ -20,7 +20,7 @@ describe("hardhat-slang-solx integration", () => {
   it("resolves plugin config through the HRE", async () => {
     const hre = await createHre();
     assert.equal(
-      hre.config.slangSolx.dangerouslyAllowSlangSolxInProduction,
+      hre.config["slang-solx"].dangerouslyAllowSlangSolxInProduction,
       false,
     );
   });
@@ -42,7 +42,7 @@ describe("hardhat-slang-solx integration", () => {
     });
 
     assert.equal(
-      hre.config.slangSolx.dangerouslyAllowSlangSolxInProduction,
+      hre.config["slang-solx"].dangerouslyAllowSlangSolxInProduction,
       false,
     );
   });

--- a/packages/hardhat-slang-solx/test/optimizer-mode.ts
+++ b/packages/hardhat-slang-solx/test/optimizer-mode.ts
@@ -16,7 +16,7 @@ import {
 describe("hardhat-slang-solx optimizer mode reaches the solc input", () => {
   useEphemeralFixtureProject("simple");
 
-  it("defaults optimizer.mode to -O1 in the slangSolx profile's solcInput", async () => {
+  it("defaults optimizer.mode to -O1 in the slang-solx profile's solcInput", async () => {
     const configPath = await resolveHardhatConfigPath();
     const userConfig = await importUserConfig(configPath);
     const hre = await createHardhatRuntimeEnvironment(userConfig);
@@ -28,11 +28,11 @@ describe("hardhat-slang-solx optimizer mode reaches the solc input", () => {
     const jobsResult = await hre.solidity.getCompilationJobs(rootFilePaths, {
       force: true,
       quiet: true,
-      buildProfile: "slangSolx",
+      buildProfile: "slang-solx",
     });
     assert.ok(
       jobsResult.success,
-      "getCompilationJobs should succeed for the slangSolx profile",
+      "getCompilationJobs should succeed for the slang-solx profile",
     );
 
     const job = [...jobsResult.compilationJobsPerFile.values()][0];

--- a/packages/hardhat-slang-solx/test/output-augmentation.ts
+++ b/packages/hardhat-slang-solx/test/output-augmentation.ts
@@ -58,11 +58,11 @@ describe(
       const jobsResult = await hre.solidity.getCompilationJobs(fixturePaths, {
         force: true,
         quiet: true,
-        buildProfile: "slangSolx",
+        buildProfile: "slang-solx",
       });
       assert.ok(
         jobsResult.success,
-        "getCompilationJobs should succeed for the slangSolx profile",
+        "getCompilationJobs should succeed for the slang-solx profile",
       );
 
       // The fixtures are independent (no shared imports) so they can land in
@@ -78,7 +78,7 @@ describe(
         seenJobs.add(job);
         const { output } = await hre.solidity.runCompilationJob(job, {
           quiet: true,
-          buildProfile: "slangSolx",
+          buildProfile: "slang-solx",
         });
         for (const e of output.errors ?? []) {
           mergedErrors.push(e);

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -93,7 +93,7 @@
     "typescript": "~6.0.3"
   },
   "dependencies": {
-    "@nomicfoundation/edr": "0.18.0",
+    "@nomicfoundation/edr": "0.19.0",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.17",
     "@nomicfoundation/hardhat-utils": "workspace:^4.1.6",
     "@nomicfoundation/hardhat-vendored": "workspace:^3.0.4",

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/edr-artifacts.ts
@@ -18,7 +18,7 @@ export interface EdrArtifactWithMetadata {
 }
 
 export const BUILD_INFO_FORMAT: RegExp =
-  /^solc-(?<major>\d+)_(?<minor>\d+)_(?<patch>\d+)(?:-(?<compilerType>[a-zA-Z][a-zA-Z0-9]*))?-[0-9a-fA-F]*$/;
+  /^solc-(?<major>\d+)_(?<minor>\d+)_(?<patch>\d+)(?:-(?<compilerType>[a-zA-Z][a-zA-Z0-9-]*))?-[0-9a-fA-F]*$/;
 
 /**
  * This function returns all the build infos and associated outputs.

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/type-extensions.ts
@@ -20,7 +20,7 @@ declare module "../../../types/config.js" {
    * The types of the values don't matter; we use `true` as a convention.
    *
    * By default, only "solc" is provided. Plugins can extend this via
-   * declaration merging to add new compiler types (e.g. "slangSolx").
+   * declaration merging to add new compiler types (e.g. "slang-solx").
    */
   export interface SolidityCompilerTypeDefinitions {
     solc: true;
@@ -358,7 +358,7 @@ declare module "../../../types/hooks.js" {
     /**
      * Hook to obtain a Compiler instance for a given compiler configuration.
      * The default handler returns a solc compiler. Plugins can intercept to
-     * return their own compiler (e.g. SlangSolxCompiler for type: "slangSolx").
+     * return their own compiler (e.g. SlangSolxCompiler for type: "slang-solx").
      *
      * @param context The hook context.
      * @param compilerConfig The compiler configuration to get a compiler for.

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/edr-artifacts.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/edr-artifacts.ts
@@ -29,6 +29,17 @@ describe("BUILD_INFO_FORMAT", () => {
     assert.equal(match.groups.compilerType, "solx");
   });
 
+  it("matches a build ID with a hyphenated compiler type", () => {
+    const match = BUILD_INFO_FORMAT.exec("solc-0_8_0-slang-solx-abc123");
+
+    assert.ok(
+      match !== null && match.groups !== undefined,
+      "Regexp should match and have groups",
+    );
+
+    assert.equal(match.groups.compilerType, "slang-solx");
+  });
+
   it("matches a build ID with empty hash", () => {
     // The regex allows zero hex chars in the hash portion
     const match = BUILD_INFO_FORMAT.exec("solc-0_8_0-");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
   packages/hardhat:
     dependencies:
       '@nomicfoundation/edr':
-        specifier: 0.18.0
-        version: 0.18.0
+        specifier: 0.19.0
+        version: 0.19.0
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.17
         version: link:../hardhat-errors
@@ -3011,54 +3011,54 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.18.0':
-    resolution: {integrity: sha512-57gFc/RPzAVyajUZ7NKOXwE0SmlUX/Yqo0kBQs7lFMfhvJinkDj7q6rIy+1fQNN6FDx0qsk4ChHJs/Amt5Zg3A==}
+  '@nomicfoundation/edr-darwin-arm64@0.19.0':
+    resolution: {integrity: sha512-Yo2MkZoM85zkasUPJDj8l8QezPdrMzqQUJhp78TUQDq8FQXhdJTZ39k3Jax5OQ3hqjMhMkrGbctn9w9h6mEusg==}
     engines: {node: '>= 22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@nomicfoundation/edr-darwin-x64@0.18.0':
-    resolution: {integrity: sha512-SUhAPJUkAmqx6vjKTKKRCM9L1SAECZg9nSmCAdgRuV2mD3yO/lAijJ8b1YX4fpWk9aH5XnL2xVW0KXdmgKEsxw==}
+  '@nomicfoundation/edr-darwin-x64@0.19.0':
+    resolution: {integrity: sha512-RC7RVX1iATg9SlJTnKD57A8jRBIBiUKmAdi8maBN4zhmK5Z7aAeiwdQX6VjPOum3c2Mdpp2Q7JfooJxxF6bCvw==}
     engines: {node: '>= 22'}
     cpu: [x64]
     os: [darwin]
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.18.0':
-    resolution: {integrity: sha512-zk2yUJhA5I/2ARunQomsz1muSo8piFBj7No7+nuAl4d3CoBOWyw3Ocowcf1pKZVqk4V/HHh5divW1gVZwLQFZA==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.19.0':
+    resolution: {integrity: sha512-vhEKPUomGwM0Lsjpwd5q/Jc6yE2hpspJBCRYFkCghzCmwgZHtoYn/2nd1nOLsTt7jqMlvAKJSaLCrhz1HCTCTA==}
     engines: {node: '>= 22'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.18.0':
-    resolution: {integrity: sha512-GXSdaHFnrWj1dFJ9NcGg9I0V495/KT0LB3DhGoqcgnTtGnPYZHYATi/sLYZuTZJPtbeue+mu+iIPOYkCcZx7fA==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.19.0':
+    resolution: {integrity: sha512-mlkpVUolkSpMIriZyiJeTbgx/m4Ngm9lQtah2BG92H+dgtwMIMze6Q6OQfZG6oi6wMrhDgu8WEyAy3XgIwlcRg==}
     engines: {node: '>= 22'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.18.0':
-    resolution: {integrity: sha512-OkZjL/CMC2TQWJDxCzEvfskdem496AiI+PFqK8psQfkJ5aJbFPYp0+5uarqCnqrE2KxtU8kjxRTWevhQT4RaDw==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.19.0':
+    resolution: {integrity: sha512-d0Z+WVbX5mm6s9ozc5TXrCRjQykdN81tGI+eaM4hQcD/S5VSY9rwKuCXyLJ/GkgeI5S8HEHsyVdXEsDJznPyhA==}
     engines: {node: '>= 22'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@nomicfoundation/edr-linux-x64-musl@0.18.0':
-    resolution: {integrity: sha512-YR9LNVaWiK01MfszO85Q2eXzg2T+G5HxnHX4ZchREZQeTzd94NTDrSGKDOjr7t/asZnK8KUg+0oEFGpzp6sTqg==}
+  '@nomicfoundation/edr-linux-x64-musl@0.19.0':
+    resolution: {integrity: sha512-UIrlNqYj9lbUXpBy++WwHeC0xZqyFw9TXy06/8+0PLffI7Si4kiTKfXqdITGQhP6Vf/JuJ8y+jos8oy6bL8jFQ==}
     engines: {node: '>= 22'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.18.0':
-    resolution: {integrity: sha512-8UKx4/T6OvNmdSMbBoNzw7ckCh73BTqkh2nJHaqMUFrmrSO1t9/135oBes49nrXvihRBAn/K8E8VdJiRn6vXlw==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.19.0':
+    resolution: {integrity: sha512-pIyEJBiS8l09Yndz+aE/JmkD39FCqtyiRO+wlx6tX426o4290acRfJ0r7GwTBmqqZD5G4pLOOB0uLIMRyDrY+g==}
     engines: {node: '>= 22'}
     cpu: [x64]
     os: [win32]
 
-  '@nomicfoundation/edr@0.18.0':
-    resolution: {integrity: sha512-2pwljJssIWpc8Wl8RNRP6qQIDIntA6UevSnyRmosMUCtxzm+HX9gajQe96w+nPuH6dQt9Yx7ek/nuW+yWa0Hvw==}
+  '@nomicfoundation/edr@0.19.0':
+    resolution: {integrity: sha512-wzuyAylm4XWIahFjy1pFDQfHny4Xsx73T98d8KJAkGG/Rpgp0M36rqS4lzjbGQ1tXDrWEBG0WRr0v1jrQhQ0xg==}
     engines: {node: '>= 22'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -8871,36 +8871,36 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.18.0':
+  '@nomicfoundation/edr-darwin-arm64@0.19.0':
     optional: true
 
-  '@nomicfoundation/edr-darwin-x64@0.18.0':
+  '@nomicfoundation/edr-darwin-x64@0.19.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.18.0':
+  '@nomicfoundation/edr-linux-arm64-gnu@0.19.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.18.0':
+  '@nomicfoundation/edr-linux-arm64-musl@0.19.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.18.0':
+  '@nomicfoundation/edr-linux-x64-gnu@0.19.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-x64-musl@0.18.0':
+  '@nomicfoundation/edr-linux-x64-musl@0.19.0':
     optional: true
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.18.0':
+  '@nomicfoundation/edr-win32-x64-msvc@0.19.0':
     optional: true
 
-  '@nomicfoundation/edr@0.18.0':
+  '@nomicfoundation/edr@0.19.0':
     optionalDependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.18.0
-      '@nomicfoundation/edr-darwin-x64': 0.18.0
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.18.0
-      '@nomicfoundation/edr-linux-arm64-musl': 0.18.0
-      '@nomicfoundation/edr-linux-x64-gnu': 0.18.0
-      '@nomicfoundation/edr-linux-x64-musl': 0.18.0
-      '@nomicfoundation/edr-win32-x64-msvc': 0.18.0
+      '@nomicfoundation/edr-darwin-arm64': 0.19.0
+      '@nomicfoundation/edr-darwin-x64': 0.19.0
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.19.0
+      '@nomicfoundation/edr-linux-arm64-musl': 0.19.0
+      '@nomicfoundation/edr-linux-x64-gnu': 0.19.0
+      '@nomicfoundation/edr-linux-x64-musl': 0.19.0
+      '@nomicfoundation/edr-win32-x64-msvc': 0.19.0
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true


### PR DESCRIPTION
> [!IMPORTANT]
> This PR will remain in draft until EDR has been updated with `slang-solx` support 

Rename the compiler type, supporting config profile and top level config property to `slang-solx` (from `slangSolx`):

1. Compiler type discriminator (`type: "solx"` → `type: "slang-solx"`)
2. Build profile name "slangSolx" → "slang-solx" (the plugin's config validation requires a profile named the same as the type)
3. the top-level config namespace (`HardhatUserConfig.slangSolx` → `.["slang-solx"]`)

```ts
solidity: {
  profiles: {
   "slang-solx": {
      type: "slang-solx",
      version: "0.8.34"
    }
  }
}
"slang-solx": {
  dangerouslyAllowSlangSolxInProduction: true
}
```

## Review

> [!TIP]
> Review a commit at a time to understand the highlights

This is a mechanical rename, with one interesting commit; the widening of the accepted build info filename regex to allow hyphens in compiler types. I intentionally went with only a small enhancement here (rather than eliminating odd compiler types like `slang-solx-`, the plugin author should catch those.