### PR TITLE
feat: expose native secp256k1 public key derivation

### DIFF
--- a/.changeset/native-secp256k1-in-hardhat-ethers.md
+++ b/.changeset/native-secp256k1-in-hardhat-ethers.md
@@ -1,0 +1,6 @@
+---
+"@nomicfoundation/hardhat-ethers": minor
+"hardhat": minor
+---
+
+Made ethers derive secp256k1 public keys with EDR's native implementation instead of its pure-JS one, speeding up `new Wallet(secretKey)`, `Wallet.createRandom()`, HD wallet derivation and `computeAddress`. It falls back to ethers' own implementation when the native one isn't available, or when a version of ethers no longer derives keys through the replaced method.

--- a/packages/hardhat-ethers/README.md
+++ b/packages/hardhat-ethers/README.md
@@ -293,3 +293,15 @@ function getContractAtFromArtifact(
   signer?: ethers.Signer,
 ): Promise<ethers.Contract>;
 ```
+
+## Native secp256k1 public key derivation
+
+Deriving a public key from a secret key is the slowest cryptographic primitive ethers implements in JavaScript, and it runs whenever a wallet is created: `new Wallet(secretKey)`, `Wallet.createRandom()`, `computeAddress` and every node of an HD wallet derivation.
+
+When you connect to a network, this plugin replaces ethers' derivation with EDR's native one. The results are identical, invalid secret keys are still reported by ethers, and only the speed differs. If the native implementation isn't available (e.g. due to an unsupported platform or an EDR version that predates it), ethers keeps using its own and nothing else changes.
+
+A few limitations are worth knowing about:
+
+- ethers offers hooks to register alternative implementations of its hash functions, but none for this, so the plugin overwrites `SigningKey.computePublicKey`, which isn't part of its public API. A future version of ethers could derive keys some other way, which would leave the results correct but silently undo the speedup. To avoid that going unnoticed, the plugin derives a known secret key right after installing the replacement, and checks both that the values are right and that ethers actually used it. If either check fails, ethers' own implementation is restored, and the reason is reported under the `hardhat:ethers:native-secp256k1` debug scope.
+- The replacement reaches the ethers module instance that this plugin resolves: the ESM build of the copy it imports. Code that resolves a **separate** copy, or that `require`s ethers, which loads its distinct CommonJS build even from the same copy, keeps using the JavaScript implementation. Using `ethers` from the network connection avoids this.
+- Only the derivation of a public key from a secret key is replaced. Converting a public key between its compressed and uncompressed encodings, and recovering one from a signature, still run in JavaScript.

--- a/packages/hardhat-ethers/src/internal/initialization.ts
+++ b/packages/hardhat-ethers/src/internal/initialization.ts
@@ -7,6 +7,7 @@ import * as ethers from "ethers";
 
 import { HardhatEthersProvider } from "./hardhat-ethers-provider/hardhat-ethers-provider.js";
 import { HardhatHelpers } from "./hardhat-helpers/hardhat-helpers.js";
+import { installNativeSecp256k1 } from "./native-secp256k1.js";
 
 export async function initializeEthers(
   ethereumProvider: EthereumProvider,
@@ -14,6 +15,8 @@ export async function initializeEthers(
   networkConfig: NetworkConfig,
   artifactManager: ArtifactManager,
 ): Promise<HardhatEthers> {
+  await installNativeSecp256k1();
+
   const provider = new HardhatEthersProvider(
     ethereumProvider,
     networkName,

--- a/packages/hardhat-ethers/src/internal/native-secp256k1.ts
+++ b/packages/hardhat-ethers/src/internal/native-secp256k1.ts
@@ -1,0 +1,181 @@
+import type { BytesLike } from "ethers";
+
+import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
+import { computeAddress, getBytes, hexlify, SigningKey } from "ethers";
+
+const log = createDebug("hardhat:ethers:native-secp256k1");
+
+/**
+ * A known secret key and the values ethers must derive from it, used to
+ * validate the replacement before keeping it.
+ */
+const SELF_CHECK_SECRET_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const SELF_CHECK_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+const SELF_CHECK_COMPRESSED_PUBLIC_KEY =
+  "0x038318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed75";
+
+const SECRET_KEY_LENGTH = 32;
+const UNCOMPRESSED_PUBLIC_KEY_LENGTH = 65;
+
+let installationPromise: Promise<void> | undefined;
+let nativeCallCount = 0;
+
+/**
+ * How many times the native derivation has been used. Only meant for tests
+ * asserting that ethers still routes through it.
+ */
+export function getNativeSecp256k1CallCount(): number {
+  return nativeCallCount;
+}
+
+/**
+ * Replaces ethers' pure-JS secp256k1 public key derivation with EDR's native
+ * one, which is several times faster. Every derivation ethers performs routes
+ * through `SigningKey.computePublicKey`, so this covers `new Wallet(secretKey)`,
+ * `Wallet.createRandom()`, HD wallet derivation and `computeAddress`.
+ *
+ * ethers has hooks to register alternative implementations of its hash
+ * functions, but none for this, so the static method is overwritten instead.
+ * That isn't part of ethers' public API: a future
+ * version could stop routing through it, which wouldn't produce wrong results
+ * but would silently undo this optimization. To detect that, the replacement is
+ * validated against a known secret key before being kept, checking both that
+ * the derived values are correct and that ethers actually called it. If either
+ * fails, ethers' own implementation is restored.
+ *
+ * The replacement is per-module-instance, so this only affects the ethers
+ * instance that this plugin resolves; code that resolves another one keeps
+ * using the JS implementation.
+ *
+ * If the native implementation isn't available, this leaves ethers as it is,
+ * reporting it only under DEBUG.
+ */
+export async function installNativeSecp256k1(): Promise<void> {
+  installationPromise ??= loadAndInstallNativeSecp256k1();
+  return await installationPromise;
+}
+
+async function loadAndInstallNativeSecp256k1(): Promise<void> {
+  try {
+    const { getNativeSecp256k1PublicKeyFromSecretKey } =
+      await import("hardhat/internal/edr");
+
+    const nativePublicKeyFromSecretKey =
+      await getNativeSecp256k1PublicKeyFromSecretKey();
+
+    if (nativePublicKeyFromSecretKey === undefined) {
+      log(
+        "EDR's native secp256k1 derivation isn't available; keeping ethers' JS one",
+      );
+      return;
+    }
+
+    const jsComputePublicKey = SigningKey.computePublicKey;
+
+    SigningKey.computePublicKey = function (
+      key: BytesLike,
+      compressed?: boolean,
+    ): string {
+      const bytes = getBytes(key, "key");
+
+      // Only secret keys are derived natively. The other inputs ethers accepts
+      // are public keys being converted between encodings, which is cheap and
+      // has more involved semantics, so they are left to ethers.
+      if (bytes.length !== SECRET_KEY_LENGTH) {
+        return jsComputePublicKey(key, compressed);
+      }
+
+      let publicKey;
+      try {
+        publicKey = nativePublicKeyFromSecretKey(bytes);
+      } catch (error) {
+        // Invalid secret keys end up here, and ethers' implementation is the
+        // reference for how they must be reported, so it produces the error.
+        // Anything else that could go wrong is also better served by falling
+        // back than by failing.
+        log("EDR's native secp256k1 derivation failed: %O", error);
+        return jsComputePublicKey(key, compressed);
+      }
+
+      nativeCallCount++;
+
+      // ethers defaults this path to the uncompressed encoding.
+      if (compressed !== true) {
+        return hexlify(publicKey);
+      }
+
+      return hexlify(compressPublicKey(publicKey));
+    };
+
+    if (!selfCheckPasses()) {
+      SigningKey.computePublicKey = jsComputePublicKey;
+      return;
+    }
+
+    log("Installed EDR's native secp256k1 derivation into ethers");
+  } catch (error) {
+    // Swallowed to avoid breaking users if it's missing.
+    log("Failed to install EDR's native secp256k1 derivation: %O", error);
+  }
+}
+
+/**
+ * Turns an uncompressed public key (`0x04 || X || Y`) into its compressed
+ * encoding: X, prefixed by the parity of Y.
+ */
+function compressPublicKey(publicKey: Uint8Array): Uint8Array {
+  const compressed = new Uint8Array(33);
+
+  /* eslint-disable-next-line no-bitwise -- the SEC1 prefix encodes the parity
+  of the last byte of Y */
+  compressed[0] = 0x02 | (publicKey[UNCOMPRESSED_PUBLIC_KEY_LENGTH - 1] & 1);
+  compressed.set(publicKey.subarray(1, 33), 1);
+
+  return compressed;
+}
+
+/**
+ * Asks ethers to derive a known secret key and returns whether the results are
+ * correct *and* were produced by the native implementation. A future version of
+ * ethers that stops calling `SigningKey.computePublicKey` internally would
+ * still return the right values, so correctness alone isn't enough.
+ */
+function selfCheckPasses(): boolean {
+  const callCountBefore = nativeCallCount;
+
+  let address;
+  let compressedPublicKey;
+  try {
+    // Exercises the uncompressed encoding, which `computeAddress` hashes, and
+    // the compressed one, through the getter that HD wallets use.
+    address = computeAddress(SELF_CHECK_SECRET_KEY);
+    compressedPublicKey = new SigningKey(SELF_CHECK_SECRET_KEY)
+      .compressedPublicKey;
+  } catch (error) {
+    log("Self-check of the native secp256k1 derivation threw: %O", error);
+    return false;
+  }
+
+  if (
+    address !== SELF_CHECK_ADDRESS ||
+    compressedPublicKey !== SELF_CHECK_COMPRESSED_PUBLIC_KEY
+  ) {
+    log(
+      "The native secp256k1 derivation returned unexpected values; restoring ethers' JS one",
+    );
+    return false;
+  }
+
+  // One derivation each, so a version of ethers that computes either of them
+  // some other way is caught, not just one that stops calling the method
+  // altogether.
+  if (nativeCallCount - callCountBefore < 2) {
+    log(
+      "This version of ethers doesn't derive public keys through SigningKey.computePublicKey; restoring its JS one",
+    );
+    return false;
+  }
+
+  return true;
+}

--- a/packages/hardhat-ethers/test/helpers/hide-edr-loader-hooks.mjs
+++ b/packages/hardhat-ethers/test/helpers/hide-edr-loader-hooks.mjs
@@ -1,0 +1,10 @@
+// Makes EDR fail to load, to simulate an installation where it isn't present.
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier !== "@nomicfoundation/edr") {
+    return nextResolve(specifier, context);
+  }
+
+  const error = new Error(`Cannot find package '${specifier}'`);
+  error.code = "ERR_MODULE_NOT_FOUND";
+  throw error;
+}

--- a/packages/hardhat-ethers/test/helpers/native-secp256k1-child.mjs
+++ b/packages/hardhat-ethers/test/helpers/native-secp256k1-child.mjs
@@ -1,0 +1,43 @@
+// Installs the native secp256k1 derivation under the scenario named in argv[2],
+// then prints the address ethers derives for a known secret key and whether the
+// native implementation ended up being used, so the parent can check that
+// ethers keeps working either way.
+import { register } from "node:module";
+
+const SECRET_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+const scenario = process.argv[2];
+
+if (scenario === "edr-missing") {
+  register(new URL("./hide-edr-loader-hooks.mjs", import.meta.url));
+}
+
+const ethers = await import("ethers");
+
+if (scenario === "ethers-drifted") {
+  // Simulates a future ethers that computes the compressed public key without
+  // going through SigningKey.computePublicKey: the values it returns are still
+  // correct, so only a check that the method was called can catch it.
+  const { compressedPublicKey } = new ethers.SigningKey(SECRET_KEY);
+  Object.defineProperty(ethers.SigningKey.prototype, "compressedPublicKey", {
+    get: () => compressedPublicKey,
+    configurable: true,
+  });
+}
+
+// The `.ts` path is used so the test doesn't need the package to be built.
+const { installNativeSecp256k1, getNativeSecp256k1CallCount } =
+  await import("../../src/internal/native-secp256k1.ts");
+
+await installNativeSecp256k1();
+
+const callCountBefore = getNativeSecp256k1CallCount();
+const address = new ethers.Wallet(SECRET_KEY).address;
+
+console.log(
+  JSON.stringify({
+    address,
+    native: getNativeSecp256k1CallCount() > callCountBefore,
+  }),
+);

--- a/packages/hardhat-ethers/test/native-secp256k1-degraded.ts
+++ b/packages/hardhat-ethers/test/native-secp256k1-degraded.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const CHILD_PATH = fileURLToPath(
+  new URL("./helpers/native-secp256k1-child.mjs", import.meta.url),
+);
+
+const ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+// Each scenario needs a new process: the installation is memoized, and EDR can
+// only be hidden from a process that hasn't loaded it.
+async function deriveUnder(
+  scenario: string,
+): Promise<{ address: string; native: boolean }> {
+  const { stdout } = await execFileAsync(process.execPath, [
+    "--import",
+    "tsx/esm",
+    CHILD_PATH,
+    scenario,
+  ]);
+
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+  the child prints exactly this shape */
+  return JSON.parse(stdout.trim()) as { address: string; native: boolean };
+}
+
+describe("native secp256k1 installation when it can't be used", () => {
+  it("should leave ethers working when EDR isn't installed", async () => {
+    assert.deepEqual(await deriveUnder("edr-missing"), {
+      address: ADDRESS,
+      native: false,
+    });
+  });
+
+  it("should restore ethers' implementation when it stops using the replaced method", async () => {
+    assert.deepEqual(await deriveUnder("ethers-drifted"), {
+      address: ADDRESS,
+      native: false,
+    });
+  });
+
+  it("should use the native implementation when nothing is in the way", async () => {
+    assert.deepEqual(await deriveUnder("installed"), {
+      address: ADDRESS,
+      native: true,
+    });
+  });
+});

--- a/packages/hardhat-ethers/test/native-secp256k1-initialization.ts
+++ b/packages/hardhat-ethers/test/native-secp256k1-initialization.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+
+import * as ethers from "ethers";
+import { createHardhatRuntimeEnvironment } from "hardhat/hre";
+import { getNativeSecp256k1PublicKeyFromSecretKey } from "hardhat/internal/edr";
+
+import hardhatEthersPlugin from "../src/index.js";
+import { getNativeSecp256k1CallCount } from "../src/internal/native-secp256k1.js";
+
+const SECRET_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+describe("native secp256k1 installation from a network connection", () => {
+  before(async () => {
+    assert.ok(
+      (await getNativeSecp256k1PublicKeyFromSecretKey()) !== undefined,
+      "EDR's native secp256k1 derivation should be available on the platforms that run this suite",
+    );
+
+    const hre = await createHardhatRuntimeEnvironment({
+      plugins: [hardhatEthersPlugin],
+    });
+
+    await hre.network.create();
+  });
+
+  it("should have replaced ethers' implementation", () => {
+    const callCountBefore = getNativeSecp256k1CallCount();
+
+    new ethers.Wallet(SECRET_KEY);
+
+    assert.ok(
+      getNativeSecp256k1CallCount() > callCountBefore,
+      "creating a connection should have installed the native derivation",
+    );
+  });
+});

--- a/packages/hardhat-ethers/test/native-secp256k1.ts
+++ b/packages/hardhat-ethers/test/native-secp256k1.ts
@@ -1,0 +1,210 @@
+import type { Secp256k1PublicKeyFromSecretKey } from "hardhat/internal/edr";
+
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { describe, it, before } from "node:test";
+
+import { assertThrows } from "@nomicfoundation/hardhat-test-utils";
+import * as ethers from "ethers";
+import { getNativeSecp256k1PublicKeyFromSecretKey } from "hardhat/internal/edr";
+
+import {
+  getNativeSecp256k1CallCount,
+  installNativeSecp256k1,
+} from "../src/internal/native-secp256k1.js";
+
+const SECRET_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+// The mnemonic from the BIP-39 test vectors.
+const MNEMONIC =
+  "legal winner thank year wave sausage worth useful legal winner thank yellow";
+
+describe("native secp256k1 installation", () => {
+  let nativePublicKeyFromSecretKey: Secp256k1PublicKeyFromSecretKey;
+
+  before(async () => {
+    const maybeNative = await getNativeSecp256k1PublicKeyFromSecretKey();
+    assert.ok(
+      maybeNative !== undefined,
+      "EDR's native secp256k1 derivation should be available on the platforms that run this suite",
+    );
+    nativePublicKeyFromSecretKey = maybeNative;
+
+    await installNativeSecp256k1();
+  });
+
+  it("should derive public keys through the native implementation", () => {
+    const callCountBefore = getNativeSecp256k1CallCount();
+
+    new ethers.Wallet(SECRET_KEY);
+
+    assert.ok(
+      getNativeSecp256k1CallCount() > callCountBefore,
+      "ethers should route public key derivation through the native implementation",
+    );
+  });
+
+  it("should agree with EDR on both encodings", () => {
+    const signingKey = new ethers.SigningKey(SECRET_KEY);
+    const publicKey = nativePublicKeyFromSecretKey(ethers.getBytes(SECRET_KEY));
+
+    assert.equal(signingKey.publicKey, ethers.hexlify(publicKey));
+
+    /* eslint-disable-next-line no-bitwise -- the SEC1 prefix encodes the parity
+    of the last byte of Y */
+    const parityPrefix = 0x02 | (publicKey[64] & 1);
+    assert.equal(
+      signingKey.compressedPublicKey,
+      ethers.hexlify(
+        ethers.concat([
+          new Uint8Array([parityPrefix]),
+          publicKey.subarray(1, 33),
+        ]),
+      ),
+    );
+  });
+
+  it("should derive the well-known address of a known secret key", () => {
+    assert.equal(ethers.computeAddress(SECRET_KEY), ADDRESS);
+    assert.equal(new ethers.Wallet(SECRET_KEY).address, ADDRESS);
+  });
+
+  it("should derive the same values as ethers for random secret keys", () => {
+    for (let i = 0; i < 256; i++) {
+      const secretKey = randomBytes(32);
+
+      let signingKey;
+      try {
+        signingKey = new ethers.SigningKey(secretKey);
+      } catch {
+        continue; // outside [1, n), which the loop below covers explicitly
+      }
+
+      const publicKey = nativePublicKeyFromSecretKey(secretKey);
+
+      assert.equal(signingKey.publicKey, ethers.hexlify(publicKey));
+      assert.equal(
+        ethers.computeAddress(signingKey.publicKey),
+        ethers.computeAddress(ethers.hexlify(secretKey)),
+      );
+    }
+  });
+
+  it("should keep rejecting secret keys outside the curve order", () => {
+    // The curve order itself, and the values right around the ends of the
+    // valid range.
+    for (const secretKey of [
+      `0x${"00".repeat(32)}`,
+      "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+      "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+      `0x${"ff".repeat(32)}`,
+    ]) {
+      assertThrows(
+        () => ethers.SigningKey.computePublicKey(secretKey),
+        undefined,
+        `${secretKey} should be rejected`,
+      );
+    }
+
+    // The ends of the valid range, which must keep working.
+    ethers.SigningKey.computePublicKey(`0x${"00".repeat(31)}01`);
+    ethers.SigningKey.computePublicKey(
+      "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+    );
+  });
+
+  it("should keep reporting non-byte-like input as an invalid argument", () => {
+    assertThrows(
+      () => ethers.SigningKey.computePublicKey("not a hex string"),
+      (error) =>
+        error instanceof TypeError &&
+        "code" in error &&
+        error.code === "INVALID_ARGUMENT",
+      "ethers should reject it as an invalid argument",
+    );
+  });
+
+  it("should leave the public key re-encoding paths to ethers", () => {
+    const signingKey = new ethers.SigningKey(SECRET_KEY);
+    const { publicKey, compressedPublicKey } = signingKey;
+
+    // Compressing and expanding an existing public key, in every shape ethers
+    // accepts: uncompressed, compressed, and without the 0x04 header.
+    assert.equal(
+      ethers.SigningKey.computePublicKey(publicKey, true),
+      compressedPublicKey,
+    );
+    assert.equal(
+      ethers.SigningKey.computePublicKey(compressedPublicKey, false),
+      publicKey,
+    );
+    assert.equal(
+      ethers.SigningKey.computePublicKey(`0x${publicKey.slice(4)}`, true),
+      compressedPublicKey,
+    );
+
+    // ethers defaults these paths to the compressed encoding, unlike the
+    // secret key one.
+    assert.equal(
+      ethers.SigningKey.computePublicKey(publicKey),
+      compressedPublicKey,
+    );
+  });
+
+  it("should keep the operations built on top of the replaced method working", () => {
+    const signingKey = new ethers.SigningKey(SECRET_KEY);
+    const other = new ethers.SigningKey(`0x${"11".repeat(32)}`);
+
+    assert.equal(
+      ethers.SigningKey.addPoints(signingKey.publicKey, other.publicKey, true)
+        .length,
+      68,
+    );
+
+    assert.equal(
+      signingKey.computeSharedSecret(other.publicKey),
+      other.computeSharedSecret(signingKey.publicKey),
+    );
+
+    const digest = ethers.id("a message to sign");
+    assert.equal(
+      ethers.SigningKey.recoverPublicKey(digest, signingKey.sign(digest)),
+      signingKey.publicKey,
+    );
+  });
+
+  it("should derive HD wallets identically", () => {
+    const wallet = ethers.HDNodeWallet.fromPhrase(MNEMONIC);
+
+    // The address of m/44'/60'/0'/0/0 for this mnemonic.
+    assert.equal(wallet.address, "0x58A57ed9d8d624cBD12e2C467D34787555bB1b25");
+
+    for (let index = 0; index < 4; index++) {
+      const derived = ethers.HDNodeWallet.fromPhrase(
+        MNEMONIC,
+        "",
+        `m/44'/60'/0'/0/${index}`,
+      );
+
+      assert.equal(
+        derived.address,
+        new ethers.Wallet(derived.privateKey).address,
+        `account ${index} should derive the same address from its secret key`,
+      );
+    }
+  });
+
+  it("should not install again on later calls", async () => {
+    const computePublicKey = ethers.SigningKey.computePublicKey;
+
+    await installNativeSecp256k1();
+
+    assert.equal(
+      ethers.SigningKey.computePublicKey,
+      computePublicKey,
+      "a repeated call shouldn't replace the method again",
+    );
+  });
+});

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -38,6 +38,7 @@
     "./types/solidity": "./dist/src/types/solidity.js",
     "./console.sol": "./console.sol",
     "./internal/coverage": "./dist/src/internal/builtin-plugins/coverage/exports.js",
