### PR TITLE
Upgrade to EDR v0.20.0

### DIFF
--- a/.changeset/silent-balloons-send.md
+++ b/.changeset/silent-balloons-send.md
@@ -1,0 +1,5 @@
+---
+"hardhat": patch
+---
+
+Upgrade to EDR v0.20.0.

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -93,7 +93,7 @@
     "typescript": "~6.0.3"
   },
   "dependencies": {
-    "@nomicfoundation/edr": "0.19.0",
+    "@nomicfoundation/edr": "0.20.0",
     "@nomicfoundation/hardhat-errors": "workspace:^3.0.17",
     "@nomicfoundation/hardhat-utils": "workspace:^4.1.6",
     "@nomicfoundation/hardhat-vendored": "workspace:^3.0.4",

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -262,9 +262,14 @@ export function hardhatMiningIntervalToEdrMiningInterval(
       return BigInt(config);
     }
   } else {
+    // EDR requires both bounds of a range to be at least 1. A range means
+    // interval mining is enabled, so a bound of 0 can't be forwarded as the
+    // "disabled" value a scalar 0 stands for: 1ms is the nearest interval that
+    // keeps the user's intent. The bounds are otherwise left as they are, so
+    // EDR still reports a range whose minimum is above its maximum.
     return {
-      min: BigInt(config[0]),
-      max: BigInt(config[1]),
+      min: BigInt(Math.max(1, config[0])),
+      max: BigInt(Math.max(1, config[1])),
     };
   }
 }

--- a/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -262,11 +262,6 @@ export function hardhatMiningIntervalToEdrMiningInterval(
       return BigInt(config);
     }
   } else {
-    // EDR requires both bounds of a range to be at least 1. A range means
-    // interval mining is enabled, so a bound of 0 can't be forwarded as the
-    // "disabled" value a scalar 0 stands for: 1ms is the nearest interval that
-    // keeps the user's intent. The bounds are otherwise left as they are, so
-    // EDR still reports a range whose minimum is above its maximum.
     return {
       min: BigInt(Math.max(1, config[0])),
       max: BigInt(Math.max(1, config[1])),

--- a/packages/hardhat/src/internal/builtin-plugins/solidity-test/formatters.ts
+++ b/packages/hardhat/src/internal/builtin-plugins/solidity-test/formatters.ts
@@ -32,9 +32,21 @@ export function formatInlineConfigErrors(
         return `- ${sourceName}: ${formatInlineConfigSourceProblem(error.problem)}`;
       }
 
-      return `- ${sourceName}:${error.line}: ${error.contract}.${error.function}: ${formatInlineConfigDirectiveProblem(error.problem)}`;
+      return `- ${sourceName}:${error.line}: ${formatDirectiveOrigin(error.contract, error.function)}: ${formatInlineConfigDirectiveProblem(error.problem)}`;
     })
     .join("\n");
+}
+
+/**
+ * Names where a directive was found: `Contract.testFn` for a function-level
+ * directive, and just `Contract` for a contract-level one, which EDR reports
+ * without a function.
+ */
+function formatDirectiveOrigin(
+  contract: string,
+  functionName: string | undefined,
+): string {
+  return functionName === undefined ? contract : `${contract}.${functionName}`;
 }
 
 function formatInlineConfigDirectiveProblem(
@@ -65,6 +77,6 @@ function formatInlineConfigSourceProblem(
     case "InlineConfigSourceFileNotFound":
       return `the source file could not be read at "${problem.path}": ${problem.reason}`;
     case "InlineConfigDirectiveLocation":
-      return `a directive of ${problem.contract}.${problem.function} could not be located: ${problem.reason}`;
+      return `a directive of ${formatDirectiveOrigin(problem.contract, problem.function)} could not be located: ${problem.reason}`;
   }
 }

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -11,6 +11,7 @@ import {
 import {
   edrL1HardforkToHardhatL1HardforkName,
   hardhatHardforkToEdrSpecId,
+  hardhatMiningIntervalToEdrMiningInterval,
   resolveDefaultTransactionGasLimit,
 } from "../../../../../../src/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.js";
 import {
@@ -157,5 +158,40 @@ describe("Amsterdam L1 hardfork conversion round-trip", () => {
       edrL1HardforkToHardhatL1HardforkName(SpecId.Amsterdam),
       L1HardforkName.AMSTERDAM,
     );
+  });
+});
+
+describe("hardhatMiningIntervalToEdrMiningInterval", () => {
+  it("disables interval mining for a scalar 0", () => {
+    assert.equal(hardhatMiningIntervalToEdrMiningInterval(0), undefined);
+  });
+
+  it("converts a scalar interval to a bigint", () => {
+    assert.equal(hardhatMiningIntervalToEdrMiningInterval(5000), 5000n);
+  });
+
+  it("converts a range as it is", () => {
+    assert.deepEqual(hardhatMiningIntervalToEdrMiningInterval([1000, 5000]), {
+      min: 1000n,
+      max: 5000n,
+    });
+  });
+
+  // EDR rejects a range whose minimum is 0, so it has to be raised to 1 here.
+  // A range means interval mining is enabled, so 0 can't be passed through as
+  // the "disabled" value a scalar 0 stands for; 1ms is the nearest interval
+  // that keeps the user's intent.
+  it("raises a range minimum of 0 to 1", () => {
+    assert.deepEqual(hardhatMiningIntervalToEdrMiningInterval([0, 5000]), {
+      min: 1n,
+      max: 5000n,
+    });
+  });
+
+  it("raises both bounds of a [0, 0] range to 1", () => {
+    assert.deepEqual(hardhatMiningIntervalToEdrMiningInterval([0, 0]), {
+      min: 1n,
+      max: 1n,
+    });
   });
 });

