### PR TITLE
fix: tsx module not found for dirs

### DIFF
--- a/.changeset/module-not-found-for-directories.md
+++ b/.changeset/module-not-found-for-directories.md
@@ -1,0 +1,5 @@
+---
+"@nomicfoundation/hardhat-verify": patch
+---
+
+Report a directory with no importable entry point as a module-not-found error, instead of the generic "importing the module failed".

--- a/packages/hardhat-verify/src/internal/module.ts
+++ b/packages/hardhat-verify/src/internal/module.ts
@@ -32,7 +32,13 @@ export async function loadModule(
   } catch (error) {
     ensureError(error);
 
-    if ("code" in error && error.code === "ERR_MODULE_NOT_FOUND") {
+    if (
+      "code" in error &&
+      (error.code === "ERR_MODULE_NOT_FOUND" ||
+        // Loading a directory is valid, but if it doesn't have an index file,
+        // you get this error
+        error.code === "ERR_UNSUPPORTED_DIR_IMPORT")
+    ) {
       throw new HardhatError(
         HardhatError.ERRORS.HARDHAT_VERIFY.VALIDATION.MODULE_NOT_FOUND,
         { modulePath },

--- a/packages/hardhat-verify/test/fixture-projects/load-module/directory-with-index/index.ts
+++ b/packages/hardhat-verify/test/fixture-projects/load-module/directory-with-index/index.ts
@@ -1,0 +1,1 @@
+export default "This is a directory index module";

--- a/packages/hardhat-verify/test/fixture-projects/load-module/directory-without-index/not-an-index.txt
+++ b/packages/hardhat-verify/test/fixture-projects/load-module/directory-without-index/not-an-index.txt
@@ -1,0 +1,1 @@
+Not an index module.

--- a/packages/hardhat-verify/test/module.ts
+++ b/packages/hardhat-verify/test/module.ts
@@ -48,6 +48,25 @@ describe("utils", () => {
       assert.equal(module.default, "This is a test module");
     });
 
+    it("should load a directory with an index module", async () => {
+      const module = await loadModule(
+        "./test/fixture-projects/load-module/directory-with-index",
+      );
+
+      assert.equal(module.default, "This is a directory index module");
+    });
+
+    it("should throw an error if a directory has no index module", async () => {
+      const modulePath =
+        "./test/fixture-projects/load-module/directory-without-index";
+
+      await assertRejectsWithHardhatError(
+        loadModule(modulePath),
+        HardhatError.ERRORS.HARDHAT_VERIFY.VALIDATION.MODULE_NOT_FOUND,
+        { modulePath },
+      );
+    });
+
     it("should throw an error if the module does not exist", async () => {
       let modulePath =
         "./test/fixture-projects/load-module/non-existent-module.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,7 +214,7 @@ importers:
         version: 7.8.5
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       ws:
         specifier: ^8.21.1
         version: 8.21.1
@@ -288,7 +288,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -343,7 +343,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -416,7 +416,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -456,7 +456,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -544,7 +544,7 @@ importers:
         version: 22.1.0
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -608,7 +608,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -666,7 +666,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -724,7 +724,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -797,7 +797,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -815,7 +815,7 @@ importers:
         version: link:../hardhat-zod-utils
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -895,7 +895,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -929,7 +929,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -950,7 +950,7 @@ importers:
         version: link:../hardhat-zod-utils
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -1024,7 +1024,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1061,7 +1061,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1142,7 +1142,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1205,7 +1205,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1269,7 +1269,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1324,7 +1324,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1357,7 +1357,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1412,7 +1412,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1455,7 +1455,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1504,7 +1504,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1547,7 +1547,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1769,7 +1769,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1844,7 +1844,7 @@ importers:
         version: 3.6.2
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1883,7 +1883,7 @@ importers:
         version: 6.1.3
       tsx:
         specifier: ^4.23.1
-        version: 4.23.1
+        version: 4.23.12
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -7054,8 +7054,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.23.1:
-    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -13501,7 +13501,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.23.1:
+  tsx@4.23.12:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:


### PR DESCRIPTION
This is a fix for the Hardhat CI failure due to running out test suite with the latest dependencies.

A change in tsx means that `loadModule` now encounters a `ERR_UNSUPPORTED_DIR_IMPORT` if there is no `my_module/index.js` file, were previously tsx would through `ERR_MODULE_NOT_FOUND`.

We now treat both as indications of a failure to load a module and throw the appropriate `HardhatError`.