### PR TITLE
feat(solidity-test): add support for Solidity test profiles

### DIFF
--- a/.changeset/solidity-test-profiles.md
+++ b/.changeset/solidity-test-profiles.md
@@ -1,0 +1,9 @@
+---
+# docs: https://github.com/NomicFoundation/hardhat-website/pull/297
+"@nomicfoundation/hardhat-errors": patch
+"hardhat": minor
+---
+
+Added support for Solidity Test Profiles. You can now declare several sets of Solidity test settings under `test.solidity.profiles` and choose between them with the `--test-profile` argument or the `HARDHAT_TEST_PROFILE` environment variable. Each profile is configured independently, and a `default` profile is required.
+
+Inline test configuration directives can now be scoped to a profile, so `/// hardhat-config: ci.fuzz.runs = 10000` only applies when the `ci` profile is selected, while an unprefixed directive applies under every profile.

--- a/packages/hardhat-errors/src/descriptors.ts
+++ b/packages/hardhat-errors/src/descriptors.ts
@@ -1384,6 +1384,14 @@ EIP-712 cheatcodes resolve types by name, so each struct name must have a single
         websiteDescription:
           "One or more inline test configuration directives (`forge-config:` / `hardhat-config:` NatSpec comments) in your Solidity test sources are invalid. Fix the reported directives and run the tests again.",
       },