--- a/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/network-manager/edr/utils/convert-to-edr.ts
@@ -177,10 +177,6 @@ describe("hardhatMiningIntervalToEdrMiningInterval", () => {
     });
   });
 
-  // EDR rejects a range whose minimum is 0, so it has to be raised to 1 here.
-  // A range means interval mining is enabled, so 0 can't be passed through as
-  // the "disabled" value a scalar 0 stands for; 1ms is the nearest interval
-  // that keeps the user's intent.
   it("raises a range minimum of 0 to 1", () => {
     assert.deepEqual(hardhatMiningIntervalToEdrMiningInterval([0, 5000]), {
       min: 1n,

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/formatters.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/formatters.ts
@@ -100,7 +100,7 @@ describe("formatInlineConfigErrors", () => {
     );
   });
 
-  it("names only the contract for an unlocatable contract-level directive", () => {
+  it("names only the contract for a contract-level directive that can't be located", () => {
     const formatted = formatInlineConfigErrors(
       [
         sourceError({

--- a/packages/hardhat/test/internal/builtin-plugins/solidity-test/formatters.ts
+++ b/packages/hardhat/test/internal/builtin-plugins/solidity-test/formatters.ts
@@ -26,6 +26,21 @@ function directiveError(
   };
 }
 
+function contractLevelDirectiveError(
+  problem: InlineConfigDirectiveProblem,
+): InlineConfigError {
+  return {
+    kind: "directive",
+    sourceName: SOURCE_NAME,
+    contract: "FooTest",
+    // A contract-level directive doesn't belong to any test function, so EDR
+    // leaves this undefined.
+    function: undefined,
+    line: 12,
+    problem,
+  };
+}
+
 function sourceError(problem: InlineConfigSourceProblem): InlineConfigError {
   return {
     kind: "source",
@@ -65,6 +80,42 @@ describe("formatInlineConfigErrors", () => {
     assert.equal(
       formatted,
       `- project/test/Foo.t.sol:12: FooTest.testFuzz: invalid key "nope"`,
+    );
+  });
+
+  it("names only the contract for a contract-level directive", () => {
+    const formatted = formatInlineConfigErrors(
+      [
+        contractLevelDirectiveError({
+          kind: "InlineConfigDuplicateKey",
+          key: "default.fuzz.runs",
+        }),
+      ],
+      sourceNameToUserSourceName,
+    );
+
+    assert.equal(
+      formatted,
+      `- test/Foo.t.sol:12: FooTest: duplicate key "default.fuzz.runs"`,
+    );
+  });
+
+  it("names only the contract for an unlocatable contract-level directive", () => {
+    const formatted = formatInlineConfigErrors(
+      [
+        sourceError({
+          kind: "InlineConfigDirectiveLocation",
+          contract: "FooTest",
+          function: undefined,
+          reason: "offset out of bounds",
+        }),
+      ],
+      sourceNameToUserSourceName,
+    );
+
+    assert.equal(
+      formatted,
+      "- test/Foo.t.sol: a directive of FooTest could not be located: offset out of bounds",
     );
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
   packages/hardhat:
     dependencies:
       '@nomicfoundation/edr':
-        specifier: 0.19.0
-        version: 0.19.0
+        specifier: 0.20.0
+        version: 0.20.0
       '@nomicfoundation/hardhat-errors':
         specifier: workspace:^3.0.17
         version: link:../hardhat-errors
@@ -3011,54 +3011,54 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nomicfoundation/edr-darwin-arm64@0.19.0':
-    resolution: {integrity: sha512-Yo2MkZoM85zkasUPJDj8l8QezPdrMzqQUJhp78TUQDq8FQXhdJTZ39k3Jax5OQ3hqjMhMkrGbctn9w9h6mEusg==}
+  '@nomicfoundation/edr-darwin-arm64@0.20.0':
+    resolution: {integrity: sha512-RmET+vMxXzKdAnaySms85Ec9U3F/LxwCLMkFT+6NAWqeTMzvuTJYMnaD1e33PZ2C4v9C1UPOT+s+FbEpv4h3ZQ==}
     engines: {node: '>= 22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@nomicfoundation/edr-darwin-x64@0.19.0':
-    resolution: {integrity: sha512-RC7RVX1iATg9SlJTnKD57A8jRBIBiUKmAdi8maBN4zhmK5Z7aAeiwdQX6VjPOum3c2Mdpp2Q7JfooJxxF6bCvw==}
+  '@nomicfoundation/edr-darwin-x64@0.20.0':
+    resolution: {integrity: sha512-2M5i8EpsXKRKdeVRHVfsjke/m9x4kG7+eK7II4V/Cjof9an76vpMNNvx/VoIkuk6Ttytm1xXUUv0OaVwnYV7rg==}
     engines: {node: '>= 22'}
     cpu: [x64]
     os: [darwin]
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.19.0':
-    resolution: {integrity: sha512-vhEKPUomGwM0Lsjpwd5q/Jc6yE2hpspJBCRYFkCghzCmwgZHtoYn/2nd1nOLsTt7jqMlvAKJSaLCrhz1HCTCTA==}
+  '@nomicfoundation/edr-linux-arm64-gnu@0.20.0':
+    resolution: {integrity: sha512-Wz9sBmQEcrM1D1IX68f4ktTsWJiN2FLcc1WFWifbLT06yaF/GEOn1Kg54VZ1IGoV2Fndm1pJEs/4SUQnJ4Wmdw==}
     engines: {node: '>= 22'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.19.0':
-    resolution: {integrity: sha512-mlkpVUolkSpMIriZyiJeTbgx/m4Ngm9lQtah2BG92H+dgtwMIMze6Q6OQfZG6oi6wMrhDgu8WEyAy3XgIwlcRg==}
+  '@nomicfoundation/edr-linux-arm64-musl@0.20.0':
+    resolution: {integrity: sha512-J4KK55Kk0r+bXwO1SqxbMg3Nkhg7+7ezKgI/SPTjn2EALF8jGuMYvRt9oWe8lz49sraEex7k9GGqicSTe8w1gA==}
     engines: {node: '>= 22'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.19.0':
-    resolution: {integrity: sha512-d0Z+WVbX5mm6s9ozc5TXrCRjQykdN81tGI+eaM4hQcD/S5VSY9rwKuCXyLJ/GkgeI5S8HEHsyVdXEsDJznPyhA==}
+  '@nomicfoundation/edr-linux-x64-gnu@0.20.0':
+    resolution: {integrity: sha512-hlzg26kOHCH7Wg+MIie/maoF6qPr2imrnuQ+N4Spy5miRLgza8nip12GdMunwCvf2Zp1wn8bf2dcp7RGUX0jkw==}
     engines: {node: '>= 22'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@nomicfoundation/edr-linux-x64-musl@0.19.0':
-    resolution: {integrity: sha512-UIrlNqYj9lbUXpBy++WwHeC0xZqyFw9TXy06/8+0PLffI7Si4kiTKfXqdITGQhP6Vf/JuJ8y+jos8oy6bL8jFQ==}
+  '@nomicfoundation/edr-linux-x64-musl@0.20.0':
+    resolution: {integrity: sha512-n1wS0SoKuqvuUbL7HakmSWZx8aSBRuPW3wtC4ly6I0FCCB4xXNEf7bj1KLGNbayWL7ZG3BJIARHUMO8hy7efzQ==}
     engines: {node: '>= 22'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.19.0':
-    resolution: {integrity: sha512-pIyEJBiS8l09Yndz+aE/JmkD39FCqtyiRO+wlx6tX426o4290acRfJ0r7GwTBmqqZD5G4pLOOB0uLIMRyDrY+g==}
+  '@nomicfoundation/edr-win32-x64-msvc@0.20.0':
+    resolution: {integrity: sha512-+E2srJzdeZ2Ro0siU5NqbptzJVSj5Pk79uGj39o5MgJMn5mcPONs3E6w/1SBtB/fmFlD8PPxnL9hN+jlcv1Naw==}
     engines: {node: '>= 22'}
     cpu: [x64]
     os: [win32]
 
-  '@nomicfoundation/edr@0.19.0':
-    resolution: {integrity: sha512-wzuyAylm4XWIahFjy1pFDQfHny4Xsx73T98d8KJAkGG/Rpgp0M36rqS4lzjbGQ1tXDrWEBG0WRr0v1jrQhQ0xg==}
+  '@nomicfoundation/edr@0.20.0':
+    resolution: {integrity: sha512-pjqWjQBWtNZRnDcs05YipQCVQehze3Ap5R/QfDHC8RBUU7ufYW1zluJLxuZZQjdO8jfCaRTkSNUvRWVTnq/EKw==}
     engines: {node: '>= 22'}
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
@@ -8871,36 +8871,36 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nomicfoundation/edr-darwin-arm64@0.19.0':
+  '@nomicfoundation/edr-darwin-arm64@0.20.0':
     optional: true
 
-  '@nomicfoundation/edr-darwin-x64@0.19.0':
+  '@nomicfoundation/edr-darwin-x64@0.20.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-arm64-gnu@0.19.0':
+  '@nomicfoundation/edr-linux-arm64-gnu@0.20.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-arm64-musl@0.19.0':
+  '@nomicfoundation/edr-linux-arm64-musl@0.20.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-x64-gnu@0.19.0':
+  '@nomicfoundation/edr-linux-x64-gnu@0.20.0':
     optional: true
 
-  '@nomicfoundation/edr-linux-x64-musl@0.19.0':
+  '@nomicfoundation/edr-linux-x64-musl@0.20.0':
     optional: true
 
-  '@nomicfoundation/edr-win32-x64-msvc@0.19.0':
+  '@nomicfoundation/edr-win32-x64-msvc@0.20.0':
     optional: true
 
-  '@nomicfoundation/edr@0.19.0':
+  '@nomicfoundation/edr@0.20.0':
     optionalDependencies:
-      '@nomicfoundation/edr-darwin-arm64': 0.19.0
-      '@nomicfoundation/edr-darwin-x64': 0.19.0
-      '@nomicfoundation/edr-linux-arm64-gnu': 0.19.0
-      '@nomicfoundation/edr-linux-arm64-musl': 0.19.0
-      '@nomicfoundation/edr-linux-x64-gnu': 0.19.0
-      '@nomicfoundation/edr-linux-x64-musl': 0.19.0
-      '@nomicfoundation/edr-win32-x64-msvc': 0.19.0
+      '@nomicfoundation/edr-darwin-arm64': 0.20.0
+      '@nomicfoundation/edr-darwin-x64': 0.20.0
+      '@nomicfoundation/edr-linux-arm64-gnu': 0.20.0
+      '@nomicfoundation/edr-linux-arm64-musl': 0.20.0
+      '@nomicfoundation/edr-linux-x64-gnu': 0.20.0
+      '@nomicfoundation/edr-linux-x64-musl': 0.20.0
+      '@nomicfoundation/edr-win32-x64-msvc': 0.20.0
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2':
     optional: true


### PR DESCRIPTION
# Upgrade EDR to v0.20.0

Bumps `@nomicfoundation/edr` `0.19.0` → `0.20.0` and fixes the two breakages it causes.

Release: [edr-0.20.0 (#1670)](https://github.com/NomicFoundation/edr/pull/1670) · [changelog](https://github.com/NomicFoundation/edr/blob/868c866c6d7cdf709761f56babdea01b79102416/crates/edr_napi/CHANGELOG.md)

## 1. `mining.interval: [0, N]` crashes on connect

[edr#1686](https://github.com/NomicFoundation/edr/pull/1686) (BREAKING): ranges now require `1 <= min <= max`. `[0, N]` and `[0, 0]` are rejected when the provider is created — "a zero minimum inside a range must be normalised by the caller".

**Fix:** clamp both bounds to `>= 1` in `hardhatMiningIntervalToEdrMiningInterval`. Clamping, not rejecting: an error could only say "change 0 to 1". Both bounds, because `[0, 0]` → `{min: 1, max: 0}` would trip EDR's min>max check.

## 2. Contract-level inline config errors print `undefined`

[edr#1627](https://github.com/NomicFoundation/edr/pull/1627) added `forge-config` directives above a *contract* instead of above a test function. Those have no function name, so `function` on `InlineConfigDirectiveError` and `InlineConfigDirectiveLocation` went from `string` to `string | undefined`.

We printed that field straight into the message. Given:

```solidity
/// forge-config: default.fuzz.runs = not-a-number
contract FooTest {
```

before:

```
- test/Foo.t.sol:4: FooTest.undefined: invalid value "not-a-number" for key "default.fuzz.runs"
```

after:

```
- test/Foo.t.sol:4: FooTest: invalid value "not-a-number" for key "default.fuzz.runs"
```

**Fix:** new `formatDirectiveOrigin(contract, function)` used at both print sites — `Contract.testFn` when the function is known, `Contract` when it isn't.