### PR TITLE
bench(e2e): benchmark tests at -vvv and -vvvv

### DIFF
--- a/end-to-end/1inch-aqua/scenario.json
+++ b/end-to-end/1inch-aqua/scenario.json
@@ -43,6 +43,16 @@
         "runs": 2,
         "command": "npx hardhat test solidity --no-compile",
         "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvv": {
+        "runs": 2,
+        "command": "npx hardhat test solidity --no-compile -vvv",
+        "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvvv": {
+        "runs": 2,
+        "command": "npx hardhat test solidity --no-compile -vvvv",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/1inch-cross-chain-swap/scenario.json
+++ b/end-to-end/1inch-cross-chain-swap/scenario.json
@@ -46,6 +46,16 @@
         "runs": 15,
         "command": "npx hardhat test solidity --no-compile",
         "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvv": {
+        "runs": 15,
+        "command": "npx hardhat test solidity --no-compile -vvv",
+        "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvvv": {
+        "runs": 15,
+        "command": "npx hardhat test solidity --no-compile -vvvv",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/1inch-swap-vm/scenario.json
+++ b/end-to-end/1inch-swap-vm/scenario.json
@@ -47,6 +47,16 @@
         "runs": 4,
         "command": "npx hardhat test solidity --no-compile",
         "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvv": {
+        "runs": 4,
+        "command": "npx hardhat test solidity --no-compile -vvv",
+        "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvvv": {
+        "runs": 4,
+        "command": "npx hardhat test solidity --no-compile -vvvv",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/aave-v4/scenario.json
+++ b/end-to-end/aave-v4/scenario.json
@@ -44,6 +44,16 @@
         "runs": 24,
         "command": "npx hardhat test solidity --no-compile",
         "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvv": {
+        "runs": 24,
+        "command": "npx hardhat test solidity --no-compile -vvv",
+        "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvvv": {
+        "runs": 24,
+        "command": "npx hardhat test solidity --no-compile -vvvv",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/ens-contracts/scenario.json
+++ b/end-to-end/ens-contracts/scenario.json
@@ -43,6 +43,16 @@
         "runs": 2,
         "command": "NODE_OPTIONS=\"--disable-warning=ExperimentalWarning\" bunx vitest run",
         "dependsOn": ["cold compile"]
+      },
+      "test vitest -vvv": {
+        "runs": 2,
+        "command": "HARDHAT_VERBOSITY=3 NODE_OPTIONS=\"--disable-warning=ExperimentalWarning\" bunx vitest run",
+        "dependsOn": ["cold compile"]
+      },
+      "test vitest -vvvv": {
+        "runs": 2,
+        "command": "HARDHAT_VERBOSITY=4 NODE_OPTIONS=\"--disable-warning=ExperimentalWarning\" bunx vitest run",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/ens-verifiable-factory/scenario.json
+++ b/end-to-end/ens-verifiable-factory/scenario.json
@@ -46,6 +46,16 @@
         "runs": 2,
         "command": "npx hardhat test solidity --no-compile",
         "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvv": {
+        "runs": 2,
+        "command": "npx hardhat test solidity --no-compile -vvv",
+        "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvvv": {
+        "runs": 2,
+        "command": "npx hardhat test solidity --no-compile -vvvv",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/lidofinance-core/scenario.json
+++ b/end-to-end/lidofinance-core/scenario.json
@@ -44,6 +44,16 @@
         "runs": 2,
         "command": "yarn run test --no-compile",
         "dependsOn": ["cold compile"]
+      },
+      "test mocha -vvv": {
+        "runs": 2,
+        "command": "yarn run test --no-compile -vvv",
+        "dependsOn": ["cold compile"]
+      },
+      "test mocha -vvvv": {
+        "runs": 2,
+        "command": "yarn run test --no-compile -vvvv",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/lidofinance-dual-governance/scenario.json
+++ b/end-to-end/lidofinance-dual-governance/scenario.json
@@ -46,6 +46,16 @@
         "runs": 15,
         "command": "npx hardhat test solidity --no-compile --grep=\"^(test_|testFuzz_)\"",
         "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvv": {
+        "runs": 15,
+        "command": "npx hardhat test solidity --no-compile --grep=\"^(test_|testFuzz_)\" -vvv",
+        "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvvv": {
+        "runs": 15,
+        "command": "npx hardhat test solidity --no-compile --grep=\"^(test_|testFuzz_)\" -vvvv",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/openzeppelin-contracts/scenario.json
+++ b/end-to-end/openzeppelin-contracts/scenario.json
@@ -44,6 +44,16 @@
         "runs": 2,
         "command": "npx hardhat test mocha --no-compile",
         "dependsOn": ["cold compile"]
+      },
+      "test mocha -vvv": {
+        "runs": 2,
+        "command": "npx hardhat test mocha --no-compile -vvv",
+        "dependsOn": ["cold compile"]
+      },
+      "test mocha -vvvv": {
+        "runs": 2,
+        "command": "npx hardhat test mocha --no-compile -vvvv",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/uniswap-v4-core/scenario.json
+++ b/end-to-end/uniswap-v4-core/scenario.json
@@ -46,6 +46,16 @@
         "runs": 9,
         "command": "npx hardhat test solidity --no-compile",
         "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvv": {
+        "runs": 9,
+        "command": "npx hardhat test solidity --no-compile -vvv",
+        "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvvv": {
+        "runs": 9,
+        "command": "npx hardhat test solidity --no-compile -vvvv",
+        "dependsOn": ["cold compile"]
       }
     }
   }

--- a/end-to-end/uniswap-x/scenario.json
+++ b/end-to-end/uniswap-x/scenario.json
@@ -46,6 +46,16 @@
         "runs": 2,
         "command": "npx hardhat test solidity --no-compile",
         "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvv": {
+        "runs": 2,
+        "command": "npx hardhat test solidity --no-compile -vvv",
+        "dependsOn": ["cold compile"]
+      },
+      "test solidity -vvvv": {
+        "runs": 2,
+        "command": "npx hardhat test solidity --no-compile -vvvv",
+        "dependsOn": ["cold compile"]
       }
     }
   }


### PR DESCRIPTION
Every test entry in the E2E regression suite runs at the default verbosity (2), so the cost of trace collection is unmeasured. This duplicates each scenario's test entry at two higher levels:

- `-vvv` — `IncludeTraces.Failing`, i.e. traces collected for failing tests only.
- `-vvvv` — `IncludeTraces.All`, i.e. traces for every test.

Those are the two thresholds in `verbosityToIncludeTraces`. Other levels are deliberately left out as they map to the same EDR configuration flags as the now supported 2,3,4.

The new entries keep the base entry's `runs` count and its `dependsOn: ["cold compile"]`, so the three read as comparable samples of the same suite.

## Scenarios touched

| Scenario | Base entry | `runs` |
| --- | --- | --- |
| `1inch-aqua` | `test solidity` | 2 |
| `1inch-cross-chain-swap` | `test solidity` | 15 |
| `1inch-swap-vm` | `test solidity` | 4 |
| `aave-v4` | `test solidity` | 24 |
| `ens-contracts` | `test vitest` | 2 |
| `ens-verifiable-factory` | `test solidity` | 2 |
| `lidofinance-core` | `test mocha` | 2 |
| `lidofinance-dual-governance` | `test solidity` | 15 |
| `openzeppelin-contracts` | `test mocha` | 2 |
| `uniswap-v4-core` | `test solidity` | 9 |
| `uniswap-x` | `test solidity` | 2 |

`openzeppelin-contracts-hh2` is untouched — it is `"benchmark": { "skip": true }` and declares no commands.

## Notes for review

**Flag placement.** `verbosity` is a global option, and `parseGlobalOptions` scans the whole argv before the task is parsed, so appending `-vvv` after `--no-compile` (and after `lidofinance-dual-governance`'s `--grep`) resolves correctly.

**`ens-contracts` is the one exception.** It drives `bunx vitest run` rather than the Hardhat CLI, so a `-v` flag would land on vitest. It sets `HARDHAT_VERBOSITY=3`/`=4` instead, which `resolveGlobalOptions` reads on the programmatic HRE path when no CLI value is given. The entry names still read `-vvv`/`-vvvv` so report labels and `--benchmarks` globs stay uniform across scenarios.

**Selector behaviour is unchanged.** `plan.ts` anchors its globs fully, so `--benchmarks "test solidity"` still selects only the base entry; `"test *"` picks up all three.

## CI cost

The test portion of the suite goes from 1× to 3×, and each verbose run is individually slower than its base. The self-hosted job has `timeout-minutes: 180`. If it starts running long, we will need to do a new variance analysis to try to reduce the number of test runs.

## Testing

- [x] Test run in EDR using `hardhat-ref`: https://github.com/NomicFoundation/edr/actions/runs/33735178146
