### PR TITLE
fix(e2e): keep yarn working when setup-node leaves NODE_AUTH_TOKEN unset

### DIFF
--- a/scripts/end-to-end/helpers/install.ts
+++ b/scripts/end-to-end/helpers/install.ts
@@ -76,6 +76,17 @@ function runPackageManager(
       ...process.env,
       ...env,
       COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+      // actions/setup-node (with `registry-url`) writes $RUNNER_TEMP/.npmrc
+      // with an `_authToken` referencing ${NODE_AUTH_TOKEN}, and the CI clone
+      // dir ($RUNNER_TEMP/hardhat-e2e-clones) lives right under it. Yarn
+      // Classic registers every .npmrc in the cwd's ancestor directories and
+      // hard-fails on any unset variable in a config it reads (npm only
+      // warns). The variable is only set in publish jobs; setup-node ≤v6
+      // exported a placeholder that kept the substitution working, v7
+      // stopped, so provide the fallback here. The registry these installs
+      // actually use is unaffected: the Verdaccio config outranks any
+      // ambient npmrc.
+      NODE_AUTH_TOKEN: process.env.NODE_AUTH_TOKEN ?? "",
       ...(packageManager === "pnpm"
         ? {
             // The local packages (hardhat, @nomicfoundation/*) are published to

--- a/scripts/end-to-end/helpers/install.ts
+++ b/scripts/end-to-end/helpers/install.ts
@@ -86,7 +86,8 @@ function runPackageManager(
       // stopped, so provide the fallback here. The registry these installs
       // actually use is unaffected: the Verdaccio config outranks any
       // ambient npmrc.
-      NODE_AUTH_TOKEN: process.env.NODE_AUTH_TOKEN ?? "",
+      NODE_AUTH_TOKEN:
+        env?.NODE_AUTH_TOKEN ?? process.env.NODE_AUTH_TOKEN ?? "",
       ...(packageManager === "pnpm"
         ? {
             // The local packages (hardhat, @nomicfoundation/*) are published to


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
Every yarn-based scenario (`1inch-aqua`, `1inch-cross-chain-swap`, `aave-v4`) has been failing in the Regression Benchmark workflow since Aug 18 with:

```
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

**Root cause:** `setup-env` passes `registry-url` to `actions/setup-node`, which writes `$RUNNER_TEMP/.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`. The e2e clone dir (`$RUNNER_TEMP/hardhat-e2e-clones`) lives directly under it, and Yarn Classic registers every `.npmrc` in the cwd's ancestor directories, then hard-fails on any unset variable in a config it reads (npm only warns). `NODE_AUTH_TOKEN` is only set in publish jobs. The failures started with the `actions/setup-node` v7 bump (784356b84): versions ≤v6 exported a placeholder `NODE_AUTH_TOKEN` when writing that file, which kept the substitution working; v7 no longer does (last full green run on Aug 14 used v4).

**Fix:** the e2e install helper now sets `NODE_AUTH_TOKEN` to `""` when unset in the environment passed to package managers, restoring what setup-node's placeholder used to guarantee. The registry the installs use is unaffected — the Verdaccio config (`npm_config_registry` / `.yarnrc.yml` / `bunfig.toml`) outranks any ambient npmrc.

Unsetting `NPM_CONFIG_USERCONFIG` instead was considered and rejected: yarn's ancestor-directory walk finds the runner's npmrc regardless of the userconfig setting, so the env fallback is the only mechanism that covers all paths.