### PR TITLE
ci(bench): notify Slack on perf regressions in main

### DIFF
--- a/.github/workflows/regression-benchmark.yml
+++ b/.github/workflows/regression-benchmark.yml
@@ -94,8 +94,10 @@ jobs:
     runs-on: hardhat-linux-amd64-self-hosted
     timeout-minutes: 180
     permissions:
-      # Lets the short-lived GITHUB_TOKEN used on non-baseline runs read commit
-      # metadata via the REST API (see "Store benchmark result").
+      # Lets the GITHUB_TOKEN used by "Compare benchmark result against
+      # baseline" read commit metadata via the REST API. Only needed on
+      # dispatch and `/bench` runs; push events carry the commit in the
+      # event payload.
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -222,38 +224,100 @@ jobs:
           cat regression-report.json 2>/dev/null \
             || echo "(no regression-report.json produced)"
 
-      - name: Store benchmark result
+      # Comparing and recording are split so that a regression can be told
+      # apart from a failed write. This invocation only reads, so it cannot
+      # fail the way "Record baseline in the results repo" can.
+      #
+      # It can still fail on a fetch or clone error instead of on the alert.
+      # Nothing here distinguishes the two, so the Slack message calls both a
+      # regression. The step's error annotation on the run says which it was.
+      #
+      # The comparison is against the last recorded data point, i.e. the
+      # previous push to main. So the baseline moves: a regression alerts
+      # once, then becomes the new normal.
+      - name: Compare benchmark result against baseline
+        id: compare
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        # A regression must not break main, so absorb the alert on baseline
+        # runs and let the Slack step report it instead. Comparison runs
+        # (`/bench`, dispatch) still fail.
+        continue-on-error: ${{ needs.setup.outputs.is_baseline == 'true' }}
         with:
           tool: customSmallerIsBetter
           output-file-path: regression-report.json
           gh-repository: github.com/nomic-foundation-automation/hardhat-benchmark-results
           gh-pages-branch: main
           benchmark-data-dir-path: hardhat3