+    "./internal/edr": "./dist/src/internal/edr/exports.js",
     "./internal/gas-analytics": "./dist/src/internal/builtin-plugins/gas-analytics/exports.js",
     "./internal/solidity": "./dist/src/internal/builtin-plugins/solidity/exports.js",
     "./utils/contract-names": "./dist/src/utils/contract-names.js",

--- a/packages/hardhat/src/internal/edr/exports.ts
+++ b/packages/hardhat/src/internal/edr/exports.ts
@@ -1,0 +1,2 @@
+export { getNativeSecp256k1PublicKeyFromSecretKey } from "./secp256k1.js";
+export type { Secp256k1PublicKeyFromSecretKey } from "./secp256k1.js";

--- a/packages/hardhat/src/internal/edr/secp256k1.ts
+++ b/packages/hardhat/src/internal/edr/secp256k1.ts
@@ -1,0 +1,64 @@
+import { createDebug } from "@nomicfoundation/hardhat-utils/debug";
+
+const log = createDebug("hardhat:core:edr:secp256k1");
+
+/**
+ * A secp256k1 public key derivation: takes a 32-byte secret key, returns the
+ * 65-byte uncompressed public key (`0x04 || X || Y`).
+ *
+ * Throws if the secret key isn't a valid scalar in `[1, n)`.
+ */
+export type Secp256k1PublicKeyFromSecretKey = (
+  secretKey: Uint8Array,
+) => Uint8Array;
+
+let publicKeyFromSecretKeyPromise:
+  Promise<Secp256k1PublicKeyFromSecretKey | undefined> | undefined;
+
+/**
+ * Returns EDR's native secp256k1 public key derivation, or `undefined` if it
+ * isn't available in this installation.
+ *
+ * It is meant to be used to replace pure-JS implementations, which are
+ * significantly slower. Callers must handle `undefined` by keeping the JS
+ * implementation they would otherwise use.
+ *
+ * The result is cached for the lifetime of the process, including the
+ * `undefined` of a failed load: EDR's availability can't change while the
+ * process is running, so a failure is never retried.
+ */
+export async function getNativeSecp256k1PublicKeyFromSecretKey(): Promise<
+  Secp256k1PublicKeyFromSecretKey | undefined
+> {
+  publicKeyFromSecretKeyPromise ??= loadNativePublicKeyFromSecretKey();
+  return await publicKeyFromSecretKeyPromise;
+}
+
+async function loadNativePublicKeyFromSecretKey(): Promise<
+  Secp256k1PublicKeyFromSecretKey | undefined
+> {
+  try {
+    const edr = await import("@nomicfoundation/edr");
+
+    /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions --
+    EDR versions older than the one that introduced the native secp256k1
+    derivation don't declare it, so destructuring it directly wouldn't compile
+    against them. The check below validates the assertion at runtime. */
+    const { secp256k1PublicKeyFromSecretKey } = edr as {
+      secp256k1PublicKeyFromSecretKey?: Secp256k1PublicKeyFromSecretKey;
+    };
+
+    if (typeof secp256k1PublicKeyFromSecretKey !== "function") {
+      log(
+        "This version of EDR doesn't export a native secp256k1 public key derivation",
+      );
+      return undefined;
+    }
+
+    return secp256k1PublicKeyFromSecretKey;
+  } catch (error) {
+    // Swallowed to avoid breaking users if it's missing.
+    log("Failed to load EDR's native secp256k1 derivation: %O", error);
+    return undefined;
+  }
+}

