### PR TITLE
fix: guard against solc compiler download race condition

### DIFF
--- a/.changeset/tender-pianos-wear.md
+++ b/.changeset/tender-pianos-wear.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+fix: guard against solc compiler download race condition

--- a/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity/build-system/compiler/downloader.ts
@@ -18,6 +18,7 @@ import {
   createFile,
   ensureDir,
   exists,
+  move,
   readBinaryFile,
   readJsonFile,
   remove,
@@ -430,10 +431,11 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
     log(`Downloading compiler ${build.version} from ${url}`);
 
     const downloadPath = this.#getCompilerDownloadPathFromBuild(build);
+    const tmpDownloadPath = `${downloadPath}.tmp`;
 
-    await this.#downloadFunction(url, downloadPath);
+    await this.#downloadFunction(url, tmpDownloadPath);
 
-    return downloadPath;
+    return tmpDownloadPath;
   }
 
   async #verifyCompilerDownload(
@@ -457,7 +459,10 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
     build: CompilerBuild,
     downloadPath: string,
   ): Promise<boolean> {
+    const finalDownloadPath = this.#getCompilerDownloadPathFromBuild(build);
+
     if (this.#platform === CompilerPlatform.WASM) {
+      await move(downloadPath, finalDownloadPath);
       return true;
     }
 
@@ -467,6 +472,7 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
       this.#platform === CompilerPlatform.MACOS
     ) {
       await chmod(downloadPath, 0o755);
+      await move(downloadPath, finalDownloadPath);
     } else if (
       this.#platform === CompilerPlatform.WINDOWS &&
       downloadPath.endsWith(".zip")
@@ -477,6 +483,9 @@ export class CompilerDownloaderImplementation implements CompilerDownloader {
 
       const zip = new AdmZip(downloadPath);
       zip.extractAllTo(solcFolder);
+      await remove(downloadPath);
+    } else {
+      await move(downloadPath, finalDownloadPath);
     }
 
     log("Checking native solc binary");


### PR DESCRIPTION
Fixes #8569

## Summary

This follows the same approach used in #8556 for the solx downloader.

Previously, the solc downloader checked for cached compilers by testing file existence at the final path — but a full download involves three steps: download, checksum verification, and chmod. Only step 1 was needed for another process to see the file as "cached", even if it wasn't yet verified or executable.

## Changes

- `#downloadCompiler` now downloads to a `<path>.tmp` sibling instead of the final path
- `#verifyCompilerDownload` verifies the checksum on the tmp path
- `#postProcessCompilerDownload` runs chmod / zip-extract on the tmp path, then atomically moves it into place with `move()` only after verification succeeds

This closes the race window where a concurrent process could pick up a half-verified or non-executable binary.

## Testing

Ran the full `downloader.ts` test suite — all 24 tests passing.