-          # Baseline (main push) runs push to the external results repo, which
-          # needs the cross-repo PAT. Non-baseline runs (dispatch and the
-          # `/bench` issue_comment path) never push — the token is only used to
-          # read commit metadata and to clone the (public) results repo for
-          # comparison — so use the short-lived GITHUB_TOKEN.
-          github-token: ${{ needs.setup.outputs.is_baseline == 'true' && secrets.BENCHMARK_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          # Only push a new baseline on main-branch pushes; dispatch/`/bench`
-          # runs only compare.
-          auto-push: ${{ needs.setup.outputs.is_baseline == 'true' }}
+          # This invocation only reads the (public) results repo, so the
+          # short-lived GITHUB_TOKEN suffices on every trigger. A token is
+          # still required: with `gh-repository` set, the action rejects an
+          # empty `github-token` during config validation.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
           alert-threshold: "110%"
-          # Fail the run on a regression for comparisons; never break main.
-          fail-on-alert: ${{ needs.setup.outputs.is_baseline != 'true' }}
+          fail-on-alert: true
           summary-always: true
 
-      - name: Notify failures
-        # Only ping Slack for failed baseline runs (pushes to main)
-        if: ${{ failure() && needs.setup.outputs.is_baseline == 'true' }}
+      - name: Clear the results-repo clone
+        # "Compare benchmark result against baseline" leaves its clone of the
+        # results repo in the workspace, and `git clone` refuses a non-empty
+        # destination, so remove it before "Record baseline in the results
+        # repo" clones again. `always()` because a comparison run that
+        # fails on a regression has to clean up too.
+        if: always()
+        run: rm -rf "${GITHUB_WORKSPACE:?}/benchmark-data-repository"
+
+      # Record the data point whether or not it regressed, so main's baseline
+      # always tracks the newest commit. `fail-on-alert` is off here, so the
+      # only way this fails is a genuine store failure (clone, auth or push
+      # error) — which fails the run and gets the generic Slack notification
+      # rather than the regression one.
+      - name: Record baseline in the results repo
+        id: record
+        if: ${{ needs.setup.outputs.is_baseline == 'true' }}
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        # `tool` through `benchmark-data-dir-path` must stay identical to
+        # "Compare benchmark result against baseline" — the two invocations
+        # have to address the same dataset.
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: regression-report.json
+          gh-repository: github.com/nomic-foundation-automation/hardhat-benchmark-results
+          gh-pages-branch: main
+          benchmark-data-dir-path: hardhat3
+          # Pushing to another repository needs the cross-repo PAT.
+          github-token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
+          auto-push: true
+          fail-on-alert: false
+          # The comparison above already wrote the summary.
+          summary-always: false
+
+      - name: Notify failures and regressions
+        # Fires on baseline runs for a failed run, or for a regression that
+        # `continue-on-error` deliberately left green.
+        #
+        # Two details in the condition that look removable but are not:
+        # 1. `failure()` suppresses the implicit `success()` that GitHub wraps
+        #    every step `if:` in. Without it, this step is skipped on the
+        #    failed runs it exists to report.
+        # 2. It reads `outcome`, not `conclusion`, because `continue-on-error`
+        #    rewrites `conclusion` to `success`.
+        #
+        # The regression wording needs the record step to have succeeded too.
+        # An infra error that trips both steps therefore reads as a plain
+        # failure.
+        if: ${{ needs.setup.outputs.is_baseline == 'true' && (failure() || steps.compare.outcome == 'failure') }}
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook: ${{ secrets.GH_ACTION_NOTIFICATIONS_SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
+          # Slack is the only channel a regression is reported on, so a
+          # rejected delivery must fail the step rather than just warn — even
+          # though on the green regression path that reddens the run.
+          errors: true
           payload: |
             {
-              "workflow_name": "${{ github.workflow }}",
+              "workflow_name": "${{ github.workflow }}${{ (steps.compare.outcome == 'failure' && steps.record.outcome == 'success') && ' — perf regression on main (baseline updated)' || '' }}",
               "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 


### PR DESCRIPTION


<!--
Thank you for using Hardhat and taking the time to send a Pull Request!

If you are introducing a new feature, please discuss it in an Issue or with someone from the team before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.

## Note about small PRs and airdrop farming

We generally really appreciate external contributions, and strongly encourage meaningful additions and fixes! However, due to a recent increase in small PRs potentially created to farm airdrops, we might need to close a PR without explanation if any of the following apply:

- It is a change of very minor value that still requires additional review time/fixes (e.g. PRs fixing trivial spelling errors that can’t be merged in less than a couple of minutes due to incorrect suggestions)
- It introduces inconsequential changes (e.g. rewording phrases)
- The author of the PR does not respond in a timely manner
- We suspect the Github account of the author was created for airdrop farming
-->

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed on an Issue or with someone from the team.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

This PR ports the compare/record split from EDR's `hh3-regression-benchmark.yml` into the regression benchmark workflow, so Slack is also notified when a regression is detected on a `main` baseline run.

- Splits the single "Store benchmark result" step into a read-only compare step (`fail-on-alert: true`, absorbed on baseline runs via `continue-on-error` so main stays green) and a record step that always pushes the new baseline (`auto-push: true`, `fail-on-alert: false`).
- Adds a cleanup step between the two, since the compare step's results-repo clone would make the record step's `git clone` fail.
- Upgrades the notify step to also fire on the absorbed regression, appending " — perf regression on main (baseline updated)" to the Slack message, and sets `errors: true` so a rejected delivery fails the step.

Previously a >110% regression on a main push was silently swallowed by `fail-on-alert: false`; now it's recorded as the new baseline **and** reported to Slack. `/bench` and dispatch runs are unaffected.
