### PR TITLE
fix: let a selected EIP-712 definition win name clashes with non-selected sources

### DIFF
--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/canonicalize.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/eip712/canonicalize.ts
@@ -6,7 +6,7 @@ export const SELECTED_CONFLICT_REMEDIATION =
   "Rename one of the structs, or scope your `test.solidity.eip712Types.include` / `exclude` globs in `hardhat.config.ts` so that only one of them is selected.";
 
 export const DEPENDENCY_CONFLICT_REMEDIATION =
-  "Rename one of the structs so the name has a single definition. The clashing name is pulled in as a dependency of a selected struct, so if you don't need that selected struct, deselecting it with your `test.solidity.eip712Types.include` / `exclude` globs in `hardhat.config.ts` also resolves the conflict.";
+  "Rename one of the structs so the name has a single definition. The clashing name is pulled in as a dependency of a selected struct, but none of its definitions is in a selected source, so you can also resolve the conflict with your `test.solidity.eip712Types.include` / `exclude` globs in `hardhat.config.ts`: include the source containing the canonical definition so it wins the clash, or deselect the struct that depends on it if you don't need it.";
 
 /**
  * Produces the flat list of canonical EIP-712 type strings expected by EDR.
@@ -220,12 +220,14 @@ function transitiveDeps(
  *   - Both sides selected: throw immediately — genuinely ambiguous which to
  *     emit.
  *   - Current side non-selected: defer; the stored definition keeps the name.
- *     Throw only if the name is reachable from a selected struct (its
- *     transitive deps), since then which copy got inlined would depend on
- *     iteration order. Names unreachable from the selected set are silently
- *     deduped (first wins), so a non-selected struct that merely shares a
- *     name with a selected root or an unreferenced struct never aborts the
- *     run.
+ *     Throw only if the name has no selected definition AND is reachable from
+ *     a selected struct (its transitive deps), since only then which copy got
+ *     inlined would depend on iteration order. A name with a selected
+ *     definition always resolves to it deterministically (selected structs
+ *     come first), so a non-selected struct that shares a name with a
+ *     selected one never aborts the run — even when that name is also a
+ *     dependency of another selected struct. Names unreachable from the
+ *     selected set are likewise silently deduped (first wins).
  */
 function indexByName(
   structs: CollectedStruct[],
@@ -276,9 +278,9 @@ function indexByName(
 
     // Non-selected side, so the stored definition (selected if the name has
     // one, since selected sources come first) keeps the name. Defer: throw
-    // later only if the name is reachable from a selected struct. Sharing a
-    // name with a selected root or an unreferenced struct is harmless and
-    // must not abort.
+    // later only if the name has no selected definition and is reachable from
+    // a selected struct. Sharing a name with a selected definition or an
+    // unreferenced struct is harmless and must not abort.
     if (!deferredConflicts.has(struct.name)) {
       deferredConflicts.set(struct.name, {
         firstSource: sourceByName.get(struct.name) ?? "<unknown>",
@@ -290,7 +292,7 @@ function indexByName(
   if (deferredConflicts.size > 0) {
     const reachable = reachableFromSelected(byName, selectedNames);
     for (const [name, sources] of deferredConflicts) {
-      if (reachable.has(name)) {
+      if (reachable.has(name) && !selectedNames.has(name)) {
         throw new HardhatError(
           HardhatError.ERRORS.CORE.SOLIDITY_TESTS.EIP712_DUPLICATE_STRUCT_NAME,
           { name, ...sources, remediation: DEPENDENCY_CONFLICT_REMEDIATION },

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/canonicalize.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/canonicalize.ts
@@ -549,11 +549,12 @@ describe("eip712 - canonicalize", () => {
       );
     });
 
-    it("throws when a selected struct depends on a name that a selected and a non-selected source define differently", () => {
+    it("lets the selected definition win a reachable name clash with a non-selected source", () => {
       // Selected `Mail` depends on `Person`, which has a selected definition
       // (test/Other.sol) AND a different non-selected one (lib/Imported.sol).
-      // Unlike the selected-root case above, the name is reachable, so it is
-      // ambiguous which `Person` definition `Mail.from` should inline: throw.
+      // Even though the name is reachable, there is no ambiguity: selected
+      // definitions deterministically win a clash, so `Mail.from` inlines the
+      // selected `Person` and the non-selected copy is ignored.
       const collected = [
         struct("Mail", [["Person", "from"]], "test/Mail.sol"),
         struct(
@@ -567,19 +568,64 @@ describe("eip712 - canonicalize", () => {
         struct("Person", [["uint256", "id"]], "lib/Imported.sol"),
       ];
 
-      assertThrowsHardhatError(
-        () =>
-          canonicalizeStructs(
-            collected,
-            new Set(["test/Mail.sol", "test/Other.sol"]),
-          ),
-        HardhatError.ERRORS.CORE.SOLIDITY_TESTS.EIP712_DUPLICATE_STRUCT_NAME,
-        {
-          name: "Person",
-          firstSource: "test/Other.sol",
-          secondSource: "lib/Imported.sol",
-          remediation: DEPENDENCY_CONFLICT_REMEDIATION,
-        },
+      const expected = [
+        "Mail(Person from)Person(address wallet,string name)",
+        "Person(address wallet,string name)",
+      ];
+
+      const selected = new Set(["test/Mail.sol", "test/Other.sol"]);
+
+      assert.deepEqual(canonicalizeStructs(collected, selected).sort(), [
+        ...expected.sort(),
+      ]);
+
+      // Order-independent: the selected definition wins even when the
+      // non-selected copy comes first in `collected`.
+      assert.deepEqual(
+        canonicalizeStructs([...collected].reverse(), selected).sort(),
+        [...expected.sort()],
+      );
+    });
+
+    it("lets the selected definition win when the root and the clashed dependency live in the same selected source", () => {
+      // Real-world shape (aave-v4): one included file defines both the signed
+      // root and its dependency, while a non-selected production interface
+      // reuses the dependency's name for an unrelated struct. The included
+      // definitions are canonical; the clash must not abort the run.
+      const collected = [
+        struct(
+          "SetUserPositionManagers",
+          [
+            ["address", "onBehalfOf"],
+            ["PositionManagerUpdate[]", "updates"],
+          ],
+          "tests/EIP712Types.sol",
+        ),
+        struct(
+          "PositionManagerUpdate",
+          [
+            ["address", "positionManager"],
+            ["bool", "approve"],
+          ],
+          "tests/EIP712Types.sol",
+        ),
+        struct(
+          "PositionManagerUpdate",
+          [
+            ["address", "spoke"],
+            ["address", "positionManager"],
+            ["bool", "active"],
+          ],
+          "src/IConfigEngine.sol",
+        ),
+      ];
+
+      assert.deepEqual(
+        canonicalizeStructs(collected, new Set(["tests/EIP712Types.sol"])),
+        [
+          "SetUserPositionManagers(address onBehalfOf,PositionManagerUpdate[] updates)PositionManagerUpdate(address positionManager,bool approve)",
+          "PositionManagerUpdate(address positionManager,bool approve)",
+        ],
       );
     });
 

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/canonicalize.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/eip712/canonicalize.ts
@@ -553,8 +553,8 @@ describe("eip712 - canonicalize", () => {
       // Selected `Mail` depends on `Person`, which has a selected definition
       // (test/Other.sol) AND a different non-selected one (lib/Imported.sol).
       // Even though the name is reachable, there is no ambiguity: selected
-      // definitions deterministically win a clash, so `Mail.from` inlines the
-      // selected `Person` and the non-selected copy is ignored.
+      // definitions deterministically win a clash, so `Mail.from` resolves to
+      // the selected `Person` and the non-selected copy is ignored.
       const collected = [
         struct("Mail", [["Person", "from"]], "test/Mail.sol"),
         struct(


### PR DESCRIPTION
<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [x] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
Running `test solidity` on the aave-v4 migration branch (pinned at [`27c95ea`](https://github.com/anaPerezGhiglia/aave-v4/commit/27c95eae18c60547933b6486774f816175e124f0)) aborts with:

```
Error HHE818: Two different EIP-712 struct definitions named "PositionManagerUpdate" were found:
- tests/helpers/mocks/EIP712Types.sol
- src/config-engine/interfaces/IAaveV4ConfigEngine.sol
```

**The two definitions.** The project's `hardhat.config.ts` selects a single file, `eip712Types.include: ['tests/helpers/mocks/EIP712Types.sol']`, which defines both the signed root [`SetUserPositionManagers`](https://github.com/anaPerezGhiglia/aave-v4/blob/27c95eae18c60547933b6486774f816175e124f0/tests/helpers/mocks/EIP712Types.sol#L10) and, right below it, the dependency it references, [`PositionManagerUpdate {address positionManager; bool approve;}`](https://github.com/anaPerezGhiglia/aave-v4/blob/27c95eae18c60547933b6486774f816175e124f0/tests/helpers/mocks/EIP712Types.sol#L17) — the type whose name is baked into the on-chain typehash, so it cannot be renamed. The clash comes from a **non-selected** production interface that reuses the name for an unrelated configuration payload: [`IAaveV4ConfigEngine.PositionManagerUpdate {ISpokeConfigurator spokeConfigurator; address spoke; address positionManager; bool active;}`](https://github.com/anaPerezGhiglia/aave-v4/blob/27c95eae18c60547933b6486774f816175e124f0/src/config-engine/interfaces/IAaveV4ConfigEngine.sol#L256). Neither side is reasonably renameable (one is typehash-compatible with the deployed contracts, the other is audited production source shared with the Foundry build), and the config already does exactly what our docs prescribe.

**Why the collector throws.** `canonicalizeStructs` indexes struct definitions by name, selected sources first, so a selected definition deterministically wins any name clash. Conflicting non-selected definitions are deferred, and the deferred path threw whenever the clashing name was *reachable* from a selected struct — here `PositionManagerUpdate` is reachable because selected `SetUserPositionManagers` has a `PositionManagerUpdate[]` member. The throw's rationale ("which copy got inlined would depend on iteration order") is only true when the name has **no** selected definition; when one exists, it always wins, so the abort was spurious. It also made behavior inconsistent: the same clash was documented as harmless when the selected struct was only a root, but became fatal the moment a sibling selected struct referenced it. #8344 fixed the unreferenced-clash case; this is the remaining mixed (selected-vs-non-selected, reachable) case its repro didn't exercise.

**Fix.** The deferred conflict now throws only when the name is reachable AND has no selected definition (`reachable.has(name) && !selectedNames.has(name)`). This bounds the registry the way `include` promises (and matches Foundry's include-scoped `bind-json` registry, where non-included sources never contribute definitions), while `HHE818` still fires on the genuinely ambiguous cases: two selected definitions of the same name, and clashes among non-selected definitions that a selected struct depends on. The `HHE818` remediation text now also mentions resolving a dependency clash by including the source with the canonical definition.

**Tests.** The case asserting the old throw now asserts the selected definition wins (order-independently), plus a new regression test mirroring the aave-v4 shape exactly (one included file defines both the root and the dependency; a non-selected file redefines the dependency's name). All EIP-712 suites pass (89 tests); package lint/build pass; changeset included.