### PR TITLE
test: update fixture to node 24 changes

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Whether to save the pnpm cache
     required: false
     default: "false"
+  check-latest:
+    description: Whether to ignore the runner's cached node and always install the latest release matching node-version
+    required: false
+    default: "false"
 outputs:
   cache-hit:
     description: Whether the cache was restored
@@ -29,6 +33,7 @@ runs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
+        check-latest: ${{ inputs.check-latest }}
         cache: ${{ inputs.cache-save == 'true' && 'pnpm' || '' }}
         cache-dependency-path: "**/pnpm-lock.yaml"
         registry-url: https://registry.npmjs.org

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,10 @@ jobs:
       - uses: ./.github/actions/setup-env
         with:
           node-version: ${{ matrix.node }}
+          # The fixtures capture `node:test`'s exact output, which changes in
+          # patch releases, so we need the newest release of each major rather
+          # than whichever one the runner image happens to have cached.
+          check-latest: true
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build

--- a/packages/hardhat-node-test-reporter/integration-tests/fixture-tests/async-describe-test/result.v24.txt
+++ b/packages/hardhat-node-test-reporter/integration-tests/fixture-tests/async-describe-test/result.v24.txt
@@ -1,0 +1,31 @@
+  describe.async
+    [32m✔[39m[90m describe.async.it.only[39m
+    describe.async.describe.only.async
+      [32m✔[39m[90m describe.async.describe.only.async.it.only[39m
+    describe.async.describe
+      [32m✔[39m[90m describe.async.describe.it.only[39m
+
+  describe.only.async
+    [32m✔[39m[90m describe.only.async.it.only[39m
+    describe.only.async.describe.only.async
+      [32m✔[39m[90m describe.only.async.describe.only.async.it.only[39m
+    describe.only.async.describe
+      [32m✔[39m[90m describe.only.async.describe.it.only[39m
+
+  describe.only
+    [32m✔[39m[90m describe.only.it.only[39m
+    describe.only.describe.only.async
+      [32m✔[39m[90m describe.only.describe.only.async.it.only[39m
+    describe.only.describe
+      [32m✔[39m[90m describe.only.describe.it.only[39m
+
+  describe
+    [32m✔[39m[90m describe.it.only[39m
+    describe.describe.only.async
+      [32m✔[39m[90m describe.describe.only.async.it.only[39m
+    describe.describe
+      [32m✔[39m[90m describe.describe.it.only[39m
+
+
+  [32m12 passing[39m[90m (103ms)[39m
+

--- a/packages/hardhat-node-test-reporter/scripts/regenerate-fixtures.sh
+++ b/packages/hardhat-node-test-reporter/scripts/regenerate-fixtures.sh
@@ -38,8 +38,9 @@ for dir in $dirs; do
   node_major_version="$(node --version | cut -d. -f1)"
   if [ "$dir" == "integration-tests/fixture-tests/nested-test" ]; then
     result_file_name="result.$node_major_version"
-  elif [ "$dir" == "integration-tests/fixture-tests/async-describe-test" ] && [ "$node_major_version" == "v26" ]; then
-    # Only v26 currently diverges from the generic result.txt for this fixture.
+  elif [ "$dir" == "integration-tests/fixture-tests/async-describe-test" ] &&
+    { [ "$node_major_version" == "v24" ] || [ "$node_major_version" == "v26" ]; }; then
+    # v24 and v26 currently diverge from the generic result.txt for this fixture.
     result_file_name="result.$node_major_version"
   fi
 


### PR DESCRIPTION
Node 24 has had the same bug fix backported from Node 26, that we exempted previously: https://github.com/nodejs/node#64208.

This PR applies the exemption to Node 24 as well