+      TEST_PROFILE_NOT_FOUND: {
+        number: 822,
+        messageTemplate: `The Solidity test profile "{testProfile}" is not defined in your Hardhat config. Declared profiles: {declaredProfiles}`,
+        websiteTitle: "Solidity test profile not defined",
+        websiteDescription: `The Solidity test profile you are trying to use is not defined in your Hardhat config.
+
+Declare it under \`test.solidity.profiles\`, or select one of the profiles you already declared.`,
+      },
     },
     SOLIDITY: {
       PROJECT_ROOT_RESOLUTION_ERROR: {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -26,7 +26,11 @@ import {
 } from "@nomicfoundation/hardhat-zod-utils";
 import { z } from "zod";
 
-import { DEFAULT_TEST_PROFILE } from "./test-profiles.js";
+import {
+  DEFAULT_TEST_PROFILE,
+  RESERVED_TEST_PROFILE_NAMES,
+  TEST_PROFILE_NAME_PATTERN,
+} from "./test-profiles.js";
 
 // the keccak256 of "built for ethereum"
 export const DEFAULT_FUZZ_SEED =
@@ -136,12 +140,27 @@ const solidityTestProfilesUserConfigType = z.object({
       (profiles) => DEFAULT_TEST_PROFILE in profiles,
       "A `default` profile is required when using `profiles`",
     )
-    .refine(
-      (profiles) =>
-        !(DEFAULT_TEST_PROFILE in profiles) ||
-        Object.keys(profiles).every((name) => name === DEFAULT_TEST_PROFILE),
-      "Only the `default` profile is supported. Other profile names will be supported in a future release.",
-    ),
+    .superRefine((profiles, ctx) => {
+      for (const profileName of Object.keys(profiles)) {
+        if (!TEST_PROFILE_NAME_PATTERN.test(profileName)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [profileName],
+            message:
+              "Invalid profile name. Profile names can only contain letters, numbers, underscores and dashes",
+          });
+          continue;
+        }
+
+        if (RESERVED_TEST_PROFILE_NAMES.includes(profileName)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [profileName],
+            message: `\`${profileName}\` can't be used as a profile name, as it's an inline test configuration key`,
+          });
+        }
+      }
+    }),
 });
 
 const solidityTestUserConfigType = conditionalUnionType(

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/config.ts
@@ -241,42 +241,33 @@ export async function resolveSolidityTestUserConfig(
   testsPath = typeof testsPath === "object" ? testsPath.solidity : testsPath;
   testsPath ??= "test";
 
-  const defaultRpcCachePath = path.join(resolvedConfig.paths.cache, "edr");
+  const rpcCachePath = path.join(resolvedConfig.paths.cache, "edr");
 
   const solidityUserConfig = userConfig.test?.solidity;
-  let profileUserConfig: SolidityTestProfileUserConfig | undefined;
+
+  // The flat config shape is sugar for a single `default` profile.
+  let profilesUserConfig: Record<string, SolidityTestProfileUserConfig>;
   if (solidityUserConfig !== undefined && "profiles" in solidityUserConfig) {
-    profileUserConfig = solidityUserConfig.profiles[DEFAULT_TEST_PROFILE];
-    assertHardhatInvariant(
-      profileUserConfig !== undefined,
-      "default profile must be present when the profiles wrapper user config is supplied",
-    );
+    profilesUserConfig = solidityUserConfig.profiles;
   } else {
-    profileUserConfig = solidityUserConfig;
+    profilesUserConfig = { [DEFAULT_TEST_PROFILE]: solidityUserConfig ?? {} };
   }
 
-  const resolvedForking = resolveSolidityTestForkingConfig(
-    profileUserConfig?.forking,
-    resolveConfigurationVariable,
+  assertHardhatInvariant(
+    DEFAULT_TEST_PROFILE in profilesUserConfig,
+    "default profile must be present when the profiles wrapper user config is supplied",
   );
 
-  const {
-    memoryLimit,
-    fuzz,
-    invariant,
-    eip712Types,
-    ...otherProfileUserConfig
-  } = profileUserConfig ?? {};
-
-  const resolvedDefaultProfile = {
-    rpcCachePath: defaultRpcCachePath,
-    ...otherProfileUserConfig,
-    memoryLimit: memoryLimit !== undefined ? BigInt(memoryLimit) : undefined,
-    fuzz: resolveFuzzConfig(fuzz),
-    invariant: resolveInvariantConfig(invariant),
-    forking: resolvedForking,
-    eip712Types: resolveEip712TypesConfig(eip712Types),
-  };
+  const profiles: Record<string, SolidityTestProfileConfig> = {};
+  for (const [profileName, profileUserConfig] of Object.entries(
+    profilesUserConfig,
+  )) {
+    profiles[profileName] = resolveSolidityTestProfileUserConfig(
+      profileUserConfig,
+      rpcCachePath,
+      resolveConfigurationVariable,
+    );
+  }
 
   return {
     ...resolvedConfig,
@@ -289,10 +280,36 @@ export async function resolveSolidityTestUserConfig(
     },
     test: {
       ...resolvedConfig.test,
-      solidity: {
-        profiles: { [DEFAULT_TEST_PROFILE]: resolvedDefaultProfile },
-      },
+      solidity: { profiles },
     },
+  };
+}
+
+function resolveSolidityTestProfileUserConfig(
+  profileUserConfig: SolidityTestProfileUserConfig,
+  rpcCachePath: string,
+  resolveConfigurationVariable: ConfigurationVariableResolver,
+): SolidityTestProfileConfig {
+  const {
+    memoryLimit,
+    fuzz,
+    invariant,
+    forking,
+    eip712Types,
+    ...otherProfileUserConfig
+  } = profileUserConfig;
+
+  return {
+    rpcCachePath,
+    ...otherProfileUserConfig,
+    memoryLimit: memoryLimit !== undefined ? BigInt(memoryLimit) : undefined,
+    fuzz: resolveFuzzConfig(fuzz),
+    invariant: resolveInvariantConfig(invariant),
+    forking: resolveSolidityTestForkingConfig(
+      forking,
+      resolveConfigurationVariable,
+    ),
+    eip712Types: resolveEip712TypesConfig(eip712Types),
   };
 }
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/formatters.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/formatters.ts
@@ -43,8 +43,8 @@ function formatInlineConfigDirectiveProblem(
   switch (problem.kind) {
     case "InlineConfigInvalidSyntax":
       return `missing "=" in "${problem.directive}"`;
-    case "InlineConfigUnsupportedProfile":
-      return `unsupported profile "${problem.profile}". Only the "default" profile is supported`;
+    case "InlineConfigUndeclaredProfile":
+      return `unknown profile "${problem.profile}". Declared profiles: ${problem.declaredProfiles.map((name) => `"${name}"`).join(", ")}`;
     case "InlineConfigInvalidKey":
       return `invalid key "${problem.key}"`;
     case "InlineConfigInvalidKeyForTestType":

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/helpers.ts
@@ -47,6 +47,8 @@ interface SolidityTestConfigParams {
   generateGasReport: boolean;
   eip712CanonicalTypes?: string[];
   testSourcePaths?: Record<string, string>;
+  testProfile?: string;
+  declaredTestProfiles?: string[];
 }
 
 export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
@@ -61,6 +63,8 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
   generateGasReport,
   eip712CanonicalTypes,
   testSourcePaths,
+  testProfile,
+  declaredTestProfiles,
 }: SolidityTestConfigParams): Promise<SolidityTestRunnerConfigArgs> {
   const fsPermissions: PathPermission[] | undefined = [
     config.fsPermissions?.readWriteFile?.map((p) => ({
@@ -175,6 +179,8 @@ export async function solidityTestConfigToSolidityTestRunnerConfigArgs({
       : CollectStackTraces.OnFailure,
     eip712CanonicalTypes,
     testSourcePaths,
+    testProfile,
+    declaredTestProfiles,
   };
 }
 

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/index.ts
@@ -3,7 +3,7 @@ import type { HardhatPlugin } from "../../../types/plugins.js";
 import { ArgumentType } from "hardhat/types/arguments";
 
 import { definePlugin } from "../../../plugins.js";
-import { task } from "../../core/config.js";
+import { overrideTask, task } from "../../core/config.js";
 
 export type * from "./type-extensions.js";
 
@@ -24,6 +24,12 @@ const hardhatPlugin: HardhatPlugin = definePlugin({
         name: "chainType",
         description: "The chain type to use",
         defaultValue: "l1",
+      })
+      .addOption({
+        name: "testProfile",
+        description: "The Solidity test profile to use",
+        type: ArgumentType.STRING_WITHOUT_DEFAULT,
+        defaultValue: undefined,
       })
       .addOption({
         name: "grep",
@@ -50,6 +56,21 @@ const hardhatPlugin: HardhatPlugin = definePlugin({
         hidden: true,
       })
       .setAction(async () => await import("./task-action.js"))
+      .build(),
+    overrideTask("test")
+      .addOption({
+        name: "testProfile",
+        description: "The Solidity test profile to use (Solidity tests only)",
+        type: ArgumentType.STRING_WITHOUT_DEFAULT,
+        defaultValue: undefined,
+      })
+      .setAction(async () => ({
+        default: async (args, _hre, runSuper) => {
+          // We don't need to do anything here, as the test task will forward
+          // the arguments to its subtasks.
+          return await runSuper(args);
+        },
+      }))
       .build(),
   ],
   dependencies: () => [

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -297,6 +297,8 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
         hre.globalOptions.gasStatsJson !== undefined,
       eip712CanonicalTypes,
       testSourcePaths,
+      testProfile: testProfileName,
+      declaredTestProfiles: Object.keys(testProfiles),
     });
   const tracingConfig: TracingConfigWithBuffers = {
     buildInfos: allBuildInfosAndOutputs.map(({ buildInfo, output }) => ({

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/task-action.ts
@@ -17,6 +17,7 @@ import type {
 } from "@nomicfoundation/edr";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
+import { getEnvVariableNameFromGlobalOption } from "@nomicfoundation/hardhat-utils/env";
 import { exists } from "@nomicfoundation/hardhat-utils/fs";
 import { resolveFromRoot } from "@nomicfoundation/hardhat-utils/path";
 import { createNonClosingWriter } from "@nomicfoundation/hardhat-utils/stream";
@@ -51,6 +52,7 @@ interface TestActionArguments {
   grepExclude?: string;
   noCompile: boolean;
   testSummaryIndex: number;
+  testProfile?: string;
 }
 
 export interface SolidityTestRunResult extends TestRunResult {
@@ -58,11 +60,42 @@ export interface SolidityTestRunResult extends TestRunResult {
 }
 
 const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
-  { testFiles, chainType, grep, grepExclude, noCompile, testSummaryIndex },
+  {
+    testFiles,
+    chainType,
+    grep,
+    grepExclude,
+    noCompile,
+    testSummaryIndex,
+    testProfile,
+  },
   hre,
 ): Promise<Result<SolidityTestRunResult, SolidityTestRunResult>> => {
   // Set an environment variable that plugins can use to detect when a process is running tests
   process.env.HH_TEST = "true";
+
+  // Only global options get an environment variable fallback for free, so we
+  // apply the same naming convention by hand for this task option.
+  const testProfileName =
+    testProfile ??
+    process.env[getEnvVariableNameFromGlobalOption("testProfile")] ??
+    DEFAULT_TEST_PROFILE;
+
+  const testProfiles = hre.config.test.solidity.profiles;
+  const selectedTestProfile = testProfiles[testProfileName];
+
+  if (selectedTestProfile === undefined) {
+    throw new HardhatError(
+      HardhatError.ERRORS.CORE.SOLIDITY_TESTS.TEST_PROFILE_NOT_FOUND,
+      {
+        testProfile: testProfileName,
+        declaredProfiles: Object.keys(testProfiles)
+          .sort() // to match EDR
+          .map((name) => `"${name}"`)
+          .join(", "),
+      },
+    );
+  }
 
   const verbosity = hre.globalOptions.verbosity;
 
@@ -215,8 +248,7 @@ const runSolidityTests: NewTaskActionFunction<TestActionArguments> = async (
   let includesFailures = false;
   let includesErrors = false;
 
-  const { eip712Types, ...solidityTestConfig } =
-    hre.config.test.solidity.profiles[DEFAULT_TEST_PROFILE];
+  const { eip712Types, ...solidityTestConfig } = selectedTestProfile;
 
   let observabilityConfig: ObservabilityConfig | undefined;
   if (hre.globalOptions.coverage) {

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/test-profiles.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/test-profiles.ts
@@ -1,1 +1,25 @@
 export const DEFAULT_TEST_PROFILE = "default";
+
+/**
+ * The top-level keys of the inline test configuration directives
+ * (`forge-config:` / `hardhat-config:`). The first dot-separated segment of a
+ * directive is read as a profile name unless it's one of these keys, so a
+ * profile named e.g. `fuzz` would make `fuzz.runs = 10` ambiguous.
+ *
+ * NOTE: This mirrors EDR's inline config keys. If EDR adds a new top-level key,
+ * add it here too.
+ */
+export const RESERVED_TEST_PROFILE_NAMES: readonly string[] = [
+  "allowInternalExpectRevert",
+  "evmVersion",
+  "fuzz",
+  "invariant",
+  "isolate",
+];
+
+/**
+ * Profile names are used as prefixes in inline config directives, where the
+ * grammar is dot-separated, and on the command line, so we keep them to a
+ * conservative character set.
+ */
+export const TEST_PROFILE_NAME_PATTERN: RegExp = /^[A-Za-z0-9_-]+$/;

--- a/packages/hardhat/test/fixture-projects/solidity-test-inline-config/test/profiles/Profiles.t.sol
+++ b/packages/hardhat/test/fixture-projects/solidity-test-inline-config/test/profiles/Profiles.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Every test here passes; the assertions are on the reported run counts, which
+// depend on the selected test profile.
+contract InlineConfigProfilesTest {
+  // No profile prefix, so it applies under every profile.
+  /// hardhat-config: fuzz.runs = 3
+  function testFuzzUnprefixed(uint256 x) public pure {}
+
+  // Under `ci` the prefixed directive wins, even though it's written first.
+  /// hardhat-config: ci.fuzz.runs = 8
+  /// hardhat-config: fuzz.runs = 3
+  function testFuzzProfileWinsOverUnprefixed(uint256 x) public pure {}
+
+  // Applies only under `default`; other profiles use the file config.
+  /// hardhat-config: default.fuzz.runs = 4
+  function testFuzzDefaultProfileOnly(uint256 x) public pure {}
+}

--- a/packages/hardhat/test/fixture-projects/solidity-test/test/contracts/profiles/Profiles.t.sol
+++ b/packages/hardhat/test/fixture-projects/solidity-test/test/contracts/profiles/Profiles.t.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// A self-contained fuzz test (no forge-std) whose run count comes from the
+// selected test profile's `fuzz.runs`, used to exercise --test-profile
+// end-to-end.
+contract ProfilesTest {
+  function testFuzzProfileRuns(uint256 x) public pure {}
+}

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-resolution.ts
@@ -151,5 +151,36 @@ describe("config resolution", () => {
         flatHre.config.test.solidity,
       );
     });
+
+    it("should resolve every declared profile independently", async () => {
+      const hre = await createHardhatRuntimeEnvironment({
+        test: {
+          solidity: {
+            profiles: {
+              default: { isolate: true, fuzz: { runs: 5, seed: "0x1" } },
+              ci: {
+                fuzz: { runs: 500 },
+                forking: { url: "https://example.com/ci", blockNumber: 123 },
+              },
+            },
+          },
+        },
+      });
+
+      const { default: defaultProfile, ci } = hre.config.test.solidity.profiles;
+
+      assert.equal(defaultProfile.isolate, true);
+      assert.equal(defaultProfile.fuzz.runs, 5);
+      assert.equal(defaultProfile.fuzz.seed, "0x1");
+      assert.equal(defaultProfile.forking, undefined);
+
+      // Everything `ci` doesn't set comes from the built-in defaults rather
+      // than from `default`: profiles don't inherit from each other.
+      assert.equal(ci.isolate, undefined);
+      assert.equal(ci.fuzz.runs, 500);
+      assert.equal(ci.fuzz.seed, DEFAULT_FUZZ_SEED);
+      assert.equal(ci.forking?.blockNumber, 123n);
+      assert.equal(await ci.forking?.url?.get(), "https://example.com/ci");
+    });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -84,8 +84,6 @@ describe("config validation", () => {
   });
 
   it("should accept the `profiles` wrapper with non-`default` profiles", async () => {
-    // Only validation is asserted here; that every declared profile is
-    // resolved is covered by the config resolution tests.
     const hre = await createHardhatRuntimeEnvironment({
       test: {
         solidity: {
@@ -98,6 +96,7 @@ describe("config validation", () => {
     });
 
     assert.equal(hre.config.test.solidity.profiles.default.isolate, true);
+    assert.equal(hre.config.test.solidity.profiles.ci.isolate, false);
   });
 
   it("should throw when a profile name is an inline test configuration key", async () => {

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/config-validation.ts
@@ -83,13 +83,30 @@ describe("config validation", () => {
     );
   });
 
-  it("should throw when the `profiles` wrapper has a non-`default` profile", async () => {
-    const userConfig: HardhatUserConfig = {
+  it("should accept the `profiles` wrapper with non-`default` profiles", async () => {
+    // Only validation is asserted here; that every declared profile is
+    // resolved is covered by the config resolution tests.
+    const hre = await createHardhatRuntimeEnvironment({
       test: {
         solidity: {
           profiles: {
             default: { isolate: true },
             ci: { isolate: false },
+          },
+        },
+      },
+    });
+
+    assert.equal(hre.config.test.solidity.profiles.default.isolate, true);
+  });
+
+  it("should throw when a profile name is an inline test configuration key", async () => {
+    const userConfig: HardhatUserConfig = {
+      test: {
+        solidity: {
+          profiles: {
+            default: { isolate: true },
+            fuzz: { isolate: false },
           },
         },
       },
@@ -100,7 +117,29 @@ describe("config validation", () => {
       HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
       {
         errors:
-          "\t* Config error in config.test.solidity.profiles: Only the `default` profile is supported. Other profile names will be supported in a future release.",
+          "\t* Config error in config.test.solidity.profiles.fuzz: `fuzz` can't be used as a profile name, as it's an inline test configuration key",
+      },
+    );
+  });
+
+  it("should throw when a profile name has invalid characters", async () => {
+    const userConfig: HardhatUserConfig = {
+      test: {
+        solidity: {
+          profiles: {
+            default: { isolate: true },
+            "my.profile": { isolate: false },
+          },
+        },
+      },
+    };
+
+    await assertRejectsWithHardhatError(
+      createHardhatRuntimeEnvironment(userConfig),
+      HardhatError.ERRORS.CORE.GENERAL.INVALID_CONFIG,
+      {
+        errors:
+          "\t* Config error in config.test.solidity.profiles.my.profile: Invalid profile name. Profile names can only contain letters, numbers, underscores and dashes",
       },
     );
   });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/formatters.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/formatters.ts
@@ -75,8 +75,12 @@ describe("formatInlineConfigErrors", () => {
         `missing "=" in "fuzz.runs 7"`,
       ],
       [
-        { kind: "InlineConfigUnsupportedProfile", profile: "ci" },
-        `unsupported profile "ci". Only the "default" profile is supported`,
+        {
+          kind: "InlineConfigUndeclaredProfile",
+          profile: "nope",
+          declaredProfiles: ["ci", "default"],
+        },
+        `unknown profile "nope". Declared profiles: "ci", "default"`,
       ],
       [
         { kind: "InlineConfigInvalidKey", key: "default.nope" },

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/inline-config.ts
@@ -1,7 +1,7 @@
 import type { TestResult } from "@nomicfoundation/edr";
 
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { after, before, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import { useFixtureProject } from "@nomicfoundation/hardhat-test-utils";
@@ -19,8 +19,36 @@ const hardhatConfigInvalidTests = {
   paths: { tests: { solidity: "test/invalid" } },
 };
 
+const hardhatConfigProfileTests = {
+  ...hardhatConfig,
+  paths: { tests: { solidity: "test/profiles" } },
+  test: {
+    solidity: {
+      profiles: {
+        default: { fuzz: { runs: 11 } },
+        ci: { fuzz: { runs: 11 } },
+      },
+    },
+  },
+};
+
 describe("solidity-test/inline-config", () => {
+  let ambientTestProfile: string | undefined;
+
   useFixtureProject("solidity-test-inline-config");
+
+  before(() => {
+    // These runs read `HARDHAT_TEST_PROFILE`, and the configs here declare only
+    // the profiles they need, so an ambient value would fail them.
+    ambientTestProfile = process.env.HARDHAT_TEST_PROFILE;
+    delete process.env.HARDHAT_TEST_PROFILE;
+  });
+
+  after(() => {
+    if (ambientTestProfile !== undefined) {
+      process.env.HARDHAT_TEST_PROFILE = ambientTestProfile;
+    }
+  });
 
   it("should apply inline config directives found in the test sources", async () => {
     const hre = await createHardhatRuntimeEnvironment(hardhatConfigValidTests);
@@ -124,5 +152,66 @@ describe("solidity-test/inline-config", () => {
       /Found invalid inline configuration/,
       "EDR's heading line should be stripped from the message",
     );
+  });
+
+  describe("profile-scoped directives", () => {
+    /**
+     * Runs the profile fixture and returns each test's fuzz run count. Both
+     * declared profiles set `fuzz.runs` to 11, so any other value comes from an
+     * inline directive.
+     */
+    async function runsByTest(
+      testProfile?: string,
+    ): Promise<Record<string, bigint>> {
+      const hre = await createHardhatRuntimeEnvironment(
+        hardhatConfigProfileTests,
+      );
+
+      const result = await hre.tasks
+        .getTask(["test", "solidity"])
+        .run({ testProfile });
+
+      assert.equal(result.success, true);
+
+      const runs: Record<string, bigint> = {};
+      for (const testResult of result.value.suiteResults.flatMap(
+        (suiteResult: { testResults: TestResult[] }) => suiteResult.testResults,
+      )) {
+        assert.ok(
+          "runs" in testResult.kind,
+          `${testResult.name} isn't a fuzz test`,
+        );
+        runs[testResult.name] = testResult.kind.runs;
+      }
+      return runs;
+    }
+
+    it("applies unprefixed directives under every profile", async () => {
+      assert.equal((await runsByTest())["testFuzzUnprefixed(uint256)"], 3n);
+      assert.equal((await runsByTest("ci"))["testFuzzUnprefixed(uint256)"], 3n);
+    });
+
+    it("applies a prefixed directive only under its own profile", async () => {
+      // The file config's 11 runs win when the directive doesn't apply.
+      assert.equal(
+        (await runsByTest())["testFuzzDefaultProfileOnly(uint256)"],
+        4n,
+      );
+      assert.equal(
+        (await runsByTest("ci"))["testFuzzDefaultProfileOnly(uint256)"],
+        11n,
+      );
+    });
+
+    it("prefers the selected profile's directive over an unprefixed one", async () => {
+      assert.equal(
+        (await runsByTest())["testFuzzProfileWinsOverUnprefixed(uint256)"],
+        3n,
+      );
+      assert.equal(
+        (await runsByTest("ci"))["testFuzzProfileWinsOverUnprefixed(uint256)"],
+        8n,
+      );
+    });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/task-action.ts
@@ -2,7 +2,7 @@ import type { HardhatRuntimeEnvironment } from "../../../../src/types/hre.js";
 import type { SuiteResult, TestResult } from "@nomicfoundation/edr";
 
 import assert from "node:assert/strict";
-import { before, describe, it } from "node:test";
+import { after, before, describe, it } from "node:test";
 
 import { HardhatError } from "@nomicfoundation/hardhat-errors";
 import {
@@ -13,6 +13,7 @@ import {
 import { overrideTask } from "../../../../src/config.js";
 import { createHardhatRuntimeEnvironment } from "../../../../src/internal/hre-initialization.js";
 import hardhatConfig from "../../../fixture-projects/solidity-test/hardhat.config.js";
+import { createTestEnvManager } from "../../../utils.js";
 
 /**
  * The fixture project for this test has two folders:
@@ -66,6 +67,19 @@ const hardhatConfigGrepTests = {
   paths: { tests: { solidity: "test/contracts/grep" } },
 };
 
+const hardhatConfigProfileTests = {
+  ...hardhatConfig,
+  paths: { tests: { solidity: "test/contracts/profiles" } },
+  test: {
+    solidity: {
+      profiles: {
+        default: { fuzz: { runs: 3 } },
+        ci: { fuzz: { runs: 7 } },
+      },
+    },
+  },
+};
+
 const TX_GAS_CAP_TEST_PATH = {
   tests: { solidity: "test/contracts/transaction-gas-cap" },
 };
@@ -112,10 +126,17 @@ const hardhatConfigBlockGasLimitLow = {
 
 describe("solidity-test/task-action", function () {
   let hre: HardhatRuntimeEnvironment;
+  let ambientTestProfile: string | undefined;
 
   useFixtureProject("solidity-test");
 
   before(async function () {
+    // Every run in this file reads `HARDHAT_TEST_PROFILE`, and the configs
+    // below only declare `default`, so an ambient value fails all of them.
+    // `createTestEnvManager` can only set variables, not unset them.
+    ambientTestProfile = process.env.HARDHAT_TEST_PROFILE;
+    delete process.env.HARDHAT_TEST_PROFILE;
+
     // Build with a config that covers all test subdirectories so that
     // noCompile: true tests find pre-compiled artifacts on disk.
     const buildHre = await createHardhatRuntimeEnvironment(
@@ -124,6 +145,12 @@ describe("solidity-test/task-action", function () {
     await buildHre.tasks.getTask(["build"]).run({});
 
     hre = await createHardhatRuntimeEnvironment(hardhatConfigAllTests);
+  });
+
+  after(function () {
+    if (ambientTestProfile !== undefined) {
+      process.env.HARDHAT_TEST_PROFILE = ambientTestProfile;
+    }
   });
 
   describe("when the solidity task test runner is specified", () => {
@@ -797,6 +824,75 @@ describe("solidity-test/task-action", function () {
       assert.deepEqual(
         suite.testResults.map((t: TestResult) => t.name).sort(),
         ["testAlpha()", "testBeta()", "testGamma()"],
+      );
+    });
+  });
+
+  describe("when selecting a test profile", () => {
+    const { setEnvVar } = createTestEnvManager();
+
+    before(async () => {
+      const buildHre = await createHardhatRuntimeEnvironment(
+        hardhatConfigProfileTests,
+      );
+
+      await buildHre.tasks.getTask(["build"]).run({});
+    });
+
+    /**
+     * Runs the fixture's single fuzz test and returns the number of fuzz runs
+     * it performed, which is what the selected profile controls.
+     */
+    async function runsWith(args: {
+      testProfile?: string;
+    }): Promise<bigint | undefined> {
+      hre = await createHardhatRuntimeEnvironment(hardhatConfigProfileTests);
+
+      const result = await hre.tasks
+        .getTask(["test", "solidity"])
+        .run({ ...args, noCompile: true });
+
+      assert.equal(result.success, true);
+      const testResult = result.value.suiteResults
+        .flatMap((s: SuiteResult) => s.testResults)
+        .find((t: TestResult) => t.name === "testFuzzProfileRuns(uint256)");
+      assert.ok(testResult !== undefined, "expected the fuzz test to run");
+
+      return "runs" in testResult.kind ? testResult.kind.runs : undefined;
+    }
+
+    it("uses the default profile when none is selected", async () => {
+      assert.equal(await runsWith({}), 3n);
+    });
+
+    it("uses the selected profile", async () => {
+      assert.equal(await runsWith({ testProfile: "ci" }), 7n);
+    });
+
+    it("falls back to the HARDHAT_TEST_PROFILE environment variable", async () => {
+      setEnvVar("HARDHAT_TEST_PROFILE", "ci");
+
+      assert.equal(await runsWith({}), 7n);
+    });
+
+    it("prefers the option over the environment variable", async () => {
+      setEnvVar("HARDHAT_TEST_PROFILE", "ci");
+
+      assert.equal(await runsWith({ testProfile: "default" }), 3n);
+    });
+
+    it("throws when the selected profile is not declared", async () => {
+      hre = await createHardhatRuntimeEnvironment(hardhatConfigProfileTests);
+
+      await assertRejectsWithHardhatError(
+        hre.tasks
+          .getTask(["test", "solidity"])
+          .run({ testProfile: "nope", noCompile: true }),
+        HardhatError.ERRORS.CORE.SOLIDITY_TESTS.TEST_PROFILE_NOT_FOUND,
+        {
+          testProfile: "nope",
+          declaredProfiles: '"ci", "default"',
+        },
       );
     });
   });

--- a/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/test/task-action.ts
@@ -36,6 +36,12 @@ function mockRunner(name: string, action: (...args: any[]) => unknown) {
       type: ArgumentType.STRING_WITHOUT_DEFAULT,
       defaultValue: undefined,
     })
+    .addOption({
+      name: "testProfile",
+      description: "The test profile to use",
+      type: ArgumentType.STRING_WITHOUT_DEFAULT,
+      defaultValue: undefined,
+    })
     .addFlag({ name: "noCompile" })
     .setInlineAction(action)
     .build();
@@ -457,6 +463,21 @@ describe("test/task-action", function () {
       assert.equal(received.length, 1);
       assert.equal(received[0].grep, "unit_");
       assert.equal(received[0].grepExclude, "sub");
+    });
+
+    it("forwards testProfile to a subtask that declares it", async () => {
+      const received: Array<Record<string, unknown>> = [];
+      const hre = await createHardhatRuntimeEnvironment({
+        tasks: [solidityNoOp, capturingRunner("runner-a", received)],
+      });
+
+      await hre.tasks.getTask("test").run({
+        noCompile: true,
+        testProfile: "ci",
+      });
+
+      assert.equal(received.length, 1);
+      assert.equal(received[0].testProfile, "ci");
     });
   });
 });


### PR DESCRIPTION
Adds support for solidity test profiles. 

Design Doc: https://app.notion.com/p/nomicfoundation/Solidity-test-profiles-3bc578cdeaf58000ba6bffbdc1ca735e

### Notes

- Requires https://github.com/NomicFoundation/edr/pull/1715 to be merged, an EDR release and bump. Until that happens, CI will fail.
- Documentation PR: https://github.com/NomicFoundation/hardhat-website/pull/297