--- a/packages/hardhat/test/internal/edr/edr-unavailable-loader-hooks.mjs
+++ b/packages/hardhat/test/internal/edr/edr-unavailable-loader-hooks.mjs
@@ -1,0 +1,29 @@
+// Makes EDR fail to load, to simulate the installations where it does:
+// `missing` as if it weren't installed, `not-callable` as if it were too old
+// to have the native implementations.
+const EDR_SPECIFIER = "@nomicfoundation/edr";
+
+const EDR_WITHOUT_CALLABLE_NATIVES =
+  "data:text/javascript,export const secp256k1PublicKeyFromSecretKey = 'not a function';";
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier !== EDR_SPECIFIER) {
+    return nextResolve(specifier, context);
+  }
+
+  const scenario = new URL(context.parentURL ?? "file:///").searchParams.get(
+    "edr",
+  );
+
+  if (scenario === "missing") {
+    const error = new Error(`Cannot find package '${specifier}'`);
+    error.code = "ERR_MODULE_NOT_FOUND";
+    throw error;
+  }
+
+  if (scenario === "not-callable") {
+    return { url: EDR_WITHOUT_CALLABLE_NATIVES, shortCircuit: true };
+  }
+
+  return nextResolve(specifier, context);
+}

--- a/packages/hardhat/test/internal/edr/secp256k1-unavailable.ts
+++ b/packages/hardhat/test/internal/edr/secp256k1-unavailable.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import { describe, it } from "node:test";
+
+register(new URL("./edr-unavailable-loader-hooks.mjs", import.meta.url));
+
+const SECP256K1_MODULE_URL = new URL(
+  "../../../src/internal/edr/secp256k1.ts",
+  import.meta.url,
+).href;
+
+// `?edr=<scenario>` tells the loader hooks how to break the EDR import, and
+// makes node load a new copy of secp256k1.ts so its cached result is not
+// reused.
+async function getNativeSecp256k1PublicKeyFromSecretKeyUnder(scenario: string) {
+  const { getNativeSecp256k1PublicKeyFromSecretKey } = await import(
+    `${SECP256K1_MODULE_URL}?edr=${scenario}`
+  );
+
+  return getNativeSecp256k1PublicKeyFromSecretKey();
+}
+
+/**
+ * Loading EDR's native secp256k1 derivation must never take Hardhat down, so
+ * these check that every way it can be unavailable comes back as `undefined`.
+ */
+describe("getNativeSecp256k1PublicKeyFromSecretKey when EDR's native secp256k1 derivation is unavailable", () => {
+  it("should resolve to undefined when EDR isn't installed", async () => {
+    assert.equal(
+      await getNativeSecp256k1PublicKeyFromSecretKeyUnder("missing"),
+      undefined,
+    );
+  });
+
+  it("should resolve to undefined when EDR's derivation isn't callable", async () => {
+    assert.equal(
+      await getNativeSecp256k1PublicKeyFromSecretKeyUnder("not-callable"),
+      undefined,
+    );
+  });
+});

--- a/packages/hardhat/test/internal/edr/secp256k1.ts
+++ b/packages/hardhat/test/internal/edr/secp256k1.ts
@@ -1,0 +1,93 @@
+import type { Secp256k1PublicKeyFromSecretKey } from "../../../src/internal/edr/secp256k1.js";
+
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+
+import { assertThrows } from "@nomicfoundation/hardhat-test-utils";
+import {
+  bytesToHexString,
+  hexStringToBytes,
+} from "@nomicfoundation/hardhat-utils/hex";
+
+import { getNativeSecp256k1PublicKeyFromSecretKey } from "../../../src/internal/edr/secp256k1.js";
+
+// The order of the secp256k1 curve, i.e. the first scalar that is out of range.
+const CURVE_ORDER = BigInt(
+  "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+);
+
+function secretKeyOf(scalar: bigint): Uint8Array {
+  return hexStringToBytes(scalar.toString(16).padStart(64, "0"));
+}
+
+describe("getNativeSecp256k1PublicKeyFromSecretKey", () => {
+  let publicKeyFromSecretKey: Secp256k1PublicKeyFromSecretKey;
+
+  before(async () => {
+    const native = await getNativeSecp256k1PublicKeyFromSecretKey();
+
+    assert.ok(
+      native !== undefined,
+      "EDR's native secp256k1 derivation should be available on the platforms that run this suite",
+    );
+
+    publicKeyFromSecretKey = native;
+  });
+
+  it("should return the same instance on every call", async () => {
+    assert.equal(
+      await getNativeSecp256k1PublicKeyFromSecretKey(),
+      publicKeyFromSecretKey,
+    );
+  });
+
+  it("should derive the well-known public key of a known secret key", () => {
+    const publicKey = publicKeyFromSecretKey(
+      hexStringToBytes(
+        "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+      ),
+    );
+
+    assert.equal(
+      bytesToHexString(publicKey),
+      "0x048318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed75" +
+        "3547f11ca8696646f2f3acb08e31016afac23e630c5d11f59f61fef57b0d2aa5",
+    );
+  });
+
+  it("should return an uncompressed point for every valid secret key", () => {
+    for (const scalar of [BigInt(1), BigInt(1337), CURVE_ORDER - BigInt(1)]) {
+      const publicKey = publicKeyFromSecretKey(secretKeyOf(scalar));
+
+      assert.equal(publicKey.length, 65);
+      assert.equal(publicKey[0], 0x04);
+    }
+  });
+
+  it("should throw for secret keys outside the curve order", () => {
+    for (const scalar of [
+      BigInt(0),
+      CURVE_ORDER,
+      CURVE_ORDER + BigInt(1),
+      BigInt(2) ** BigInt(256) - BigInt(1),
+    ]) {
+      const secretKey = secretKeyOf(scalar);
+
+      assertThrows(
+        () => publicKeyFromSecretKey(secretKey),
+        undefined,
+        `0x${scalar.toString(16)} should be rejected`,
+      );
+    }
+  });
+
+  it("should throw for inputs that aren't 32 bytes", () => {
+    for (const length of [0, 31, 33, 65]) {
+      assertThrows(
+        () => publicKeyFromSecretKey(new Uint8Array(length).fill(1)),
+        undefined,
+        `a ${length}-byte input should be rejected`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Use secp256k1 EDR implementation to override the ethers one. Similar to the keccak PR: https://github.com/NomicFoundation/hardhat/pull/8580.

Depends on EDR PR: https://github.com/NomicFoundation/edr/pull/1727